### PR TITLE
Add automatic backward dependency detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ When you open `main.R`, Raven:
 3. Provides completions, hover, and go-to-definition for `helper_function`
 4. Only shows `helper_function` as available *after* the `source()` line
 
-But if you open `utils.R` directly, Raven doesn’t know which file sources it. Add a directive to tell it:
+And if you open `utils.R` directly, Raven automatically discovers that `main.R` sources it (by scanning the workspace) and resolves the full chain in both directions — no configuration needed.
+
+For complex setups or when you want explicit control, you can add directives:
 
 ```r
 # utils.R
@@ -41,7 +43,7 @@ But if you open `utils.R` directly, Raven doesn’t know which file sources it. 
 helper_function <- function(x) { x * 2 }
 ```
 
-Now Raven resolves the full chain in both directions. See [Cross-File Awareness](docs/cross-file.md) for more directives and dynamic-path handling.
+See [Cross-File Awareness](docs/cross-file.md) for directives, dynamic-path handling, and [backward dependency modes](docs/cross-file.md#backward-dependency-modes).
 
 ## Installation
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -214,6 +214,17 @@ pub(crate) fn parse_cross_file_config(
             config.hoist_globals_in_functions = v;
         }
 
+        if let Some(v) = cross_file
+            .get("backwardDependencies")
+            .and_then(|v| v.as_str())
+        {
+            config.backward_dependencies = match v {
+                "explicit" => crate::cross_file::BackwardDependencyMode::Explicit,
+                "off" => crate::cross_file::BackwardDependencyMode::Off,
+                _ => crate::cross_file::BackwardDependencyMode::Auto,
+            };
+        }
+
         // Parse on-demand indexing settings
         if let Some(on_demand) = cross_file.get("onDemandIndexing") {
             if let Some(v) = on_demand.get("enabled").and_then(|v| v.as_bool()) {
@@ -311,6 +322,10 @@ pub(crate) fn parse_cross_file_config(
     log::info!(
         "  hoist_globals_in_functions: {}",
         config.hoist_globals_in_functions
+    );
+    log::info!(
+        "  backward_dependencies: {:?}",
+        config.backward_dependencies
     );
     log::info!("  On-demand indexing:");
     log::info!("    enabled: {}", config.on_demand_indexing_enabled);
@@ -881,6 +896,7 @@ impl LanguageServer for Backend {
         // priority over the background scan.
         let state_clone = self.state.clone();
         let folders_clone = folders.clone();
+        let client_clone = self.client.clone();
         if index_workspace {
             tokio::task::spawn(async move {
                 // Run the blocking scan in a blocking task
@@ -902,20 +918,56 @@ impl LanguageServer for Backend {
                 // Apply results when scan completes
                 match scan_result {
                     Ok((index, imports, cross_file_entries, new_index_entries)) => {
-                        let mut state = state_clone.write().await;
-                        state.apply_workspace_index(
-                            index,
-                            imports,
-                            cross_file_entries,
-                            new_index_entries,
-                        );
+                        // Apply index and snapshot trigger versions under a single write lock
+                        let (work_items, debounce_ms) = {
+                            let mut state = state_clone.write().await;
+                            state.apply_workspace_index(
+                                index,
+                                imports,
+                                cross_file_entries,
+                                new_index_entries,
+                            );
+                            // Mark force republish for all open documents so they pick up
+                            // newly discovered backward edges from the dependency graph
+                            // and snapshot trigger versions while we hold the lock
+                            let items: Vec<(Url, Option<i32>, Option<u64>)> = state
+                                .documents
+                                .keys()
+                                .map(|uri| {
+                                    state.diagnostics_gate.mark_force_republish(uri);
+                                    let v = state.documents.get(uri).and_then(|d| d.version);
+                                    let r = state.documents.get(uri).map(|d| d.revision);
+                                    (uri.clone(), v, r)
+                                })
+                                .collect();
+                            let debounce = state.cross_file_config.revalidation_debounce_ms;
+                            (items, debounce)
+                        };
                         log::info!("[Background] Workspace index applied");
+
+                        // Revalidate all open documents to pick up auto-detected backward edges
+                        for (uri, trigger_version, trigger_revision) in work_items {
+                            let state_arc = state_clone.clone();
+                            let client = client_clone.clone();
+                            tokio::spawn(run_debounced_diagnostics(
+                                state_arc,
+                                client,
+                                uri,
+                                debounce_ms,
+                                trigger_version,
+                                trigger_revision,
+                            ));
+                        }
                     }
                     Err(e) => {
                         log::error!("Background workspace scan task failed: {}", e);
                     }
                 }
             });
+        } else {
+            // No workspace scan — mark complete immediately
+            let mut state = self.state.write().await;
+            state.workspace_scan_complete = true;
         }
 
         // Task B: Initialize PackageLibrary (await this - diagnostics need it)
@@ -1630,6 +1682,7 @@ impl LanguageServer for Backend {
                     state.cross_file_config.max_chain_depth,
                     &empty_base_exports,
                     false, // package prefetching doesn't need hoisting
+                    state.cross_file_config.backward_dependencies,
                 );
 
                 let mut pkgs = scope.inherited_packages;

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -2256,6 +2256,7 @@ mod integration_tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Requirement 12.2: Declared symbol from indexed child file should be available

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -8,6 +8,23 @@ use std::path::PathBuf;
 use tower_lsp::lsp_types::DiagnosticSeverity;
 
 
+/// How backward dependencies (parent files that source this file) are resolved
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BackwardDependencyMode {
+    /// Require explicit `@lsp-sourced-by` directives (current behavior).
+    /// Forward-created backward edges from the dependency graph are still used
+    /// when available, but diagnostics are not deferred for the workspace scan.
+    Explicit,
+    /// Automatically infer backward relationships from forward directives and
+    /// `source()` calls in other workspace files. Files without explicit backward
+    /// directives defer undefined variable diagnostics until the workspace scan
+    /// completes. Files with explicit backward directives use only those directives.
+    #[default]
+    Auto,
+    /// Suppress all undefined variable diagnostics.
+    Off,
+}
+
 /// Default call site assumption when not specified
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CallSiteDefault {
@@ -84,6 +101,10 @@ pub struct CrossFileConfig {
     /// regardless of position, since by the time any function executes the entire file
     /// has been sourced. Function-local variables remain positional.
     pub hoist_globals_in_functions: bool,
+    /// How backward dependencies are resolved.
+    /// Controls whether the LSP auto-detects parent files from forward source() calls
+    /// in other workspace files, or requires explicit @lsp-sourced-by directives.
+    pub backward_dependencies: BackwardDependencyMode,
 }
 
 impl Default for CrossFileConfig {
@@ -136,6 +157,7 @@ impl Default for CrossFileConfig {
             cache_existence_max_entries: 2000,
             cache_workspace_index_max_entries: 5000,
             hoist_globals_in_functions: true,
+            backward_dependencies: BackwardDependencyMode::Auto,
         }
     }
 }
@@ -148,6 +170,7 @@ impl CrossFileConfig {
             || self.max_backward_depth != other.max_backward_depth
             || self.max_forward_depth != other.max_forward_depth
             || self.hoist_globals_in_functions != other.hoist_globals_in_functions
+            || self.backward_dependencies != other.backward_dependencies
     }
 }
 
@@ -186,6 +209,8 @@ mod tests {
         );
         // Hoist globals in functions default
         assert!(config.hoist_globals_in_functions);
+        // Backward dependencies default
+        assert_eq!(config.backward_dependencies, BackwardDependencyMode::Auto);
     }
 
     #[test]
@@ -208,6 +233,11 @@ mod tests {
         // Reset and change hoist_globals_in_functions
         config2 = CrossFileConfig::default();
         config2.hoist_globals_in_functions = false;
+        assert!(config1.scope_settings_changed(&config2));
+
+        // Reset and change backward_dependencies
+        config2 = CrossFileConfig::default();
+        config2.backward_dependencies = BackwardDependencyMode::Explicit;
         assert!(config1.scope_settings_changed(&config2));
     }
 

--- a/crates/raven/src/cross_file/integration_tests.rs
+++ b/crates/raven/src/cross_file/integration_tests.rs
@@ -4812,6 +4812,7 @@ child_var <- 100
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -4837,6 +4838,7 @@ child_var <- 100
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -4861,6 +4863,7 @@ child_var <- 100
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -4989,6 +4992,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -5010,6 +5014,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -5128,6 +5133,7 @@ x <- 1
                 10,
                 &HashSet::new(),
                 false,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -5618,6 +5624,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -5693,6 +5700,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -5793,6 +5801,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -5868,6 +5877,7 @@ x <- 1
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -6041,6 +6051,7 @@ mod cross_directory_hoisting_tests {
             10,
             &base_exports,
             true,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         println!("  Scope symbols: {:?}", scope.symbols.keys().collect::<Vec<_>>());

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -2629,6 +2629,7 @@ proptest! {
         let scope_at_start = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_at_start.symbols.contains_key(parent_symbol.as_str()),
             "Parent symbol should be available at start due to backward directive");
@@ -2639,6 +2640,7 @@ proptest! {
         let scope_at_middle = scope_at_position_with_graph(
             &child_uri, 1, 10, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_at_middle.symbols.contains_key(parent_symbol.as_str()),
             "Parent symbol should still be available");
@@ -2651,6 +2653,7 @@ proptest! {
         let scope_at_end = scope_at_position_with_graph(
             &child_uri, 3, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_at_end.symbols.contains_key(parent_symbol.as_str()),
             "Parent symbol should be available at end");
@@ -2718,6 +2721,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope.symbols.contains_key(parent_symbol.as_str()),
             "Parent symbol from backward directive should be available at (0, 0)");
@@ -2809,6 +2813,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 10, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // symbol_before (defined on line 0) should be available (before call site)
@@ -2890,6 +2895,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 10, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Default is "end", so all parent symbols should be included
@@ -2970,6 +2976,7 @@ proptest! {
         let scope_with_end = scope_at_position_with_graph(
             &child_uri, 10, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_with_end.symbols.contains_key(parent_symbol.as_str()),
             "With assume_call_site=End, parent symbol should be available");
@@ -6958,6 +6965,7 @@ proptest! {
         let scope_before_rm = scope_at_position_with_graph(
             &parent_uri, 0, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_before_rm.symbols.contains_key(symbol.as_str()),
             "Symbol from sourced file should be in scope after source() but before rm()");
@@ -6966,6 +6974,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope after rm()");
@@ -6974,6 +6983,7 @@ proptest! {
         let scope_eof = scope_at_position_with_graph(
             &parent_uri, 10, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_eof.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope at end of file after rm()");
@@ -7028,6 +7038,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol_to_remove.as_str()),
             "Removed symbol should NOT be in scope after rm()");
@@ -7085,6 +7096,7 @@ proptest! {
         let scope_before_rm = scope_at_position_with_graph(
             &parent_uri, 0, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_before_rm.symbols.contains_key(symbol_a.as_str()),
             "symbol_a should be in scope before rm()");
@@ -7097,6 +7109,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol_a.as_str()),
             "symbol_a should NOT be in scope after rm()");
@@ -7148,6 +7161,7 @@ proptest! {
         let scope_before_remove = scope_at_position_with_graph(
             &parent_uri, 0, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_before_remove.symbols.contains_key(symbol.as_str()),
             "Symbol from sourced file should be in scope after source() but before remove()");
@@ -7156,6 +7170,7 @@ proptest! {
         let scope_after_remove = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_remove.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope after remove()");
@@ -7203,6 +7218,7 @@ proptest! {
         let scope_before_rm = scope_at_position_with_graph(
             &parent_uri, 0, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_before_rm.symbols.contains_key(symbol.as_str()),
             "Symbol from sourced file should be in scope after source() but before rm(list=...)");
@@ -7211,6 +7227,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope after rm(list=...)");
@@ -7269,6 +7286,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 40, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol_a.as_str()),
             "symbol_a should NOT be in scope after rm(list=c(...))");
@@ -7323,6 +7341,7 @@ proptest! {
         let scope_after_source = scope_at_position_with_graph(
             &parent_uri, 0, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_after_source.symbols.contains_key(symbol.as_str()),
             "Symbol should be in scope after source() but before rm()");
@@ -7331,6 +7350,7 @@ proptest! {
         let scope_after_rm = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_after_rm.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope after rm() but before redefinition");
@@ -7339,6 +7359,7 @@ proptest! {
         let scope_after_redef = scope_at_position_with_graph(
             &parent_uri, 2, 40, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_after_redef.symbols.contains_key(symbol.as_str()),
             "Symbol should be in scope after redefinition");
@@ -7387,6 +7408,7 @@ proptest! {
         let scope_in_child = scope_at_position_with_graph(
             &child_uri, 0, 40, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(scope_in_child.symbols.contains_key(symbol.as_str()),
             "Symbol should still be in scope in child file (child's own definition)");
@@ -7395,6 +7417,7 @@ proptest! {
         let scope_in_parent = scope_at_position_with_graph(
             &parent_uri, 1, 20, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         prop_assert!(!scope_in_parent.symbols.contains_key(symbol.as_str()),
             "Symbol should NOT be in scope in parent file after rm()");
@@ -9607,6 +9630,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the package from parent
@@ -9668,6 +9692,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Child should NOT have the package (loaded after source() call)
@@ -9733,6 +9758,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited both packages from parent
@@ -9806,6 +9832,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited pkg_before (loaded before source())
@@ -9880,6 +9907,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Child should NOT have the package (it's function-scoped in parent)
@@ -9956,6 +9984,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the package from grandparent (through parent)
@@ -10009,6 +10038,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, query_line, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the package at any position
@@ -10090,6 +10120,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Parent should have the package (loaded in child, available after source())
@@ -10165,6 +10196,7 @@ proptest! {
         let grandparent_scope = scope_at_position_with_graph(
             &grandparent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Grandparent should have the package (loaded in grandchild)
@@ -10179,6 +10211,7 @@ proptest! {
         let parent_scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Parent should also have the package (loaded in child)
@@ -10244,6 +10277,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Symbols from child SHOULD be available in parent
@@ -10320,6 +10354,7 @@ proptest! {
         let child_scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child SHOULD have parent's package (forward propagation works)
@@ -10333,6 +10368,7 @@ proptest! {
         let parent_scope = scope_at_position_with_graph(
             &parent_uri, 2, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Parent should have child's package (propagated from child via loaded_packages)
@@ -10385,6 +10421,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, query_line, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Packages from sourced files go into loaded_packages, not inherited_packages
@@ -10449,6 +10486,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Parent should have all of the child's packages (via loaded_packages)
@@ -19709,6 +19747,7 @@ proptest! {
                 10,
                 &HashSet::new(),
                 false,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             prop_assert!(
@@ -19733,6 +19772,7 @@ proptest! {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         prop_assert!(
@@ -19883,6 +19923,7 @@ proptest! {
                 10,
                 &HashSet::new(),
                 false,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             prop_assert!(
@@ -19908,6 +19949,7 @@ proptest! {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         prop_assert!(
@@ -20052,6 +20094,7 @@ proptest! {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         prop_assert!(
@@ -20078,6 +20121,7 @@ proptest! {
                 10,
                 &HashSet::new(),
                 false,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             prop_assert!(
@@ -20221,6 +20265,7 @@ proptest! {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         prop_assert!(
@@ -20243,6 +20288,7 @@ proptest! {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         prop_assert!(
@@ -22356,6 +22402,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the declared symbol from parent (Requirement 9.1)
@@ -22443,6 +22490,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Child should NOT have the declared symbol (declaration is after source() call)
@@ -22529,6 +22577,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the declared symbol even with local=TRUE (Requirement 9.4)
@@ -22620,6 +22669,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Declared symbol should be available (Requirement 9.4)
@@ -22741,6 +22791,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited the declared symbol from grandparent through parent (Requirement 9.3)
@@ -22824,6 +22875,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Both declared symbols should be available in child file
@@ -22916,6 +22968,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &child_uri, 0, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Symbol declared BEFORE source() should be available (Requirement 9.1)
@@ -23528,6 +23581,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Requirement 12.2: Declared symbol from indexed child should be available in parent's scope
@@ -23671,6 +23725,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Requirement 12.3: After opening, new declared symbol should be available
@@ -23796,6 +23851,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &parent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // All declared variables should be available
@@ -23931,6 +23987,7 @@ proptest! {
         let scope = scope_at_position_with_graph(
             &grandparent_uri, 1, 0, &get_artifacts, &get_metadata, &graph, Some(&workspace_root), 10, &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Declared symbol from child should be available in grandparent's scope

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -2300,6 +2300,7 @@ pub fn scope_at_position_with_graph<F, G>(
     max_depth: usize,
     base_exports: &HashSet<String>,
     hoist_globals: bool,
+    backward_dep_mode: super::config::BackwardDependencyMode,
 ) -> ScopeAtPosition
 where
     F: Fn(&Url) -> Option<ScopeArtifacts>,
@@ -2330,6 +2331,7 @@ where
         &empty_packages,
         base_exports,
         hoist_globals,
+        backward_dep_mode,
     )
 }
 
@@ -2361,6 +2363,7 @@ fn scope_at_position_with_graph_recursive<F, G>(
     inherited_packages: &HashSet<String>,
     base_exports: &HashSet<String>,
     hoist_globals: bool,
+    backward_dep_mode: super::config::BackwardDependencyMode,
 ) -> ScopeAtPosition
 where
     F: Fn(&Url) -> Option<ScopeArtifacts>,
@@ -2501,6 +2504,28 @@ where
         }
     }
 
+    // Filter backward edges based on the backward dependency mode.
+    //
+    // - Explicit: Only use backward-directive edges (edges created from
+    //   @lsp-sourced-by directives). Forward-created backward entries from
+    //   the workspace scan are ignored.
+    // - Auto: Use all backward edges, UNLESS the file has explicit backward
+    //   directives — then only use those (per-file opt-out).
+    // - Off: No filtering here (diagnostics are suppressed at a higher level).
+    match backward_dep_mode {
+        super::config::BackwardDependencyMode::Explicit => {
+            parent_edges.retain(|e| e.is_backward_directive);
+        }
+        super::config::BackwardDependencyMode::Auto => {
+            let file_has_backward_directives = get_metadata(uri)
+                .map_or(false, |m| !m.sourced_by.is_empty());
+            if file_has_backward_directives {
+                parent_edges.retain(|e| e.is_backward_directive);
+            }
+        }
+        super::config::BackwardDependencyMode::Off => {}
+    }
+
     for edge in parent_edges {
         // Determine if this is a local-scoped edge (local=TRUE or sys.source with non-global env)
         // For local-scoped edges, only declared symbols are inherited (Requirement 9.4)
@@ -2570,6 +2595,7 @@ where
             &empty_packages, // Parent collects its own inherited packages
             base_exports,
             hoist_globals,
+            backward_dep_mode,
         );
 
         // Merge parent symbols (they are available at the START of this file)
@@ -2859,6 +2885,7 @@ where
                             packages_for_child, // Pass inherited packages to child
                             base_exports,
                             hoist_globals,
+                            backward_dep_mode,
                         );
                         // Merge child symbols (local definitions take precedence)
                         for (name, symbol) in child_scope.symbols {
@@ -3282,6 +3309,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Should have: a (from parent line 0), x1 (from parent line 1), z (local)
@@ -3519,6 +3547,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(scope.symbols.contains_key("a"), "a should be available");
@@ -3595,6 +3624,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         assert!(
@@ -3713,6 +3743,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         assert!(
@@ -3854,6 +3885,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         assert!(
@@ -4021,6 +4053,7 @@ mod tests {
             2,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Should have depth_exceeded entry
@@ -4214,6 +4247,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(scope.symbols.contains_key("x"), "x should be available");
@@ -4302,6 +4336,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -6271,6 +6306,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_before_rm.symbols.contains_key("helper_func"),
@@ -6289,6 +6325,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("helper_func"),
@@ -6307,6 +6344,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_eof.symbols.contains_key("helper_func"),
@@ -6384,6 +6422,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_before_rm.symbols.contains_key("func_a"),
@@ -6410,6 +6449,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("func_a"),
@@ -6504,6 +6544,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -6593,6 +6634,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -6675,6 +6717,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_after_source.symbols.contains_key("helper_func"),
@@ -6693,6 +6736,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("helper_func"),
@@ -6711,6 +6755,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_after_redef.symbols.contains_key("helper_func"),
@@ -6795,6 +6840,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("func_a"),
@@ -6879,6 +6925,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_in_child.symbols.contains_key("helper_func"),
@@ -6897,6 +6944,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_in_parent.symbols.contains_key("helper_func"),
@@ -6998,6 +7046,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             scope_before_rm.symbols.contains_key("deep_func"),
@@ -7016,6 +7065,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("deep_func"),
@@ -7125,6 +7175,7 @@ mod tests {
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         assert!(
@@ -8817,6 +8868,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have inherited dplyr from parent
@@ -8894,6 +8946,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Child should NOT have dplyr (it was loaded after source() call)
@@ -8971,6 +9024,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child should have both packages
@@ -9053,6 +9107,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Child should NOT have dplyr (it's function-scoped in parent)
@@ -9136,6 +9191,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Parent should have dplyr (loaded in child, available after source())
@@ -9215,6 +9271,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Symbols from child SHOULD be available in parent
@@ -9332,6 +9389,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Grandparent should have stringr (loaded in grandchild, propagated via loaded_packages)
@@ -9354,6 +9412,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
         );
 
         // Parent should also have stringr (loaded in child, propagated via loaded_packages)
@@ -9434,6 +9493,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Child SHOULD have dplyr (propagated from parent)
@@ -9456,6 +9516,7 @@ x <- 1"#;
             10,
             &HashSet::new(),
             false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
         );
 
         // Parent should have ggplot2 (loaded in child, propagated via loaded_packages)
@@ -9983,6 +10044,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true, // hoisting ON
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10002,6 +10064,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 false, // hoisting OFF
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10046,6 +10109,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10161,6 +10225,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10242,6 +10307,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10373,6 +10439,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10495,6 +10562,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10610,6 +10678,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10731,6 +10800,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10834,6 +10904,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 false, // hoisting OFF
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -10948,6 +11019,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -11035,6 +11107,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -11131,6 +11204,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true, // hoisting ON, but query is at global level
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             // At global level, parent is queried at call site (line 0 col 0),
@@ -11255,6 +11329,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -11373,6 +11448,7 @@ y <- filter(df)"#;
                 10,
                 &base_exports,
                 true,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
             );
 
             assert!(
@@ -11383,6 +11459,535 @@ y <- filter(df)"#;
             assert!(
                 scope.symbols.contains_key("leaf_var"),
                 "Child function body should see 'leaf_var' from leaf via helper sourced after child. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+        }
+
+        // =======================================================================
+        // Auto backward dependency mode tests
+        // =======================================================================
+
+        /// Test: In Auto mode, child file sees parent symbols via forward-created
+        /// backward edge (no @lsp-sourced-by directive needed).
+        #[test]
+        fn test_auto_mode_child_sees_parent_symbols() {
+            use crate::cross_file::dependency::DependencyGraph;
+            use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+            let parent_uri = Url::parse("file:///project/parent.R").unwrap();
+            let child_uri = Url::parse("file:///project/helpers/child.R").unwrap();
+            let workspace_root = Url::parse("file:///project").unwrap();
+
+            // Parent defines config, then sources child at line 2
+            let parent_code = "library(jsonlite)\nconfig <- list()\nsource(\"helpers/child.R\")";
+            let parent_tree = parse_r(parent_code);
+            let parent_artifacts = compute_artifacts(&parent_uri, &parent_tree, parent_code);
+
+            // Child — no @lsp-sourced-by directive
+            let child_code = "child_result <- 42";
+            let child_tree = parse_r(child_code);
+            let child_artifacts = compute_artifacts(&child_uri, &child_tree, child_code);
+
+            // Build dependency graph from parent's forward source
+            let mut graph = DependencyGraph::new();
+            let parent_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "helpers/child.R".to_string(),
+                    line: 2,
+                    column: 0,
+                    is_directive: false,
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let child_meta = CrossFileMetadata::default(); // No sourced_by!
+            graph.update_file(&parent_uri, &parent_meta, Some(&workspace_root), |_| None);
+
+            let get_artifacts = |uri: &Url| -> Option<ScopeArtifacts> {
+                if uri == &parent_uri {
+                    Some(parent_artifacts.clone())
+                } else if uri == &child_uri {
+                    Some(child_artifacts.clone())
+                } else {
+                    None
+                }
+            };
+
+            let get_metadata = |uri: &Url| -> Option<CrossFileMetadata> {
+                if uri == &parent_uri {
+                    Some(parent_meta.clone())
+                } else if uri == &child_uri {
+                    Some(child_meta.clone())
+                } else {
+                    None
+                }
+            };
+
+            // In Auto mode, child should see parent's 'config' via auto-detected backward edge
+            let scope = scope_at_position_with_graph(
+                &child_uri,
+                0,
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                10,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+            );
+
+            assert!(
+                scope.symbols.contains_key("config"),
+                "In Auto mode, child should see 'config' from parent via auto-detected backward edge. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+        }
+
+        /// Test: In Auto mode, if a child has explicit @lsp-sourced-by, only those
+        /// declared parents are used (per-file opt-out of auto-inference).
+        #[test]
+        fn test_auto_mode_explicit_directive_opts_out() {
+            use crate::cross_file::dependency::DependencyGraph;
+            use crate::cross_file::types::{CrossFileMetadata, ForwardSource, BackwardDirective, CallSiteSpec};
+
+            let parent_a_uri = Url::parse("file:///project/parent_a.R").unwrap();
+            let parent_b_uri = Url::parse("file:///project/parent_b.R").unwrap();
+            let child_uri = Url::parse("file:///project/child.R").unwrap();
+            let workspace_root = Url::parse("file:///project").unwrap();
+
+            // Parent A defines var_a, sources child at line 1
+            let parent_a_code = "var_a <- 1\nsource(\"child.R\")";
+            let parent_a_tree = parse_r(parent_a_code);
+            let parent_a_artifacts = compute_artifacts(&parent_a_uri, &parent_a_tree, parent_a_code);
+
+            // Parent B defines var_b, sources child at line 1
+            let parent_b_code = "var_b <- 2\nsource(\"child.R\")";
+            let parent_b_tree = parse_r(parent_b_code);
+            let parent_b_artifacts = compute_artifacts(&parent_b_uri, &parent_b_tree, parent_b_code);
+
+            // Child explicitly declares only parent_a as its parent
+            let child_code = "# @lsp-sourced-by parent_a.R\nchild_var <- 3";
+            let child_tree = parse_r(child_code);
+            let child_artifacts = compute_artifacts(&child_uri, &child_tree, child_code);
+
+            // Build dependency graph from both parents' forward sources
+            let mut graph = DependencyGraph::new();
+            let parent_a_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "child.R".to_string(),
+                    line: 1,
+                    column: 0,
+                    is_directive: false,
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let parent_b_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "child.R".to_string(),
+                    line: 1,
+                    column: 0,
+                    is_directive: false,
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let child_meta = CrossFileMetadata {
+                sourced_by: vec![BackwardDirective {
+                    path: "parent_a.R".to_string(),
+                    call_site: CallSiteSpec::Default,
+                    directive_line: 0,
+                }],
+                ..Default::default()
+            };
+            graph.update_file(&parent_a_uri, &parent_a_meta, Some(&workspace_root), |_| None);
+            graph.update_file(&parent_b_uri, &parent_b_meta, Some(&workspace_root), |_| None);
+            graph.update_file(&child_uri, &child_meta, Some(&workspace_root), |_| None);
+
+            let get_artifacts = |uri: &Url| -> Option<ScopeArtifacts> {
+                if uri == &parent_a_uri {
+                    Some(parent_a_artifacts.clone())
+                } else if uri == &parent_b_uri {
+                    Some(parent_b_artifacts.clone())
+                } else if uri == &child_uri {
+                    Some(child_artifacts.clone())
+                } else {
+                    None
+                }
+            };
+
+            let get_metadata = |uri: &Url| -> Option<CrossFileMetadata> {
+                if uri == &parent_a_uri {
+                    Some(parent_a_meta.clone())
+                } else if uri == &parent_b_uri {
+                    Some(parent_b_meta.clone())
+                } else if uri == &child_uri {
+                    Some(child_meta.clone())
+                } else {
+                    None
+                }
+            };
+
+            // In Auto mode, child with explicit directive should only see parent_a
+            let scope = scope_at_position_with_graph(
+                &child_uri,
+                1, // line 1 (after directive)
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                10,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+            );
+
+            assert!(
+                scope.symbols.contains_key("var_a"),
+                "Child with explicit directive should see var_a from declared parent_a. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                !scope.symbols.contains_key("var_b"),
+                "Child with explicit directive should NOT see var_b from undeclared parent_b. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+        }
+
+        /// Test: In Auto mode, child does NOT see parent symbols when Explicit mode
+        /// is used (backward compatibility — the old behavior).
+        #[test]
+        fn test_explicit_mode_child_does_not_see_parent_without_directive() {
+            use crate::cross_file::dependency::DependencyGraph;
+            use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+            let parent_uri = Url::parse("file:///project/parent.R").unwrap();
+            let child_uri = Url::parse("file:///project/child.R").unwrap();
+            let workspace_root = Url::parse("file:///project").unwrap();
+
+            let parent_code = "parent_var <- 1\nsource(\"child.R\")";
+            let parent_tree = parse_r(parent_code);
+            let parent_artifacts = compute_artifacts(&parent_uri, &parent_tree, parent_code);
+
+            let child_code = "child_var <- 2";
+            let child_tree = parse_r(child_code);
+            let child_artifacts = compute_artifacts(&child_uri, &child_tree, child_code);
+
+            let mut graph = DependencyGraph::new();
+            let parent_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "child.R".to_string(),
+                    line: 1,
+                    column: 0,
+                    is_directive: false,
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let child_meta = CrossFileMetadata::default();
+            graph.update_file(&parent_uri, &parent_meta, Some(&workspace_root), |_| None);
+
+            let get_artifacts = |uri: &Url| -> Option<ScopeArtifacts> {
+                if uri == &parent_uri {
+                    Some(parent_artifacts.clone())
+                } else if uri == &child_uri {
+                    Some(child_artifacts.clone())
+                } else {
+                    None
+                }
+            };
+
+            let get_metadata = |uri: &Url| -> Option<CrossFileMetadata> {
+                if uri == &parent_uri {
+                    Some(parent_meta.clone())
+                } else if uri == &child_uri {
+                    Some(child_meta.clone())
+                } else {
+                    None
+                }
+            };
+
+            // In Explicit mode, child without directive should NOT see parent's symbols
+            let scope = scope_at_position_with_graph(
+                &child_uri,
+                0,
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                10,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Explicit,
+            );
+
+            assert!(
+                !scope.symbols.contains_key("parent_var"),
+                "In Explicit mode, child without directive should NOT see parent_var. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+        }
+
+        /// Test: Multi-level chain — main sources runner which sources
+        /// helpers/format.R. In Auto mode, format.R sees symbols from runner.R
+        /// (its direct parent) and the chain respects call-site position (only
+        /// symbols defined before the source() call).
+        #[test]
+        fn test_auto_mode_multi_level_chain() {
+            use crate::cross_file::dependency::DependencyGraph;
+            use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+            let main_uri = Url::parse("file:///project/main.R").unwrap();
+            let runner_uri = Url::parse("file:///project/runner.R").unwrap();
+            let format_uri = Url::parse("file:///project/helpers/format.R").unwrap();
+            let workspace_root = Url::parse("file:///project").unwrap();
+
+            // main.R sources setup.R, runner.R, output.R sequentially
+            let main_code = "source(\"setup.R\")\nsource(\"runner.R\")\nsource(\"output.R\")";
+            let main_tree = parse_r(main_code);
+            let main_artifacts = compute_artifacts(&main_uri, &main_tree, main_code);
+
+            // runner.R: defines conn and max_items, then sources format.R
+            let runner_code = "conn <- db_connect()\nmax_items <- 100\nsource(\"helpers/format.R\")\nformatted <- format_output";
+            let runner_tree = parse_r(runner_code);
+            let runner_artifacts = compute_artifacts(&runner_uri, &runner_tree, runner_code);
+
+            // helpers/format.R: defines render_opts and format_output
+            let format_code = "render_opts <- list(width = 80)\nformat_output <- NULL";
+            let format_tree = parse_r(format_code);
+            let format_artifacts = compute_artifacts(&format_uri, &format_tree, format_code);
+
+            // Build the full dependency graph
+            let mut graph = DependencyGraph::new();
+            let main_meta = CrossFileMetadata {
+                sources: vec![
+                    ForwardSource {
+                        path: "setup.R".to_string(),
+                        line: 0,
+                        column: 0,
+                        is_directive: false,
+                        local: false,
+                        chdir: false,
+                        is_sys_source: false,
+                        sys_source_global_env: true,
+                        ..Default::default()
+                    },
+                    ForwardSource {
+                        path: "runner.R".to_string(),
+                        line: 1,
+                        column: 0,
+                        is_directive: false,
+                        local: false,
+                        chdir: false,
+                        is_sys_source: false,
+                        sys_source_global_env: true,
+                        ..Default::default()
+                    },
+                    ForwardSource {
+                        path: "output.R".to_string(),
+                        line: 2,
+                        column: 0,
+                        is_directive: false,
+                        local: false,
+                        chdir: false,
+                        is_sys_source: false,
+                        sys_source_global_env: true,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            };
+            let runner_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "helpers/format.R".to_string(),
+                    line: 2,
+                    column: 0,
+                    is_directive: false,
+                    local: false,
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let format_meta = CrossFileMetadata::default(); // No sourced_by directive
+            graph.update_file(&main_uri, &main_meta, Some(&workspace_root), |_| None);
+            graph.update_file(&runner_uri, &runner_meta, Some(&workspace_root), |_| None);
+
+            let get_artifacts = |uri: &Url| -> Option<ScopeArtifacts> {
+                if uri == &main_uri {
+                    Some(main_artifacts.clone())
+                } else if uri == &runner_uri {
+                    Some(runner_artifacts.clone())
+                } else if uri == &format_uri {
+                    Some(format_artifacts.clone())
+                } else {
+                    None
+                }
+            };
+
+            let get_metadata = |uri: &Url| -> Option<CrossFileMetadata> {
+                if uri == &main_uri {
+                    Some(main_meta.clone())
+                } else if uri == &runner_uri {
+                    Some(runner_meta.clone())
+                } else if uri == &format_uri {
+                    Some(format_meta.clone())
+                } else {
+                    None
+                }
+            };
+
+            // helpers/format.R should see 'conn' and 'max_items' from runner.R
+            // (both defined before the source() call at line 2)
+            let scope = scope_at_position_with_graph(
+                &format_uri,
+                0,
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                20,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+            );
+
+            assert!(
+                scope.symbols.contains_key("conn"),
+                "format.R should see 'conn' from runner.R via auto backward edge. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                scope.symbols.contains_key("max_items"),
+                "format.R should see 'max_items' from runner.R. Got: {:?}",
+                scope.symbols.keys().collect::<Vec<_>>()
+            );
+
+            // runner.R after sourcing format.R should see its exports
+            let parent_scope = scope_at_position_with_graph(
+                &runner_uri,
+                3, // line 3, after source()
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                20,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+            );
+
+            assert!(
+                parent_scope.symbols.contains_key("format_output"),
+                "runner.R should see 'format_output' from sourced format.R. Got: {:?}",
+                parent_scope.symbols.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                parent_scope.symbols.contains_key("render_opts"),
+                "runner.R should see 'render_opts' from sourced format.R. Got: {:?}",
+                parent_scope.symbols.keys().collect::<Vec<_>>()
+            );
+        }
+
+        /// Test: Auto mode with local=TRUE — parent sources child with local=TRUE,
+        /// child should NOT see parent's globals through that edge.
+        #[test]
+        fn test_auto_mode_local_true_blocks_parent_scope() {
+            use crate::cross_file::dependency::DependencyGraph;
+            use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+            let parent_uri = Url::parse("file:///project/parent.R").unwrap();
+            let child_uri = Url::parse("file:///project/child.R").unwrap();
+            let workspace_root = Url::parse("file:///project").unwrap();
+
+            let parent_code = "parent_var <- 1\nsource(\"child.R\", local = TRUE)";
+            let parent_tree = parse_r(parent_code);
+            let parent_artifacts = compute_artifacts(&parent_uri, &parent_tree, parent_code);
+
+            let child_code = "child_var <- 2";
+            let child_tree = parse_r(child_code);
+            let child_artifacts = compute_artifacts(&child_uri, &child_tree, child_code);
+
+            let mut graph = DependencyGraph::new();
+            let parent_meta = CrossFileMetadata {
+                sources: vec![ForwardSource {
+                    path: "child.R".to_string(),
+                    line: 1,
+                    column: 0,
+                    is_directive: false,
+                    local: true, // local=TRUE
+                    chdir: false,
+                    is_sys_source: false,
+                    sys_source_global_env: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let child_meta = CrossFileMetadata::default();
+            graph.update_file(&parent_uri, &parent_meta, Some(&workspace_root), |_| None);
+
+            let get_artifacts = |uri: &Url| -> Option<ScopeArtifacts> {
+                if uri == &parent_uri {
+                    Some(parent_artifacts.clone())
+                } else if uri == &child_uri {
+                    Some(child_artifacts.clone())
+                } else {
+                    None
+                }
+            };
+
+            let get_metadata = |uri: &Url| -> Option<CrossFileMetadata> {
+                if uri == &parent_uri {
+                    Some(parent_meta.clone())
+                } else if uri == &child_uri {
+                    Some(child_meta.clone())
+                } else {
+                    None
+                }
+            };
+
+            // In Auto mode, local=TRUE should block parent scope from child
+            let scope = scope_at_position_with_graph(
+                &child_uri,
+                0,
+                0,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                10,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+            );
+
+            assert!(
+                !scope.symbols.contains_key("parent_var"),
+                "With local=TRUE, child should NOT see parent_var. Got: {:?}",
                 scope.symbols.keys().collect::<Vec<_>>()
             );
         }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -1954,6 +1954,7 @@ fn get_cross_file_scope(
         max_depth,
         &base_exports,
         state.cross_file_config.hoist_globals_in_functions,
+        state.cross_file_config.backward_dependencies,
     )
 }
 
@@ -3443,6 +3444,7 @@ fn collect_max_depth_diagnostics(state: &WorldState, uri: &Url, diagnostics: &mu
         max_depth,
         &empty_base_exports,
         false, // depth-exceeded check doesn't need hoisting
+        state.cross_file_config.backward_dependencies,
     );
 
     // Emit diagnostics for depth exceeded, filtering to only those in this file
@@ -6100,10 +6102,26 @@ pub(crate) fn collect_undefined_variables_position_aware(
     cancel: &DiagCancelToken,
 ) {
     use crate::content_provider::ContentProvider;
+    use crate::cross_file::config::BackwardDependencyMode;
     use crate::cross_file::path_resolve::{
         resolve_path_with_workspace_fallback, PathContext,
     };
     use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    // Backward dependency mode gating:
+    // - Off: suppress all undefined variable diagnostics
+    // - Auto + no backward directives + workspace scan incomplete: defer diagnostics
+    match state.cross_file_config.backward_dependencies {
+        BackwardDependencyMode::Off => return,
+        BackwardDependencyMode::Auto => {
+            if directive_meta.sourced_by.is_empty() && !state.workspace_scan_complete {
+                // Defer: the workspace scan hasn't finished building the dependency
+                // graph yet, so auto-inferred backward edges may not be available.
+                return;
+            }
+        }
+        BackwardDependencyMode::Explicit => {} // proceed normally
+    }
 
     let mut used: Vec<(String, Node)> = Vec::new();
 
@@ -6140,6 +6158,25 @@ pub(crate) fn collect_undefined_variables_position_aware(
     // Pre-compute workspace_imports as a HashSet for O(1) lookups
     let workspace_imports_set: std::collections::HashSet<&str> =
         workspace_imports.iter().map(|s| s.as_str()).collect();
+
+    // Local-first optimization: collect this file's own exported symbols and
+    // function scope tree for a fast check before expensive cross-file scope
+    // resolution. When hoisting is enabled and the usage is inside a function
+    // body, any symbol in exported_interface is guaranteed to be in scope
+    // (R late-binding semantics) — so we can skip graph traversal entirely.
+    let hoist_globals = state.cross_file_config.hoist_globals_in_functions;
+    let local_opt: Option<(std::collections::HashSet<String>, scope::FunctionScopeTree)> = {
+        let provider = state.content_provider();
+        use crate::content_provider::ContentProvider;
+        provider.get_artifacts(uri).map(|artifacts| {
+            let exports = artifacts
+                .exported_interface
+                .keys()
+                .map(|k| k.to_string())
+                .collect();
+            (exports, artifacts.function_scope_tree.clone())
+        })
+    };
 
     // Build a position-aware list of directly sourced files whose symbols are inherited.
     // This is a fallback path for cases where a sourced file has not been indexed into
@@ -6185,6 +6222,27 @@ pub(crate) fn collect_undefined_variables_position_aware(
         // Skip if builtin or workspace import
         if is_builtin(&name) || workspace_imports_set.contains(name.as_str()) {
             continue;
+        }
+
+        // Local-first fast path: if the symbol is in this file's exported_interface,
+        // hoisting is enabled, and the usage is inside a function body, we know it's
+        // in scope without graph traversal (R late-binding semantics). This avoids
+        // expensive cross-file scope computation for helper files where all symbols
+        // are defined locally. At the global level, position matters, so we can't skip.
+        if hoist_globals {
+            if let Some((ref exports, ref fn_tree)) = local_opt {
+                if exports.contains(name.as_str()) {
+                    let usage_col_byte = usage_node.start_position().column as u32;
+                    let line_text = get_line(usage_node.start_position().row);
+                    let usage_col_utf16 = byte_offset_to_utf16_column(line_text, usage_col_byte as usize);
+                    let inside_function = !fn_tree
+                        .query_point(scope::Position::new(usage_line, usage_col_utf16))
+                        .is_empty();
+                    if inside_function {
+                        continue;
+                    }
+                }
+            }
         }
 
         // Get or compute the scope for this position (cached)
@@ -20827,6 +20885,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -20884,6 +20943,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -20939,6 +20999,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -20993,6 +21054,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -21922,6 +21984,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -21984,6 +22047,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -22049,6 +22113,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -22134,6 +22199,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -22220,6 +22286,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -22341,6 +22408,7 @@ mod proptests {
             let tree = parse_r_code(&code);
 
             let mut state = WorldState::new(vec![]);
+            state.workspace_scan_complete = true;
             state.cross_file_config.undefined_variables_enabled = true;
             let uri = Url::parse("file:///test.R").unwrap();
             state.documents.insert(uri.clone(), Document::new(&code, None));
@@ -31186,7 +31254,9 @@ mod position_aware_tests {
     }
 
     fn create_test_state() -> WorldState {
-        WorldState::new(vec![])
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+        state
     }
 
     fn add_document(state: &mut WorldState, uri_str: &str, content: &str) -> Url {
@@ -31908,7 +31978,9 @@ mod function_parameter_tests {
     }
 
     fn create_test_state() -> WorldState {
-        WorldState::new(vec![])
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+        state
     }
 
     fn add_document(state: &mut WorldState, uri_str: &str, content: &str) -> Url {
@@ -32210,15 +32282,15 @@ my_func <- function(a = default_value) {
 
         let main_uri = Url::from_file_path(workspace_dir.path().join("main.R"))
             .expect("main uri should be valid");
-        let child_uri = Url::from_file_path(workspace_dir.path().join("characteristics.R"))
+        let child_uri = Url::from_file_path(workspace_dir.path().join("helpers.R"))
             .expect("child uri should be valid");
 
-        let child_code = "tbl_user_demographics <- data.frame(x = 1)\n";
+        let child_code = "summary_table <- data.frame(x = 1)\n";
         state
             .workspace_index
             .insert(child_uri.clone(), Document::new(child_code, None));
 
-        let main_code = "source(\"characteristics.R\")\ntbl_user_demographics\n";
+        let main_code = "source(\"helpers.R\")\nsummary_table\n";
         state
             .documents
             .insert(main_uri.clone(), Document::new(main_code, None));
@@ -32250,7 +32322,7 @@ my_func <- function(a = default_value) {
         assert!(
             !diagnostics
                 .iter()
-                .any(|d| d.message == "Undefined variable: tbl_user_demographics"),
+                .any(|d| d.message == "Undefined variable: summary_table"),
             "Symbol exported by sourced file should not be flagged as undefined: {:?}",
             diagnostics
                 .iter()
@@ -32268,16 +32340,16 @@ my_func <- function(a = default_value) {
         state.workspace_folders.push(workspace_url);
 
         let main_path = workspace_dir.path().join("main.R");
-        let child_path = workspace_dir.path().join("characteristics.R");
+        let child_path = workspace_dir.path().join("helpers.R");
         let main_uri = Url::from_file_path(&main_path).expect("main uri should be valid");
 
         std::fs::write(
             &child_path,
-            "tbl_user_demographics <- data.frame(x = 1)\n",
+            "summary_table <- data.frame(x = 1)\n",
         )
         .expect("child file should be written");
 
-        let main_code = "source(\"characteristics.R\")\ntbl_user_demographics\n";
+        let main_code = "source(\"helpers.R\")\nsummary_table\n";
         state
             .documents
             .insert(main_uri.clone(), Document::new(main_code, None));
@@ -32303,7 +32375,7 @@ my_func <- function(a = default_value) {
         assert!(
             !diagnostics
                 .iter()
-                .any(|d| d.message == "Undefined variable: tbl_user_demographics"),
+                .any(|d| d.message == "Undefined variable: summary_table"),
             "Symbol exported by sourced on-disk file should not be flagged as undefined: {:?}",
             diagnostics
                 .iter()

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -780,6 +780,7 @@ fn get_scope(
         max_depth,
         &base_exports,
         state.cross_file_config.hoist_globals_in_functions,
+        state.cross_file_config.backward_dependencies,
     )
 }
 

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -547,6 +547,11 @@ pub struct WorldState {
     pub cross_file_activity: CrossFileActivityState,
     pub cross_file_workspace_index: CrossFileWorkspaceIndex,
     pub package_library_ready: bool,
+    /// Whether the background workspace scan has completed and the dependency
+    /// graph has been populated from workspace entries. In `Auto` backward
+    /// dependency mode, undefined variable diagnostics are deferred for files
+    /// without explicit backward directives until this flag is true.
+    pub workspace_scan_complete: bool,
 }
 
 impl WorldState {
@@ -641,6 +646,7 @@ impl WorldState {
             cross_file_activity: CrossFileActivityState::new(),
             cross_file_workspace_index: CrossFileWorkspaceIndex::new(),
             package_library_ready: false,
+            workspace_scan_complete: false,
         }
     }
 
@@ -778,6 +784,50 @@ impl WorldState {
             self.workspace_imports.len(),
             self.cross_file_workspace_index.uris().len(),
             self.workspace_index_new.len()
+        );
+
+        // Build the dependency graph from all workspace entries so that
+        // forward-created backward edges are available for auto-detect mode.
+        self.build_dependency_graph_from_workspace();
+        self.workspace_scan_complete = true;
+        log::info!("[Background] Dependency graph built from workspace entries, workspace_scan_complete = true");
+    }
+
+    /// Build the dependency graph from all entries in the workspace index.
+    ///
+    /// For each file, calls `update_file` on the dependency graph using its
+    /// metadata. This creates forward edges (parent→child) and their
+    /// corresponding backward entries (child→parent) for all workspace files,
+    /// enabling auto-detection of backward dependencies.
+    fn build_dependency_graph_from_workspace(&mut self) {
+        let workspace_root = self.workspace_folders.first().cloned();
+
+        // Collect URIs and metadata to avoid borrow conflicts with self.
+        // Build the content map directly (no intermediate Vec with cloned content).
+        let mut entries: Vec<(Url, crate::cross_file::CrossFileMetadata)> = Vec::new();
+        let mut content_map: std::collections::HashMap<Url, String> =
+            std::collections::HashMap::new();
+
+        for (uri, entry) in self.workspace_index_new.iter() {
+            entries.push((uri.clone(), entry.metadata.clone()));
+            content_map.insert(uri, entry.contents.to_string());
+        }
+
+        for (uri, meta) in &entries {
+            let get_content = |parent_uri: &Url| -> Option<String> {
+                content_map.get(parent_uri).cloned()
+            };
+            let _result = self.cross_file_graph.update_file(
+                uri,
+                meta,
+                workspace_root.as_ref(),
+                get_content,
+            );
+        }
+
+        log::info!(
+            "Built dependency graph from {} workspace files",
+            entries.len()
         );
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ All settings can be configured via VS Code settings or LSP initialization option
 | `raven.crossFile.revalidationDebounceMs` | 200 | Debounce delay for dependent file diagnostics (ms) |
 | `raven.crossFile.editedFileDebounceMs` | 50 | Debounce delay for the actively-edited file (ms) |
 | `raven.crossFile.hoistGlobalsInFunctions` | true | Hoist global definitions inside function bodies (see [Global Symbol Hoisting](cross-file.md#global-symbol-hoisting)) |
+| `raven.crossFile.backwardDependencies` | "auto" | How backward dependencies are resolved: `"auto"` infers from workspace scan, `"explicit"` requires `@lsp-sourced-by` directives, `"off"` suppresses undefined variable diagnostics (see [Backward Dependency Modes](cross-file.md#backward-dependency-modes)) |
 
 ## Diagnostic Severity Settings
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -340,11 +340,11 @@ The LSP automatically infers backward relationships by scanning the workspace fo
 3. After the scan, all open files are revalidated with the complete dependency graph.
 4. As files are added or modified, the dependency graph is updated in real time.
 
-**Rationale:** Most R projects do not use `@lsp-sourced-by` directives. Auto mode provides cross-file intelligence out of the box for any workspace where files are connected via `source()` calls. The startup deferral ensures diagnostics are accurate rather than prematurely flagging symbols that come from parent files.
+**Rationale:** `@lsp-sourced-by` directives are Raven-specific — without auto mode, you'd have to annotate your entire codebase before cross-file diagnostics become useful. Auto mode provides cross-file intelligence out of the box for any workspace where files are connected via `source()` calls. The startup deferral ensures diagnostics are accurate rather than prematurely flagging symbols that come from parent files.
 
 **Per-file opt-out:** If a file has explicit `@lsp-sourced-by` directives, only those declared parents are used — auto-inference is disabled for that file. This gives you full control when needed, and means adding a directive is never additive — it replaces auto-detection entirely for that file.
 
-**Performance:** Helper files where all symbols are defined locally do not incur graph traversal costs — a local-first optimization skips cross-file scope resolution when the symbol is found in the file's own definitions. This means the majority of files in a workspace (self-contained utilities, function libraries) have zero overhead from the backward dependency graph.
+**Performance:** Helper files where all symbols are defined locally do not incur graph traversal costs — a local-first optimization skips cross-file scope resolution when the symbol is found in the file's own definitions. This means self-contained files — utilities, function libraries, or any file where all referenced symbols are defined locally — have zero overhead from the backward dependency graph.
 
 **`local=TRUE` is respected:** If a parent sources a child with `source("child.R", local = TRUE)`, the child does not inherit the parent's global scope through that edge. This matches R's runtime behavior where `local = TRUE` evaluates the sourced file in a local environment.
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -323,3 +323,53 @@ source("b.R")  # ERROR: Circular dependency if b.R sources a.R
 # b.R
 source("a.R")  # Creates cycle back to a.R
 ```
+
+## Backward Dependency Modes
+
+The `raven.crossFile.backwardDependencies` setting controls how the LSP discovers which files source the current file. This affects undefined variable diagnostics, completions, hover, and go-to-definition.
+
+**Why this matters:** In multi-file R projects, a child file (e.g., `helpers.R`) often references symbols defined in its parent (e.g., `main.R`). For Raven to resolve these symbols, it needs to know the backward relationship — that `helpers.R` is sourced by `main.R`. This setting controls how those relationships are discovered.
+
+### `"auto"` (default)
+
+The LSP automatically infers backward relationships by scanning the workspace for files that contain `source()` calls or `@lsp-source` directives pointing to the current file. No `@lsp-sourced-by` directives are needed.
+
+**How it works:**
+1. On startup, Raven scans the workspace and builds a dependency graph from all `source()` calls and forward directives.
+2. Undefined variable diagnostics are deferred for files without explicit `@lsp-sourced-by` directives until the workspace scan completes. This prevents false positives during startup — symbols from parent files are not yet discoverable until the graph is built.
+3. After the scan, all open files are revalidated with the complete dependency graph.
+4. As files are added or modified, the dependency graph is updated in real time.
+
+**Rationale:** Most R projects do not use `@lsp-sourced-by` directives. Auto mode provides cross-file intelligence out of the box for any workspace where files are connected via `source()` calls. The startup deferral ensures diagnostics are accurate rather than prematurely flagging symbols that come from parent files.
+
+**Per-file opt-out:** If a file has explicit `@lsp-sourced-by` directives, only those declared parents are used — auto-inference is disabled for that file. This gives you full control when needed, and means adding a directive is never additive — it replaces auto-detection entirely for that file.
+
+**Performance:** Helper files where all symbols are defined locally do not incur graph traversal costs — a local-first optimization skips cross-file scope resolution when the symbol is found in the file's own definitions. This means the majority of files in a workspace (self-contained utilities, function libraries) have zero overhead from the backward dependency graph.
+
+**`local=TRUE` is respected:** If a parent sources a child with `source("child.R", local = TRUE)`, the child does not inherit the parent's global scope through that edge. This matches R's runtime behavior where `local = TRUE` evaluates the sourced file in a local environment.
+
+**Example:**
+```r
+# main.R
+source("helpers.R")
+result <- helper_func(42)
+```
+
+```r
+# helpers.R (no @lsp-sourced-by needed in auto mode)
+helper_func <- function(x) {
+  parent_var + x  # parent_var from main.R is in scope
+}
+```
+
+### `"explicit"`
+
+The LSP only uses backward relationships explicitly declared via `@lsp-sourced-by` directives. Forward-created backward edges from workspace scanning are not used for scope resolution.
+
+**Rationale:** Use this mode if you prefer full manual control over cross-file relationships, or if your workspace has complex sourcing patterns where automatic inference produces unwanted results (e.g., a file is sourced by multiple parents with conflicting scopes). Diagnostics are not deferred for the workspace scan.
+
+### `"off"`
+
+Suppresses all undefined variable diagnostics. Other cross-file features (completions, hover, go-to-definition) still work based on whatever dependency edges are available.
+
+**Rationale:** Use this when your project uses patterns that Raven's static analysis cannot resolve (e.g., heavy use of `eval`, `do.call`, or metaprogramming) and the resulting false positives are not helpful.


### PR DESCRIPTION
## Summary

- Add `raven.crossFile.backwardDependencies` setting with three modes: `"auto"` (new default), `"explicit"` (original behavior), and `"off"` (suppress diagnostics)
- In auto mode, backward relationships are inferred from workspace-wide `source()` calls — no `@lsp-sourced-by` directives needed
- Diagnostics deferred until workspace scan completes to prevent false positives during startup
- Per-file opt-out: adding `@lsp-sourced-by` replaces auto-inference for that file
- Local-first optimization skips graph traversal for locally-defined symbols
- Fix: post-scan revalidation now correctly snapshots trigger versions so deferred diagnostics are delivered
- Fix: `build_dependency_graph_from_workspace` no longer double-clones file content

## Test plan

- [x] All 2818 unit tests pass
- [x] All 103 integration tests pass
- [x] All 60 doc tests pass
- [x] 5 new auto-mode scope tests (child sees parent, explicit opt-out, explicit mode blocks, multi-level chain, local=TRUE)
- [x] Manual integration test against real multi-file R workspace confirms completions work end-to-end
- [ ] Manual VS Code testing with workspace scan timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic backward dependency detection: the extension now automatically discovers cross-file dependencies without explicit configuration.
  * Three configurable modes for backward dependency resolution (auto, explicit, off) provide flexibility in managing dependencies.

* **Configuration**
  * New `raven.crossFile.backwardDependencies` setting allows users to choose between automatic detection, explicit directives, or disabling backward dependency resolution.

* **Documentation**
  * Updated README and new documentation explain automatic cross-file discovery and backward dependency modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->