### PR TITLE
Fix qualified-member goto-def across source chains

### DIFF
--- a/crates/raven/proptest-regressions/handlers.txt
+++ b/crates/raven/proptest-regressions/handlers.txt
@@ -13,3 +13,4 @@ cc 2250c8f29bc61283775c429485d811bc470b61dc653492a4f3296a3aab75251d # shrinks to
 cc 983b057cd15b41227acf67a33b60f8aad42d25970dfa29401494b609f8d246fe # shrinks to reserved_word = "if", var_name = "ifa"
 cc d3a667aae8fefd13d4da291efa222936bb1f1f6806e9bf2c52529364e215c4de # shrinks to symbol_name = "bmp", is_function = false, lines_between = 0
 cc 45e6028c72f7d8b279bbde2cb156a3ac934a6cff2e4f83142171fa19e7706317 # shrinks to func = "i__", lhs = "aa0", rhs = "i__"
+cc 5ffd8e9d8fe0cb62ca747b14ce4eea20ff072c71b60bc3fcdeb7dd6869a03705 # shrinks to content = "NA<-", ext = "jags"

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -743,6 +743,10 @@ impl Default for ScopeArtifacts {
 pub struct ScopeAtPosition {
     pub symbols: HashMap<Arc<str>, ScopedSymbol>,
     pub chain: Vec<Url>,
+    /// Widest query position from each contributing file that was visible when
+    /// this scope was computed. Forward-sourced files typically contribute at
+    /// EOF; backward-parent files contribute only up to their call site.
+    pub visible_positions: HashMap<Url, (u32, u32)>,
     /// URIs where max depth was exceeded, with the source call position (line, col)
     pub depth_exceeded: Vec<(Url, u32, u32)>,
     /// Packages inherited from parent files (loaded before the source() call site)
@@ -766,6 +770,30 @@ pub struct ScopeAtPosition {
     /// Origins are stored as `Arc<Url>` so cross-file propagation between
     /// scopes is a refcount bump rather than a Url-internals string clone.
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
+}
+
+fn record_visible_position(
+    visible_positions: &mut HashMap<Url, (u32, u32)>,
+    uri: &Url,
+    line: u32,
+    column: u32,
+) {
+    match visible_positions.entry(uri.clone()) {
+        std::collections::hash_map::Entry::Occupied(mut entry) => {
+            if (line, column) > *entry.get() {
+                entry.insert((line, column));
+            }
+        }
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert((line, column));
+        }
+    }
+}
+
+fn extend_visible_positions(dst: &mut HashMap<Url, (u32, u32)>, src: &HashMap<Url, (u32, u32)>) {
+    for (uri, &(line, column)) in src {
+        record_visible_position(dst, uri, line, column);
+    }
 }
 
 /// Record that `package` was loaded by `origin_uri`. Idempotent.
@@ -1868,6 +1896,7 @@ where
     }
     visited.insert(uri.clone());
     scope.chain.push(uri.clone());
+    record_visible_position(&mut scope.visible_positions, uri, line, column);
 
     let artifacts = match get_artifacts(uri) {
         Some(a) => a,
@@ -1958,6 +1987,10 @@ where
                             max_depth,
                             current_depth + 1,
                             visited,
+                        );
+                        extend_visible_positions(
+                            &mut scope.visible_positions,
+                            &child_scope.visible_positions,
                         );
                         // Merge child symbols (local definitions take precedence)
                         //
@@ -3039,6 +3072,7 @@ where
 pub(crate) struct ParentPrefix {
     pub symbols: HashMap<Arc<str>, ScopedSymbol>,
     pub chain: Vec<Url>,
+    pub visible_positions: HashMap<Url, (u32, u32)>,
     pub depth_exceeded: Vec<(Url, u32, u32)>,
     // All parent-loaded packages flow into `inherited_packages` here —
     // `parent_prefix_at` never writes to `loaded_packages`. Both the
@@ -3272,6 +3306,10 @@ where
             }
         }
         prefix.chain.extend(parent_scope.chain);
+        extend_visible_positions(
+            &mut prefix.visible_positions,
+            &parent_scope.visible_positions,
+        );
         prefix.depth_exceeded.extend(parent_scope.depth_exceeded);
 
         // Requirements 5.1, 5.2, 5.3: Propagate PackageLoad events from parent files
@@ -3464,6 +3502,7 @@ where
     if !is_revisit {
         scope.chain.push(uri.clone());
     }
+    record_visible_position(&mut scope.visible_positions, uri, line, column);
 
     let artifacts = match get_artifacts(uri) {
         Some(a) => a,
@@ -3503,6 +3542,7 @@ where
                         .or_insert_with(|| symbol.clone());
                 }
                 scope.chain.extend(prefix.chain.iter().cloned());
+                extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope
                     .depth_exceeded
                     .extend(prefix.depth_exceeded.iter().cloned());
@@ -3541,6 +3581,7 @@ where
                     scope.symbols.entry(name).or_insert(symbol);
                 }
                 scope.chain.extend(prefix.chain);
+                extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope.depth_exceeded.extend(prefix.depth_exceeded);
                 for pkg in prefix.inherited_packages {
                     scope.inherited_packages.insert(pkg);
@@ -3755,6 +3796,10 @@ where
                             is_cancelled,
                             None,
                         );
+                        extend_visible_positions(
+                            &mut scope.visible_positions,
+                            &child_scope.visible_positions,
+                        );
                         // Merge child symbols (local definitions take precedence)
                         //
                         // Filter out symbols whose `source_uri` is the current
@@ -3948,6 +3993,7 @@ pub(crate) struct ChildSourceContribution {
     pub packages: HashSet<String>,
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
     pub chain: Vec<Url>,
+    pub visible_positions: HashMap<Url, (u32, u32)>,
     pub depth_exceeded: Vec<(Url, u32, u32)>,
 }
 
@@ -4432,9 +4478,17 @@ where
         let mut chain = Vec::with_capacity(1 + prefix.chain.len());
         chain.push(self.queried_uri.clone());
         chain.extend(prefix.chain.iter().cloned());
