### PR TITLE
claude/fix assignment operators dastc

### DIFF
--- a/crates/raven/proptest-regressions/handlers.txt
+++ b/crates/raven/proptest-regressions/handlers.txt
@@ -10,3 +10,4 @@ cc 753f8957dde0ae658593179be5ae64ef0c8768a360bfa26dfff8a80b643b8844 # shrinks to
 cc f95ee9c31758748cf4113c2a8e4c8e7cc2b557e139677d2e0edd653b8d33187f # shrinks to var1 = "sin", var2 = "a__"
 cc 2dedd5b15f894237256947bc7c1391c87277bd9351679cedb9c8e946685c5834 # shrinks to outer_func = "a0", pkg_name = "aaa", partial_token = "", use_triple_colon = false
 cc 2250c8f29bc61283775c429485d811bc470b61dc653492a4f3296a3aab75251d # shrinks to func_name = "a_a", params = []
+cc 983b057cd15b41227acf67a33b60f8aad42d25970dfa29401494b609f8d246fe # shrinks to reserved_word = "if", var_name = "ifa"

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -18357,7 +18357,7 @@ mod proptests {
             // Filter for "Undefined variable" diagnostics for this reserved word
             let undefined_diags: Vec<_> = diagnostics
                 .iter()
-                .filter(|d| d.message.contains(&format!("Undefined variable: {}", reserved_word)))
+                .filter(|d| d.message == format!("Undefined variable: {}", reserved_word))
                 .collect();
 
             prop_assert!(
@@ -18412,7 +18412,7 @@ mod proptests {
             // Filter for "Undefined variable" diagnostics for this reserved word
             let undefined_diags: Vec<_> = diagnostics
                 .iter()
-                .filter(|d| d.message.contains(&format!("Undefined variable: {}", reserved_word)))
+                .filter(|d| d.message == format!("Undefined variable: {}", reserved_word))
                 .collect();
 
             prop_assert!(
@@ -18465,7 +18465,7 @@ mod proptests {
             // Filter for "Undefined variable" diagnostics for this reserved word
             let undefined_diags: Vec<_> = diagnostics
                 .iter()
-                .filter(|d| d.message.contains(&format!("Undefined variable: {}", reserved_word)))
+                .filter(|d| d.message == format!("Undefined variable: {}", reserved_word))
                 .collect();
 
             prop_assert!(


### PR DESCRIPTION
- **Fix ->> (right super assignment) not indexed for cross-file scope**
- **Fix flaky proptest: use exact match for diagnostic message filtering**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for R's right-side assignment operators (`->` and `->>`)
  * Improved symbol detection for R6 classes, reference classes, and constants
  * Enhanced code hierarchy with proper nesting and multi-level section support
  * Better hover information, signature help, and cross-file definition lookup
  * Enhanced diagnostics for missing packages and undefined variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->