### PR TITLE
perf(test): use simulated time for debounce property tests

### DIFF
--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -38,6 +38,7 @@ xdg = "2.5.2"
 criterion = { version = "0.5", features = ["async_tokio"] }
 proptest = "1.4"
 tempfile = "3"
+tokio = { version = "1.26.0", features = ["test-util"] }
 
 [[bench]]
 name = "startup"

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -1368,6 +1368,9 @@ mod tests {
                 .unwrap();
 
             rt.block_on(async {
+                // Pause time so tests run instantly with simulated time
+                tokio::time::pause();
+
                 // Use a short debounce for faster tests
                 let debounce_ms = 50u64;
                 let config = WorkspaceIndexConfig {
@@ -1473,6 +1476,9 @@ mod tests {
                 .unwrap();
 
             rt.block_on(async {
+                // Pause time so tests run instantly with simulated time
+                tokio::time::pause();
+
                 let debounce_ms = 100u64;
                 let config = WorkspaceIndexConfig {
                     debounce_ms,
@@ -1548,6 +1554,9 @@ mod tests {
                 .unwrap();
 
             rt.block_on(async {
+                // Pause time so tests run instantly with simulated time
+                tokio::time::pause();
+
                 let debounce_ms = 50u64;
                 let config = WorkspaceIndexConfig {
                     debounce_ms,


### PR DESCRIPTION
Enable tokio's test-util feature and use tokio::time::pause() in
debounce property tests. This makes tests use simulated time instead
of real sleeps, reducing test duration from ~72s to <1s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution speed and determinism by implementing time control mechanisms for debounced operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->