### PR TITLE
fix: make compute_section_ranges() level-aware for correct hierarchy nesting

### DIFF
--- a/.kiro/specs/section-range-hierarchy-fix/.config.kiro
+++ b/.kiro/specs/section-range-hierarchy-fix/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/section-range-hierarchy-fix/design.md
+++ b/.kiro/specs/section-range-hierarchy-fix/design.md
@@ -1,0 +1,168 @@
+# Design Document: Section Range Hierarchy Fix
+
+## Overview
+
+The `HierarchyBuilder::compute_section_ranges()` method in `crates/raven/src/handlers.rs` currently treats all sections as flat siblings when computing their end-line ranges. Each section's range ends at `next_section_start_line - 1`, regardless of heading level. This causes parent sections to be truncated at the start of their first child subsection, resulting in symbols after subsections being orphaned to the root level.
+
+The fix modifies `compute_section_ranges()` to be level-aware: a section at level N ends at the line before the next section at level ≤ N (a sibling or ancestor), not at the next section of any level. Subsections (level > N) are contained within the parent section's range.
+
+## Architecture
+
+The fix is localized to a single method: `HierarchyBuilder::compute_section_ranges()`. No other methods need modification because:
+
+- `build_section_hierarchy()` already correctly builds nesting from section levels
+- `try_insert_into_section()` already correctly uses range containment to nest symbols
+- `insert_symbol_into_hierarchy()` already correctly traverses the hierarchy
+
+The bug is purely in range computation. Once ranges are correct, the downstream nesting logic works as intended.
+
+### Current Flow (Buggy)
+
+```text
+compute_section_ranges() → flat sibling ranges → nest_in_sections() → incorrect nesting
+```
+
+### Fixed Flow
+
+```text
+compute_section_ranges() → level-aware ranges → nest_in_sections() → correct nesting
+```
+
+## Components and Interfaces
+
+### Modified Component: `HierarchyBuilder::compute_section_ranges()`
+
+The method signature remains unchanged (`pub fn compute_section_ranges(&mut self)`). Only the internal logic for computing `end_line` changes.
+
+#### Current Algorithm (Buggy)
+
+```text
+for each section i (sorted by start line):
+    end_line = next_section[i+1].start_line - 1   // or EOF if last
+```
+
+#### Fixed Algorithm
+
+```rust
+for each section i (sorted by start line):
+    let current_level = sections[i].section_level
+    // Scan forward for the next section at level <= current_level
+    let end_line = scan_forward_for_sibling_or_ancestor(i, current_level)
+    // If none found, extend to EOF
+```
+
+Specifically, for each section at index `i` with level `current_level`:
+1. Iterate through sections `j = i+1, i+2, ...` (sorted by start line)
+2. If `sections[j].section_level <= current_level`, then `end_line = sections[j].start_line - 1`
+3. If no such section is found, `end_line = line_count - 1` (EOF)
+
+### Unchanged Components
+
+- `RawSymbol` struct — no changes needed
+- `build_section_hierarchy()` — already level-aware
+- `try_insert_into_section()` — already uses range containment
+- `insert_symbol_into_hierarchy()` — already traverses hierarchy correctly
+- `build()` — orchestration unchanged
+
+## Data Models
+
+No data model changes. The existing `RawSymbol` struct with its `section_level: Option<u32>` field and `range: Range` field are sufficient.
+
+### Example: Before and After
+
+Given sections (sorted by line):
+
+| Index | Name | Level | Start Line |
+|-------|------|-------|------------|
+| 0 | Section A | 1 | 0 |
+| 1 | Subsection B | 2 | 2 |
+| 2 | Section C | 1 | 5 |
+
+**Before (buggy):**
+
+| Section | End Line | Reason |
+|---------|----------|--------|
+| Section A | 1 | Next section (Subsection B) at line 2 → 2-1=1 |
+| Subsection B | 4 | Next section (Section C) at line 5 → 5-1=4 |
+| Section C | EOF | Last section |
+
+**After (fixed):**
+
+| Section | End Line | Reason |
+|---------|----------|--------|
+| Section A | 4 | Next section at level ≤ 1 is Section C at line 5 → 5-1=4 |
+| Subsection B | 4 | Next section at level ≤ 2 is Section C at line 5 → 5-1=4 |
+| Section C | EOF | Last section |
+
+Now a symbol at line 4 falls within both Section A's range (0–4) and Subsection B's range (2–4). The `try_insert_into_section()` method correctly nests it in Subsection B first (deepest match), which is itself a child of Section A.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Level-aware section range end lines
+
+*For any* list of sections with arbitrary levels and start lines (sorted by start line), after calling `compute_section_ranges()`, each section at level N shall have its end line equal to `next_sibling_or_ancestor.start_line - 1` where the next sibling or ancestor is the first subsequent section with level ≤ N, or `line_count - 1` (EOF) if no such section exists.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+
+### Property 2: Correct symbol nesting after build
+
+*For any* valid configuration of sections (with varying levels) and non-section symbols, after calling `build()`, every non-section symbol whose start line falls within a section's computed range shall appear as a descendant of that section (nested in the deepest containing section), and symbols outside all section ranges shall appear at the root level.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 3: Selection range preservation
+
+*For any* list of symbols (sections and non-sections), after calling `compute_section_ranges()`, the `selection_range` of every symbol shall be identical to its `selection_range` before the call.
+
+**Validates: Requirements 3.1**
+
+### Property 4: Input order independence (confluence)
+
+*For any* list of sections, the computed section ranges after `compute_section_ranges()` shall be identical regardless of the initial ordering of sections in the input list.
+
+**Validates: Requirements 4.4**
+
+## Error Handling
+
+This fix does not introduce new error conditions. The existing error handling in `compute_section_ranges()` is preserved:
+
+- **Empty symbol list**: Returns immediately (no-op). No change needed.
+- **No sections in symbol list**: Returns immediately (no-op). No change needed.
+- **Section at line 0 with next section at line 0**: The `if next_start_line > 0` guard prevents underflow. This guard is preserved in the fixed algorithm.
+- **`line_count` of 0**: The `if self.line_count > 0` guard handles this. Preserved.
+
+## Testing Strategy
+
+### Property-Based Tests (proptest)
+
+Use the existing `proptest` crate (already a dev-dependency). Each property test runs a minimum of 100 iterations.
+
+**Generators needed:**
+- Random section lists: generate `Vec<RawSymbol>` where each entry has `kind = Module`, `section_level = Some(1..=4)`, and unique start lines within `0..line_count`
+- Random non-section symbols: generate `Vec<RawSymbol>` with `section_level = None` and start lines within `0..line_count`
+- Random `line_count` values (e.g., `1..=100`)
+
+**Edge cases to cover in generators:**
+- Sections on consecutive lines with different levels
+- Symbols before any section (should remain at root)
+- Level-2+ sections without preceding level-1 sections
+- Documents with no sections
+- Single section documents
+
+**Property test tags:**
+- `Feature: section-range-hierarchy-fix, Property 1: Level-aware section range end lines`
+- `Feature: section-range-hierarchy-fix, Property 2: Correct symbol nesting after build`
+- `Feature: section-range-hierarchy-fix, Property 3: Selection range preservation`
+- `Feature: section-range-hierarchy-fix, Property 4: Input order independence`
+
+### Unit Tests
+
+Unit tests complement property tests by covering specific, readable scenarios:
+
+- **Core bug scenario**: Parent section with child subsection, symbol after subsection — verify symbol nests under parent
+- **Three-level nesting**: Level 1 > Level 2 > Level 3 with symbols at each level
+- **Multiple subsections under one parent**: Verify parent range spans all subsections
+- **Existing test updates**: Update existing `compute_section_ranges` tests that assumed flat sibling behavior to reflect level-aware behavior (tests with mixed levels will have different expected end lines)

