### PR TITLE
Fix false positive diagnostics for single-line anonymous function params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ When making significant changes:
 - Tiered loading (static → R → INDEX fallback) provides both speed and accuracy: sub-5ms for 94% of packages, accurate exports for all.
 - When parsing structured R output (markers like `__PKG:name__`), handle missing end markers gracefully to avoid losing partial results.
 - Always wrap R subprocess calls with `tokio::time::timeout()` to prevent hung R processes from blocking the LSP indefinitely.
-- When iterating over identifiers in a file for diagnostics, cache scope resolution results by line number — the cross-file scope is identical for all identifiers on the same line, so calling `get_cross_file_scope()` per-identifier is wasteful.
+- When iterating over identifiers in a file for diagnostics, cache scope resolution results by `(line, column)` — different columns on the same line can have different scopes (e.g., inside vs outside a single-line anonymous function like `sapply(x, function(p) p + 1)`). Line-only caching causes false positives for function parameters.
 - Pre-compute a line-offset index (`Vec<usize>` of line start positions) to avoid repeated `text.lines().nth(row)` calls, which are O(n) each time.
 - Use `HashSet` for membership checks in hot loops (package deduplication, workspace imports); `Vec::contains()` is O(n) and adds up quickly in completion/diagnostic paths.
 - For background work queues, maintain a companion `HashSet` of pending URIs alongside the `VecDeque` to enable O(1) duplicate detection instead of O(n) `iter().any()` scans.

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -2682,8 +2682,9 @@ pub fn diagnostics(state: &WorldState, uri: &Url, cancel: &DiagCancelToken) -> V
     }
 
     // Shared scope cache: computed once, reused by both out-of-scope and undefined-variable
-    // collectors. Keyed by line number — within a single line the cross-file scope is identical.
-    let mut scope_cache: HashMap<u32, scope::ScopeAtPosition> = HashMap::new();
+    // collectors. Keyed by (line, column) — different columns on the same line can have
+    // different scopes (e.g., inside vs outside a single-line anonymous function).
+    let mut scope_cache: HashMap<(u32, u32), scope::ScopeAtPosition> = HashMap::new();
 
     // Check for out-of-scope symbol usage (Requirement 10.3)
     collect_out_of_scope_diagnostics(
@@ -3707,7 +3708,7 @@ fn collect_out_of_scope_diagnostics(
     text: &str,
     directive_meta: &crate::cross_file::CrossFileMetadata,
     diagnostics: &mut Vec<Diagnostic>,
-    scope_cache: &mut HashMap<u32, scope::ScopeAtPosition>,
+    scope_cache: &mut HashMap<(u32, u32), scope::ScopeAtPosition>,
     cancel: &DiagCancelToken,
 ) {
     // Skip if out-of-scope diagnostics are disabled
@@ -3740,7 +3741,7 @@ fn collect_out_of_scope_diagnostics(
     let mut locally_resolved_usages: std::collections::HashSet<(String, u32, u32)> =
         std::collections::HashSet::new();
     for (name, usage_line, usage_col, _) in &usages {
-        let scope = scope_cache.entry(*usage_line).or_insert_with(|| {
+        let scope = scope_cache.entry((*usage_line, *usage_col)).or_insert_with(|| {
             get_cross_file_scope(state, uri, *usage_line, *usage_col)
         });
         if let Some(symbol) = scope.symbols.get(name.as_str()) {
@@ -6095,7 +6096,7 @@ pub(crate) fn collect_undefined_variables_position_aware(
     package_library: &crate::package_library::PackageLibrary,
     directive_meta: &crate::cross_file::CrossFileMetadata,
     diagnostics: &mut Vec<Diagnostic>,
-    scope_cache: &mut HashMap<u32, scope::ScopeAtPosition>,
+    scope_cache: &mut HashMap<(u32, u32), scope::ScopeAtPosition>,
     cancel: &DiagCancelToken,
 ) {
     use crate::content_provider::ContentProvider;
@@ -6186,13 +6187,15 @@ pub(crate) fn collect_undefined_variables_position_aware(
             continue;
         }
 
-        // Get or compute the scope for this line (cached)
-        let scope = scope_cache.entry(usage_line).or_insert_with(|| {
+        // Get or compute the scope for this position (cached)
+        let scope = {
             let line_text = get_line(usage_node.start_position().row);
             let usage_col =
                 byte_offset_to_utf16_column(line_text, usage_node.start_position().column);
-            get_cross_file_scope(state, uri, usage_line, usage_col)
-        });
+            scope_cache.entry((usage_line, usage_col)).or_insert_with(|| {
+                get_cross_file_scope(state, uri, usage_line, usage_col)
+            })
+        };
 
         // Check if symbol is in cross-file scope
         if scope.symbols.contains_key(name.as_str()) {


### PR DESCRIPTION
## Summary
- The diagnostic scope cache was keyed by line number only, assuming all identifiers on the same line share the same cross-file scope
- This caused false positives for function parameters in single-line anonymous functions (e.g., `sapply(x, function(method) which(y == method))`) because the scope was computed at the first identifier's column (before the function) and cached, missing the function's parameters
- Changed the cache key from `u32` (line) to `(u32, u32)` (line, column) so each identifier gets scope resolved at its actual position

## Test plan
- [x] All 60 existing tests pass
- [ ] Verify with reproduction case: `sapply(desired_method_order, function(method) which(tbl_temp[1, ] == method))` no longer emits false "used before source() call" diagnostic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved diagnostic accuracy by refining position-aware scope resolution, reducing false positives in complex code scenarios.
  * Enhanced error handling for malformed syntax to avoid duplicate diagnostics.

* **Performance**
  * Optimized memory usage with bounded caching strategies.
  * Improved performance in symbol collection and scope resolution.

* **Tests**
  * Expanded test coverage with property-based validation for edge cases and complex code structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->