### PR TITLE
fix: log warning instead of unwrap on spawn_blocking join failure in debounce_loop

### DIFF
--- a/crates/raven/src/libpath_watcher.rs
+++ b/crates/raven/src/libpath_watcher.rs
@@ -471,7 +471,7 @@ async fn debounce_loop(
                 };
                 tokio::time::sleep(debounce).await;
                 let rx_arc = Arc::clone(&raw_rx);
-                let drained_paths: Vec<PathBuf> = tokio::task::spawn_blocking(move || {
+                let drained_paths: Vec<PathBuf> = match tokio::task::spawn_blocking(move || {
                     let mut paths = Vec::new();
                     let guard = rx_arc.lock().unwrap();
                     while let Ok(res) = guard.try_recv() {
@@ -485,7 +485,13 @@ async fn debounce_loop(
                     paths
                 })
                 .await
-                .unwrap_or_default();
+                {
+                    Ok(paths) => paths,
+                    Err(e) => {
+                        log::warn!("LibpathWatcher: drain task failed: {e}");
+                        Vec::new()
+                    }
+                };
                 event_paths.extend(drained_paths);
 
                 // Diff and derive touched under a single snapshot-lock acquisition.


### PR DESCRIPTION
Replace `.unwrap_or_default()` on the `spawn_blocking` join handle with an
explicit match so a panicking drain task produces a visible warning instead of
silently dropping the error.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
Closes #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging for internal event tracking to better diagnose processing failures when they occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->