### PR TITLE
Install the packaged extension into supported editors during setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,18 +29,35 @@ npm run compile
 echo "Packaging extension..."
 npm run package
 
-echo "Installing extension to VS Code..."
 VERSION=$(node -p "require('./package.json').version")
 VSIX_FILE="raven-${VERSION}.vsix"
-if [ -f "$VSIX_FILE" ]; then
-    code --install-extension "$VSIX_FILE"
-    echo "✓ Extension installed: $VSIX_FILE"
-else
+if [ ! -f "$VSIX_FILE" ]; then
     echo "✗ No .vsix file found"
+    exit 1
+fi
+
+echo "Installing extension to editors..."
+EDITORS=("code" "code-insiders" "codium" "kiro" "antigravity" "cursor" "windsurf")
+INSTALLED=0
+
+for editor in "${EDITORS[@]}"; do
+    if command -v "$editor" &> /dev/null; then
+        echo -n "  $editor: "
+        if "$editor" --install-extension "$VSIX_FILE" --force &> /dev/null; then
+            echo "✓"
+            INSTALLED=$((INSTALLED + 1))
+        else
+            echo "failed"
+        fi
+    fi
+done
+
+if [ $INSTALLED -eq 0 ]; then
+    echo "✗ Extension was not installed to any editor"
     exit 1
 fi
 
 echo ""
 echo "✅ Setup complete!"
 echo "   - Binary: ~/bin/raven"
-echo "   - Extension: $VSIX_FILE"
+echo "   - Extension: $VSIX_FILE ($INSTALLED editor(s))"


### PR DESCRIPTION
## Summary
- update `scripts/setup.sh` to install the generated VSIX into multiple supported editor CLIs, not just VS Code
- fail setup when the VSIX is missing or when installation does not succeed in any detected editor
- report how many editors received the extension in the final setup output

## Testing
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup script now installs the extension to multiple code editors available on your system instead of VS Code only. Installation summary now displays the total number of editors where the extension was successfully installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->