### PR TITLE
fix(ci): overhaul release workflow and add marketplace publishing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Build
 
 on:
   push:
@@ -7,6 +7,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+
+concurrency:
+  group: release-build-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   build-lsp:
@@ -25,6 +29,10 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             platform: macos-arm64
+            use-zigbuild: false
+          - os: macos-13
+            target: x86_64-apple-darwin
+            platform: macos-x64
             use-zigbuild: false
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
@@ -79,13 +87,14 @@ jobs:
         with:
           name: lsp-${{ matrix.platform }}
           path: raven-${{ matrix.platform }}.zip
+          retention-days: 30
 
   build-vscode:
     needs: build-lsp
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [darwin-arm64, linux-x64, linux-arm64, win32-x64, win32-arm64]
+        target: [darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64, win32-arm64]
 
     steps:
       - uses: actions/checkout@v4
@@ -110,65 +119,40 @@ jobs:
 
       - name: Update package.json version
         run: |
-          cd vscode-extension
+          cd editors/vscode
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
       - name: Install dependencies
         run: |
-          cd vscode-extension
+          cd editors/vscode
           npm install
 
       - name: Compile extension
         run: |
-          cd vscode-extension
-          npm run compile
+          cd editors/vscode
+          npx esbuild src/extension.ts --bundle --platform=node --outfile=dist/extension.js --external:vscode --minify
 
       - name: Copy LSP binary
         run: |
-          cd vscode-extension
+          cd editors/vscode
           mkdir -p bin
           case "${{ matrix.target }}" in
-            darwin-arm64) cp ../lsp-binaries/lsp-macos-arm64/raven-macos-arm64.zip bin/ && cd bin && unzip raven-macos-arm64.zip && mv raven raven-server ;;
-            linux-x64) cp ../lsp-binaries/lsp-linux-x64/raven-linux-x64.zip bin/ && cd bin && unzip raven-linux-x64.zip && mv raven raven-server ;;
-            linux-arm64) cp ../lsp-binaries/lsp-linux-arm64/raven-linux-arm64.zip bin/ && cd bin && unzip raven-linux-arm64.zip && mv raven raven-server ;;
-            win32-x64) cp ../lsp-binaries/lsp-windows-x64/raven-windows-x64.zip bin/ && cd bin && unzip raven-windows-x64.zip && mv raven.exe raven-server.exe ;;
-            win32-arm64) cp ../lsp-binaries/lsp-windows-arm64/raven-windows-arm64.zip bin/ && cd bin && unzip raven-windows-arm64.zip && mv raven.exe raven-server.exe ;;
+            darwin-arm64) cp ../../lsp-binaries/lsp-macos-arm64/raven-macos-arm64.zip bin/ && cd bin && unzip raven-macos-arm64.zip && rm -f raven-macos-arm64.zip ;;
+            darwin-x64) cp ../../lsp-binaries/lsp-macos-x64/raven-macos-x64.zip bin/ && cd bin && unzip raven-macos-x64.zip && rm -f raven-macos-x64.zip ;;
+            linux-x64) cp ../../lsp-binaries/lsp-linux-x64/raven-linux-x64.zip bin/ && cd bin && unzip raven-linux-x64.zip && rm -f raven-linux-x64.zip ;;
+            linux-arm64) cp ../../lsp-binaries/lsp-linux-arm64/raven-linux-arm64.zip bin/ && cd bin && unzip raven-linux-arm64.zip && rm -f raven-linux-arm64.zip ;;
+            win32-x64) cp ../../lsp-binaries/lsp-windows-x64/raven-windows-x64.zip bin/ && cd bin && unzip raven-windows-x64.zip && rm -f raven-windows-x64.zip ;;
+            win32-arm64) cp ../../lsp-binaries/lsp-windows-arm64/raven-windows-arm64.zip bin/ && cd bin && unzip raven-windows-arm64.zip && rm -f raven-windows-arm64.zip ;;
           esac
 
       - name: Package extension
         run: |
-          cd vscode-extension
+          cd editors/vscode
           vsce package --target ${{ matrix.target }}
 
       - name: Upload extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: vscode-${{ matrix.target }}
