### PR TITLE
perf: bounded allocation and sort cleanups in re-enrichment helpers

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -653,7 +653,7 @@ fn cap_watched_file_revalidations(
     activity: &crate::cross_file::revalidation::CrossFileActivityState,
     max_revalidations: usize,
 ) {
-    affected.sort_by_key(|u| activity.priority_score(u).saturating_add(1));
+    affected.sort_by_cached_key(|u| activity.priority_score(u).saturating_add(1));
     if affected.len() > max_revalidations {
         log::trace!(
             "Watched-files revalidation cap exceeded: {} affected, scheduling {}",
@@ -677,19 +677,19 @@ fn cap_watched_file_revalidations(
 /// neighbors regardless of priority.
 fn merge_and_cap_reenrichment_revalidations(
     pinned_uri: &Url,
-    prev_uris: &std::collections::HashSet<Url>,
+    prev_uris: std::collections::HashSet<Url>,
     new_neighbors: Vec<Url>,
     max_revalidations: usize,
     activity: &crate::cross_file::revalidation::CrossFileActivityState,
 ) -> Vec<Url> {
     let mut union: Vec<Url> = prev_uris.iter().cloned().collect();
-    let mut seen = prev_uris.clone();
+    let mut seen = prev_uris;
     for dep in new_neighbors {
         if seen.insert(dep.clone()) {
             union.push(dep);
         }
     }
-    union.sort_by_key(|u| {
+    union.sort_by_cached_key(|u| {
         if u == pinned_uri {
             0
         } else {
@@ -722,7 +722,7 @@ fn rebuild_work_items_after_reenrichment(
         prev_work_items.iter().map(|(u, _, _)| u.clone()).collect();
     let final_uris = merge_and_cap_reenrichment_revalidations(
         pinned_uri,
-        &prev_uris,
+        prev_uris,
         new_neighbors,
         max_revalidations,
         &state.cross_file_activity,
@@ -1612,9 +1612,12 @@ impl LanguageServer for Backend {
             let mut affected: Vec<Url> = affected.into_iter().collect();
 
             // Prioritize by activity
-            // Use saturating_add to prevent integer overflow at usize::MAX
+            // Use saturating_add to prevent integer overflow at usize::MAX.
+            // sort_by_cached_key memoizes priority_score per URI so the
+            // O(N) recent_uris position scan runs once per element rather
+            // than once per sort comparison.
             let activity = &state.cross_file_activity;
-            affected.sort_by_key(|u| {
+            affected.sort_by_cached_key(|u| {
                 if *u == uri {
                     0
                 } else {
@@ -2317,9 +2320,12 @@ impl LanguageServer for Backend {
             let mut affected: Vec<Url> = affected.into_iter().collect();
 
             // Prioritize by activity (trigger first, then active, then visible, then recent)
-            // Use saturating_add to prevent integer overflow at usize::MAX
+            // Use saturating_add to prevent integer overflow at usize::MAX.
+            // sort_by_cached_key memoizes priority_score per URI so the
+            // O(N) recent_uris position scan runs once per element rather
+            // than once per sort comparison.
             let activity = &state.cross_file_activity;
-            affected.sort_by_key(|u| {
+            affected.sort_by_cached_key(|u| {
                 if *u == uri {
                     0
                 } else {
@@ -4851,7 +4857,7 @@ mod tests {
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
                 &edited,
-                &prev_uris,
+                prev_uris,
                 new_neighbors,
                 2,
                 &activity,
@@ -4885,7 +4891,7 @@ mod tests {
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
                 &edited,
-                &prev_uris,
+                prev_uris,
                 vec![],
                 10,
                 &activity,
@@ -4908,7 +4914,7 @@ mod tests {
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
                 &edited,
-                &prev_uris,
+                prev_uris,
                 new_neighbors,
                 10,
                 &activity,
@@ -4934,7 +4940,7 @@ mod tests {
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
                 &edited,
-                &prev_uris,
+                prev_uris,
                 new_neighbors,
                 2,
                 &activity,
@@ -4956,7 +4962,7 @@ mod tests {
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
                 &edited,
-                &prev_uris,
+                prev_uris,
                 new_neighbors,
                 0,
                 &activity,


### PR DESCRIPTION
## Summary

Closes #136 — two bounded perf cleanups in `crates/raven/src/backend.rs`.

- **`merge_and_cap_reenrichment_revalidations`** now takes `prev_uris: HashSet<Url>` by value and moves it into the dedup `seen` set, dropping one HashSet clone (one alloc instead of two). The sole production caller already discarded `prev_uris` after the call; the five unit tests updated to match.
- **All four `priority_score` sort sites** switched from `sort_by_key` to `sort_by_cached_key` (watched-files cap, re-enrichment helper, `did_open` / `did_change` activity sorts). `priority_score`'s fallback scans `recent_uris` (capped at 100), so memoizing once per element collapses the sort cost from O(M log M · N) to O(M·N + M log M).

Both are bounded by `max_revalidations_per_trigger` (default 10) and `recent_uris` (capped at 100), so absolute savings are small — this is the free-time cleanup #136 called out, not a regression fix.

## Test plan

- [x] `cargo build -p raven` clean
- [x] `cargo test -p raven --lib reenrichment_revalidation_cap` — 5/5 pass
- [x] `cargo test -p raven` — full suite green (3119 lib + 103 + 58 doctests)
- [x] `cargo clippy -p raven --lib --tests` — no new warnings in modified regions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced performance of revalidation scheduling through optimized sorting and reduced memory allocation in reenrichment logic.

* **Tests**
  * Updated test cases to align with internal optimization changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->