### PR TITLE
Thread cancel token through qualified goto-def

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-lsp",
  "tree-sitter",
  "tree-sitter-r",
@@ -1493,6 +1494,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1547,6 +1549,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["preserve_order"] }
 tokio = { version = "1.26.0", features = ["full"] }
 tokio-util = "0.7"
+tower = "0.4"
 tower-lsp.workspace = true
 tree-sitter = "0.24.7"
 tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", rev = "95aff097aa927a66bb357f715b58cde821be8867" }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -5,11 +5,20 @@
 // Modifications copyright (C) 2026 Jonathan Marc Bearak
 //
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock as StdRwLock};
+use std::task::{Context, Poll};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;
-use tower_lsp::jsonrpc::Result;
+use tokio_util::sync::CancellationToken;
+use tower::Service;
+use tower_lsp::jsonrpc::{
+    Error as JsonRpcError, Id as JsonRpcId, Request as JsonRpcRequest, Response as JsonRpcResponse,
+    Result,
+};
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
 use tower_lsp::LanguageServer;
@@ -21,6 +30,9 @@ use crate::indentation;
 use crate::r_env;
 use crate::state::{scan_workspace, IndentationSettings, SymbolConfig, WorldState};
 use crate::utf16::utf16_column_to_byte_offset;