-          path: vscode-extension/*.vsix
-
-  release:
-    needs: [build-lsp, build-vscode]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: Release v${{ steps.version.outputs.version }}
-          files: |
-            artifacts/lsp-*/raven-*.zip
-            artifacts/vscode-*/*.vsix
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: editors/vscode/*.vsix
+          retention-days: 30

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Update package.json version
         run: |
           cd editors/vscode
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,7 +30,7 @@ jobs:
             target: aarch64-apple-darwin
             platform: macos-arm64
             use-zigbuild: false
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             platform: macos-x64
             use-zigbuild: false
@@ -143,6 +143,7 @@ jobs:
             linux-arm64) cp ../../lsp-binaries/lsp-linux-arm64/raven-linux-arm64.zip bin/ && cd bin && unzip raven-linux-arm64.zip && rm -f raven-linux-arm64.zip ;;
             win32-x64) cp ../../lsp-binaries/lsp-windows-x64/raven-windows-x64.zip bin/ && cd bin && unzip raven-windows-x64.zip && rm -f raven-windows-x64.zip ;;
             win32-arm64) cp ../../lsp-binaries/lsp-windows-arm64/raven-windows-arm64.zip bin/ && cd bin && unzip raven-windows-arm64.zip && rm -f raven-windows-arm64.zip ;;
+            *) echo "ERROR: Unknown target '${{ matrix.target }}'" && exit 1 ;;
           esac
 
       - name: Package extension

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,143 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.1.0)'
+        required: true
+        type: string
+      publish_vscode:
+        description: 'Publish to VS Code Marketplace and Open VSX'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        run: |
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "ERROR: Tag must match format v*.*.* (e.g., v0.1.0)"
+            exit 1
+          fi
+
+      - name: Validate tag exists
+        run: |
+          if ! git rev-parse -q --verify "refs/tags/${{ inputs.tag }}" >/dev/null; then
+            echo "ERROR: Tag '${{ inputs.tag }}' does not exist. Push the tag first."
+            exit 1
+          fi
+
+      - name: Extract version
+        id: version
+        run: echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+        env:
+          TAG: ${{ inputs.tag }}
+
+  download-artifacts:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts from build workflow
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: release-build.yml
+          branch: ${{ inputs.tag }}
+          event: push
+          path: artifacts
+
+      - name: List artifacts
+        run: find artifacts -type f | sort
+
+      - name: Re-upload LSP artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-lsp-artifacts
+          path: artifacts/lsp-*/*
+          retention-days: 5
+
+      - name: Re-upload VSIX artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-vscode-artifacts
+          path: artifacts/vscode-*/*
+          retention-days: 5
+
+  github-release:
+    needs: [validate, download-artifacts]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download LSP artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-lsp-artifacts
+          path: lsp-artifacts
+
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-vscode-artifacts
+          path: vscode-artifacts
+
+      - name: List release files
+        run: |
+          echo "=== LSP binaries ==="
+          find lsp-artifacts -type f | sort
+          echo "=== VSIX packages ==="
+          find vscode-artifacts -type f | sort
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: Release ${{ inputs.tag }}
+          files: |
+            lsp-artifacts/*
+            vscode-artifacts/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-marketplace:
+    needs: [validate, download-artifacts]
+    if: inputs.publish_vscode
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-vscode-artifacts
+          path: vscode-artifacts
+
+      - name: Install vsce and ovsx
+        run: npm install -g @vscode/vsce ovsx
+
+      - name: Publish to VS Code Marketplace
+        run: |
+          for vsix in vscode-artifacts/*.vsix; do
+            echo "Publishing $vsix to VS Code Marketplace..."
+            vsce publish --packagePath "$vsix"
+          done
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX
+        continue-on-error: true
+        run: |
+          for vsix in vscode-artifacts/*.vsix; do
+            echo "Publishing $vsix to Open VSX..."
+            ovsx publish "$vsix"
+          done
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,11 +40,11 @@ jobs:
 
       - name: Get tag commit SHA
         id: tag_sha
-        run: echo "sha=$(git rev-parse refs/tags/${{ inputs.tag }})" >> $GITHUB_OUTPUT
+        run: echo "sha=$(git rev-parse refs/tags/${{ inputs.tag }})" >> "$GITHUB_OUTPUT"
 
       - name: Extract version
         id: version
-        run: echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
         env:
           TAG: ${{ inputs.tag }}
 
@@ -135,8 +135,8 @@ jobs:
           tag_name: ${{ inputs.tag }}
           name: Release ${{ inputs.tag }}
           files: |
-            lsp-artifacts/*
-            vscode-artifacts/*
+            lsp-artifacts/**/*.zip
+            vscode-artifacts/**/*.vsix
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,7 +157,8 @@ jobs:
 
       - name: Publish to VS Code Marketplace
         run: |
