### PR TITLE
Fix parent-after-source leak in cross-file member completions

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -3438,13 +3438,16 @@ where
 ///
 /// # Invariants
 ///
-/// **`visible_positions[uri]` is pinned to the first-visit position.** A re-visit
-/// happens when a transitive cycle forward-sources `uri` at a wider position
-/// (typically EOF). The *original* visit already recorded the legitimate cap for
-/// `uri`'s role in the cursor's execution chain; expanding it on re-visit lets a
-/// side-trip recursion overwrite the cap and reveal later-than-source definitions
-/// that aren't actually in scope. The re-visit still re-runs STEP 2 to collect any
-/// new symbols — only the visibility cutoff stays put.
+/// **`visible_positions[uri]` is pinned to the first-visit position.** A
+/// re-visit happens when the recursion re-enters `uri` at a strictly wider
+/// position than the first-visit cap (typically a transitive forward
+/// `source()` reaching `uri` at EOF). The *original* visit already recorded
+/// the legitimate cap for `uri`'s role in the cursor's execution chain;
+/// expanding it on re-visit lets a side-trip recursion overwrite the cap and
+/// reveal later-than-source definitions that aren't actually in scope. The
+/// re-visit still re-runs STEP 2 to collect any new symbols — only the
+/// visibility cutoff stays put. Regression coverage:
+/// `qualified_resolve::tests::dollar_member_completion_excludes_parent_after_source_via_transitive_revisit`.
 ///
 /// # Returns
 ///

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -3530,8 +3530,15 @@ where
     visited.insert(uri.clone(), (line, column));
     if !is_revisit {
         scope.chain.push(uri.clone());
+        // Skip this on re-visit. A re-visit happens when a transitive cycle
+        // forward-sources `uri` at a wider position (typically EOF). The
+        // *original* visit already recorded the legitimate cap for `uri`'s
+        // role in the cursor's execution chain; expanding it here lets a
+        // side-trip recursion overwrite the cap and reveal later-than-source
+        // definitions that aren't actually in scope. The re-visit still
+        // collects symbols via STEP 2 below — only the cap stays pinned.
+        record_visible_position(&mut scope.visible_positions, uri, line, column);
     }
-    record_visible_position(&mut scope.visible_positions, uri, line, column);
 
     let artifacts = match get_artifacts(uri) {
         Some(a) => a,

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -3436,6 +3436,16 @@ where
 /// Function-scoped visibility, sys.source/local scoping rules, cycle prevention, and `max_depth`
 /// are respected; entries that would exceed `max_depth` are recorded in `ScopeAtPosition::depth_exceeded`.
 ///
+/// # Invariants
+///
+/// **`visible_positions[uri]` is pinned to the first-visit position.** A re-visit
+/// happens when a transitive cycle forward-sources `uri` at a wider position
+/// (typically EOF). The *original* visit already recorded the legitimate cap for
+/// `uri`'s role in the cursor's execution chain; expanding it on re-visit lets a
+/// side-trip recursion overwrite the cap and reveal later-than-source definitions
+/// that aren't actually in scope. The re-visit still re-runs STEP 2 to collect any
+/// new symbols — only the visibility cutoff stays put.
+///
 /// # Returns
 ///
 /// A `ScopeAtPosition` containing the merged symbols, provenance chain, recorded depth-exceeded
@@ -3530,13 +3540,8 @@ where
     visited.insert(uri.clone(), (line, column));
     if !is_revisit {
         scope.chain.push(uri.clone());
-        // Skip this on re-visit. A re-visit happens when a transitive cycle
-        // forward-sources `uri` at a wider position (typically EOF). The
-        // *original* visit already recorded the legitimate cap for `uri`'s
-        // role in the cursor's execution chain; expanding it here lets a
-        // side-trip recursion overwrite the cap and reveal later-than-source
-        // definitions that aren't actually in scope. The re-visit still
-        // collects symbols via STEP 2 below — only the cap stays pinned.
+        // First-visit only — see the `visible_positions[uri]` invariant in this
+        // function's doc comment.
         record_visible_position(&mut scope.visible_positions, uri, line, column);
     }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -2177,6 +2177,77 @@ source(\"main.R\")
         );
     }
 
