### PR TITLE
fix: remove unused context parameter from promptWordSeparators

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -212,10 +212,10 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Prompt for word separators configuration
-    promptWordSeparators(context);
+    promptWordSeparators();
 }
 
-async function promptWordSeparators(context: vscode.ExtensionContext) {
+async function promptWordSeparators() {
     const config = vscode.workspace.getConfiguration('raven');
     const setting = config.get<string>('editor.dotInWordSeparators', 'ask');
 


### PR DESCRIPTION
## Summary

Remove the unused `context: vscode.ExtensionContext` parameter from `promptWordSeparators()` and its call site in `activate()`.

The function only uses `vscode.workspace.getConfiguration()` and `vscode.window` APIs — the `context` parameter was never referenced in the function body, triggering TypeScript warning TS6133.

## Changes

- **`editors/vscode/src/extension.ts`**: Removed `context` parameter from `promptWordSeparators` signature and the argument from the call site in `activate()`.

## Testing

- `tsc --noEmit` passes cleanly with no errors.

Closes #115
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
