### PR TITLE
Fix UTF-16 position conversion in LSP handlers

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -2797,9 +2797,10 @@ pub fn selection_range(
     let doc = state.get_document(uri)?;
     let tree = doc.tree.as_ref()?;
 
+    let text = doc.text();
     let mut results = Vec::new();
     for pos in positions {
-        let point = Point::new(pos.line as usize, pos.character as usize);
+        let point = lsp_position_to_ts_point(&text, pos);
         if let Some(range) = build_selection_range(tree.root_node(), point) {
             results.push(range);
         }
@@ -40239,6 +40240,7 @@ generated quantities {
 mod issue_149_utf16_handlers {
     use super::{
         completion, goto_definition, lsp_position_to_ts_point, prepare_signature_help, references,
+        selection_range,
     };
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::{CompletionResponse, GotoDefinitionResponse, Position, Url};
@@ -40362,6 +40364,45 @@ mod issue_149_utf16_handlers {
             labels.contains(&"my_local"),
             "expected `my_local` in completions; cursor on `+` is outside the namespace expression. got {:?}",
             labels
+        );
+    }
+
+    /// Same input-direction bug pattern as the four sites in #149, but in
+    /// `selection_range`. With the bug, the cursor on `abc` lands at byte
+    /// col 6 (`;`) instead of byte col 8 (`a`), so tree-sitter descends
+    /// into the wrong node and the returned chain doesn't contain the
+    /// identifier's range.
+    ///
+    /// NB: the columns reported in the response are still tree-sitter byte
+    /// columns; the byte→UTF-16 output-direction conversion in
+    /// `build_selection_range` is a separate bug.
+    #[test]
+    fn selection_range_with_non_bmp_before_cursor_on_cursor_line() {
+        let mut state = create_state();
+        let code = "abc <- 1\n\"🦀\"; abc\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let result = selection_range(&state, &uri, vec![Position::new(1, 6)])
+            .expect("expected Some(selection ranges)");
+        assert_eq!(result.len(), 1, "one position in, one chain out");
+
+        // Walk the chain and assert the cursor's identifier (`abc` on
+        // line 1, bytes 8..11) is reachable. With the input-direction
+        // bug the cursor lands on a different node and that range is
+        // missing from the chain.
+        let mut node = Some(&result[0]);
+        let mut found_identifier = false;
+        while let Some(sr) = node {
+            if sr.range.start == Position::new(1, 8) && sr.range.end == Position::new(1, 11) {
+                found_identifier = true;
+                break;
+            }
+            node = sr.parent.as_deref();
+        }
+        assert!(
+            found_identifier,
+            "expected the chain to contain the `abc` identifier range; got {:#?}",
+            result[0]
         );
     }
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -2801,7 +2801,7 @@ pub fn selection_range(
     let mut results = Vec::new();
     for pos in positions {
         let point = lsp_position_to_ts_point(&text, pos);
-        if let Some(range) = build_selection_range(tree.root_node(), point) {
+        if let Some(range) = build_selection_range(tree.root_node(), point, &text) {
             results.push(range);
         }
     }
@@ -2809,20 +2809,14 @@ pub fn selection_range(
     Some(results)
 }
 
-fn build_selection_range(root: Node, point: Point) -> Option<SelectionRange> {
+fn build_selection_range(root: Node, point: Point, text: &str) -> Option<SelectionRange> {
     let mut node = root.descendant_for_point_range(point, point)?;
     let mut ranges: Vec<Range> = Vec::new();
 
     loop {
         let range = Range {
-            start: Position::new(
-                node.start_position().row as u32,
-                node.start_position().column as u32,
-            ),
-            end: Position::new(
-                node.end_position().row as u32,
-                node.end_position().column as u32,
-            ),
+            start: ts_point_to_lsp_position(text, node.start_position()),
+            end: ts_point_to_lsp_position(text, node.end_position()),
         };
 
         if ranges.last() != Some(&range) {
@@ -8508,6 +8502,14 @@ fn lsp_position_to_ts_point(text: &str, position: Position) -> Point {
     let line_text = text.lines().nth(position.line as usize).unwrap_or("");
     let byte_col = utf16_column_to_byte_offset(line_text, position.character);
     Point::new(position.line as usize, byte_col)
+}
+
+/// Convert a tree-sitter `Point` (byte column) into an LSP `Position`
+/// (UTF-16 column) by indexing into the file's text.
+fn ts_point_to_lsp_position(text: &str, point: Point) -> Position {
+    let line_text = text.lines().nth(point.row).unwrap_or("");
+    let character = crate::utf16::byte_offset_to_utf16_column(line_text, point.column);
+    Position::new(point.row as u32, character)
 }
 
 pub fn completion(
@@ -40401,9 +40403,6 @@ mod issue_149_utf16_handlers {
     /// into the wrong node and the returned chain doesn't contain the
     /// identifier's range.
     ///
-    /// NB: the columns reported in the response are still tree-sitter byte
-    /// columns; the byte→UTF-16 output-direction conversion in
-    /// `build_selection_range` is a separate bug.
     #[test]
     fn selection_range_with_non_bmp_before_cursor_on_cursor_line() {
         let mut state = create_state();
@@ -40415,13 +40414,13 @@ mod issue_149_utf16_handlers {
         assert_eq!(result.len(), 1, "one position in, one chain out");
 
         // Walk the chain and assert the cursor's identifier (`abc` on
-        // line 1, bytes 8..11) is reachable. With the input-direction
+        // line 1, UTF-16 columns 6..9) is reachable. With the input-direction
         // bug the cursor lands on a different node and that range is
         // missing from the chain.
         let mut node = Some(&result[0]);
         let mut found_identifier = false;
         while let Some(sr) = node {
-            if sr.range.start == Position::new(1, 8) && sr.range.end == Position::new(1, 11) {
+            if sr.range.start == Position::new(1, 6) && sr.range.end == Position::new(1, 9) {
                 found_identifier = true;
                 break;
             }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -40283,6 +40283,32 @@ mod issue_149_utf16_handlers {
     }
 
     #[test]
+    fn goto_definition_qualified_member_with_non_bmp_before_cursor_on_cursor_line() {
+        let mut state = create_state();
+        // Mirrors the issue #149 repro shape: the cursor is on the RHS of
+        // `foo$bar`, and the cursor line has `🦀` before `bar`. UTF-16 col
+        // 10 is `b`; the corresponding tree-sitter byte column is 12.
+        // Without UTF-16 -> byte conversion, the cursor lands in `foo`
+        // instead of `bar`, bypassing the qualified-member resolver.
+        let code = "foo <- list(bar = 1)\n\"🦀\"; foo$bar\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let result = goto_definition(&state, &uri, Position::new(1, 10));
+
+        let location = match result {
+            Some(GotoDefinitionResponse::Scalar(loc)) => loc,
+            other => panic!("expected Scalar response, got {:?}", other),
+        };
+        assert_eq!(location.uri, uri);
+        assert_eq!(
+            location.range.start,
+            Position::new(0, 12),
+            "`bar` in `foo <- list(bar = 1)` starts at UTF-16 col 12"
+        );
+        assert_eq!(location.range.end, Position::new(0, 15));
+    }
+
+    #[test]
     fn goto_definition_fallback_reports_utf16_columns_on_non_bmp_definition_line() {
         let mut state = create_state();
         let use_uri = add_doc(&mut state, "file:///use.R", "abc\n");

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -11217,17 +11217,21 @@ fn find_references_in_tree(
     locations: &mut Vec<Location>,
 ) {
     if node.kind() == "identifier" && node_text(node, text) == name {
+        let start_pos = node.start_position();
+        let end_pos = node.end_position();
+        let start_line = text.lines().nth(start_pos.row).unwrap_or("");
+        let end_line = if end_pos.row == start_pos.row {
+            start_line
+        } else {
+            text.lines().nth(end_pos.row).unwrap_or("")
+        };
+        let start_char = crate::utf16::byte_offset_to_utf16_column(start_line, start_pos.column);
+        let end_char = crate::utf16::byte_offset_to_utf16_column(end_line, end_pos.column);
         locations.push(Location {
             uri: uri.clone(),
             range: Range {
-                start: Position::new(
-                    node.start_position().row as u32,
-                    node.start_position().column as u32,
-                ),
-                end: Position::new(
-                    node.end_position().row as u32,
-                    node.end_position().column as u32,
-                ),
+                start: Position::new(start_pos.row as u32, start_char),
+                end: Position::new(end_pos.row as u32, end_char),
             },
         });
     }
@@ -40309,14 +40313,6 @@ mod issue_149_utf16_handlers {
         // lands on `;` (not an identifier) so the handler returns None.
         let locations =
             references(&state, &uri, Position::new(1, 6)).expect("expected Some(references)");
-
-        // Two occurrences: the LHS of `abc <- 1` on line 0 and the use on
-        // line 1. NB: the second reference's `character` field is currently
-        // reported as a byte column (8), not a UTF-16 column. That's a
-        // separate output-direction bug in `find_references_in_tree` and is
-        // out of scope for issue #149 (input-direction conversion). The
-        // important regression here is that the handler resolved the
-        // identifier at all.
         let lines: Vec<u32> = locations.iter().map(|l| l.range.start.line).collect();
         assert_eq!(lines, vec![0, 1], "expected references on lines 0 and 1");
     }
@@ -40365,6 +40361,38 @@ mod issue_149_utf16_handlers {
             "expected `my_local` in completions; cursor on `+` is outside the namespace expression. got {:?}",
             labels
         );
+    }
+
+    /// Output-direction sibling of the #149 bug: `find_references_in_tree`
+    /// reports tree-sitter byte columns directly as `Position.character`,
+    /// which is supposed to be a UTF-16 column. On lines with multi-byte
+    /// UTF-8 characters before the reference, the reported column is
+    /// off by the difference between byte and UTF-16 widths.
+    ///
+    /// Cursor here sits on the pure-ASCII LHS so no input-direction
+    /// conversion is needed — only the output direction is exercised.
+    #[test]
+    fn references_report_utf16_columns_on_non_bmp_line() {
+        let mut state = create_state();
+        let code = "abc <- 1\n\"🦀\"; abc\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let locations =
+            references(&state, &uri, Position::new(0, 1)).expect("expected Some(references)");
+        let mut found: Vec<_> = locations
+            .iter()
+            .map(|l| {
+                (
+                    l.range.start.line,
+                    l.range.start.character,
+                    l.range.end.character,
+                )
+            })
+            .collect();
+        found.sort();
+        // `abc` on line 0 cols 0..3, and on line 1 cols 6..9 (UTF-16).
+        // With the bug, the line-1 entry is reported as 8..11 (bytes).
+        assert_eq!(found, vec![(0, 0, 3), (1, 6, 9)]);
     }
 
     /// Same input-direction bug pattern as the four sites in #149, but in

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -11198,19 +11198,11 @@ fn find_references_in_tree(
     if node.kind() == "identifier" && node_text(node, text) == name {
         let start_pos = node.start_position();
         let end_pos = node.end_position();
-        let start_line = text.lines().nth(start_pos.row).unwrap_or("");
-        let end_line = if end_pos.row == start_pos.row {
-            start_line
-        } else {
-            text.lines().nth(end_pos.row).unwrap_or("")
-        };
-        let start_char = crate::utf16::byte_offset_to_utf16_column(start_line, start_pos.column);
-        let end_char = crate::utf16::byte_offset_to_utf16_column(end_line, end_pos.column);
         locations.push(Location {
             uri: uri.clone(),
             range: Range {
-                start: Position::new(start_pos.row as u32, start_char),
-                end: Position::new(end_pos.row as u32, end_char),
+                start: ts_point_to_lsp_position(text, start_pos),
+                end: ts_point_to_lsp_position(text, end_pos),
             },
         });
     }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8498,6 +8498,17 @@ fn stan_completion(text: &str, uri: &Url) -> CompletionResponse {
     CompletionResponse::Array(items)
 }
 
+/// Convert an LSP `Position` (UTF-16 column) into a tree-sitter `Point`
+/// (byte column) by indexing into the file's text. Necessary because
+/// `Position.character` and `Point.column` use different units, so passing
+/// the LSP column as-is misplaces the cursor on lines containing multi-byte
+/// UTF-8 characters before the cursor.
+fn lsp_position_to_ts_point(text: &str, position: Position) -> Point {
+    let line_text = text.lines().nth(position.line as usize).unwrap_or("");
+    let byte_col = utf16_column_to_byte_offset(line_text, position.character);
+    Point::new(position.line as usize, byte_col)
+}
+
 pub fn completion(
     state: &WorldState,
     uri: &Url,
@@ -8558,7 +8569,7 @@ pub fn completion(
         return Some(CompletionResponse::Array(items));
     }
 
-    let point = Point::new(position.line as usize, position.character as usize);
+    let point = lsp_position_to_ts_point(&text, position);
     let node = tree.root_node().descendant_for_point_range(point, point)?;
 
     let mut items = Vec::new();
@@ -10429,7 +10440,7 @@ pub fn prepare_signature_help(
     let tree = doc.tree.as_ref()?;
     let text = doc.text();
 
-    let point = Point::new(position.line as usize, position.character as usize);
+    let point = lsp_position_to_ts_point(&text, position);
 
     // Find enclosing call
     let mut node = tree.root_node().descendant_for_point_range(point, point)?;
@@ -10714,7 +10725,7 @@ pub fn goto_definition(
     }
 
     // Continue with normal identifier-based go-to-definition
-    let point = Point::new(position.line as usize, position.character as usize);
+    let point = lsp_position_to_ts_point(&text, position);
     let node = tree.root_node().descendant_for_point_range(point, point)?;
 
     if node.kind() != "identifier" {
@@ -11113,7 +11124,7 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
 
     let tree = doc.tree.as_ref()?;
 
-    let point = Point::new(position.line as usize, position.character as usize);
+    let point = lsp_position_to_ts_point(&text, position);
     let node = tree.root_node().descendant_for_point_range(point, point)?;
 
     if node.kind() != "identifier" {
@@ -40215,5 +40226,142 @@ generated quantities {
         // function body is found). This tests actual behavior.
         let syms = BlockDetector::detect_jags("model <- function() { }");
         assert_eq!(syms.len(), 1);
+    }
+}
+
+/// Regression tests for issue #149: LSP request handlers passed
+/// `position.character` (UTF-16 column) directly as the byte column to
+/// `tree_sitter::Point::new`. On lines containing a multi-byte UTF-8
+/// character before the cursor, that misplaces the cursor and tree-sitter
+/// descends into the wrong AST node. Each test puts a non-BMP character
+/// (`🦀`, 4 bytes / 2 UTF-16 units) on the cursor line before the cursor.
+#[cfg(test)]
+mod issue_149_utf16_handlers {
+    use super::{
+        completion, goto_definition, lsp_position_to_ts_point, prepare_signature_help, references,
+    };
+    use crate::state::{Document, WorldState};
+    use tower_lsp::lsp_types::{CompletionResponse, GotoDefinitionResponse, Position, Url};
+    use tree_sitter::Point;
+
+    fn create_state() -> WorldState {
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+        state
+    }
+
+    fn add_doc(state: &mut WorldState, uri_str: &str, content: &str) -> Url {
+        let uri = Url::parse(uri_str).expect("invalid URI");
+        state
+            .documents
+            .insert(uri.clone(), Document::new(content, None));
+        uri
+    }
+
+    #[test]
+    fn helper_converts_utf16_position_to_byte_point() {
+        // Line: `"🦀"; abc`. UTF-16 col of `a` = 6, byte col = 8.
+        let text = "abc <- 1\n\"🦀\"; abc\n";
+        let point = lsp_position_to_ts_point(text, Position::new(1, 6));
+        assert_eq!(point, Point::new(1, 8));
+    }
+
+    #[test]
+    fn helper_pure_ascii_passes_through() {
+        // Pure ASCII: UTF-16 column equals byte column, so the helper is
+        // identity on the column.
+        let text = "abc <- 1\nuse(abc)\n";
+        let point = lsp_position_to_ts_point(text, Position::new(1, 4));
+        assert_eq!(point, Point::new(1, 4));
+    }
+
+    #[test]
+    fn goto_definition_with_non_bmp_before_cursor_on_cursor_line() {
+        let mut state = create_state();
+        // Line 1 cursor line has `🦀` (2 UTF-16 units / 4 bytes) before `abc`.
+        // UTF-16 col of `a` of `abc` on line 1 = 6, byte col = 8.
+        let code = "abc <- 1\n\"🦀\"; abc\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let result = goto_definition(&state, &uri, Position::new(1, 6));
+
+        let location = match result {
+            Some(GotoDefinitionResponse::Scalar(loc)) => loc,
+            other => panic!("expected Scalar response, got {:?}", other),
+        };
+        assert_eq!(location.uri, uri);
+        assert_eq!(
+            location.range.start.line, 0,
+            "definition lives on line 0 (`abc <- 1`)"
+        );
+        assert_eq!(location.range.start.character, 0);
+    }
+
+    #[test]
+    fn references_with_non_bmp_before_cursor_on_cursor_line() {
+        let mut state = create_state();
+        let code = "abc <- 1\n\"🦀\"; abc\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        // UTF-16 col 6 on line 1 = `a` of `abc`. With the bug, byte col 6
+        // lands on `;` (not an identifier) so the handler returns None.
+        let locations =
+            references(&state, &uri, Position::new(1, 6)).expect("expected Some(references)");
+
+        // Two occurrences: the LHS of `abc <- 1` on line 0 and the use on
+        // line 1. NB: the second reference's `character` field is currently
+        // reported as a byte column (8), not a UTF-16 column. That's a
+        // separate output-direction bug in `find_references_in_tree` and is
+        // out of scope for issue #149 (input-direction conversion). The
+        // important regression here is that the handler resolved the
+        // identifier at all.
+        let lines: Vec<u32> = locations.iter().map(|l| l.range.start.line).collect();
+        assert_eq!(lines, vec![0, 1], "expected references on lines 0 and 1");
+    }
+
+    #[tokio::test]
+    async fn signature_help_active_parameter_with_non_bmp_before_cursor() {
+        let mut state = create_state();
+        // Line 1: `"🦀"; add(1, 2)`.
+        // UTF-16 col 13 = `2` (the second arg). Byte col = 15.
+        // Comma is at byte col 13. With the bug, cursor.column = 13 is taken
+        // as a byte column; detect_active_parameter requires the comma's
+        // end (14) to be `<= cursor.column`, so 14 <= 13 is false and the
+        // comma is not counted, yielding active_parameter = 0.
+        let code = "add <- function(x, y) x + y\n\"🦀\"; add(1, 2)\n";
+        let uri = Url::parse("file:///t.R").unwrap();
+        state.open_document(uri.clone(), code, None);
+
+        let ctx =
+            prepare_signature_help(&state, &uri, Position::new(1, 13)).expect("ctx must be Some");
+        assert_eq!(ctx.active_parameter, Some(1));
+    }
+
+    #[test]
+    fn completion_outside_namespace_with_non_bmp_before_cursor() {
+        let mut state = create_state();
+        // Line 1: `"🦀"; pkg::foo + 1`.
+        // UTF-16 col 15 = `+` (logically OUTSIDE the namespace expression).
+        // Byte col = 17. With the bug, cursor.column = 15 is taken as byte,
+        // landing inside `foo`; tree-sitter descends into the
+        // `namespace_operator` parent and `find_namespace_context` returns
+        // `Some("pkg")`, causing completion to short-circuit with an empty
+        // list. With the fix, the cursor lands on `+` and completion
+        // produces the normal list including the local `my_local`.
+        let code = "my_local <- 1\n\"🦀\"; pkg::foo + 1\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let response = completion(&state, &uri, Position::new(1, 15), None)
+            .expect("expected Some(completion response)");
+        let items = match response {
+            CompletionResponse::Array(items) => items,
+            other => panic!("expected Array response, got {:?}", other),
+        };
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.contains(&"my_local"),
+            "expected `my_local` in completions; cursor on `+` is outside the namespace expression. got {:?}",
+            labels
+        );
     }
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -10826,13 +10826,7 @@ pub fn goto_definition(
 
         return Some(GotoDefinitionResponse::Scalar(Location {
             uri: symbol.source_uri.clone(),
-            range: Range {
-                start: Position::new(symbol.defined_line, symbol.defined_column),
-                end: Position::new(
-                    symbol.defined_line,
-                    symbol.defined_column + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>(),
-                ),
-            },
+            range: scoped_symbol_range(symbol, name),
         }));
     }
 
@@ -10849,13 +10843,7 @@ pub fn goto_definition(
                 }
                 return Some(GotoDefinitionResponse::Scalar(Location {
                     uri: symbol.source_uri.clone(),
-                    range: Range {
-                        start: Position::new(symbol.defined_line, symbol.defined_column),
-                        end: Position::new(
-                            symbol.defined_line,
-                            symbol.defined_column + name.len() as u32,
-                        ),
-                    },
+                    range: scoped_symbol_range(symbol, name),
                 }));
             }
         }
@@ -10874,13 +10862,7 @@ pub fn goto_definition(
                 }
                 return Some(GotoDefinitionResponse::Scalar(Location {
                     uri: symbol.source_uri.clone(),
-                    range: Range {
-                        start: Position::new(symbol.defined_line, symbol.defined_column),
-                        end: Position::new(
-                            symbol.defined_line,
-                            symbol.defined_column + name.len() as u32,
-                        ),
-                    },
+                    range: scoped_symbol_range(symbol, name),
                 }));
             }
         }
@@ -10951,6 +10933,13 @@ fn find_definition_in_tree(node: Node, name: &str, text: &str) -> Option<Range> 
     }
 
     None
+}
+
+fn scoped_symbol_range(symbol: &ScopedSymbol, name: &str) -> Range {
+    Range {
+        start: Position::new(symbol.defined_line, symbol.defined_column),
+        end: Position::new(symbol.defined_line, symbol.defined_column + utf16_len(name)),
+    }
 }
 
 // ============================================================================
@@ -40312,6 +40301,31 @@ mod issue_149_utf16_handlers {
             "`abc` starts at UTF-16 col 6, not byte col 8"
         );
         assert_eq!(location.range.end, Position::new(0, 9));
+    }
+
+    #[tokio::test]
+    async fn goto_definition_artifact_fallback_reports_utf16_identifier_length() {
+        let mut state = create_state();
+        let use_uri = add_doc(&mut state, "file:///use.R", "éclair\n");
+        let def_uri = Url::parse("file:///def.R").unwrap();
+        state
+            .document_store
+            .open(def_uri.clone(), "éclair <- 1\n", 1)
+            .await;
+
+        let result = goto_definition(&state, &use_uri, Position::new(0, 1));
+
+        let location = match result {
+            Some(GotoDefinitionResponse::Scalar(loc)) => loc,
+            other => panic!("expected Scalar response, got {:?}", other),
+        };
+        assert_eq!(location.uri, def_uri);
+        assert_eq!(location.range.start, Position::new(0, 0));
+        assert_eq!(
+            location.range.end,
+            Position::new(0, 6),
+            "`éclair` is 6 UTF-16 code units but 7 UTF-8 bytes"
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -9750,14 +9750,8 @@ pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<
     };
 
     let node_range = Range {
-        start: Position::new(
-            node.start_position().row as u32,
-            node.start_position().column as u32,
-        ),
-        end: Position::new(
-            node.end_position().row as u32,
-            node.end_position().column as u32,
-        ),
+        start: ts_point_to_lsp_position(&text, node.start_position()),
+        end: ts_point_to_lsp_position(&text, node.end_position()),
     };
 
     // Try cross-file symbols (includes local scope with definition extraction)
@@ -10942,14 +10936,8 @@ fn find_definition_in_tree(node: Node, name: &str, text: &str) -> Option<Range> 
                 && node_text(lhs, text) == name
             {
                 return Some(Range {
-                    start: Position::new(
-                        lhs.start_position().row as u32,
-                        lhs.start_position().column as u32,
-                    ),
-                    end: Position::new(
-                        lhs.end_position().row as u32,
-                        lhs.end_position().column as u32,
-                    ),
+                    start: ts_point_to_lsp_position(text, lhs.start_position()),
+                    end: ts_point_to_lsp_position(text, lhs.end_position()),
                 });
             }
         }
@@ -40245,8 +40233,8 @@ generated quantities {
 #[cfg(test)]
 mod issue_149_utf16_handlers {
     use super::{
-        completion, goto_definition, lsp_position_to_ts_point, prepare_signature_help, references,
-        selection_range,
+        completion, goto_definition, hover, lsp_position_to_ts_point, prepare_signature_help,
+        references, selection_range,
     };
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::{CompletionResponse, GotoDefinitionResponse, Position, Url};
@@ -40303,6 +40291,27 @@ mod issue_149_utf16_handlers {
             "definition lives on line 0 (`abc <- 1`)"
         );
         assert_eq!(location.range.start.character, 0);
+    }
+
+    #[test]
+    fn goto_definition_fallback_reports_utf16_columns_on_non_bmp_definition_line() {
+        let mut state = create_state();
+        let use_uri = add_doc(&mut state, "file:///use.R", "abc\n");
+        let def_uri = add_doc(&mut state, "file:///def.R", "\"🦀\"; abc <- 1\n");
+
+        let result = goto_definition(&state, &use_uri, Position::new(0, 1));
+
+        let location = match result {
+            Some(GotoDefinitionResponse::Scalar(loc)) => loc,
+            other => panic!("expected Scalar response, got {:?}", other),
+        };
+        assert_eq!(location.uri, def_uri);
+        assert_eq!(
+            location.range.start,
+            Position::new(0, 6),
+            "`abc` starts at UTF-16 col 6, not byte col 8"
+        );
+        assert_eq!(location.range.end, Position::new(0, 9));
     }
 
     #[test]
@@ -40395,6 +40404,19 @@ mod issue_149_utf16_handlers {
         // `abc` on line 0 cols 0..3, and on line 1 cols 6..9 (UTF-16).
         // With the bug, the line-1 entry is reported as 8..11 (bytes).
         assert_eq!(found, vec![(0, 0, 3), (1, 6, 9)]);
+    }
+    #[tokio::test]
+    async fn hover_reports_utf16_range_on_non_bmp_cursor_line() {
+        let mut state = create_state();
+        let code = "abc <- 1\n\"🦀\"; abc\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+
+        let result = hover(&state, &uri, Position::new(1, 6))
+            .await
+            .expect("expected Some(hover)");
+        let range = result.range.expect("hover should include identifier range");
+        assert_eq!(range.start, Position::new(1, 6));
+        assert_eq!(range.end, Position::new(1, 9));
     }
 
     /// Same input-direction bug pattern as the four sites in #149, but in


### PR DESCRIPTION
## Summary
- Convert LSP UTF-16 input columns to tree-sitter byte columns before cursor-based AST lookups in affected handlers.
- Convert tree-sitter byte-column output ranges back to UTF-16 columns for hover, references, selection ranges, and goto-definition fallback/artifact paths.
- Add non-ASCII and non-BMP regression coverage, including the qualified `foo$bar` cursor-line repro shape from #149.

Closes #149.

## Validation
- `cargo test -p raven issue_149_utf16_handlers`
- `cargo test -p raven dollar_rhs_utf16_non_bmp_on_defining_line`
- `cargo check -p raven`
- `cargo test -p raven`

## Notes
- Did not run cargo formatting commands; formatting drift remains out of scope.

## Oz
- Conversation: https://app.warp.dev/conversation/9e2f7eff-5b2d-469c-94b1-3cf3466af1f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cursor positioning and range calculations to use UTF-16-aware conversions, improving accuracy for goto-definition, references, hover, completion, and selection-range—notably with emojis and other non-BMP characters.

* **Tests**
  * Added regression tests covering multiple handlers with non-BMP characters to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->