-          for vsix in vscode-artifacts/*.vsix; do
+          shopt -s globstar
+          for vsix in vscode-artifacts/**/*.vsix; do
             echo "Publishing $vsix to VS Code Marketplace..."
             vsce publish --packagePath "$vsix"
           done
@@ -167,7 +168,8 @@ jobs:
       - name: Publish to Open VSX
         continue-on-error: true
         run: |
-          for vsix in vscode-artifacts/*.vsix; do
+          shopt -s globstar
+          for vsix in vscode-artifacts/**/*.vsix; do
             echo "Publishing $vsix to Open VSX..."
             ovsx publish "$vsix"
           done

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      tag_sha: ${{ steps.tag_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,10 @@ jobs:
             exit 1
           fi
 
+      - name: Get tag commit SHA
+        id: tag_sha
+        run: echo "sha=$(git rev-parse refs/tags/${{ inputs.tag }})" >> $GITHUB_OUTPUT
+
       - name: Extract version
         id: version
         run: echo "version=${TAG#v}" >> $GITHUB_OUTPUT
@@ -47,12 +52,39 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check build workflow status
+        run: |
+          COMMIT_SHA="${{ needs.validate.outputs.tag_sha }}"
+          echo "Checking workflow status for commit: $COMMIT_SHA"
+
+          RUN_INFO=$(gh run list --workflow=release-build.yml --commit="$COMMIT_SHA" --limit=1 --json status,conclusion --jq '.[0]')
+          if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
+            echo "ERROR: No release-build.yml workflow run found for commit $COMMIT_SHA"
+            exit 1
+          fi
+
+          STATUS=$(echo "$RUN_INFO" | jq -r '.status')
+          CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
+
+          if [ "$STATUS" != "completed" ] || [ "$CONCLUSION" != "success" ]; then
+            echo "ERROR: release-build.yml has not completed successfully for tag ${{ inputs.tag }}"
+            echo "Status: $STATUS, Conclusion: $CONCLUSION"
+            exit 1
+          fi
+
+          echo "Build workflow completed successfully"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download artifacts from build workflow
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: release-build.yml
-          branch: ${{ inputs.tag }}
-          event: push
+          commit: ${{ needs.validate.outputs.tag_sha }}
           path: artifacts
 
       - name: List artifacts
@@ -98,7 +130,7 @@ jobs:
           find vscode-artifacts -type f | sort
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag }}
           name: Release ${{ inputs.tag }}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -e
