### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,13 +19,13 @@ jobs:
     name: Time-Budget Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -45,13 +45,13 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +64,7 @@ jobs:
       # Criterion baselines are stored under target/criterion/.
       # We cache them so PR runs can compare against the main baseline.
       - name: Restore Criterion baseline cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target/criterion
           key: criterion-baseline-${{ runner.os }}-main-${{ github.run_id }}
@@ -72,7 +72,7 @@ jobs:
             criterion-baseline-${{ runner.os }}-
 
       - name: Install critcmp
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: critcmp-cache
         with:
           path: ~/.cargo/bin/critcmp
@@ -194,13 +194,13 @@ jobs:
     name: Binary Size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -47,7 +47,7 @@ jobs:
             use-zigbuild: false
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
@@ -56,7 +56,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Upload LSP artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: lsp-${{ matrix.platform }}
           path: raven-${{ matrix.platform }}.zip
@@ -106,21 +106,21 @@ jobs:
         target: [darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64, win32-arm64]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install vsce
         run: npm install -g @vscode/vsce@3.7.1
 
       - name: Download LSP artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: lsp-*
           path: lsp-binaries
@@ -164,7 +164,7 @@ jobs:
           vsce package --target ${{ matrix.target }}
 
       - name: Upload extension artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: vscode-${{ matrix.target }}
           path: editors/vscode/*.vsix
@@ -188,14 +188,14 @@ jobs:
       contents: write
     steps:
       - name: Download LSP artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: lsp-*
           path: lsp-artifacts
           merge-multiple: true
 
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: vscode-*
           path: vscode-artifacts
@@ -217,7 +217,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
@@ -236,7 +236,7 @@ jobs:
     environment: marketplace
     steps:
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: vscode-*
           path: vscode-artifacts

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,7 +25,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag_sha: ${{ steps.tag_sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts from build workflow
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           workflow: release-build.yml
           commit: ${{ needs.validate.outputs.tag_sha }}
@@ -96,14 +96,14 @@ jobs:
         run: find artifacts -type f | sort
 
       - name: Re-upload LSP artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: release-lsp-artifacts
           path: artifacts/lsp-*/*
           retention-days: 5
 
       - name: Re-upload VSIX artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: release-vscode-artifacts
           path: artifacts/vscode-*/*
@@ -116,13 +116,13 @@ jobs:
       contents: write
     steps:
       - name: Download LSP artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: release-lsp-artifacts
           path: lsp-artifacts
 
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: release-vscode-artifacts
           path: vscode-artifacts
@@ -143,7 +143,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ inputs.tag }}
           name: Release ${{ inputs.tag }}
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: release-vscode-artifacts
           path: vscode-artifacts


### PR DESCRIPTION
## Summary

GitHub has deprecated the Node 20 runtime for JavaScript-based actions. This PR bumps every action in the workflows to a release that runs on Node 24 (pinned by commit SHA), and updates the VS Code extension build to Node 24 as well.

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 | v5.0.1 |
| `actions/setup-node` | v4 | v5.0.0 |
| `actions/cache` | v4 | v5.0.5 |
| `actions/upload-artifact` | v4 | v6.0.0 (v5 still ran on Node 20) |
| `actions/download-artifact` | v4 | v7.0.0 (v6 still ran on Node 20) |
| `oven-sh/setup-bun` | v2 | v2.2.0 |
| `softprops/action-gh-release` | v2.5.0 | v3.0.0 (v2.x still ran on Node 20) |
| `dawidd6/action-download-artifact` | `@v6` (floating) | v21 (SHA-pinned) |
| `node-version` (extension build) | `'22'` | `'24'` |

`dtolnay/rust-toolchain` and `anthropics/claude-code-action` are composite actions and are unaffected.

### Notes

- `actions/setup-node@v5` enables automatic caching when `packageManager` is set in `package.json`. Not currently set, so no change in behavior — pass `package-manager-cache: false` to opt out if needed later.
- `actions/download-artifact@v7` only breaks single-artifact-by-ID downloads. We use `name`/`pattern`, so unaffected.
- All upgrades require the GitHub Actions runner ≥ 2.327.1, which GitHub-hosted runners have had for a while.

## Test plan

- [ ] CI on this PR runs green (perf workflow exercises `checkout`/`cache`).
- [ ] Next tagged release confirms `release-build.yml` end-to-end (LSP build matrix, VSIX packaging, artifact upload/download, GitHub release).
- [ ] No "Node 20 deprecation" warnings appear in the Actions logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to use newer pinned versions (checkout, cache, artifact, and setup actions) across build, release, and CI pipelines for improved consistency and reliability.
  * Updated Node.js runtime version from 22 to 24 in release build workflow.
  * Enhanced performance testing infrastructure with dedicated baseline caching strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->