### PR TITLE
Use cached scope for qualified member goto-def

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -2924,9 +2924,17 @@ where
 /// Per-snapshot cache for `ParentPrefix` results, keyed by `(target URI,
 /// query_inside_function)`.
 ///
-/// Lives inside `DiagnosticsSnapshot` so it shares the snapshot's lifetime;
-/// never shared across snapshots. Within one diagnostic pass, all scope queries
-/// against the same URI reuse the same prefix entries.
+/// Use one instance per `WorldState` snapshot and never share across
+/// snapshots. Two patterns:
+///
+/// - **Diagnostic pass**: lives inside `DiagnosticsSnapshot` so it shares the
+///   snapshot's lifetime; all scope queries against the same URI reuse the
+///   same prefix entries.
+/// - **Interactive request batch**: a request handler that resolves many
+///   positions under one read guard (for example
+///   `qualified_resolve::resolve_qualified_member`) creates a cache at the
+///   start of the call, threads it through `get_cross_file_scope_with_cache`,
+///   and drops it when the call returns.
 #[derive(Debug, Default)]
 pub struct ParentPrefixCache {
     entries: HashMap<(Url, bool), Arc<ParentPrefix>>,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -2706,34 +2706,17 @@ pub(crate) fn get_cross_file_scope(
     column: u32,
     cancel: &DiagCancelToken,
 ) -> scope::ScopeAtPosition {
-    // Use ContentProvider for unified access
     let content_provider = state.content_provider();
-
-    // Closure to get artifacts for a URI
     let get_artifacts = |target_uri: &Url| -> Option<Arc<scope::ScopeArtifacts>> {
         content_provider.get_artifacts(target_uri)
     };
-
-    // Closure to get metadata for a URI
     let get_metadata =
         |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
             content_provider.get_metadata(target_uri)
         };
-
-    let max_depth = state.cross_file_config.max_chain_depth;
-
-    // Get base_exports from package_library if ready, otherwise empty set.
-    // This ensures base R functions (stop, sprintf, exists, etc.) are available
-    // in cross-file scope resolution for hover, completions, and go-to-definition.
-    let base_exports = if state.package_library_ready {
-        state.package_library.base_exports().clone()
-    } else {
-        empty_base_exports().clone()
-    };
-
+    let base_exports = cross_file_base_exports(state);
     let is_cancelled = || cancel.is_cancelled();
 
-    // Use the graph-aware scope resolution with PathContext
     scope::scope_at_position_with_graph(
         uri,
         line,
@@ -2742,7 +2725,7 @@ pub(crate) fn get_cross_file_scope(
         &get_metadata,
         &state.cross_file_graph,
         state.workspace_folders.first(),
-        max_depth,
+        state.cross_file_config.max_chain_depth,
         &base_exports,
         state.cross_file_config.hoist_globals_in_functions,
         state.cross_file_config.backward_dependencies,
@@ -2756,6 +2739,11 @@ pub(crate) fn get_cross_file_scope(
 /// positions while holding the same `WorldState` read guard. The caller owns
 /// the `ParentPrefixCache`; do not share it across independent requests or
 /// state snapshots.
+///
+/// Note: this entry point's parent-prefix seeding (`(u32::MAX, u32::MAX)`)
+/// is a slightly wider over-approximation than `get_cross_file_scope`'s
+/// for cyclic dependency graphs. Single-position callers that want the
+/// non-cached behavior must continue to use `get_cross_file_scope`.
 pub(crate) fn get_cross_file_scope_with_cache(
     state: &WorldState,
     uri: &Url,
@@ -2764,36 +2752,17 @@ pub(crate) fn get_cross_file_scope_with_cache(
     cancel: &DiagCancelToken,
     prefix_cache: &mut scope::ParentPrefixCache,
 ) -> scope::ScopeAtPosition {
-    // Use ContentProvider for unified access
     let content_provider = state.content_provider();
-
-    // Closure to get artifacts for a URI
     let get_artifacts = |target_uri: &Url| -> Option<Arc<scope::ScopeArtifacts>> {
         content_provider.get_artifacts(target_uri)
     };
-
-    // Closure to get metadata for a URI
     let get_metadata =
         |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
             content_provider.get_metadata(target_uri)
         };
-
-    let max_depth = state.cross_file_config.max_chain_depth;
-
-    // Get base_exports from package_library if ready, otherwise empty set.
-    // This ensures base R functions (stop, sprintf, exists, etc.) are available
-    // in cross-file scope resolution for hover, completions, and go-to-definition.
-    let base_exports = if state.package_library_ready {
-        state.package_library.base_exports().clone()
-    } else {
-        empty_base_exports().clone()
-    };
-
+    let base_exports = cross_file_base_exports(state);
     let is_cancelled = || cancel.is_cancelled();
 
-    // Use the graph-aware cached scope resolution with PathContext. The cache
-    // only memoizes the position-invariant parent-prefix walk; local STEP 2
-    // still runs for every queried candidate position.
     scope::scope_at_position_with_graph_cached(
         uri,
         line,
@@ -2802,13 +2771,24 @@ pub(crate) fn get_cross_file_scope_with_cache(
         &get_metadata,
         &state.cross_file_graph,
         state.workspace_folders.first(),
-        max_depth,
+        state.cross_file_config.max_chain_depth,
         &base_exports,
         state.cross_file_config.hoist_globals_in_functions,
         state.cross_file_config.backward_dependencies,
         &is_cancelled,
         prefix_cache,
     )
+}
+
+/// Pick the right `base_exports` for cross-file scope resolution. Returns
+/// the cached empty set during cold start so we don't allocate a fresh Arc
+/// per call when the package library hasn't reported library paths yet.
+fn cross_file_base_exports(state: &WorldState) -> Arc<HashSet<String>> {
+    if state.package_library_ready {
+        state.package_library.base_exports().clone()
+    } else {
+        empty_base_exports().clone()
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -2687,10 +2687,13 @@ fn get_cross_file_symbols(
 /// release it, and only then resolve scopes. See CLAUDE.md "Locking
 /// discipline in cross-file work".
 ///
-/// **Interactive request handlers** — `goto_definition` (including
-/// `qualified_resolve::resolve_qualified_member`), `hover`, `completion`,
-/// `signature_help` — resolve a single position per request and may hold
-/// the guard for the call's duration.
+/// **Interactive request handlers** — `goto_definition`, `hover`,
+/// `completion`, `signature_help` — generally resolve a single position per
+/// request and may hold the guard for the call's duration. Interactive paths
+/// that resolve many related positions under one request (for example
+/// `qualified_resolve::resolve_qualified_member` candidate validation) should
+/// use `get_cross_file_scope_with_cache` with a request-local
+/// `ParentPrefixCache` so repeated parent walks are shared.
 ///
 /// # Returns
 ///
@@ -2744,6 +2747,67 @@ pub(crate) fn get_cross_file_scope(
         state.cross_file_config.hoist_globals_in_functions,
         state.cross_file_config.backward_dependencies,
         &is_cancelled,
+    )
+}
+
+/// Cached counterpart of `get_cross_file_scope` for request-local batches.
+///
+/// Use this when one interactive request needs to resolve multiple related
+/// positions while holding the same `WorldState` read guard. The caller owns
+/// the `ParentPrefixCache`; do not share it across independent requests or
+/// state snapshots.
+pub(crate) fn get_cross_file_scope_with_cache(
+    state: &WorldState,
+    uri: &Url,
+    line: u32,
+    column: u32,
+    cancel: &DiagCancelToken,
+    prefix_cache: &mut scope::ParentPrefixCache,
+) -> scope::ScopeAtPosition {
+    // Use ContentProvider for unified access
+    let content_provider = state.content_provider();
+
+    // Closure to get artifacts for a URI
+    let get_artifacts = |target_uri: &Url| -> Option<Arc<scope::ScopeArtifacts>> {
+        content_provider.get_artifacts(target_uri)
+    };
+
+    // Closure to get metadata for a URI
+    let get_metadata =
+        |target_uri: &Url| -> Option<std::sync::Arc<crate::cross_file::CrossFileMetadata>> {
+            content_provider.get_metadata(target_uri)
+        };
+
+    let max_depth = state.cross_file_config.max_chain_depth;
+
+    // Get base_exports from package_library if ready, otherwise empty set.
+    // This ensures base R functions (stop, sprintf, exists, etc.) are available
+    // in cross-file scope resolution for hover, completions, and go-to-definition.
+    let base_exports = if state.package_library_ready {
+        state.package_library.base_exports().clone()
+    } else {
+        empty_base_exports().clone()
+    };
+
+    let is_cancelled = || cancel.is_cancelled();
+
+    // Use the graph-aware cached scope resolution with PathContext. The cache
+    // only memoizes the position-invariant parent-prefix walk; local STEP 2
+    // still runs for every queried candidate position.
+    scope::scope_at_position_with_graph_cached(
+        uri,
+        line,
+        column,
+        &get_artifacts,
+        &get_metadata,
+        &state.cross_file_graph,
+        state.workspace_folders.first(),
+        max_depth,
+        &base_exports,
+        state.cross_file_config.hoist_globals_in_functions,
+        state.cross_file_config.backward_dependencies,
+        &is_cancelled,
+        prefix_cache,
     )
 }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -123,8 +123,8 @@ pub fn resolve_qualified_member(
     let mut prefix_cache = crate::cross_file::scope::ParentPrefixCache::new();
 
     // The cancel token is `never()` until raven gains a backend-level
-    // request-cancellation registry (see issue #155 mitigation #3). Once
-    // that exists, thread the request's token through here and through
+    // request-cancellation registry (tracked in issue #158). Once that
+    // exists, thread the request's token through here and through
     // `candidate_lhs_matches_symbol` so a superseded goto-def can bail
     // out of the retain loop early.
     let scope = crate::handlers::get_cross_file_scope_with_cache(

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -122,7 +122,11 @@ pub fn resolve_qualified_member(
     // snapshot under the caller's read guard.
     let mut prefix_cache = crate::cross_file::scope::ParentPrefixCache::new();
 
-    // Resolve the LHS via the existing position-aware cross-file scope.
+    // The cancel token is `never()` until raven gains a backend-level
+    // request-cancellation registry (see issue #155 mitigation #3). Once
+    // that exists, thread the request's token through here and through
+    // `candidate_lhs_matches_symbol` so a superseded goto-def can bail
+    // out of the retain loop early.
     let scope = crate::handlers::get_cross_file_scope_with_cache(
         state,
         uri,

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -116,14 +116,20 @@ pub fn resolve_qualified_member(
     if lhs_node_kind != "identifier" {
         return None;
     }
+    // Reuse parent-prefix work across the initial cursor lookup and the
+    // per-candidate validation loop. A single qualified-member request can
+    // resolve many candidate positions, but all of them see the same state
+    // snapshot under the caller's read guard.
+    let mut prefix_cache = crate::cross_file::scope::ParentPrefixCache::new();
 
     // Resolve the LHS via the existing position-aware cross-file scope.
-    let scope = crate::handlers::get_cross_file_scope(
+    let scope = crate::handlers::get_cross_file_scope_with_cache(
         state,
         uri,
         position.line,
         position.character,
         &DiagCancelToken::never(),
+        &mut prefix_cache,
     );
     let symbol = scope.symbols.get(lhs_name)?;
 
@@ -188,7 +194,7 @@ pub fn resolve_qualified_member(
         });
         defining_candidates.retain(|c| {
             candidate_effect_visible_in_scope(c, &scope.visible_positions)
-                && candidate_lhs_matches_symbol(state, c, lhs_name, symbol)
+                && candidate_lhs_matches_symbol(state, c, lhs_name, symbol, &mut prefix_cache)
         });
     }
 
@@ -220,7 +226,7 @@ pub fn resolve_qualified_member(
     }
     cross_file_candidates.retain(|c| {
         candidate_effect_visible_in_scope(c, &scope.visible_positions)
-            && candidate_lhs_matches_symbol(state, c, lhs_name, symbol)
+            && candidate_lhs_matches_symbol(state, c, lhs_name, symbol, &mut prefix_cache)
     });
 
     let mut all_candidates = defining_candidates;
@@ -353,13 +359,15 @@ fn candidate_lhs_matches_symbol(
     c: &Candidate,
     lhs_name: &str,
     symbol: &crate::cross_file::scope::ScopedSymbol,
+    prefix_cache: &mut crate::cross_file::scope::ParentPrefixCache,
 ) -> bool {
-    let scope = crate::handlers::get_cross_file_scope(
+    let scope = crate::handlers::get_cross_file_scope_with_cache(
         state,
         &c.uri,
         c.lhs_pos.line,
         c.lhs_pos.character,
         &DiagCancelToken::never(),
+        prefix_cache,
     );
     scope
         .symbols


### PR DESCRIPTION
## Summary
- Use a request-local `ParentPrefixCache` for qualified-member goto-definition scope lookups.
- Add a cached cross-file scope helper for interactive requests that resolve multiple related positions.
- Update scope helper locking guidance for multi-position interactive paths.

## Validation
- `cargo fmt --check`
- `cargo test -p raven qualified_resolve::tests --lib`
- `cargo test -p raven`

Fixes #155.

Oz conversation: https://app.warp.dev/conversation/a0494f9a-1533-4416-b3d2-7a1d385cb0ae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for snapshot-scoped cache usage patterns in cross-file scope resolution, including instantiation guidelines and lifetime examples for both diagnostic passes and interactive request scenarios.

* **Refactor**
  * Improved performance for multi-position request handling by implementing an optimized caching mechanism for scope resolution, reducing redundant computations across interactive request batching and diagnostic analysis phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->