+    /// Regression: parent assignments after `source(child)` must stay invisible
+    /// in the child even when a transitive forward-source descendant has a
+    /// dependent that *also* sources the parent. Reproduces the worldwide-repo
+    /// bug:
+    ///
+    /// - cursor file `data.R` is sourced by `main.R` at line 1
+    /// - `main.R` line 2: `ww$c.oos <- 1` (must NOT be visible in `data.R`)
+    /// - `main.R` sources a sibling `helper.R` *before* sourcing `data.R`
+    /// - `helper.R` forward-sources `shared.R`
+    /// - `runner.R` ALSO sources `main.R` and `shared.R`
+    ///
+    /// The diamond means resolving `shared.R`'s parent_prefix re-visits
+    /// `runner.R` at a wider position, whose STEP 2 then forward-sources
+    /// `main.R` at EOF. Without the fix, that re-visit's `visible_positions`
+    /// for `main.R` (= EOF) leaks back through the merge chain and overwrites
+    /// the original `(call_site, 0)` cap, exposing later-than-source
+    /// assignments.
+    #[test]
+    fn dollar_member_completion_excludes_parent_after_source_via_transitive_revisit() {
+        let mut state = fresh_state();
+        let data_code = "\
+ww <- list()
+ww$name.w <- 1
+ww$
+";
+        let main_code = "\
+source(\"helper.R\")
+source(\"data.R\")
+ww$c.oos <- 1
+ww$seeds <- 2
+";
+        let helper_code = "source(\"shared.R\")\n";
+        let shared_code = "shared_value <- 1\n";
+        // `runner.R` sources `main.R` first (line 0) and then `shared.R` later
+        // (line 1). The diamond on `shared.R` is what triggers the wider-position
+        // revisit of `runner.R` during `shared.R`'s parent_prefix walk.
+        let runner_code = "\
+source(\"main.R\")
+source(\"shared.R\")
+";
+
+        let data_uri = add_doc(&mut state, "file:///workspace/data.R", data_code);
+        let main_uri = add_indexed_doc(&mut state, "file:///workspace/main.R", main_code);
+        let helper_uri = add_indexed_doc(&mut state, "file:///workspace/helper.R", helper_code);
+        let shared_uri = add_indexed_doc(&mut state, "file:///workspace/shared.R", shared_code);
+        let runner_uri = add_indexed_doc(&mut state, "file:///workspace/runner.R", runner_code);
+
+        for (uri, code) in [
+            (&data_uri, data_code),
+            (&main_uri, main_code),
+            (&helper_uri, helper_code),
+            (&shared_uri, shared_code),
+            (&runner_uri, runner_code),
+        ] {
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        // Cursor is in `data.R` at the `ww$` line.  `c.oos` and `seeds` are
+        // assigned in `main.R` strictly after the `source("data.R")` call,
+        // so they must not leak into `data.R`'s completions.
+        assert_eq!(
+            completion_names(&state, &data_uri, Position::new(2, 3), "ww"),
+            vec!["name.w"]
+        );
+    }
+
     /// Regression for workspaces where `main.R` first sources an unrelated
     /// helper before the file that actually defines `ww`. The helper inherits a
     /// parent-prefix `ww` through the graph, but sourcing it should not consume

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -2193,7 +2193,9 @@ source(\"main.R\")
     /// `main.R` at EOF. Without the fix, that re-visit's `visible_positions`
     /// for `main.R` (= EOF) leaks back through the merge chain and overwrites
     /// the original `(call_site, 0)` cap, exposing later-than-source
-    /// assignments.
+    /// assignments. See the `visible_positions[uri]` invariant on
+    /// `cross_file::scope::scope_at_position_with_graph_recursive` for the
+    /// pinning rule this exercises.
     #[test]
     fn dollar_member_completion_excludes_parent_after_source_via_transitive_revisit() {
         let mut state = fresh_state();
@@ -2218,6 +2220,9 @@ source(\"main.R\")
 source(\"shared.R\")
 ";
 
+        // Cursor file goes through `add_doc` (open document); the rest are
+        // closed/indexed via `add_indexed_doc` to mirror the editor runtime
+        // where only the active buffer is open.
         let data_uri = add_doc(&mut state, "file:///workspace/data.R", data_code);
         let main_uri = add_indexed_doc(&mut state, "file:///workspace/main.R", main_code);
         let helper_uri = add_indexed_doc(&mut state, "file:///workspace/helper.R", helper_code);


### PR DESCRIPTION
## Summary

In a workspace with a *diamond* of `source()` relationships, `ww$c.oos` and `ww$seeds` assigned in `main.r` *after* `source("scripts/data.r")` were appearing in member completions inside `data.r` — even though they execute strictly after `data.r` returns and shouldn't be in scope yet.

Root cause: when computing `data.r`'s `parent_prefix`, a transitive walk visits a grandparent of `main.r` at a *wider* position than its initial call-site visit (because that grandparent also sources a sibling forward-sourced from `main.r`). The re-visit's STEP 2 forward-sources `main.r` at EOF, and `record_visible_position` overwrote `main.r`'s cap from `(call_site, 0)` to `(MAX, MAX)`. That EOF cap propagated back through the merge chain, defeating the visibility filter in `qualified_resolve::candidate_effect_visible_in_scope`.

Fix: pin the cap on re-visit. `record_visible_position` now runs only on the first visit. The first visit's position is the legitimate cap for that file's role in the cursor's execution chain — side-trip recursions must not widen it. STEP 2 still re-runs at the wider position to collect any new symbols; only the visibility cutoff stays put.

- Reproduces against `worldwide/scripts/data.r` (`ww$|` → `c.oos`, `seeds` no longer appear).
- New regression test exercises the minimal diamond.
- All 3211 lib tests pass.

## Test plan

- [x] `cargo test -p raven --lib qualified_resolve::tests::dollar_member_completion_excludes_parent_after_source_via_transitive_revisit` — passes.
- [x] TDD red→green verified: revert the fix → test fails with `["c.oos", "name.w", "seeds"]`; restore → test passes with `["name.w"]`.
- [x] `cargo test -p raven --lib` — 3211 passed, 0 failed.
- [x] Manual completion request against the actual `~/repos/worldwide` repo at `scripts/data.r` line 28 — completion list goes from 75 labels (with `c.oos`, `seeds`) to 73 labels (without).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-file scope resolution now records symbol visibility only on the initial visit, preventing unintended expansion of visibility during revisits and ensuring correct handling of cycles and forward-source anchoring.
  * Prevented parent-prefix visibility leakage in member completion across transitive file relationships, preserving proper scope boundaries.

* **Tests**
  * Added test coverage for dollar-member completion behavior across transitive file dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->