### PR TITLE
fix(perf): optimize interval tree query pruning

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -483,7 +483,8 @@ impl FunctionScopeTree {
         // Since the tree is sorted by start position, if the current node's start is greater
         // than the query position, all nodes in the right subtree also have start > pos,
         // so none of them can contain the position.
-        // We also check max_end to prune subtrees that end before the query position.
+        // We also skip the right subtree when its max_end is before the query position,
+        // since no interval in it can contain pos.
         if let Some(ref right) = node.right {
             if node.interval.start <= pos && right.max_end >= pos {
                 Self::query_point_recursive(right, pos, results);

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -483,8 +483,9 @@ impl FunctionScopeTree {
         // Since the tree is sorted by start position, if the current node's start is greater
         // than the query position, all nodes in the right subtree also have start > pos,
         // so none of them can contain the position.
+        // We also check max_end to prune subtrees that end before the query position.
         if let Some(ref right) = node.right {
-            if node.interval.start <= pos {
+            if node.interval.start <= pos && right.max_end >= pos {
                 Self::query_point_recursive(right, pos, results);
             }
         }


### PR DESCRIPTION
## Summary

- Add `right.max_end >= pos` check to `query_point_recursive` in `FunctionScopeTree` to prune right subtrees where no interval can contain the query position
- Restores O(log n + k) query complexity for trees with many small non-overlapping intervals before the query point

## Test plan

- [x] All 2,828 unit tests + 59 doc tests pass
- [x] Interval tree-specific tests pass
- [x] CodeRabbit review: no critical or high-priority issues
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved correctness of scope resolution logic at interval boundaries by enhancing traversal conditions, preventing unnecessary subtree processing in edge cases.

* **Documentation**
  * Added clarifying comments to pruning logic for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->