### PR TITLE
Fix false positive diagnostics for namespace-qualified calls

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -10229,9 +10229,10 @@ mod tests {
     /// Test that arguments to namespace-qualified calls are still checked.
     #[test]
     fn test_namespace_call_arguments_still_checked() {
-        // Arguments in call-like nodes are suppressed by in_call_like_arguments,
-        // but if the argument is not in a call (e.g., pkg::var + x), x should be checked.
-        let code = "y <- stats::median(x)";
+        // Use a non-call context so x is not suppressed by in_call_like_arguments.
+        // This verifies that namespace-qualified references don't suppress
+        // surrounding non-qualified identifiers.
+        let code = "y <- stats::median + x";
         let tree = parse_r_code(code);
         let mut used = Vec::new();
         collect_usages_with_context(tree.root_node(), code, &UsageContext::default(), &mut used);
@@ -10239,6 +10240,8 @@ mod tests {
         // Neither 'stats' nor 'median' should be collected
         assert!(!used.iter().any(|(name, _)| name == "stats"));
         assert!(!used.iter().any(|(name, _)| name == "median"));
+        // 'x' should still be collected
+        assert!(used.iter().any(|(name, _)| name == "x"));
     }
 
     // ========================================================================

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6647,6 +6647,13 @@ fn collect_usages_with_context<'a>(
                 }
             }
 
+            // Skip if this identifier is inside a namespace_operator (pkg:: or pkg:::)
+            // Both the package name (LHS) and function name (RHS) are qualified
+            // references and should not be checked as standalone variables.
+            if parent.kind() == "namespace_operator" {
+                return;
+            }
+
             // Skip if this is the RHS of an extract operator ($ or @)
             // e.g., df$column or obj@slot - we don't want to check if column/slot is defined
             // The LHS (df, obj) should still be checked for undefined variables
@@ -10186,6 +10193,52 @@ mod tests {
             1,
             "Only 'df' should be collected in chained extracts"
         );
+    }
+
+    /// Test that namespace-qualified calls (pkg::func) don't produce diagnostics
+    /// for either the package name or the function name.
+    #[test]
+    fn test_namespace_operator_skipped() {
+        let code = "knitr::knit('file.Rmd')";
+        let tree = parse_r_code(code);
+        let mut used = Vec::new();
+        collect_usages_with_context(tree.root_node(), code, &UsageContext::default(), &mut used);
+
+        let knitr_used = used.iter().any(|(name, _)| name == "knitr");
+        assert!(!knitr_used, "Package name 'knitr' in pkg::func should NOT be collected");
+
+        let knit_used = used.iter().any(|(name, _)| name == "knit");
+        assert!(!knit_used, "Function name 'knit' in pkg::func should NOT be collected");
+    }
+
+    /// Test that triple-colon namespace operator (pkg:::func) is also skipped.
+    #[test]
+    fn test_triple_colon_namespace_operator_skipped() {
+        let code = "stats:::C_something()";
+        let tree = parse_r_code(code);
+        let mut used = Vec::new();
+        collect_usages_with_context(tree.root_node(), code, &UsageContext::default(), &mut used);
+
+        let stats_used = used.iter().any(|(name, _)| name == "stats");
+        assert!(!stats_used, "Package name 'stats' in pkg:::func should NOT be collected");
+
+        let func_used = used.iter().any(|(name, _)| name == "C_something");
+        assert!(!func_used, "Function name in pkg:::func should NOT be collected");
+    }
+
+    /// Test that arguments to namespace-qualified calls are still checked.
+    #[test]
+    fn test_namespace_call_arguments_still_checked() {
+        // Arguments in call-like nodes are suppressed by in_call_like_arguments,
+        // but if the argument is not in a call (e.g., pkg::var + x), x should be checked.
+        let code = "y <- stats::median(x)";
+        let tree = parse_r_code(code);
+        let mut used = Vec::new();
+        collect_usages_with_context(tree.root_node(), code, &UsageContext::default(), &mut used);
+
+        // Neither 'stats' nor 'median' should be collected
+        assert!(!used.iter().any(|(name, _)| name == "stats"));
+        assert!(!used.iter().any(|(name, _)| name == "median"));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
- Skip identifiers inside `namespace_operator` nodes (`pkg::func`, `pkg:::func`) in the undefined variable diagnostic pass
- Both the package name (LHS) and function name (RHS) are qualified references and should not be checked as standalone variables
- Previously, expressions like `knitr::knit()` or `stats::median()` would emit "Undefined variable: knitr" / "Undefined variable: stats"

## Test plan
- [x] Added `test_namespace_operator_skipped` — `pkg::func` skips both identifiers
- [x] Added `test_triple_colon_namespace_operator_skipped` — `pkg:::func` works too
- [x] Added `test_namespace_call_arguments_still_checked` — arguments unaffected
- [x] Full test suite passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved signature help, hover content, completion items, and go-to-definition behavior with better formatting and cross-file handling.
  * Enhanced document symbol hierarchy and section handling for more accurate nesting and ranges.

* **Tests**
  * Added extensive tests (including property-based) covering symbols, signatures, hierarchy, formatting, and edge cases.

* **Chores**
  * Internal refactors to function interfaces and parameter handling for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->