--- a/.kiro/specs/section-range-hierarchy-fix/requirements.md
+++ b/.kiro/specs/section-range-hierarchy-fix/requirements.md
@@ -1,0 +1,58 @@
+# Requirements Document
+
+## Introduction
+
+Fix a bug in Raven's `HierarchyBuilder::compute_section_ranges()` method where section ranges are computed without considering heading levels. Currently, all sections are treated as flat siblings when computing end-line ranges, causing a parent section's range to be truncated at the start of its first child subsection. This results in symbols that appear after a subsection (but still logically within the parent section) being placed at the root level of the document outline instead of nested under the parent section.
+
+## Glossary
+
+- **HierarchyBuilder**: The component in `handlers.rs` that builds a hierarchical `DocumentSymbol` tree from a flat list of `RawSymbol` entries for the LSP document outline.
+- **Section**: An R code section comment (e.g., `# Section ----`) represented as a `RawSymbol` with `kind = Module` and a non-None `section_level`.
+- **Section_Level**: An integer (1, 2, 3, ...) representing the heading depth of a section. Level 1 corresponds to `#`, level 2 to `##`, etc.
+- **Section_Range**: The LSP `Range` of a section symbol, spanning from the section comment line to the computed end line. Used to determine which symbols are contained within a section.
+- **Sibling_Section**: A section at the same or lower (numerically smaller) heading level as the current section, indicating the start of a new peer or ancestor section.
+- **Child_Section**: A section at a higher (numerically larger) heading level than the current section, indicating a subsection contained within the current section.
+- **Symbol**: A code construct (function, variable, constant, class, method, or section) extracted from an R document for the document outline.
+
+## Requirements
+
+### Requirement 1: Level-Aware Section Range Computation
+
+**User Story:** As a developer using Raven's document outline, I want parent sections to span over their child subsections, so that symbols appearing after a subsection are correctly nested under the parent section.
+
+#### Acceptance Criteria
+
+1. WHEN computing the end line for a section at Section_Level N, THE HierarchyBuilder SHALL set the end line to the line before the next section at Section_Level less than or equal to N.
+2. WHEN a section at Section_Level N is followed only by Child_Sections (Section_Level greater than N) and no Sibling_Section before end of file, THE HierarchyBuilder SHALL set the end line of that section to the last line of the document.
+3. WHEN a section at Section_Level N is the last section in the document, THE HierarchyBuilder SHALL set the end line to the last line of the document.
+4. THE HierarchyBuilder SHALL preserve the existing behavior for same-level sections: a section's range ends at the line before the next section of the same level.
+
+### Requirement 2: Correct Symbol Nesting After Subsections
+
+**User Story:** As a developer using Raven's document outline, I want symbols that appear after a subsection but before the next sibling section to be nested under the correct parent section, so that the outline accurately reflects the logical structure of my code.
+
+#### Acceptance Criteria
+
+1. WHEN a Symbol appears on a line after a Child_Section but within the Section_Range of a parent section, THE HierarchyBuilder SHALL nest that Symbol under the parent section (or the deepest containing section).
+2. WHEN a Symbol appears on a line within a Child_Section's range, THE HierarchyBuilder SHALL nest that Symbol under the Child_Section.
+3. WHEN a Symbol appears on a line before any section, THE HierarchyBuilder SHALL place that Symbol at the root level of the outline.
+
+### Requirement 3: Selection Range Preservation
+
+**User Story:** As a developer, I want the selection range of section symbols to remain unchanged after the fix, so that clicking on a section in the outline still navigates to the section comment line.
+
+#### Acceptance Criteria
+
+1. THE HierarchyBuilder SHALL preserve the `selection_range` of each section symbol unchanged during section range computation.
+
+### Requirement 4: Edge Case Handling
+
+**User Story:** As a developer, I want the section range computation to handle edge cases correctly, so that the outline remains stable for unusual section arrangements.
+
+#### Acceptance Criteria
+
+1. WHEN a document contains no sections, THE HierarchyBuilder SHALL leave all symbol ranges unchanged.
+2. WHEN a document contains only a single section, THE HierarchyBuilder SHALL set that section's range from its start line to the last line of the document.
+3. WHEN two sections of different levels start on consecutive lines, THE HierarchyBuilder SHALL compute ranges correctly without overlap or gaps.
+4. WHEN sections are provided in unsorted order, THE HierarchyBuilder SHALL sort sections by start line before computing ranges and produce correct results.
+5. WHEN a level-2 section appears without a preceding level-1 section, THE HierarchyBuilder SHALL treat the level-2 section as a root-level section with its range extending to the next section of level less than or equal to 2 or end of file.

