### PR TITLE
Add interactive R console with send-to-R commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ User-facing:
 - `docs/directives.md`
 - `docs/diagnostics.md`
 - `docs/indentation.md`
+- `docs/send-to-r.md`
 - `docs/document-outline.md`
 - `docs/configuration.md`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ And if you open `utils.R` directly, Raven automatically discovers that `main.R` 
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)
-- **Bundled binary** — No separate installation needed in VS Code
 
 > [!NOTE]
 > Raven also provides lightweight support for **JAGS** (`.jags`, `.bugs`) and **Stan** (`.stan`) files: syntax highlighting, completions (keywords, distributions, file-local symbols), go-to-definition, find references, and document outline with model structure navigation. See [Document Outline](docs/document-outline.md#jags-and-stan-model-structure).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ And if you open `utils.R` directly, Raven automatically discovers that `main.R` 
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
+- **[Send to R](docs/send-to-r.md)** — Interactive R console with statement detection and radian support
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And if you open `utils.R` directly, Raven automatically discovers that `main.R` 
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
-- **[Send to R](docs/send-to-r.md)** — Interactive R console with statement detection and radian support
+- **[Send to R](docs/send-to-r.md)** — Interactive R console with statement detection; supports arf and radian
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And if you open `utils.R` directly, Raven automatically discovers that `main.R` 
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
-- **[Send to R](docs/send-to-r.md)** — Interactive R console with statement detection; supports arf and radian
+- **[Send to R](docs/send-to-r.md)** — Interactive R console with statement detection; supports R, arf, and radian
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -41,7 +41,12 @@ The selected program must be available on your PATH.
 
 ## Editor Toolbar
 
-A toolbar button (▶) appears in the editor title bar for R files, providing quick access to all send commands.
+A toolbar button (▶) appears in the editor title bar for R files, providing quick access to all send commands. The menu is organized into two sections:
+
+- **Main commands** — Send code to the managed R (Raven) terminal. If no R terminal is open, one is created automatically.
+- **Terminal submenu** — Send code to whatever terminal is currently active in VS Code, regardless of type. This is useful for sending commands to R running inside `tmux`, a Docker container, or any other terminal session that isn't the extension's built-in R terminal.
+
+The Terminal submenu uses a temporary file and `source()` to send code, which avoids issues with large pastes over SSH or slow connections.
 
 ## Statement Detection
 

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -17,7 +17,7 @@ The `raven.rTerminal.program` setting controls which program is launched:
 | **radian** | Python-based R console with syntax highlighting, multiline editing, and mouse support |
 
 > [!TIP]
-> Both [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) provide a significantly better interactive experience than the standard R console: syntax highlighting, multiline editing, and richer history. Note that radian is no longer under active development; its author [recommends arf](https://github.com/randy3k/radian) as the successor.
+> Both [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) provide a significantly better interactive experience than the standard R console: syntax highlighting, multiline editing, and `Ctrl+R` history search. Note that radian is no longer under active development; its author [recommends arf](https://github.com/randy3k/radian) as the successor.
 
 The selected program must be available on your PATH.
 

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -1,0 +1,85 @@
+# Send to R
+
+The extension provides an interactive R console and commands to send R code directly from the editor to R for execution. It supports both the standard R console and [radian](https://github.com/randy3k/radian) (a modern R console with syntax highlighting, multiline editing, and full mouse support).
+
+## R Terminal Profile
+
+The extension registers an "R" terminal profile in VS Code's terminal dropdown. You can open an R terminal manually from the terminal profile picker at any time.
+
+### Choosing Between R and radian
+
+The `raven.rTerminal.program` setting controls which program is launched:
+
+| Value | Description |
+|-------|-------------|
+| **R** (default) | Standard R console |
+| **radian** | Modern R console with syntax highlighting, multiline editing, and mouse support |
+
+> [!TIP]
+> [radian](https://github.com/randy3k/radian) provides a significantly better interactive experience: syntax highlighting, multiline editing, tab completion with a popup menu, and full mouse support (click to position cursor, scroll through history). Install it with `pip install radian`.
+
+The selected program must be available on your PATH.
+
+## Keyboard Shortcuts
+
+| Mac | Windows/Linux | Action |
+|-----|---------------|--------|
+| `Cmd+Enter` | `Ctrl+Enter` | Run line or selection |
+| `Shift+Cmd+Enter` | `Shift+Ctrl+Enter` | Source file |
+
+> [!TIP]
+> You can also access these commands via the editor toolbar menu (`▶` button) or the command palette (`Cmd+Shift+P`).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| **Run Line or Selection** | Sends the current selection to R. If no selection, detects and sends the complete multi-line statement at the cursor. |
+| **Run Upward Lines** | Sends all lines from the start of the file to the current line (extending to complete any multi-line statement). |
+| **Run Downward Lines** | Sends all lines from the current line to the end of the file (extending upward to include the full statement start). |
+| **Source File** | Runs `source("filepath", echo = TRUE)` in the R terminal. |
+
+## Editor Toolbar
+
+A toolbar button (▶) appears in the editor title bar for R files, providing quick access to all send commands.
+
+## Statement Detection
+
+When no text is selected, **Run Line or Selection** intelligently detects complete R statements spanning multiple lines. The extension recognizes:
+
+- **Unmatched brackets** — `(`, `[`, `{` that haven't been closed
+- **Trailing operators** — lines ending with `+`, `-`, `*`, `/`, `|>`, `%>%`, `%any%`, `||`, `&&`, `|`, `&`, `~`, `=`, `<-`, `->`, `,`, `::`, `:::`
+- **Continuation lines** — lines starting with `|>`, `%>%`, `)`, `]`, `}`, `+`, or other operators
+
+This means pipe chains, multi-line function calls, ggplot layers, and if/else blocks are sent as complete units:
+
+```r
+# Cursor anywhere in this block sends all 3 lines:
+df |>
+  filter(x > 1) |>
+  select(a, b)
+
+# Same for ggplot:
+ggplot(df, aes(x, y)) +
+  geom_point() +
+  theme_minimal()
+
+# And function calls:
+result <- foo(
+  x = 1,
+  y = 2
+)
+```
+
+## Cursor Advancement
+
+By default, the cursor advances to the next line after sending a single statement (not a selection or file). This allows rapid line-by-line execution with repeated `Cmd+Enter` presses.
+
+**Configuration**: `raven.sendToR.advanceCursorOnSend` (default: `true`)
+
+## Configuration Options
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `raven.rTerminal.program` | enum | `"R"` | Program for the R terminal: `"R"` or `"radian"` |
+| `raven.sendToR.advanceCursorOnSend` | boolean | `true` | Advance cursor to next line after sending a single statement |

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -17,7 +17,7 @@ The `raven.rTerminal.program` setting controls which program is launched:
 | **radian** | Python-based R console with syntax highlighting, multiline editing, and mouse support |
 
 > [!TIP]
-> Both [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) provide a significantly better interactive experience than the standard R console: syntax highlighting, multiline editing, and `Ctrl+R` history search. Note that radian is no longer under active development; its author [recommends arf](https://github.com/randy3k/radian) as the successor.
+> Both [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) provide a significantly better interactive experience than the standard R console: syntax highlighting, multiline editing, popup completions, and `Ctrl+R` history search. Note that radian is no longer under active development; its author [recommends arf](https://github.com/randy3k/radian) as the successor.
 
 The selected program must be available on your PATH.
 

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -17,7 +17,7 @@ The `raven.rTerminal.program` setting controls which program is launched:
 | **radian** | Python-based R console with syntax highlighting, multiline editing, and mouse support |
 
 > [!TIP]
-> Both `arf` and `radian` provide a significantly better interactive experience than the standard R console. `radian` is no longer under active development, and its author [recommends](https://github.com/randy3k/radian) `arf` as the successor — new users should pick `arf`. Install arf via the [shell installer](https://github.com/eitsupi/arf#shell-installer-linuxmacos), or install radian with `pip install radian`.
+> Both [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) provide a significantly better interactive experience than the standard R console: syntax highlighting, multiline editing, and richer history. Note that radian is no longer under active development; its author [recommends arf](https://github.com/randy3k/radian) as the successor.
 
 The selected program must be available on your PATH.
 

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -1,22 +1,23 @@
 # Send to R
 
-The extension provides an interactive R console and commands to send R code directly from the editor to R for execution. It supports both the standard R console and [radian](https://github.com/randy3k/radian) (a modern R console with syntax highlighting, multiline editing, and full mouse support).
+The extension provides an interactive R console and commands to send R code directly from the editor to R for execution. It supports the standard R console as well as [arf](https://github.com/eitsupi/arf) and [radian](https://github.com/randy3k/radian) — modern third-party R consoles with syntax highlighting and richer interactive features.
 
 ## R Terminal Profile
 
 The extension registers an "R" terminal profile in VS Code's terminal dropdown. You can open an R terminal manually from the terminal profile picker at any time.
 
-### Choosing Between R and radian
+### Choosing the R program
 
 The `raven.rTerminal.program` setting controls which program is launched:
 
 | Value | Description |
 |-------|-------------|
 | **R** (default) | Standard R console |
-| **radian** | Modern R console with syntax highlighting, multiline editing, and mouse support |
+| **arf** | Rust-based R console with syntax highlighting, fuzzy history search (`Ctrl+R`), interactive help, and rig integration |
+| **radian** | Python-based R console with syntax highlighting, multiline editing, and mouse support |
 
 > [!TIP]
-> [radian](https://github.com/randy3k/radian) provides a significantly better interactive experience: syntax highlighting, multiline editing, tab completion with a popup menu, and full mouse support (click to position cursor, scroll through history). Install it with `pip install radian`.
+> Both `arf` and `radian` provide a significantly better interactive experience than the standard R console. `radian` is no longer under active development, and its author [recommends](https://github.com/randy3k/radian) `arf` as the successor — new users should pick `arf`. Install arf via the [shell installer](https://github.com/eitsupi/arf#shell-installer-linuxmacos), or install radian with `pip install radian`.
 
 The selected program must be available on your PATH.
 
@@ -86,5 +87,5 @@ By default, the cursor advances to the next line after sending a single statemen
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `raven.rTerminal.program` | enum | `"R"` | Program for the R terminal: `"R"` or `"radian"` |
+| `raven.rTerminal.program` | enum | `"R"` | Program for the R terminal: `"R"`, `"arf"`, or `"radian"` |
 | `raven.sendToR.advanceCursorOnSend` | boolean | `true` | Advance cursor to next line after sending a single statement |

--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -47,7 +47,7 @@ A toolbar button (▶) appears in the editor title bar for R files, providing qu
 - **Main commands** — Send code to the managed R (Raven) terminal. If no R terminal is open, one is created automatically.
 - **Terminal submenu** — Send code to whatever terminal is currently active in VS Code, regardless of type. This is useful for sending commands to R running inside `tmux`, a Docker container, or any other terminal session that isn't the extension's built-in R terminal.
 
-The Terminal submenu uses a temporary file and `source()` to send code, which avoids issues with large pastes over SSH or slow connections.
+Selections and line ranges sent via the Terminal submenu are written to a temporary file and executed with `source()`, which avoids issues with large pastes over SSH or slow connections. **Terminal: Source File** runs `source()` directly against the document's saved path on disk (saving first if the buffer has unsaved changes).
 
 ## Statement Detection
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -47,6 +47,22 @@
       {
         "command": "raven.sourceFile",
         "title": "Raven: Source File"
+      },
+      {
+        "command": "raven.terminal.runLineOrSelection",
+        "title": "Raven: Terminal - Run Line or Selection"
+      },
+      {
+        "command": "raven.terminal.runUpwardLines",
+        "title": "Raven: Terminal - Run Upward Lines"
+      },
+      {
+        "command": "raven.terminal.runDownwardLines",
+        "title": "Raven: Terminal - Run Downward Lines"
+      },
+      {
+        "command": "raven.terminal.sourceFile",
+        "title": "Raven: Terminal - Source File"
       }
     ],
     "keybindings": [
@@ -68,6 +84,10 @@
         "id": "raven.sendToR",
         "label": "Send to R",
         "icon": "$(play)"
+      },
+      {
+        "id": "raven.sendToR.terminal",
+        "label": "Terminal"
       }
     ],
     "menus": {
@@ -93,6 +113,28 @@
         },
         {
           "command": "raven.sourceFile",
+          "group": "2_file@1"
+        },
+        {
+          "submenu": "raven.sendToR.terminal",
+          "group": "3_terminal"
+        }
+      ],
+      "raven.sendToR.terminal": [
+        {
+          "command": "raven.terminal.runLineOrSelection",
+          "group": "1_run@1"
+        },
+        {
+          "command": "raven.terminal.runUpwardLines",
+          "group": "1_run@2"
+        },
+        {
+          "command": "raven.terminal.runDownwardLines",
+          "group": "1_run@3"
+        },
+        {
+          "command": "raven.terminal.sourceFile",
           "group": "2_file@1"
         }
       ]

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -218,10 +218,11 @@
           "type": "string",
           "enum": [
             "R",
+            "arf",
             "radian"
           ],
           "default": "R",
-          "description": "Program to use for the R terminal. 'R' uses the standard R console, 'radian' uses the radian console (must be installed separately)."
+          "description": "Program to use for the R terminal. 'R' is the standard R console; 'arf' and 'radian' are modern third-party R consoles (must be installed separately)."
         },
         "raven.sendToR.advanceCursorOnSend": {
           "type": "boolean",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -18,7 +18,8 @@
   "activationEvents": [
     "onLanguage:r",
     "onLanguage:jags",
-    "onLanguage:stan"
+    "onLanguage:stan",
+    "onTerminalProfile:raven.rTerminal"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -30,8 +31,80 @@
       {
         "command": "raven.refreshPackages",
         "title": "Raven: Refresh package cache"
+      },
+      {
+        "command": "raven.runLineOrSelection",
+        "title": "Raven: Run Line or Selection"
+      },
+      {
+        "command": "raven.runUpwardLines",
+        "title": "Raven: Run Upward Lines"
+      },
+      {
+        "command": "raven.runDownwardLines",
+        "title": "Raven: Run Downward Lines"
+      },
+      {
+        "command": "raven.sourceFile",
+        "title": "Raven: Source File"
       }
     ],
+    "keybindings": [
+      {
+        "command": "raven.runLineOrSelection",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && editorLangId == r"
+      },
+      {
+        "command": "raven.sourceFile",
+        "key": "shift+ctrl+enter",
+        "mac": "shift+cmd+enter",
+        "when": "editorTextFocus && editorLangId == r"
+      }
+    ],
+    "submenus": [
+      {
+        "id": "raven.sendToR",
+        "label": "Send to R",
+        "icon": "$(play)"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "submenu": "raven.sendToR",
+          "when": "editorLangId == r",
+          "group": "navigation"
+        }
+      ],
+      "raven.sendToR": [
+        {
+          "command": "raven.runLineOrSelection",
+          "group": "1_run@1"
+        },
+        {
+          "command": "raven.runUpwardLines",
+          "group": "1_run@2"
+        },
+        {
+          "command": "raven.runDownwardLines",
+          "group": "1_run@3"
+        },
+        {
+          "command": "raven.sourceFile",
+          "group": "2_file@1"
+        }
+      ]
+    },
+    "terminal": {
+      "profiles": [
+        {
+          "id": "raven.rTerminal",
+          "title": "R"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "r",
@@ -99,6 +172,20 @@
       "type": "object",
       "title": "Raven",
       "properties": {
+        "raven.rTerminal.program": {
+          "type": "string",
+          "enum": [
+            "R",
+            "radian"
+          ],
+          "default": "R",
+          "description": "Program to use for the R terminal. 'R' uses the standard R console, 'radian' uses the radian console (must be installed separately)."
+        },
+        "raven.sendToR.advanceCursorOnSend": {
+          "type": "boolean",
+          "default": true,
+          "description": "Advance cursor to the next line after sending a single statement to R."
+        },
         "raven.server.path": {
           "type": "string",
           "default": "",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -300,7 +300,7 @@ function checkRExtensionConflict(context: vscode.ExtensionContext) {
     if (!rExt) return;
 
     vscode.window.showInformationMessage(
-        'Both Raven and REditorSupport (R) are installed. They share the Cmd+Enter / Ctrl+Enter keybinding for sending code to R. You may want to disable one extension\'s keybindings to avoid conflicts.',
+        'Both Raven and REditorSupport (R) are installed with the same Cmd+Enter / Ctrl+Enter keybinding. Only one will handle the shortcut, but which one depends on load order. You can control this in the Keybindings editor.',
         'Got it',
         'Don\'t show again'
     ).then(choice => {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -19,6 +19,7 @@ import {
     shouldTriggerDirectivePathSuggest,
     shouldTriggerNestedPathSuggest,
 } from './pathCompletionTriggers';
+import { register_r_terminal, register_send_to_r_commands } from './send-to-r';
 
 /**
  * Read all raven.* settings from VS Code configuration and construct
@@ -162,6 +163,13 @@ export function activate(context: vscode.ExtensionContext) {
     // Register auto-close pair overtype fix
     context.subscriptions.push(registerAutoCloseFix());
 
+    // Register R terminal and send-to-R commands
+    register_r_terminal(context);
+    register_send_to_r_commands(context);
+
+    // Warn if REditorSupport is also installed (keybinding conflict)
+    checkRExtensionConflict(context);
+
     // Register activity signal listeners for cross-file revalidation prioritization
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(() => {
@@ -281,6 +289,25 @@ async function ensureWordSeparators(wordSeparators: string) {
             await config.update(`[${languageId}]`, updatedLanguageConfig, vscode.ConfigurationTarget.Global);
         }
     }
+}
+
+const R_EXTENSION_CONFLICT_DISMISSED = 'raven.rExtensionConflictDismissed';
+
+function checkRExtensionConflict(context: vscode.ExtensionContext) {
+    if (context.globalState.get<boolean>(R_EXTENSION_CONFLICT_DISMISSED)) return;
+
+    const rExt = vscode.extensions.getExtension('REditorSupport.r');
+    if (!rExt) return;
+
+    vscode.window.showInformationMessage(
+        'Both Raven and REditorSupport (R) are installed. They share the Cmd+Enter / Ctrl+Enter keybinding for sending code to R. You may want to disable one extension\'s keybindings to avoid conflicts.',
+        'Got it',
+        'Don\'t show again'
+    ).then(choice => {
+        if (choice === 'Don\'t show again') {
+            context.globalState.update(R_EXTENSION_CONFLICT_DISMISSED, true);
+        }
+    });
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -32,11 +32,6 @@ function advance_cursor(
     editor.revealRange(new vscode.Range(pos, pos));
 }
 
-function is_radian(): boolean {
-    const config = vscode.workspace.getConfiguration('raven.rTerminal');
-    return config.get<string>('program', 'R') === 'radian';
-}
-
 async function handle_send(mode: SendMode): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -32,50 +32,49 @@ function advance_cursor(
     editor.revealRange(new vscode.Range(pos, pos));
 }
 
-async function handle_send(mode: SendMode): Promise<void> {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) return;
-
+async function compute_send_payload(
+    editor: vscode.TextEditor,
+    mode: SendMode,
+): Promise<{ code: string; advance_to_line: number | null }> {
     const document = editor.document;
-    let code: string;
-    let statement_end_line: number | null = null;
 
     if (mode === 'file') {
         if (document.isDirty) {
             await document.save();
         }
-        const fsPath = document.uri.fsPath.replace(/\\/g, '/').replace(/"/g, '\\"');
-        code = `source("${fsPath}", echo = TRUE)`;
-    } else if (mode === 'statement') {
-        if (!editor.selection.isEmpty) {
-            code = document.getText(editor.selection);
-        } else {
-            const lines = get_lines(document);
-            const bounds = detect_r_statement(lines, editor.selection.active.line);
-            const selected: string[] = [];
-            for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-                selected.push(lines[i]);
-            }
-            code = selected.join('\n');
-            statement_end_line = bounds.end_line;
-        }
-    } else if (mode === 'upward') {
-        const lines = get_lines(document);
-        const bounds = get_upward_bounds(lines, editor.selection.active.line);
-        const selected: string[] = [];
-        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-            selected.push(lines[i]);
-        }
-        code = selected.join('\n');
-    } else {
-        const lines = get_lines(document);
-        const bounds = get_downward_bounds(lines, editor.selection.active.line);
-        const selected: string[] = [];
-        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-            selected.push(lines[i]);
-        }
-        code = selected.join('\n');
+        return {
+            code: `source(${JSON.stringify(document.uri.fsPath)}, echo = TRUE)`,
+            advance_to_line: null,
+        };
     }
+
+    if (mode === 'statement') {
+        if (!editor.selection.isEmpty) {
+            return { code: document.getText(editor.selection), advance_to_line: null };
+        }
+        const lines = get_lines(document);
+        const bounds = detect_r_statement(lines, editor.selection.active.line);
+        return {
+            code: lines.slice(bounds.start_line, bounds.end_line + 1).join('\n'),
+            advance_to_line: bounds.end_line,
+        };
+    }
+
+    const lines = get_lines(document);
+    const bounds = mode === 'upward'
+        ? get_upward_bounds(lines, editor.selection.active.line)
+        : get_downward_bounds(lines, editor.selection.active.line);
+    return {
+        code: lines.slice(bounds.start_line, bounds.end_line + 1).join('\n'),
+        advance_to_line: null,
+    };
+}
+
+async function handle_send(mode: SendMode): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const { code, advance_to_line } = await compute_send_payload(editor, mode);
 
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
@@ -86,8 +85,8 @@ async function handle_send(mode: SendMode): Promise<void> {
         terminal.sendText(code);
     }
 
-    if (statement_end_line !== null) {
-        advance_cursor(editor, statement_end_line);
+    if (advance_to_line !== null) {
+        advance_cursor(editor, advance_to_line);
     }
 }
 
@@ -101,62 +100,30 @@ async function handle_terminal_send(mode: SendMode): Promise<void> {
         return;
     }
 
-    const document = editor.document;
-    let code: string;
-    let statement_end_line: number | null = null;
+    const { code, advance_to_line } = await compute_send_payload(editor, mode);
 
     if (mode === 'file') {
-        if (document.isDirty) {
-            await document.save();
-        }
-        const fsPath = document.uri.fsPath.replace(/\\/g, '/').replace(/"/g, '\\"');
-        code = `source("${fsPath}", echo = TRUE)`;
         terminal.sendText(code);
-    } else if (mode === 'statement') {
-        if (!editor.selection.isEmpty) {
-            code = document.getText(editor.selection);
-        } else {
-            const lines = get_lines(document);
-            const bounds = detect_r_statement(lines, editor.selection.active.line);
-            const selected: string[] = [];
-            for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-                selected.push(lines[i]);
-            }
-            code = selected.join('\n');
-            statement_end_line = bounds.end_line;
-        }
-        send_via_tempfile(terminal, code);
-    } else if (mode === 'upward') {
-        const lines = get_lines(document);
-        const bounds = get_upward_bounds(lines, editor.selection.active.line);
-        const selected: string[] = [];
-        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-            selected.push(lines[i]);
-        }
-        code = selected.join('\n');
-        send_via_tempfile(terminal, code);
     } else {
-        const lines = get_lines(document);
-        const bounds = get_downward_bounds(lines, editor.selection.active.line);
-        const selected: string[] = [];
-        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
-            selected.push(lines[i]);
-        }
-        code = selected.join('\n');
         send_via_tempfile(terminal, code);
     }
 
     terminal.show(true);
 
-    if (statement_end_line !== null) {
-        advance_cursor(editor, statement_end_line);
+    if (advance_to_line !== null) {
+        advance_cursor(editor, advance_to_line);
     }
 }
 
 function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
     const tmp = create_temp_file(code);
-    const escaped = tmp.replace(/\\/g, '/').replace(/"/g, '\\"');
-    terminal.sendText(`source("${escaped}", echo = TRUE)`);
+    // Have R unlink the file as part of consuming it, so cleanup is tied to
+    // execution rather than a wall-clock timer. The JS fallback below only
+    // runs if R never reaches the source() line (e.g. session crashed).
+    const path_literal = JSON.stringify(tmp);
+    terminal.sendText(
+        `local({ .raven_src <- ${path_literal}; on.exit(unlink(.raven_src)); source(.raven_src, echo = TRUE) })`
+    );
     schedule_temp_file_cleanup(tmp);
 }
 

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import {
+    detect_r_statement,
+    get_upward_bounds,
+    get_downward_bounds,
+} from './statement-detector';
+import { get_or_create_r_terminal } from './r-terminal-manager';
+
+type SendMode = 'statement' | 'upward' | 'downward' | 'file';
+
+function get_lines(document: vscode.TextDocument): string[] {
+    const lines: string[] = [];
+    for (let i = 0; i < document.lineCount; i++) {
+        lines.push(document.lineAt(i).text);
+    }
+    return lines;
+}
+
+function advance_cursor(
+    editor: vscode.TextEditor,
+    end_line: number
+): void {
+    const config = vscode.workspace.getConfiguration('raven.sendToR');
+    if (!config.get<boolean>('advanceCursorOnSend', true)) return;
+
+    const next = end_line + 1;
+    if (next >= editor.document.lineCount) return;
+
+    const pos = new vscode.Position(next, 0);
+    editor.selection = new vscode.Selection(pos, pos);
+    editor.revealRange(new vscode.Range(pos, pos));
+}
+
+function is_radian(): boolean {
+    const config = vscode.workspace.getConfiguration('raven.rTerminal');
+    return config.get<string>('program', 'R') === 'radian';
+}
+
+function send_to_terminal(terminal: vscode.Terminal, code: string): void {
+    if (is_radian() && code.includes('\n')) {
+        // Bracketed paste mode for radian multi-line support
+        terminal.sendText(`\x1b[200~${code}\x1b[201~`, false);
+    } else {
+        terminal.sendText(code);
+    }
+}
+
+async function handle_send(mode: SendMode): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    let code: string;
+    let statement_end_line: number | null = null;
+
+    if (mode === 'file') {
+        if (document.isDirty) {
+            await document.save();
+        }
+        const fsPath = document.uri.fsPath.replace(/\\/g, '/').replace(/"/g, '\\"');
+        code = `source("${fsPath}", echo = TRUE)`;
+    } else if (mode === 'statement') {
+        if (!editor.selection.isEmpty) {
+            code = document.getText(editor.selection);
+        } else {
+            const lines = get_lines(document);
+            const bounds = detect_r_statement(lines, editor.selection.active.line);
+            const selected: string[] = [];
+            for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+                selected.push(lines[i]);
+            }
+            code = selected.join('\n');
+            statement_end_line = bounds.end_line;
+        }
+    } else if (mode === 'upward') {
+        const lines = get_lines(document);
+        const bounds = get_upward_bounds(lines, editor.selection.active.line);
+        const selected: string[] = [];
+        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+            selected.push(lines[i]);
+        }
+        code = selected.join('\n');
+    } else {
+        const lines = get_lines(document);
+        const bounds = get_downward_bounds(lines, editor.selection.active.line);
+        const selected: string[] = [];
+        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+            selected.push(lines[i]);
+        }
+        code = selected.join('\n');
+    }
+
+    const terminal = await get_or_create_r_terminal();
+    terminal.show(true);
+    send_to_terminal(terminal, code);
+
+    if (statement_end_line !== null) {
+        advance_cursor(editor, statement_end_line);
+    }
+}
+
+export function register_send_to_r_commands(
+    context: vscode.ExtensionContext
+): void {
+    const commands: Array<[string, SendMode]> = [
+        ['raven.runLineOrSelection', 'statement'],
+        ['raven.runUpwardLines', 'upward'],
+        ['raven.runDownwardLines', 'downward'],
+        ['raven.sourceFile', 'file'],
+    ];
+
+    for (const [id, mode] of commands) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(id, () => handle_send(mode))
+        );
+    }
+}

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -5,6 +5,7 @@ import {
     get_downward_bounds,
 } from './statement-detector';
 import { get_or_create_r_terminal } from './r-terminal-manager';
+import { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
 
 type SendMode = 'statement' | 'upward' | 'downward' | 'file';
 
@@ -99,6 +100,75 @@ async function handle_send(mode: SendMode): Promise<void> {
     }
 }
 
+async function handle_terminal_send(mode: SendMode): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const terminal = vscode.window.activeTerminal;
+    if (!terminal) {
+        vscode.window.showErrorMessage('No active terminal. Open a terminal first.');
+        return;
+    }
+
+    const document = editor.document;
+    let code: string;
+    let statement_end_line: number | null = null;
+
+    if (mode === 'file') {
+        if (document.isDirty) {
+            await document.save();
+        }
+        const fsPath = document.uri.fsPath.replace(/\\/g, '/').replace(/"/g, '\\"');
+        code = `source("${fsPath}", echo = TRUE)`;
+        terminal.sendText(code);
+    } else if (mode === 'statement') {
+        if (!editor.selection.isEmpty) {
+            code = document.getText(editor.selection);
+        } else {
+            const lines = get_lines(document);
+            const bounds = detect_r_statement(lines, editor.selection.active.line);
+            const selected: string[] = [];
+            for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+                selected.push(lines[i]);
+            }
+            code = selected.join('\n');
+            statement_end_line = bounds.end_line;
+        }
+        send_via_tempfile(terminal, code);
+    } else if (mode === 'upward') {
+        const lines = get_lines(document);
+        const bounds = get_upward_bounds(lines, editor.selection.active.line);
+        const selected: string[] = [];
+        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+            selected.push(lines[i]);
+        }
+        code = selected.join('\n');
+        send_via_tempfile(terminal, code);
+    } else {
+        const lines = get_lines(document);
+        const bounds = get_downward_bounds(lines, editor.selection.active.line);
+        const selected: string[] = [];
+        for (let i = bounds.start_line; i <= bounds.end_line; i++) {
+            selected.push(lines[i]);
+        }
+        code = selected.join('\n');
+        send_via_tempfile(terminal, code);
+    }
+
+    terminal.show(true);
+
+    if (statement_end_line !== null) {
+        advance_cursor(editor, statement_end_line);
+    }
+}
+
+function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
+    const tmp = create_temp_file(code);
+    const escaped = tmp.replace(/\\/g, '/').replace(/"/g, '\\"');
+    terminal.sendText(`source("${escaped}", echo = TRUE)`);
+    schedule_temp_file_cleanup(tmp);
+}
+
 export function register_send_to_r_commands(
     context: vscode.ExtensionContext
 ): void {
@@ -112,6 +182,20 @@ export function register_send_to_r_commands(
     for (const [id, mode] of commands) {
         context.subscriptions.push(
             vscode.commands.registerCommand(id, () => handle_send(mode))
+        );
+    }
+
+    // Terminal submenu: send to active terminal via tempfile
+    const terminal_commands: Array<[string, SendMode]> = [
+        ['raven.terminal.runLineOrSelection', 'statement'],
+        ['raven.terminal.runUpwardLines', 'upward'],
+        ['raven.terminal.runDownwardLines', 'downward'],
+        ['raven.terminal.sourceFile', 'file'],
+    ];
+
+    for (const [id, mode] of terminal_commands) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(id, () => handle_terminal_send(mode))
         );
     }
 }

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -35,13 +35,15 @@ function advance_cursor(
 async function compute_send_payload(
     editor: vscode.TextEditor,
     mode: SendMode,
-): Promise<{ code: string; advance_to_line: number | null }> {
+): Promise<{ code: string; advance_to_line: number | null } | null> {
     const document = editor.document;
 
     if (mode === 'file') {
-        if (document.isDirty) {
-            await document.save();
+        if (document.isUntitled || document.isDirty) {
+            const saved = await document.save();
+            if (!saved) return null;
         }
+        if (document.isUntitled) return null;
         return {
             code: `source(${JSON.stringify(document.uri.fsPath)}, echo = TRUE)`,
             advance_to_line: null,
@@ -74,7 +76,9 @@ async function handle_send(mode: SendMode): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
 
-    const { code, advance_to_line } = await compute_send_payload(editor, mode);
+    const payload = await compute_send_payload(editor, mode);
+    if (!payload) return;
+    const { code, advance_to_line } = payload;
 
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
@@ -100,15 +104,17 @@ async function handle_terminal_send(mode: SendMode): Promise<void> {
         return;
     }
 
-    const { code, advance_to_line } = await compute_send_payload(editor, mode);
+    const payload = await compute_send_payload(editor, mode);
+    if (!payload) return;
+    const { code, advance_to_line } = payload;
+
+    terminal.show(true);
 
     if (mode === 'file') {
         terminal.sendText(code);
     } else {
         send_via_tempfile(terminal, code);
     }
-
-    terminal.show(true);
 
     if (advance_to_line !== null) {
         advance_cursor(editor, advance_to_line);

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -37,15 +37,6 @@ function is_radian(): boolean {
     return config.get<string>('program', 'R') === 'radian';
 }
 
-function send_to_terminal(terminal: vscode.Terminal, code: string): void {
-    if (is_radian() && code.includes('\n')) {
-        // Bracketed paste mode for radian multi-line support
-        terminal.sendText(`\x1b[200~${code}\x1b[201~`, false);
-    } else {
-        terminal.sendText(code);
-    }
-}
-
 async function handle_send(mode: SendMode): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
@@ -93,7 +84,12 @@ async function handle_send(mode: SendMode): Promise<void> {
 
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
-    send_to_terminal(terminal, code);
+
+    if (code.includes('\n')) {
+        send_via_tempfile(terminal, code);
+    } else {
+        terminal.sendText(code);
+    }
 
     if (statement_end_line !== null) {
         advance_cursor(editor, statement_end_line);

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -2,7 +2,6 @@ export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-mana
 export { register_send_to_r_commands } from './commands';
 export { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
 export {
-    StatementBounds,
     detect_r_statement,
     get_upward_bounds,
     get_downward_bounds,
@@ -10,3 +9,4 @@ export {
     is_r_line_continuation,
     strip_strings_and_comments,
 } from './statement-detector';
+export type { StatementBounds } from './statement-detector';

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -1,5 +1,6 @@
 export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-manager';
 export { register_send_to_r_commands } from './commands';
+export { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
 export {
     StatementBounds,
     detect_r_statement,

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -1,0 +1,11 @@
+export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-manager';
+export { register_send_to_r_commands } from './commands';
+export {
+    StatementBounds,
+    detect_r_statement,
+    get_upward_bounds,
+    get_downward_bounds,
+    is_r_line_incomplete,
+    is_r_line_continuation,
+    strip_strings_and_comments,
+} from './statement-detector';

--- a/editors/vscode/src/send-to-r/r-terminal-manager.ts
+++ b/editors/vscode/src/send-to-r/r-terminal-manager.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode';
+
+const PROFILE_ID = 'raven.rTerminal';
+const TERMINAL_NAME = 'R (Raven)';
+
+const profile_terminals = new Set<vscode.Terminal>();
+let last_active_terminal: vscode.Terminal | null = null;
+let creation_in_flight: Promise<vscode.Terminal> | null = null;
+let pending_profile_creation_count = 0;
+
+function get_program(): string {
+    const config = vscode.workspace.getConfiguration('raven.rTerminal');
+    return config.get<string>('program', 'R');
+}
+
+function handle_terminal_opened(terminal: vscode.Terminal): void {
+    if (
+        pending_profile_creation_count > 0
+        && terminal.name === TERMINAL_NAME
+        && !profile_terminals.has(terminal)
+    ) {
+        pending_profile_creation_count--;
+        profile_terminals.add(terminal);
+        last_active_terminal = terminal;
+    }
+}
+
+function handle_terminal_closed(terminal: vscode.Terminal): void {
+    profile_terminals.delete(terminal);
+    if (last_active_terminal === terminal) {
+        last_active_terminal = null;
+        for (const t of profile_terminals) {
+            last_active_terminal = t;
+        }
+    }
+}
+
+function handle_active_terminal_changed(
+    terminal: vscode.Terminal | undefined
+): void {
+    if (terminal && profile_terminals.has(terminal)) {
+        last_active_terminal = terminal;
+    }
+}
+
+export function register_r_terminal(
+    context: vscode.ExtensionContext
+): void {
+    const provider: vscode.TerminalProfileProvider = {
+        async provideTerminalProfile(
+            _token: vscode.CancellationToken
+        ): Promise<vscode.TerminalProfile> {
+            pending_profile_creation_count++;
+            return new vscode.TerminalProfile({
+                name: TERMINAL_NAME,
+                shellPath: get_program(),
+                shellArgs: ['--no-save', '--no-restore'],
+            });
+        }
+    };
+
+    context.subscriptions.push(
+        vscode.window.registerTerminalProfileProvider(PROFILE_ID, provider),
+        vscode.window.onDidOpenTerminal(handle_terminal_opened),
+        vscode.window.onDidCloseTerminal(handle_terminal_closed),
+        vscode.window.onDidChangeActiveTerminal(handle_active_terminal_changed),
+        vscode.workspace.onDidChangeConfiguration(event => {
+            if (event.affectsConfiguration('raven.rTerminal.program')) {
+                // Clear tracked terminal so next send creates one with the new program
+                last_active_terminal = null;
+            }
+        }),
+    );
+}
+
+export async function get_or_create_r_terminal(): Promise<vscode.Terminal> {
+    if (last_active_terminal) {
+        return last_active_terminal;
+    }
+    if (creation_in_flight) {
+        return creation_in_flight;
+    }
+    creation_in_flight = create_r_terminal().finally(() => {
+        creation_in_flight = null;
+    });
+    return creation_in_flight;
+}
+
+async function create_r_terminal(): Promise<vscode.Terminal> {
+    const terminal = vscode.window.createTerminal({
+        name: TERMINAL_NAME,
+        shellPath: get_program(),
+        shellArgs: ['--no-save', '--no-restore'],
+    });
+    profile_terminals.add(terminal);
+    last_active_terminal = terminal;
+    return terminal;
+}

--- a/editors/vscode/src/send-to-r/r-terminal-manager.ts
+++ b/editors/vscode/src/send-to-r/r-terminal-manager.ts
@@ -48,14 +48,18 @@ export function register_r_terminal(
 ): void {
     const provider: vscode.TerminalProfileProvider = {
         async provideTerminalProfile(
-            _token: vscode.CancellationToken
+            token: vscode.CancellationToken
         ): Promise<vscode.TerminalProfile> {
-            pending_profile_creation_count++;
-            return new vscode.TerminalProfile({
+            if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
+            }
+            const profile = new vscode.TerminalProfile({
                 name: TERMINAL_NAME,
                 shellPath: get_program(),
                 shellArgs: ['--no-save', '--no-restore'],
             });
+            pending_profile_creation_count++;
+            return profile;
         }
     };
 
@@ -66,7 +70,10 @@ export function register_r_terminal(
         vscode.window.onDidChangeActiveTerminal(handle_active_terminal_changed),
         vscode.workspace.onDidChangeConfiguration(event => {
             if (event.affectsConfiguration('raven.rTerminal.program')) {
-                // Clear tracked terminal so next send creates one with the new program
+                // Untrack existing terminals so the next send spawns one with the
+                // new program. Terminals are left alive so the user can finish
+                // whatever they were doing in them.
+                profile_terminals.clear();
                 last_active_terminal = null;
             }
         }),

--- a/editors/vscode/src/send-to-r/statement-detector.ts
+++ b/editors/vscode/src/send-to-r/statement-detector.ts
@@ -1,0 +1,202 @@
+/**
+ * R multi-line statement detection.
+ * Pure functions (no VS Code dependency) so they can be unit tested.
+ *
+ * An R expression is incomplete when:
+ * - Brackets/parens/braces are unmatched
+ * - Line ends with a binary operator (+, -, *, /, |>, %>%, %any%, ||, &&, |, &, ~, =, <-, ->, ,, ::, :::)
+ * - Line ends with an opening bracket/paren/brace
+ * - Next line starts with a pipe, closing bracket, or binary operator continuation
+ */
+
+export interface StatementBounds {
+    start_line: number;  // 0-indexed, inclusive
+    end_line: number;    // 0-indexed, inclusive
+}
+
+/**
+ * Trailing operators that signal the expression continues on the next line.
+ * Order matters: longer patterns must come before shorter ones that are prefixes.
+ */
+const TRAILING_OPERATORS = [
+    '|>', '%>%', ':::', '::', '||', '&&', '<<-', '->>',
+    '<-', '->',  '<=', '>=', '==', '!=',
+    '+', '-', '*', '/', '^', '~', ',', '|', '&', '=',
+    '<', '>',
+];
+
+/**
+ * Leading tokens that signal this line continues a previous expression.
+ */
+const LEADING_CONTINUATION_RE = /^\s*(\|>|%>%|%[^%]+%|\)|\]|\}|\+|-|\*|\/|\^|~|\||&|,)/;
+
+/**
+ * Strip comments and strings from a line to avoid false positives.
+ * Returns the "code-only" content for bracket/operator analysis.
+ */
+export function strip_strings_and_comments(line: string): string {
+    let result = '';
+    let i = 0;
+    while (i < line.length) {
+        const ch = line[i];
+        if (ch === '#') {
+            break; // rest is comment
+        }
+        if (ch === '"' || ch === "'") {
+            // skip string
+            const quote = ch;
+            i++;
+            while (i < line.length) {
+                if (line[i] === '\\') {
+                    i += 2;
+                } else if (line[i] === quote) {
+                    i++;
+                    break;
+                } else {
+                    i++;
+                }
+            }
+            result += '""'; // placeholder
+        } else if (ch === '`') {
+            // skip backtick-quoted name
+            i++;
+            while (i < line.length && line[i] !== '`') {
+                i++;
+            }
+            i++; // skip closing backtick
+            result += '``';
+        } else {
+            result += ch;
+            i++;
+        }
+    }
+    return result;
+}
+
+/**
+ * Count net open brackets in a code line (after stripping strings/comments).
+ */
+function net_open_brackets(code: string): number {
+    let count = 0;
+    for (const ch of code) {
+        if (ch === '(' || ch === '[' || ch === '{') count++;
+        else if (ch === ')' || ch === ']' || ch === '}') count--;
+    }
+    return count;
+}
+
+/**
+ * Check if a line's expression is incomplete (continues on the next line).
+ */
+export function is_r_line_incomplete(line: string): boolean {
+    const code = strip_strings_and_comments(line);
+    const trimmed = code.trimEnd();
+    if (trimmed.length === 0) return false;
+
+    // Unmatched open brackets
+    if (net_open_brackets(code) > 0) return true;
+
+    // Ends with a trailing operator
+    for (const op of TRAILING_OPERATORS) {
+        if (trimmed.endsWith(op)) return true;
+    }
+
+    // Ends with an opening bracket (block/call continues on next line)
+    const last_char = trimmed[trimmed.length - 1];
+    if (last_char === '(' || last_char === '[' || last_char === '{') return true;
+
+    // Ends with %infix% operator
+    if (/%.+%\s*$/.test(trimmed)) return true;
+
+    return false;
+}
+
+/**
+ * Check if a line is a continuation of a previous expression.
+ */
+export function is_r_line_continuation(line: string): boolean {
+    return LEADING_CONTINUATION_RE.test(line);
+}
+
+/**
+ * Detect the full statement bounds around the cursor line.
+ * Walks upward while previous lines are incomplete or current line is a continuation,
+ * then walks downward while current line is incomplete or next line is a continuation.
+ */
+export function detect_r_statement(
+    lines: string[],
+    cursor_line: number
+): StatementBounds {
+    let start_line = cursor_line;
+    let end_line = cursor_line;
+
+    // Walk upward
+    while (start_line > 0) {
+        const prev = lines[start_line - 1];
+        const curr = lines[start_line];
+        if (is_r_line_incomplete(prev) || is_r_line_continuation(curr)) {
+            start_line--;
+        } else {
+            break;
+        }
+    }
+
+    // Walk downward
+    while (end_line < lines.length - 1) {
+        const curr = lines[end_line];
+        const next = lines[end_line + 1];
+        if (is_r_line_incomplete(curr) || is_r_line_continuation(next)) {
+            end_line++;
+        } else {
+            break;
+        }
+    }
+
+    return { start_line, end_line };
+}
+
+/**
+ * Get bounds from start of file to cursor (extending to complete the statement).
+ */
+export function get_upward_bounds(
+    lines: string[],
+    cursor_line: number
+): StatementBounds {
+    let end_line = cursor_line;
+
+    // Extend downward to complete the statement at cursor
+    while (end_line < lines.length - 1) {
+        const curr = lines[end_line];
+        const next = lines[end_line + 1];
+        if (is_r_line_incomplete(curr) || is_r_line_continuation(next)) {
+            end_line++;
+        } else {
+            break;
+        }
+    }
+
+    return { start_line: 0, end_line };
+}
+
+/**
+ * Get bounds from cursor to end of file (extending upward to include statement start).
+ */
+export function get_downward_bounds(
+    lines: string[],
+    cursor_line: number
+): StatementBounds {
+    let start_line = cursor_line;
+
+    // Extend upward to find statement start
+    while (start_line > 0) {
+        const prev = lines[start_line - 1];
+        const curr = lines[start_line];
+        if (is_r_line_incomplete(prev) || is_r_line_continuation(curr)) {
+            start_line--;
+        } else {
+            break;
+        }
+    }
+
+    return { start_line, end_line: lines.length - 1 };
+}

--- a/editors/vscode/src/send-to-r/temp-file.ts
+++ b/editors/vscode/src/send-to-r/temp-file.ts
@@ -2,13 +2,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-const CLEANUP_DELAY_MS = 5000;
+// Long fallback only — primary cleanup is R's own on.exit(unlink(...)) inside
+// the source() wrapper. This timer catches the case where R never reaches the
+// source line at all (session crashed before reading it).
+const CLEANUP_DELAY_MS = 120_000;
 let counter = 0;
 
 export function create_temp_file(content: string): string {
     const tmp_dir = os.tmpdir();
     const file_path = path.join(tmp_dir, `raven_send_${Date.now()}_${counter++}.R`);
-    fs.writeFileSync(file_path, content, 'utf8');
+    fs.writeFileSync(file_path, content, { encoding: 'utf8', mode: 0o600 });
     return file_path;
 }
 

--- a/editors/vscode/src/send-to-r/temp-file.ts
+++ b/editors/vscode/src/send-to-r/temp-file.ts
@@ -3,10 +3,11 @@ import * as path from 'path';
 import * as os from 'os';
 
 const CLEANUP_DELAY_MS = 5000;
+let counter = 0;
 
 export function create_temp_file(content: string): string {
     const tmp_dir = os.tmpdir();
-    const file_path = path.join(tmp_dir, `raven_send_${Date.now()}.R`);
+    const file_path = path.join(tmp_dir, `raven_send_${Date.now()}_${counter++}.R`);
     fs.writeFileSync(file_path, content, 'utf8');
     return file_path;
 }

--- a/editors/vscode/src/send-to-r/temp-file.ts
+++ b/editors/vscode/src/send-to-r/temp-file.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const CLEANUP_DELAY_MS = 5000;
+
+export function create_temp_file(content: string): string {
+    const tmp_dir = os.tmpdir();
+    const file_path = path.join(tmp_dir, `raven_send_${Date.now()}.R`);
+    fs.writeFileSync(file_path, content, 'utf8');
+    return file_path;
+}
+
+export function schedule_temp_file_cleanup(file_path: string): void {
+    setTimeout(() => {
+        try { fs.unlinkSync(file_path); } catch {}
+    }, CLEANUP_DELAY_MS);
+}

--- a/tests/bun/statement-detector.test.ts
+++ b/tests/bun/statement-detector.test.ts
@@ -1,0 +1,288 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    strip_strings_and_comments,
+    is_r_line_incomplete,
+    is_r_line_continuation,
+    detect_r_statement,
+    get_upward_bounds,
+    get_downward_bounds,
+} from '../../editors/vscode/src/send-to-r/statement-detector';
+
+describe('strip_strings_and_comments', () => {
+    test('removes comments', () => {
+        expect(strip_strings_and_comments('x <- 1 # comment')).toBe('x <- 1 ');
+    });
+
+    test('removes double-quoted strings', () => {
+        expect(strip_strings_and_comments('x <- "hello"')).toBe('x <- ""');
+    });
+
+    test('removes single-quoted strings', () => {
+        expect(strip_strings_and_comments("x <- 'world'")).toBe("x <- \"\"");
+    });
+
+    test('handles escaped quotes in strings', () => {
+        expect(strip_strings_and_comments('x <- "he\\"llo"')).toBe('x <- ""');
+    });
+
+    test('removes backtick-quoted names', () => {
+        expect(strip_strings_and_comments('`my var` <- 1')).toBe('`` <- 1');
+    });
+
+    test('brackets inside strings are removed', () => {
+        expect(strip_strings_and_comments('x <- "((("')).toBe('x <- ""');
+    });
+
+    test('comment character inside string is not treated as comment', () => {
+        expect(strip_strings_and_comments('x <- "# not a comment"')).toBe('x <- ""');
+    });
+});
+
+describe('is_r_line_incomplete', () => {
+    test('simple complete line', () => {
+        expect(is_r_line_incomplete('x <- 1')).toBe(false);
+    });
+
+    test('empty line', () => {
+        expect(is_r_line_incomplete('')).toBe(false);
+    });
+
+    test('comment-only line', () => {
+        expect(is_r_line_incomplete('# comment')).toBe(false);
+    });
+
+    test('trailing comma', () => {
+        expect(is_r_line_incomplete('x = foo(a,')).toBe(true);
+    });
+
+    test('trailing plus', () => {
+        expect(is_r_line_incomplete('x + ')).toBe(true);
+    });
+
+    test('trailing pipe |>', () => {
+        expect(is_r_line_incomplete('df |>')).toBe(true);
+    });
+
+    test('trailing magrittr pipe %>%', () => {
+        expect(is_r_line_incomplete('df %>%')).toBe(true);
+    });
+
+    test('trailing assignment <-', () => {
+        expect(is_r_line_incomplete('x <-')).toBe(true);
+    });
+
+    test('trailing right assignment ->', () => {
+        expect(is_r_line_incomplete('1 ->')).toBe(true);
+    });
+
+    test('trailing tilde', () => {
+        expect(is_r_line_incomplete('y ~')).toBe(true);
+    });
+
+    test('trailing double colon', () => {
+        expect(is_r_line_incomplete('dplyr::')).toBe(true);
+    });
+
+    test('trailing triple colon', () => {
+        expect(is_r_line_incomplete('pkg:::')).toBe(true);
+    });
+
+    test('unmatched open paren', () => {
+        expect(is_r_line_incomplete('foo(x,')).toBe(true);
+    });
+
+    test('unmatched open bracket', () => {
+        expect(is_r_line_incomplete('df[1,')).toBe(true);
+    });
+
+    test('unmatched open brace', () => {
+        expect(is_r_line_incomplete('if (TRUE) {')).toBe(true);
+    });
+
+    test('matched brackets are complete', () => {
+        expect(is_r_line_incomplete('foo(x, y)')).toBe(false);
+    });
+
+    test('brackets inside strings do not count', () => {
+        expect(is_r_line_incomplete('x <- "((("')).toBe(false);
+    });
+
+    test('trailing infix operator %in%', () => {
+        expect(is_r_line_incomplete('x %in%')).toBe(true);
+    });
+
+    test('trailing logical OR', () => {
+        expect(is_r_line_incomplete('x ||')).toBe(true);
+    });
+
+    test('trailing logical AND', () => {
+        expect(is_r_line_incomplete('x &&')).toBe(true);
+    });
+
+    test('trailing equals (named arg)', () => {
+        expect(is_r_line_incomplete('foo(x =')).toBe(true);
+    });
+
+    test('trailing slash (division)', () => {
+        expect(is_r_line_incomplete('x /')).toBe(true);
+    });
+
+    test('trailing caret (power)', () => {
+        expect(is_r_line_incomplete('x ^')).toBe(true);
+    });
+});
+
+describe('is_r_line_continuation', () => {
+    test('line starting with pipe', () => {
+        expect(is_r_line_continuation('  |> filter(x > 1)')).toBe(true);
+    });
+
+    test('line starting with magrittr pipe', () => {
+        expect(is_r_line_continuation('  %>% select(a)')).toBe(true);
+    });
+
+    test('line starting with closing paren', () => {
+        expect(is_r_line_continuation('  )')).toBe(true);
+    });
+
+    test('line starting with closing bracket', () => {
+        expect(is_r_line_continuation('  ]')).toBe(true);
+    });
+
+    test('line starting with closing brace', () => {
+        expect(is_r_line_continuation('}')).toBe(true);
+    });
+
+    test('line starting with plus', () => {
+        expect(is_r_line_continuation('  + geom_point()')).toBe(true);
+    });
+
+    test('line starting with comma', () => {
+        expect(is_r_line_continuation('  , y = 2')).toBe(true);
+    });
+
+    test('normal line is not continuation', () => {
+        expect(is_r_line_continuation('x <- 1')).toBe(false);
+    });
+
+    test('line starting with infix %in%', () => {
+        expect(is_r_line_continuation('  %in% c(1,2)')).toBe(true);
+    });
+});
+
+describe('detect_r_statement', () => {
+    test('single line statement', () => {
+        const lines = ['x <- 1', 'y <- 2', 'z <- 3'];
+        expect(detect_r_statement(lines, 1)).toEqual({ start_line: 1, end_line: 1 });
+    });
+
+    test('multi-line function call (unmatched paren)', () => {
+        const lines = [
+            'result <- foo(',
+            '  x = 1,',
+            '  y = 2',
+            ')',
+            'next_line <- 3',
+        ];
+        expect(detect_r_statement(lines, 0)).toEqual({ start_line: 0, end_line: 3 });
+        expect(detect_r_statement(lines, 2)).toEqual({ start_line: 0, end_line: 3 });
+    });
+
+    test('pipe chain', () => {
+        const lines = [
+            'df |>',
+            '  filter(x > 1) |>',
+            '  select(a, b)',
+            'other <- 1',
+        ];
+        expect(detect_r_statement(lines, 0)).toEqual({ start_line: 0, end_line: 2 });
+        expect(detect_r_statement(lines, 1)).toEqual({ start_line: 0, end_line: 2 });
+        expect(detect_r_statement(lines, 2)).toEqual({ start_line: 0, end_line: 2 });
+    });
+
+    test('ggplot with + continuation', () => {
+        const lines = [
+            'ggplot(df, aes(x, y)) +',
+            '  geom_point() +',
+            '  theme_minimal()',
+            '',
+        ];
+        expect(detect_r_statement(lines, 0)).toEqual({ start_line: 0, end_line: 2 });
+    });
+
+    test('cursor on continuation line finds full statement', () => {
+        const lines = [
+            'x <- foo(',
+            '  bar',
+            ')',
+        ];
+        expect(detect_r_statement(lines, 2)).toEqual({ start_line: 0, end_line: 2 });
+    });
+
+    test('if/else block', () => {
+        const lines = [
+            'if (condition) {',
+            '  x <- 1',
+            '} else {',
+            '  x <- 2',
+            '}',
+        ];
+        expect(detect_r_statement(lines, 0)).toEqual({ start_line: 0, end_line: 4 });
+    });
+
+    test('trailing assignment', () => {
+        const lines = [
+            'result <-',
+            '  compute_value()',
+            'next <- 1',
+        ];
+        expect(detect_r_statement(lines, 0)).toEqual({ start_line: 0, end_line: 1 });
+    });
+
+    test('magrittr pipe chain', () => {
+        const lines = [
+            'df %>%',
+            '  mutate(z = x + y) %>%',
+            '  filter(z > 0)',
+        ];
+        expect(detect_r_statement(lines, 1)).toEqual({ start_line: 0, end_line: 2 });
+    });
+});
+
+describe('get_upward_bounds', () => {
+    test('extends downward to complete statement', () => {
+        const lines = [
+            'a <- 1',
+            'b <- foo(',
+            '  x',
+            ')',
+            'c <- 3',
+        ];
+        // Cursor on line 1 (start of multi-line), should extend to line 3
+        expect(get_upward_bounds(lines, 1)).toEqual({ start_line: 0, end_line: 3 });
+    });
+
+    test('single line at cursor', () => {
+        const lines = ['a <- 1', 'b <- 2', 'c <- 3'];
+        expect(get_upward_bounds(lines, 1)).toEqual({ start_line: 0, end_line: 1 });
+    });
+});
+
+describe('get_downward_bounds', () => {
+    test('extends upward to find statement start', () => {
+        const lines = [
+            'a <- 1',
+            'b <- foo(',
+            '  x',
+            ')',
+            'c <- 3',
+        ];
+        // Cursor on line 2 (middle of multi-line), should extend up to line 1
+        expect(get_downward_bounds(lines, 2)).toEqual({ start_line: 1, end_line: 4 });
+    });
+
+    test('cursor at start of statement', () => {
+        const lines = ['a <- 1', 'b <- 2', 'c <- 3'];
+        expect(get_downward_bounds(lines, 1)).toEqual({ start_line: 1, end_line: 2 });
+    });
+});


### PR DESCRIPTION
Features

  - R terminal profile — Choose between R and radian via raven.rTerminal.program
  setting. Radian provides full mouse support, syntax highlighting, and multiline
  editing.
  - Send-to-R commands — Run Line or Selection, Run Upward Lines, Run Downward Lines,
  Source File
  - Smart statement detection — Automatically detects multi-line R expressions (pipe
  chains, function calls, ggplot layers, if/else blocks) and sends them as complete
  units
  - Editor toolbar menu (▶) with all commands, plus a Terminal submenu for sending to
  the active terminal
  - Keybindings — Cmd+Enter / Ctrl+Enter for Run Line or Selection, Shift+Cmd+Enter /
  Shift+Ctrl+Enter for Source File
  - Cursor advancement after single-statement sends (configurable)
  - Tempfile-based execution for multi-line code (robust over SSH)
  - REditorSupport conflict detection — one-time notification if both extensions are
  installed

  Implementation

  - Single-line statements sent via sendText() directly; multi-line code written to a
  temp file and executed via source()
  - Terminal submenu always uses tempfiles (reliable for any terminal, including over
  SSH)
  - 51 unit tests for the statement detector


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send to R workflow: interactive R console support (R/arf/radian) with a dedicated R terminal profile
  * New commands/shortcuts to run/source lines, selections, and blocks with intelligent multi-line statement detection
  * Option to advance the editor cursor after sending; startup conflict-warning for keybinding overlaps

* **Documentation**
  * Added comprehensive Send to R docs and updated feature list

* **Tests**
  * Added statement-detection test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->