### PR TITLE
fix: shrink workspace index cap back to user_cap when safe (#128)

### DIFF
--- a/crates/raven/src/cross_file/workspace_index.rs
+++ b/crates/raven/src/cross_file/workspace_index.rs
@@ -5,6 +5,7 @@
 //
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -48,6 +49,14 @@ pub struct CrossFileWorkspaceIndex {
     /// pressure. Lock order: acquire `inner` before `pinned` when both
     /// are needed.
     pinned: RwLock<HashSet<Url>>,
+    /// Original user-configured capacity.
+    ///
+    /// `inner.cap()` may temporarily exceed this when an all-pinned
+    /// overflow forces growth (see `pin_aware_push`). `set_pinned_uris`
+    /// uses this value to opportunistically shrink the cache back when
+    /// `len() <= user_cap` so the runtime cap doesn't ratchet upward
+    /// across repeated overflow/unpin cycles (issue #128).
+    user_cap: usize,
 }
 
 impl std::fmt::Debug for CrossFileWorkspaceIndex {
@@ -69,11 +78,12 @@ impl CrossFileWorkspaceIndex {
     }
 
     pub fn with_capacity(cap: usize) -> Self {
-        let cap = non_zero_or(cap, DEFAULT_WORKSPACE_INDEX_CAPACITY);
+        let cap_nz = non_zero_or(cap, DEFAULT_WORKSPACE_INDEX_CAPACITY);
         Self {
-            inner: RwLock::new(LruCache::new(cap)),
+            inner: RwLock::new(LruCache::new(cap_nz)),
             version: AtomicU64::new(0),
             pinned: RwLock::new(HashSet::new()),
+            user_cap: cap_nz.get(),
         }
     }
 
@@ -83,9 +93,28 @@ impl CrossFileWorkspaceIndex {
     /// pinned, the cache is allowed to grow past its configured capacity.
     /// Explicit `invalidate` and `update_from_disk` still work for pinned
     /// URIs (the open-document gate in `update_from_disk` is unchanged).
+    ///
+    /// Also opportunistically shrinks the runtime cap back to `user_cap`
+    /// when `len() <= user_cap`, so repeated all-pinned overflow events
+    /// followed by safe unpins don't ratchet the cap upward indefinitely
+    /// (issue #128). The shrink only fires when it can't itself force
+    /// eviction.
+    ///
+    /// Lock order: acquires `inner.write()` before `pinned.write()`,
+    /// matching the order established by `pin_aware_push` (which holds
+    /// `inner.write()` and then takes `pinned.read()`).
     pub fn set_pinned_uris(&self, uris: HashSet<Url>) {
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
         if let Ok(mut pinned) = self.pinned.write() {
             *pinned = uris;
+        }
+
+        if let Some(user_cap_nz) = NonZeroUsize::new(self.user_cap) {
+            if guard.cap().get() > self.user_cap && guard.len() <= self.user_cap {
+                guard.resize(user_cap_nz);
+            }
         }
     }
 
@@ -207,6 +236,18 @@ impl CrossFileWorkspaceIndex {
             .ok()
             .map(|g| g.iter().map(|(k, _)| k.clone()).collect())
             .unwrap_or_default()
+    }
+
+    /// Get the current cache capacity.
+    ///
+    /// May exceed the user-configured capacity after an all-pinned
+    /// overflow has forced the underlying LRU to grow.
+    pub fn cap(&self) -> usize {
+        self.inner
+            .read()
+            .ok()
+            .map(|g| g.cap().get())
+            .unwrap_or(0)
     }
 
     /// Resize the cache capacity. If shrinking, LRU entries are evicted.
@@ -426,6 +467,61 @@ mod tests {
         assert!(index.contains(&uri1));
         assert!(index.contains(&uri2));
         assert!(index.contains(&uri3));
+        assert_eq!(index.uris().len(), 3);
+    }
+
+    #[test]
+    fn test_cap_shrinks_back_to_user_cap_when_safe() {
+        // Issue #128: after an all-pinned overflow grew the cap, calling
+        // `set_pinned_uris` while `uris().len() <= user_cap` should
+        // restore the cap to its configured value.
+        let index = CrossFileWorkspaceIndex::with_capacity(2);
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+        let uri3 = test_uri("c.R");
+
+        index.insert(uri1.clone(), test_entry(1));
+        index.insert(uri2.clone(), test_entry(2));
+
+        let mut pinned = HashSet::new();
+        pinned.insert(uri1.clone());
+        pinned.insert(uri2.clone());
+        index.set_pinned_uris(pinned);
+        index.insert(uri3.clone(), test_entry(3));
+        assert_eq!(index.cap(), 3, "all-pinned overflow grew the cap");
+        assert_eq!(index.uris().len(), 3);
+
+        // Drop one entry so len falls back to user_cap.
+        index.invalidate(&uri3);
+        assert_eq!(index.uris().len(), 2);
+
+        // Clearing the pin set should now opportunistically shrink cap.
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(index.cap(), 2, "cap should shrink back to user_cap");
+    }
+
+    #[test]
+    fn test_cap_does_not_shrink_when_len_still_exceeds_user_cap() {
+        // Issue #128: shrinking must never force eviction.
+        let index = CrossFileWorkspaceIndex::with_capacity(2);
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+        let uri3 = test_uri("c.R");
+
+        index.insert(uri1.clone(), test_entry(1));
+        index.insert(uri2.clone(), test_entry(2));
+
+        let mut pinned = HashSet::new();
+        pinned.insert(uri1.clone());
+        pinned.insert(uri2.clone());
+        index.set_pinned_uris(pinned);
+        index.insert(uri3.clone(), test_entry(3));
+        assert_eq!(index.cap(), 3);
+        assert_eq!(index.uris().len(), 3);
+
+        // Clear pins; len(3) > user_cap(2) so cap must remain 3.
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(index.cap(), 3, "cap must not shrink when len > user_cap");
         assert_eq!(index.uris().len(), 3);
     }
 

--- a/crates/raven/src/cross_file/workspace_index.rs
+++ b/crates/raven/src/cross_file/workspace_index.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use lru::LruCache;
@@ -49,14 +49,20 @@ pub struct CrossFileWorkspaceIndex {
     /// pressure. Lock order: acquire `inner` before `pinned` when both
     /// are needed.
     pinned: RwLock<HashSet<Url>>,
-    /// Original user-configured capacity.
+    /// User-configured baseline capacity.
     ///
     /// `inner.cap()` may temporarily exceed this when an all-pinned
     /// overflow forces growth (see `pin_aware_push`). `set_pinned_uris`
     /// uses this value to opportunistically shrink the cache back when
     /// `len() <= user_cap` so the runtime cap doesn't ratchet upward
     /// across repeated overflow/unpin cycles (issue #128).
-    user_cap: usize,
+    ///
+    /// Mutable so `resize()` can keep it in sync with the new runtime
+    /// cap; otherwise a post-resize shrink-back would silently revert
+    /// to the constructor value rather than the configured one. Stored
+    /// as `AtomicUsize` and updated under `inner.write()` so writers
+    /// see a consistent (`inner.cap()`, `user_cap`) pair.
+    user_cap: AtomicUsize,
 }
 
 impl std::fmt::Debug for CrossFileWorkspaceIndex {
@@ -83,7 +89,7 @@ impl CrossFileWorkspaceIndex {
             inner: RwLock::new(LruCache::new(cap_nz)),
             version: AtomicU64::new(0),
             pinned: RwLock::new(HashSet::new()),
-            user_cap: cap_nz.get(),
+            user_cap: AtomicUsize::new(cap_nz.get()),
         }
     }
 
@@ -111,8 +117,9 @@ impl CrossFileWorkspaceIndex {
             *pinned = uris;
         }
 
-        if let Some(user_cap_nz) = NonZeroUsize::new(self.user_cap) {
-            if guard.cap().get() > self.user_cap && guard.len() <= self.user_cap {
+        let user_cap = self.user_cap.load(Ordering::Relaxed);
+        if let Some(user_cap_nz) = NonZeroUsize::new(user_cap) {
+            if guard.cap().get() > user_cap && guard.len() <= user_cap {
                 guard.resize(user_cap_nz);
             }
         }
@@ -251,10 +258,17 @@ impl CrossFileWorkspaceIndex {
     }
 
     /// Resize the cache capacity. If shrinking, LRU entries are evicted.
+    ///
+    /// Also updates the `user_cap` baseline so `set_pinned_uris` will
+    /// shrink back to this resized value after a future all-pinned
+    /// overflow, rather than reverting to the constructor capacity.
+    /// `inner` and `user_cap` are written together under
+    /// `inner.write()` so concurrent readers see a consistent pair.
     pub fn resize(&self, cap: usize) {
         let cap = non_zero_or(cap, DEFAULT_WORKSPACE_INDEX_CAPACITY);
         if let Ok(mut guard) = self.inner.write() {
             guard.resize(cap);
+            self.user_cap.store(cap.get(), Ordering::Relaxed);
         }
     }
 }
@@ -567,5 +581,45 @@ mod tests {
         assert!(!index.contains(&test_uri("2.R")));
         assert!(index.contains(&test_uri("3.R")));
         assert!(index.contains(&test_uri("4.R")));
+    }
+
+    #[test]
+    fn test_resize_updates_shrink_baseline() {
+        // Issue #128 review finding 2: `resize()` is called from
+        // production at startup (`state::resize_caches`). After a resize
+        // grows the cache, `set_pinned_uris` must shrink back to the
+        // *resized* baseline, not the original constructor value, or
+        // shrink-back would silently override the user's configured
+        // `cache_workspace_index_max_entries`.
+        let index = CrossFileWorkspaceIndex::with_capacity(2);
+        index.resize(5);
+        assert_eq!(index.cap(), 5);
+
+        // Fill to the resized capacity and pin everything.
+        let mut pin_set = HashSet::new();
+        for i in 0..5 {
+            let uri = test_uri(&format!("a{}.R", i));
+            index.insert(uri.clone(), test_entry(i));
+            pin_set.insert(uri);
+        }
+        index.set_pinned_uris(pin_set);
+
+        // Trigger an all-pinned overflow.
+        let overflow = test_uri("overflow.R");
+        index.insert(overflow.clone(), test_entry(99));
+        assert_eq!(index.cap(), 6);
+
+        // Drain back below the resized baseline.
+        index.invalidate(&overflow);
+        assert_eq!(index.uris().len(), 5);
+
+        // Clearing pins should shrink to the resized baseline (5),
+        // not the constructor value (2).
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(
+            index.cap(),
+            5,
+            "shrink-back must track the resized baseline, not the constructor cap"
+        );
     }
 }

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -158,7 +158,7 @@ impl WorkspaceIndex {
     /// # Returns
     /// A new WorkspaceIndex instance
     pub fn new(config: WorkspaceIndexConfig) -> Self {
-        let cap = crate::cross_file::cache::non_zero_or(config.max_files, 1000);
+        let cap = Self::effective_cap_for(&config);
         Self {
             inner: RwLock::new(LruCache::new(cap)),
             version: AtomicU64::new(0),
@@ -168,6 +168,14 @@ impl WorkspaceIndex {
             metrics: RwLock::new(WorkspaceIndexMetrics::default()),
             pinned: RwLock::new(HashSet::new()),
         }
+    }
+
+    /// Effective runtime cap for a config — `max_files`, normalized to
+    /// `NonZeroUsize` with the same default `new()` applies. Shared by
+    /// the constructor and the shrink-back path so both interpret
+    /// `max_files == 0` identically.
+    fn effective_cap_for(config: &WorkspaceIndexConfig) -> NonZeroUsize {
+        crate::cross_file::cache::non_zero_or(config.max_files, 1000)
     }
 
     /// Replace the set of URIs protected from LRU eviction.
@@ -195,11 +203,10 @@ impl WorkspaceIndex {
             *pinned = uris;
         }
 
-        let user_cap = self.config.max_files;
-        if let Some(user_cap_nz) = NonZeroUsize::new(user_cap) {
-            if guard.cap().get() > user_cap && guard.len() <= user_cap {
-                guard.resize(user_cap_nz);
-            }
+        let user_cap_nz = Self::effective_cap_for(&self.config);
+        let user_cap = user_cap_nz.get();
+        if guard.cap().get() > user_cap && guard.len() <= user_cap {
+            guard.resize(user_cap_nz);
         }
     }
 
@@ -1072,6 +1079,54 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn test_cap_shrinks_back_when_max_files_is_zero_and_runtime_cap_is_default() {
+        // Issue #128 review finding 1: `new()` normalizes `max_files == 0`
+        // to the default runtime cap (1000) via `non_zero_or`, so the
+        // shrink-back path must compare and resize against that same
+        // normalized value — not the raw `config.max_files == 0`,
+        // which would disable shrink entirely.
+        let config = WorkspaceIndexConfig {
+            debounce_ms: 50,
+            max_files: 0,
+            // No file-size cap so we can insert tiny entries freely.
+            max_file_size_bytes: 0,
+        };
+        let index = WorkspaceIndex::new(config);
+        // Effective runtime cap is the default (1000) because of the
+        // `non_zero_or(max_files, 1000)` normalization in `new()`.
+        assert_eq!(index.cap(), 1000, "runtime cap should default to 1000");
+
+        // Pin every entry up to the effective cap, then trigger an
+        // all-pinned overflow.
+        let mut pin_set = HashSet::new();
+        for i in 0..1000 {
+            let uri = test_uri(&format!("pre_{}.R", i));
+            assert!(index.insert(uri.clone(), make_test_entry(i as u64)));
+            pin_set.insert(uri);
+        }
+        assert_eq!(index.len(), 1000);
+        index.set_pinned_uris(pin_set.clone());
+
+        // All-pinned overflow grows cap to 1001.
+        let overflow_uri = test_uri("overflow.R");
+        assert!(index.insert(overflow_uri.clone(), make_test_entry(9999)));
+        assert_eq!(index.cap(), 1001);
+
+        // Drain back to the effective cap (1000).
+        assert!(index.invalidate(&overflow_uri));
+        assert_eq!(index.len(), 1000);
+
+        // Clearing pins should now shrink cap back to 1000 — the
+        // effective user_cap, not the raw `0` from config.
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(
+            index.cap(),
+            1000,
+            "shrink-back must use the normalized cap, not raw max_files"
+        );
+    }
 
     #[test]
     fn test_cap_shrinks_back_to_user_cap_when_safe() {

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code)]
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -176,9 +177,29 @@ impl WorkspaceIndex {
     /// drop a reachable neighbor. Oversized files remain rejected by
     /// `insert`, and explicit `invalidate` / disk-update replacement still
     /// work for pinned URIs.
+    ///
+    /// Also opportunistically shrinks the runtime cap back to
+    /// `config.max_files` when `len() <= max_files`, so repeated all-pinned
+    /// overflow events followed by safe unpins don't ratchet the cap
+    /// upward indefinitely (issue #128). The shrink only fires when it
+    /// can't itself force eviction.
+    ///
+    /// Lock order: acquires `inner.write()` before `pinned.write()`,
+    /// matching the order established by `pin_aware_push` (which holds
+    /// `inner.write()` and then takes `pinned.read()`).
     pub fn set_pinned_uris(&self, uris: HashSet<Url>) {
+        let Ok(mut guard) = self.inner.write() else {
+            return;
+        };
         if let Ok(mut pinned) = self.pinned.write() {
             *pinned = uris;
+        }
+
+        let user_cap = self.config.max_files;
+        if let Some(user_cap_nz) = NonZeroUsize::new(user_cap) {
+            if guard.cap().get() > user_cap && guard.len() <= user_cap {
+                guard.resize(user_cap_nz);
+            }
         }
     }
 
@@ -333,6 +354,19 @@ impl WorkspaceIndex {
     /// Get the number of indexed entries
     pub fn len(&self) -> usize {
         self.inner.read().map(|guard| guard.len()).unwrap_or(0)
+    }
+
+    /// Get the current cache capacity.
+    ///
+    /// May exceed `config.max_files` after an all-pinned overflow has
+    /// forced the underlying LRU to grow (see `pin_aware_push`).
+    /// `set_pinned_uris` opportunistically restores the cap to
+    /// `config.max_files` when shrinking is safe (`len() <= max_files`).
+    pub fn cap(&self) -> usize {
+        self.inner
+            .read()
+            .map(|guard| guard.cap().get())
+            .unwrap_or(0)
     }
 
     /// Check if the index is empty
@@ -1038,6 +1072,120 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn test_cap_shrinks_back_to_user_cap_when_safe() {
+        // Issue #128: after an all-pinned overflow grew the cap, calling
+        // `set_pinned_uris` while `len() <= user_cap` should restore the
+        // cap to its configured value, so repeated overflow/unpin cycles
+        // don't grow `cap()` monotonically beyond `user_cap`.
+        let config = WorkspaceIndexConfig {
+            debounce_ms: 50,
+            max_files: 2,
+            max_file_size_bytes: 1024,
+        };
+        let index = WorkspaceIndex::new(config);
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+        let uri3 = test_uri("c.R");
+
+        assert!(index.insert(uri1.clone(), make_test_entry(0)));
+        assert!(index.insert(uri2.clone(), make_test_entry(1)));
+
+        let mut pinned = HashSet::new();
+        pinned.insert(uri1.clone());
+        pinned.insert(uri2.clone());
+        index.set_pinned_uris(pinned);
+        assert!(index.insert(uri3.clone(), make_test_entry(2)));
+        assert_eq!(index.cap(), 3, "all-pinned overflow grew the cap");
+        assert_eq!(index.len(), 3);
+
+        // Drop one entry so len falls back to user_cap.
+        assert!(index.invalidate(&uri3));
+        assert_eq!(index.len(), 2);
+
+        // Clearing the pin set should now opportunistically shrink cap
+        // back to user_cap (precondition: len() <= user_cap).
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(index.cap(), 2, "cap should shrink back to user_cap");
+    }
+
+    #[test]
+    fn test_cap_does_not_shrink_when_len_still_exceeds_user_cap() {
+        // Issue #128: shrinking must never force eviction. If `len()`
+        // currently exceeds `user_cap`, leave the cap alone — the next
+        // safe call to `set_pinned_uris` (after `len()` falls back) will
+        // shrink it.
+        let config = WorkspaceIndexConfig {
+            debounce_ms: 50,
+            max_files: 2,
+            max_file_size_bytes: 1024,
+        };
+        let index = WorkspaceIndex::new(config);
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+        let uri3 = test_uri("c.R");
+
+        assert!(index.insert(uri1.clone(), make_test_entry(0)));
+        assert!(index.insert(uri2.clone(), make_test_entry(1)));
+
+        let mut pinned = HashSet::new();
+        pinned.insert(uri1.clone());
+        pinned.insert(uri2.clone());
+        index.set_pinned_uris(pinned);
+        assert!(index.insert(uri3.clone(), make_test_entry(2)));
+        assert_eq!(index.cap(), 3);
+        assert_eq!(index.len(), 3);
+
+        // Clear pins. len(3) > user_cap(2): shrinking would force eviction,
+        // so cap must stay at 3.
+        index.set_pinned_uris(HashSet::new());
+        assert_eq!(index.cap(), 3, "cap must not shrink when len > user_cap");
+        assert_eq!(index.len(), 3);
+    }
+
+    #[test]
+    fn test_repeated_overflow_then_unpin_does_not_grow_cap_monotonically() {
+        // Issue #128: the worst-case trace from the issue. Repeated
+        // all-pinned overflow events, each followed by an unpin to a
+        // safe state, must not let `cap()` ratchet upward forever.
+        let config = WorkspaceIndexConfig {
+            debounce_ms: 50,
+            max_files: 2,
+            max_file_size_bytes: 1024,
+        };
+        let index = WorkspaceIndex::new(config);
+
+        for cycle in 0..5 {
+            let a = test_uri(&format!("cycle{}_a.R", cycle));
+            let b = test_uri(&format!("cycle{}_b.R", cycle));
+            let c = test_uri(&format!("cycle{}_c.R", cycle));
+
+            assert!(index.insert(a.clone(), make_test_entry(cycle * 3)));
+            assert!(index.insert(b.clone(), make_test_entry(cycle * 3 + 1)));
+
+            let mut pinned = HashSet::new();
+            pinned.insert(a.clone());
+            pinned.insert(b.clone());
+            index.set_pinned_uris(pinned);
+
+            assert!(index.insert(c.clone(), make_test_entry(cycle * 3 + 2)));
+
+            // Drain back to a safe state so cap-shrink can fire.
+            index.invalidate(&a);
+            index.invalidate(&b);
+            index.invalidate(&c);
+            assert_eq!(index.len(), 0);
+
+            index.set_pinned_uris(HashSet::new());
+            assert_eq!(
+                index.cap(),
+                2,
+                "cap must shrink back to user_cap on cycle {}",
+                cycle
+            );
+        }
+    }
 
     #[test]
     fn test_unpinning_restores_normal_eviction() {


### PR DESCRIPTION
## Summary

- `set_pinned_uris` on both `WorkspaceIndex` and `CrossFileWorkspaceIndex` now opportunistically shrinks the runtime LRU cap back to the user-configured value when `len() <= user_cap`, so the shrink itself never forces eviction.
- Closes #128: prior to this change, repeated all-pinned overflow events (where `pin_aware_push` resizes to `len() + 1`) let the cap ratchet upward indefinitely, defeating `max_files` as a memory-tuning knob.
- `CrossFileWorkspaceIndex` gains a `user_cap: usize` field (previously only the runtime LRU cap was tracked); both indices expose `cap()`.
- Lock order matches PR #127: `inner.write()` is acquired before `pinned.write()`.

## Test plan

- [x] `cargo test -p raven` — 3117 lib + 103 integration + 58 doctest cases pass; 0 failures.
- [x] New regression tests cover (a) cap shrinks back when safe, (b) cap stays bumped when `len() > user_cap`, (c) repeated overflow/unpin cycles do not grow `cap` monotonically.
- [x] RED verified before GREEN: tests fail with `cap=3, expected=2` against the unmodified `set_pinned_uris`, then pass after the shrink is wired in.
- [x] Pre-existing PR #127 tests still pass unchanged, including `test_unpinning_restores_normal_eviction` and `test_pinned_set_held_across_lru_search_and_pop`.
- [x] `cargo clippy -p raven --tests` — no new warnings on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace cache now intelligently shrinks capacity back to configured limits when safe, improving memory efficiency.
  * Added safeguards to avoid unsafe or blocking cache resizing.
  * Exposed current cache capacity via a read-only accessor for visibility.

* **Tests**
  * Added test coverage for capacity shrinking, non-shrink conditions, and baseline tracking after resize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->