### PR TITLE
fix: canonicalize libpath roots so touched_from_events matches FSEvents paths

### DIFF
--- a/crates/raven/src/libpath_watcher.rs
+++ b/crates/raven/src/libpath_watcher.rs
@@ -403,7 +403,17 @@ pub fn spawn_watcher(
         // listing) fire events we can turn into `touched`. See the module-level
         // docstring for the Linux inotify cost tradeoff.
         match watcher.watch(p, RecursiveMode::Recursive) {
-            Ok(()) => attached.push(p.canonicalize().unwrap_or_else(|_| p.clone())),
+            Ok(()) => {
+                // Canonicalize so that `attached` stores the same symlink-resolved
+                // form that the OS (FSEvents on macOS, inotify on Linux) uses when
+                // reporting event paths. `touched_from_events` strips these roots as
+                // a prefix from incoming event paths; if the stored root and the event
+                // path use different representations (e.g. `/var/...` vs
+                // `/private/var/...` on macOS where `/var -> /private/var`),
+                // strip_prefix always fails and in-place package upgrades are silently
+                // missed. Removing canonicalize() here breaks that matching invariant.
+                attached.push(p.canonicalize().unwrap_or_else(|_| p.clone()));
+            }
             Err(e) => {
                 // A libpath directory may not exist yet (e.g. empty renv); log and continue.
                 log::warn!("LibpathWatcher: cannot watch {}: {e}", p.display());

--- a/crates/raven/src/libpath_watcher.rs
+++ b/crates/raven/src/libpath_watcher.rs
@@ -403,7 +403,7 @@ pub fn spawn_watcher(
         // listing) fire events we can turn into `touched`. See the module-level
         // docstring for the Linux inotify cost tradeoff.
         match watcher.watch(p, RecursiveMode::Recursive) {
-            Ok(()) => attached.push(p.clone()),
+            Ok(()) => attached.push(p.canonicalize().unwrap_or_else(|_| p.clone())),
             Err(e) => {
                 // A libpath directory may not exist yet (e.g. empty renv); log and continue.
                 log::warn!("LibpathWatcher: cannot watch {}: {e}", p.display());
@@ -596,8 +596,14 @@ mod watcher_tests {
     async fn watcher_emits_touched_on_in_place_upgrade() {
         // Regression for the NonRecursive → Recursive switch: rewriting files
         // inside an existing package directory must report it as `touched`.
+        //
+        // Start the watcher on an empty libpath, then install the package and
+        // drain the resulting `added` event. Once that event has arrived we
+        // know FSEvents is fully settled and delivering recursive events for
+        // `foo/` — only then do we trigger the in-place overwrite. This
+        // avoids the flakiness that came from using a fixed sleep as the
+        // only readiness barrier.
         let t = tempdir().unwrap();
-        make_pkg(t.path(), "foo");
 
         let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
         let _handle = spawn_watcher(
@@ -607,7 +613,20 @@ mod watcher_tests {
         )
         .expect("watcher attached");
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Create the package and wait for the watcher to confirm it via an
+        // `added` event. This is the readiness signal: once the debounce loop
+        // has delivered a Changed event, recursive watching for `foo/` is live.
+        make_pkg(t.path(), "foo");
+        let added_evt = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("added event arrived in time")
+            .expect("channel not closed");
+        match added_evt {
+            LibpathEvent::Changed { added, .. } => {
+                assert!(added.contains("foo"), "expected foo in added: {:?}", added);
+            }
+            LibpathEvent::Dropped => panic!("expected Changed for add, got Dropped"),
+        }
 
         // Rewrite files inside the existing package directory — no listing
         // delta, so only recursive watching surfaces this as a signal.
@@ -622,9 +641,9 @@ mod watcher_tests {
         )
         .unwrap();
 
-        let evt = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+        let evt = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
-            .expect("event arrived in time")
+            .expect("touched event arrived in time")
             .expect("channel not closed");
 
         match evt {


### PR DESCRIPTION
## Summary

- On macOS, `/var` is a symlink to `/private/var`. FSEvents delivers event paths in their canonical (symlink-resolved) form, but `spawn_watcher` was storing the original unresolved paths in `attached`. This caused `touched_from_events` to fail `path.strip_prefix(root)` on every event, silently dropping cache-invalidation signals for in-place package upgrades whenever a library path involves a symlink.
- Fix: canonicalize each successfully-watched path before pushing it into `attached`, so the roots used for prefix-stripping match what FSEvents reports.
- Also restructures `watcher_emits_touched_on_in_place_upgrade` to use the watcher's own `added` event as a readiness signal instead of a fixed 200ms sleep, making the test deterministic rather than timing-dependent.

## Root cause

`spawn_watcher` calls `watcher.watch(p, ...)` and stores `p.clone()` in `attached`. The `notify` FSEvents backend canonicalizes the path internally for its own filtering, so events do arrive — but `touched_from_events` then tries to strip the non-canonical root from the canonical event path, which always fails, so `touched` stays empty and no `Changed` event is ever sent for in-place upgrades.

## Test plan

- [ ] `cargo test -p raven --lib -- --ignored` — all three libpath watcher integration tests pass
- [ ] `cargo test -p raven` — no regressions in the regular test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced library path handling for more robust file monitoring.

* **Tests**
  * Improved test reliability with refined setup procedures and adjusted timeout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->