### PR TITLE
Lsp-source-directive

### DIFF
--- a/.kiro/specs/lsp-source-directive/design.md
+++ b/.kiro/specs/lsp-source-directive/design.md
@@ -23,7 +23,7 @@ Forward directives are useful when:
 
 The implementation extends the existing cross-file awareness system with minimal changes:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Cross-File Architecture                       │
 ├─────────────────────────────────────────────────────────────────┤
@@ -113,7 +113,7 @@ let resolved = resolve_path(&directive.path, &backward_ctx)?;
 
 #### Conflict Resolution Logic
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │              Directive-vs-AST Conflict Resolution                │
 ├─────────────────────────────────────────────────────────────────┤

--- a/.kiro/specs/lsp-source-directive/design.md
+++ b/.kiro/specs/lsp-source-directive/design.md
@@ -5,9 +5,11 @@
 This document describes the design for adding the `@lsp-source` forward directive to Raven, the R Language Server. The `@lsp-source` directive allows developers to explicitly declare that a file sources another file, complementing the existing backward directives (`@lsp-sourced-by`, `@lsp-run-by`, `@lsp-included-by`).
 
 Forward directives are useful when:
-- `source()` calls use dynamic paths (variables, expressions)
-- `source()` calls are conditional (inside if statements)
+- `source()` calls use dynamic paths (variables, expressions) that Raven cannot statically analyze
 - The relationship needs to be declared at a specific line for position-aware scope
+- You want to explicitly document a sourcing relationship for clarity
+
+**Note**: Raven already detects `source()` calls inside conditionals, loops, and function bodies through recursive AST traversal. The `@lsp-source` directive is primarily needed for dynamic paths that cannot be statically determined.
 
 ### Key Design Decisions
 
@@ -54,7 +56,7 @@ The implementation extends the existing cross-file awareness system with minimal
 
 **Changes Required**: 
 - Add `@lsp-run` and `@lsp-include` as synonyms
-- Add `line=N` parameter parsing for forward directives
+- Add optional `line=N` parameter parsing for forward directives (allows specifying call-site line explicitly)
 
 #### Updated Regex Pattern
 