+tokio::task_local! {
+    static CURRENT_LSP_REQUEST_ID: JsonRpcId;
+}
 
 /// Category of files for on-demand indexing
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -561,10 +573,174 @@ fn build_completion_trigger_chars(trigger_on_open_paren: bool) -> Vec<String> {
     chars
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CancellableRequestKind {
+    GotoDefinition,
+}
+
+impl CancellableRequestKind {
+    fn from_method(method: &str) -> Option<Self> {
+        match method {
+            "textDocument/definition" => Some(Self::GotoDefinition),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ActiveCancellableRequest {
+    kind: CancellableRequestKind,
+    token: CancellationToken,
+}
+
+/// Request-scoped cooperative cancellation registry for interactive LSP work.
+///
+/// `tower-lsp` only runs the built-in `$/cancelRequest` handler when that
+/// notification's future is polled. Raven keeps `Server::concurrency_level(1)`
+/// to preserve ordered text-sync handling, so cancellation notifications can sit
+/// behind an in-flight request. `RequestCancellationService` therefore updates
+/// this registry synchronously in `Service::call`, before tower-lsp queues the
+/// notification future, and request handlers poll the matching token while doing
+/// CPU-bound work under the `WorldState` read guard.
+#[derive(Debug, Default)]
+struct RequestCancellationRegistry {
+    active: StdRwLock<HashMap<JsonRpcId, ActiveCancellableRequest>>,
+}
+
+impl RequestCancellationRegistry {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn register(&self, id: JsonRpcId, kind: CancellableRequestKind) -> CancellationToken {
+        let token = CancellationToken::new();
+        let mut active = self.active.write().unwrap();
+
+        // Treat a newer request of the same interactive kind as superseding
+        // older ones. Editors usually send `$/cancelRequest`, but this keeps
+        // cursor-move storms responsive even when they do not.
+        for (active_id, request) in active.iter() {
+            if *active_id != id && request.kind == kind {
+                request.token.cancel();
+            }
+        }
+
+        if let Some(previous) = active.insert(
+            id,
+            ActiveCancellableRequest {
+                kind,
+                token: token.clone(),
+            },
+        ) {
+            previous.token.cancel();
+        }
+
+        token
+    }
+
+    fn cancel(&self, id: &JsonRpcId) {
+        let active = self.active.read().unwrap();
+        if let Some(request) = active.get(id) {
+            request.token.cancel();
+        }
+    }
+
+    fn complete(&self, id: &JsonRpcId) {
+        let mut active = self.active.write().unwrap();
+        active.remove(id);
+    }
+
+    fn token_for_current_request(
+        &self,
+        kind: CancellableRequestKind,
+    ) -> Option<handlers::DiagCancelToken> {
+        CURRENT_LSP_REQUEST_ID
+            .try_with(|id| self.token_for_id(id, kind))
+            .ok()
+            .flatten()
+            .map(handlers::DiagCancelToken::from_token)
+    }
+
+    fn token_for_id(
+        &self,
+        id: &JsonRpcId,
+        kind: CancellableRequestKind,
+    ) -> Option<CancellationToken> {
+        let active = self.active.read().unwrap();
+        let request = active.get(id)?;
+        (request.kind == kind).then(|| request.token.clone())
+    }
+}
+
+type RequestCancellationFuture<E> =
+    Pin<Box<dyn Future<Output = std::result::Result<Option<JsonRpcResponse>, E>> + Send + 'static>>;
+
+struct RequestCancellationService<S> {
+    inner: S,
+    registry: Arc<RequestCancellationRegistry>,
+}
+
+impl<S> RequestCancellationService<S> {
+    fn new(inner: S, registry: Arc<RequestCancellationRegistry>) -> Self {
+        Self { inner, registry }
+    }
+
+    fn cancel_from_params(&self, params: Option<&serde_json::Value>) {
+        let Some(params) = params else {
+            log::trace!("Received $/cancelRequest without params");
+            return;
+        };
+        match serde_json::from_value::<CancelParams>(params.clone()) {
+            Ok(params) => self.registry.cancel(&JsonRpcId::from(params.id)),
+            Err(err) => log::trace!("Ignoring malformed $/cancelRequest params: {err}"),
+        }
+    }
+}
+
+impl<S> Service<JsonRpcRequest> for RequestCancellationService<S>
+where
+    S: Service<JsonRpcRequest, Response = Option<JsonRpcResponse>> + Send + 'static,
+    S::Error: Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Option<JsonRpcResponse>;
+    type Error = S::Error;
+    type Future = RequestCancellationFuture<S::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
+        if req.method() == "$/cancelRequest" {
+            self.cancel_from_params(req.params());
+        }
+
+        let kind = CancellableRequestKind::from_method(req.method());
+        let id = req.id().cloned();
+
+        if let (Some(kind), Some(id)) = (kind, id) {
+            self.registry.register(id.clone(), kind);
+            let fut = self.inner.call(req);
+            let registry = Arc::clone(&self.registry);
+            let scope_id = id.clone();
+
+            Box::pin(CURRENT_LSP_REQUEST_ID.scope(scope_id, async move {
+                let result = fut.await;
+                registry.complete(&id);
+                result
+            }))
+        } else {
+            Box::pin(self.inner.call(req))
+        }
+    }
+}
+
 pub struct Backend {
     client: Client,
     state: Arc<RwLock<WorldState>>,
     background_indexer: Arc<crate::cross_file::BackgroundIndexer>,
+    request_cancellation: Arc<RequestCancellationRegistry>,
 }
 
 impl Backend {
@@ -625,7 +801,15 @@ impl Backend {
         }
         state.package_library_ready
     }
+    #[allow(dead_code)]
     pub fn new(client: Client) -> Self {
+        Self::new_with_request_cancellation(client, Arc::new(RequestCancellationRegistry::new()))
+    }
+
+    fn new_with_request_cancellation(
+        client: Client,
+        request_cancellation: Arc<RequestCancellationRegistry>,
+    ) -> Self {
         let library_paths = r_env::find_library_paths();
         log::info!("Discovered R library paths: {:?}", library_paths);
 
@@ -636,6 +820,7 @@ impl Backend {
             client,
             state,
             background_indexer,
+            request_cancellation,
         }
     }
 }
@@ -3365,12 +3550,29 @@ impl LanguageServer for Backend {
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
+        let cancel = self
+            .request_cancellation
+            .token_for_current_request(CancellableRequestKind::GotoDefinition)
+            .unwrap_or_else(handlers::DiagCancelToken::never);
+        if cancel.is_cancelled() {
+            return Err(JsonRpcError::request_cancelled());
+        }
         let state = self.state.read().await;
-        Ok(handlers::goto_definition(
+        if cancel.is_cancelled() {
+            return Err(JsonRpcError::request_cancelled());
+        }
+
+        let result = handlers::goto_definition_with_cancel(
             &state,
             &params.text_document_position_params.text_document.uri,
             params.text_document_position_params.position,
-        ))
+            &cancel,
+        );
+        if cancel.is_cancelled() {
+            return Err(JsonRpcError::request_cancelled());
+        }
+
+        Ok(result)
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
@@ -4205,13 +4407,17 @@ impl Backend {
 pub async fn start_lsp() -> anyhow::Result<()> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-
-    let (service, socket) = LspService::build(Backend::new)
-        .custom_method(
-            "raven/activeDocumentsChanged",
-            Backend::handle_active_documents_changed,
-        )
-        .finish();
+    let request_cancellation = Arc::new(RequestCancellationRegistry::new());
+    let backend_request_cancellation = Arc::clone(&request_cancellation);
+    let (service, socket) = LspService::build(move |client| {
+        Backend::new_with_request_cancellation(client, Arc::clone(&backend_request_cancellation))
+    })
+    .custom_method(
+        "raven/activeDocumentsChanged",
+        Backend::handle_active_documents_changed,
+    )
+    .finish();
+    let service = RequestCancellationService::new(service, request_cancellation);
     // Force sequential message processing to prevent out-of-order did_change
     // notifications from corrupting incremental text sync.
     // tower-lsp 0.20 defaults to buffer_unordered(4) which can reorder messages.
@@ -4692,6 +4898,82 @@ async fn run_libpath_consumer(
 
 #[cfg(test)]
 mod tests {
+    mod request_cancellation {
+        use super::super::{
+            CancellableRequestKind, RequestCancellationRegistry, CURRENT_LSP_REQUEST_ID,
+        };
+        use tower_lsp::jsonrpc::Id as JsonRpcId;
+
+        #[test]
+        fn superseding_same_kind_cancels_older_request() {
+            let registry = RequestCancellationRegistry::new();
+            let first = registry.register(
+                JsonRpcId::from(1_i64),
+                CancellableRequestKind::GotoDefinition,
+            );
+            let second = registry.register(
+                JsonRpcId::from(2_i64),
+                CancellableRequestKind::GotoDefinition,
+            );
+
+            assert!(first.is_cancelled());
+            assert!(!second.is_cancelled());
+        }
+
+        #[tokio::test]
+        async fn current_request_token_tracks_registered_id() {
+            let registry = RequestCancellationRegistry::new();
+            let id = JsonRpcId::from("definition-1");
+            let token = registry.register(id.clone(), CancellableRequestKind::GotoDefinition);
+
+            let cancel = CURRENT_LSP_REQUEST_ID
+                .scope(id.clone(), async {
+                    registry
+                        .token_for_current_request(CancellableRequestKind::GotoDefinition)
+                        .expect("current request has token")
+                })
+                .await;
+
+            assert!(!cancel.is_cancelled());
+            registry.cancel(&id);
+            assert!(token.is_cancelled());
+            assert!(cancel.is_cancelled());
+
+            registry.complete(&id);
+            let missing = CURRENT_LSP_REQUEST_ID
+                .scope(id, async {
+                    registry.token_for_current_request(CancellableRequestKind::GotoDefinition)
+                })
+                .await;
+            assert!(missing.is_none());
+        }
+
+        #[test]
+        fn completed_request_has_no_token() {
+            let registry = RequestCancellationRegistry::new();
+            let id = JsonRpcId::from(7_i64);
+            registry.register(id.clone(), CancellableRequestKind::GotoDefinition);
+            registry.complete(&id);
+
+            assert!(registry
+                .token_for_id(&id, CancellableRequestKind::GotoDefinition)
+                .is_none());
+        }
+
+        #[tokio::test]
+        async fn unregistered_current_request_has_no_token() {
+            let registry = RequestCancellationRegistry::new();
+            let id = JsonRpcId::from("definition-1");
+
+            let missing = CURRENT_LSP_REQUEST_ID
+                .scope(id, async {
+                    registry.token_for_current_request(CancellableRequestKind::GotoDefinition)
+                })
+                .await;
+
+            assert!(missing.is_none());
+        }
+    }
     /// Tests for saturating arithmetic used in priority scoring
     /// Validates Requirements 1.1, 1.2
     mod saturating_arithmetic {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -4903,19 +4903,39 @@ async fn run_libpath_consumer(
 mod tests {
     mod request_cancellation {
         use super::super::{
-            CancellableRequestKind, RequestCancellationRegistry, RequestCancellationService,
-            CURRENT_LSP_REQUEST_ID,
+            Backend, CancellableRequestKind, RequestCancellationRegistry,
+            RequestCancellationService, CURRENT_LSP_REQUEST_ID,
         };
         use std::convert::Infallible;
         use std::future::Future;
         use std::pin::Pin;
         use std::sync::Arc;
         use std::task::{Context, Poll};
+        use std::time::Duration;
         use tokio::sync::oneshot;
         use tower::Service;
         use tower_lsp::jsonrpc::{
             Id as JsonRpcId, Request as JsonRpcRequest, Response as JsonRpcResponse,
         };
+        use tower_lsp::lsp_types::{GotoDefinitionParams, InitializeParams, InitializeResult};
+        use tower_lsp::{LanguageServer, LspService};
+
+        #[derive(Debug)]
+        struct DummyLanguageServer;
+
+        #[tower_lsp::async_trait]
+        impl LanguageServer for DummyLanguageServer {
+            async fn initialize(
+                &self,
+                _: InitializeParams,
+            ) -> tower_lsp::jsonrpc::Result<InitializeResult> {
+                Ok(InitializeResult::default())
+            }
+
+            async fn shutdown(&self) -> tower_lsp::jsonrpc::Result<()> {
+                Ok(())
+            }
+        }
 
         struct ObservingService {
             registry: Arc<RequestCancellationRegistry>,
@@ -4950,6 +4970,52 @@ mod tests {
                     observed.send(token_visible).ok();
                     release.await.ok();
                     Ok(id.map(|id| JsonRpcResponse::from_ok(id, serde_json::Value::Null)))
+                })
+            }
+        }
+
+        struct BackendGotoDefinitionService {
+            backend: Arc<Backend>,
+            registry: Arc<RequestCancellationRegistry>,
+            observed: Option<oneshot::Sender<bool>>,
+        }
+
+        impl Service<JsonRpcRequest> for BackendGotoDefinitionService {
+            type Response = Option<JsonRpcResponse>;
+            type Error = Infallible;
+            type Future =
+                Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
+                if req.method() != "textDocument/definition" {
+                    return Box::pin(async { Ok(None) });
+                }
+
+                let id = req.id().cloned().expect("definition request has id");
+                let params: GotoDefinitionParams = serde_json::from_value(
+                    req.params()
+                        .cloned()
+                        .expect("definition request has params"),
+                )
+                .expect("valid definition params");
+                let backend = Arc::clone(&self.backend);
+                let registry = Arc::clone(&self.registry);
+                let observed = self.observed.take().expect("single observed request");
+
+                Box::pin(async move {
+                    let token_visible = registry
+                        .token_for_current_request(CancellableRequestKind::GotoDefinition)
+                        .is_some_and(|token| !token.is_cancelled());
+                    observed.send(token_visible).ok();
+
+                    let body = Backend::goto_definition(&backend, params)
+                        .await
+                        .map(|result| serde_json::to_value(result).expect("serializable result"));
+                    Ok(Some(JsonRpcResponse::from_parts(id, body)))
                 })
             }
         }
@@ -5070,6 +5136,71 @@ mod tests {
                 .expect("inner service succeeds")
                 .expect("request has a response");
             assert!(response.is_ok());
+            assert!(registry
+                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                .is_none());
+        }
+
+        #[tokio::test]
+        async fn goto_definition_cancels_while_waiting_for_state_read_lock() {
+            let registry = Arc::new(RequestCancellationRegistry::new());
+            let (client_tx, client_rx) = std::sync::mpsc::channel();
+            let (_service, _socket) = LspService::new(|client| {
+                client_tx.send(client).expect("capture client");
+                DummyLanguageServer
+            });
+            let client = client_rx.recv().expect("client captured");
+            let backend = Arc::new(Backend::new_with_request_cancellation(
+                client,
+                Arc::clone(&registry),
+            ));
+
+            let _state_write_guard = backend.state.write().await;
+            let request_id = JsonRpcId::from(321_i64);
+            let (observed_tx, observed_rx) = oneshot::channel();
+            let inner = BackendGotoDefinitionService {
+                backend: Arc::clone(&backend),
+                registry: Arc::clone(&registry),
+                observed: Some(observed_tx),
+            };
+            let mut service = RequestCancellationService::new(inner, Arc::clone(&registry));
+
+            let request = JsonRpcRequest::build("textDocument/definition")
+                .id(request_id.clone())
+                .params(serde_json::json!({
+                    "textDocument": { "uri": "file:///tmp/goto-definition-cancel.R" },
+                    "position": { "line": 0, "character": 0 }
+                }))
+                .finish();
+            let request_fut = service.call(request);
+
+            let token = registry
+                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                .expect("request token registered on service call");
+            assert!(!token.is_cancelled());
+
+            let request_task = tokio::spawn(request_fut);
+            assert!(
+                observed_rx.await.expect("backend future observed request"),
+                "Backend::goto_definition should see the CURRENT_LSP_REQUEST_ID token"
+            );
+
+            let cancel = JsonRpcRequest::build("$/cancelRequest")
+                .params(serde_json::json!({ "id": 321 }))
+                .finish();
+            service.call(cancel).await.expect("cancel request handled");
+
+            assert!(token.is_cancelled());
+            let response = tokio::time::timeout(Duration::from_secs(1), request_task)
+                .await
+                .expect("Backend::goto_definition should cancel without acquiring state read lock")
+                .expect("request task completes")
+                .expect("inner service succeeds")
+                .expect("request has a response");
+            assert_eq!(
+                response.error(),
+                Some(&tower_lsp::jsonrpc::Error::request_cancelled())
+            );
             assert!(registry
                 .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
                 .is_none());

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3557,7 +3557,10 @@ impl LanguageServer for Backend {
         if cancel.is_cancelled() {
             return Err(JsonRpcError::request_cancelled());
         }
-        let state = self.state.read().await;
+        let state = tokio::select! {
+            state = self.state.read() => state,
+            _ = cancel.cancelled() => return Err(JsonRpcError::request_cancelled()),
+        };
         if cancel.is_cancelled() {
             return Err(JsonRpcError::request_cancelled());
         }
@@ -4900,9 +4903,56 @@ async fn run_libpath_consumer(
 mod tests {
     mod request_cancellation {
         use super::super::{
-            CancellableRequestKind, RequestCancellationRegistry, CURRENT_LSP_REQUEST_ID,
+            CancellableRequestKind, RequestCancellationRegistry, RequestCancellationService,
+            CURRENT_LSP_REQUEST_ID,
         };
-        use tower_lsp::jsonrpc::Id as JsonRpcId;
+        use std::convert::Infallible;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::task::{Context, Poll};
+        use tokio::sync::oneshot;
+        use tower::Service;
+        use tower_lsp::jsonrpc::{
+            Id as JsonRpcId, Request as JsonRpcRequest, Response as JsonRpcResponse,
+        };
+
+        struct ObservingService {
+            registry: Arc<RequestCancellationRegistry>,
+            observed: Option<oneshot::Sender<bool>>,
+            release: Option<oneshot::Receiver<()>>,
+        }
+
+        impl Service<JsonRpcRequest> for ObservingService {
+            type Response = Option<JsonRpcResponse>;
+            type Error = Infallible;
+            type Future =
+                Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
+                let method = req.method().to_string();
+                let id = req.id().cloned();
+                if method != "textDocument/definition" {
+                    return Box::pin(async { Ok(None) });
+                }
+
+                let registry = Arc::clone(&self.registry);
+                let observed = self.observed.take().expect("single observed request");
+                let release = self.release.take().expect("single observed request");
+                Box::pin(async move {
+                    let token_visible = registry
+                        .token_for_current_request(CancellableRequestKind::GotoDefinition)
+                        .is_some_and(|token| !token.is_cancelled());
+                    observed.send(token_visible).ok();
+                    release.await.ok();
+                    Ok(id.map(|id| JsonRpcResponse::from_ok(id, serde_json::Value::Null)))
+                })
+            }
+        }
 
         #[test]
         fn superseding_same_kind_cancels_older_request() {
@@ -4972,6 +5022,57 @@ mod tests {
                 .await;
 
             assert!(missing.is_none());
+        }
+
+        #[tokio::test]
+        async fn service_registers_scopes_cancels_and_completes_request_tokens() {
+            let registry = Arc::new(RequestCancellationRegistry::new());
+            let request_id = JsonRpcId::from(99_i64);
+            let (observed_tx, observed_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            let inner = ObservingService {
+                registry: Arc::clone(&registry),
+                observed: Some(observed_tx),
+                release: Some(release_rx),
+            };
+            let mut service = RequestCancellationService::new(inner, Arc::clone(&registry));
+
+            let request = JsonRpcRequest::build("textDocument/definition")
+                .id(request_id.clone())
+                .finish();
+            let request_fut = service.call(request);
+
+            let token = registry
+                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                .expect("request token registered on service call");
+            assert!(!token.is_cancelled());
+
+            let request_task = tokio::spawn(request_fut);
+            assert!(
+                observed_rx.await.expect("inner future observed request"),
+                "inner future should see the task-local request token"
+            );
+
+            let cancel = JsonRpcRequest::build("$/cancelRequest")
+                .params(serde_json::json!({ "id": 99 }))
+                .finish();
+            service.call(cancel).await.expect("cancel request handled");
+
+            assert!(token.is_cancelled());
+            assert!(registry
+                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                .is_some_and(|token| token.is_cancelled()));
+
+            release_tx.send(()).expect("release observed request");
+            let response = request_task
+                .await
+                .expect("request task completes")
+                .expect("inner service succeeds")
+                .expect("request has a response");
+            assert!(response.is_ok());
+            assert!(registry
+                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                .is_none());
         }
     }
     /// Tests for saturating arithmetic used in priority scoring

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -48,6 +48,19 @@ impl DiagCancelToken {
     pub fn is_cancelled(&self) -> bool {
         self.0.as_ref().is_some_and(|t| t.is_cancelled())
     }
+    /// Returns `true` for the no-op token created by [`DiagCancelToken::never`].
+    #[inline]
+    pub(crate) fn is_never(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Resolves when the computation should stop.
+    pub async fn cancelled(&self) {
+        match &self.0 {
+            Some(token) => token.cancelled().await,
+            None => std::future::pending::<()>().await,
+        }
+    }
 }
 
 // ============================================================================
@@ -390,10 +403,6 @@ pub(crate) fn diagnostics_from_snapshot(
         &mut scope_cache,
         cancel,
     );
-
-    if cancel.is_cancelled() {
-        return None;
-    }
 
     if cancel.is_cancelled() {
         log::trace!(
@@ -10818,17 +10827,29 @@ pub fn goto_definition_with_cancel(
     if let Some((lhs_node, op)) = crate::extract_op::extract_operator_rhs(node) {
         let rhs_name = node_text(node, &text);
         let lhs_name = node_text(lhs_node, &text);
-        return crate::qualified_resolve::resolve_qualified_member_with_cancel(
-            state,
-            uri,
-            position,
-            lhs_node.kind(),
-            lhs_name,
-            rhs_name,
-            op,
-            cancel,
-        )
-        .map(GotoDefinitionResponse::Scalar);
+        let location = if cancel.is_never() {
+            crate::qualified_resolve::resolve_qualified_member(
+                state,
+                uri,
+                position,
+                lhs_node.kind(),
+                lhs_name,
+                rhs_name,
+                op,
+            )
+        } else {
+            crate::qualified_resolve::resolve_qualified_member_with_cancel(
+                state,
+                uri,
+                position,
+                lhs_node.kind(),
+                lhs_name,
+                rhs_name,
+                op,
+                cancel,
+            )
+        };
+        return location.map(GotoDefinitionResponse::Scalar);
     }
 
     let name = node_text(node, &text);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -392,6 +392,10 @@ pub(crate) fn diagnostics_from_snapshot(
     );
 
     if cancel.is_cancelled() {
+        return None;
+    }
+
+    if cancel.is_cancelled() {
         log::trace!(
             "Diagnostics cancelled after out-of-scope ({}ms)",
             start.elapsed().as_millis()
@@ -10687,11 +10691,25 @@ fn build_fallback_signature(
 /// let result = goto_definition(&state, &uri, pos);
 /// // `result` will be `Some(...)` when a navigable definition exists, otherwise `None`.
 /// ```
+#[allow(dead_code)]
 pub fn goto_definition(
     state: &WorldState,
     uri: &Url,
     position: Position,
 ) -> Option<GotoDefinitionResponse> {
+    goto_definition_with_cancel(state, uri, position, &DiagCancelToken::never())
+}
+
+/// Variant of [`goto_definition`] that cooperates with request-scoped cancellation.
+pub fn goto_definition_with_cancel(
+    state: &WorldState,
+    uri: &Url,
+    position: Position,
+    cancel: &DiagCancelToken,
+) -> Option<GotoDefinitionResponse> {
+    if cancel.is_cancelled() {
+        return None;
+    }
     // Use ContentProvider for unified access
     let content_provider = state.content_provider();
 
@@ -10734,6 +10752,9 @@ pub fn goto_definition(
     }
 
     if doc.file_type == FileType::Stan {
+        if cancel.is_cancelled() {
+            return None;
+        }
         let occurrences = collect_stan_identifier_occurrences(&text);
         let target = stan_identifier_at_position(&occurrences, position)?;
         let definition = find_stan_definition(&text, &target.name, position)?;
@@ -10748,6 +10769,9 @@ pub fn goto_definition(
     }
 
     if doc.file_type == FileType::Jags {
+        if cancel.is_cancelled() {
+            return None;
+        }
         let occurrences = collect_jags_identifier_occurrences(&text);
         let target = stan_identifier_at_position(&occurrences, position)?;
 
@@ -10794,7 +10818,7 @@ pub fn goto_definition(
     if let Some((lhs_node, op)) = crate::extract_op::extract_operator_rhs(node) {
         let rhs_name = node_text(node, &text);
         let lhs_name = node_text(lhs_node, &text);
-        return crate::qualified_resolve::resolve_qualified_member(
+        return crate::qualified_resolve::resolve_qualified_member_with_cancel(
             state,
             uri,
             position,
@@ -10802,6 +10826,7 @@ pub fn goto_definition(
             lhs_name,
             rhs_name,
             op,
+            cancel,
         )
         .map(GotoDefinitionResponse::Scalar);
     }
@@ -10813,13 +10838,7 @@ pub fn goto_definition(
     // 1. Position (definitions must be before usage)
     // 2. Function scope (locals don't leak)
     // 3. Shadowing (locals override globals)
-    let scope = get_cross_file_scope(
-        state,
-        uri,
-        position.line,
-        position.character,
-        &DiagCancelToken::never(),
-    );
+    let scope = get_cross_file_scope(state, uri, position.line, position.character, cancel);
 
     if let Some(symbol) = scope.symbols.get(name) {
         // Check if this is a package export (source_uri starts with "package:")
@@ -10889,6 +10908,9 @@ pub fn goto_definition(
 
     // Search all open documents using ContentProvider
     for file_uri in state.document_store.uris() {
+        if cancel.is_cancelled() {
+            return None;
+        }
         if &file_uri == uri {
             continue;
         }
@@ -10908,6 +10930,9 @@ pub fn goto_definition(
 
     // Search workspace index using ContentProvider
     for (file_uri, _) in state.workspace_index_new.iter() {
+        if cancel.is_cancelled() {
+            return None;
+        }
         if &file_uri == uri {
             continue;
         }
@@ -10927,6 +10952,9 @@ pub fn goto_definition(
 
     // Fallback: Search legacy open documents
     for (file_uri, doc) in &state.documents {
+        if cancel.is_cancelled() {
+            return None;
+        }
         if file_uri == uri {
             continue;
         }
@@ -10943,6 +10971,9 @@ pub fn goto_definition(
 
     // Fallback: Search legacy workspace index
     for (file_uri, doc) in &state.workspace_index {
+        if cancel.is_cancelled() {
+            return None;
+        }
         if file_uri == uri {
             continue;
         }

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -112,9 +112,7 @@ struct Candidate {
 /// (as `goto_definition` does) while calling this function so
 /// `get_cross_file_scope_with_cache` and subsequent scope lookups, including
 /// `candidate_lhs_matches_symbol`, observe the same graph/artifacts snapshot.
-/// The current implementation uses `DiagCancelToken::never()`; if
-/// request-cancellation is threaded through this path later, pass the request's
-/// token through these lookups while preserving the same snapshot invariant.
+#[allow(dead_code)]
 pub fn resolve_qualified_member(
     state: &WorldState,
     uri: &Url,
@@ -124,8 +122,31 @@ pub fn resolve_qualified_member(
     rhs_name: &str,
     op: ExtractOp,
 ) -> Option<Location> {
+    resolve_qualified_member_with_cancel(
+        state,
+        uri,
+        position,
+        lhs_node_kind,
+        lhs_name,
+        rhs_name,
+        op,
+        &DiagCancelToken::never(),
+    )
+}
+
+/// Cancellation-aware variant of [`resolve_qualified_member`].
+pub fn resolve_qualified_member_with_cancel(
+    state: &WorldState,
+    uri: &Url,
+    position: Position,
+    lhs_node_kind: &str,
+    lhs_name: &str,
+    rhs_name: &str,
+    op: ExtractOp,
+    cancel: &DiagCancelToken,
+) -> Option<Location> {
     // LHS shape gate — only bare `identifier` LHS is supported in Step 1.
-    if lhs_node_kind != "identifier" {
+    if lhs_node_kind != "identifier" || cancel.is_cancelled() {
         return None;
     }
     // Reuse parent-prefix work across the initial cursor lookup and the
@@ -134,19 +155,17 @@ pub fn resolve_qualified_member(
     // snapshot under the caller's read guard.
     let mut prefix_cache = crate::cross_file::scope::ParentPrefixCache::new();
 
-    // The cancel token is `never()` until raven gains a backend-level
-    // request-cancellation registry (tracked in issue #158). Once that
-    // exists, thread the request's token through here and through
-    // `candidate_lhs_matches_symbol` so a superseded goto-def can bail
-    // out of the retain loop early.
     let scope = crate::handlers::get_cross_file_scope_with_cache(
         state,
         uri,
         position.line,
         position.character,
-        &DiagCancelToken::never(),
+        cancel,
         &mut prefix_cache,
     );
+    if cancel.is_cancelled() {
+        return None;
+    }
     let symbol = scope.symbols.get(lhs_name)?;
 
     // Package exports (pseudo-URIs like `package:dplyr`) are not navigable.
@@ -210,8 +229,18 @@ pub fn resolve_qualified_member(
         });
         defining_candidates.retain(|c| {
             candidate_effect_visible_in_scope(c, &scope.visible_positions)
-                && candidate_lhs_matches_symbol(state, c, lhs_name, symbol, &mut prefix_cache)
+                && candidate_lhs_matches_symbol(
+                    state,
+                    c,
+                    lhs_name,
+                    symbol,
+                    cancel,
+                    &mut prefix_cache,
+                )
         });
+        if cancel.is_cancelled() {
+            return None;
+        }
     }
 
     // Phase 2: collect from every non-defining file that contributed to the
@@ -226,6 +255,9 @@ pub fn resolve_qualified_member(
         .iter()
         .filter(|candidate_uri| **candidate_uri != defining_uri)
     {
+        if cancel.is_cancelled() {
+            return None;
+        }
         if let Some((candidate_text, candidate_tree)) =
             crate::parameter_resolver::get_text_and_tree(state, candidate_uri)
         {
@@ -242,8 +274,11 @@ pub fn resolve_qualified_member(
     }
     cross_file_candidates.retain(|c| {
         candidate_effect_visible_in_scope(c, &scope.visible_positions)
-            && candidate_lhs_matches_symbol(state, c, lhs_name, symbol, &mut prefix_cache)
+            && candidate_lhs_matches_symbol(state, c, lhs_name, symbol, cancel, &mut prefix_cache)
     });
+    if cancel.is_cancelled() {
+        return None;
+    }
 
     let mut all_candidates = defining_candidates;
     all_candidates.extend(cross_file_candidates);
@@ -375,16 +410,23 @@ fn candidate_lhs_matches_symbol(
     c: &Candidate,
     lhs_name: &str,
     symbol: &crate::cross_file::scope::ScopedSymbol,
+    cancel: &DiagCancelToken,
     prefix_cache: &mut crate::cross_file::scope::ParentPrefixCache,
 ) -> bool {
+    if cancel.is_cancelled() {
+        return false;
+    }
     let scope = crate::handlers::get_cross_file_scope_with_cache(
         state,
         &c.uri,
         c.lhs_pos.line,
         c.lhs_pos.character,
-        &DiagCancelToken::never(),
+        cancel,
         prefix_cache,
     );
+    if cancel.is_cancelled() {
+        return false;
+    }
     scope
         .symbols
         .get(lhs_name)
@@ -737,7 +779,7 @@ fn nth_line(text: &str, n: usize) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use crate::handlers::goto_definition;
+    use crate::handlers::{goto_definition, goto_definition_with_cancel, DiagCancelToken};
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::{GotoDefinitionResponse, Position, Url};
 
@@ -760,6 +802,21 @@ mod tests {
             Some(GotoDefinitionResponse::Scalar(l)) => l,
             other => panic!("expected Scalar location, got {:?}", other),
         }
+    }
+    /// Request-scoped cancellation short-circuits qualified-member lookup before
+    /// cross-file scope resolution returns a location.
+    #[test]
+    fn dollar_rhs_cancelled_request_returns_none() {
+        let mut state = fresh_state();
+        let code = "foo <- list(bar = 1)\nuse(foo$bar)\n";
+        let uri = add_doc(&mut state, "file:///t.R", code);
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let cancel = DiagCancelToken::from_token(token);
+
+        let result = goto_definition_with_cancel(&state, &uri, Position::new(1, 9), &cancel);
+
+        assert!(result.is_none());
     }
 
     /// Cmd-click on the RHS of `$` in `foo$bar` finds the constructor-literal

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -112,7 +112,11 @@ struct Candidate {
 /// (as `goto_definition` does) while calling this function so
 /// `get_cross_file_scope_with_cache` and subsequent scope lookups, including
 /// `candidate_lhs_matches_symbol`, observe the same graph/artifacts snapshot.
-#[allow(dead_code)]
+///
+/// This stable convenience API delegates to
+/// [`resolve_qualified_member_with_cancel`] with [`DiagCancelToken::never`],
+/// so callers that do not have a request-scoped cancellation token keep the
+/// same uncancelled behavior.
 pub fn resolve_qualified_member(
     state: &WorldState,
     uri: &Url,

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -139,6 +139,16 @@ pub fn resolve_qualified_member(
 }
 
 /// Cancellation-aware variant of [`resolve_qualified_member`].
+///
+/// Same snapshot-scope invariant: callers must hold a `WorldState` read guard
+/// (as `goto_definition_with_cancel` does) so the single `ParentPrefixCache`
+/// created here, the initial `get_cross_file_scope_with_cache` lookup, and
+/// every per-candidate `candidate_lhs_matches_symbol` re-resolve all observe
+/// the same graph/artifacts snapshot.
+///
+/// `cancel` is polled cooperatively at scope-lookup and loop boundaries.
+/// Returns `None` on cancellation; passing [`DiagCancelToken::never`] yields
+/// the same behavior as [`resolve_qualified_member`].
 pub fn resolve_qualified_member_with_cancel(
     state: &WorldState,
     uri: &Url,

--- a/docs/development.md
+++ b/docs/development.md
@@ -171,6 +171,12 @@ A diagnostics gate enforces monotonic publishing:
 
 See `crates/raven/src/cross_file/revalidation.rs`.
 
+### Interactive request cancellation
+
+Raven keeps `tower-lsp` at `.concurrency_level(1)` to preserve ordered text sync, which means tower-lsp's built-in `$/cancelRequest` notification can be delayed behind the in-flight request it is supposed to cancel. `start_lsp()` wraps the `LspService` in `RequestCancellationService`, which intercepts `$/cancelRequest` synchronously in `Service::call` and records cancellations in a request-id keyed registry before tower-lsp queues the notification.
+
+Interactive handlers that can spend noticeable time in cross-file scope resolution should use a request-scoped `DiagCancelToken` from the registry and poll it through long loops and scope helpers. Qualified-member go-to-definition threads this token through `goto_definition_with_cancel` → `resolve_qualified_member_with_cancel` → `get_cross_file_scope_with_cache`, including per-candidate validation. New interactive multi-position resolvers should follow the same pattern: keep a request-local `ParentPrefixCache`, pass the token into every scope lookup, and check the token between candidate batches while still preserving a single `WorldState` snapshot.
+
 ### On-demand background indexing
 
 On-demand indexing is used to index files that are not currently open in the editor, prioritizing:


### PR DESCRIPTION
## Summary
- Add request-scoped cancellation for interactive definition requests while preserving `.concurrency_level(1)` text-sync ordering.
- Thread the request cancel token through `goto_definition`, qualified-member resolution, cross-file scope lookup, and per-candidate validation.
- Document the cancellation architecture and add regression coverage for registry behavior and canceled qualified-member lookup.

## Validation
- `cargo fmt --manifest-path /Users/jmb/repos/raven/Cargo.toml`
- `cargo build -p raven`
- `cargo test -p raven`
- `git --no-pager diff --check`

Closes #158

Conversation: https://app.warp.dev/conversation/86b6ff1c-999d-4cbe-ba3a-1d51de76c23c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive request cancellation for LSP: long-running operations (e.g., Go to Definition) can be interrupted and return promptly.

* **Tests**
  * Added unit and integration tests covering cancellation behavior, scoping, superseding of prior requests, visibility during processing, and cleanup after completion.

* **Documentation**
  * Updated development guide with guidance on using and integrating request-scoped cancellation for interactive handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->