+        let mut visible_positions = prefix.visible_positions.clone();
+        record_visible_position(
+            &mut visible_positions,
+            self.queried_uri,
+            self.cursor.0,
+            self.cursor.1,
+        );
         let mut scope = ScopeAtPosition {
             symbols: prefix.symbols.clone(),
             chain,
+            visible_positions,
             depth_exceeded: prefix.depth_exceeded.clone(),
             inherited_packages: prefix.inherited_packages.clone(),
             // `ParentPrefix` no longer has a `loaded_packages` field —
@@ -4540,6 +4594,7 @@ where
             let effect_col = src_col.saturating_add(1);
             if (src_line, effect_col) <= self.cursor {
                 scope.chain.extend(contrib.chain.iter().cloned());
+                extend_visible_positions(&mut scope.visible_positions, &contrib.visible_positions);
                 scope
                     .depth_exceeded
                     .extend(contrib.depth_exceeded.iter().cloned());
@@ -4882,6 +4937,10 @@ where
             contrib.symbols.entry(name).or_insert(symbol);
         }
         contrib.chain.extend(child_scope.chain);
+        extend_visible_positions(
+            &mut contrib.visible_positions,
+            &child_scope.visible_positions,
+        );
         contrib.depth_exceeded.extend(child_scope.depth_exceeded);
 
         // Same-file leak filter for packages (mirrors `scope.rs:3632-3650`).

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8161,6 +8161,9 @@ fn collect_jags_document_completions(
         for candidate in std::iter::once(code).chain(code.rsplit_once('{').map(|(_, tail)| tail)) {
             if let Some(captures) = symbol_re.captures(candidate) {
                 if let Some(name) = captures.get(1) {
+                    if is_r_only_jags_completion_name(name.as_str()) {
+                        break;
+                    }
                     push_local_symbol_completion(
                         items,
                         seen_names,
@@ -8434,6 +8437,14 @@ fn jags_completion(text: &str, uri: &Url) -> CompletionResponse {
     CompletionResponse::Array(items)
 }
 
+fn is_r_only_jags_completion_name(name: &str) -> bool {
+    // These names are valid R keywords/constants or common R functions but
+    // are not JAGS built-ins. If malformed/random JAGS text contains lines
+    // like `NA<-`, do not promote those R-specific names into JAGS completion.
+    (crate::reserved_words::is_reserved_word(name)
+        && !crate::jags_builtins::JAGS_KEYWORDS.contains(&name))
+        || matches!(name, "library" | "require")
+}
 fn stan_completion(text: &str, uri: &Url) -> CompletionResponse {
     let mut items = Vec::new();
     let mut seen_names = std::collections::HashSet::new();
@@ -39233,6 +39244,7 @@ mod file_type_tests {
         fn prop_jags_completions_include_local_symbols(
             varname in "[a-zA-Z][a-zA-Z0-9_]{0,10}"
         ) {
+            prop_assume!(!is_r_only_jags_completion_name(&varname));
             let content = format!("model {{ {} ~ dnorm(0, 1) }}\n", varname);
             let uri = Url::parse("file:///test/model.jags").unwrap();
             let mut state = crate::state::WorldState::new(vec![]);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8445,6 +8445,7 @@ fn is_r_only_jags_completion_name(name: &str) -> bool {
         && !crate::jags_builtins::JAGS_KEYWORDS.contains(&name))
         || matches!(name, "library" | "require")
 }
+
 fn stan_completion(text: &str, uri: &Url) -> CompletionResponse {
     let mut items = Vec::new();
     let mut seen_names = std::collections::HashSet::new();

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -189,7 +189,6 @@ pub fn resolve_qualified_member(
         state.cross_file_config.max_chain_depth,
         state.cross_file_config.max_transitive_dependents_visited,
     );
-    scanned_uris.insert(cursor_uri.clone());
     scanned_uris.remove(&defining_uri);
     let mut scanned_uris: Vec<Url> = scanned_uris.into_iter().collect();
     scanned_uris.sort_by(|a, b| a.as_str().cmp(b.as_str()));
@@ -385,12 +384,10 @@ fn collect_member_assignments(
         let Some(target_op) = target.child_by_field_name("operator") else {
             continue;
         };
-        let target_op_kind = match (target_op.kind(), op) {
-            ("$", ExtractOp::Dollar) => true,
-            ("@", ExtractOp::At) => true,
-            _ => false,
-        };
-        if !target_op_kind {
+        if !matches!(
+            (target_op.kind(), op),
+            ("$", ExtractOp::Dollar) | ("@", ExtractOp::At)
+        ) {
             continue;
         }
         let Some(t_lhs) = target.child_by_field_name("lhs") else {

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -10,6 +10,10 @@
 //!    - **Defining file**: `foo$bar <- ...` member-assignments and any
 //!      constructor-call named argument from the allowlist. Filtered by
 //!      same-function-scope and "effect position at or after the binding".
+//!      Defining-file candidates are also filtered by
+//!      `candidate_effect_visible_in_scope` and `candidate_lhs_matches_symbol`,
+//!      which excludes candidates past the parent file's `source()` site that
+//!      made the cursor file visible.
 //!    - **Every non-defining file in the cursor scope's contributor chain**:
 //!      each `foo$bar <- ...` site is validated by re-resolving `foo` at
 //!      that site's position via cross-file scope; only sites where `foo`
@@ -1085,6 +1089,38 @@ print(foo$bar)
         // file's constructor literal wins.
         assert_eq!(l.uri, helpers_uri);
         assert_eq!(l.range.start.line, 0);
+    }
+    /// Regression: a defining-file member assignment after the `source()` site
+    /// that brought the cursor file into scope is not visible to that child.
+    #[test]
+    fn dollar_rhs_defining_file_visibility_cutoff() {
+        let mut state = fresh_state();
+
+        let a_code = "\
+foo <- list()
+source(\"b.R\")
+foo$bar <- 1
+";
+        let b_code = "print(foo$bar)\n";
+
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+
+        for (uri, code) in [(&a_uri, a_code), (&b_uri, b_code)] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 0 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(0, 10);
+        assert!(
+            goto_definition(&state, &b_uri, pos).is_none(),
+            "must not see `foo$bar <- 1` after the `source(\"b.R\")` cutoff in a.R",
+        );
     }
 
     /// CRLF regression: with `\r\n` line endings, position columns must

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -5,34 +5,28 @@
 //! For `foo$bar` (or `foo@bar`) where the cursor is on `bar`:
 //!
 //! 1. Resolve `foo` via the existing position-aware scope.
-//! 2. Collect candidates from two scopes:
+//! 2. Collect candidates from the defining file and the cursor's cross-file
+//!    neighborhood:
 //!    - **Defining file**: `foo$bar <- ...` member-assignments and any
 //!      constructor-call named argument from the allowlist. Filtered by
 //!      same-function-scope and "effect position at or after the binding".
-//!    - **Cursor file** (when different from the defining file): each
-//!      `foo$bar <- ...` site is validated by re-resolving `foo` at that
-//!      site's position via cross-file scope; only sites where `foo`
-//!      resolves to the *same* binding are kept. This handles the very
-//!      common pattern of "skeleton object defined in helpers.R, members
-//!      attached in main.R".
+//!    - **Every non-defining file in the cursor's cross-file neighborhood**:
+//!      each `foo$bar <- ...` site is validated by re-resolving `foo` at
+//!      that site's position via cross-file scope; only sites where `foo`
+//!      resolves to the *same* binding are kept. This handles both the common
+//!      "skeleton object defined in helpers.R, members attached in main.R"
+//!      pattern and intermediate-file attachments in longer `source()` chains.
 //! 3. Tie-break: `pick_winner` partitions all candidates by whether their
 //!    `uri` equals the cursor's. The in-cursor-file partition is filtered
 //!    by `effect <= cursor`, then the candidate with the latest effect
 //!    wins. If no in-cursor-file candidate qualifies, the other-file
 //!    partition's max-effect candidate wins as a fallback.
 //!
-//!    In the **same-file case** (cursor file = defining file), Phase 2 is
-//!    skipped, so every candidate lives in the cursor's own file and the
-//!    partition has only one non-empty side — both the `effect <= cursor`
-//!    filter and the max-effect rule apply once over the merged set.
-//!    There is no separate "defining-file tier" to fall back to in this
-//!    case; the two-tier story only kicks in when the files differ.
+//!    In the **same-file case** (cursor file = defining file), defining-file
+//!    candidates live in the cursor partition and are filtered by
+//!    `effect <= cursor`. Non-defining neighborhood candidates can still be
+//!    used as a fallback if no cursor-file candidate qualifies.
 //! 4. Never fall back to free-identifier lookup.
-//!
-//! Limitation (step 2): only the cursor file and the defining file are
-//! scanned. A `foo$bar <- ...` in some *third* file in the middle of a
-//! `source()` chain is not currently found. Extending to the cursor's
-//! cross-file connected component is a follow-up.
 
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 use tree_sitter::{Node, Tree};
@@ -81,19 +75,20 @@ impl EffectPos {
 #[derive(Debug, Clone)]
 struct Candidate {
     /// File the candidate lives in. For defining-file candidates this is
-    /// `defining_uri`; for cursor-file candidates this is the cursor's URI.
+    /// `defining_uri`; for cross-file candidates this is the file containing
+    /// the validated member-assignment site.
     uri: Url,
     effect: EffectPos,
     name_range: Range,
     /// `None` for top-level, else the `function_definition` node id of the
     /// closest enclosing function scope. Tree-local — only meaningful when
     /// comparing candidates collected from the *same* tree (i.e. defining
-    /// file vs the binding's `symbol_fn_scope`). For cursor-file candidates
-    /// this is recorded but unused (a per-site scope-resolve replaces the
-    /// `fn_scope` correctness gate across files).
+    /// file vs the binding's `symbol_fn_scope`). For non-defining-file
+    /// candidates this is recorded but unused (a per-site scope-resolve
+    /// replaces the `fn_scope` correctness gate across files).
     fn_scope: FunctionScopeId,
     /// Position of the LHS identifier (`foo` in `foo$bar <- ...`). Used as
-    /// the query position when re-resolving `foo` for cursor-file
+    /// the query position when re-resolving `foo` for non-defining-file
     /// candidates; ignored for defining-file candidates.
     lhs_pos: Position,
 }
@@ -183,30 +178,41 @@ pub fn resolve_qualified_member(
         });
     }
 
-    // Phase 2: collect from the cursor file (if distinct). Tree-local IDs
-    // are not comparable to those in the defining tree, so we replace the
-    // `fn_scope` gate with a per-site scope-resolve: at the LHS identifier's
-    // position, does `foo` resolve to the *same* binding we navigated from?
-    let mut cursor_candidates: Vec<Candidate> = Vec::new();
-    if cursor_uri != defining_uri {
-        if let Some((cursor_text, cursor_tree)) =
-            crate::parameter_resolver::get_text_and_tree(state, &cursor_uri)
+    // Phase 2: collect from every non-defining file in the cursor's cross-file
+    // neighborhood. Tree-local IDs are not comparable to those in the defining
+    // tree, so we replace the `fn_scope` gate with a per-site scope-resolve:
+    // at the LHS identifier's position, does `foo` resolve to the *same*
+    // binding we navigated from?
+    let mut cross_file_candidates: Vec<Candidate> = Vec::new();
+    let mut scanned_uris = state.cross_file_graph.collect_neighborhood(
+        &cursor_uri,
+        state.cross_file_config.max_chain_depth,
+        state.cross_file_config.max_transitive_dependents_visited,
+    );
+    scanned_uris.insert(cursor_uri.clone());
+    scanned_uris.remove(&defining_uri);
+    let mut scanned_uris: Vec<Url> = scanned_uris.into_iter().collect();
+    scanned_uris.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+    for candidate_uri in scanned_uris {
+        if let Some((candidate_text, candidate_tree)) =
+            crate::parameter_resolver::get_text_and_tree(state, &candidate_uri)
         {
             collect_member_assignments(
-                cursor_tree.root_node(),
-                &cursor_text,
-                &cursor_uri,
+                candidate_tree.root_node(),
+                &candidate_text,
+                &candidate_uri,
                 lhs_name,
                 rhs_name,
                 op,
-                &mut cursor_candidates,
+                &mut cross_file_candidates,
             );
-            cursor_candidates.retain(|c| candidate_lhs_matches_symbol(state, c, lhs_name, symbol));
         }
     }
+    cross_file_candidates.retain(|c| candidate_lhs_matches_symbol(state, c, lhs_name, symbol));
 
     let mut all_candidates = defining_candidates;
-    all_candidates.extend(cursor_candidates);
+    all_candidates.extend(cross_file_candidates);
     pick_winner(all_candidates, &cursor_uri, position).map(|c| Location {
         uri: c.uri,
         range: c.name_range,
@@ -255,11 +261,11 @@ fn effect_at_or_after(a: EffectPos, b: EffectPos) -> bool {
 /// at-or-before the cursor (you can't "see" an assignment that hasn't
 /// happened yet) and pick the one with the latest effect position.
 ///
-/// If no cursor-file candidate qualifies, fall back to the
-/// non-cursor-file candidate with the latest effect position. (Effect
-/// positions across different non-cursor files are not directly
-/// comparable, but in practice all such candidates come from the same
-/// defining file, so the comparison is well-defined.)
+/// If no cursor-file candidate qualifies, fall back to the non-cursor-file
+/// candidate with the latest effect position. Effect positions across
+/// different non-cursor files are not directly comparable; if that becomes
+/// observable, prefer candidates whose file is closer to the cursor in the
+/// dependency graph.
 fn pick_winner(
     candidates: Vec<Candidate>,
     cursor_uri: &Url,
@@ -476,7 +482,7 @@ fn collect_constructor_candidate(
         }
         // Constructor candidates always live in the defining file. The
         // `lhs_pos` field is unused for them (cross-file scope-check only
-        // applies to cursor-file member-assignment candidates), so we
+        // applies to non-defining-file member-assignment candidates), so we
         // anchor it at the constructor's named-arg position.
         let name_range = node_range_in_text(name_node, text);
         return Some(Candidate {
@@ -1096,15 +1102,12 @@ use(foo$bar)
         assert_eq!(l.range.start.character, 12);
     }
 
-    /// Documented "third-file gap": `foo` is defined in `a.R`, the
-    /// `foo$bar <- 1` lives in the *middle* file `b.R`, and the cursor is
-    /// in `c.R`. Today we scan only the cursor file (c.R) and the defining
-    /// file (a.R), so the candidate in b.R is invisible. Neither file has
-    /// a qualifying candidate, so the resolver returns `None`. Pin this so
-    /// extending scanning to the full connected component (issue #148) has
-    /// a clean before/after.
+    /// `foo` is defined in `a.R`, `foo$bar <- 1` lives in the middle file
+    /// `b.R`, and the cursor is in `c.R`. The connected-component scan must
+    /// find the b.R member assignment even though it is neither the cursor
+    /// file nor the defining file.
     #[test]
-    fn dollar_rhs_third_file_member_assignment_returns_none() {
+    fn dollar_rhs_third_file_member_assignment_resolves_to_intermediate_file() {
         let mut state = fresh_state();
 
         let c_code = "\
@@ -1132,13 +1135,94 @@ foo$bar <- 1
 
         // line 1 col 10 = `bar` in `print(foo$bar)`
         let pos = Position::new(1, 10);
-        let result = goto_definition(&state, &c_uri, pos);
+        let l = loc(goto_definition(&state, &c_uri, pos));
+        assert_eq!(l.uri, b_uri, "must resolve to the intermediate file");
+        assert_eq!(l.range.start.line, 1);
+        assert_eq!(l.range.start.character, 4);
+    }
+
+    /// Negative: the connected-component scan sees `b.R`, but the only
+    /// `foo$bar <- 99` candidate there is inside a function where `foo` is
+    /// shadowed. The per-site scope-resolve must reject it.
+    #[test]
+    fn dollar_rhs_third_file_shadowed_assignment_does_not_match() {
+        let mut state = fresh_state();
+
+        let c_code = "\
+source(\"b.R\")
+print(foo$bar)
+";
+        let b_code = "\
+source(\"a.R\")
+g <- function() {
+  foo <- list()
+  foo$bar <- 99
+}
+";
+        let a_code = "foo <- list()\n";
+
+        let c_uri = add_doc(&mut state, "file:///workspace/c.R", c_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+
+        for (uri, code) in [(&c_uri, c_code), (&b_uri, b_code), (&a_uri, a_code)] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 1 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(1, 10);
         assert!(
-            result.is_none(),
-            "third-file `foo$bar <- 1` is invisible to current scanning — \
-             a.R (defining) has no member-assignment or matching constructor \
-             arg, c.R (cursor) has none either, so no candidate qualifies. \
-             Tracked by issue #148.",
+            goto_definition(&state, &c_uri, pos).is_none(),
+            "must not match `foo$bar <- 99` inside g(); that's a different `foo`",
+        );
+    }
+
+    /// Negative: a matching-looking `foo$bar <- 99` in a document outside the
+    /// cursor's cross-file connected component is not scanned.
+    #[test]
+    fn dollar_rhs_member_assignment_outside_connected_component_does_not_match() {
+        let mut state = fresh_state();
+
+        let c_code = "\
+source(\"b.R\")
+print(foo$bar)
+";
+        let b_code = "source(\"a.R\")\n";
+        let a_code = "foo <- list()\n";
+        let unrelated_code = "\
+foo <- list()
+foo$bar <- 99
+";
+
+        let c_uri = add_doc(&mut state, "file:///workspace/c.R", c_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+        let unrelated_uri = add_doc(&mut state, "file:///workspace/unrelated.R", unrelated_code);
+
+        for (uri, code) in [
+            (&c_uri, c_code),
+            (&b_uri, b_code),
+            (&a_uri, a_code),
+            (&unrelated_uri, unrelated_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 1 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(1, 10);
+        assert!(
+            goto_definition(&state, &c_uri, pos).is_none(),
+            "must not scan unrelated.R outside c.R's connected component",
         );
     }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -5,28 +5,32 @@
 //! For `foo$bar` (or `foo@bar`) where the cursor is on `bar`:
 //!
 //! 1. Resolve `foo` via the existing position-aware scope.
-//! 2. Collect candidates from the defining file and the cursor's cross-file
-//!    neighborhood:
+//! 2. Collect candidates from the defining file and the files that actually
+//!    contribute to the cursor's resolved cross-file scope:
 //!    - **Defining file**: `foo$bar <- ...` member-assignments and any
 //!      constructor-call named argument from the allowlist. Filtered by
 //!      same-function-scope and "effect position at or after the binding".
-//!    - **Every non-defining file in the cursor's cross-file neighborhood**:
+//!    - **Every non-defining file in the cursor scope's contributor chain**:
 //!      each `foo$bar <- ...` site is validated by re-resolving `foo` at
 //!      that site's position via cross-file scope; only sites where `foo`
-//!      resolves to the *same* binding are kept. This handles both the common
-//!      "skeleton object defined in helpers.R, members attached in main.R"
-//!      pattern and intermediate-file attachments in longer `source()` chains.
+//!      resolves to the *same* binding are kept. Using the resolved scope's
+//!      `chain` and per-file visible cutoffs avoids false positives from files
+//!      that merely depend on the cursor file or from parent files past the
+//!      `source()` call site that brought the cursor file into scope.
 //! 3. Tie-break: `pick_winner` partitions all candidates by whether their
 //!    `uri` equals the cursor's. The in-cursor-file partition is filtered
 //!    by `effect <= cursor`, then the candidate with the latest effect
 //!    wins. If no in-cursor-file candidate qualifies, the other-file
-//!    partition's max-effect candidate wins as a fallback.
+//!    partition falls back to the earliest file in the cursor scope's
+//!    contributor chain, then chooses that file's latest-effect candidate.
 //!
 //!    In the **same-file case** (cursor file = defining file), defining-file
 //!    candidates live in the cursor partition and are filtered by
-//!    `effect <= cursor`. Non-defining neighborhood candidates can still be
-//!    used as a fallback if no cursor-file candidate qualifies.
+//!    `effect <= cursor`. Non-defining contributor-chain candidates can still
+//!    be used as a fallback if no cursor-file candidate qualifies.
 //! 4. Never fall back to free-identifier lookup.
+
+use std::collections::HashMap;
 
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 use tree_sitter::{Node, Tree};
@@ -178,29 +182,25 @@ pub fn resolve_qualified_member(
         });
     }
 
-    // Phase 2: collect from every non-defining file in the cursor's cross-file
-    // neighborhood. Tree-local IDs are not comparable to those in the defining
-    // tree, so we replace the `fn_scope` gate with a per-site scope-resolve:
-    // at the LHS identifier's position, does `foo` resolve to the *same*
-    // binding we navigated from?
+    // Phase 2: collect from every non-defining file that contributed to the
+    // cursor's resolved scope. Tree-local IDs are not comparable to those in
+    // the defining tree, so we replace the `fn_scope` gate with a per-site
+    // scope-resolve: at the LHS identifier's position, does `foo` resolve to
+    // the *same* binding we navigated from?
     let mut cross_file_candidates: Vec<Candidate> = Vec::new();
-    let mut scanned_uris = state.cross_file_graph.collect_neighborhood(
-        &cursor_uri,
-        state.cross_file_config.max_chain_depth,
-        state.cross_file_config.max_transitive_dependents_visited,
-    );
-    scanned_uris.remove(&defining_uri);
-    let mut scanned_uris: Vec<Url> = scanned_uris.into_iter().collect();
-    scanned_uris.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-
-    for candidate_uri in scanned_uris {
+    let contributor_ranks = contributor_file_ranks(&scope.chain);
+    for candidate_uri in scope
+        .chain
+        .iter()
+        .filter(|candidate_uri| **candidate_uri != defining_uri)
+    {
         if let Some((candidate_text, candidate_tree)) =
-            crate::parameter_resolver::get_text_and_tree(state, &candidate_uri)
+            crate::parameter_resolver::get_text_and_tree(state, candidate_uri)
         {
             collect_member_assignments(
                 candidate_tree.root_node(),
                 &candidate_text,
-                &candidate_uri,
+                candidate_uri,
                 lhs_name,
                 rhs_name,
                 op,
@@ -208,14 +208,37 @@ pub fn resolve_qualified_member(
             );
         }
     }
-    cross_file_candidates.retain(|c| candidate_lhs_matches_symbol(state, c, lhs_name, symbol));
+    cross_file_candidates.retain(|c| {
+        candidate_effect_visible_in_scope(c, &scope.visible_positions)
+            && candidate_lhs_matches_symbol(state, c, lhs_name, symbol)
+    });
 
     let mut all_candidates = defining_candidates;
     all_candidates.extend(cross_file_candidates);
-    pick_winner(all_candidates, &cursor_uri, position).map(|c| Location {
+    pick_winner(all_candidates, &cursor_uri, position, &contributor_ranks).map(|c| Location {
         uri: c.uri,
         range: c.name_range,
     })
+}
+
+fn contributor_file_ranks(chain: &[Url]) -> HashMap<Url, usize> {
+    let mut ranks = HashMap::new();
+    for (idx, uri) in chain.iter().enumerate() {
+        ranks.entry(uri.clone()).or_insert(idx);
+    }
+    ranks
+}
+
+fn candidate_effect_visible_in_scope(
+    candidate: &Candidate,
+    visible_positions: &HashMap<Url, (u32, u32)>,
+) -> bool {
+    visible_positions
+        .get(&candidate.uri)
+        .map(|&(line, column)| {
+            (candidate.effect.line, candidate.effect.utf16_column) <= (line, column)
+        })
+        .unwrap_or(false)
 }
 
 /// Re-resolve `lhs_name` at the candidate's LHS-identifier position via the
@@ -260,15 +283,14 @@ fn effect_at_or_after(a: EffectPos, b: EffectPos) -> bool {
 /// at-or-before the cursor (you can't "see" an assignment that hasn't
 /// happened yet) and pick the one with the latest effect position.
 ///
-/// If no cursor-file candidate qualifies, fall back to the non-cursor-file
-/// candidate with the latest effect position. Effect positions across
-/// different non-cursor files are not directly comparable; if that becomes
-/// observable, prefer candidates whose file is closer to the cursor in the
-/// dependency graph.
+/// If no cursor-file candidate qualifies, fall back to the earliest file in
+/// the cursor scope's contributor chain, then pick that file's latest effect
+/// position. Effect positions are only compared within a single file.
 fn pick_winner(
     candidates: Vec<Candidate>,
     cursor_uri: &Url,
     cursor: Position,
+    contributor_ranks: &HashMap<Url, usize>,
 ) -> Option<Candidate> {
     let (mut in_cursor_file, other): (Vec<_>, Vec<_>) =
         candidates.into_iter().partition(|c| &c.uri == cursor_uri);
@@ -281,9 +303,35 @@ fn pick_winner(
     {
         return Some(c);
     }
-    other
-        .into_iter()
-        .max_by_key(|c| (c.effect.line, c.effect.utf16_column))
+
+    let mut best_per_file: HashMap<Url, Candidate> = HashMap::new();
+    for candidate in other {
+        match best_per_file.entry(candidate.uri.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if effect_at_or_after(candidate.effect, entry.get().effect) {
+                    entry.insert(candidate);
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(candidate);
+            }
+        }
+    }
+
+    best_per_file
+        .into_values()
+        .filter_map(|candidate| {
+            contributor_ranks
+                .get(&candidate.uri)
+                .copied()
+                .map(|rank| (rank, candidate))
+        })
+        .min_by(|(rank_a, candidate_a), (rank_b, candidate_b)| {
+            rank_a
+                .cmp(rank_b)
+                .then_with(|| candidate_a.uri.as_str().cmp(candidate_b.uri.as_str()))
+        })
+        .map(|(_, candidate)| candidate)
 }
 
 /// Compute the resolved symbol's *visible-from* position: the end of its
@@ -1100,9 +1148,9 @@ use(foo$bar)
     }
 
     /// `foo` is defined in `a.R`, `foo$bar <- 1` lives in the middle file
-    /// `b.R`, and the cursor is in `c.R`. The connected-component scan must
-    /// find the b.R member assignment even though it is neither the cursor
-    /// file nor the defining file.
+    /// `b.R`, and the cursor is in `c.R`. The contributor-aware cross-file
+    /// scan must find the b.R member assignment even though it is neither the
+    /// cursor file nor the defining file.
     #[test]
     fn dollar_rhs_third_file_member_assignment_resolves_to_intermediate_file() {
         let mut state = fresh_state();
@@ -1138,7 +1186,97 @@ foo$bar <- 1
         assert_eq!(l.range.start.character, 4);
     }
 
-    /// Negative: the connected-component scan sees `b.R`, but the only
+    /// Regression: files that depend on the cursor file are in the undirected
+    /// neighborhood but do not contribute to the cursor's scope. Their member
+    /// assignments must not be considered fallback definitions.
+    #[test]
+    fn dollar_rhs_dependent_file_member_assignment_does_not_match() {
+        let mut state = fresh_state();
+
+        let main_code = "\
+source(\"helpers.R\")
+print(foo$bar)
+";
+        let helpers_code = "foo <- list()\n";
+        let runner_code = "\
+source(\"main.R\")
+foo$bar <- 1
+";
+
+        let main_uri = add_doc(&mut state, "file:///workspace/main.R", main_code);
+        let helpers_uri = add_doc(&mut state, "file:///workspace/helpers.R", helpers_code);
+        let runner_uri = add_doc(&mut state, "file:///workspace/runner.R", runner_code);
+
+        for (uri, code) in [
+            (&main_uri, main_code),
+            (&helpers_uri, helpers_code),
+            (&runner_uri, runner_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 1 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(1, 10);
+        assert!(
+            goto_definition(&state, &main_uri, pos).is_none(),
+            "must not jump to runner.R; dependent files do not contribute to main.R's scope",
+        );
+    }
+
+    /// Regression: across contributing files, prefer the file that runs later
+    /// in the cursor's source chain rather than comparing unrelated file-local
+    /// line numbers.
+    #[test]
+    fn dollar_rhs_prefers_closer_contributing_file_over_later_line_in_defining_file() {
+        let mut state = fresh_state();
+
+        let c_code = "\
+source(\"b.R\")
+print(foo$bar)
+";
+        let b_code = "\
+source(\"a.R\")
+foo$bar <- 2
+";
+        let a_code = "\
+foo <- list()
+
+
+
+foo$bar <- 1
+";
+
+        let c_uri = add_doc(&mut state, "file:///workspace/c.R", c_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+
+        for (uri, code) in [(&c_uri, c_code), (&b_uri, b_code), (&a_uri, a_code)] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 1 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(1, 10);
+        let l = loc(goto_definition(&state, &c_uri, pos));
+        assert_eq!(l.uri, b_uri, "b.R runs after a.R in c.R's source chain");
+        assert_ne!(
+            l.uri, a_uri,
+            "must not compare file-local line numbers across files"
+        );
+        assert_eq!(l.range.start.line, 1);
+        assert_eq!(l.range.start.character, 4);
+    }
+
+    /// Negative: the contributor-aware scan sees `b.R`, but the only
     /// `foo$bar <- 99` candidate there is inside a function where `foo` is
     /// shadowed. The per-site scope-resolve must reject it.
     #[test]
@@ -1180,7 +1318,7 @@ g <- function() {
     }
 
     /// Negative: a matching-looking `foo$bar <- 99` in a document outside the
-    /// cursor's cross-file connected component is not scanned.
+    /// cursor's contributing cross-file files is not scanned.
     #[test]
     fn dollar_rhs_member_assignment_outside_connected_component_does_not_match() {
         let mut state = fresh_state();

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -180,6 +180,10 @@ pub fn resolve_qualified_member(
         defining_candidates.retain(|c| {
             c.fn_scope == symbol_fn_scope && effect_at_or_after(c.effect, symbol_effect)
         });
+        defining_candidates.retain(|c| {
+            candidate_effect_visible_in_scope(c, &scope.visible_positions)
+                && candidate_lhs_matches_symbol(state, c, lhs_name, symbol)
+        });
     }
 
     // Phase 2: collect from every non-defining file that contributed to the
@@ -525,17 +529,18 @@ fn collect_constructor_candidate(
         if node_text(name_node, text) != rhs_name {
             continue;
         }
-        // Constructor candidates always live in the defining file. The
-        // `lhs_pos` field is unused for them (cross-file scope-check only
-        // applies to non-defining-file member-assignment candidates), so we
-        // anchor it at the constructor's named-arg position.
         let name_range = node_range_in_text(name_node, text);
+        let effect = EffectPos::from_node_end(assignment, text);
+        // Constructor candidates become visible only after the defining
+        // assignment completes, so use the effect position for the shared
+        // symbol identity check.
+        let lhs_pos = Position::new(effect.line, effect.utf16_column);
         return Some(Candidate {
             uri: file_uri.clone(),
-            effect: EffectPos::from_node_end(assignment, text),
+            effect,
             name_range,
             fn_scope: enclosing_function_id(assignment),
-            lhs_pos: name_range.start,
+            lhs_pos,
         });
     }
     None

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -382,20 +382,24 @@ a free variable. This avoids the surprise where a same-named top-level
 binding (e.g. `bar <- ...`) was previously chosen as the target.
 
 Concretely, after resolving `foo` with the existing position-aware scope,
-Raven looks for two kinds of candidates inside the file where `foo` is
-defined:
+Raven looks for candidates in the file where `foo` is defined and in any other
+file that actually contributes to the cursor's cross-file scope:
 
-- **Member assignments** — any `foo$bar <- …` (or `foo@bar <- …`) statement.
+- **Member assignments** — any `foo$bar <- …` (or `foo@bar <- …`) statement in
+  the defining file or a contributing cross-file source/parent file, as long
+  as re-resolving `foo` at that assignment site still points to the same
+  binding.
 - **Constructor-literal members** — when `foo`'s defining assignment's RHS
   is a call to one of `list`, `c`, `data.frame`, `tibble`, `data.table`,
   `environment`, `list2env`, or `new`, the named argument matching `bar` is a
   candidate.
 
 The candidate with the latest *effect position* (the end of the assignment
-that introduces it) before the cursor wins. Across files, the latest
-candidate in `foo`'s defining file wins. If no qualified candidate exists,
-go-to-definition returns nothing — Raven does not fall back to a free-variable
-lookup for the RHS of `$`/`@`.
+that introduces it) before the cursor wins within the cursor file. If the best
+match lives in another file, Raven prefers the file closest to the cursor in
+the contributing cross-file chain, then chooses that file's latest matching
+assignment. If no qualified candidate exists, go-to-definition returns nothing
+— Raven does not fall back to a free-variable lookup for the RHS of `$`/`@`.
 
 Out of scope today: S4 slot resolution from `setClass`, R6 fields/methods,
 aliasing (`foo <- bar; foo$x`), function-return inference, package-data

--- a/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
+++ b/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
@@ -55,19 +55,23 @@ When the cursor is on the RHS identifier `bar` of an `extract_operator` node
 1. **Resolve `foo`** using the existing position-aware scope
    (`get_cross_file_scope`). If unresolved → return `None`.
 2. **Build a candidate set** of qualified definitions of `bar` against this
-   `foo`, drawn only from `foo`'s scope chain (the file where `foo` is defined,
-   plus whatever files that scope already pulls in via the cross-file scope
-   resolver). Two candidate kinds:
+   `foo`, drawn from `foo`'s defining file and from non-defining files in the
+   cursor file's cross-file connected component. Non-defining-file member
+   assignment sites are retained only when a per-site `get_cross_file_scope`
+   check resolves their LHS `foo` to the same `ScopedSymbol`. Two candidate
+   kinds:
    - **Member-assignment** — any `foo$bar <- …` (or `foo@bar <- …`) statement.
    - **Constructor-literal** — when `foo`'s defining assignment's RHS is a
      call to an allowlisted constructor, find the named argument whose name
      is `bar`.
 3. **Pick a winner**: position-aware single result.
-   - If the cursor's file is the same as `foo`'s defining file: the latest
-     candidate whose effect position is `<=` the cursor.
-   - If different files: the latest candidate in `foo`'s defining file.
-   - This mirrors how the position-aware scope resolver decides among
-     redefinitions of plain identifiers.
+   - If the cursor file has a visible candidate, the latest cursor-file
+     candidate wins. This includes defining-file candidates when the cursor is
+     in the file where `foo` is defined.
+   - Otherwise, the latest candidate among `foo`'s defining file and the
+     cursor file's cross-file connected component wins.
+   - This mirrors the existing resolver's local-position preference while
+     keeping non-cursor cross-file ordering best-effort.
 4. **No fallback to free-identifier lookup.** If no qualified candidate exists,
    return `None`. The whole point of this fix is that the RHS of `$`/`@` is not
    a reference to a free variable; reintroducing that lookup as a fallback would
@@ -172,31 +176,28 @@ that.
 
 ## Cross-file behavior
 
-Per the design decision (option C from brainstorming), the candidate search
-runs in `foo`'s defining scope — not the cursor's file:
+Candidate search has two tiers:
 
-- **Member-assignments**: walk the AST of `foo`'s defining file and collect
-  `foo$bar <- …` (and `foo@bar <- …`) nodes. The tree is obtained via
-  `parameter_resolver::get_text_and_tree` (see "Where the defining file's AST
-  comes from" above), since `ScopeArtifacts` does not carry it.
+- **Defining-file member-assignments**: walk the AST of `foo`'s defining file
+  and collect `foo$bar <- …` (and `foo@bar <- …`) nodes. The tree is obtained
+  via `parameter_resolver::get_text_and_tree` (see "Where the defining file's
+  AST comes from" above), since `ScopeArtifacts` does not carry it. These
+  candidates use same-tree function-scope and effect-position checks.
+- **Connected-component member-assignments**: walk every non-defining file in
+  the cursor file's cross-file neighborhood (`DependencyGraph::collect_neighborhood`,
+  which follows both forward and backward edges). Each matching text site is
+  validated by re-resolving `foo` at the assignment's LHS position via
+  `get_cross_file_scope`; only sites where `foo` resolves to the exact same
+  `ScopedSymbol` are retained.
 - **Constructor-literals**: only the single assignment that defined `foo`
   matters. We already have its line/column from the resolved symbol; re-fetch
   its RHS in the defining file's tree, then look for an `argument` node whose
   `child_by_field_name("name")` matches `rhs_name`. This is the same field
   shape `is_structural_non_reference` already uses (`handlers.rs:5083-5089`).
 
-This avoids the false-positive risk where an unrelated `other_foo$bar <- …` in
-a random file would match.
-
-**Limitation acknowledged**: forward-source merging (where another file
-sourced *after* `foo`'s defining file mutates `foo`) is not searched in
-Step 1. The full scope-resolution machinery does merge parent and forward
-contributions (`cross_file/scope.rs` `parent_prefix_at` ~3053-3245, forward
-source merge ~3592-3773); applying that merge model to qualified-member
-candidates is in scope for a follow-up. For Step 1 we only walk the defining
-file's own AST. This is a deliberate trade-off: covers the common case at
-modest implementation cost, with no incorrect *positive* results — only
-missed targets.
+The per-site scope gate avoids the false-positive risk where a same-looking
+`foo$bar <- …` in a random file, or inside a function that shadows `foo`, would
+match the symbol the user navigated from.
 
 ## Position-aware tie-breaking
 
@@ -213,11 +214,14 @@ binding is not visible inside its own RHS.
 
 Selection:
 
-- Cursor in `foo`'s defining file → candidate with the latest effect position
-  that is `<= (cursor_line, cursor_col)`. (Equality is fine: by construction
-  every effect position lies on a syntactically-prior statement.)
-- Cursor in a different file → candidate with the latest effect position in
-  the defining file. Cursor-relative filtering does not apply across files.
+- Candidates in the cursor file are filtered to effect positions
+  `<= (cursor_line, cursor_col)`, then the latest cursor-file candidate wins.
+  (Equality is fine: by construction every effect position lies on a
+  syntactically-prior statement.)
+- If no cursor-file candidate qualifies, fall back to the latest effect
+  position among non-cursor candidates. Cross-file effect-position ordering is
+  only a best-effort tie-break; if this becomes observable, prefer candidates
+  whose file is closer to the cursor in the dependency graph.
 
 Returned `Location` is still the range of the `bar` *identifier token* (so the
 editor highlight lands on the name); only the *ranking* uses the effect
@@ -260,13 +264,20 @@ Required cases:
     with cursor on the *middle* `foo$bar` → jumps to the `bar = 1` literal,
     not the later `foo$bar <- 2` (which has an effect position after the
     cursor).
+13. Three-file chain: `c.R` sources `b.R`, `b.R` sources `a.R`, `a.R` defines
+    `foo`, and `b.R` attaches `foo$bar <- 1` → cursor in `c.R` jumps to `b.R`.
+14. Connected-component negatives: a shadowed `foo$bar <- 99` inside an
+    unrelated function in an intermediate file does not match, and a
+    matching-looking assignment in a document outside the cursor file's
+    connected component does not match.
 
 ## Risk & rollback
 
 - **Users who relied on the wrong jump** lose it. This is the exact bug the user
   reported; release-notes mention is sufficient.
-- **Same-named member in an unrelated `foo`** cannot leak in: candidates are
-  collected only from `foo`'s defining scope.
+- **Same-named member in an unrelated `foo`** cannot leak in: non-defining-file
+  candidates are validated against the exact `foo` binding the user navigated
+  from.
 - **Rollback**: revert the dispatcher branch in `goto_definition`. The new
   module becomes dead code with no external callers; safe to leave or delete.
 

--- a/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
+++ b/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
@@ -55,11 +55,12 @@ When the cursor is on the RHS identifier `bar` of an `extract_operator` node
 1. **Resolve `foo`** using the existing position-aware scope
    (`get_cross_file_scope`). If unresolved → return `None`.
 2. **Build a candidate set** of qualified definitions of `bar` against this
-   `foo`, drawn from `foo`'s defining file and from non-defining files in the
-   cursor file's cross-file connected component. Non-defining-file member
-   assignment sites are retained only when a per-site `get_cross_file_scope`
-   check resolves their LHS `foo` to the same `ScopedSymbol`. Two candidate
-   kinds:
+   `foo`, drawn from `foo`'s defining file and the resolved scope's contributor
+   chain, not every non-defining file in the cursor file's cross-file connected
+   component. Per-file `visible_positions` cutoffs are applied, and
+   non-defining-file member assignment sites are retained only when a per-site
+   `get_cross_file_scope` check resolves their LHS `foo` to the same
+   `ScopedSymbol`. The contributor-chain scan yields two candidate kinds:
    - **Member-assignment** — any `foo$bar <- …` (or `foo@bar <- …`) statement.
    - **Constructor-literal** — when `foo`'s defining assignment's RHS is a
      call to an allowlisted constructor, find the named argument whose name
@@ -68,10 +69,14 @@ When the cursor is on the RHS identifier `bar` of an `extract_operator` node
    - If the cursor file has a visible candidate, the latest cursor-file
      candidate wins. This includes defining-file candidates when the cursor is
      in the file where `foo` is defined.
-   - Otherwise, the latest candidate among `foo`'s defining file and the
-     cursor file's cross-file connected component wins.
-   - This mirrors the existing resolver's local-position preference while
-     keeping non-cursor cross-file ordering best-effort.
+   - Otherwise, `pick_winner` considers the non-cursor candidate set by
+     contributor-chain rank: prefer the earliest/closest contributor file, then
+     take that file's latest-effect candidate. This includes the defining-file
+     candidate when appropriate and deliberately avoids choosing a globally
+     latest non-cursor candidate from the whole connected component.
+   - This mirrors the existing resolver's local-position preference and aligns
+     `pick_winner` with the cursor file / defining-file behavior pinned by the
+     `a.R`/`b.R` regression tests.
 4. **No fallback to free-identifier lookup.** If no qualified candidate exists,
    return `None`. The whole point of this fix is that the RHS of `$`/`@` is not
    a reference to a free variable; reintroducing that lookup as a fallback would
@@ -183,12 +188,11 @@ Candidate search has two tiers:
   via `parameter_resolver::get_text_and_tree` (see "Where the defining file's
   AST comes from" above), since `ScopeArtifacts` does not carry it. These
   candidates use same-tree function-scope and effect-position checks.
-- **Connected-component member-assignments**: walk every non-defining file in
-  the cursor file's cross-file neighborhood (`DependencyGraph::collect_neighborhood`,
-  which follows both forward and backward edges). Each matching text site is
-  validated by re-resolving `foo` at the assignment's LHS position via
-  `get_cross_file_scope`; only sites where `foo` resolves to the exact same
-  `ScopedSymbol` are retained.
+- **Contributor-chain member-assignments**: walk every non-defining file in the
+  resolved scope's contributor chain. Each matching text site is filtered by
+  that file's `visible_positions` cutoff and validated by re-resolving `foo` at
+  the assignment's LHS position via `get_cross_file_scope`; only sites where
+  `foo` resolves to the exact same `ScopedSymbol` are retained.
 - **Constructor-literals**: only the single assignment that defined `foo`
   matters. We already have its line/column from the resolved symbol; re-fetch
   its RHS in the defining file's tree, then look for an `argument` node whose
@@ -218,10 +222,11 @@ Selection:
   `<= (cursor_line, cursor_col)`, then the latest cursor-file candidate wins.
   (Equality is fine: by construction every effect position lies on a
   syntactically-prior statement.)
-- If no cursor-file candidate qualifies, fall back to the latest effect
-  position among non-cursor candidates. Cross-file effect-position ordering is
-  only a best-effort tie-break; if this becomes observable, prefer candidates
-  whose file is closer to the cursor in the dependency graph.
+- If no cursor-file candidate qualifies, `pick_winner` prefers the
+  earliest/closest contributor file, then takes that file's latest-effect
+  candidate. This avoids comparing file-local effect positions across the
+  connected component and matches the defining-file / cursor file behavior
+  covered by the `a.R`/`b.R` regression tests.
 
 Returned `Location` is still the range of the `bar` *identifier token* (so the
 editor highlight lands on the name); only the *ranking* uses the effect


### PR DESCRIPTION
## Summary
- Scan the cursor file's full cross-file neighborhood for qualified-member assignments instead of only the cursor and defining files.
- Keep per-site scope validation so shadowed or unrelated `foo$bar <- ...` assignments are rejected.
- Update qualified-member design notes and regression tests for the three-file source chain.

## Tests
- `cargo fmt`
- `cargo test -p raven qualified_resolve`
- `cargo test -p raven`

## Artifacts
- Conversation: https://app.warp.dev/conversation/d9901a72-d31b-4858-9288-8e515411021d

Closes #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate go-to-definition for `$` and `@`, searching and preferring closer contributing files across the workspace.
  * Improved JAGS completion that excludes R-only identifiers.

* **Documentation**
  * Updated specs and guides describing the refined member-access/goto-definition behavior.

* **Tests**
  * Added regressions and updated property tests to validate the new resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->