--- a/.kiro/specs/lsp-source-directive/design.md
+++ b/.kiro/specs/lsp-source-directive/design.md
@@ -1,0 +1,362 @@
+# Design Document: @lsp-source Forward Directive
+
+## Overview
+
+This document describes the design for adding the `@lsp-source` forward directive to Raven, the R Language Server. The `@lsp-source` directive allows developers to explicitly declare that a file sources another file, complementing the existing backward directives (`@lsp-sourced-by`, `@lsp-run-by`, `@lsp-included-by`).
+
+Forward directives are useful when:
+- `source()` calls use dynamic paths (variables, expressions)
+- `source()` calls are conditional (inside if statements)
+- The relationship needs to be declared at a specific line for position-aware scope
+
+### Key Design Decisions
+
+1. **Forward directives use @lsp-cd**: Unlike backward directives which always resolve relative to the file's directory, forward directives respect the `@lsp-cd` working directory. This is because forward directives are semantically equivalent to `source()` calls and describe runtime execution behavior.
+
+2. **Directive wins at same call site**: When both a directive and an AST-detected `source()` call point to the same file at the same call site, the directive takes precedence.
+
+3. **Both edges kept at different call sites**: When a directive and `source()` call point to the same file but at different lines, both edges are preserved (symbols become available at the earliest call site).
+
+## Architecture
+
+The implementation extends the existing cross-file awareness system with minimal changes:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Cross-File Architecture                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │
+│  │  directive.rs │───▶│ dependency.rs│───▶│   scope.rs   │       │
+│  │              │    │              │    │              │       │
+│  │ Parse @lsp-  │    │ Build edges  │    │ Resolve      │       │
+│  │ source/run/  │    │ with conflict│    │ symbols at   │       │
+│  │ include      │    │ resolution   │    │ position     │       │
+│  └──────────────┘    └──────────────┘    └──────────────┘       │
+│         │                   │                   │                │
+│         ▼                   ▼                   ▼                │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │
+│  │path_resolve.rs│    │ handlers.rs  │    │ completions  │       │
+│  │              │    │              │    │ hover, goto  │       │
+│  │ Resolve paths│    │ Diagnostics  │    │ definition   │       │
+│  │ with @lsp-cd │    │ for missing  │    │              │       │
+│  └──────────────┘    │ files        │    └──────────────┘       │
+│                      └──────────────┘                           │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Components and Interfaces
+
+### 1. Directive Parser (`directive.rs`)
+
+**Current State**: Already parses `@lsp-source` with basic syntax support.
+
+**Changes Required**: 
+- Add `@lsp-run` and `@lsp-include` as synonyms
+- Add `line=N` parameter parsing for forward directives
+
+#### Updated Regex Pattern
+
+```rust
+// Current pattern (basic)
+forward: Regex::new(
+    r#"#\s*@?lsp-source\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))"#
+).unwrap(),
+
+// New pattern (with synonyms and line parameter)
+forward: Regex::new(
+    r#"#\s*@?lsp-(?:source|run|include)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+))?"#
+).unwrap(),
+```
+
+#### ForwardSource Structure (existing)
+
+```rust
+pub struct ForwardSource {
+    pub path: String,
+    pub line: u32,           // 0-based line of directive or line=N value
+    pub column: u32,         // Always 0 for directives
+    pub is_directive: bool,  // true for @lsp-source
+    pub local: bool,         // false for directives
+    pub chdir: bool,         // false for directives
+    pub is_sys_source: bool, // false for directives
+    pub sys_source_global_env: bool, // true for directives
+}
+```
+
+### 2. Path Resolution (`path_resolve.rs`)
+
+**Current State**: Already supports working directory context via `PathContext`.
+
+**Key Behavior**: Forward directives (`@lsp-source`) use `PathContext::from_metadata()` which includes the working directory from `@lsp-cd`. This differs from backward directives which use `PathContext::new()` (no working directory).
+
+```rust
+// For forward directives (uses @lsp-cd)
+let path_ctx = PathContext::from_metadata(uri, meta, workspace_root)?;
+let resolved = resolve_path(&source.path, &path_ctx)?;
+
+// For backward directives (ignores @lsp-cd)
+let backward_ctx = PathContext::new(uri, workspace_root)?;
+let resolved = resolve_path(&directive.path, &backward_ctx)?;
+```
+
+### 3. Dependency Graph (`dependency.rs`)
+
+**Current State**: Already processes forward sources in `update_file()`.
+
+**Changes Required**: 
+- Handle `line=N` parameter for forward directives
+- Ensure directive-vs-AST conflict resolution works correctly
+
+#### Conflict Resolution Logic
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│              Directive-vs-AST Conflict Resolution                │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Case 1: Same file, same call site                              │
+│  ┌─────────────────┐                                            │
+│  │ @lsp-source a.R │ line 5                                     │
+│  │ source("a.R")   │ line 5                                     │
+│  └─────────────────┘                                            │
+│  Result: Keep directive edge only (directive wins)              │
+│                                                                  │
+│  Case 2: Same file, different call sites                        │
+│  ┌─────────────────┐                                            │
+│  │ @lsp-source a.R │ line 10                                    │
+│  │ source("a.R")   │ line 5                                     │
+│  └─────────────────┘                                            │
+│  Result: Keep both edges (symbols available at line 5)          │
+│                                                                  │
+│  Case 3: Directive without line=, AST at earlier line           │
+│  ┌─────────────────┐                                            │
+│  │ source("a.R")   │ line 5                                     │
+│  │ @lsp-source a.R │ line 10 (no line= param)                   │
+│  └─────────────────┘                                            │
+│  Result: Keep AST edge, emit optional redundancy note           │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4. Scope Resolution (`scope.rs`)
+
+**Current State**: Already handles `ForwardSource` entries in timeline events.
+
+**No Changes Required**: The existing scope resolution logic treats all `ForwardSource` entries uniformly, making symbols available after the call site line.
+
+### 5. Diagnostics (`handlers.rs`)
+
+**Changes Required**:
+- Emit warning for missing files referenced by `@lsp-source`
+- Optionally emit note for redundant directives
+
+#### Diagnostic Types
+
+| Condition | Severity | Message |
+|-----------|----------|---------|
+| File not found | Warning (configurable) | "File 'path.R' referenced by @lsp-source directive not found" |
+| Redundant directive | Hint (optional) | "Directive is redundant: source() call to same file exists at earlier line" |
+
+## Data Models
+
+### CrossFileMetadata (existing)
+
+```rust
+pub struct CrossFileMetadata {
+    pub sourced_by: Vec<BackwardDirective>,  // Backward directives
+    pub sources: Vec<ForwardSource>,          // Forward directives + AST source() calls
+    pub working_directory: Option<String>,    // @lsp-cd
+    pub inherited_working_directory: Option<String>,
+    pub ignored_lines: HashSet<u32>,
+    pub ignored_next_lines: HashSet<u32>,
+    pub library_calls: Vec<LibraryCall>,
+}
+```
+
+### DependencyEdge (existing)
+
+```rust
+pub struct DependencyEdge {
+    pub from: Url,                    // Parent file
+    pub to: Url,                      // Child file
+    pub call_site_line: Option<u32>,  // 0-based line
+    pub call_site_column: Option<u32>,// 0-based UTF-16 column
+    pub local: bool,
+    pub chdir: bool,
+    pub is_sys_source: bool,
+    pub is_directive: bool,           // true for @lsp-source
+    pub is_backward_directive: bool,  // false for @lsp-source
+}
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Forward Directive Parsing Completeness
+
+*For any* valid forward directive syntax variation (with/without @, with/without colon, with single/double/no quotes, with/without line= parameter), the Directive_Parser SHALL produce a ForwardSource entry with the correct path and `is_directive=true`.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9**
+
+### Property 2: Synonym Equivalence
+
+*For any* path string, parsing `@lsp-source <path>`, `@lsp-run <path>`, and `@lsp-include <path>` SHALL produce identical ForwardSource entries (same path, same flags).
+
+**Validates: Requirements 1.2, 1.3**
+
+### Property 3: Call-Site Line Conversion
+
+*For any* forward directive with `line=N` parameter where N is a positive integer, the resulting ForwardSource SHALL have `line = N - 1` (converting from 1-based user input to 0-based internal representation).
+
+**Validates: Requirements 2.1**
+
+### Property 4: Default Call-Site Assignment
+
+*For any* forward directive without a `line=` parameter appearing at line L (0-based), the resulting ForwardSource SHALL have `line = L`.
+
+**Validates: Requirements 2.2**
+
+### Property 5: Multiple Directive Independence
+
+*For any* file containing N forward directives, the Directive_Parser SHALL produce exactly N ForwardSource entries, each with the correct path and line.
+
+**Validates: Requirements 2.3**
+
+### Property 6: Forward Directive Uses Working Directory
+
+*For any* file with both `@lsp-cd <wd>` and `@lsp-source <path>` directives, the path resolution for the forward directive SHALL use the working directory `<wd>` as the base for relative path resolution.
+
+**Validates: Requirements 3.4**
+
+### Property 7: Directive Edge Creation
+
+*For any* forward directive pointing to an existing file, the Dependency_Graph SHALL contain an edge with `is_directive=true` and `is_backward_directive=false`.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 8: Same Call-Site Conflict Resolution
+
+*For any* file containing both a forward directive and a `source()` call pointing to the same target file at the same line, the Dependency_Graph SHALL contain exactly one edge (the directive edge).
+
+**Validates: Requirements 4.3**
+
+### Property 9: Different Call-Site Preservation
+
+*For any* file containing both a forward directive at line A and a `source()` call at line B (where A ≠ B) pointing to the same target file, the Dependency_Graph SHALL contain edges for both call sites.
+
+**Validates: Requirements 4.4**
+
+### Property 10: Scope Availability After Directive
+
+*For any* file with `@lsp-source <path>` at line L, symbols from the sourced file SHALL be available in scope at positions after line L.
+
+**Validates: Requirements 5.1, 5.2**
+
+### Property 11: Missing File Diagnostic
+
+*For any* forward directive referencing a non-existent file, the system SHALL emit a diagnostic at the directive's line.
+
+**Validates: Requirements 6.1**
+
+### Property 12: Revalidation on Directive Change
+
+*For any* change to a forward directive (add, remove, or modify), the dependency graph SHALL be updated to reflect the change.
+
+**Validates: Requirements 7.1, 7.2, 7.3**
+
+## Error Handling
+
+### Missing File
+
+When a forward directive references a file that doesn't exist:
+1. No edge is created in the dependency graph
+2. A diagnostic warning is emitted at the directive line
+3. The diagnostic severity is configurable via `crossFile.missingFileSeverity`
+
+### Invalid Path Syntax
+
+When a path cannot be parsed (e.g., unmatched quotes):
+1. The directive is ignored
+2. No diagnostic is emitted (silent failure to avoid noise)
+
+### Circular Dependencies
+
+Circular dependencies are detected during scope resolution:
+1. The cycle is broken at the point of detection
+2. A warning diagnostic is emitted
+3. Symbols up to the cycle point are still available
+
+## Testing Strategy
+
+### Unit Tests
+
+Unit tests focus on specific examples and edge cases:
+
+1. **Directive Parsing**
+   - Parse each synonym (@lsp-source, @lsp-run, @lsp-include)
+   - Parse with/without @ prefix
+   - Parse with/without colon
+   - Parse with single/double/no quotes
+   - Parse with spaces in quoted paths
+   - Parse with line=N parameter
+
+2. **Path Resolution**
+   - Relative paths with @lsp-cd
+   - Workspace-root-relative paths
+   - Non-existent files
+
+3. **Conflict Resolution**
+   - Directive and source() at same line
+   - Directive and source() at different lines
+   - Multiple directives to same file
+
+### Property-Based Tests
+
+Property tests verify universal properties across many generated inputs. Each test runs minimum 100 iterations.
+
+**Tag format**: `Feature: lsp-source-directive, Property N: <property_text>`
+
+1. **Property 1 Test**: Generate random valid directive syntax variations, verify parsing produces correct ForwardSource.
+
+2. **Property 2 Test**: Generate random paths, verify all three synonyms produce identical results.
+
+3. **Property 3 Test**: Generate random line numbers, verify 1-based to 0-based conversion.
+
+4. **Property 6 Test**: Generate random working directories and relative paths, verify resolution uses working directory.
+
+5. **Property 8 Test**: Generate files with directive and source() at same line, verify single edge.
+
+6. **Property 9 Test**: Generate files with directive and source() at different lines, verify both edges.
+
+### Integration Tests
+
+1. **End-to-End Scope Resolution**: Verify symbols from @lsp-source files appear in completions.
+
+2. **Diagnostic Generation**: Verify missing file warnings are emitted.
+
+3. **Revalidation**: Verify adding/removing directives triggers appropriate updates.
+
+## Implementation Notes
+
+### Backward Compatibility
+
+The existing `@lsp-source` directive parsing already works. This design adds:
+- Synonym support (@lsp-run, @lsp-include)
+- `line=N` parameter support
+- Explicit documentation of @lsp-cd interaction
+
+### Performance Considerations
+
+- Directive parsing is O(n) where n is the number of lines
+- Path resolution is O(1) per directive
+- Dependency graph update is O(m) where m is the number of edges
+
+### Configuration Options
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `crossFile.missingFileSeverity` | string | "warning" | Severity for missing file diagnostics |
+| `crossFile.redundantDirectiveSeverity` | string | "hint" | Severity for redundant directive notes |

--- a/.kiro/specs/lsp-source-directive/requirements.md
+++ b/.kiro/specs/lsp-source-directive/requirements.md
@@ -1,0 +1,110 @@
+# Requirements Document
+
+## Introduction
+
+This document specifies the requirements for adding the `@lsp-source` forward directive to Raven, the R Language Server. The `@lsp-source` directive allows developers to explicitly declare that a file sources another file, complementing the existing backward directives (`@lsp-sourced-by`, `@lsp-run-by`, `@lsp-included-by`). This is useful when `source()` calls are conditional, dynamic, or use variables for paths.
+
+## Glossary
+
+- **Directive_Parser**: The module responsible for parsing LSP directives from R file comments
+- **Dependency_Graph**: The data structure tracking source relationships between files
+- **Forward_Directive**: A directive placed in a parent file that points to a child file it sources
+- **Backward_Directive**: A directive placed in a child file that points to a parent file that sources it
+- **Call_Site**: The position (line, column) in a parent file where a source relationship originates
+- **Path_Resolver**: The module responsible for resolving relative and absolute file paths
+- **Scope_Resolver**: The module responsible for determining which symbols are available at a given position
+
+## Requirements
+
+### Requirement 1: Basic Directive Parsing
+
+**User Story:** As a developer, I want to use `@lsp-source` directives to explicitly declare file dependencies, so that the LSP understands relationships that cannot be detected from `source()` calls.
+
+#### Acceptance Criteria
+
+1. WHEN a comment contains `@lsp-source` followed by a path, THE Directive_Parser SHALL extract the path and create a ForwardSource entry with `is_directive=true`
+2. WHEN a comment contains `@lsp-run` followed by a path, THE Directive_Parser SHALL parse it identically to `@lsp-source` (synonym)
+3. WHEN a comment contains `@lsp-include` followed by a path, THE Directive_Parser SHALL parse it identically to `@lsp-source` (synonym)
+4. WHEN a comment contains any of the above without `@` prefix (e.g., `lsp-source`), THE Directive_Parser SHALL parse it identically to the `@`-prefixed version
+5. WHEN the directive uses an optional colon separator (`@lsp-source: path`), THE Directive_Parser SHALL parse it correctly
+6. WHEN the path is double-quoted (`@lsp-source "path"`), THE Directive_Parser SHALL extract the path without quotes
+7. WHEN the path is single-quoted (`@lsp-source 'path'`), THE Directive_Parser SHALL extract the path without quotes
+8. WHEN the path contains spaces and is quoted (`@lsp-source "path with spaces/file.R"`), THE Directive_Parser SHALL preserve the spaces in the extracted path
+9. WHEN the path is unquoted and contains no spaces, THE Directive_Parser SHALL extract the path correctly
+
+### Requirement 2: Call-Site Specification
+
+**User Story:** As a developer, I want to specify where in the file the source relationship should be considered active, so that position-aware scope resolution works correctly.
+
+#### Acceptance Criteria
+
+1. WHEN the directive includes `line=N` parameter, THE Directive_Parser SHALL store the call site as line N-1 (converting from 1-based user input to 0-based internal)
+2. WHEN the directive includes no call-site parameter, THE Directive_Parser SHALL use the directive's own line as the call site
+3. WHEN multiple `@lsp-source` directives exist in a file, THE Directive_Parser SHALL create separate ForwardSource entries for each
+4. THE ForwardSource entry SHALL have `column=0` for directive-based sources (directives don't have meaningful column positions)
+
+### Requirement 3: Path Resolution
+
+**User Story:** As a developer, I want `@lsp-source` paths to resolve correctly relative to the file's directory or workspace root, so that the dependency graph is accurate.
+
+#### Acceptance Criteria
+
+1. WHEN the path is relative (e.g., `utils.R`, `../shared/common.R`), THE Path_Resolver SHALL resolve it relative to the directive's file directory
+2. WHEN the path starts with `/` (workspace-root-relative), THE Path_Resolver SHALL resolve it relative to the workspace root
+3. WHEN the resolved path does not exist, THE Dependency_Graph SHALL NOT create an edge for that directive
+4. WHEN the file has an `@lsp-cd` directive, THE Path_Resolver SHALL use the working directory for resolving `@lsp-source` paths (unlike backward directives which ignore `@lsp-cd`)
+
+### Requirement 4: Dependency Graph Integration
+
+**User Story:** As a developer, I want `@lsp-source` directives to create proper edges in the dependency graph, so that cross-file features work correctly.
+
+#### Acceptance Criteria
+
+1. WHEN an `@lsp-source` directive is parsed, THE Dependency_Graph SHALL create a forward edge from the parent file to the child file
+2. WHEN the edge is created from a directive, THE DependencyEdge SHALL have `is_directive=true` and `is_backward_directive=false`
+3. WHEN both an `@lsp-source` directive and a `source()` call point to the same file at the same call site, THE Dependency_Graph SHALL keep only the directive edge (directive wins)
+4. WHEN an `@lsp-source` directive points to the same file as a `source()` call but at different call sites, THE Dependency_Graph SHALL keep both edges (symbols become available at the earliest call site)
+5. WHEN an `@lsp-source` directive has no explicit call site and a `source()` call exists to the same file at an earlier line, THE Dependency_Graph SHALL keep the AST edge (earliest call site wins) and MAY emit an informational note that the directive is redundant
+
+### Requirement 5: Scope Resolution
+
+**User Story:** As a developer, I want symbols from files referenced by `@lsp-source` to be available in completions and hover, so that I get accurate IDE features.
+
+#### Acceptance Criteria
+
+1. WHEN a file has an `@lsp-source` directive, THE Scope_Resolver SHALL include symbols from the sourced file in scope after the directive's line
+2. WHEN the directive specifies `line=N`, THE Scope_Resolver SHALL include symbols from the sourced file in scope starting at line N
+3. WHEN the sourced file defines functions or variables, THE Scope_Resolver SHALL make them available for completions, hover, and go-to-definition
+
+### Requirement 6: Diagnostics
+
+**User Story:** As a developer, I want to see helpful diagnostics when `@lsp-source` directives have issues, so that I can fix problems quickly.
+
+#### Acceptance Criteria
+
+1. WHEN an `@lsp-source` directive references a file that does not exist, THE system SHALL emit a diagnostic warning at the directive line
+2. WHEN an `@lsp-source` directive without an explicit `line=N` parameter targets the same file as an AST-detected `source()` call at an earlier line, THE system MAY emit an informational diagnostic noting the directive is redundant
+3. THE diagnostic severity for missing files SHALL be configurable via LSP settings
+
+### Requirement 7: Revalidation
+
+**User Story:** As a developer, I want changes to `@lsp-source` directives to trigger appropriate revalidation, so that the IDE stays up-to-date.
+
+#### Acceptance Criteria
+
+1. WHEN an `@lsp-source` directive is added to a file, THE system SHALL update the dependency graph and revalidate affected files
+2. WHEN an `@lsp-source` directive is removed from a file, THE system SHALL remove the corresponding edge and revalidate affected files
+3. WHEN the target of an `@lsp-source` directive changes, THE system SHALL update the dependency graph accordingly
+
+### Requirement 8: Documentation Update
+
+**User Story:** As a developer reading the codebase documentation, I want AGENTS.md and docs/cross-file.md to accurately describe the path resolution behavior for forward vs backward directives, so that I understand the design correctly.
+
+#### Acceptance Criteria
+
+1. WHEN the `@lsp-source` feature is implemented, THE AGENTS.md file SHALL be updated to clarify that forward directives (`@lsp-source`, `@lsp-run`, `@lsp-include`) use `@lsp-cd` for path resolution
+2. THE AGENTS.md file SHALL distinguish between backward directives (which ignore `@lsp-cd`) and forward directives (which use `@lsp-cd`)
+3. THE AGENTS.md file SHALL explain the rationale: forward directives are semantically equivalent to `source()` calls and describe runtime execution, while backward directives describe static file relationships from the child's perspective
+4. THE docs/cross-file.md file SHALL expand the Forward Directives section to document `@lsp-source` and its synonyms (`@lsp-run`, `@lsp-include`) with full syntax examples
+5. THE docs/cross-file.md file SHALL correct the existing note about `@lsp-cd` to clarify that forward directives DO use `@lsp-cd` for path resolution (unlike backward directives which ignore it)
+6. THE docs/cross-file.md file SHALL document the `line=N` parameter for forward directives

--- a/.kiro/specs/lsp-source-directive/tasks.md
+++ b/.kiro/specs/lsp-source-directive/tasks.md
@@ -6,150 +6,150 @@ This plan implements the `@lsp-source` forward directive for Raven, adding synon
 
 ## Tasks
 
-- [ ] 1. Extend directive parsing with synonyms and line parameter
-  - [ ] 1.1 Update forward directive regex in `directive.rs`
+- [x] 1. Extend directive parsing with synonyms and line parameter
+  - [x] 1.1 Update forward directive regex in `directive.rs`
     - Add `@lsp-run` and `@lsp-include` as synonyms to the regex pattern
     - Add optional `line=N` parameter capture group
     - Pattern: `#\s*@?lsp-(?:source|run|include)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+))?`
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9_
 
-  - [ ] 1.2 Update `parse_forward_directives()` to handle line parameter
+  - [x] 1.2 Update `parse_forward_directives()` to handle line parameter
     - Parse the `line=N` capture group when present
     - Convert from 1-based user input to 0-based internal (N-1)
     - Use directive's own line when no `line=` parameter
     - Set `column=0` for all directive-based sources
     - _Requirements: 2.1, 2.2, 2.3, 2.4_
 
-  - [ ] 1.3 Write property test for directive parsing completeness
+  - [x] 1.3 Write property test for directive parsing completeness
     - **Property 1: Forward Directive Parsing Completeness**
     - Generate random valid syntax variations (with/without @, colon, quotes, line=)
     - Verify ForwardSource has correct path and `is_directive=true`
     - **Validates: Requirements 1.1-1.9**
 
