### PR TITLE
feat: support multi-level banner-style section headings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,7 +695,7 @@ The document symbol and workspace symbol providers use a two-phase extraction an
 **Key Patterns:**
 
 - Single-line R code sections use regex: `^\s*#(#*)\s*(%%)?\s*(\S.+?)\s*(#{4,}|-{4,}|={4,}|\*{4,}|\+{4,})\s*$`
-- Banner-style sections: delimiter line above and below a comment name line (e.g., `# ====` / `# Name` / `# ====`). Delimiters must use the same character type (`#`, `-`, `=`, `*`, `+`) but don't need to be the same length. Banner sections are always heading level 1.
+- Banner-style sections: delimiter line above and below a comment name line (e.g., `# ====` / `# Name` / `# ====`). Delimiters must use the same character type (`#`, `-`, `=`, `*`, `+`) but don't need to be the same length. Banner section heading level is determined by the number of `#` characters on the name line (`# Name` = level 1, `## Name` = level 2, etc.), matching the single-line section convention.
 - ALL_CAPS constants: `^[A-Z][A-Z0-9_.]+$` (min 2 chars)
 - Reserved words are filtered from both document and workspace symbols
 - Workspace symbols include `containerName` (filename without extension)


### PR DESCRIPTION
Banner section heading level is now determined by the number of `#` characters on the name line (# = level 1, ## = level 2, etc.), matching the single-line section convention. Previously banner sections were always hardcoded to level 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Banner-style sections now correctly interpret heading levels based on the number of leading `#` characters, enabling proper hierarchical nesting instead of treating all sections as the same level.

* **Documentation**
  * Updated section semantics in AGENTS.md to reflect heading level determination by prefix count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->