### PR TITLE
ci: scope GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs for the same branch/PR
 concurrency:
   group: perf-${{ github.ref }}
@@ -43,6 +46,7 @@ jobs:
     name: Criterion Benchmarks
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-build-${{ github.ref_name }}
   cancel-in-progress: false
@@ -234,6 +237,7 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     environment: marketplace
+    permissions: {}
     steps:
       - name: Download VSIX artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -56,6 +59,9 @@ jobs:
   download-artifacts:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -160,6 +166,7 @@ jobs:
     needs: [validate, download-artifacts]
     if: inputs.publish_vscode
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Download VSIX artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
## Summary
- Add a top-level `permissions: contents: read` block to `perf.yml`, `release-build.yml`, and `release-publish.yml` so the default `GITHUB_TOKEN` follows the principle of least privilege.
- Per-job overrides where extra scopes are needed: `pull-requests: write` for the benchmarks PR-comment job, `contents: write` for the GitHub Release jobs (already present), and `actions: read` for the cross-workflow artifact download in `release-publish.yml`.
- `permissions: {}` on the marketplace publish jobs — they only use VSCE/OVSX PATs, no GitHub token scopes required.

Resolves the 7 open `actions/missing-workflow-permissions` code-scanning alerts.

## Test plan
- [ ] CI runs green on this PR (perf workflow exercises the benchmarks PR-comment path).
- [ ] After merge, confirm the code-scanning alerts auto-close on the next scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security by implementing explicit permission scoping across CI/CD workflows to follow least-privilege principles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->