### PR TITLE
Exclude parent-prefix member assignments from child completions

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -776,12 +776,6 @@ pub struct ScopeAtPosition {
     /// Origins are stored as `Arc<Url>` so cross-file propagation between
     /// scopes is a refcount bump rather than a Url-internals string clone.
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
-    /// URIs that entered the scope chain via the parent/backward prefix
-    /// (i.e. files that *source* the queried file). These files contribute
-    /// symbols to the child's environment but their own member assignments
-    /// (e.g. `foo$bar <- 1`) should not appear as completions in the child
-    /// because the child executes before the parent's post-source code.
-    pub parent_prefix_chain_uris: HashSet<Url>,
 }
 
 fn record_visible_position(
@@ -3579,9 +3573,6 @@ where
                         }
                     }
                 }
-                scope
-                    .parent_prefix_chain_uris
-                    .extend(prefix.chain.iter().cloned());
                 scope.chain.extend(prefix.chain.iter().cloned());
                 extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope
@@ -3627,9 +3618,6 @@ where
                         }
                     }
                 }
-                scope
-                    .parent_prefix_chain_uris
-                    .extend(prefix.chain.iter().cloned());
                 scope.chain.extend(prefix.chain);
                 extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope.depth_exceeded.extend(prefix.depth_exceeded);
@@ -4611,7 +4599,6 @@ where
             // a few lines below.
             loaded_packages: HashSet::new(),
             package_origins: prefix.package_origins.clone(),
-            parent_prefix_chain_uris: prefix.chain.iter().cloned().collect(),
         };
 
         // Layer global frame on top. The global frame contains base exports

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -776,6 +776,12 @@ pub struct ScopeAtPosition {
     /// Origins are stored as `Arc<Url>` so cross-file propagation between
     /// scopes is a refcount bump rather than a Url-internals string clone.
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
+    /// URIs that entered the scope chain via the parent/backward prefix
+    /// (i.e. files that *source* the queried file). These files contribute
+    /// symbols to the child's environment but their own member assignments
+    /// (e.g. `foo$bar <- 1`) should not appear as completions in the child
+    /// because the child executes before the parent's post-source code.
+    pub parent_prefix_chain_uris: HashSet<Url>,
 }
 
 fn record_visible_position(
@@ -3573,6 +3579,9 @@ where
                         }
                     }
                 }
+                scope
+                    .parent_prefix_chain_uris
+                    .extend(prefix.chain.iter().cloned());
                 scope.chain.extend(prefix.chain.iter().cloned());
                 extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope
@@ -3618,6 +3627,9 @@ where
                         }
                     }
                 }
+                scope
+                    .parent_prefix_chain_uris
+                    .extend(prefix.chain.iter().cloned());
                 scope.chain.extend(prefix.chain);
                 extend_visible_positions(&mut scope.visible_positions, &prefix.visible_positions);
                 scope.depth_exceeded.extend(prefix.depth_exceeded);
@@ -4599,6 +4611,7 @@ where
             // a few lines below.
             loaded_packages: HashSet::new(),
             package_origins: prefix.package_origins.clone(),
