### PR TITLE
Fix transitive uuid vulnerability (Dependabot #35)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -5748,13 +5748,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -446,7 +446,8 @@
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "uuid": ">=14.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry to pin `uuid >= 14.0.0`, resolving the transitive vulnerability introduced via `@vscode/vsce 3.9.1`.

**Issue:** https://github.com/jbearak/raven/security/dependabot/35

## Details

`uuid 8.3.2` has a bounds-validation inconsistency: `v3`, `v5`, and `v6` accept external output buffers but do not reject out-of-range writes, allowing silent partial writes. This is fixed in `uuid >= 14.0.0`.

Since `@vscode/vsce` is a devDependency used only at packaging time (never shipped in the extension bundle), the practical risk is minimal — but the override silences the alert cleanly.

## Testing

- `bun install` succeeds with the override
- The `vsce package` workflow should be unaffected since uuid's public API is stable across majors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->