### PR TITLE
Normalize rustfmt baseline

### DIFF
--- a/crates/raven/benches/cross_file.rs
+++ b/crates/raven/benches/cross_file.rs
@@ -170,7 +170,7 @@ fn bench_scope_resolution(c: &mut Criterion) {
                     &base_exports,
                     true,
                     raven::cross_file::config::BackwardDependencyMode::Explicit,
-                    &|| false
+                    &|| false,
                 ))
             })
         });
@@ -232,7 +232,7 @@ fn bench_scope_hotspots(c: &mut Criterion) {
                         &base_exports,
                         true,
                         raven::cross_file::config::BackwardDependencyMode::Explicit,
-                        &|| false
+                        &|| false,
                     ))
                 })
             },

--- a/crates/raven/benches/edit_to_publish.rs
+++ b/crates/raven/benches/edit_to_publish.rs
@@ -194,14 +194,26 @@ fn bench_single_file(c: &mut Criterion) {
         BenchmarkId::new("linear_chain_15", "root"),
         &(&lc_state, &lc_root, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
     group.bench_with_input(
         BenchmarkId::new("linear_chain_15", "leaf"),
         &(&lc_state, &lc_leaf, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
 
@@ -216,14 +228,26 @@ fn bench_single_file(c: &mut Criterion) {
         BenchmarkId::new("fanout_30", "hub"),
         &(&fan_state, &fan_hub, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
     group.bench_with_input(
         BenchmarkId::new("fanout_30", "leaf"),
         &(&fan_state, &fan_leaf, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
 
@@ -239,21 +263,39 @@ fn bench_single_file(c: &mut Criterion) {
         BenchmarkId::new("mixed_20x5", "hub"),
         &(&mix_state, &mix_hub, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
     group.bench_with_input(
         BenchmarkId::new("mixed_20x5", "leaf"),
         &(&mix_state, &mix_leaf, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
     group.bench_with_input(
         BenchmarkId::new("mixed_20x5", "chain_tail"),
         &(&mix_state, &mix_chain_tail, &cancel),
         |b, &(state, uri, c)| {
-            b.iter(|| black_box(diagnostics_via_snapshot(black_box(state), black_box(uri), black_box(c))))
+            b.iter(|| {
+                black_box(diagnostics_via_snapshot(
+                    black_box(state),
+                    black_box(uri),
+                    black_box(c),
+                ))
+            })
         },
     );
 

--- a/crates/raven/benches/lsp_operations.rs
+++ b/crates/raven/benches/lsp_operations.rs
@@ -50,10 +50,9 @@ fn build_state_from_fixture(workspace_path: &std::path::Path) -> WorldState {
         // version aligned across stores so cross-store consistency checks
         // see the same value the runtime would after the first open.
         rt.block_on(state.document_store.open(uri.clone(), &content, 1));
-        state.documents.insert(
-            uri.clone(),
-            Document::new_with_uri(&content, Some(1), &uri),
-        );
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(&content, Some(1), &uri));
     }
 
     // Run workspace scan and apply index (populates cross-file state)

--- a/crates/raven/examples/profile_diagnostics.rs
+++ b/crates/raven/examples/profile_diagnostics.rs
@@ -108,8 +108,7 @@ fn build_state(workspace: &Path) -> WorldState {
             .documents
             .insert(uri.clone(), Document::new_with_uri(&content, Some(1), &uri));
     }
-    let (index, imports, cross_file_entries, new_index_entries) =
-        scan_workspace(&[folder_url], 20);
+    let (index, imports, cross_file_entries, new_index_entries) = scan_workspace(&[folder_url], 20);
     state.apply_workspace_index(index, imports, cross_file_entries, new_index_entries);
     state
 }
@@ -166,13 +165,21 @@ fn main() {
     let state = build_state(dir.path());
     measure("  file_0.R (root)", &state, &uri_of(dir.path(), "file_0.R"));
     measure("  file_7.R (mid)", &state, &uri_of(dir.path(), "file_7.R"));
-    measure("  file_14.R (leaf)", &state, &uri_of(dir.path(), "file_14.R"));
+    measure(
+        "  file_14.R (leaf)",
+        &state,
+        &uri_of(dir.path(), "file_14.R"),
+    );
 
     println!("\nTopology: fanout_30");
     let dir = TempDir::new().unwrap();
     write_fanout(dir.path(), 30);
     let state = build_state(dir.path());
-    measure("  utility.R (hub)", &state, &uri_of(dir.path(), "utility.R"));
+    measure(
+        "  utility.R (hub)",
+        &state,
+        &uri_of(dir.path(), "utility.R"),
+    );
     measure("  leaf_0.R", &state, &uri_of(dir.path(), "leaf_0.R"));
     measure("  leaf_15.R", &state, &uri_of(dir.path(), "leaf_15.R"));
 
@@ -180,16 +187,28 @@ fn main() {
     let dir = TempDir::new().unwrap();
     write_mixed(dir.path(), 20, 5);
     let state = build_state(dir.path());
-    measure("  utility.R (hub)", &state, &uri_of(dir.path(), "utility.R"));
+    measure(
+        "  utility.R (hub)",
+        &state,
+        &uri_of(dir.path(), "utility.R"),
+    );
     measure("  leaf_0.R", &state, &uri_of(dir.path(), "leaf_0.R"));
     measure("  chain_0_0.R", &state, &uri_of(dir.path(), "chain_0_0.R"));
-    measure("  chain_0_4.R (tail)", &state, &uri_of(dir.path(), "chain_0_4.R"));
+    measure(
+        "  chain_0_4.R (tail)",
+        &state,
+        &uri_of(dir.path(), "chain_0_4.R"),
+    );
 
     println!("\nTopology: fanout_100");
     let dir = TempDir::new().unwrap();
     write_fanout(dir.path(), 100);
     let state = build_state(dir.path());
-    measure("  utility.R (hub)", &state, &uri_of(dir.path(), "utility.R"));
+    measure(
+        "  utility.R (hub)",
+        &state,
+        &uri_of(dir.path(), "utility.R"),
+    );
     measure("  leaf_0.R", &state, &uri_of(dir.path(), "leaf_0.R"));
     measure("  leaf_99.R", &state, &uri_of(dir.path(), "leaf_99.R"));
 
@@ -197,8 +216,20 @@ fn main() {
     let dir = TempDir::new().unwrap();
     write_mixed(dir.path(), 50, 10);
     let state = build_state(dir.path());
-    measure("  utility.R (hub)", &state, &uri_of(dir.path(), "utility.R"));
+    measure(
+        "  utility.R (hub)",
+        &state,
+        &uri_of(dir.path(), "utility.R"),
+    );
     measure("  leaf_0.R", &state, &uri_of(dir.path(), "leaf_0.R"));
-    measure("  chain_0_5.R (mid)", &state, &uri_of(dir.path(), "chain_0_5.R"));
-    measure("  chain_0_9.R (tail)", &state, &uri_of(dir.path(), "chain_0_9.R"));
+    measure(
+        "  chain_0_5.R (mid)",
+        &state,
+        &uri_of(dir.path(), "chain_0_5.R"),
+    );
+    measure(
+        "  chain_0_9.R (tail)",
+        &state,
+        &uri_of(dir.path(), "chain_0_9.R"),
+    );
 }

--- a/crates/raven/examples/profile_real_workspace.rs
+++ b/crates/raven/examples/profile_real_workspace.rs
@@ -84,8 +84,7 @@ fn main() {
             data_uri.clone(),
             Document::new_with_uri(&data_content, None, &data_uri),
         );
-        let result =
-            diagnostics_via_snapshot_profile(&state, &data_uri, &DiagCancelToken::never());
+        let result = diagnostics_via_snapshot_profile(&state, &data_uri, &DiagCancelToken::never());
         eprintln!("  snapshot build:      {:?}", result.0);
         eprintln!("  diagnostics compute: {:?}", result.1);
         eprintln!("  diagnostic count:    {:?}", result.2);

--- a/crates/raven/examples/profile_worldwide.rs
+++ b/crates/raven/examples/profile_worldwide.rs
@@ -223,12 +223,10 @@ fn percent(d: Duration, total: Duration) -> f64 {
 }
 
 fn main() {
-    env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("warn"),
-    )
-    .format_timestamp(None)
-    .try_init()
-    .ok();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .format_timestamp(None)
+        .try_init()
+        .ok();
 
     let workspace = std::env::args()
         .nth(1)
@@ -262,7 +260,10 @@ fn main() {
         phases.files,
         phases.bytes / 1024
     );
-    println!("    discover (read_dir tree): {:>7.1}ms", ms(phases.discover));
+    println!(
+        "    discover (read_dir tree): {:>7.1}ms",
+        ms(phases.discover)
+    );
     println!(
         "    fs::read_to_string:        {:>7.1}ms ({:>4.1}%)",
         ms(phases.read),
@@ -340,7 +341,10 @@ fn main() {
     }
     apply_runs.sort();
     let median_apply = apply_runs[apply_runs.len() / 2];
-    println!("    median apply_workspace_index: {:>7.1}ms", ms(median_apply));
+    println!(
+        "    median apply_workspace_index: {:>7.1}ms",
+        ms(median_apply)
+    );
     println!(
         "    runs: {:?}",
         apply_runs.iter().map(|d| ms(*d)).collect::<Vec<_>>()
@@ -397,9 +401,7 @@ fn main() {
         println!("(skipping phases 5/6: {} does not exist)", target.display());
         return;
     }
-    println!(
-        "[5] scripts/data.r diagnostics — COLD start (workspace_scan_complete=false):"
-    );
+    println!("[5] scripts/data.r diagnostics — COLD start (workspace_scan_complete=false):");
     let mut state = make_state(&workspace);
     state.package_library = lib.clone();
     state.package_library_ready = true;
@@ -439,9 +441,7 @@ fn main() {
     // ------------------------------------------------------------------
     // Phase 6: scripts/data.r diagnostics — POST-scan (workspace index applied)
     // ------------------------------------------------------------------
-    println!(
-        "[6] scripts/data.r diagnostics — POST-scan (workspace_scan_complete=true):"
-    );
+    println!("[6] scripts/data.r diagnostics — POST-scan (workspace_scan_complete=true):");
     let (index, imports, cf, new_idx) = scan_workspace(&[folder.clone()], 20);
     state.apply_workspace_index(index, imports, cf, new_idx);
     // Warmup
@@ -478,9 +478,7 @@ fn main() {
     // Summary
     // ------------------------------------------------------------------
     println!("=== Cold-start lag attribution ===\n");
-    println!(
-        "Wall-clock from did_open(data.r) to first non-deferred diagnostic publish ≈"
-    );
+    println!("Wall-clock from did_open(data.r) to first non-deferred diagnostic publish ≈");
     println!("  scan_workspace          : {:>7.1}ms", ms(median));
     println!("  apply_workspace_index   : {:>7.1}ms", ms(median_apply));
     println!(
@@ -489,8 +487,7 @@ fn main() {
         ms(median_build_warm),
         ms(median_diag_warm)
     );
-    let cold_total =
-        median + median_apply + median_build_warm + median_diag_warm;
+    let cold_total = median + median_apply + median_build_warm + median_diag_warm;
     println!(
         "  --------------------------- {:>7.1}ms (lower bound; ignores prefetch + lock contention)",
         ms(cold_total)
@@ -543,10 +540,9 @@ fn main() {
     let mut b_runs = Vec::new();
     for _ in 0..3 {
         let t_a = measure_scan_inner_loop(&paths, |_p, text, _doc| extract_metadata(text));
-        let t_b =
-            measure_scan_inner_loop(&paths, |_p, text, doc| {
-                extract_metadata_with_tree(text, doc.tree.as_ref())
-            });
+        let t_b = measure_scan_inner_loop(&paths, |_p, text, doc| {
+            extract_metadata_with_tree(text, doc.tree.as_ref())
+        });
         a_runs.push(t_a);
         b_runs.push(t_b);
     }
@@ -617,9 +613,10 @@ fn main() {
                             } else {
                                 scope::ScopeArtifacts::default()
                             });
-                            let snap = raven::cross_file::file_cache::FileSnapshot::with_content_hash(
-                                &fs_meta, &text,
-                            );
+                            let snap =
+                                raven::cross_file::file_cache::FileSnapshot::with_content_hash(
+                                    &fs_meta, &text,
+                                );
                             let xf_meta_arc: Arc<CrossFileMetadata> = Arc::new(xf_meta);
                             local_cf.insert(
                                 uri.clone(),
@@ -680,7 +677,10 @@ fn main() {
     println!("=== Summary of fix candidates ===\n");
     println!("Cold-start path BEFORE fixes (measured):");
     println!("  scan_workspace                : {:>7.1}ms", ms(median));
-    println!("  apply_workspace_index         : {:>7.1}ms", ms(median_apply));
+    println!(
+        "  apply_workspace_index         : {:>7.1}ms",
+        ms(median_apply)
+    );
     println!(
         "  post-scan diagnostics (data.r): {:>7.1}ms",
         ms(median_build_warm + median_diag_warm)

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -317,16 +317,10 @@ pub(crate) fn parse_cross_file_config(
         {
             config.packages_missing_package_severity = parse_severity(sev);
         }
-        if let Some(v) = packages
-            .get("watchLibraryPaths")
-            .and_then(|v| v.as_bool())
-        {
+        if let Some(v) = packages.get("watchLibraryPaths").and_then(|v| v.as_bool()) {
             config.packages_watch_library_paths = v;
         }
-        if let Some(v) = packages
-            .get("watchDebounceMs")
-            .and_then(|v| v.as_u64())
-        {
+        if let Some(v) = packages.get("watchDebounceMs").and_then(|v| v.as_u64()) {
             config.packages_watch_debounce_ms = v.clamp(100, 5000);
         }
     }
@@ -984,12 +978,10 @@ impl LanguageServer for Backend {
                 document_on_type_formatting_provider: Some(
                     indentation::on_type_formatting_capability(),
                 ),
-                execute_command_provider: Some(
-                    tower_lsp::lsp_types::ExecuteCommandOptions {
-                        commands: vec![],
-                        ..Default::default()
-                    },
-                ),
+                execute_command_provider: Some(tower_lsp::lsp_types::ExecuteCommandOptions {
+                    commands: vec![],
+                    ..Default::default()
+                }),
                 ..Default::default()
             },
             server_info: Some(ServerInfo {
@@ -1116,8 +1108,7 @@ impl LanguageServer for Backend {
                         // swapped `state.package_library` with a fresh Arc. Re-read
                         // the live library so prefetch warms the right cache instead
                         // of an orphaned one.
-                        let (effective_pkg_lib, effective_packages_enabled) = if packages_enabled
-                        {
+                        let (effective_pkg_lib, effective_packages_enabled) = if packages_enabled {
                             (pkg_lib, true)
                         } else {
                             let state = state_clone.read().await;
@@ -1133,11 +1124,8 @@ impl LanguageServer for Backend {
                             (live, enabled)
                         };
                         if effective_packages_enabled {
-                            prefetch_packages_for_open_documents(
-                                &state_clone,
-                                &effective_pkg_lib,
-                            )
-                            .await;
+                            prefetch_packages_for_open_documents(&state_clone, &effective_pkg_lib)
+                                .await;
                         }
 
                         // Revalidate all open documents to pick up auto-detected backward edges
@@ -1279,8 +1267,7 @@ impl LanguageServer for Backend {
                 // fresh empty library whose `cached_count()` starts at 0.
                 // We compute the user-visible delta against the pre-rebuild
                 // count instead.
-                let before_count =
-                    self.state.read().await.package_library.cached_count().await;
+                let before_count = self.state.read().await.package_library.cached_count().await;
 
                 // Rebuild the PackageLibrary first — this re-runs `.libPaths()`
                 // so mid-session libpath changes (renv switched projects,
@@ -1288,9 +1275,8 @@ impl LanguageServer for Backend {
                 // up. `clear_cache` alone would leave the stale libpath
                 // snapshot in place and the refresh would re-populate with the
                 // same wrong paths.
-                let packages_enabled = {
-                    self.state.read().await.cross_file_config.packages_enabled
-                };
+                let packages_enabled =
+                    { self.state.read().await.cross_file_config.packages_enabled };
                 if packages_enabled {
                     let (new_lib, ready) = rebuild_package_library(&self.state).await;
                     let mut state = self.state.write().await;
@@ -1589,15 +1575,16 @@ impl LanguageServer for Backend {
             // need revalidation because their inherited scope is taken from
             // `uri`'s symbols at the source() call site.
             if interface_changed || result.edges_changed {
-                let neighbors = crate::cross_file::revalidation::compute_affected_dependents_after_edit(
-                    &uri,
-                    interface_changed,
-                    result.edges_changed,
-                    &state.cross_file_graph,
-                    |u| state.documents.contains_key(u),
-                    state.cross_file_config.max_chain_depth,
-                    state.cross_file_config.max_transitive_dependents_visited,
-                );
+                let neighbors =
+                    crate::cross_file::revalidation::compute_affected_dependents_after_edit(
+                        &uri,
+                        interface_changed,
+                        result.edges_changed,
+                        &state.cross_file_graph,
+                        |u| state.documents.contains_key(u),
+                        state.cross_file_config.max_chain_depth,
+                        state.cross_file_config.max_transitive_dependents_visited,
+                    );
                 for dep in neighbors {
                     affected.insert(dep);
                 }
@@ -1847,24 +1834,21 @@ impl LanguageServer for Backend {
                 // (their inherited scope is taken from this file's symbols at
                 // the source() call site).
                 if second_result.edges_changed {
-                    let neighbors = crate::cross_file::revalidation::compute_affected_dependents_after_edit(
-                        &uri,
-                        false,
-                        true,
-                        &state.cross_file_graph,
-                        |u| state.documents.contains_key(u),
-                        state.cross_file_config.max_chain_depth,
-                        state.cross_file_config.max_transitive_dependents_visited,
-                    );
+                    let neighbors =
+                        crate::cross_file::revalidation::compute_affected_dependents_after_edit(
+                            &uri,
+                            false,
+                            true,
+                            &state.cross_file_graph,
+                            |u| state.documents.contains_key(u),
+                            state.cross_file_config.max_chain_depth,
+                            state.cross_file_config.max_transitive_dependents_visited,
+                        );
                     // Re-enrichment changed work_items; force-republish marking
                     // is deferred until after both re-enrichment paths complete
                     // so evicted URIs don't carry orphaned force counters.
-                    work_items = rebuild_work_items_after_reenrichment(
-                        &uri,
-                        &work_items,
-                        neighbors,
-                        &state,
-                    );
+                    work_items =
+                        rebuild_work_items_after_reenrichment(&uri, &work_items, neighbors, &state);
                     // Re-enrichment moved edges; refresh pins so the open-doc
                     // neighborhood matches the post-update graph.
                     state.recompute_open_neighborhood_pins();
@@ -1958,24 +1942,21 @@ impl LanguageServer for Backend {
             );
 
             if second_result.edges_changed {
-                let neighbors = crate::cross_file::revalidation::compute_affected_dependents_after_edit(
-                    &uri,
-                    false,
-                    true,
-                    &state.cross_file_graph,
-                    |u| state.documents.contains_key(u),
-                    state.cross_file_config.max_chain_depth,
-                    state.cross_file_config.max_transitive_dependents_visited,
-                );
+                let neighbors =
+                    crate::cross_file::revalidation::compute_affected_dependents_after_edit(
+                        &uri,
+                        false,
+                        true,
+                        &state.cross_file_graph,
+                        |u| state.documents.contains_key(u),
+                        state.cross_file_config.max_chain_depth,
+                        state.cross_file_config.max_transitive_dependents_visited,
+                    );
                 // Re-enrichment changed work_items; force-republish marking
                 // is deferred until after both re-enrichment paths complete
                 // so evicted URIs don't carry orphaned force counters.
-                work_items = rebuild_work_items_after_reenrichment(
-                    &uri,
-                    &work_items,
-                    neighbors,
-                    &state,
-                );
+                work_items =
+                    rebuild_work_items_after_reenrichment(&uri, &work_items, neighbors, &state);
                 // Re-enrichment moved edges; refresh pins so the open-doc
                 // neighborhood matches the post-update graph.
                 state.recompute_open_neighborhood_pins();
@@ -1996,9 +1977,12 @@ impl LanguageServer for Backend {
                         .get(&uri)
                         .map(|d| d.text().lines().count().saturating_sub(1) as u32)
                         .unwrap_or(0);
-                    let snapshot =
-                        state.build_package_scope_snapshot(&[(uri.clone(), last_line)]);
-                    (snapshot, state.package_library.clone(), state.package_library_ready)
+                    let snapshot = state.build_package_scope_snapshot(&[(uri.clone(), last_line)]);
+                    (
+                        snapshot,
+                        state.package_library.clone(),
+                        state.package_library_ready,
+                    )
                 }; // read lock released
 
                 let empty_base_exports = std::collections::HashSet::new();
@@ -2056,7 +2040,7 @@ impl LanguageServer for Backend {
         {
             let state = self.state.read().await;
             state.diagnostics_gate.mark_force_republish_many(
-                work_items.iter().map(|(u, _, _)| u).filter(|u| **u != uri)
+                work_items.iter().map(|(u, _, _)| u).filter(|u| **u != uri),
             );
         }
 
@@ -2297,15 +2281,16 @@ impl LanguageServer for Backend {
             // Bulk-mark all dependents/children under a single write-lock to
             // skip per-URI lock churn on large fan-outs (Requirement 0.8).
             if interface_changed || edges_changed {
-                let neighbors = crate::cross_file::revalidation::compute_affected_dependents_after_edit(
-                    &uri,
-                    interface_changed,
-                    edges_changed,
-                    &state.cross_file_graph,
-                    |u| state.documents.contains_key(u),
-                    state.cross_file_config.max_chain_depth,
-                    state.cross_file_config.max_transitive_dependents_visited,
-                );
+                let neighbors =
+                    crate::cross_file::revalidation::compute_affected_dependents_after_edit(
+                        &uri,
+                        interface_changed,
+                        edges_changed,
+                        &state.cross_file_graph,
+                        |u| state.documents.contains_key(u),
+                        state.cross_file_config.max_chain_depth,
+                        state.cross_file_config.max_transitive_dependents_visited,
+                    );
                 for dep in neighbors {
                     affected.insert(dep);
                 }
@@ -2456,10 +2441,7 @@ impl LanguageServer for Backend {
                 if packages_vec.is_empty() {
                     return;
                 }
-                log::trace!(
-                    "Background prefetching {} packages",
-                    packages_vec.len()
-                );
+                log::trace!("Background prefetching {} packages", packages_vec.len());
                 pkg_lib.prefetch_packages(&packages_vec).await;
 
                 // After prefetch completes, trigger diagnostic revalidation
@@ -3186,12 +3168,8 @@ impl LanguageServer for Backend {
                         .mark_force_republish_many(affected_for_async.iter());
                 }
                 for uri in affected_for_async {
-                    Backend::publish_diagnostics_via_arc(
-                        state_arc.clone(),
-                        client.clone(),
-                        &uri,
-                    )
-                    .await;
+                    Backend::publish_diagnostics_via_arc(state_arc.clone(), client.clone(), &uri)
+                        .await;
                 }
             });
         } else {
@@ -4488,9 +4466,7 @@ pub(crate) struct ScopeProbeSnapshot {
 ///
 /// Split out of the consumer body to keep the state invariants unit-testable
 /// without needing a tower-lsp `Client`.
-pub(crate) async fn prepare_dropped_recovery(
-    state_arc: &Arc<RwLock<WorldState>>,
-) -> Vec<Url> {
+pub(crate) async fn prepare_dropped_recovery(state_arc: &Arc<RwLock<WorldState>>) -> Vec<Url> {
     let pkg_lib = { state_arc.read().await.package_library.clone() };
     pkg_lib.clear_cache().await;
 
@@ -4610,13 +4586,15 @@ async fn run_libpath_consumer(
                     state.build_package_scope_snapshot(&docs)
                 };
 
-                let get_artifacts = |target_uri: &Url| -> Option<
-                    Arc<crate::cross_file::scope::ScopeArtifacts>,
-                > { probe.artifacts_map.get(target_uri).cloned() };
-                let get_metadata =
-                    |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
-                        probe.metadata_map.get(target_uri).cloned()
+                let get_artifacts =
+                    |target_uri: &Url| -> Option<Arc<crate::cross_file::scope::ScopeArtifacts>> {
+                        probe.artifacts_map.get(target_uri).cloned()
                     };
+                let get_metadata = |target_uri: &Url| -> Option<
+                    std::sync::Arc<crate::cross_file::CrossFileMetadata>,
+                > {
+                    probe.metadata_map.get(target_uri).cloned()
+                };
                 let empty_base_exports: HashSet<String> = HashSet::new();
                 let affected_uris: Vec<Url> = probe
                     .docs
@@ -4851,8 +4829,7 @@ mod tests {
             let mut activity = CrossFileActivityState::new();
             activity.update(Some(active_post_update.clone()), vec![], 1);
 
-            let prev_uris: HashSet<Url> =
-                [stale_a.clone(), stale_b.clone()].into_iter().collect();
+            let prev_uris: HashSet<Url> = [stale_a.clone(), stale_b.clone()].into_iter().collect();
             let new_neighbors = vec![active_post_update.clone()];
 
             let final_uris = merge_and_cap_reenrichment_revalidations(
@@ -4889,13 +4866,8 @@ mod tests {
 
             let prev_uris: HashSet<Url> = [edited.clone(), active.clone()].into_iter().collect();
 
-            let final_uris = merge_and_cap_reenrichment_revalidations(
-                &edited,
-                prev_uris,
-                vec![],
-                10,
-                &activity,
-            );
+            let final_uris =
+                merge_and_cap_reenrichment_revalidations(&edited, prev_uris, vec![], 10, &activity);
 
             assert_eq!(final_uris[0], edited);
             assert_eq!(final_uris[1], active);
@@ -5139,7 +5111,9 @@ mod tests {
                     "watchDebounceMs": 250
                 }
             });
-            let cfg = crate::backend::parse_cross_file_config(&settings).unwrap().unwrap();
+            let cfg = crate::backend::parse_cross_file_config(&settings)
+                .unwrap()
+                .unwrap();
             assert!(!cfg.packages_watch_library_paths);
             assert_eq!(cfg.packages_watch_debounce_ms, 250);
         }
@@ -5149,13 +5123,17 @@ mod tests {
             let settings = json!({
                 "packages": { "watchDebounceMs": 50 }  // below floor
             });
-            let cfg = crate::backend::parse_cross_file_config(&settings).unwrap().unwrap();
+            let cfg = crate::backend::parse_cross_file_config(&settings)
+                .unwrap()
+                .unwrap();
             assert_eq!(cfg.packages_watch_debounce_ms, 100);
 
             let settings = json!({
                 "packages": { "watchDebounceMs": 99999 } // above ceiling
             });
-            let cfg = crate::backend::parse_cross_file_config(&settings).unwrap().unwrap();
+            let cfg = crate::backend::parse_cross_file_config(&settings)
+                .unwrap()
+                .unwrap();
             assert_eq!(cfg.packages_watch_debounce_ms, 5000);
         }
     }
@@ -5940,10 +5918,8 @@ mod refresh_packages_tests {
 
         {
             let mut s = state.write().await;
-            s.cross_file_config.packages_additional_library_paths = vec![
-                t_old.path().to_path_buf(),
-                t_new.path().to_path_buf(),
-            ];
+            s.cross_file_config.packages_additional_library_paths =
+                vec![t_old.path().to_path_buf(), t_new.path().to_path_buf()];
         }
         let (lib_v2, _ready_v2) = rebuild_package_library(&state).await;
         assert!(
@@ -6104,14 +6080,12 @@ mod refresh_packages_tests {
             .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
         let parent_tree = parser.parse(parent_code, None).unwrap();
-        let parent_artifacts = Arc::new(
-            crate::cross_file::scope::compute_artifacts_with_metadata(
-                &parent_uri,
-                &parent_tree,
-                parent_code,
-                Some(&parent_meta),
-            ),
-        );
+        let parent_artifacts = Arc::new(crate::cross_file::scope::compute_artifacts_with_metadata(
+            &parent_uri,
+            &parent_tree,
+            parent_code,
+            Some(&parent_meta),
+        ));
         let parent_entry = IndexEntry {
             contents: ropey::Rope::from_str(parent_code),
             tree: Some(parent_tree),
@@ -6131,18 +6105,14 @@ mod refresh_packages_tests {
 
         // Child is an OPEN document that sources the parent
         let child_meta = crate::cross_file::extract_metadata(child_code);
-        world.documents.insert(
-            child_uri.clone(),
-            Document::new(child_code, Some(1)),
-        );
+        world
+            .documents
+            .insert(child_uri.clone(), Document::new(child_code, Some(1)));
 
         // Add forward edge: child -> parent
-        world.cross_file_graph.update_file(
-            &child_uri,
-            &child_meta,
-            Some(&workspace_root),
-            |_| None,
-        );
+        world
+            .cross_file_graph
+            .update_file(&child_uri, &child_meta, Some(&workspace_root), |_| None);
 
         // Build snapshot for the child only
         let docs = vec![(child_uri.clone(), 1u32)];
@@ -6167,12 +6137,20 @@ mod refresh_packages_tests {
 
         // Debug: check child artifacts have source() in timeline
         let child_arts = snapshot.artifacts_map.get(&child_uri);
-        assert!(child_arts.is_some(), "child must have artifacts in snapshot");
+        assert!(
+            child_arts.is_some(),
+            "child must have artifacts in snapshot"
+        );
         let child_arts = child_arts.unwrap();
-        let has_source_event = child_arts.timeline.iter().any(|e| {
-            matches!(e, crate::cross_file::scope::ScopeEvent::Source { .. })
-        });
-        assert!(has_source_event, "child artifacts must have Source event in timeline; timeline has {} events", child_arts.timeline.len());
+        let has_source_event = child_arts
+            .timeline
+            .iter()
+            .any(|e| matches!(e, crate::cross_file::scope::ScopeEvent::Source { .. }));
+        assert!(
+            has_source_event,
+            "child artifacts must have Source event in timeline; timeline has {} events",
+            child_arts.timeline.len()
+        );
 
         // Debug: check graph has forward edge from child to parent
         let child_deps = snapshot.graph.get_dependencies(&child_uri);
@@ -6190,9 +6168,10 @@ mod refresh_packages_tests {
         // Debug: check parent artifacts have PackageLoad event
         let parent_arts = snapshot.artifacts_map.get(&parent_uri).unwrap();
         assert!(
-            parent_arts.timeline.iter().any(|e| {
-                matches!(e, crate::cross_file::scope::ScopeEvent::PackageLoad { .. })
-            }),
+            parent_arts
+                .timeline
+                .iter()
+                .any(|e| { matches!(e, crate::cross_file::scope::ScopeEvent::PackageLoad { .. }) }),
             "parent must have PackageLoad event"
         );
         let scope = crate::cross_file::scope::scope_at_position_with_graph(
@@ -6422,14 +6401,12 @@ mod refresh_packages_tests {
             .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
         let parent_tree = parser.parse(parent_code, None).unwrap();
-        let parent_artifacts = Arc::new(
-            crate::cross_file::scope::compute_artifacts_with_metadata(
-                &parent_uri,
-                &parent_tree,
-                parent_code,
-                Some(&parent_meta),
-            ),
-        );
+        let parent_artifacts = Arc::new(crate::cross_file::scope::compute_artifacts_with_metadata(
+            &parent_uri,
+            &parent_tree,
+            parent_code,
+            Some(&parent_meta),
+        ));
         let parent_entry = IndexEntry {
             contents: ropey::Rope::from_str(parent_code),
             tree: Some(parent_tree),

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -2248,7 +2248,8 @@ mod integration_tests {
         // Create closures for scope resolution
         let get_artifacts =
             |uri: &Url| -> Option<Arc<ScopeArtifacts>> { provider.get_artifacts(uri) };
-        let get_metadata = |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> { provider.get_metadata(uri) };
+        let get_metadata =
+            |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> { provider.get_metadata(uri) };
 
         // Query scope at end of parent file
         let scope = scope_at_position_with_graph(

--- a/crates/raven/src/cross_file/cache.rs
+++ b/crates/raven/src/cross_file/cache.rs
@@ -56,8 +56,8 @@ pub(crate) fn pin_aware_push<V>(
             if let Some(victim) = lru_unpinned {
                 guard.pop(&victim);
             } else {
-                let new_cap = NonZeroUsize::new(guard.len() + 1)
-                    .expect("len() + 1 is always non-zero");
+                let new_cap =
+                    NonZeroUsize::new(guard.len() + 1).expect("len() + 1 is always non-zero");
                 guard.resize(new_cap);
             }
         }

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -647,8 +647,7 @@ pub struct DependencyGraph {
     /// Cache of `detect_cycle` results keyed by `uri` (and gated by
     /// `edge_revision` per slot). Bounded LRU so long-lived sessions
     /// don't accumulate entries for files that never get queried again.
-    cycle_cache:
-        std::sync::RwLock<lru::LruCache<Url, (u64, Option<CycleDetection>)>>,
+    cycle_cache: std::sync::RwLock<lru::LruCache<Url, (u64, Option<CycleDetection>)>>,
     /// Counter of cache hits — exposed for tests; not used in production.
     cycle_cache_hits: std::sync::atomic::AtomicU64,
     /// Cache of `(neighborhood, extract_subgraph)` results keyed by
@@ -669,13 +668,15 @@ impl Default for DependencyGraph {
             forward: HashMap::new(),
             backward: HashMap::new(),
             edge_revision: std::sync::atomic::AtomicU64::new(0),
-            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(CYCLE_CACHE_CAPACITY, CYCLE_CACHE_CAPACITY),
-            )),
+            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                CYCLE_CACHE_CAPACITY,
+                CYCLE_CACHE_CAPACITY,
+            ))),
             cycle_cache_hits: std::sync::atomic::AtomicU64::new(0),
-            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(SUBGRAPH_CACHE_CAPACITY, SUBGRAPH_CACHE_CAPACITY),
-            )),
+            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                SUBGRAPH_CACHE_CAPACITY,
+                SUBGRAPH_CACHE_CAPACITY,
+            ))),
             subgraph_cache_hits: std::sync::atomic::AtomicU64::new(0),
         }
     }
@@ -691,13 +692,15 @@ impl Clone for DependencyGraph {
             forward: self.forward.clone(),
             backward: self.backward.clone(),
             edge_revision: std::sync::atomic::AtomicU64::new(0),
-            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(CYCLE_CACHE_CAPACITY, CYCLE_CACHE_CAPACITY),
-            )),
+            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                CYCLE_CACHE_CAPACITY,
+                CYCLE_CACHE_CAPACITY,
+            ))),
             cycle_cache_hits: std::sync::atomic::AtomicU64::new(0),
-            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(SUBGRAPH_CACHE_CAPACITY, SUBGRAPH_CACHE_CAPACITY),
-            )),
+            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                SUBGRAPH_CACHE_CAPACITY,
+                SUBGRAPH_CACHE_CAPACITY,
+            ))),
             subgraph_cache_hits: std::sync::atomic::AtomicU64::new(0),
         }
     }
@@ -710,7 +713,9 @@ impl std::fmt::Debug for DependencyGraph {
             .field("backward", &self.backward)
             .field(
                 "edge_revision",
-                &self.edge_revision.load(std::sync::atomic::Ordering::Relaxed),
+                &self
+                    .edge_revision
+                    .load(std::sync::atomic::Ordering::Relaxed),
             )
             .finish_non_exhaustive()
     }
@@ -1136,13 +1141,15 @@ impl DependencyGraph {
             forward,
             backward,
             edge_revision: std::sync::atomic::AtomicU64::new(0),
-            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(CYCLE_CACHE_CAPACITY, CYCLE_CACHE_CAPACITY),
-            )),
+            cycle_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                CYCLE_CACHE_CAPACITY,
+                CYCLE_CACHE_CAPACITY,
+            ))),
             cycle_cache_hits: std::sync::atomic::AtomicU64::new(0),
-            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(
-                super::cache::non_zero_or(SUBGRAPH_CACHE_CAPACITY, SUBGRAPH_CACHE_CAPACITY),
-            )),
+            subgraph_cache: std::sync::RwLock::new(lru::LruCache::new(super::cache::non_zero_or(
+                SUBGRAPH_CACHE_CAPACITY,
+                SUBGRAPH_CACHE_CAPACITY,
+            ))),
             subgraph_cache_hits: std::sync::atomic::AtomicU64::new(0),
         }
     }
@@ -1669,9 +1676,7 @@ impl DependencyGraph {
         let revision = self.edge_revision.load(Ordering::Acquire);
 
         if let Ok(guard) = self.subgraph_cache.read() {
-            if let Some((cached_rev, cached)) =
-                guard.peek(&(uri.clone(), max_depth, max_visited))
-            {
+            if let Some((cached_rev, cached)) = guard.peek(&(uri.clone(), max_depth, max_visited)) {
                 if *cached_rev == revision {
                     self.subgraph_cache_hits.fetch_add(1, Ordering::Relaxed);
                     return std::sync::Arc::clone(cached);
@@ -2055,7 +2060,10 @@ mod tests {
         // beyond max). With shortest-depth tracking, z must be in result
         // regardless of edge iteration order.
         let deps = graph.get_transitive_dependencies(&root, 5, 1000);
-        assert!(deps.contains(&z), "z must be reachable via the short path; deps={deps:?}");
+        assert!(
+            deps.contains(&z),
+            "z must be reachable via the short path; deps={deps:?}"
+        );
         assert!(deps.contains(&y), "y must be reachable; deps={deps:?}");
         assert!(deps.contains(&x), "x must be in deps; deps={deps:?}");
     }
@@ -2100,7 +2108,10 @@ mod tests {
         // max_depth = 2. Querying x's transitive dependents must yield
         // {mid (depth 1), short_anc (depth 1), root_anc (depth 2)}.
         let dependents = graph.get_transitive_dependents(&x, 2, 1000);
-        assert!(dependents.contains(&mid), "mid must be reachable; dependents={dependents:?}");
+        assert!(
+            dependents.contains(&mid),
+            "mid must be reachable; dependents={dependents:?}"
+        );
         assert!(
             dependents.contains(&short_anc),
             "short_anc must be reachable; dependents={dependents:?}"
@@ -2279,7 +2290,12 @@ mod tests {
 
         let meta_v1 = make_meta_with_source("child.R", 5);
         graph.update_file(&parent, &meta_v1, Some(&workspace_root()), |_| None);
-        graph.update_file(&child, &CrossFileMetadata::default(), Some(&workspace_root()), |_| None);
+        graph.update_file(
+            &child,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root()),
+            |_| None,
+        );
 
         let _ = graph.cached_neighborhood_subgraph(&parent, 10, 100);
         let hits_before = graph.subgraph_cache_hits();
@@ -2310,8 +2326,18 @@ mod tests {
         let child = Url::parse("file:///project/child.R").unwrap();
 
         // Establish baseline (no backward directive).
-        graph.update_file(&parent, &CrossFileMetadata::default(), Some(&workspace_root()), |_| None);
-        graph.update_file(&child, &CrossFileMetadata::default(), Some(&workspace_root()), |_| None);
+        graph.update_file(
+            &parent,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root()),
+            |_| None,
+        );
+        graph.update_file(
+            &child,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root()),
+            |_| None,
+        );
 
         let _ = graph.cached_neighborhood_subgraph(&parent, 10, 100);
         let _ = graph.detect_cycle(&parent);
@@ -2328,8 +2354,12 @@ mod tests {
             }],
             ..Default::default()
         };
-        let result =
-            graph.update_file(&child, &child_meta_with_backward, Some(&workspace_root()), |_| None);
+        let result = graph.update_file(
+            &child,
+            &child_meta_with_backward,
+            Some(&workspace_root()),
+            |_| None,
+        );
         assert!(
             result.edges_changed,
             "adding @lsp-sourced-by must mark edges_changed"
@@ -2353,7 +2383,12 @@ mod tests {
         let b = url("b.R");
         let meta_a = make_meta_with_source("b.R", 1);
         graph.update_file(&a, &meta_a, Some(&workspace_root()), |_| None);
-        graph.update_file(&b, &CrossFileMetadata::default(), Some(&workspace_root()), |_| None);
+        graph.update_file(
+            &b,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root()),
+            |_| None,
+        );
 
         let _ = graph.cached_neighborhood_subgraph(&a, 10, 100);
         let _ = graph.detect_cycle(&a);
@@ -2468,7 +2503,10 @@ mod tests {
         // Mutate edges → cache invalidated for this URI.
         let meta_a_no_source = CrossFileMetadata::default();
         let result = graph.update_file(&a, &meta_a_no_source, Some(&workspace_root()), |_| None);
-        assert!(result.edges_changed, "removing source() must mark edges_changed");
+        assert!(
+            result.edges_changed,
+            "removing source() must mark edges_changed"
+        );
 
         let hits_before_third = graph.cycle_cache_hits();
         // Third call: edge revision bumped, cache invalidated → recomputes.

--- a/crates/raven/src/cross_file/integration_tests.rs
+++ b/crates/raven/src/cross_file/integration_tests.rs
@@ -4817,7 +4817,7 @@ child_var <- 100
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -4844,7 +4844,7 @@ child_var <- 100
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -4870,7 +4870,7 @@ child_var <- 100
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5003,7 +5003,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5026,7 +5026,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5149,7 +5149,7 @@ x <- 1
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -5642,7 +5642,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5720,7 +5720,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5823,7 +5823,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -5901,7 +5901,7 @@ x <- 1
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -6106,7 +6106,7 @@ mod cross_directory_hoisting_tests {
             &base_exports,
             true,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         println!(

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -496,16 +496,15 @@ where
 
     let mut seen: std::collections::HashSet<Url> = std::collections::HashSet::new();
     let mut result: Vec<Url> = Vec::new();
-    let push_if_new = |dep: Url,
-                       seen: &mut std::collections::HashSet<Url>,
-                       result: &mut Vec<Url>| {
-        if dep == *edited_uri || !is_open(&dep) {
-            return;
-        }
-        if seen.insert(dep.clone()) {
-            result.push(dep);
-        }
-    };
+    let push_if_new =
+        |dep: Url, seen: &mut std::collections::HashSet<Url>, result: &mut Vec<Url>| {
+            if dep == *edited_uri || !is_open(&dep) {
+                return;
+            }
+            if seen.insert(dep.clone()) {
+                result.push(dep);
+            }
+        };
 
     // (1) Backward ancestors of edited_uri.
     let backward = graph.get_transitive_dependents(edited_uri, max_depth, max_visited);
@@ -697,9 +696,7 @@ mod tests {
         // section). Behavioral assertion: after the bulk mark, each URI's
         // gate allows a same-version republish.
         let gate = CrossFileDiagnosticsGate::new();
-        let uris: Vec<Url> = (0..5)
-            .map(|i| test_uri(&format!("file_{i}.R")))
-            .collect();
+        let uris: Vec<Url> = (0..5).map(|i| test_uri(&format!("file_{i}.R"))).collect();
 
         for u in &uris {
             gate.record_publish(u, 1);
@@ -1524,8 +1521,15 @@ mod tests {
         open.insert(parent.clone());
         open.insert(child.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&parent, false, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &parent,
+            false,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert!(affected.is_empty());
     }
 
@@ -1547,8 +1551,15 @@ mod tests {
         open.insert(parent.clone());
         open.insert(child.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&child, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &child,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert_eq!(affected.len(), 1);
         assert!(affected.contains(&parent));
     }
@@ -1576,8 +1587,15 @@ mod tests {
         open.insert(parent.clone());
         open.insert(child.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&parent, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &parent,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert_eq!(affected.len(), 1);
         assert!(
             affected.contains(&child),
@@ -1612,8 +1630,15 @@ mod tests {
         open.insert(child.clone());
         open.insert(grandchild.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&parent, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &parent,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert!(affected.contains(&child));
         assert!(affected.contains(&grandchild));
         assert_eq!(affected.len(), 2);
@@ -1647,8 +1672,15 @@ mod tests {
         open.insert(parent.clone());
         open.insert(child.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&parent, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &parent,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert_eq!(affected, vec![child]);
     }
 
@@ -1670,8 +1702,15 @@ mod tests {
         open.insert(parent.clone());
         open.insert(child.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&parent, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &parent,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert!(!affected.contains(&parent));
     }
 
@@ -1731,8 +1770,15 @@ mod tests {
         open.insert(child.clone());
         open.insert(grandchild.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&child, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &child,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert!(affected.contains(&parent), "parent must be revalidated");
         assert!(
             affected.contains(&grandchild),
@@ -1800,8 +1846,15 @@ mod tests {
         open.insert(child.clone());
         open.insert(auntie.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&child, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &child,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert!(affected.contains(&grandparent));
         assert!(affected.contains(&parent));
         assert!(
@@ -1866,8 +1919,15 @@ mod tests {
         open.insert(c.clone());
         open.insert(d.clone());
 
-        let affected =
-            compute_affected_dependents_after_edit(&a, true, false, &graph, |u| open.contains(u), 10, 200);
+        let affected = compute_affected_dependents_after_edit(
+            &a,
+            true,
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         let mut sorted = affected.clone();
         sorted.sort_by_key(|u| u.path().to_string());
         assert_eq!(sorted, vec![b, c, d], "diamond must yield deduped URIs");
@@ -1895,8 +1955,15 @@ mod tests {
 
         // child edited; only edges changed (e.g. it added a new source()
         // line), but its exported interface is unchanged.
-        let affected_from_child =
-            compute_affected_dependents_after_edit(&child, false, true, &graph, |u| open.contains(u), 10, 200);
+        let affected_from_child = compute_affected_dependents_after_edit(
+            &child,
+            false,
+            true,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert_eq!(affected_from_child.len(), 1);
         assert!(
             affected_from_child.contains(&parent),
@@ -1904,8 +1971,15 @@ mod tests {
         );
 
         // parent edited; only edges changed.
-        let affected_from_parent =
-            compute_affected_dependents_after_edit(&parent, false, true, &graph, |u| open.contains(u), 10, 200);
+        let affected_from_parent = compute_affected_dependents_after_edit(
+            &parent,
+            false,
+            true,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
         assert_eq!(affected_from_parent.len(), 1);
         assert!(
             affected_from_parent.contains(&child),

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -3298,8 +3298,7 @@ where
                 {
                     // Only propagate packages loaded before the effective call site
                     // Requirement 5.1: Package loaded before source() call is available in sourced file
-                    if (*pkg_line, *pkg_col)
-                        <= (effective_call_site_line, effective_call_site_col)
+                    if (*pkg_line, *pkg_col) <= (effective_call_site_line, effective_call_site_col)
                     {
                         // Requirement 5.3: Respect function scope - only propagate global packages
                         // or packages in the same function scope as the source() call
@@ -3314,10 +3313,7 @@ where
                                         effective_call_site_line,
                                         effective_call_site_col,
                                     ));
-                                is_same_or_descendant_function_scope(
-                                    call_site_scope,
-                                    *pkg_scope,
-                                )
+                                is_same_or_descendant_function_scope(call_site_scope, *pkg_scope)
                             }
                         };
 
@@ -3325,11 +3321,7 @@ where
                             prefix.inherited_packages.insert(package.clone());
                             // Record the parent file as origin so downstream
                             // merge sites can apply the same-file leak filter.
-                            record_package_origin(
-                                &mut prefix.package_origins,
-                                package,
-                                &edge.from,
-                            );
+                            record_package_origin(&mut prefix.package_origins, package, &edge.from);
                         }
                     }
                 }
@@ -3353,7 +3345,11 @@ where
                 continue;
             }
             prefix.inherited_packages.insert(pkg.clone());
-            propagate_package_origins(&parent_scope.package_origins, pkg, &mut prefix.package_origins);
+            propagate_package_origins(
+                &parent_scope.package_origins,
+                pkg,
+                &mut prefix.package_origins,
+            );
         }
 
         // Also propagate packages that are loaded in the parent at the call site.
@@ -3366,7 +3362,11 @@ where
                 continue;
             }
             prefix.inherited_packages.insert(pkg.clone());
-            propagate_package_origins(&parent_scope.package_origins, pkg, &mut prefix.package_origins);
+            propagate_package_origins(
+                &parent_scope.package_origins,
+                pkg,
+                &mut prefix.package_origins,
+            );
         }
     }
 
@@ -3785,11 +3785,7 @@ where
                             .iter()
                             .chain(child_scope.inherited_packages.iter())
                         {
-                            if package_only_origin_is_uri(
-                                &child_scope.package_origins,
-                                pkg,
-                                uri,
-                            ) {
+                            if package_only_origin_is_uri(&child_scope.package_origins, pkg, uri) {
                                 continue;
                             }
                             scope.loaded_packages.insert(pkg.clone());
@@ -4725,18 +4721,16 @@ where
                         .extend(origins);
                 }
             }
-            ScopeEvent::Declaration { symbol, .. } => {
-                match frame.symbols.get_mut(&symbol.name) {
-                    Some(existing) if existing.is_declared => {
-                        *existing = symbol.clone();
-                    }
-                    Some(_) => {}
-                    None => {
-                        frame.removed_names.remove(&symbol.name);
-                        frame.symbols.insert(symbol.name.clone(), symbol.clone());
-                    }
+            ScopeEvent::Declaration { symbol, .. } => match frame.symbols.get_mut(&symbol.name) {
+                Some(existing) if existing.is_declared => {
+                    *existing = symbol.clone();
                 }
-            }
+                Some(_) => {}
+                None => {
+                    frame.removed_names.remove(&symbol.name);
+                    frame.symbols.insert(symbol.name.clone(), symbol.clone());
+                }
+            },
         }
     }
 
@@ -4900,7 +4894,11 @@ where
                 continue;
             }
             contrib.packages.insert(pkg.clone());
-            propagate_package_origins(&child_scope.package_origins, pkg, &mut contrib.package_origins);
+            propagate_package_origins(
+                &child_scope.package_origins,
+                pkg,
+                &mut contrib.package_origins,
+            );
         }
 
         contrib
@@ -5412,7 +5410,7 @@ mod tests {
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Should have: a (from parent line 0), x1 (from parent line 1), z (local)
@@ -5590,13 +5588,14 @@ outside_var <- 2"#;
             }
         };
 
-        let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
-            if uri == &parent_uri {
-                Some(std::sync::Arc::new(parent_meta.clone()))
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if uri == &parent_uri {
+                    Some(std::sync::Arc::new(parent_meta.clone()))
+                } else {
+                    None
+                }
+            };
 
         let scope_inside_function = scope_at_position_with_graph(
             &parent_uri,
@@ -5610,7 +5609,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_inside_function.symbols.contains_key("child_var"),
@@ -5636,7 +5635,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_function.symbols.contains_key("child_var"),
@@ -5689,13 +5688,14 @@ outside_var <- 2"#;
             }
         };
 
-        let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
-            if uri == &parent_uri {
-                Some(std::sync::Arc::new(parent_meta.clone()))
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if uri == &parent_uri {
+                    Some(std::sync::Arc::new(parent_meta.clone()))
+                } else {
+                    None
+                }
+            };
 
         // Inside the function: child_var should be visible (source is before this point)
         let scope_inside_function = scope_at_position_with_graph(
@@ -5710,7 +5710,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_inside_function.symbols.contains_key("child_var"),
@@ -5738,7 +5738,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_after_function.symbols.contains_key("child_var"),
@@ -5850,7 +5850,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(scope.symbols.contains_key("a"), "a should be available");
@@ -5928,7 +5928,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -6048,7 +6048,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -6191,7 +6191,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -6360,7 +6360,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         // Should have depth_exceeded entry
@@ -6556,7 +6556,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(scope.symbols.contains_key("x"), "x should be available");
@@ -6646,7 +6646,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -7132,10 +7132,8 @@ outside_var <- 2"#;
         let tree = parse_r(code);
         let artifacts = compute_artifacts(&test_uri(), &tree, code);
 
-        let inner_call =
-            find_recursive_self_call(tree.root_node(), code, "f").unwrap_or_else(|| {
-                panic!("Test setup error: could not find inner `f()` call via AST")
-            });
+        let inner_call = find_recursive_self_call(tree.root_node(), code, "f")
+            .unwrap_or_else(|| panic!("Test setup error: could not find inner `f()` call via AST"));
         let inner_call_pos = inner_call.start_position();
         // `start_position().column` is a byte column; `scope_at_position`
         // expects a UTF-16 column. Convert via the line text so this test
@@ -7212,9 +7210,7 @@ outside_var <- 2"#;
         let now_inside_function = inside_function || node.kind() == "function_definition";
         if now_inside_function && node.kind() == "call" {
             if let Some(func_node) = node.child_by_field_name("function") {
-                if func_node.kind() == "identifier"
-                    && &content[func_node.byte_range()] == name
-                {
+                if func_node.kind() == "identifier" && &content[func_node.byte_range()] == name {
                     return Some(node);
                 }
             }
@@ -8922,7 +8918,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_before_rm.symbols.contains_key("helper_func"),
@@ -8942,7 +8938,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("helper_func"),
@@ -8962,7 +8958,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_eof.symbols.contains_key("helper_func"),
@@ -9041,7 +9037,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_before_rm.symbols.contains_key("func_a"),
@@ -9069,7 +9065,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("func_a"),
@@ -9301,7 +9297,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -9392,7 +9388,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -9476,7 +9472,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_after_source.symbols.contains_key("helper_func"),
@@ -9496,7 +9492,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("helper_func"),
@@ -9516,7 +9512,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_after_redef.symbols.contains_key("helper_func"),
@@ -9602,7 +9598,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("func_a"),
@@ -9688,7 +9684,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_in_child.symbols.contains_key("helper_func"),
@@ -9708,7 +9704,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_in_parent.symbols.contains_key("helper_func"),
@@ -9811,7 +9807,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             scope_before_rm.symbols.contains_key("deep_func"),
@@ -9831,7 +9827,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
         assert!(
             !scope_after_rm.symbols.contains_key("deep_func"),
@@ -9944,7 +9940,7 @@ outside_var <- 2"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -11654,7 +11650,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         // Child should have inherited dplyr from parent
@@ -11733,7 +11729,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Child should NOT have dplyr (it was loaded after source() call)
@@ -11812,7 +11808,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         // Child should have both packages
@@ -11896,7 +11892,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Child should NOT have dplyr (it's function-scoped in parent)
@@ -11970,7 +11966,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -12054,7 +12050,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Parent should have dplyr (loaded in child, available after source())
@@ -12135,7 +12131,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Symbols from child SHOULD be available in parent
@@ -12254,7 +12250,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Grandparent should have stringr (loaded in grandchild, propagated via loaded_packages)
@@ -12278,7 +12274,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         // Parent should also have stringr (loaded in child, propagated via loaded_packages)
@@ -12360,7 +12356,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         // Child SHOULD have dplyr (propagated from parent)
@@ -12384,7 +12380,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         // Parent should have ggplot2 (loaded in child, propagated via loaded_packages)
@@ -12542,7 +12538,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -12646,7 +12642,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Auto,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -12669,7 +12665,7 @@ x <- 1"#;
             &HashSet::new(),
             false,
             crate::cross_file::config::BackwardDependencyMode::Explicit,
-            &|| false
+            &|| false,
         );
 
         assert!(
@@ -13126,9 +13122,10 @@ y <- filter(df)"#;
 
             // Detect main's source() calls (only literal-string sources
             // are detected; that's what our fixtures use).
-            let main_meta = std::sync::Arc::new(
-                crate::cross_file::extract_metadata_with_tree(main_code, Some(&main_tree)),
-            );
+            let main_meta = std::sync::Arc::new(crate::cross_file::extract_metadata_with_tree(
+                main_code,
+                Some(&main_tree),
+            ));
             let helper_meta = std::sync::Arc::new(CrossFileMetadata::default());
 
             let mut graph = DependencyGraph::new();
@@ -13572,9 +13569,10 @@ y <- filter(df)"#;
             let helper2_artifacts =
                 Arc::new(compute_artifacts(&helper2_uri, &helper2_tree, helper2_code));
 
-            let main_meta = std::sync::Arc::new(
-                crate::cross_file::extract_metadata_with_tree(main_code, Some(&main_tree)),
-            );
+            let main_meta = std::sync::Arc::new(crate::cross_file::extract_metadata_with_tree(
+                main_code,
+                Some(&main_tree),
+            ));
             let helper1_meta = std::sync::Arc::new(CrossFileMetadata::default());
             let helper2_meta = std::sync::Arc::new(CrossFileMetadata::default());
 
@@ -13968,8 +13966,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata =
-                |_u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+            let get_metadata = |_u: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > { None };
             let graph = crate::cross_file::dependency::DependencyGraph::new();
             let base_exports = HashSet::new();
 
@@ -13985,7 +13984,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true, // hoisting ON
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14006,7 +14005,7 @@ y <- filter(df)"#;
                 &base_exports,
                 false, // hoisting OFF
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14039,8 +14038,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata =
-                |_u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+            let get_metadata = |_u: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > { None };
             let graph = crate::cross_file::dependency::DependencyGraph::new();
             let base_exports = HashSet::new();
 
@@ -14057,7 +14057,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14160,7 +14160,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -14185,7 +14187,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14254,8 +14256,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata =
-                |_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+            let get_metadata = |_uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > { None };
 
             let base_exports = HashSet::new();
 
@@ -14272,7 +14275,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14391,7 +14394,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &middle_uri {
@@ -14418,7 +14423,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14531,7 +14536,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -14556,7 +14563,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14659,7 +14666,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &a_uri {
                     Some(std::sync::Arc::new(a_meta.clone()))
                 } else if uri == &b_uri {
@@ -14684,7 +14693,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14794,7 +14803,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &sibling_uri {
@@ -14820,7 +14831,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -14910,7 +14921,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -14936,7 +14949,7 @@ y <- filter(df)"#;
                 &base_exports,
                 false, // hoisting OFF
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15042,7 +15055,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -15067,7 +15082,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15146,7 +15161,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -15170,7 +15187,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15258,7 +15275,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &child_uri {
@@ -15283,7 +15302,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true, // hoisting ON, but query is at global level
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             // At global level, parent is queried at call site (line 0 col 0),
@@ -15406,7 +15425,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &grandparent_uri {
                     Some(std::sync::Arc::new(grandparent_meta.clone()))
                 } else if uri == &parent_uri {
@@ -15432,7 +15453,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15543,7 +15564,9 @@ y <- filter(df)"#;
                     None
                 }
             };
-            let get_metadata = |uri: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+            let get_metadata = |uri: &Url| -> Option<
+                std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
+            > {
                 if uri == &parent_uri {
                     Some(std::sync::Arc::new(parent_meta.clone()))
                 } else if uri == &helper_uri {
@@ -15569,7 +15592,7 @@ y <- filter(df)"#;
                 &base_exports,
                 true,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15661,7 +15684,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Auto,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15785,7 +15808,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Auto,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -15870,7 +15893,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Explicit,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -16005,7 +16028,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Auto,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -16032,7 +16055,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Auto,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -16117,7 +16140,7 @@ y <- filter(df)"#;
                 &HashSet::new(),
                 false,
                 crate::cross_file::config::BackwardDependencyMode::Auto,
-                &|| false
+                &|| false,
             );
 
             assert!(
@@ -16155,16 +16178,14 @@ y <- filter(df)"#;
 
         let parent_code = "library(stats)\nhelper <- function() 1\n";
         let parent_tree = parse_r(parent_code);
-        let parent_artifacts =
-            Arc::new(compute_artifacts(&parent_uri, &parent_tree, parent_code));
+        let parent_artifacts = Arc::new(compute_artifacts(&parent_uri, &parent_tree, parent_code));
         let parent_meta = std::sync::Arc::new(CrossFileMetadata::default());
 
         // Child sources parent at line 0 col 0, then defines a function that
         // uses `helper`, then uses `helper` at top-level too.
         let child_code = "source(\"parent.R\")\nf <- function() {\n  helper()\n}\nx <- helper()\n";
         let child_tree = parse_r(child_code);
-        let child_artifacts =
-            Arc::new(compute_artifacts(&child_uri, &child_tree, child_code));
+        let child_artifacts = Arc::new(compute_artifacts(&child_uri, &child_tree, child_code));
         let child_meta = std::sync::Arc::new(CrossFileMetadata {
             sources: vec![ForwardSource {
                 path: "parent.R".to_string(),
@@ -16386,16 +16407,10 @@ y <- filter(df)"#;
 
             // Compare key fields. Symbol HashMap, package sets, package
             // origins, chain, and depth_exceeded must all match.
-            let cached_syms: std::collections::BTreeSet<&str> = cached
-                .symbols
-                .keys()
-                .map(|n| n.as_ref())
-                .collect();
-            let direct_syms: std::collections::BTreeSet<&str> = direct
-                .symbols
-                .keys()
-                .map(|n| n.as_ref())
-                .collect();
+            let cached_syms: std::collections::BTreeSet<&str> =
+                cached.symbols.keys().map(|n| n.as_ref()).collect();
+            let direct_syms: std::collections::BTreeSet<&str> =
+                direct.symbols.keys().map(|n| n.as_ref()).collect();
             assert_eq!(
                 cached_syms, direct_syms,
                 "symbol set mismatch at ({line}, {col})"
@@ -16453,15 +16468,14 @@ y <- filter(df)"#;
         };
         let uri_for_meta = uri.clone();
         let meta_for_closure = meta.clone();
-        let get_metadata = move |u: &Url| -> Option<
-            std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
-        > {
-            if u == &uri_for_meta {
-                Some(meta_for_closure.clone())
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            move |u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if u == &uri_for_meta {
+                    Some(meta_for_closure.clone())
+                } else {
+                    None
+                }
+            };
 
         let graph = crate::cross_file::dependency::DependencyGraph::new();
         let base_exports: HashSet<String> = HashSet::new();
@@ -16563,9 +16577,10 @@ y <- filter(df)"#;
         let helper_tree = parse_r(helper_code);
         let helper_artifacts = Arc::new(compute_artifacts(&helper_uri, &helper_tree, helper_code));
 
-        let main_meta = std::sync::Arc::new(
-            crate::cross_file::extract_metadata_with_tree(main_code, Some(&main_tree)),
-        );
+        let main_meta = std::sync::Arc::new(crate::cross_file::extract_metadata_with_tree(
+            main_code,
+            Some(&main_tree),
+        ));
         let helper_meta = std::sync::Arc::new(CrossFileMetadata::default());
 
         let mut graph = DependencyGraph::new();
@@ -16649,15 +16664,14 @@ y <- filter(df)"#;
         };
         let uri_for_meta = uri.clone();
         let meta_for_closure = meta.clone();
-        let get_metadata = move |u: &Url| -> Option<
-            std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
-        > {
-            if u == &uri_for_meta {
-                Some(meta_for_closure.clone())
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            move |u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if u == &uri_for_meta {
+                    Some(meta_for_closure.clone())
+                } else {
+                    None
+                }
+            };
 
         let graph = crate::cross_file::dependency::DependencyGraph::new();
         let base_exports: HashSet<String> = HashSet::new();
@@ -16722,15 +16736,14 @@ y <- filter(df)"#;
         };
         let uri_for_meta = uri.clone();
         let meta_for_closure = meta.clone();
-        let get_metadata = move |u: &Url| -> Option<
-            std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
-        > {
-            if u == &uri_for_meta {
-                Some(meta_for_closure.clone())
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            move |u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if u == &uri_for_meta {
+                    Some(meta_for_closure.clone())
+                } else {
+                    None
+                }
+            };
 
         let graph = crate::cross_file::dependency::DependencyGraph::new();
         let base_exports: HashSet<String> = HashSet::new();
@@ -16754,7 +16767,10 @@ y <- filter(df)"#;
 
         // After the second `x <- 2` (line 2), x must be visible.
         stream.advance_to(3, 0);
-        assert!(stream.is_visible("x"), "x must be visible after resurrection");
+        assert!(
+            stream.is_visible("x"),
+            "x must be visible after resurrection"
+        );
 
         // Compare against the cached path.
         let mut throwaway = ParentPrefixCache::new();
@@ -16809,15 +16825,14 @@ y <- filter(df)"#;
         };
         let uri_for_meta = uri.clone();
         let meta_for_closure = meta.clone();
-        let get_metadata = move |u: &Url| -> Option<
-            std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
-        > {
-            if u == &uri_for_meta {
-                Some(meta_for_closure.clone())
-            } else {
-                None
-            }
-        };
+        let get_metadata =
+            move |u: &Url| -> Option<std::sync::Arc<crate::cross_file::types::CrossFileMetadata>> {
+                if u == &uri_for_meta {
+                    Some(meta_for_closure.clone())
+                } else {
+                    None
+                }
+            };
 
         let graph = crate::cross_file::dependency::DependencyGraph::new();
         let base_exports: HashSet<String> = HashSet::new();

--- a/crates/raven/src/cross_file/workspace_index.rs
+++ b/crates/raven/src/cross_file/workspace_index.rs
@@ -127,10 +127,7 @@ impl CrossFileWorkspaceIndex {
 
     /// Returns true if the URI is currently pinned.
     pub fn is_pinned(&self, uri: &Url) -> bool {
-        self.pinned
-            .read()
-            .map(|p| p.contains(uri))
-            .unwrap_or(false)
+        self.pinned.read().map(|p| p.contains(uri)).unwrap_or(false)
     }
 
     /// Get current version
@@ -250,11 +247,7 @@ impl CrossFileWorkspaceIndex {
     /// May exceed the user-configured capacity after an all-pinned
     /// overflow has forced the underlying LRU to grow.
     pub fn cap(&self) -> usize {
-        self.inner
-            .read()
-            .ok()
-            .map(|g| g.cap().get())
-            .unwrap_or(0)
+        self.inner.read().ok().map(|g| g.cap().get()).unwrap_or(0)
     }
 
     /// Resize the cache capacity. If shrinking, LRU entries are evicted.

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -990,10 +990,7 @@ mod tests {
         let doc = store.get_without_touch(&uri).unwrap();
         let arc1: Arc<CrossFileMetadata> = doc.metadata.clone();
         let arc2 = arc1.clone();
-        assert!(
-            Arc::ptr_eq(&arc1, &arc2),
-            "Arc clones must share storage"
-        );
+        assert!(Arc::ptr_eq(&arc1, &arc2), "Arc clones must share storage");
     }
 
     #[tokio::test]

--- a/crates/raven/src/file_path_intellisense.rs
+++ b/crates/raven/src/file_path_intellisense.rs
@@ -933,8 +933,7 @@ pub fn file_path_definition(
             }
             DirectiveType::Source => {
                 // Forward directives respect @lsp-cd but do not use workspace-root fallback.
-                let path_context =
-                    PathContext::from_metadata(file_uri, metadata, workspace_root)?;
+                let path_context = PathContext::from_metadata(file_uri, metadata, workspace_root)?;
                 resolve_path(&normalized_path, &path_context)?
             }
         },
@@ -1391,8 +1390,7 @@ pub fn resolve_base_directory(
             }
             DirectiveType::Source => {
                 // Forward directives respect @lsp-cd but do not use workspace-root fallback.
-                let path_context =
-                    PathContext::from_metadata(file_uri, metadata, workspace_root)?;
+                let path_context = PathContext::from_metadata(file_uri, metadata, workspace_root)?;
                 if partial_dir.is_empty() {
                     Some(path_context.effective_working_directory())
                 } else {
@@ -1528,8 +1526,7 @@ fn directive_path_patterns() -> &'static DirectivePathPatterns {
                 r#"^\s*#\s*@lsp-(?:sourced-by|run-by|included-by)(?:\s+:?\s*|:\s*)"#,
             )
             .unwrap(),
-            forward: Regex::new(r#"^\s*#\s*@lsp-(?:source|run|include)(?:\s+:?\s*|:\s*)"#)
-                .unwrap(),
+            forward: Regex::new(r#"^\s*#\s*@lsp-(?:source|run|include)(?:\s+:?\s*|:\s*)"#).unwrap(),
         }
     })
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -323,7 +323,10 @@ pub(crate) fn diagnostics_from_snapshot(
                 .unwrap_or_default();
             let closing_line_1based = close.call_site_line.map(|l| l + 1);
 
-            let message = match (closing_line_1based, snapshot.cycle_closing_snippet.as_deref()) {
+            let message = match (
+                closing_line_1based,
+                snapshot.cycle_closing_snippet.as_deref(),
+            ) {
                 (Some(cl), Some(code)) => {
                     format!(
                         "Circular dependency: {closing_file} line {cl} sources this file: `{code}`"
@@ -3985,7 +3988,6 @@ pub async fn collect_missing_file_diagnostics_standalone_for_test(
         .await
 }
 
-
 /// Async version of missing file diagnostics that checks disk existence
 ///
 /// This version uses `AsyncContentProvider::check_existence_batch` to perform
@@ -4178,9 +4180,6 @@ pub async fn collect_missing_file_diagnostics_async(
 
     diagnostics
 }
-
-
-
 
 /// Emit diagnostics for forward directives with invalid `line=0` parameter.
 ///
@@ -4429,7 +4428,6 @@ fn collect_redundant_directive_diagnostics_from_snapshot(
     }
 }
 
-
 fn collect_out_of_scope_diagnostics_from_snapshot(
     snapshot: &DiagnosticsSnapshot,
     uri: &Url,
@@ -4544,9 +4542,10 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
     let get_artifacts = |target_uri: &Url| -> Option<Arc<scope::ScopeArtifacts>> {
         snapshot.artifacts_map.get(target_uri).cloned()
     };
-    let get_metadata = |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
-        snapshot.metadata_map.get(target_uri).cloned()
-    };
+    let get_metadata =
+        |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
+            snapshot.metadata_map.get(target_uri).cloned()
+        };
     let is_cancelled_fn = || cancel.is_cancelled();
 
     let mut stream_opt = scope::ScopeStream::new(
@@ -4829,9 +4828,10 @@ fn collect_undefined_variables_from_snapshot(
     let get_artifacts = |target_uri: &Url| -> Option<Arc<scope::ScopeArtifacts>> {
         snapshot.artifacts_map.get(target_uri).cloned()
     };
-    let get_metadata = |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
-        snapshot.metadata_map.get(target_uri).cloned()
-    };
+    let get_metadata =
+        |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
+            snapshot.metadata_map.get(target_uri).cloned()
+        };
     let is_cancelled_fn = || cancel.is_cancelled();
 
     let mut stream_opt = scope::ScopeStream::new(
@@ -5039,7 +5039,6 @@ fn collect_undefined_variables_from_snapshot(
     }
 }
 
-
 /// Returns true if the given identifier node is a *structural non-reference*:
 /// an identifier that exists in the AST but never refers to a value at runtime,
 /// regardless of which diagnostic pipeline is consuming it.
@@ -5160,7 +5159,10 @@ fn references_formal_from_default_expression(node: Node, text: &str) -> bool {
         return false;
     }
 
-    let Some(parameters) = default_parameter.parent().filter(|n| n.kind() == "parameters") else {
+    let Some(parameters) = default_parameter
+        .parent()
+        .filter(|n| n.kind() == "parameters")
+    else {
         return false;
     };
 
@@ -7409,7 +7411,6 @@ fn find_closing_brace_line(node: &Node, text: &str) -> Option<usize> {
 
     last_brace_line
 }
-
 
 /// True when an identifier is textually followed by `(` (ignoring whitespace),
 /// indicating call-target usage.
@@ -32524,10 +32525,7 @@ result <- helper_with_spaces(42)"#;
             !undefined_helper.is_empty(),
             "Expected 'Undefined variable: helper' diagnostic — local=TRUE \
              doesn't inherit. Got: {:?}",
-            diags
-                .iter()
-                .map(|d| d.message.clone())
-                .collect::<Vec<_>>()
+            diags.iter().map(|d| d.message.clone()).collect::<Vec<_>>()
         );
     }
 
@@ -32548,8 +32546,7 @@ result <- helper_with_spaces(42)"#;
         let main_path = workspace_path.join("main.R");
         let helper_path = workspace_path.join("helper.R");
 
-        let main_code =
-            "result <- helper(1)\nsys.source(\"helper.R\", envir=new.env())\n";
+        let main_code = "result <- helper(1)\nsys.source(\"helper.R\", envir=new.env())\n";
         let helper_code = "helper <- function(x) x + 1\n";
         std::fs::write(&main_path, main_code).unwrap();
         std::fs::write(&helper_path, helper_code).unwrap();
@@ -32620,8 +32617,7 @@ result <- helper_with_spaces(42)"#;
 
         // Use `globalenv()` so the source IS inheriting. Use BEFORE the source
         // call to trigger "used before sourced".
-        let main_code =
-            "result <- helper(1)\nsys.source(\"helper.R\", envir=globalenv())\n";
+        let main_code = "result <- helper(1)\nsys.source(\"helper.R\", envir=globalenv())\n";
         let helper_code = "helper <- function(x) x + 1\n";
         std::fs::write(&main_path, main_code).unwrap();
         std::fs::write(&helper_path, helper_code).unwrap();
@@ -34012,18 +34008,12 @@ y <- x"#;
 
         let meta_a = crate::cross_file::extract_metadata(a_initial);
         let meta_b = crate::cross_file::extract_metadata(b_code);
-        state.cross_file_graph.update_file(
-            &a_url,
-            &meta_a,
-            Some(&workspace_url),
-            |_| None,
-        );
-        state.cross_file_graph.update_file(
-            &b_url,
-            &meta_b,
-            Some(&workspace_url),
-            |_| None,
-        );
+        state
+            .cross_file_graph
+            .update_file(&a_url, &meta_a, Some(&workspace_url), |_| None);
+        state
+            .cross_file_graph
+            .update_file(&b_url, &meta_b, Some(&workspace_url), |_| None);
 
         // Pre-condition: B should NOT report `x` as undefined — A defines it.
         let pre_diags = diagnostics(&state, &b_url, &DiagCancelToken::never());
@@ -34043,12 +34033,9 @@ y <- x"#;
             .documents
             .insert(a_url.clone(), Document::new(a_after, None));
         let meta_a_after = crate::cross_file::extract_metadata(a_after);
-        state.cross_file_graph.update_file(
-            &a_url,
-            &meta_a_after,
-            Some(&workspace_url),
-            |_| None,
-        );
+        state
+            .cross_file_graph
+            .update_file(&a_url, &meta_a_after, Some(&workspace_url), |_| None);
 
         // Post-condition: B SHOULD now report "Undefined variable: x".
         let post_diags = diagnostics(&state, &b_url, &DiagCancelToken::never());
@@ -34129,18 +34116,12 @@ y <- x"#;
         let child_meta = crate::cross_file::extract_metadata(child_code);
         let grandchild_meta = crate::cross_file::extract_metadata(grandchild_code);
 
-        state.cross_file_graph.update_file(
-            &parent_url,
-            &parent_meta,
-            Some(&workspace_url),
-            |_| None,
-        );
-        state.cross_file_graph.update_file(
-            &child_url,
-            &child_meta,
-            Some(&workspace_url),
-            |_| None,
-        );
+        state
+            .cross_file_graph
+            .update_file(&parent_url, &parent_meta, Some(&workspace_url), |_| None);
+        state
+            .cross_file_graph
+            .update_file(&child_url, &child_meta, Some(&workspace_url), |_| None);
         state.cross_file_graph.update_file(
             &grandchild_url,
             &grandchild_meta,
@@ -34185,15 +34166,18 @@ y <- x"#;
             &DiagCancelToken::never(),
         )
         .unwrap_or_default();
-        let snapshot_messages: Vec<_> =
-            snapshot_diags.iter().map(|d| d.message.clone()).collect();
+        let snapshot_messages: Vec<_> = snapshot_diags.iter().map(|d| d.message.clone()).collect();
         assert!(
-            snapshot_messages.iter().any(|m| m == "Undefined variable: z"),
+            snapshot_messages
+                .iter()
+                .any(|m| m == "Undefined variable: z"),
             "snapshot path: z should be flagged as undefined; got: {:?}",
             snapshot_messages
         );
         assert!(
-            snapshot_messages.iter().any(|m| m == "Undefined variable: x"),
+            snapshot_messages
+                .iter()
+                .any(|m| m == "Undefined variable: x"),
             "snapshot path: x should be flagged as undefined; got: {:?}",
             snapshot_messages
         );
@@ -34245,24 +34229,15 @@ y <- x"#;
         let child1_meta = crate::cross_file::extract_metadata(child1_code);
         let child2_meta = crate::cross_file::extract_metadata(child2_code);
 
-        state.cross_file_graph.update_file(
-            &parent_url,
-            &parent_meta,
-            Some(&workspace_url),
-            |_| None,
-        );
-        state.cross_file_graph.update_file(
-            &child1_url,
-            &child1_meta,
-            Some(&workspace_url),
-            |_| None,
-        );
-        state.cross_file_graph.update_file(
-            &child2_url,
-            &child2_meta,
-            Some(&workspace_url),
-            |_| None,
-        );
+        state
+            .cross_file_graph
+            .update_file(&parent_url, &parent_meta, Some(&workspace_url), |_| None);
+        state
+            .cross_file_graph
+            .update_file(&child1_url, &child1_meta, Some(&workspace_url), |_| None);
+        state
+            .cross_file_graph
+            .update_file(&child2_url, &child2_meta, Some(&workspace_url), |_| None);
 
         // Diagnose parent.R — x must be undefined at the implicit usage site
         // inside child2.R when computed as part of the parent's neighborhood.
@@ -35294,8 +35269,7 @@ source(\"helpers.R\")
         let used_before_x: Vec<_> = diagnostics
             .iter()
             .filter(|d| {
-                d.message.contains("is used before it's available")
-                    && d.message.contains("'x'")
+                d.message.contains("is used before it's available") && d.message.contains("'x'")
             })
             .collect();
 
@@ -35354,8 +35328,7 @@ source(\"helpers.R\")
         let used_before_y: Vec<_> = diagnostics
             .iter()
             .filter(|d| {
-                d.message.contains("is used before it's available")
-                    && d.message.contains("'y'")
+                d.message.contains("is used before it's available") && d.message.contains("'y'")
             })
             .collect();
 
@@ -35428,8 +35401,7 @@ source(\"failure.R\")
         let used_before_x: Vec<_> = diagnostics
             .iter()
             .filter(|d| {
-                d.message.contains("is used before it's available")
-                    && d.message.contains("'X'")
+                d.message.contains("is used before it's available") && d.message.contains("'X'")
             })
             .collect();
         assert!(
@@ -35992,11 +35964,9 @@ source(\"helpers.R\")
         state.workspace_scan_complete = true;
         // undefined_variables_enabled and diagnostics_enabled default to true;
         // out_of_scope_severity just needs to be non-None to enable that collector.
-        state.cross_file_config.out_of_scope_severity =
-            Some(DiagnosticSeverity::WARNING);
+        state.cross_file_config.out_of_scope_severity = Some(DiagnosticSeverity::WARNING);
 
-        let workspace_url =
-            url::Url::from_file_path(fixture._dir.path()).expect("workspace url");
+        let workspace_url = url::Url::from_file_path(fixture._dir.path()).expect("workspace url");
         // workspace_folders must be set so workspace-root fallback resolution works.
         state.workspace_folders = vec![workspace_url.clone()];
 
@@ -36014,8 +35984,7 @@ source(\"helpers.R\")
             );
         }
 
-        let snapshot =
-            DiagnosticsSnapshot::build(&state, &fixture.mid_file_uri).expect("snapshot");
+        let snapshot = DiagnosticsSnapshot::build(&state, &fixture.mid_file_uri).expect("snapshot");
         let diags =
             diagnostics_from_snapshot(&snapshot, &fixture.mid_file_uri, &DiagCancelToken::never())
                 .expect("diagnostics");
@@ -36057,7 +36026,9 @@ source(\"helpers.R\")
 
         // 4. Diagnostic: the pipeline must also report "Undefined variable: xyz".
         assert!(
-            diags.iter().any(|d| d.message.contains("Undefined variable: xyz")),
+            diags
+                .iter()
+                .any(|d| d.message.contains("Undefined variable: xyz")),
             "Expected 'Undefined variable: xyz' diagnostic; got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
@@ -36350,10 +36321,9 @@ source(\"helpers.R\")
 
         let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot");
 
-        let get_artifacts =
-            |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>> {
-                snapshot.artifacts_map.get(target_uri).cloned()
-            };
+        let get_artifacts = |target_uri: &Url| -> Option<
+            std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>,
+        > { snapshot.artifacts_map.get(target_uri).cloned() };
         let get_metadata =
             |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
                 snapshot.metadata_map.get(target_uri).cloned()
@@ -36392,10 +36362,8 @@ source(\"helpers.R\")
                 &|| false,
             );
 
-            let cached_keys: BTreeSet<&str> =
-                cached.symbols.keys().map(|n| n.as_ref()).collect();
-            let direct_keys: BTreeSet<&str> =
-                direct.symbols.keys().map(|n| n.as_ref()).collect();
+            let cached_keys: BTreeSet<&str> = cached.symbols.keys().map(|n| n.as_ref()).collect();
+            let direct_keys: BTreeSet<&str> = direct.symbols.keys().map(|n| n.as_ref()).collect();
             assert_eq!(
                 cached_keys, direct_keys,
                 "symbol set differs at ({line}, {col}) for fixture:\n{text}"
@@ -36422,14 +36390,24 @@ source(\"helpers.R\")
                 .symbols
                 .iter()
                 .map(|(name, sym)| {
-                    (name.as_ref(), &sym.source_uri, sym.defined_line, sym.defined_column)
+                    (
+                        name.as_ref(),
+                        &sym.source_uri,
+                        sym.defined_line,
+                        sym.defined_column,
+                    )
                 })
                 .collect();
             let direct_provenance: BTreeSet<(&str, &Url, u32, u32)> = direct
                 .symbols
                 .iter()
                 .map(|(name, sym)| {
-                    (name.as_ref(), &sym.source_uri, sym.defined_line, sym.defined_column)
+                    (
+                        name.as_ref(),
+                        &sym.source_uri,
+                        sym.defined_line,
+                        sym.defined_column,
+                    )
                 })
                 .collect();
             assert_eq!(
@@ -36584,10 +36562,9 @@ source(\"helpers.R\")
 
         let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).expect("snapshot");
 
-        let get_artifacts =
-            |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>> {
-                snapshot.artifacts_map.get(target_uri).cloned()
-            };
+        let get_artifacts = |target_uri: &Url| -> Option<
+            std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>,
+        > { snapshot.artifacts_map.get(target_uri).cloned() };
         let get_metadata =
             |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
                 snapshot.metadata_map.get(target_uri).cloned()
@@ -36641,16 +36618,8 @@ source(\"helpers.R\")
             snapshot.cross_file_config.backward_dependencies,
             &|| false,
         );
-        let cached_keys: BTreeSet<&str> = cached
-            .symbols
-            .keys()
-            .map(|n| n.as_ref())
-            .collect();
-        let direct_keys: BTreeSet<&str> = direct
-            .symbols
-            .keys()
-            .map(|n| n.as_ref())
-            .collect();
+        let cached_keys: BTreeSet<&str> = cached.symbols.keys().map(|n| n.as_ref()).collect();
+        let direct_keys: BTreeSet<&str> = direct.symbols.keys().map(|n| n.as_ref()).collect();
         assert_eq!(
             cached_keys, direct_keys,
             "Cached and uncached scopes differ at xyz <- xyz RHS"
@@ -36677,7 +36646,8 @@ source(\"helpers.R\")
         let main_code = "source(\"data.R\")\n";
         // Wrap `xyz <- xyz` in a function body so the query at the RHS
         // resolves with `query_inside_function = true`.
-        let data_code = "source(\"covariates.R\")\nf <- function() {\n  xyz <- xyz\n}\nsource(\"indices.R\")\n";
+        let data_code =
+            "source(\"covariates.R\")\nf <- function() {\n  xyz <- xyz\n}\nsource(\"indices.R\")\n";
         let covariates_code = "cov_a <- 1\ncov_b <- 2\n";
         let indices_code = "idx_a <- 10\n";
 
@@ -36703,10 +36673,9 @@ source(\"helpers.R\")
 
         let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).expect("snapshot");
 
-        let get_artifacts =
-            |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>> {
-                snapshot.artifacts_map.get(target_uri).cloned()
-            };
+        let get_artifacts = |target_uri: &Url| -> Option<
+            std::sync::Arc<crate::cross_file::scope::ScopeArtifacts>,
+        > { snapshot.artifacts_map.get(target_uri).cloned() };
         let get_metadata =
             |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
                 snapshot.metadata_map.get(target_uri).cloned()
@@ -36757,10 +36726,8 @@ source(\"helpers.R\")
             snapshot.cross_file_config.backward_dependencies,
             &|| false,
         );
-        let cached_keys: BTreeSet<&str> =
-            cached.symbols.keys().map(|n| n.as_ref()).collect();
-        let direct_keys: BTreeSet<&str> =
-            direct.symbols.keys().map(|n| n.as_ref()).collect();
+        let cached_keys: BTreeSet<&str> = cached.symbols.keys().map(|n| n.as_ref()).collect();
+        let direct_keys: BTreeSet<&str> = direct.symbols.keys().map(|n| n.as_ref()).collect();
         assert_eq!(
             cached_keys, direct_keys,
             "Cached and uncached scopes differ inside function body at xyz <- xyz RHS"
@@ -37206,11 +37173,8 @@ my_func <- function(a = default_value) {
             .cross_file_graph
             .update_file(&main_uri, &main_meta, None, |_| None);
 
-        let diagnostics = crate::handlers::diagnostics_via_snapshot(
-            &state,
-            &main_uri,
-            &DiagCancelToken::never(),
-        );
+        let diagnostics =
+            crate::handlers::diagnostics_via_snapshot(&state, &main_uri, &DiagCancelToken::never());
 
         assert!(
             !diagnostics
@@ -37263,11 +37227,8 @@ my_func <- function(a = default_value) {
             .cross_file_graph
             .update_file(&main_uri, &main_meta, None, |_| None);
 
-        let diagnostics = crate::handlers::diagnostics_via_snapshot(
-            &state,
-            &main_uri,
-            &DiagCancelToken::never(),
-        );
+        let diagnostics =
+            crate::handlers::diagnostics_via_snapshot(&state, &main_uri, &DiagCancelToken::never());
 
         assert!(
             !diagnostics

--- a/crates/raven/src/libpath_watcher.rs
+++ b/crates/raven/src/libpath_watcher.rs
@@ -113,10 +113,7 @@ impl LibpathSnapshot {
     ///   effective on-disk package differs even though the name persists.
     ///
     /// Consumers should treat all three as invalidation triggers.
-    pub(crate) fn diff(
-        &self,
-        other: &Self,
-    ) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
+    pub(crate) fn diff(&self, other: &Self) -> (HashSet<String>, HashSet<String>, HashSet<String>) {
         let prev = self.winning_roots();
         let next = other.winning_roots();
         let mut added = HashSet::new();
@@ -270,15 +267,11 @@ mod snapshot_tests {
         let t_high = tempdir().unwrap();
         let t_low = tempdir().unwrap();
         make_pkg(t_low.path(), "foo");
-        let prev = LibpathSnapshot::capture(&[
-            t_high.path().to_path_buf(),
-            t_low.path().to_path_buf(),
-        ]);
+        let prev =
+            LibpathSnapshot::capture(&[t_high.path().to_path_buf(), t_low.path().to_path_buf()]);
         make_pkg(t_high.path(), "foo");
-        let next = LibpathSnapshot::capture(&[
-            t_high.path().to_path_buf(),
-            t_low.path().to_path_buf(),
-        ]);
+        let next =
+            LibpathSnapshot::capture(&[t_high.path().to_path_buf(), t_low.path().to_path_buf()]);
 
         let (added, removed, moved) = prev.diff(&next);
         assert!(added.is_empty(), "name is in union both times");
@@ -311,12 +304,7 @@ mod snapshot_tests {
             t.path().join("foo").join("help").join("aliases.rds"),
         ];
 
-        let touched = touched_from_events(
-            &event_paths,
-            &[t.path().to_path_buf()],
-            &prev,
-            &next,
-        );
+        let touched = touched_from_events(&event_paths, &[t.path().to_path_buf()], &prev, &next);
         assert_eq!(touched, ["foo".to_string()].into_iter().collect());
     }
 
@@ -331,15 +319,14 @@ mod snapshot_tests {
 
         let event_paths = vec![
             t.path().join("00LOCK-foo").join("DESCRIPTION"),
-            t.path().join("00LOCK-foo").join("foo").join("R").join("foo.R"),
+            t.path()
+                .join("00LOCK-foo")
+                .join("foo")
+                .join("R")
+                .join("foo.R"),
         ];
 
-        let touched = touched_from_events(
-            &event_paths,
-            &[t.path().to_path_buf()],
-            &snap,
-            &snap,
-        );
+        let touched = touched_from_events(&event_paths, &[t.path().to_path_buf()], &snap, &snap);
         assert!(touched.is_empty(), "expected no touched, got {:?}", touched);
     }
 }
@@ -431,8 +418,7 @@ pub fn spawn_watcher(
     // events queued between watcher.watch() and task startup are correctly
     // detected as deltas. block_in_place signals tokio that this thread is
     // about to block, allowing it to move other tasks off this worker.
-    let initial_snap =
-        tokio::task::block_in_place(|| LibpathSnapshot::capture(&attached));
+    let initial_snap = tokio::task::block_in_place(|| LibpathSnapshot::capture(&attached));
 
     let raw_rx = Arc::new(StdMutex::new(raw_rx));
     let task = tokio::spawn(async move {
@@ -574,12 +560,8 @@ mod watcher_tests {
         let t = tempdir().unwrap();
         let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
 
-        let _handle = spawn_watcher(
-            vec![t.path().to_path_buf()],
-            Duration::from_millis(300),
-            tx,
-        )
-        .expect("watcher attached");
+        let _handle = spawn_watcher(vec![t.path().to_path_buf()], Duration::from_millis(300), tx)
+            .expect("watcher attached");
 
         // Give the watcher a moment to register.
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -616,12 +598,8 @@ mod watcher_tests {
         let t = tempdir().unwrap();
 
         let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
-        let _handle = spawn_watcher(
-            vec![t.path().to_path_buf()],
-            Duration::from_millis(300),
-            tx,
-        )
-        .expect("watcher attached");
+        let _handle = spawn_watcher(vec![t.path().to_path_buf()], Duration::from_millis(300), tx)
+            .expect("watcher attached");
 
         // Create the package and wait for the watcher to confirm it via an
         // `added` event. This is the readiness signal: once the debounce loop
@@ -645,11 +623,7 @@ mod watcher_tests {
             "Package: foo\nVersion: 2.0\n",
         )
         .unwrap();
-        std::fs::write(
-            t.path().join("foo").join("NAMESPACE"),
-            "export(new_fn)\n",
-        )
-        .unwrap();
+        std::fs::write(t.path().join("foo").join("NAMESPACE"), "export(new_fn)\n").unwrap();
 
         let evt = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
@@ -681,12 +655,8 @@ mod watcher_tests {
         make_pkg(t.path(), "foo");
 
         let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
-        let _handle = spawn_watcher(
-            vec![t.path().to_path_buf()],
-            Duration::from_millis(300),
-            tx,
-        )
-        .expect("watcher attached");
+        let _handle = spawn_watcher(vec![t.path().to_path_buf()], Duration::from_millis(300), tx)
+            .expect("watcher attached");
 
         tokio::time::sleep(Duration::from_millis(200)).await;
 

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -464,10 +464,15 @@ impl PackageLibrary {
             loop {
                 let new_dependents: HashSet<String> = cache
                     .iter()
-                    .filter(|(k, _)| !frontier.contains(k.as_str()) && !dependents.contains(k.as_str()))
+                    .filter(|(k, _)| {
+                        !frontier.contains(k.as_str()) && !dependents.contains(k.as_str())
+                    })
                     .filter(|(_, info)| {
                         info.depends.iter().any(|dep| frontier.contains(dep))
-                            || info.attached_packages.iter().any(|dep| frontier.contains(dep))
+                            || info
+                                .attached_packages
+                                .iter()
+                                .any(|dep| frontier.contains(dep))
                     })
                     .map(|(k, _)| k.clone())
                     .collect();
@@ -3468,8 +3473,7 @@ mod tests {
             .await;
         assert_eq!(lib.cached_count().await, 3);
 
-        let to_invalidate: HashSet<String> =
-            ["dplyr".into(), "readr".into()].into_iter().collect();
+        let to_invalidate: HashSet<String> = ["dplyr".into(), "readr".into()].into_iter().collect();
         lib.invalidate_many(&to_invalidate).await;
 
         assert_eq!(lib.cached_count().await, 1);
@@ -3485,12 +3489,8 @@ mod tests {
         let lib = PackageLibrary::new_empty();
         // Seed packages cache too so invalidate_many can discover dependent
         // combined keys from cached PackageInfo.attached_packages.
-        let tidyverse_info = PackageInfo::with_details(
-            "tidyverse".into(),
-            HashSet::new(),
-            vec![],
-            vec![],
-        );
+        let tidyverse_info =
+            PackageInfo::with_details("tidyverse".into(), HashSet::new(), vec![], vec![]);
         {
             let mut packages = lib.packages.write().await;
             packages.insert("tidyverse".into(), std::sync::Arc::new(tidyverse_info));
@@ -3542,8 +3542,11 @@ mod tests {
     async fn invalidate_many_returns_empty_for_names_not_in_combined_exports() {
         use std::collections::HashSet;
         let lib = PackageLibrary::new_empty();
-        lib.insert_package(PackageInfo::new("uncached_meta_child".into(), HashSet::new()))
-            .await;
+        lib.insert_package(PackageInfo::new(
+            "uncached_meta_child".into(),
+            HashSet::new(),
+        ))
+        .await;
 
         // combined_exports is empty for this package name — invalidate_many
         // must not claim it was dropped.

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -758,9 +758,10 @@ fn get_scope(
         content_provider.get_artifacts(target_uri)
     };
 
-    let get_metadata = |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
-        content_provider.get_metadata(target_uri)
-    };
+    let get_metadata =
+        |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
+            content_provider.get_metadata(target_uri)
+        };
 
     let max_depth = state.cross_file_config.max_chain_depth;
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -201,8 +201,7 @@ pub fn resolve_qualified_member(
                 op,
                 &mut cursor_candidates,
             );
-            cursor_candidates
-                .retain(|c| candidate_lhs_matches_symbol(state, c, lhs_name, symbol));
+            cursor_candidates.retain(|c| candidate_lhs_matches_symbol(state, c, lhs_name, symbol));
         }
     }
 
@@ -233,7 +232,11 @@ fn candidate_lhs_matches_symbol(
         c.lhs_pos.character,
         &DiagCancelToken::never(),
     );
-    scope.symbols.get(lhs_name).map(|s| s == symbol).unwrap_or(false)
+    scope
+        .symbols
+        .get(lhs_name)
+        .map(|s| s == symbol)
+        .unwrap_or(false)
 }
 
 fn effect_at_or_after(a: EffectPos, b: EffectPos) -> bool {
@@ -265,9 +268,8 @@ fn pick_winner(
     let (mut in_cursor_file, other): (Vec<_>, Vec<_>) =
         candidates.into_iter().partition(|c| &c.uri == cursor_uri);
     // Cursor file: filter to effect <= cursor (unit-consistent UTF-16 cmp).
-    in_cursor_file.retain(|c| {
-        (c.effect.line, c.effect.utf16_column) <= (cursor.line, cursor.character)
-    });
+    in_cursor_file
+        .retain(|c| (c.effect.line, c.effect.utf16_column) <= (cursor.line, cursor.character));
     if let Some(c) = in_cursor_file
         .into_iter()
         .max_by_key(|c| (c.effect.line, c.effect.utf16_column))
@@ -296,13 +298,19 @@ fn symbol_visible_from_position(
         line: defined_line,
         utf16_column: defined_column_utf16,
     };
-    let Some(line_text) = nth_line(text, defined_line as usize) else { return fallback };
+    let Some(line_text) = nth_line(text, defined_line as usize) else {
+        return fallback;
+    };
     let byte_col = utf16_column_to_byte_offset(line_text, defined_column_utf16);
     let line_byte_len = line_text.len();
     let start = tree_sitter::Point::new(defined_line as usize, byte_col);
     let end = tree_sitter::Point::new(defined_line as usize, (byte_col + 1).min(line_byte_len));
-    let Some(id_node) = tree.root_node().descendant_for_point_range(start, end) else { return fallback };
-    let Some(assignment) = ascend_to_assignment_for(id_node, text, lhs_name) else { return fallback };
+    let Some(id_node) = tree.root_node().descendant_for_point_range(start, end) else {
+        return fallback;
+    };
+    let Some(assignment) = ascend_to_assignment_for(id_node, text, lhs_name) else {
+        return fallback;
+    };
     EffectPos::from_node_end(assignment, text)
 }
 
@@ -355,7 +363,9 @@ fn collect_member_assignments(
         if node.kind() != "binary_operator" {
             continue;
         }
-        let Some(op_node) = node.child_by_field_name("operator") else { continue };
+        let Some(op_node) = node.child_by_field_name("operator") else {
+            continue;
+        };
         let op_text = node_text(op_node, text);
         let target = match op_text {
             "<-" | "=" | "<<-" => node.child_by_field_name("lhs"),
@@ -366,7 +376,9 @@ fn collect_member_assignments(
         if target.kind() != "extract_operator" {
             continue;
         }
-        let Some(target_op) = target.child_by_field_name("operator") else { continue };
+        let Some(target_op) = target.child_by_field_name("operator") else {
+            continue;
+        };
         let target_op_kind = match (target_op.kind(), op) {
             ("$", ExtractOp::Dollar) => true,
             ("@", ExtractOp::At) => true,
@@ -375,8 +387,12 @@ fn collect_member_assignments(
         if !target_op_kind {
             continue;
         }
-        let Some(t_lhs) = target.child_by_field_name("lhs") else { continue };
-        let Some(t_rhs) = target.child_by_field_name("rhs") else { continue };
+        let Some(t_lhs) = target.child_by_field_name("lhs") else {
+            continue;
+        };
+        let Some(t_rhs) = target.child_by_field_name("rhs") else {
+            continue;
+        };
         if t_lhs.kind() != "identifier" || t_rhs.kind() != "identifier" {
             continue;
         }
@@ -449,7 +465,9 @@ fn collect_constructor_candidate(
         if child.kind() != "argument" {
             continue;
         }
-        let Some(name_node) = child.child_by_field_name("name") else { continue };
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
         if name_node.kind() != "identifier" {
             continue;
         }
@@ -546,7 +564,9 @@ mod tests {
 
     fn add_doc(state: &mut WorldState, uri: &str, text: &str) -> Url {
         let url = Url::parse(uri).expect("uri");
-        state.documents.insert(url.clone(), Document::new(text, None));
+        state
+            .documents
+            .insert(url.clone(), Document::new(text, None));
         url
     }
 
@@ -600,7 +620,10 @@ mod tests {
         let uri = add_doc(&mut state, "file:///t.R", code);
         let pos = Position::new(2, 8);
         let l = loc(goto_definition(&state, &uri, pos));
-        assert_eq!(l.range.start.line, 1, "expected member-assignment on line 1");
+        assert_eq!(
+            l.range.start.line, 1,
+            "expected member-assignment on line 1"
+        );
     }
 
     /// Cursor between literal and a later member-assignment → literal wins
@@ -969,8 +992,7 @@ g <- function() {
 print(foo$bar)
 ";
         let helpers_code = "foo <- list(bar = 1)\n";
-        let (main_uri, helpers_uri) =
-            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let (main_uri, helpers_uri) = setup_two_file_workspace(&mut state, main_code, helpers_code);
 
         // line 5 col 10 = `bar` in `print(foo$bar)`
         let pos = Position::new(5, 10);
@@ -998,8 +1020,7 @@ source(\"helpers.R\")
 print(foo$bar)
 ";
         let helpers_code = "foo <- list(bar = 1)\n";
-        let (main_uri, helpers_uri) =
-            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let (main_uri, helpers_uri) = setup_two_file_workspace(&mut state, main_code, helpers_code);
 
         // line 2 col 10 = `bar` in `print(foo$bar)`
         let pos = Position::new(2, 10);
@@ -1050,11 +1071,7 @@ use(foo$bar)
         let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
         let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
 
-        for (uri, code) in [
-            (&main_uri, main_code),
-            (&a_uri, a_code),
-            (&b_uri, b_code),
-        ] {
+        for (uri, code) in [(&main_uri, main_code), (&a_uri, a_code), (&b_uri, b_code)] {
             state.cross_file_graph.update_file(
                 uri,
                 &crate::cross_file::extract_metadata(code),
@@ -1151,4 +1168,3 @@ use(foo$inner)
         );
     }
 }
-

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -212,10 +212,7 @@ impl WorkspaceIndex {
 
     /// Returns true if the URI is currently pinned.
     pub fn is_pinned(&self, uri: &Url) -> bool {
-        self.pinned
-            .read()
-            .map(|p| p.contains(uri))
-            .unwrap_or(false)
+        self.pinned.read().map(|p| p.contains(uri)).unwrap_or(false)
     }
 
     // ========================================================================
@@ -1078,7 +1075,6 @@ mod tests {
             );
         }
     }
-
 
     #[test]
     fn test_cap_shrinks_back_when_max_files_is_zero_and_runtime_cap_is_default() {

--- a/crates/raven/tests/libpath_watching.rs
+++ b/crates/raven/tests/libpath_watching.rs
@@ -29,12 +29,8 @@ async fn install_triggers_cache_invalidation() {
     assert!(lib.is_cached("foo").await);
 
     let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
-    let _handle = spawn_watcher(
-        vec![t.path().to_path_buf()],
-        Duration::from_millis(300),
-        tx,
-    )
-    .expect("watcher attached");
+    let _handle = spawn_watcher(vec![t.path().to_path_buf()], Duration::from_millis(300), tx)
+        .expect("watcher attached");
 
     tokio::time::sleep(Duration::from_millis(200)).await;
     make_pkg(t.path(), "foo");
@@ -67,12 +63,8 @@ async fn in_place_upgrade_triggers_cache_invalidation() {
     assert!(lib.is_cached("foo").await);
 
     let (tx, mut rx) = mpsc::channel::<LibpathEvent>(16);
-    let _handle = spawn_watcher(
-        vec![t.path().to_path_buf()],
-        Duration::from_millis(300),
-        tx,
-    )
-    .expect("watcher attached");
+    let _handle = spawn_watcher(vec![t.path().to_path_buf()], Duration::from_millis(300), tx)
+        .expect("watcher attached");
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -83,11 +75,7 @@ async fn in_place_upgrade_triggers_cache_invalidation() {
         "Package: foo\nVersion: 2.0\n",
     )
     .unwrap();
-    std::fs::write(
-        t.path().join("foo").join("NAMESPACE"),
-        "export(new_fn)\n",
-    )
-    .unwrap();
+    std::fs::write(t.path().join("foo").join("NAMESPACE"), "export(new_fn)\n").unwrap();
 
     let evt = tokio::time::timeout(Duration::from_secs(3), rx.recv())
         .await

--- a/crates/raven/tests/performance_budgets.rs
+++ b/crates/raven/tests/performance_budgets.rs
@@ -430,7 +430,7 @@ fn assert_scope_resolution_budget_50_file_workspace(
         &base_exports,
         true,
         mode,
-        &never_cancel
+        &never_cancel,
     );
 
     let elapsed = median_of_3(|| {
@@ -446,7 +446,7 @@ fn assert_scope_resolution_budget_50_file_workspace(
             &base_exports,
             true,
             mode,
-            &never_cancel
+            &never_cancel,
         );
     });
 


### PR DESCRIPTION
## Summary
- Run cargo fmt --all to normalize the repository-wide Rust formatting baseline
- Keep this formatting-only cleanup separate from feature or bugfix branches

## Validation
- cargo fmt --check --all

Fixes #150

Conversation: https://app.warp.dev/conversation/ac6f65c9-935d-4f9c-a8e5-206fd71d7a8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting consistency improvements across multiple source files, including multi-line argument lists and closure formatting adjustments.

* **Tests**
  * Test files reformatted to align with updated style conventions; all assertions and test logic remain unchanged.

* **Refactor**
  * Minor expression simplifications and code condensing for improved readability without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->