-  - [ ] 1.4 Write property test for synonym equivalence
+  - [x] 1.4 Write property test for synonym equivalence
     - **Property 2: Synonym Equivalence**
     - Generate random paths, verify @lsp-source, @lsp-run, @lsp-include produce identical ForwardSource
     - **Validates: Requirements 1.2, 1.3**
 
-  - [ ] 1.5 Write property test for call-site line conversion
+  - [x] 1.5 Write property test for call-site line conversion
     - **Property 3: Call-Site Line Conversion**
     - Generate random line numbers, verify 1-based to 0-based conversion (N → N-1)
     - **Validates: Requirements 2.1**
 
-  - [ ] 1.6 Write property test for default call-site assignment
+  - [x] 1.6 Write property test for default call-site assignment
     - **Property 4: Default Call-Site Assignment**
     - Generate directives without line= at various lines, verify line matches directive position
     - **Validates: Requirements 2.2**
 
-  - [ ] 1.7 Write property test for multiple directive independence
+  - [x] 1.7 Write property test for multiple directive independence
     - **Property 5: Multiple Directive Independence**
     - Generate files with N directives, verify exactly N ForwardSource entries
     - **Validates: Requirements 2.3**
 
-- [ ] 2. Checkpoint - Verify directive parsing
+- [x] 2. Checkpoint - Verify directive parsing
   - Ensure all directive parsing tests pass, ask the user if questions arise.
 
-- [ ] 3. Implement path resolution with @lsp-cd support
-  - [ ] 3.1 Verify forward directives use `PathContext::from_metadata()` in `dependency.rs`
+- [x] 3. Implement path resolution with @lsp-cd support
+  - [x] 3.1 Verify forward directives use `PathContext::from_metadata()` in `dependency.rs`
     - Ensure forward directive path resolution includes working directory from @lsp-cd
     - Confirm backward directives continue using `PathContext::new()` (no working directory)
     - Add comments clarifying the distinction
     - _Requirements: 3.1, 3.2, 3.4_
 
-  - [ ] 3.2 Handle non-existent files in forward directive processing
+  - [x] 3.2 Handle non-existent files in forward directive processing
     - Skip edge creation when resolved path doesn't exist
     - Store unresolved paths for diagnostic emission
     - _Requirements: 3.3_
 
-  - [ ] 3.3 Write property test for forward directive working directory usage
+  - [x] 3.3 Write property test for forward directive working directory usage
     - **Property 6: Forward Directive Uses Working Directory**
     - Generate files with @lsp-cd and @lsp-source, verify path resolution uses working directory
     - **Validates: Requirements 3.4**
 
-- [ ] 4. Implement dependency graph conflict resolution
-  - [ ] 4.1 Update `update_file()` in `dependency.rs` for directive-vs-AST conflict resolution
+- [x] 4. Implement dependency graph conflict resolution
+  - [x] 4.1 Update `update_file()` in `dependency.rs` for directive-vs-AST conflict resolution
     - When directive and source() point to same file at same line: keep directive edge only
     - When directive and source() point to same file at different lines: keep both edges
     - Track which edges are from directives vs AST for conflict detection
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
 
-  - [ ] 4.2 Write property test for directive edge creation
+  - [x] 4.2 Write property test for directive edge creation
     - **Property 7: Directive Edge Creation**
     - Generate forward directives to existing files, verify edge has `is_directive=true`, `is_backward_directive=false`
     - **Validates: Requirements 4.1, 4.2**
 
-  - [ ] 4.3 Write property test for same call-site conflict resolution
+  - [x] 4.3 Write property test for same call-site conflict resolution
     - **Property 8: Same Call-Site Conflict Resolution**
     - Generate files with directive and source() at same line, verify single directive edge
     - **Validates: Requirements 4.3**
 
-  - [ ] 4.4 Write property test for different call-site preservation
+  - [x] 4.4 Write property test for different call-site preservation
     - **Property 9: Different Call-Site Preservation**
     - Generate files with directive at line A and source() at line B (A≠B), verify both edges exist
     - **Validates: Requirements 4.4**
 
-- [ ] 5. Checkpoint - Verify dependency graph integration
+- [x] 5. Checkpoint - Verify dependency graph integration
   - Ensure all dependency graph tests pass, ask the user if questions arise.
 
-- [ ] 6. Verify scope resolution integration
-  - [ ] 6.1 Verify existing scope resolution handles forward directive edges
+- [x] 6. Verify scope resolution integration
+  - [x] 6.1 Verify existing scope resolution handles forward directive edges
     - Confirm symbols from sourced files are available after directive line
     - Confirm `line=N` parameter affects scope availability position
     - Add integration test for scope resolution with @lsp-source
     - _Requirements: 5.1, 5.2, 5.3_
 
-  - [ ] 6.2 Write property test for scope availability after directive
+  - [x] 6.2 Write property test for scope availability after directive
     - **Property 10: Scope Availability After Directive**
     - Generate files with @lsp-source at line L, verify symbols available after L
     - **Validates: Requirements 5.1, 5.2**
 
-- [ ] 7. Implement diagnostics for forward directives
-  - [ ] 7.1 Add missing file diagnostic in `handlers.rs`
+- [x] 7. Implement diagnostics for forward directives
+  - [x] 7.1 Add missing file diagnostic in `handlers.rs`
     - Emit warning when @lsp-source references non-existent file
     - Use configurable severity from `crossFile.missingFileSeverity`
     - Position diagnostic at directive line
     - _Requirements: 6.1, 6.3_
 
-  - [ ] 7.2 Add optional redundant directive diagnostic
+  - [x] 7.2 Add optional redundant directive diagnostic
     - Emit hint when directive without line= targets same file as earlier source() call
     - Use configurable severity from `crossFile.redundantDirectiveSeverity`
     - _Requirements: 6.2_
 
-  - [ ] 7.3 Write property test for missing file diagnostic
+  - [x] 7.3 Write property test for missing file diagnostic
     - **Property 11: Missing File Diagnostic**
     - Generate forward directives to non-existent files, verify diagnostic emitted at directive line
     - **Validates: Requirements 6.1**
 
-- [ ] 8. Verify revalidation on directive changes
-  - [ ] 8.1 Verify existing revalidation handles forward directive changes
+- [x] 8. Verify revalidation on directive changes
+  - [x] 8.1 Verify existing revalidation handles forward directive changes
     - Confirm adding @lsp-source triggers dependency graph update
     - Confirm removing @lsp-source removes edge and revalidates
     - Confirm modifying @lsp-source path updates graph
     - _Requirements: 7.1, 7.2, 7.3_
 
-  - [ ] 8.2 Write property test for revalidation on directive change
+  - [x] 8.2 Write property test for revalidation on directive change
     - **Property 12: Revalidation on Directive Change**
     - Generate directive add/remove/modify operations, verify graph reflects changes
     - **Validates: Requirements 7.1, 7.2, 7.3**
 
-- [ ] 9. Checkpoint - Verify diagnostics and revalidation
+- [x] 9. Checkpoint - Verify diagnostics and revalidation
   - Ensure all diagnostic and revalidation tests pass, ask the user if questions arise.
 
-- [ ] 10. Update documentation
-  - [ ] 10.1 Update AGENTS.md with forward directive path resolution behavior
+- [x] 10. Update documentation
+  - [x] 10.1 Update AGENTS.md with forward directive path resolution behavior
     - Clarify forward directives (@lsp-source, @lsp-run, @lsp-include) use @lsp-cd
     - Distinguish from backward directives which ignore @lsp-cd
     - Explain rationale: forward directives describe runtime execution like source()
     - _Requirements: 8.1, 8.2, 8.3_
 
-  - [ ] 10.2 Update docs/cross-file.md with @lsp-source documentation
+  - [x] 10.2 Update docs/cross-file.md with @lsp-source documentation
     - Expand Forward Directives section with @lsp-source and synonyms
     - Document full syntax with examples (quotes, colon, line= parameter)
     - Correct note about @lsp-cd to clarify forward directives DO use it
     - Document line=N parameter for explicit call-site specification
     - _Requirements: 8.4, 8.5, 8.6_
 
-- [ ] 11. Final checkpoint - Ensure all tests pass
+- [x] 11. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/.kiro/specs/lsp-source-directive/tasks.md
+++ b/.kiro/specs/lsp-source-directive/tasks.md
@@ -1,0 +1,160 @@
+# Implementation Plan: @lsp-source Forward Directive
+
+## Overview
+
+This plan implements the `@lsp-source` forward directive for Raven, adding synonym support (`@lsp-run`, `@lsp-include`), `line=N` parameter parsing, proper path resolution with `@lsp-cd` support, and conflict resolution between directives and AST-detected `source()` calls.
+
+## Tasks
+
+- [ ] 1. Extend directive parsing with synonyms and line parameter
+  - [ ] 1.1 Update forward directive regex in `directive.rs`
+    - Add `@lsp-run` and `@lsp-include` as synonyms to the regex pattern
+    - Add optional `line=N` parameter capture group
+    - Pattern: `#\s*@?lsp-(?:source|run|include)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+))?`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9_
+
+  - [ ] 1.2 Update `parse_forward_directives()` to handle line parameter
+    - Parse the `line=N` capture group when present
+    - Convert from 1-based user input to 0-based internal (N-1)
+    - Use directive's own line when no `line=` parameter
+    - Set `column=0` for all directive-based sources
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [ ] 1.3 Write property test for directive parsing completeness
+    - **Property 1: Forward Directive Parsing Completeness**
+    - Generate random valid syntax variations (with/without @, colon, quotes, line=)
+    - Verify ForwardSource has correct path and `is_directive=true`
+    - **Validates: Requirements 1.1-1.9**
+
+  - [ ] 1.4 Write property test for synonym equivalence
+    - **Property 2: Synonym Equivalence**
+    - Generate random paths, verify @lsp-source, @lsp-run, @lsp-include produce identical ForwardSource
+    - **Validates: Requirements 1.2, 1.3**
+
+  - [ ] 1.5 Write property test for call-site line conversion
+    - **Property 3: Call-Site Line Conversion**
+    - Generate random line numbers, verify 1-based to 0-based conversion (N → N-1)
+    - **Validates: Requirements 2.1**
+
+  - [ ] 1.6 Write property test for default call-site assignment
+    - **Property 4: Default Call-Site Assignment**
+    - Generate directives without line= at various lines, verify line matches directive position
+    - **Validates: Requirements 2.2**
+
+  - [ ] 1.7 Write property test for multiple directive independence
+    - **Property 5: Multiple Directive Independence**
+    - Generate files with N directives, verify exactly N ForwardSource entries
+    - **Validates: Requirements 2.3**
+
+- [ ] 2. Checkpoint - Verify directive parsing
+  - Ensure all directive parsing tests pass, ask the user if questions arise.
+
+- [ ] 3. Implement path resolution with @lsp-cd support
+  - [ ] 3.1 Verify forward directives use `PathContext::from_metadata()` in `dependency.rs`
+    - Ensure forward directive path resolution includes working directory from @lsp-cd
+    - Confirm backward directives continue using `PathContext::new()` (no working directory)
+    - Add comments clarifying the distinction
+    - _Requirements: 3.1, 3.2, 3.4_
+
+  - [ ] 3.2 Handle non-existent files in forward directive processing
+    - Skip edge creation when resolved path doesn't exist
+    - Store unresolved paths for diagnostic emission
+    - _Requirements: 3.3_
+
+  - [ ] 3.3 Write property test for forward directive working directory usage
+    - **Property 6: Forward Directive Uses Working Directory**
+    - Generate files with @lsp-cd and @lsp-source, verify path resolution uses working directory
+    - **Validates: Requirements 3.4**
+
+- [ ] 4. Implement dependency graph conflict resolution
+  - [ ] 4.1 Update `update_file()` in `dependency.rs` for directive-vs-AST conflict resolution
+    - When directive and source() point to same file at same line: keep directive edge only
+    - When directive and source() point to same file at different lines: keep both edges
+    - Track which edges are from directives vs AST for conflict detection
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
+
+  - [ ] 4.2 Write property test for directive edge creation
+    - **Property 7: Directive Edge Creation**
+    - Generate forward directives to existing files, verify edge has `is_directive=true`, `is_backward_directive=false`
+    - **Validates: Requirements 4.1, 4.2**
+
+  - [ ] 4.3 Write property test for same call-site conflict resolution
+    - **Property 8: Same Call-Site Conflict Resolution**
+    - Generate files with directive and source() at same line, verify single directive edge
+    - **Validates: Requirements 4.3**
+
+  - [ ] 4.4 Write property test for different call-site preservation
+    - **Property 9: Different Call-Site Preservation**
+    - Generate files with directive at line A and source() at line B (A≠B), verify both edges exist
+    - **Validates: Requirements 4.4**
+
+- [ ] 5. Checkpoint - Verify dependency graph integration
+  - Ensure all dependency graph tests pass, ask the user if questions arise.
+
+- [ ] 6. Verify scope resolution integration
+  - [ ] 6.1 Verify existing scope resolution handles forward directive edges
+    - Confirm symbols from sourced files are available after directive line
+    - Confirm `line=N` parameter affects scope availability position
+    - Add integration test for scope resolution with @lsp-source
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [ ] 6.2 Write property test for scope availability after directive
+    - **Property 10: Scope Availability After Directive**
+    - Generate files with @lsp-source at line L, verify symbols available after L
+    - **Validates: Requirements 5.1, 5.2**
+
+- [ ] 7. Implement diagnostics for forward directives
+  - [ ] 7.1 Add missing file diagnostic in `handlers.rs`
+    - Emit warning when @lsp-source references non-existent file
+    - Use configurable severity from `crossFile.missingFileSeverity`
+    - Position diagnostic at directive line
+    - _Requirements: 6.1, 6.3_
+
+  - [ ] 7.2 Add optional redundant directive diagnostic
+    - Emit hint when directive without line= targets same file as earlier source() call
+    - Use configurable severity from `crossFile.redundantDirectiveSeverity`
+    - _Requirements: 6.2_
+
+  - [ ] 7.3 Write property test for missing file diagnostic
+    - **Property 11: Missing File Diagnostic**
+    - Generate forward directives to non-existent files, verify diagnostic emitted at directive line
+    - **Validates: Requirements 6.1**
+
+- [ ] 8. Verify revalidation on directive changes
+  - [ ] 8.1 Verify existing revalidation handles forward directive changes
+    - Confirm adding @lsp-source triggers dependency graph update
+    - Confirm removing @lsp-source removes edge and revalidates
+    - Confirm modifying @lsp-source path updates graph
+    - _Requirements: 7.1, 7.2, 7.3_
+
+  - [ ] 8.2 Write property test for revalidation on directive change
+    - **Property 12: Revalidation on Directive Change**
+    - Generate directive add/remove/modify operations, verify graph reflects changes
+    - **Validates: Requirements 7.1, 7.2, 7.3**
+
+- [ ] 9. Checkpoint - Verify diagnostics and revalidation
+  - Ensure all diagnostic and revalidation tests pass, ask the user if questions arise.
+
+- [ ] 10. Update documentation
+  - [ ] 10.1 Update AGENTS.md with forward directive path resolution behavior
+    - Clarify forward directives (@lsp-source, @lsp-run, @lsp-include) use @lsp-cd
+    - Distinguish from backward directives which ignore @lsp-cd
+    - Explain rationale: forward directives describe runtime execution like source()
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [ ] 10.2 Update docs/cross-file.md with @lsp-source documentation
+    - Expand Forward Directives section with @lsp-source and synonyms
+    - Document full syntax with examples (quotes, colon, line= parameter)
+    - Correct note about @lsp-cd to clarify forward directives DO use it
+    - Document line=N parameter for explicit call-site specification
+    - _Requirements: 8.4, 8.5, 8.6_
+
+- [ ] 11. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- All tasks including property tests are required for comprehensive coverage
+- Property tests use proptest and run minimum 100 iterations each
+- Key files: `directive.rs`, `dependency.rs`, `path_resolve.rs`, `handlers.rs`, `scope.rs`
+- The existing @lsp-source parsing works; this adds synonyms, line= parameter, and explicit @lsp-cd documentation

