### PR TITLE
docs: switch pseudocode doctests from ```ignore to ```text

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -79,7 +79,7 @@ struct ActiveDocumentsChangedParams {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// use serde_json::json;
 /// let settings = json!({
 ///     "crossFile": {
@@ -477,7 +477,7 @@ pub(crate) fn parse_severity(s: &str) -> Option<DiagnosticSeverity> {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// use serde_json::json;
 /// let settings = json!({
 ///     "symbols": {
@@ -3270,7 +3270,7 @@ impl LanguageServer for Backend {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```text
     /// // Call from an async context with a prepared `backend` and params:
     /// let params = lsp_types::WorkspaceSymbolParams { query: "my_fn".into(), ..Default::default() };
     /// let symbols_opt = backend.symbol(params).await?;

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -402,7 +402,7 @@ pub fn detect_parent_wd_change_affected_children(
 /// Returns an empty vector if the working directory hasn't changed.
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// // When parent's @lsp-cd changes, invalidate affected children
 /// let affected = invalidate_children_on_parent_wd_change(
 ///     &parent_uri,

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -1019,7 +1019,7 @@ fn annotate_event_function_scopes(artifacts: &mut ScopeArtifacts) {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Given a parser-produced `tree`, file `content`, and `uri`:
 /// let artifacts = compute_artifacts(&uri, &tree, content);
 /// // `artifacts.timeline` contains the extracted scope events in source order.
@@ -1171,7 +1171,7 @@ pub fn compute_artifacts(uri: &Url, tree: &Tree, content: &str) -> ScopeArtifact
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Given a parser-produced `tree`, file `content`, `uri`, and `metadata`:
 /// let artifacts = compute_artifacts_with_metadata(&uri, &tree, content, Some(&metadata));
 /// // `artifacts.timeline` contains both AST-detected and directive sources.
@@ -1826,7 +1826,7 @@ where
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// use lsp_types::Url;
 /// use std::collections::HashSet;
 ///

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -453,7 +453,7 @@ fn is_c_call(node: Node, content: &str) -> bool {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Given a Tree-sitter `Node` for `c("a", "b")`:
 /// let strings = extract_c_string_args(node, r#"c("a", "b")"#);
 /// assert_eq!(strings, vec!["a".to_string(), "b".to_string()]);
@@ -665,7 +665,7 @@ fn has_character_only_true(args_node: &Node, content: &str) -> bool {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```text
 /// // Parse an R call, obtain its arguments node, then:
 /// let pkg = extract_package_name(&args_node, source_text);
 /// assert_eq!(pkg, Some("dplyr".to_string()));

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -604,7 +604,7 @@ impl DocumentStore {
     /// * `uri` - Document URI to wait for
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // Wait for an update to complete before reading
     /// store.wait_for_update(&uri).await;
     /// let doc = store.get(&uri);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -1342,7 +1342,7 @@ impl<'a> SymbolExtractor<'a> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```text
     /// assert!(is_all_caps_constant("MAX_VALUE")); // constant
     /// assert!(is_all_caps_constant("PI"));        // constant (2 chars)
     /// assert!(is_all_caps_constant("API_KEY"));   // constant

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -78,7 +78,7 @@ impl SymbolConfig {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```text
     /// let config = SymbolConfig::with_max_results(500);
     /// assert_eq!(config.workspace_max_results, 500);
     ///


### PR DESCRIPTION
## Summary
- `cargo test -- --ignored` was attempting to compile 12 illustrative pseudocode blocks fenced as ` ```ignore`, which all failed since they reference out-of-scope identifiers
- Switch those fences to ` ```text` so rustdoc treats them as prose and never tries to compile them
- The 4 remaining `ignore`-marked doctests are valid Rust and continue to pass under `--ignored`

## Test plan
- [x] `cargo test --doc -p raven` — 58 passed, 0 failed
- [x] `cargo test --doc -p raven -- --ignored` — 4 passed, 0 failed