+            parent_prefix_chain_uris: prefix.chain.iter().cloned().collect(),
         };
 
         // Layer global frame on top. The global frame contains base exports

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -573,7 +573,6 @@ fn collect_qualified_member_candidates_with_cancel(
         .chain
         .iter()
         .filter(|candidate_uri| **candidate_uri != defining_uri)
-        .filter(|candidate_uri| !scope.parent_prefix_chain_uris.contains(candidate_uri))
     {
         if cancel.is_cancelled() {
             return None;
@@ -3159,6 +3158,47 @@ foo$bar <- 1
         assert!(
             completion_names(&state, &child_uri, Position::new(1, 4), "foo").is_empty(),
             "parent-prefix member assignments must not appear in child completions"
+        );
+    }
+
+    /// Parent-side member assignments before the source() call are visible in
+    /// the child when the parent imported the LHS binding from an upstream file.
+    #[test]
+    fn dollar_member_completion_keeps_parent_prefix_assignments_before_source() {
+        let mut state = fresh_state();
+        let defs_code = "foo <- list()\n";
+        let child_code = "foo$\n";
+        let parent_code = "\
+source(\"defs.R\")
+foo$bar <- 1
+source(\"child.R\")
+foo$baz <- 2
+";
+        let defs_uri = add_doc(&mut state, "file:///workspace/defs.R", defs_code);
+        let child_uri = add_doc(&mut state, "file:///workspace/child.R", child_code);
+        let parent_uri = add_indexed_doc(&mut state, "file:///workspace/parent.R", parent_code);
+
+        for (uri, code) in [
+            (&defs_uri, defs_code),
+            (&child_uri, child_code),
+            (&parent_uri, parent_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        let names = completion_names(&state, &child_uri, Position::new(0, 4), "foo");
+        assert!(
+            names.contains(&"bar".to_string()),
+            "parent member assignments before source(child.R) must remain visible"
+        );
+        assert!(
+            !names.contains(&"baz".to_string()),
+            "parent member assignments after source(child.R) must stay hidden"
         );
     }
 }

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -3129,14 +3129,19 @@ use(foo$inner)
     }
 
     /// Member assignments in a parent (backward-dependency) file must NOT
-    /// appear as completions in the child file. The parent executes *after*
-    /// the child, so its `foo$bar <- 1` is not visible at the child's cursor.
+    /// appear as completions or goto-definition targets in the child file. The
+    /// parent executes *after* the child, so its `foo$bar <- 1` is not visible
+    /// at the child's cursor. `collect_qualified_member_candidates_with_cancel`
+    /// feeds both `complete_qualified_members_with_cancel` and
+    /// `resolve_qualified_member_with_cancel`, so this test asserts both paths
+    /// reject the parent's assignment.
     #[test]
     fn dollar_member_completion_excludes_parent_prefix_assignments() {
         let mut state = fresh_state();
         let child_code = "\
 foo <- list()
 foo$
+foo$bar
 ";
         let parent_code = "\
 source(\"child.R\")
@@ -3154,10 +3159,17 @@ foo$bar <- 1
             );
         }
 
-        // Cursor in child.R at `foo$` — parent's `foo$bar` must not leak.
+        // Cursor in child.R at `foo$` — parent's `foo$bar` must not leak into
+        // the completion list.
         assert!(
             completion_names(&state, &child_uri, Position::new(1, 4), "foo").is_empty(),
             "parent-prefix member assignments must not appear in child completions"
+        );
+        // Cursor on `bar` in child.R's `foo$bar` — parent's `foo$bar <- 1`
+        // must not be reachable via goto-definition either.
+        assert!(
+            goto_definition(&state, &child_uri, Position::new(2, 5)).is_none(),
+            "parent-prefix member assignments must not be reachable via goto-definition"
         );
     }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -573,6 +573,7 @@ fn collect_qualified_member_candidates_with_cancel(
         .chain
         .iter()
         .filter(|candidate_uri| **candidate_uri != defining_uri)
+        .filter(|candidate_uri| !scope.parent_prefix_chain_uris.contains(candidate_uri))
     {
         if cancel.is_cancelled() {
             return None;
@@ -3125,6 +3126,39 @@ use(foo$inner)
             "chained `foo$inner$bar <- 99` (outer extract's LHS is itself \
              an extract, not a bare identifier) must not be collected as a \
              candidate for `foo$inner`",
+        );
+    }
+
+    /// Member assignments in a parent (backward-dependency) file must NOT
+    /// appear as completions in the child file. The parent executes *after*
+    /// the child, so its `foo$bar <- 1` is not visible at the child's cursor.
+    #[test]
+    fn dollar_member_completion_excludes_parent_prefix_assignments() {
+        let mut state = fresh_state();
+        let child_code = "\
+foo <- list()
+foo$
+";
+        let parent_code = "\
+source(\"child.R\")
+foo$bar <- 1
+";
+        let child_uri = add_doc(&mut state, "file:///workspace/child.R", child_code);
+        let parent_uri = add_indexed_doc(&mut state, "file:///workspace/parent.R", parent_code);
+
+        for (uri, code) in [(&child_uri, child_code), (&parent_uri, parent_code)] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // Cursor in child.R at `foo$` — parent's `foo$bar` must not leak.
+        assert!(
+            completion_names(&state, &child_uri, Position::new(1, 4), "foo").is_empty(),
+            "parent-prefix member assignments must not appear in child completions"
         );
     }
 }


### PR DESCRIPTION
Track URIs that enter the scope chain via the parent/backward prefix in
ScopeAtPosition::parent_prefix_chain_uris. Filter these out when
collecting qualified member candidates, since parent files execute after
the child and their member assignments (e.g. foo$bar <- 1) are not
visible at the child's cursor position.

Adds test to verify parent-prefix assignments don't leak into child
completions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests to ensure member completion and goto-definition behavior correctly respects file dependency boundaries across sourced files.
  * Verifies that member assignments from parent files are only visible to dependent files when defined before the source statement, ensuring proper variable scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->