--- a/crates/raven/proptest-regressions/cross_file/property_tests.txt
+++ b/crates/raven/proptest-regressions/cross_file/property_tests.txt
@@ -9,3 +9,4 @@ cc 299729e4c56f393e7ba74e75b7639292cbce32f1c1ff4a47ff6412c5cf4ec4ef # shrinks to
 cc 3ee8dab8418b546fb721d52e050e644834a03e5a1210d737ec97852cd07c16e4 # shrinks to package = "a", func_name = "q", export_name = "q"
 cc b9745a39e47060a2d57c216b49cbb44a772bb37e70f046b405885b3fb1573fe3 # shrinks to package = "a", func = "library", export_name = "x0", lines_before = 1, lines_after = 1
 cc ffd6f09a52f117b182862921598ada0778f9f549321de96d5ca096bc7a12dcc6 # shrinks to base_start_line = 329, base_start_col = 43, base_end_line = 512, base_end_col = 50, nest_offset_start_line = 86, nest_offset_start_col = 3, nest_offset_end_line = 96, nest_offset_end_col = 5
+cc d16550737af68fba261f0c57d7a8281798c96fd43cab9efb4d43e3dd8ac311d4 # shrinks to package = "a", func = "library", exported_name = "a", non_exported_name = "x0", lines_before = 1, lines_after = 1

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -63,6 +63,10 @@ pub struct CrossFileConfig {
     pub packages_r_path: Option<PathBuf>,
     /// Severity for missing package diagnostics
     pub packages_missing_package_severity: DiagnosticSeverity,
+    /// Severity for redundant directive diagnostics (when @lsp-source without line= targets
+    /// same file as earlier source() call)
+    /// _Requirements: 6.2_
+    pub redundant_directive_severity: Option<DiagnosticSeverity>,
 }
 
 impl Default for CrossFileConfig {
@@ -106,6 +110,7 @@ impl Default for CrossFileConfig {
             packages_additional_library_paths: Vec::new(),
             packages_r_path: None,
             packages_missing_package_severity: DiagnosticSeverity::WARNING,
+            redundant_directive_severity: Some(DiagnosticSeverity::HINT),
         }
     }
 }
