### PR TITLE
Fix false positive 'Package is not installed' diagnostics (race condition)

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -577,9 +577,17 @@ impl Backend {
         };
         lib.add_library_paths(&additional_paths);
         let mut state = self.state.write().await;
-        state.package_library = std::sync::Arc::new(lib);
-        state.package_library_ready = ready;
-        ready
+        // Re-check under write lock: `initialized()` may have raced ahead
+        // and already written a library with prefetched caches.
+        if state.package_library.lib_paths().is_empty() {
+            state.package_library = std::sync::Arc::new(lib);
+            state.package_library_ready = ready;
+        } else {
+            log::trace!(
+                "PackageLibrary already initialized (race), keeping existing"
+            );
+        }
+        state.package_library_ready
     }
     pub fn new(client: Client) -> Self {
         let library_paths = r_env::find_library_paths();
@@ -963,11 +971,21 @@ impl LanguageServer for Backend {
             }
         };
 
-        // Apply PackageLibrary immediately (workspace index will be applied when background scan completes)
+        // Apply PackageLibrary only if not already initialized.
+        // `ensure_package_library_initialized` (called from `did_open`) may have raced
+        // ahead and already written a library with prefetched package caches.
+        // Overwriting it would discard those caches and cause false-positive
+        // "Package is not installed" diagnostics until the next prefetch.
         {
             let mut state = self.state.write().await;
-            state.package_library = new_package_library;
-            state.package_library_ready = package_library_ready;
+            if state.package_library.lib_paths().is_empty() {
+                state.package_library = new_package_library;
+                state.package_library_ready = package_library_ready;
+            } else {
+                log::info!(
+                    "PackageLibrary already initialized (from did_open), skipping overwrite"
+                );
+            }
         }
 
         let init_duration = init_start.elapsed();
@@ -1632,15 +1650,6 @@ impl LanguageServer for Backend {
                 } else {
                     log::trace!("did_open prefetch: package library not ready, skipping");
                 }
-                let has_ddply =
-                    package_library.is_symbol_from_loaded_packages("ddply", &scope_packages);
-                let has_row_medians =
-                    package_library.is_symbol_from_loaded_packages("rowMedians", &scope_packages);
-                log::trace!(
-                    "did_open prefetch: symbol check ddply={} rowMedians={}",
-                    has_ddply,
-                    has_row_medians
-                );
             }
         }
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -531,19 +531,19 @@ pub struct Backend {
 
 impl Backend {
     async fn ensure_package_library_initialized(&self) -> bool {
-        let (enabled, lib_paths_empty) = {
+        let (enabled, already_ready) = {
             let state = self.state.read().await;
             (
                 state.cross_file_config.packages_enabled,
-                state.package_library.lib_paths().is_empty(),
+                state.package_library_ready,
             )
         };
 
         if !enabled {
             return false;
         }
-        if !lib_paths_empty {
-            return self.state.read().await.package_library_ready;
+        if already_ready {
+            return true;
         }
 
         let (packages_r_path, additional_paths, workspace_root) = {
@@ -561,7 +561,7 @@ impl Backend {
             )
         };
 
-        log::trace!("Initializing PackageLibrary on demand (lib_paths empty)");
+        log::trace!("Initializing PackageLibrary on demand (not yet ready)");
         let r_subprocess = crate::r_subprocess::RSubprocess::new(packages_r_path);
         let r_subprocess = match (r_subprocess, workspace_root) {
             (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
@@ -579,7 +579,7 @@ impl Backend {
         let mut state = self.state.write().await;
         // Re-check under write lock: `initialized()` may have raced ahead
         // and already written a library with prefetched caches.
-        if state.package_library.lib_paths().is_empty() {
+        if !state.package_library_ready {
             state.package_library = std::sync::Arc::new(lib);
             state.package_library_ready = ready;
         } else {
@@ -978,7 +978,7 @@ impl LanguageServer for Backend {
         // "Package is not installed" diagnostics until the next prefetch.
         {
             let mut state = self.state.write().await;
-            if state.package_library.lib_paths().is_empty() {
+            if !state.package_library_ready {
                 state.package_library = new_package_library;
                 state.package_library_ready = package_library_ready;
             } else {


### PR DESCRIPTION
## Summary

- **Fix race between `initialized()` and `did_open`'s `ensure_package_library_initialized()`**: Both can create separate `PackageLibrary` instances concurrently. When `did_open` wins the race, it writes a library with prefetched package caches. Then `initialized()` unconditionally overwrites it with a fresh library (empty cache, potentially different `lib_paths`), causing false "Package is not installed" diagnostics.
- **Fix**: Both paths now re-check under write lock whether the library is already initialized (`lib_paths` non-empty) before writing. Whichever completes first wins; the second is a no-op.
- Remove leftover debug probe logging (`ddply`/`rowMedians` symbol checks).

## Test plan

- [x] `cargo build -p raven` succeeds
- [x] `cargo test -p raven` passes (60 tests)
- [ ] Open a workspace with `library()` calls — verify no false positive "Package is not installed" diagnostics for installed packages
- [ ] Verify packages still get flagged when genuinely not installed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in package library initialization so simultaneous operations no longer overwrite in-progress library state.
  * Prefetched package caches are now preserved across concurrent actions, preventing needless reloading.
  * Reduced unnecessary runtime symbol checks during prefetch, improving stability and prefetch performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->