### PR TITLE
Fix qualified member fallback tiebreak

### DIFF
--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -252,17 +252,22 @@ fn contributor_file_ranks(chain: &[Url]) -> HashMap<Url, usize> {
     }
     ranks
 }
-/// Compute shortest undirected dependency-graph distances from the cursor file
-/// to candidate files, walking only through forward source edges that are visible in
-/// the cursor scope's contributor chain. `scope.chain` remains the source of
-/// truth for which files are allowed to contribute; `visible_positions`
-/// constrains which outgoing edges from those files were in effect at the
-/// positions that contributed. These distances only rank already-retained
-/// candidates so that file-local effect positions are never compared across
-/// files. Restricting intermediate nodes and edges, and never walking through
-/// dependents, prevents unrelated parents/aggregators from creating shortcut
-/// paths that do not correspond to files the cursor executes to build its
-/// contributing scope.
+/// Compute shortest directed contributor-chain distances from the cursor file
+/// to candidate files. The traversal follows only forward dependency edges
+/// (`edge.from -> edge.to`) that are both in the cursor scope's contributor
+/// chain and visible at the contributing position recorded in
+/// `visible_positions`.
+///
+/// `scope.chain` remains the source of truth for which files are allowed to
+/// contribute, so both intermediate nodes and traversed edges are restricted to
+/// files that can contribute to the cursor's resolved scope. The walk never
+/// enters dependents or aggregators and intentionally has no dependent-file
+/// shortcuts; otherwise an unrelated parent that sources both the cursor file
+/// and a candidate file could create a path that does not correspond to files
+/// the cursor executes to build its contributing scope.
+///
+/// These distances only rank already-retained candidates so that file-local
+/// effect positions are never compared across files.
 fn contributor_file_distances<'a, I>(
     graph: &crate::cross_file::dependency::DependencyGraph,
     cursor_uri: &Url,

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -228,6 +228,8 @@ pub fn resolve_qualified_member(
     let contributor_distances = contributor_file_distances(
         &state.cross_file_graph,
         &cursor_uri,
+        &scope.chain,
+        &scope.visible_positions,
         all_candidates.iter().map(|candidate| &candidate.uri),
     );
     pick_winner(
@@ -251,18 +253,27 @@ fn contributor_file_ranks(chain: &[Url]) -> HashMap<Url, usize> {
     ranks
 }
 /// Compute shortest undirected dependency-graph distances from the cursor file
-/// to candidate files. `scope.chain` remains the source of truth for which
-/// files are allowed to contribute; these distances only rank already-retained
+/// to candidate files, walking only through forward source edges that are visible in
+/// the cursor scope's contributor chain. `scope.chain` remains the source of
+/// truth for which files are allowed to contribute; `visible_positions`
+/// constrains which outgoing edges from those files were in effect at the
+/// positions that contributed. These distances only rank already-retained
 /// candidates so that file-local effect positions are never compared across
-/// files.
+/// files. Restricting intermediate nodes and edges, and never walking through
+/// dependents, prevents unrelated parents/aggregators from creating shortcut
+/// paths that do not correspond to files the cursor executes to build its
+/// contributing scope.
 fn contributor_file_distances<'a, I>(
     graph: &crate::cross_file::dependency::DependencyGraph,
     cursor_uri: &Url,
+    contributor_chain: &[Url],
+    visible_positions: &HashMap<Url, (u32, u32)>,
     candidate_uris: I,
 ) -> HashMap<Url, usize>
 where
     I: IntoIterator<Item = &'a Url>,
 {
+    let contributor_files: HashSet<Url> = contributor_chain.iter().cloned().collect();
     let mut remaining: HashSet<Url> = candidate_uris
         .into_iter()
         .filter(|uri| *uri != cursor_uri)
@@ -289,18 +300,29 @@ where
         }
 
         for edge in graph.get_dependencies(&uri) {
-            if !visited.contains(&edge.to) {
+            if contributor_files.contains(&edge.to)
+                && !visited.contains(&edge.to)
+                && edge_call_site_visible(edge, visible_positions)
+            {
                 queue.push_back((edge.to.clone(), distance + 1));
-            }
-        }
-        for edge in graph.get_dependents(&uri) {
-            if !visited.contains(&edge.from) {
-                queue.push_back((edge.from.clone(), distance + 1));
             }
         }
     }
 
     distances
+}
+
+fn edge_call_site_visible(
+    edge: &crate::cross_file::dependency::DependencyEdge,
+    visible_positions: &HashMap<Url, (u32, u32)>,
+) -> bool {
+    match (edge.call_site_line, edge.call_site_column) {
+        (Some(line), Some(column)) => visible_positions
+            .get(&edge.from)
+            .map(|&cutoff| (line, column) <= cutoff)
+            .unwrap_or(false),
+        _ => true,
+    }
 }
 
 fn candidate_effect_visible_in_scope(
@@ -1450,6 +1472,78 @@ foo$bar <- 1
         assert_ne!(
             l.uri, c_uri,
             "must not use contributor-chain rank or cross-file line numbers as the primary tiebreak",
+        );
+        assert_eq!(l.range.start.line, 1);
+        assert_eq!(l.range.start.character, 4);
+    }
+
+    /// Regression: an unrelated runner that sources both the cursor file and a
+    /// farther contributor must not create an undirected shortcut path that
+    /// makes the farther contributor appear as close as the actually-nearer
+    /// file in the cursor's contributing scope.
+    #[test]
+    fn dollar_rhs_distance_ignores_unrelated_runner_shortcut_paths() {
+        let mut state = fresh_state();
+
+        let d_code = "\
+source(\"y.R\")
+source(\"v.R\")
+print(foo$bar)
+";
+        let y_code = "source(\"z.R\")\n";
+        let z_code = "source(\"c.R\")\n";
+        let c_code = "\
+source(\"a.R\")
+foo$bar <- 2
+";
+        let v_code = "source(\"b.R\")\n";
+        let b_code = "\
+source(\"a.R\")
+foo$bar <- 1
+";
+        let a_code = "foo <- list()\n";
+        let runner_code = "\
+source(\"d.R\")
+source(\"c.R\")
+";
+
+        let d_uri = add_doc(&mut state, "file:///workspace/d.R", d_code);
+        let y_uri = add_doc(&mut state, "file:///workspace/y.R", y_code);
+        let z_uri = add_doc(&mut state, "file:///workspace/z.R", z_code);
+        let c_uri = add_doc(&mut state, "file:///workspace/c.R", c_code);
+        let v_uri = add_doc(&mut state, "file:///workspace/v.R", v_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+        let runner_uri = add_doc(&mut state, "file:///workspace/runner.R", runner_code);
+
+        for (uri, code) in [
+            (&d_uri, d_code),
+            (&y_uri, y_code),
+            (&z_uri, z_code),
+            (&c_uri, c_code),
+            (&v_uri, v_code),
+            (&b_uri, b_code),
+            (&a_uri, a_code),
+            (&runner_uri, runner_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 2 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(2, 10);
+        let l = loc(goto_definition(&state, &d_uri, pos));
+        assert_eq!(
+            l.uri, b_uri,
+            "b.R is closer in d.R's contributing scope; runner.R must not shorten c.R"
+        );
+        assert_ne!(
+            l.uri, c_uri,
+            "must not rank through unrelated non-contributing runner.R"
         );
         assert_eq!(l.range.start.line, 1);
         assert_eq!(l.range.start.character, 4);

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -25,8 +25,10 @@
 //!    `uri` equals the cursor's. The in-cursor-file partition is filtered
 //!    by `effect <= cursor`, then the candidate with the latest effect
 //!    wins. If no in-cursor-file candidate qualifies, the other-file
-//!    partition falls back to the earliest file in the cursor scope's
-//!    contributor chain, then chooses that file's latest-effect candidate.
+//!    partition first chooses the file with the shortest dependency-graph
+//!    distance from the cursor file, then chooses that file's latest-effect
+//!    candidate. Contributor-chain order and URI only break ties where graph
+//!    distance is equal or unavailable.
 //!
 //!    In the **same-file case** (cursor file = defining file), defining-file
 //!    candidates live in the cursor partition and are filtered by
@@ -34,7 +36,7 @@
 //!    be used as a fallback if no cursor-file candidate qualifies.
 //! 4. Never fall back to free-identifier lookup.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use tower_lsp::lsp_types::{Location, Position, Range, Url};
 use tree_sitter::{Node, Tree};
@@ -223,7 +225,19 @@ pub fn resolve_qualified_member(
 
     let mut all_candidates = defining_candidates;
     all_candidates.extend(cross_file_candidates);
-    pick_winner(all_candidates, &cursor_uri, position, &contributor_ranks).map(|c| Location {
+    let contributor_distances = contributor_file_distances(
+        &state.cross_file_graph,
+        &cursor_uri,
+        all_candidates.iter().map(|candidate| &candidate.uri),
+    );
+    pick_winner(
+        all_candidates,
+        &cursor_uri,
+        position,
+        &contributor_ranks,
+        &contributor_distances,
+    )
+    .map(|c| Location {
         uri: c.uri,
         range: c.name_range,
     })
@@ -235,6 +249,58 @@ fn contributor_file_ranks(chain: &[Url]) -> HashMap<Url, usize> {
         ranks.entry(uri.clone()).or_insert(idx);
     }
     ranks
+}
+/// Compute shortest undirected dependency-graph distances from the cursor file
+/// to candidate files. `scope.chain` remains the source of truth for which
+/// files are allowed to contribute; these distances only rank already-retained
+/// candidates so that file-local effect positions are never compared across
+/// files.
+fn contributor_file_distances<'a, I>(
+    graph: &crate::cross_file::dependency::DependencyGraph,
+    cursor_uri: &Url,
+    candidate_uris: I,
+) -> HashMap<Url, usize>
+where
+    I: IntoIterator<Item = &'a Url>,
+{
+    let mut remaining: HashSet<Url> = candidate_uris
+        .into_iter()
+        .filter(|uri| *uri != cursor_uri)
+        .cloned()
+        .collect();
+    let mut distances = HashMap::new();
+    if remaining.is_empty() {
+        return distances;
+    }
+
+    let mut visited: HashSet<Url> = HashSet::new();
+    let mut queue: VecDeque<(Url, usize)> = VecDeque::from([(cursor_uri.clone(), 0)]);
+
+    while let Some((uri, distance)) = queue.pop_front() {
+        if !visited.insert(uri.clone()) {
+            continue;
+        }
+
+        if remaining.remove(&uri) {
+            distances.insert(uri.clone(), distance);
+            if remaining.is_empty() {
+                break;
+            }
+        }
+
+        for edge in graph.get_dependencies(&uri) {
+            if !visited.contains(&edge.to) {
+                queue.push_back((edge.to.clone(), distance + 1));
+            }
+        }
+        for edge in graph.get_dependents(&uri) {
+            if !visited.contains(&edge.from) {
+                queue.push_back((edge.from.clone(), distance + 1));
+            }
+        }
+    }
+
+    distances
 }
 
 fn candidate_effect_visible_in_scope(
@@ -291,14 +357,17 @@ fn effect_at_or_after(a: EffectPos, b: EffectPos) -> bool {
 /// at-or-before the cursor (you can't "see" an assignment that hasn't
 /// happened yet) and pick the one with the latest effect position.
 ///
-/// If no cursor-file candidate qualifies, fall back to the earliest file in
-/// the cursor scope's contributor chain, then pick that file's latest effect
-/// position. Effect positions are only compared within a single file.
+/// If no cursor-file candidate qualifies, fall back to the nearest candidate
+/// file by dependency-graph distance from the cursor file, then pick that
+/// file's latest effect position. Contributor-chain rank and URI break
+/// equal-distance or unavailable-distance ties. Effect positions are only
+/// compared within a single file.
 fn pick_winner(
     candidates: Vec<Candidate>,
     cursor_uri: &Url,
     cursor: Position,
     contributor_ranks: &HashMap<Url, usize>,
+    contributor_distances: &HashMap<Url, usize>,
 ) -> Option<Candidate> {
     let (mut in_cursor_file, other): (Vec<_>, Vec<_>) =
         candidates.into_iter().partition(|c| &c.uri == cursor_uri);
@@ -329,17 +398,22 @@ fn pick_winner(
     best_per_file
         .into_values()
         .filter_map(|candidate| {
-            contributor_ranks
+            let rank = contributor_ranks.get(&candidate.uri).copied()?;
+            let distance = contributor_distances
                 .get(&candidate.uri)
                 .copied()
-                .map(|rank| (rank, candidate))
+                .unwrap_or(usize::MAX);
+            Some((distance, rank, candidate))
         })
-        .min_by(|(rank_a, candidate_a), (rank_b, candidate_b)| {
-            rank_a
-                .cmp(rank_b)
-                .then_with(|| candidate_a.uri.as_str().cmp(candidate_b.uri.as_str()))
-        })
-        .map(|(_, candidate)| candidate)
+        .min_by(
+            |(distance_a, rank_a, candidate_a), (distance_b, rank_b, candidate_b)| {
+                distance_a
+                    .cmp(distance_b)
+                    .then_with(|| rank_a.cmp(rank_b))
+                    .then_with(|| candidate_a.uri.as_str().cmp(candidate_b.uri.as_str()))
+            },
+        )
+        .map(|(_, _, candidate)| candidate)
 }
 
 /// Compute the resolved symbol's *visible-from* position: the end of its
@@ -1312,6 +1386,70 @@ foo$bar <- 1
         assert_ne!(
             l.uri, a_uri,
             "must not compare file-local line numbers across files"
+        );
+        assert_eq!(l.range.start.line, 1);
+        assert_eq!(l.range.start.character, 4);
+    }
+
+    /// Regression for issue #154: contributor-chain order can visit an
+    /// indirect branch before a directly sourced file. Non-cursor fallback
+    /// ranking must prefer the graph-closer file, not whichever contributor
+    /// appeared first and not whichever file has the later local line number.
+    #[test]
+    fn dollar_rhs_prefers_graph_closer_file_over_earlier_contributor_rank() {
+        let mut state = fresh_state();
+
+        let d_code = "\
+source(\"x.R\")
+source(\"b.R\")
+print(foo$bar)
+";
+        let x_code = "source(\"c.R\")\n";
+        let c_code = "\
+source(\"a.R\")
+
+
+
+
+foo$bar <- 2
+";
+        let b_code = "\
+source(\"a.R\")
+foo$bar <- 1
+";
+        let a_code = "foo <- list()\n";
+
+        let d_uri = add_doc(&mut state, "file:///workspace/d.R", d_code);
+        let x_uri = add_doc(&mut state, "file:///workspace/x.R", x_code);
+        let c_uri = add_doc(&mut state, "file:///workspace/c.R", c_code);
+        let b_uri = add_doc(&mut state, "file:///workspace/b.R", b_code);
+        let a_uri = add_doc(&mut state, "file:///workspace/a.R", a_code);
+
+        for (uri, code) in [
+            (&d_uri, d_code),
+            (&x_uri, x_code),
+            (&c_uri, c_code),
+            (&b_uri, b_code),
+            (&a_uri, a_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // line 2 col 10 = `bar` in `print(foo$bar)`
+        let pos = Position::new(2, 10);
+        let l = loc(goto_definition(&state, &d_uri, pos));
+        assert_eq!(
+            l.uri, b_uri,
+            "directly sourced b.R should beat indirectly reached c.R"
+        );
+        assert_ne!(
+            l.uri, c_uri,
+            "must not use contributor-chain rank or cross-file line numbers as the primary tiebreak",
         );
         assert_eq!(l.range.start.line, 1);
         assert_eq!(l.range.start.character, 4);

--- a/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
+++ b/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
@@ -69,8 +69,8 @@ When the cursor is on the RHS identifier `bar` of an `extract_operator` node
    - If the cursor file has a visible candidate, the latest cursor-file
      candidate wins. This includes defining-file candidates when the cursor is
      in the file where `foo` is defined.
-   - Otherwise, `pick_winner` considers the non-cursor candidate set by shortest
-     undirected dependency-graph distance from the cursor file. Within the
+   - Otherwise, `pick_winner` ranks non-cursor candidates by shortest
+     contributor-chain (forward-edge) distance from the cursor file. Within the
      winning file, it takes that file's latest-effect candidate. Contributor-chain
      rank and URI are used only to break equal-distance or unavailable-distance
      ties. This includes the defining-file candidate when appropriate and
@@ -225,9 +225,9 @@ Selection:
   (Equality is fine: by construction every effect position lies on a
   syntactically-prior statement.)
 - If no cursor-file candidate qualifies, `pick_winner` prefers the candidate
-  file with the shortest undirected dependency-graph distance from the cursor
-  file, then takes that file's latest-effect candidate. Contributor-chain rank
-  and URI are only deterministic fallback tiebreakers. This avoids comparing
+  file with the shortest contributor-chain (forward-edge) distance from the
+  cursor file, then takes that file's latest-effect candidate. Contributor-chain
+  rank and URI are only deterministic fallback tiebreakers. This avoids comparing
   file-local effect positions across the connected component and matches the
   defining-file / cursor file behavior covered by the `a.R`/`b.R` regression
   tests.

--- a/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
+++ b/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
@@ -69,11 +69,13 @@ When the cursor is on the RHS identifier `bar` of an `extract_operator` node
    - If the cursor file has a visible candidate, the latest cursor-file
      candidate wins. This includes defining-file candidates when the cursor is
      in the file where `foo` is defined.
-   - Otherwise, `pick_winner` considers the non-cursor candidate set by
-     contributor-chain rank: prefer the earliest/closest contributor file, then
-     take that file's latest-effect candidate. This includes the defining-file
-     candidate when appropriate and deliberately avoids choosing a globally
-     latest non-cursor candidate from the whole connected component.
+   - Otherwise, `pick_winner` considers the non-cursor candidate set by shortest
+     undirected dependency-graph distance from the cursor file. Within the
+     winning file, it takes that file's latest-effect candidate. Contributor-chain
+     rank and URI are used only to break equal-distance or unavailable-distance
+     ties. This includes the defining-file candidate when appropriate and
+     deliberately avoids choosing a globally latest non-cursor candidate from
+     the whole connected component.
    - This mirrors the existing resolver's local-position preference and aligns
      `pick_winner` with the cursor file / defining-file behavior pinned by the
      `a.R`/`b.R` regression tests.
@@ -222,11 +224,13 @@ Selection:
   `<= (cursor_line, cursor_col)`, then the latest cursor-file candidate wins.
   (Equality is fine: by construction every effect position lies on a
   syntactically-prior statement.)
-- If no cursor-file candidate qualifies, `pick_winner` prefers the
-  earliest/closest contributor file, then takes that file's latest-effect
-  candidate. This avoids comparing file-local effect positions across the
-  connected component and matches the defining-file / cursor file behavior
-  covered by the `a.R`/`b.R` regression tests.
+- If no cursor-file candidate qualifies, `pick_winner` prefers the candidate
+  file with the shortest undirected dependency-graph distance from the cursor
+  file, then takes that file's latest-effect candidate. Contributor-chain rank
+  and URI are only deterministic fallback tiebreakers. This avoids comparing
+  file-local effect positions across the connected component and matches the
+  defining-file / cursor file behavior covered by the `a.R`/`b.R` regression
+  tests.
 
 Returned `Location` is still the range of the `bar` *identifier token* (so the
 editor highlight lands on the name); only the *ranking* uses the effect
@@ -275,6 +279,10 @@ Required cases:
     unrelated function in an intermediate file does not match, and a
     matching-looking assignment in a document outside the cursor file's
     connected component does not match.
+15. Graph-distance tiebreak: if traversal reaches an indirect contributing file
+    before a directly sourced file, the directly sourced file wins even when the
+    indirect file appears earlier in the contributor chain or has a later local
+    line number.
 
 ## Risk & rollback
 


### PR DESCRIPTION
## Summary
- Rank non-cursor qualified-member candidates by shortest undirected dependency-graph distance from the cursor file.
- Keep latest-effect selection within the winning file, with contributor-chain rank and URI only as deterministic fallback tiebreakers.
- Add an issue #154 regression test and update the qualified-member design notes.

Fixes #154

## Testing
- cargo fmt --all
- cargo test -p raven qualified_resolve --lib
- cargo test -p raven

## Artifacts
- Conversation: https://app.warp.dev/conversation/70811153-1be6-42cb-abee-c9d2f9c03a36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced go-to-definition resolution for qualified member lookups. The system now prioritizes candidates by shortest dependency-graph distance from the cursor file, with contributor-chain order as a tie-breaker, providing more accurate navigation.

* **Tests**
  * Added regression tests to validate distance-based candidate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->