### PR TITLE
Fix missing BackwardDependencyMode argument in performance budget tests

### DIFF
--- a/crates/raven/tests/performance_budgets.rs
+++ b/crates/raven/tests/performance_budgets.rs
@@ -431,6 +431,7 @@ fn budget_scope_resolution_50_file_workspace() {
         20,
         &base_exports,
         true,
+        raven::cross_file::config::BackwardDependencyMode::Explicit,
     );
 
     let elapsed = median_of_3(|| {
@@ -445,6 +446,7 @@ fn budget_scope_resolution_50_file_workspace() {
             20,
             &base_exports,
             true,
+            raven::cross_file::config::BackwardDependencyMode::Explicit,
         );
     });
 


### PR DESCRIPTION
## Summary
- Add the 11th parameter (`BackwardDependencyMode::Explicit`) to both `scope_at_position_with_graph` call sites in `performance_budgets.rs`, fixing compilation after the function signature change.

## Test plan
- [x] `cargo check --release -p raven --test performance_budgets --features test-support` compiles
- [x] `cargo test --release -p raven --test performance_budgets --features test-support` — all 16 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