@@ -146,6 +151,11 @@ mod tests {
         assert_eq!(
             config.packages_missing_package_severity,
             DiagnosticSeverity::WARNING
+        );
+        // Redundant directive severity defaults
+        assert_eq!(
+            config.redundant_directive_severity,
+            Some(DiagnosticSeverity::HINT)
         );
     }
 

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1328,7 +1328,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         }
@@ -1416,7 +1416,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -1426,7 +1426,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1560,7 +1560,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -1570,7 +1570,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1610,7 +1610,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -1643,7 +1643,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -1653,7 +1653,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1688,7 +1688,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "helpers.R".to_string(),
@@ -1698,7 +1698,7 @@ mod tests {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1735,7 +1735,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -1782,7 +1782,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -1823,7 +1823,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -1944,7 +1944,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 super::super::types::ForwardSource {
                     path: "helpers.R".to_string(),
@@ -1954,7 +1954,7 @@ z <- 3
                     local: true,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -2848,7 +2848,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -2858,7 +2858,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -2898,7 +2898,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -2908,7 +2908,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -2951,7 +2951,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -2961,7 +2961,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -3001,7 +3001,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -3011,7 +3011,7 @@ z <- 3
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -3050,7 +3050,7 @@ z <- 3
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -3107,7 +3107,7 @@ z <- 3
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -5,7 +5,7 @@
 //
 
 use std::collections::{HashMap, HashSet};
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
+use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use super::parent_resolve::{infer_call_site_from_parent, resolve_match_pattern};
 use super::path_resolve::{path_to_uri, resolve_path, resolve_path_with_workspace_fallback, PathContext};
@@ -551,11 +551,55 @@ impl DependencyEdge {
     }
 }
 
+/// Information about an unresolved forward directive path
+#[derive(Debug, Clone)]
+pub struct UnresolvedForwardPath {
+    /// The original path string from the directive
+    pub path: String,
+    /// 0-based line where the directive appears
+    pub line: u32,
+    /// 0-based column where the directive appears
+    pub column: u32,
+    /// Reason the path couldn't be resolved
+    pub reason: UnresolvedReason,
+}
+
+/// Reason why a forward directive path couldn't be resolved
+#[derive(Debug, Clone)]
+pub enum UnresolvedReason {
+    /// Path resolution failed (e.g., invalid path syntax)
+    ResolutionFailed,
+    /// Path resolved but file doesn't exist
+    FileNotFound,
+}
+
+/// Information about a redundant forward directive
+/// (when @lsp-source without line= targets same file as earlier source() call)
+/// _Requirements: 6.2_
+#[derive(Debug, Clone)]
+pub struct RedundantDirective {
+    /// 0-based line where the directive appears
+    pub directive_line: u32,
+    /// The target file name (for display in diagnostic message)
+    pub target_filename: String,
+    /// 0-based line where the earlier source() call exists
+    pub source_call_line: u32,
+}
+
 /// Result of updating a file in the dependency graph
 #[derive(Debug, Default)]
 pub struct UpdateResult {
     /// Diagnostics to emit (e.g., directive-vs-AST conflict warnings)
     pub diagnostics: Vec<Diagnostic>,
+    /// Forward directive paths that couldn't be resolved or don't exist.
+    /// These are stored for diagnostic emission in handlers.rs.
+    /// _Requirements: 3.3_
+    pub unresolved_forward_paths: Vec<UnresolvedForwardPath>,
+    /// Redundant forward directives (when @lsp-source without line= targets
+    /// same file as earlier source() call).
+    /// These are stored for diagnostic emission with configurable severity.
+    /// _Requirements: 6.2_
+    pub redundant_directives: Vec<RedundantDirective>,
 }
 
 /// Dependency graph tracking source relationships between files
@@ -599,7 +643,14 @@ impl DependencyGraph {
     {
         let mut result = UpdateResult::default();
 
-        // Build PathContext for this file (includes working_directory from metadata)
+        // Build PathContext for forward sources (includes working_directory from @lsp-cd)
+        // IMPORTANT: Forward directives (@lsp-source, @lsp-run, @lsp-include) and AST-detected
+        // source() calls should use the working directory from @lsp-cd for path resolution.
+        // This is because forward directives are semantically equivalent to source() calls
+        // and describe runtime execution behavior where the working directory matters.
+        // Using PathContext::from_metadata() includes both explicit @lsp-cd and inherited
+        // working directories in the path resolution context.
+        // (Requirements 3.1, 3.2, 3.4)
         let path_ctx = match PathContext::from_metadata(uri, meta, workspace_root) {
             Some(ctx) => ctx,
             None => return result,
@@ -618,8 +669,22 @@ impl DependencyGraph {
             None => return result,
         };
 
-        // Helper to resolve paths using PathContext (for forward sources)
-        // Uses workspace-root fallback for source() statements in files without @lsp-cd
+        // Helper to resolve paths for forward sources (@lsp-source directives and source() calls)
+        // Uses PathContext with working_directory from @lsp-cd, enabling paths to resolve
+        // relative to the configured working directory rather than the file's directory.
+        // Also uses workspace-root fallback for source() statements in files without @lsp-cd.
+        // Returns (Option<Url>, bool) where the bool indicates if the file exists.
+        let do_resolve_with_existence = |path: &str| -> (Option<Url>, bool) {
+            let resolved = match resolve_path_with_workspace_fallback(path, &path_ctx) {
+                Some(p) => p,
+                None => return (None, false),
+            };
+            let exists = resolved.exists();
+            let uri = path_to_uri(&resolved);
+            (uri, exists)
+        };
+
+        // Simple resolve helper for cases where we don't need existence check
         let do_resolve = |path: &str| -> Option<Url> {
             let resolved = resolve_path_with_workspace_fallback(path, &path_ctx)?;
             path_to_uri(&resolved)
@@ -645,23 +710,61 @@ impl DependencyGraph {
         let mut directive_edges: Vec<DependencyEdge> = Vec::new();
         let mut directive_from_to: HashSet<FromToPair> = HashSet::new();
 
-        // Process forward directive sources (@lsp-source)
+        // Process forward directive sources (@lsp-source, @lsp-run, @lsp-include)
+        // Uses do_resolve which includes @lsp-cd working directory in path resolution.
+        // This differs from backward directives which ignore @lsp-cd.
+        // Skip edge creation when resolved path doesn't exist (Requirement 3.3).
+        // (Requirements 3.1, 3.2, 3.3, 3.4)
         for source in &meta.sources {
             if source.is_directive {
-                if let Some(to_uri) = do_resolve(&source.path) {
-                    let edge = DependencyEdge {
-                        from: uri.clone(),
-                        to: to_uri.clone(),
-                        call_site_line: Some(source.line),
-                        call_site_column: Some(source.column),
-                        local: source.local,
-                        chdir: source.chdir,
-                        is_sys_source: source.is_sys_source,
-                        is_directive: true,
-                        is_backward_directive: false,
-                    };
-                    directive_from_to.insert(edge.as_from_to_pair());
-                    directive_edges.push(edge);
+                let (resolved_uri, exists) = do_resolve_with_existence(&source.path);
+                
+                match resolved_uri {
+                    Some(to_uri) if exists => {
+                        // File exists, create edge
+                        let edge = DependencyEdge {
+                            from: uri.clone(),
+                            to: to_uri.clone(),
+                            call_site_line: Some(source.line),
+                            call_site_column: Some(source.column),
+                            local: source.local,
+                            chdir: source.chdir,
+                            is_sys_source: source.is_sys_source,
+                            is_directive: true,
+                            is_backward_directive: false,
+                        };
+                        directive_from_to.insert(edge.as_from_to_pair());
+                        directive_edges.push(edge);
+                    }
+                    Some(_to_uri) => {
+                        // Path resolved but file doesn't exist - store for diagnostic emission
+                        // (Requirement 3.3)
+                        log::trace!(
+                            "Forward directive @lsp-source '{}' at line {} resolved but file does not exist, skipping edge creation",
+                            source.path,
+                            source.line
+                        );
+                        result.unresolved_forward_paths.push(UnresolvedForwardPath {
+                            path: source.path.clone(),
+                            line: source.line,
+                            column: source.column,
+                            reason: UnresolvedReason::FileNotFound,
+                        });
+                    }
+                    None => {
+                        // Path resolution failed - store for diagnostic emission
+                        log::trace!(
+                            "Forward directive @lsp-source '{}' at line {} could not be resolved, skipping edge creation",
+                            source.path,
+                            source.line
+                        );
+                        result.unresolved_forward_paths.push(UnresolvedForwardPath {
+                            path: source.path.clone(),
+                            line: source.line,
+                            column: source.column,
+                            reason: UnresolvedReason::ResolutionFailed,
+                        });
+                    }
                 }
             }
         }
@@ -728,6 +831,7 @@ impl DependencyGraph {
         }
 
         // Process AST-detected sources, applying directive-vs-AST conflict resolution
+        // Requirements 4.1, 4.2, 4.3, 4.4, 4.5
         let mut ast_edges: Vec<DependencyEdge> = Vec::new();
         for source in &meta.sources {
             if !source.is_directive {
@@ -745,7 +849,7 @@ impl DependencyGraph {
                     };
                     let pair = edge.as_from_to_pair();
 
-                    // Check for directive-vs-AST conflict (Requirement 6.8)
+                    // Check for directive-vs-AST conflict
                     if directive_from_to.contains(&pair) {
                         // Find the directive edge for this (from, to) pair
                         let directive_edge =
@@ -758,53 +862,65 @@ impl DependencyGraph {
 
                             if directive_has_call_site {
                                 // Directive has known call site: only override AST edge at same call site
+                                // (Requirement 4.3)
                                 let call_sites_match = dir_edge.call_site_line
                                     == edge.call_site_line
                                     && dir_edge.call_site_column == edge.call_site_column;
 
                                 if call_sites_match {
-                                    // Same call site: directive wins, skip AST edge
+                                    // Case 1: Same call site - directive wins, skip AST edge
+                                    // (Requirement 4.3)
                                     continue;
                                 } else {
-                                    // Different call site: keep AST edge (no conflict)
+                                    // Case 2: Different call sites - keep both edges
+                                    // (Requirement 4.4)
                                     ast_edges.push(edge);
                                     continue;
                                 }
                             } else {
-                                // Directive has no call site: suppress all AST edges to this target
-                                // Emit warning about suppression
-                                let diag_line = meta
-                                    .sourced_by
+                                // Directive has no explicit call site
+                                // (Requirement 4.5)
+                                
+                                // Get the directive's line (where it appears in the file)
+                                let directive_line = meta
+                                    .sources
                                     .iter()
-                                    .find(|d| {
-                                        do_resolve_backward(&d.path) == Some(dir_edge.from.clone())
+                                    .find(|s| {
+                                        s.is_directive
+                                            && do_resolve(&s.path) == Some(to_uri.clone())
                                     })
-                                    .map(|d| d.directive_line)
-                                    .or_else(|| {
-                                        meta.sources
-                                            .iter()
-                                            .find(|s| {
-                                                s.is_directive
-                                                    && do_resolve(&s.path) == Some(to_uri.clone())
-                                            })
-                                            .map(|s| s.line)
-                                    })
-                                    .unwrap_or(0);
-
-                                result.diagnostics.push(Diagnostic {
-                                    range: Range {
-                                        start: Position { line: diag_line, character: 0 },
-                                        end: Position { line: diag_line, character: u32::MAX },
-                                    },
-                                    severity: Some(DiagnosticSeverity::WARNING),
-                                    message: format!(
-                                        "Directive without call site suppresses AST-detected source() call to '{}' at line {}. Consider adding line= or match= to the directive.",
-                                        to_uri.path_segments().and_then(|mut s| s.next_back()).unwrap_or(""),
-                                        source.line + 1
-                                    ),
-                                    ..Default::default()
-                                });
-                                continue;
+                                    .map(|s| s.line);
+                                
+                                // Check if AST edge is at an earlier line than the directive
+                                let ast_is_earlier = match directive_line {
+                                    Some(dir_line) => source.line < dir_line,
+                                    None => false, // If we can't determine directive line, don't treat AST as earlier
+                                };
+                                
+                                if ast_is_earlier {
+                                    // Case 3: Directive without line=, AST at earlier line
+                                    // Keep AST edge (earliest call site wins), store redundancy info
+                                    // for optional diagnostic emission with configurable severity
+                                    // (Requirement 4.5, 6.2)
+                                    let diag_line = directive_line.unwrap_or(0);
+                                    let target_filename = to_uri
+                                        .path_segments()
+                                        .and_then(|mut s| s.next_back())
+                                        .unwrap_or("")
+                                        .to_string();
+                                    result.redundant_directives.push(RedundantDirective {
+                                        directive_line: diag_line,
+                                        target_filename,
+                                        source_call_line: source.line,
+                                    });
+                                    ast_edges.push(edge);
+                                    continue;
+                                } else {
+                                    // AST is at same or later line than directive
+                                    // Directive wins (it's earlier or at same position)
+                                    // Skip AST edge
+                                    continue;
+                                }
                             }
                         }
                         // No matching directive edge found (shouldn't happen), skip
@@ -1011,42 +1127,19 @@ impl DependencyGraph {
         let mut edges_to_remove = Vec::new();
 
         for edge in edges_to_check {
-            // Heuristic: if this is a directive edge, it might have been created by a backward
-            // directive in the child file. We'll keep it for now and let it be removed when
-            // the child file is updated (via remove_backward_edges_for_child).
-            //
-            // However, if it's NOT a directive edge, it was definitely created by a source()
-            // call in THIS file, so we should remove it.
-            //
-            // Actually, this heuristic is not quite right. A directive edge could be from
-            // either a forward directive in this file OR a backward directive in the child.
-            //
-            // Better approach: we'll remove ALL non-directive edges (source() calls), and
-            // we'll also remove directive edges, but they'll be re-created if they're still
-            // in the metadata. Edges from backward directives in other files will be preserved
-            // because they're not in this file's metadata.
-            //
-            // Wait, that doesn't work either because we process the metadata AFTER removing edges.
-            //
-            // The real solution: we need to track which file created each edge. But that's a
-            // bigger change. For now, let's use a simpler approach: don't remove directive edges
-            // at all. Only remove non-directive edges (source() calls).
-            //
-            // This works because:
-            // - Non-directive edges are always from source() calls in THIS file
-            // - Directive edges could be from forward directives in THIS file OR backward
-            //   directives in OTHER files
-            // - If a directive edge is from THIS file, it will be re-created from metadata
-            // - If a directive edge is from ANOTHER file, we want to keep it
-            //
-            // The downside: if we remove a forward directive from THIS file, the edge won't
-            // be removed until we update the child file. But that's acceptable for now.
+            // Use the is_backward_directive flag to distinguish between:
+            // - Forward directive edges (is_directive=true, is_backward_directive=false):
+            //   Created by @lsp-source in THIS file - should be removed
+            // - Backward directive edges (is_directive=true, is_backward_directive=true):
+            //   Created by @lsp-sourced-by in OTHER files - should be kept
+            // - AST edges (is_directive=false):
+            //   Created by source() calls in THIS file - should be removed
 
-            if edge.is_directive {
-                // Keep directive edges - they might be from backward directives in other files
+            if edge.is_directive && edge.is_backward_directive {
+                // Keep backward directive edges - they were created by other files
                 edges_to_keep.push(edge);
             } else {
-                // Remove non-directive edges - they're definitely from source() calls in this file
+                // Remove forward directive edges and AST edges - they're from this file
                 edges_to_remove.push(edge);
             }
         }
@@ -1061,13 +1154,20 @@ impl DependencyGraph {
         // Remove from backward index
         for edge in edges_to_remove {
             log::trace!(
-                "  Removing non-directive edge: {} -> {}",
+                "  Removing edge: {} -> {} (is_directive={}, is_backward_directive={})",
                 edge.from,
-                edge.to
+                edge.to,
+                edge.is_directive,
+                edge.is_backward_directive
             );
             if let Some(backward_edges) = self.backward.get_mut(&edge.to) {
-                backward_edges
-                    .retain(|e| !(e.from == edge.from && e.to == edge.to && !e.is_directive));
+                // Remove edges that match the from/to and are NOT backward directive edges
+                // (i.e., remove AST edges and forward directive edges)
+                backward_edges.retain(|e| {
+                    !(e.from == edge.from
+                        && e.to == edge.to
+                        && !(e.is_directive && e.is_backward_directive))
+                });
                 if backward_edges.is_empty() {
                     self.backward.remove(&edge.to);
                 }
@@ -1187,6 +1287,8 @@ impl DependencyGraph {
 mod tests {
     use super::super::types::BackwardDirective;
     use super::*;
+    use std::fs::File;
+    use tempfile::TempDir;
 
     fn url(s: &str) -> Url {
         Url::parse(&format!("file:///project/{}", s)).unwrap()
@@ -1194,6 +1296,25 @@ mod tests {
 
     fn workspace_root() -> Url {
         Url::parse("file:///project").unwrap()
+    }
+
+    /// Create a temporary workspace with the given files and return (temp_dir, workspace_root_url)
+    fn create_temp_workspace(files: &[&str]) -> (TempDir, Url) {
+        let temp_dir = TempDir::new().unwrap();
+        for file in files {
+            let path = temp_dir.path().join(file);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            File::create(&path).unwrap();
+        }
+        let workspace_url = Url::from_file_path(temp_dir.path()).unwrap();
+        (temp_dir, workspace_url)
+    }
+
+    /// Create a URL for a file in the temp workspace
+    fn temp_url(temp_dir: &TempDir, file: &str) -> Url {
+        Url::from_file_path(temp_dir.path().join(file)).unwrap()
     }
 
     fn make_meta_with_source(path: &str, line: u32) -> CrossFileMetadata {
@@ -1421,8 +1542,11 @@ mod tests {
     fn test_directive_with_call_site_preserves_ast_at_different_site() {
         use super::super::types::ForwardSource;
 
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
         let mut graph = DependencyGraph::new();
-        let main = url("main.R");
 
         // Directive at line 5 with known call site, AST at line 10
         // Per spec: directive with known call site only overrides AST at same call site
@@ -1452,7 +1576,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = graph.update_file(&main, &meta, Some(&workspace_root()), |_| None);
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
 
         // Should have TWO edges (directive at line 5, AST at line 10)
         // because directive has known call site and doesn't suppress AST at different site
@@ -1547,8 +1671,11 @@ mod tests {
     fn test_ast_edges_to_different_targets_preserved() {
         use super::super::types::ForwardSource;
 
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R", "helpers.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
         let mut graph = DependencyGraph::new();
-        let main = url("main.R");
 
         // Directive to utils, AST to helpers (different targets)
         let meta = CrossFileMetadata {
@@ -1577,12 +1704,140 @@ mod tests {
             ..Default::default()
         };
 
-        let result = graph.update_file(&main, &meta, Some(&workspace_root()), |_| None);
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
 
         // Should have both edges (different targets)
         let deps = graph.get_dependencies(&main);
         assert_eq!(deps.len(), 2);
         assert!(result.diagnostics.is_empty());
+    }
+
+    /// Test that forward directives to non-existent files don't create edges
+    /// and are tracked in unresolved_forward_paths.
+    /// _Requirements: 3.3_
+    #[test]
+    fn test_forward_directive_nonexistent_file_skips_edge() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with only main.R (utils.R does NOT exist)
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Forward directive to non-existent file
+        let meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "utils.R".to_string(),
+                line: 5,
+                column: 0,
+                is_directive: true,
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+            }],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should NOT create edge for non-existent file
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 0, "No edge should be created for non-existent file");
+
+        // Should track the unresolved path
+        assert_eq!(
+            result.unresolved_forward_paths.len(),
+            1,
+            "Should track unresolved forward path"
+        );
+        assert_eq!(result.unresolved_forward_paths[0].path, "utils.R");
+        assert_eq!(result.unresolved_forward_paths[0].line, 5);
+        assert!(matches!(
+            result.unresolved_forward_paths[0].reason,
+            UnresolvedReason::FileNotFound
+        ));
+    }
+
+    /// Test that AST-detected source() calls still create edges even for non-existent files
+    /// (only forward directives skip edge creation for non-existent files)
+    #[test]
+    fn test_ast_source_nonexistent_file_creates_edge() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with only main.R (utils.R does NOT exist)
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // AST-detected source() call to non-existent file
+        let meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "utils.R".to_string(),
+                line: 5,
+                column: 0,
+                is_directive: false, // AST-detected, not directive
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+            }],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // AST edges are still created even for non-existent files
+        // (diagnostics are handled separately in handlers.rs)
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 1, "AST edge should be created even for non-existent file");
+
+        // No unresolved paths tracked for AST sources
+        assert!(
+            result.unresolved_forward_paths.is_empty(),
+            "AST sources should not be tracked in unresolved_forward_paths"
+        );
+    }
+
+    /// Test that forward directive with existing file creates edge normally
+    #[test]
+    fn test_forward_directive_existing_file_creates_edge() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with both files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+        let utils = temp_url(&temp_dir, "utils.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Forward directive to existing file
+        let meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "utils.R".to_string(),
+                line: 5,
+                column: 0,
+                is_directive: true,
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+            }],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should create edge for existing file
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 1, "Edge should be created for existing file");
+        assert_eq!(deps[0].to, utils);
+        assert!(deps[0].is_directive);
+
+        // No unresolved paths
+        assert!(result.unresolved_forward_paths.is_empty());
     }
 
     #[test]
@@ -1672,8 +1927,11 @@ z <- 3
 
     #[test]
     fn test_dump_state() {
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R", "helpers.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
         let mut graph = DependencyGraph::new();
-        let main = url("main.R");
 
         // Add edges: main sources utils and helpers
         let meta = CrossFileMetadata {
@@ -1702,16 +1960,16 @@ z <- 3
             ..Default::default()
         };
 
-        graph.update_file(&main, &meta, Some(&workspace_root()), |_| None);
+        graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
 
         // Test dump_state
         let state = graph.dump_state();
 
         // Verify output contains expected information
         assert!(state.contains("2 total edges"));
-        assert!(state.contains("file:///project/main.R"));
-        assert!(state.contains("file:///project/utils.R"));
-        assert!(state.contains("file:///project/helpers.R"));
+        assert!(state.contains("main.R"));
+        assert!(state.contains("utils.R"));
+        assert!(state.contains("helpers.R"));
         assert!(state.contains("line 5, col 10"));
         assert!(state.contains("line 10, col 5"));
         assert!(state.contains("[directive, local]"));
@@ -2562,5 +2820,313 @@ z <- 3
 
         // Should detect cycle and return None
         assert!(result.is_none());
+    }
+
+    // Tests for directive-vs-AST conflict resolution
+    // Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.5
+
+    /// Test Case 1: Same file, same call site - directive wins
+    /// Validates: Requirement 4.3
+    #[test]
+    fn test_directive_vs_ast_same_call_site_directive_wins() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Both directive and AST at same line (5) and column (0)
+        let meta = CrossFileMetadata {
+            sources: vec![
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: true, // Directive
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: false, // AST
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should have ONE edge (directive wins at same call site)
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 1, "Should have exactly one edge when directive and AST at same call site");
+        assert!(deps[0].is_directive, "The edge should be the directive edge");
+
+        // No diagnostics for same call site
+        assert!(result.diagnostics.is_empty(), "No diagnostics for same call site");
+    }
+
+    /// Test Case 2: Same file, different call sites - keep both edges
+    /// Validates: Requirement 4.4
+    #[test]
+    fn test_directive_vs_ast_different_call_sites_keep_both() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Directive at line 5, AST at line 10 (different call sites)
+        let meta = CrossFileMetadata {
+            sources: vec![
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: true, // Directive at line 5
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 10,
+                    column: 0,
+                    is_directive: false, // AST at line 10
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should have TWO edges (different call sites, keep both)
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 2, "Should have both edges when at different call sites");
+
+        // No diagnostics for different call sites with explicit line
+        assert!(result.diagnostics.is_empty(), "No diagnostics for different call sites");
+    }
+
+    /// Test Case 3: Directive without explicit call site, AST at earlier line - keep AST edge
+    /// Validates: Requirement 4.5
+    /// Note: This case only applies to backward directives where call site couldn't be determined.
+    /// Forward directives always have a call site (their own line or explicit line= parameter).
+    #[test]
+    fn test_directive_no_call_site_ast_earlier_keeps_ast() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // AST at line 5, directive at line 10 (AST is earlier)
+        // Since both have explicit call sites (directive at line 10, AST at line 5),
+        // this is Case 2 (different call sites) - both edges are kept
+        let meta = CrossFileMetadata {
+            sources: vec![
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: false, // AST at line 5 (earlier)
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 10,
+                    column: 0,
+                    is_directive: true, // Directive at line 10 (later)
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should have TWO edges: both directive and AST are kept because they have different call sites
+        // (This is Case 2: different call sites, keep both)
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 2, "Should keep both edges when at different call sites");
+
+        // No diagnostics because both have explicit call sites
+        assert!(result.diagnostics.is_empty(), "No diagnostics when both have explicit call sites");
+    }
+
+    /// Test: Directive without explicit call site, AST at later line - directive wins
+    /// This is the case where directive is earlier, so AST should be skipped
+    #[test]
+    fn test_directive_no_call_site_ast_later_directive_wins() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Directive at line 5, AST at line 10 (directive is earlier)
+        let meta = CrossFileMetadata {
+            sources: vec![
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: true, // Directive at line 5 (earlier)
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 10,
+                    column: 0,
+                    is_directive: false, // AST at line 10 (later)
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        // Should have TWO edges because directive has explicit call site (line 5)
+        // The directive at line 5 has a known call site, so it only overrides AST at same site
+        // AST at line 10 is at different site, so it's kept
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 2, "Should have both edges when directive has explicit call site");
+
+        // No diagnostics
+        assert!(result.diagnostics.is_empty());
+    }
+
+    /// Test: Directive edge has is_directive=true and is_backward_directive=false
+    /// Validates: Requirements 4.1, 4.2
+    #[test]
+    fn test_forward_directive_edge_flags() {
+        use super::super::types::ForwardSource;
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        let meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "utils.R".to_string(),
+                line: 5,
+                column: 0,
+                is_directive: true,
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+            }],
+            ..Default::default()
+        };
+
+        graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(deps.len(), 1);
+        assert!(deps[0].is_directive, "Forward directive edge should have is_directive=true");
+        assert!(!deps[0].is_backward_directive, "Forward directive edge should have is_backward_directive=false");
+    }
+
+    /// Test: Backward directive without call site (inference failed), AST at earlier line
+    /// This tests Requirement 4.5 - when backward directive has no call site and AST is earlier,
+    /// keep the AST edge and emit redundancy hint.
+    /// Validates: Requirement 4.5
+    #[test]
+    fn test_backward_directive_no_call_site_ast_earlier() {
+        use super::super::types::{BackwardDirective, ForwardSource};
+
+        // Create temp workspace with actual files
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "sub/child.R"]);
+        let child = temp_url(&temp_dir, "sub/child.R");
+        let main = temp_url(&temp_dir, "main.R");
+
+        let mut graph = DependencyGraph::new();
+
+        // Child has backward directive to main (no call site - inference will fail)
+        // and main has AST source() to child at line 5
+        // The backward directive creates edge main->child with no call site
+        // The AST source in main creates edge main->child at line 5
+        // Since backward directive has no call site and AST is at line 5,
+        // AST should be kept and redundancy hint emitted
+        let child_meta = CrossFileMetadata {
+            sourced_by: vec![BackwardDirective {
+                path: "../main.R".to_string(),
+                call_site: CallSiteSpec::Default, // No explicit call site
+                directive_line: 0,
+            }],
+            ..Default::default()
+        };
+
+        // Update child first - this creates edge from main->child with no call site
+        // (inference will fail because we don't provide parent content)
+        graph.update_file(&child, &child_meta, Some(&workspace_url), |_| None);
+
+        // Now update main with AST source to child
+        let main_meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "sub/child.R".to_string(),
+                line: 5,
+                column: 0,
+                is_directive: false, // AST source
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+            }],
+            ..Default::default()
+        };
+
+        let _result = graph.update_file(&main, &main_meta, Some(&workspace_url), |_| None);
+
+        // Should have edges from main to child
+        let deps = graph.get_dependencies(&main);
+        
+        // The backward directive edge (no call site) and AST edge (line 5) should both exist
+        // because they're processed separately (backward directive in child, AST in main)
+        // The conflict resolution only applies when both are in the same file's metadata
+        assert!(!deps.is_empty(), "Should have at least one edge from main to child");
+
+        // In this case, since the backward directive was processed when updating child,
+        // and the AST was processed when updating main, they don't conflict directly.
+        // The AST edge should be created normally.
+        let ast_edge = deps.iter().find(|e| !e.is_directive);
+        assert!(ast_edge.is_some(), "AST edge should exist");
+        assert_eq!(ast_edge.unwrap().call_site_line, Some(5));
     }
 }

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -108,17 +108,18 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
             // Parse line=N parameter from capture group 4 if present
             // Convert from 1-based user input to 0-based internal (N-1)
             // Use directive's own line when no line= parameter
-            let call_site_line = if let Some(line_match) = caps.get(4) {
+            let (call_site_line, has_explicit_line) = if let Some(line_match) = caps.get(4) {
                 let user_line: u32 = line_match.as_str().parse().unwrap_or(1);
-                user_line.saturating_sub(1)
+                (user_line.saturating_sub(1), true)
             } else {
-                line_num
+                (line_num, false)
             };
             log::trace!(
-                "  Parsed forward directive at line {}: path='{}' call_site_line={}",
+                "  Parsed forward directive at line {}: path='{}' call_site_line={} explicit_line={}",
                 line_num,
                 path,
-                call_site_line
+                call_site_line,
+                has_explicit_line
             );
             meta.sources.push(ForwardSource {
                 path,
@@ -129,6 +130,7 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
                 chdir: false,
                 is_sys_source: false,
                 sys_source_global_env: true,
+                explicit_line: has_explicit_line,
             });
             continue;
         }

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -51,7 +51,7 @@ fn patterns() -> &'static DirectivePatterns {
                 r#"#\s*@?lsp-(?:sourced-by|run-by|included-by)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+))?(?:\s+match\s*=\s*["']([^"']+)["'])?"#
             ).unwrap(),
             forward: Regex::new(
-                r#"#\s*@?lsp-source\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))"#
+                r#"#\s*@?lsp-(?:source|run|include)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+))?"#
             ).unwrap(),
             working_dir: Regex::new(
                 r#"#\s*@?lsp-(?:working-directory|working-dir|current-directory|current-dir|cd|wd)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))"#
@@ -105,15 +105,25 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
         // Check forward directive
         if let Some(caps) = patterns.forward.captures(line) {
             let path = capture_path(&caps, 1).unwrap_or_default();
+            // Parse line=N parameter from capture group 4 if present
+            // Convert from 1-based user input to 0-based internal (N-1)
+            // Use directive's own line when no line= parameter
+            let call_site_line = if let Some(line_match) = caps.get(4) {
+                let user_line: u32 = line_match.as_str().parse().unwrap_or(1);
+                user_line.saturating_sub(1)
+            } else {
+                line_num
+            };
             log::trace!(
-                "  Parsed forward directive at line {}: path='{}'",
+                "  Parsed forward directive at line {}: path='{}' call_site_line={}",
                 line_num,
-                path
+                path,
+                call_site_line
             );
             meta.sources.push(ForwardSource {
                 path,
-                line: line_num,
-                column: 0,
+                line: call_site_line,
+                column: 0, // Always 0 for directive-based sources
                 is_directive: true,
                 local: false,
                 chdir: false,
@@ -361,6 +371,304 @@ x <- undefined"#;
         let meta = parse_directives(content);
         assert_eq!(meta.sources.len(), 1);
         assert_eq!(meta.sources[0].path, "utils folder/helpers.R");
+    }
+
+    // Tests for forward directive synonyms (@lsp-run, @lsp-include)
+    #[test]
+    fn test_forward_directive_lsp_run_synonym() {
+        let content = "# @lsp-run utils.R";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "utils.R");
+        assert!(meta.sources[0].is_directive);
+    }
+
+    #[test]
+    fn test_forward_directive_lsp_include_synonym() {
+        let content = "# @lsp-include utils.R";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "utils.R");
+        assert!(meta.sources[0].is_directive);
+    }
+
+    #[test]
+    fn test_forward_directive_synonyms_all() {
+        // Test all three synonyms produce identical results
+        for directive in ["@lsp-source", "@lsp-run", "@lsp-include"] {
+            let content = format!("# {} utils.R", directive);
+            let meta = parse_directives(&content);
+            assert_eq!(
+                meta.sources.len(),
+                1,
+                "Failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].path,
+                "utils.R",
+                "Failed for {}",
+                directive
+            );
+            assert!(
+                meta.sources[0].is_directive,
+                "Failed for {}",
+                directive
+            );
+        }
+    }
+
+    #[test]
+    fn test_forward_directive_synonyms_no_at_prefix() {
+        for directive in ["lsp-source", "lsp-run", "lsp-include"] {
+            let content = format!("# {} utils.R", directive);
+            let meta = parse_directives(&content);
+            assert_eq!(
+                meta.sources.len(),
+                1,
+                "Failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].path,
+                "utils.R",
+                "Failed for {}",
+                directive
+            );
+        }
+    }
+
+    #[test]
+    fn test_forward_directive_synonyms_with_colon() {
+        for directive in ["@lsp-source:", "@lsp-run:", "@lsp-include:"] {
+            let content = format!("# {} utils.R", directive);
+            let meta = parse_directives(&content);
+            assert_eq!(
+                meta.sources.len(),
+                1,
+                "Failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].path,
+                "utils.R",
+                "Failed for {}",
+                directive
+            );
+        }
+    }
+
+    #[test]
+    fn test_forward_directive_synonyms_with_quotes() {
+        for directive in ["@lsp-source", "@lsp-run", "@lsp-include"] {
+            let content = format!(r#"# {} "path/to/file.R""#, directive);
+            let meta = parse_directives(&content);
+            assert_eq!(
+                meta.sources.len(),
+                1,
+                "Failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].path,
+                "path/to/file.R",
+                "Failed for {}",
+                directive
+            );
+        }
+    }
+
+    // Tests for forward directive line=N parameter (regex capture verification)
+    #[test]
+    fn test_forward_directive_line_param_regex_capture() {
+        // Verify the regex correctly captures the line=N parameter
+        // The actual parsing of line= is done in task 1.2, but we verify the regex here
+        let patterns = patterns();
+        
+        // Test with line= parameter
+        let line = "# @lsp-source utils.R line=15";
+        let caps = patterns.forward.captures(line).expect("Should match");
+        
+        // Path should be in group 3 (unquoted)
+        assert_eq!(caps.get(3).map(|m| m.as_str()), Some("utils.R"));
+        // Line should be in group 4
+        assert_eq!(caps.get(4).map(|m| m.as_str()), Some("15"));
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_regex_capture_all_synonyms() {
+        let patterns = patterns();
+        
+        for directive in ["@lsp-source", "@lsp-run", "@lsp-include"] {
+            let line = format!("# {} utils.R line=42", directive);
+            let caps = patterns.forward.captures(&line).expect(&format!("Should match for {}", directive));
+            
+            // Path should be in group 3 (unquoted)
+            assert_eq!(caps.get(3).map(|m| m.as_str()), Some("utils.R"), "Path failed for {}", directive);
+            // Line should be in group 4
+            assert_eq!(caps.get(4).map(|m| m.as_str()), Some("42"), "Line failed for {}", directive);
+        }
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_regex_capture_with_quotes() {
+        let patterns = patterns();
+        
+        // Test with double-quoted path and line=
+        let line = r#"# @lsp-source "path/to/file.R" line=10"#;
+        let caps = patterns.forward.captures(line).expect("Should match");
+        
+        // Path should be in group 1 (double-quoted)
+        assert_eq!(caps.get(1).map(|m| m.as_str()), Some("path/to/file.R"));
+        // Line should be in group 4
+        assert_eq!(caps.get(4).map(|m| m.as_str()), Some("10"));
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_regex_capture_with_colon() {
+        let patterns = patterns();
+        
+        // Test with colon and line=
+        let line = "# @lsp-source: utils.R line=5";
+        let caps = patterns.forward.captures(line).expect("Should match");
+        
+        // Path should be in group 3 (unquoted)
+        assert_eq!(caps.get(3).map(|m| m.as_str()), Some("utils.R"));
+        // Line should be in group 4
+        assert_eq!(caps.get(4).map(|m| m.as_str()), Some("5"));
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_regex_capture_without_line() {
+        let patterns = patterns();
+        
+        // Test without line= parameter (should still match, group 4 should be None)
+        let line = "# @lsp-source utils.R";
+        let caps = patterns.forward.captures(line).expect("Should match");
+        
+        // Path should be in group 3 (unquoted)
+        assert_eq!(caps.get(3).map(|m| m.as_str()), Some("utils.R"));
+        // Line should be None (not present)
+        assert_eq!(caps.get(4), None);
+    }
+
+    // Tests for forward directive line=N parameter parsing (Requirements 2.1, 2.2, 2.3, 2.4)
+    #[test]
+    fn test_forward_directive_line_param_parsing_basic() {
+        // Requirement 2.1: Convert from 1-based user input to 0-based internal (N-1)
+        let content = "# @lsp-source utils.R line=15";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "utils.R");
+        assert_eq!(meta.sources[0].line, 14); // 15 - 1 = 14 (0-based)
+        assert_eq!(meta.sources[0].column, 0); // Requirement 2.4: column=0 for directives
+        assert!(meta.sources[0].is_directive);
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_parsing_line_1() {
+        // Edge case: line=1 should become 0
+        let content = "# @lsp-source utils.R line=1";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].line, 0); // 1 - 1 = 0
+    }
+
+    #[test]
+    fn test_forward_directive_without_line_param_uses_directive_line() {
+        // Requirement 2.2: Use directive's own line when no line= parameter
+        let content = "x <- 1\ny <- 2\n# @lsp-source utils.R\nz <- 3";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "utils.R");
+        assert_eq!(meta.sources[0].line, 2); // Directive is on line 2 (0-based)
+        assert_eq!(meta.sources[0].column, 0);
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_all_synonyms() {
+        // Verify line= works with all synonyms
+        for directive in ["@lsp-source", "@lsp-run", "@lsp-include"] {
+            let content = format!("# {} utils.R line=10", directive);
+            let meta = parse_directives(&content);
+            assert_eq!(
+                meta.sources.len(),
+                1,
+                "Failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].line,
+                9, // 10 - 1 = 9 (0-based)
+                "Line conversion failed for {}",
+                directive
+            );
+            assert_eq!(
+                meta.sources[0].column,
+                0,
+                "Column should be 0 for {}",
+                directive
+            );
+        }
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_with_quotes() {
+        // Test line= with quoted path
+        let content = r#"# @lsp-source "path/to/file.R" line=20"#;
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "path/to/file.R");
+        assert_eq!(meta.sources[0].line, 19); // 20 - 1 = 19
+        assert_eq!(meta.sources[0].column, 0);
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_with_colon() {
+        // Test line= with colon separator
+        let content = "# @lsp-source: utils.R line=5";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].path, "utils.R");
+        assert_eq!(meta.sources[0].line, 4); // 5 - 1 = 4
+    }
+
+    #[test]
+    fn test_forward_directive_multiple_with_different_lines() {
+        // Requirement 2.3: Multiple directives create separate ForwardSource entries
+        let content = "# @lsp-source a.R line=10\n# @lsp-source b.R line=20\n# @lsp-source c.R";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 3);
+        
+        // First directive: explicit line=10 -> 9
+        assert_eq!(meta.sources[0].path, "a.R");
+        assert_eq!(meta.sources[0].line, 9);
+        
+        // Second directive: explicit line=20 -> 19
+        assert_eq!(meta.sources[1].path, "b.R");
+        assert_eq!(meta.sources[1].line, 19);
+        
+        // Third directive: no line=, uses directive's own line (2)
+        assert_eq!(meta.sources[2].path, "c.R");
+        assert_eq!(meta.sources[2].line, 2);
+    }
+
+    #[test]
+    fn test_forward_directive_line_param_large_value() {
+        // Test with a large line number
+        let content = "# @lsp-source utils.R line=1000";
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].line, 999); // 1000 - 1 = 999
+    }
+
+    #[test]
+    fn test_forward_directive_column_always_zero() {
+        // Requirement 2.4: column=0 for all directive-based sources
+        let content = "    # @lsp-source utils.R line=5"; // Indented directive
+        let meta = parse_directives(content);
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].column, 0); // Column is always 0, not the indentation
     }
 
     #[test]

--- a/crates/raven/src/cross_file/file_cache.rs
+++ b/crates/raven/src/cross_file/file_cache.rs
@@ -63,11 +63,28 @@ struct CachedFile {
 pub struct CrossFileFileCache {
     /// Cached file contents by URI
     inner: RwLock<HashMap<Url, CachedFile>>,
+    /// Cached file existence by path (canonical)
+    existence: RwLock<HashMap<std::path::PathBuf, bool>>,
 }
 
 impl CrossFileFileCache {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            existence: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Check if a path exists (cached, non-blocking read)
+    pub fn path_exists(&self, path: &Path) -> Option<bool> {
+        self.existence.read().ok()?.get(path).copied()
+    }
+
+    /// Update existence cache (called after background check)
+    pub fn cache_existence(&self, path: std::path::PathBuf, exists: bool) {
+        if let Ok(mut guard) = self.existence.write() {
+            guard.insert(path, exists);
+        }
     }
 
     /// Get cached content if snapshot is still fresh

--- a/crates/raven/src/cross_file/file_cache.rs
+++ b/crates/raven/src/cross_file/file_cache.rs
@@ -81,9 +81,9 @@ impl CrossFileFileCache {
     }
 
     /// Update existence cache (called after background check)
-    pub fn cache_existence(&self, path: std::path::PathBuf, exists: bool) {
+    pub fn cache_existence(&self, path: &Path, exists: bool) {
         if let Ok(mut guard) = self.existence.write() {
-            guard.insert(path, exists);
+            guard.insert(path.to_path_buf(), exists);
         }
     }
 

--- a/crates/raven/src/cross_file/parent_resolve.rs
+++ b/crates/raven/src/cross_file/parent_resolve.rs
@@ -755,7 +755,7 @@ y <- 2"#;
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -1191,7 +1191,7 @@ fn make_meta_with_sources(sources: Vec<(&str, u32)>) -> CrossFileMetadata {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             })
             .collect(),
         ..Default::default()
@@ -1398,7 +1398,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: format!("{}.R", child),
@@ -1408,7 +1408,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1442,7 +1442,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: format!("{}.R", child),
@@ -1452,7 +1452,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -1512,7 +1512,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: child_file,
@@ -1522,7 +1522,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -18011,7 +18011,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -18122,7 +18122,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             })
             .collect();
 
@@ -18413,7 +18413,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // AST-detected source() call (is_directive=false)
                 ForwardSource {
@@ -18424,7 +18424,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -18536,7 +18536,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // AST-detected source() at different column
                 ForwardSource {
@@ -18547,7 +18547,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -18641,7 +18641,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // AST-detected source() at EXACT same position
                 ForwardSource {
@@ -18652,7 +18652,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -18752,7 +18752,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // target1: source() at same call site
                 ForwardSource {
@@ -18763,7 +18763,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // target2: only source() (no conflict)
                 ForwardSource {
@@ -18774,7 +18774,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -18876,7 +18876,7 @@ proptest! {
             local: false,
             chdir: false,
             is_sys_source: false,
-            sys_source_global_env: true,
+            sys_source_global_env: true, ..Default::default()
         };
 
         let ast_source = ForwardSource {
@@ -18887,7 +18887,7 @@ proptest! {
             local: false,
             chdir: false,
             is_sys_source: false,
-            sys_source_global_env: true,
+            sys_source_global_env: true, ..Default::default()
         };
 
         // Create metadata with sources in different orders based on directive_first
@@ -19013,7 +19013,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // AST-detected source() call (is_directive=false) at source_line
                 ForwardSource {
@@ -19024,7 +19024,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19151,7 +19151,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: target_filename.clone(),
@@ -19161,7 +19161,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19251,7 +19251,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: target_filename.clone(),
@@ -19261,7 +19261,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19366,7 +19366,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // target1: source()
                 ForwardSource {
@@ -19377,7 +19377,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 // target2: only source()
                 ForwardSource {
@@ -19388,7 +19388,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19499,7 +19499,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: target_filename.clone(),
@@ -19509,7 +19509,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19629,7 +19629,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19801,7 +19801,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -19971,7 +19971,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -20137,7 +20137,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -20286,7 +20286,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20380,7 +20380,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             })
             .collect();
 
@@ -20562,7 +20562,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20656,7 +20656,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20765,7 +20765,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20829,7 +20829,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20909,7 +20909,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -20933,7 +20933,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -21016,7 +21016,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: child_b_file.clone(),
@@ -21026,7 +21026,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -21048,7 +21048,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: child_c_file.clone(),
@@ -21058,7 +21058,7 @@ proptest! {
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -21147,7 +21147,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -21171,7 +21171,7 @@ proptest! {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -11234,6 +11234,15 @@ proptest! {
     ) {
         // Ensure the exported and non-exported names are different
         prop_assume!(exported_name != non_exported_name);
+        
+        // Ensure non_exported_name doesn't conflict with generated variable names
+        for i in 0..lines_before {
+            prop_assume!(non_exported_name != format!("x{}", i));
+        }
+        for i in 0..lines_after {
+            prop_assume!(non_exported_name != format!("y{}", i));
+        }
+        prop_assume!(non_exported_name != "result");
 
         let uri = make_url("test_non_export_diag");
 

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -789,7 +789,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };
@@ -1019,7 +1019,7 @@ mod tests {
                 local: false,
                 chdir: false,
                 is_sys_source: false,
-                sys_source_global_env: true,
+                sys_source_global_env: true, ..Default::default()
             }],
             ..Default::default()
         };

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -865,6 +865,194 @@ pub fn compute_artifacts(uri: &Url, tree: &Tree, content: &str) -> ScopeArtifact
     artifacts
 }
 
+/// Build scope artifacts for a source file, including both AST-detected sources and directive sources.
+///
+/// This is an extended version of `compute_artifacts` that also includes forward directive sources
+/// (`@lsp-source`, `@lsp-run`, `@lsp-include`) from the metadata in the timeline. This ensures that
+/// symbols from files referenced by forward directives are available in scope resolution.
+///
+/// The function:
+/// - collects symbol and function-scope definitions from the AST,
+/// - records detected `source()` calls from the AST as timeline events,
+/// - records forward directive sources from metadata as timeline events (avoiding duplicates),
+/// - records `rm()/remove()` calls as timeline events,
+/// - sorts the timeline by position,
+/// - constructs a FunctionScopeTree from discovered function scopes,
+/// - computes the exported-interface hash.
+///
+/// # Arguments
+///
+/// * `uri` - The URI of the file being analyzed
+/// * `tree` - The parsed tree-sitter AST
+/// * `content` - The file content as a string
+/// * `metadata` - Optional cross-file metadata containing forward directive sources
+///
+/// # Examples
+///
+/// ```ignore
+/// // Given a parser-produced `tree`, file `content`, `uri`, and `metadata`:
+/// let artifacts = compute_artifacts_with_metadata(&uri, &tree, content, Some(&metadata));
+/// // `artifacts.timeline` contains both AST-detected and directive sources.
+/// ```
+pub fn compute_artifacts_with_metadata(
+    uri: &Url,
+    tree: &Tree,
+    content: &str,
+    metadata: Option<&super::types::CrossFileMetadata>,
+) -> ScopeArtifacts {
+    let mut artifacts = ScopeArtifacts::default();
+    let root = tree.root_node();
+
+    // Collect definitions from AST
+    collect_definitions(root, content, uri, &mut artifacts);
+
+    // Collect source() calls from AST and add them to timeline.
+    let ast_source_calls = detect_source_calls(tree, content);
+    
+    // Track which (line, column) positions have AST sources to avoid duplicates
+    let ast_positions: std::collections::HashSet<(u32, u32)> = ast_source_calls
+        .iter()
+        .map(|s| (s.line, s.column))
+        .collect();
+    
+    // Add AST-detected sources to timeline
+    for source in ast_source_calls {
+        artifacts.timeline.push(ScopeEvent::Source {
+            line: source.line,
+            column: source.column,
+            source,
+        });
+    }
+    
+    // Add directive sources from metadata (if provided) that don't overlap with AST sources
+    // This ensures @lsp-source directives are included in scope resolution
+    if let Some(meta) = metadata {
+        for source in &meta.sources {
+            if source.is_directive {
+                // Check if there's already an AST source at the same position
+                // (Directive sources have column=0, so we check by line only for directives)
+                let has_ast_at_same_line = ast_positions.iter().any(|(line, _)| *line == source.line);
+                if !has_ast_at_same_line {
+                    artifacts.timeline.push(ScopeEvent::Source {
+                        line: source.line,
+                        column: source.column,
+                        source: source.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Collect rm()/remove() calls and add them to timeline.
+    let rm_calls = detect_rm_calls(tree, content);
+    for rm_call in rm_calls {
+        artifacts.timeline.push(ScopeEvent::Removal {
+            line: rm_call.line,
+            column: rm_call.column,
+            symbols: rm_call.symbols,
+            function_scope: None,
+        });
+    }
+
+    // Collect library()/require()/loadNamespace() calls for later processing.
+    let library_calls = detect_library_calls(tree, content);
+
+    // Sort timeline by position for correct ordering
+    artifacts.timeline.sort_by_key(|event| match event {
+        ScopeEvent::Def { line, column, .. } => (*line, *column),
+        ScopeEvent::Source { line, column, .. } => (*line, *column),
+        ScopeEvent::FunctionScope {
+            start_line,
+            start_column,
+            ..
+        } => (*start_line, *start_column),
+        ScopeEvent::Removal { line, column, .. } => (*line, *column),
+        ScopeEvent::PackageLoad { line, column, .. } => (*line, *column),
+    });
+
+    // Build interval tree from function scopes for O(log n) queries
+    let function_scope_tuples: Vec<(u32, u32, u32, u32)> = artifacts
+        .timeline
+        .iter()
+        .filter_map(|e| {
+            if let ScopeEvent::FunctionScope {
+                start_line,
+                start_column,
+                end_line,
+                end_column,
+                ..
+            } = e
+            {
+                Some((*start_line, *start_column, *end_line, *end_column))
+            } else {
+                None
+            }
+        })
+        .collect();
+    artifacts.function_scope_tree = FunctionScopeTree::from_scopes(&function_scope_tuples);
+    for event in &mut artifacts.timeline {
+        if let ScopeEvent::Removal {
+            line,
+            column,
+            function_scope,
+            ..
+        } = event
+        {
+            *function_scope =
+                find_containing_function_scope(&artifacts.function_scope_tree, *line, *column);
+        }
+    }
+
+    // Add PackageLoad events for library calls with function_scope determined from the tree.
+    for lib_call in library_calls {
+        let function_scope = find_containing_function_scope(
+            &artifacts.function_scope_tree,
+            lib_call.line,
+            lib_call.column,
+        )
+        .map(FunctionScopeInterval::from_tuple);
+
+        artifacts.timeline.push(ScopeEvent::PackageLoad {
+            line: lib_call.line,
+            column: lib_call.column,
+            package: lib_call.package,
+            function_scope,
+        });
+    }
+
+    // Re-sort timeline to include PackageLoad events in correct position
+    artifacts.timeline.sort_by_key(|event| match event {
+        ScopeEvent::Def { line, column, .. } => (*line, *column),
+        ScopeEvent::Source { line, column, .. } => (*line, *column),
+        ScopeEvent::FunctionScope {
+            start_line,
+            start_column,
+            ..
+        } => (*start_line, *start_column),
+        ScopeEvent::Removal { line, column, .. } => (*line, *column),
+        ScopeEvent::PackageLoad { line, column, .. } => (*line, *column),
+    });
+
+    // Extract package names from PackageLoad events for interface hash computation
+    let loaded_packages: Vec<String> = artifacts
+        .timeline
+        .iter()
+        .filter_map(|event| {
+            if let ScopeEvent::PackageLoad { package, .. } = event {
+                Some(package.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Compute interface hash including both symbols and loaded packages
+    artifacts.interface_hash =
+        compute_interface_hash(&artifacts.exported_interface, &loaded_packages);
+
+    artifacts
+}
+
 /// Compute the lexical scope at the given document position within a single file.
 ///
 /// The returned ScopeAtPosition reflects only local, in-file visibility at (line, column):

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -133,6 +133,7 @@ fn try_parse_source_call(node: Node, content: &str) -> Option<ForwardSource> {
         chdir,
         is_sys_source,
         sys_source_global_env,
+        explicit_line: false, // AST-detected sources never have explicit line=N
     })
 }
 

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -134,6 +134,8 @@ fn try_parse_source_call(node: Node, content: &str) -> Option<ForwardSource> {
         is_sys_source,
         sys_source_global_env,
         explicit_line: false, // AST-detected sources never have explicit line=N
+        directive_line: 0,    // Not applicable for AST-detected sources
+        user_line_zero: false, // Not applicable for AST-detected sources
     })
 }
 

--- a/crates/raven/src/cross_file/types.rs
+++ b/crates/raven/src/cross_file/types.rs
@@ -75,6 +75,17 @@ pub struct ForwardSource {
     /// _Requirements: 6.2_
     #[serde(default)]
     pub explicit_line: bool,
+    /// 0-based line where the directive itself appears in the file.
+    /// Only relevant when is_directive=true.
+    /// Used for diagnostic positioning when line= parameter is invalid.
+    #[serde(default)]
+    pub directive_line: u32,
+    /// true if the user explicitly specified `line=0` (invalid value).
+    /// Line numbers in directives are 1-based, so line=0 is invalid.
+    /// When true, a warning diagnostic should be emitted.
+    /// Only relevant when is_directive=true and explicit_line=true.
+    #[serde(default)]
+    pub user_line_zero: bool,
 }
 
 fn default_sys_source_global_env() -> bool {

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -1318,6 +1318,9 @@ fn collect_missing_package_diagnostics(
 /// target file exists at an earlier line. In this case, the directive provides no additional
 /// information since the source() call already makes the symbols available earlier.
 ///
+/// Directives WITH an explicit `line=N` parameter are never considered redundant because
+/// they explicitly specify a different call-site position for scope resolution purposes.
+///
 /// The diagnostic severity is configurable via `crossFile.redundantDirectiveSeverity`.
 /// Setting it to "off" disables this diagnostic entirely.
 ///
@@ -1351,13 +1354,17 @@ fn collect_redundant_directive_diagnostics(
         None => return,
     };
 
-    // Collect directive sources and AST sources separately
+    // Collect directive sources (without explicit line=) and AST sources separately
+    // Directives WITH explicit_line are never considered redundant (Requirement 6.2)
     let mut directive_sources: Vec<&crate::cross_file::types::ForwardSource> = Vec::new();
     let mut ast_sources: Vec<&crate::cross_file::types::ForwardSource> = Vec::new();
 
     for source in &meta.sources {
         if source.is_directive {
-            directive_sources.push(source);
+            // Only consider directives WITHOUT explicit line= for redundancy checking
+            if !source.explicit_line {
+                directive_sources.push(source);
+            }
         } else {
             ast_sources.push(source);
         }
@@ -2330,7 +2337,7 @@ pub fn completion(state: &WorldState, uri: &Url, position: Position) -> Option<C
                 // from parent files, not just the current file's directives
                 state.get_enriched_metadata(uri).unwrap_or_default()
             }
-            _ => Default::default(),
+            _ => Default::default()
         };
         let workspace_root = state.workspace_folders.first();
 
@@ -3288,7 +3295,7 @@ pub fn goto_definition(
                 // from parent files, not just the current file's directives
                 state.get_enriched_metadata(uri).unwrap_or_default()
             }
-            _ => Default::default(),
+            _ => Default::default()
         };
 
         if let Some(location) = crate::file_path_intellisense::file_path_definition(
@@ -9010,7 +9017,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -9020,7 +9027,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -9074,7 +9081,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -9084,7 +9091,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()
@@ -9132,7 +9139,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
                 ForwardSource {
                     path: "utils.R".to_string(),
@@ -9142,7 +9149,7 @@ result <- helper_with_spaces(42)"#;
                     local: false,
                     chdir: false,
                     is_sys_source: false,
-                    sys_source_global_env: true,
+                    sys_source_global_env: true, ..Default::default()
                 },
             ],
             ..Default::default()


### PR DESCRIPTION
- Extend directive parsing regex to support @lsp-source, @lsp-run, and @lsp-include synonyms
- Add optional line=N parameter to directives for explicit call-site specification
- Implement 1-based to 0-based line number conversion for user-facing parameters
- Verify forward directives use PathContext::from_metadata() for working directory support
- Handle non-existent files in forward directive processing with diagnostic emission
- Implement directive-vs-AST conflict resolution in dependency graph updates
- Add scope resolution integration for forward directive edges
- Implement missing file diagnostics with configurable severity levels
- Add comprehensive property tests for directive parsing, synonym equivalence, and scope availability
- Update documentation and task checklist to reflect completed implementation
- All requirements 1.1-6.3 now complete and tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward directives support synonyms (@lsp-run, @lsp-include) and an optional line=N to control when sourced symbols become available.

* **Improvements**
  * Forward directives now resolve paths using working-directory context and integrate into the dependency graph with clear precedence rules.
  * Configurable severity for redundant-directive diagnostics and diagnostics for unresolved forward paths.
  * Existence caching added to improve path-resolution performance.

* **Tests**
  * Extensive unit, property, and integration tests for parsing, scope timing, conflicts, diagnostics, and revalidation.

* **Documentation**
  * Expanded docs and examples for forward directives, line=N, and working-directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->