+
+# Release script: bumps version, commits, tags, and pushes.
+#
+# Usage:
+#   ./scripts/release.sh <version>
+#
+# Examples:
+#   ./scripts/release.sh 0.2.0
+#   ./scripts/release.sh 1.0.0-beta.1
+#
+# This script will:
+#   1. Validate the working directory is clean
+#   2. Update version in Cargo.toml and editors/vscode/package.json
+#   3. Commit the version bump
+#   4. Create and push a git tag (triggers release-build.yml)
+#
+# After this completes, go to GitHub Actions and manually run
+# release-publish.yml with the tag to create the GitHub Release
+# (and optionally publish to VS Code Marketplace).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+    echo "Usage: $0 <version>"
+    echo ""
+    echo "  version   Semantic version (e.g., 0.2.0 or 1.0.0-beta.1)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 0.2.0"
+    echo "  $0 1.0.0"
+    exit 1
+}
+
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+    usage
+fi
+
+# Validate version format
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    echo "ERROR: Invalid version format: $VERSION"
+    echo "Expected format: X.Y.Z or X.Y.Z-suffix"
+    exit 1
+fi
+
+TAG="v$VERSION"
+
+# Check for clean working directory
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+    echo "ERROR: Working directory is not clean. Commit or stash changes first."
+    git -C "$REPO_ROOT" status --short
+    exit 1
+fi
+
+# Check tag doesn't already exist
+if git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+    echo "ERROR: Tag $TAG already exists."
+    exit 1
+fi
+
+echo "Bumping version to $VERSION..."
+
+# Update workspace Cargo.toml
+sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" "$REPO_ROOT/Cargo.toml"
+
+# Update VS Code extension package.json
+cd "$REPO_ROOT/editors/vscode"
+npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null
+cd "$REPO_ROOT"
+
+echo "Updated Cargo.toml and editors/vscode/package.json"
+
+# Commit, tag, and push
+git -C "$REPO_ROOT" add Cargo.toml editors/vscode/package.json
+git -C "$REPO_ROOT" commit -m "chore: bump version to $VERSION"
+
+echo "Creating tag $TAG..."
+git -C "$REPO_ROOT" tag "$TAG"
+
+echo "Pushing commit and tag..."
+git -C "$REPO_ROOT" push origin
+git -C "$REPO_ROOT" push origin "$TAG"
+
+echo ""
+echo "Release $TAG initiated!"
+echo ""
+echo "Next steps:"
+echo "  1. Wait for release-build.yml to finish: https://github.com/jbearak/raven/actions"
+echo "  2. Run release-publish.yml manually with tag=$TAG"
+echo "     (check 'Publish to VS Code Marketplace' if ready)"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -75,6 +75,9 @@ echo "Updated Cargo.toml and editors/vscode/package.json"
 
 # Commit, tag, and push
 git -C "$REPO_ROOT" add Cargo.toml editors/vscode/package.json
+if [ -f "$REPO_ROOT/editors/vscode/package-lock.json" ]; then
+  git -C "$REPO_ROOT" add editors/vscode/package-lock.json
+fi
 git -C "$REPO_ROOT" commit -m "chore: bump version to $VERSION"
 
 echo "Creating tag $TAG..."

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,11 +4,11 @@ set -e
 # Release script: bumps version, commits, tags, and pushes.
 #
 # Usage:
-#   ./scripts/release.sh <version>
+#   ./scripts/bump-version.sh <version>
 #
 # Examples:
-#   ./scripts/release.sh 0.2.0
-#   ./scripts/release.sh 1.0.0-beta.1
+#   ./scripts/bump-version.sh 0.2.0
+#   ./scripts/bump-version.sh 1.0.0-beta.1
 #
 # This script will:
 #   1. Validate the working directory is clean


### PR DESCRIPTION
Split single release.yml into two workflows matching Sight's pattern:
- release-build.yml: tag-triggered, builds LSP binaries and per-platform .vsix packages (build-only, no publishing)
- release-publish.yml: manual trigger with tag input and marketplace publish checkbox, creates GitHub Release and optionally publishes to VS Code Marketplace and Open VSX

Fixes in release-build.yml:
- Fix directory paths (vscode-extension -> editors/vscode)
- Fix binary naming (remove raven-server rename that mismatched extension.ts)
- Fix relative paths for artifact copy (../ -> ../../)
- Fix bun dependency in CI (use npx esbuild directly)
- Add macOS x64 (Intel) platform to build matrix
- Clean up zip files from bin/ after extraction
- Add concurrency control and 30-day artifact retention

Add scripts/bump-version.sh for version bumping, tagging, and pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now supports an additional macOS variant and expanded platform coverage.
  * New publish workflow automates release creation, artifact assembly, and optional marketplace publication.
  * Added a version-bump script to validate and streamline release tagging and version updates.
  * Improved artifact handling with longer retention and simplified upload/packaging steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->