--- a/.kiro/specs/section-range-hierarchy-fix/tasks.md
+++ b/.kiro/specs/section-range-hierarchy-fix/tasks.md
@@ -1,0 +1,53 @@
+# Implementation Plan: Section Range Hierarchy Fix
+
+## Overview
+
+Fix `HierarchyBuilder::compute_section_ranges()` in `crates/raven/src/handlers.rs` to be level-aware, then update existing tests and add property-based tests to validate correctness.
+
+## Tasks
+
+- [x] 1. Fix `compute_section_ranges()` to be level-aware
+  - [x] 1.1 Modify the end-line computation loop in `HierarchyBuilder::compute_section_ranges()`
+    - For each section at index `i` with `section_level = N`, scan forward through subsequent sections (sorted by start line) to find the first section with `section_level <= N`
+    - If found, set `end_line = that_section.start_line - 1`; if not found, set `end_line = line_count - 1` (EOF)
+    - Preserve the existing `next_start_line > 0` underflow guard and `line_count > 0` guard
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [x] 1.2 Write property test for level-aware section range end lines
+    - **Property 1: Level-aware section range end lines**
+    - Generate random section lists with levels 1–4 and unique start lines; verify each section's end line matches the expected value based on the next sibling-or-ancestor section
+    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+
+  - [x] 1.3 Write property test for selection range preservation
+    - **Property 3: Selection range preservation**
+    - Generate random symbol lists, snapshot selection_ranges before `compute_section_ranges()`, verify they are unchanged after
+    - **Validates: Requirements 3.1**
+
+  - [x] 1.4 Write property test for input order independence
+    - **Property 4: Input order independence (confluence)**
+    - Generate random section lists, run `compute_section_ranges()` on two copies with different input orderings, verify identical output ranges
+    - **Validates: Requirements 4.4**
+
+- [x] 2. Update existing tests and add unit tests for the bug scenario
+  - [x] 2.1 Update existing `compute_section_ranges` unit tests
+    - Review and update any existing tests that assumed flat sibling behavior for mixed-level sections
+    - Add a new unit test for the core bug scenario: level-1 section, level-2 subsection, symbol after subsection — verify parent section range spans over the subsection
+    - _Requirements: 1.1, 2.1_
+
+  - [x] 2.2 Add unit test for three-level nesting with symbols
+    - Test level 1 > level 2 > level 3 sections with symbols at each level, verify correct nesting after `build()`
+    - _Requirements: 2.1, 2.2_
+
+  - [x] 2.3 Write property test for correct symbol nesting after build
+    - **Property 2: Correct symbol nesting after build**
+    - Generate sections with varying levels and non-section symbols at random lines; after `build()`, verify every symbol is nested in the deepest containing section, and symbols outside all sections are at root
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+
+- [x] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- The fix is localized to a single method; no interface or data model changes needed
+- Existing tests for same-level sections should continue to pass since level-aware logic degenerates to the current behavior when all sections are at the same level
+- Property tests use the existing `proptest` crate (already in dev-dependencies)

