### PR TITLE
Suppress R hover information for Stan and JAGS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Raven provides lightweight language support for JAGS (`.jags`, `.bugs`) and Stan
 
 - **Syntax highlighting** - Keyword, type, distribution, and comment highlighting
 - **Completions** - Language-specific keywords, types, distributions, and file-local symbols
-- **Hover** - Signature information for built-in functions and distributions
 - **Go-to-definition** - Jump to variable definitions within the file
 - **Find references** - Locate all usages of a variable within the file
 - **Document outline** - Navigate model structure with blocks, decorative headings, and loops (see [Document Outline](docs/document-outline.md#jags-and-stan-model-structure))

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -10303,6 +10303,9 @@ async fn get_help_cached(
 /// Returns `Some(Hover)` when information (definition, signature, package attribution, or help text) is available for the identifier at `position`, `None` when no useful hover content can be produced.
 pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<Hover> {
     let doc = state.get_document(uri)?;
+    if doc.file_type != FileType::R {
+        return None;
+    }
     let tree = doc.tree.as_ref()?;
     let text = doc.text();
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -24,7 +24,6 @@ A language server for R, JAGS, and Stan with cross-file awareness.
 - **Document symbols** — Hierarchical outline with structural blocks (e.g. `model`, `data`, `parameters`), loops, and comment sections
 - **Go-to-definition** — Navigate to variable and function definitions within a file
 - **Find references** — Locate all usages of a symbol within a file and across open documents
-- **Hover** — Symbol information including definition location
 
 ## Settings
 


### PR DESCRIPTION
Stan/JAGS identifiers like `real` were triggering R help lookups,
showing misleading documentation. Add an early return in the hover
handler for non-R file types, matching the existing pattern used by
diagnostics. Remove hover from the JAGS/Stan feature lists in both
READMEs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hover functionality now correctly restricts to R file types only, gracefully handling non-R documents.

* **Documentation**
  * Updated core and VS Code README files to remove references to hover features for JAGS/Stan support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->