### PR TITLE
Add smart indentation configuration documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ User-facing:
 - `docs/cross-file.md`
 - `docs/declaration-directives.md`
 - `docs/packages.md`
+- `docs/indentation.md`
 - `docs/configuration.md`
 
 Maintainer/internal:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ You may also want to push snippets below LSP completions to reduce duplicate ent
 - **Document symbols** - Hierarchical outline view with R code section support (`# Section ----`), S4/R6 class detection, and nested function display
 - **Workspace symbols** - Fast project-wide symbol search (Ctrl+T) with configurable result limits
 - **Workspace indexing** - Background indexing of your entire project
+- **Smart indentation** - AST-aware auto-indentation with RStudio-style alignment on Enter
 - **Package awareness** - Recognition of `library()` calls and package exports
 
 ## Documentation
@@ -117,6 +118,7 @@ You may also want to push snippets below LSP completions to reduce duplicate ent
 - [Cross-File Awareness](docs/cross-file.md) - Directives, `source()` detection, symbol resolution
 - [Declaration Directives](docs/declaration-directives.md) - `@lsp-var`, `@lsp-func` for dynamically-created symbols
 - [Package Function Awareness](docs/packages.md) - `library()` support, meta-packages, base packages
+- [Smart Indentation](docs/indentation.md) - AST-aware auto-indentation styles and configuration
 - [Configuration](docs/configuration.md) - All settings and options
 
 ## Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,25 @@ All settings can be configured via VS Code settings or LSP initialization option
 |---------|---------|-------------|
 | `raven.completion.triggerOnOpenParen` | true | Register `(` as a completion trigger character so parameter suggestions appear when opening a function call. Set to `false` to disable. |
 
+## Indentation Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `raven.indentation.style` | "rstudio" | Indentation style for R code. Controls AST-aware (Tier 2) indentation behavior. See [Smart Indentation](indentation.md) for details. |
+
+`raven.indentation.style` accepts one of:
+- `"rstudio"` — Same-line arguments align to opening paren; next-line arguments indent from function line (matches the RStudio IDE default)
+- `"rstudio-minus"` — All arguments indent relative to previous line, regardless of paren position
+- `"off"` — Disables AST-aware indentation (Tier 2); only basic declarative rules (Tier 1) remain active
+
+Raven also sets `editor.formatOnType` to `true` for R files by default (lowest-priority VS Code default — your explicit settings take precedence). This is required for Tier 2 indentation to function. You can disable it per-language:
+
+```json
+"[r]": {
+  "editor.formatOnType": false
+}
+```
+
 ## Severity Values
 
 All severity settings accept one of:


### PR DESCRIPTION
## Summary
This PR adds documentation for the new smart indentation feature, including configuration options and usage guidance.

## Key Changes
- Added "Indentation Settings" section to `docs/configuration.md` documenting the `raven.indentation.style` setting with three supported styles:
  - `"rstudio"` — Same-line arguments align to opening paren; next-line arguments indent from function line
  - `"rstudio-minus"` — All arguments indent relative to previous line
  - `"off"` — Disables AST-aware indentation
- Documented the requirement for `editor.formatOnType` to be enabled for Tier 2 indentation to function, with example configuration to disable it per-language
- Updated `README.md` to highlight smart indentation as a feature with AST-aware auto-indentation and RStudio-style alignment
- Added reference to new `docs/indentation.md` documentation in the README's Documentation section

## Notable Details
- Documentation clarifies the distinction between Tier 1 (basic declarative rules) and Tier 2 (AST-aware) indentation
- Includes practical configuration examples for users who want to disable format-on-type behavior
- Emphasizes that VS Code default settings have lowest priority, so user settings take precedence

https://claude.ai/code/session_01Q3LfYfNvkYoNcyAP2rCgpe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Smart Indentation feature docs describing AST-aware auto‑indentation with RStudio-style alignment options
  * Documented new indentation settings: rstudio, rstudio-minus, and off, plus format-on-type example for R
  * Updated severity values to list explicit options (error, warning, information, hint, off)
  * Added a new Indentation guidance page and noted the Indentation Settings block appears in two places
<!-- end of auto-generated comment: release notes by coderabbit.ai -->