--- a/crates/raven/proptest-regressions/cross_file/property_tests.txt
+++ b/crates/raven/proptest-regressions/cross_file/property_tests.txt
@@ -17,3 +17,4 @@ cc c0b2cf15ea48569706570f3e444704e5a16f7b732710c9e755b0abfc5587279c # shrinks to
 cc f6422bed12b3fd769eb1097db70cbbd7a66d07437fd0c4f8e2ce1a2801dfdbd2 # shrinks to symbol_name = "x", is_function = false
 cc 22f5803b605fb07455ff1a5ab6b25c60190d8499f4404eb03c707b8e98a2ade5 # shrinks to symbol_name = "y", is_function = false, prefix_lines = 0
 cc 44c37ae5d05d04862537acce37c6faf634169b54c37af5c402776be7983ca036 # shrinks to old_symbol = "a", new_symbol = "y", is_function = false
+cc 9532908ec73c1feeb9ba3b79344c577909065889a153eda5b70f3b7097bbe16d # shrinks to symbol_name = "x", declaration_count = 4


### PR DESCRIPTION
Parent sections now span over child subsections instead of being truncated at the first subsection boundary. A section at level N ends at the line before the next section at level <= N (sibling or ancestor), not at the next section of any level.

Adds 4 property-based tests (level-aware end lines, selection range preservation, input order independence, correct symbol nesting) and 2 unit tests (parent-spans-subsection, three-level nesting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Section range computation is now level-aware, fixing incorrect end-line assignments and improving nested section hierarchy.

* **Tests**
  * Added and expanded unit and property-based tests covering nested sections, ordering, edge cases, and regression scenarios.

* **Documentation**
  * Added design, requirements, and task plans describing the new level-aware behavior and acceptance criteria.

* **Chores**
  * Added a config entry and updated test regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->