### PR TITLE
feat(cross-file): detect package loads in apply-family calls (#172)

### DIFF
--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -552,6 +552,10 @@ fn visit_node_for_library(node: Node, content: &str, library_calls: &mut Vec<Lib
     if node.kind() == "call" {
         if let Some(lib_call) = try_parse_library_call(node, content) {
             library_calls.push(lib_call);
+        } else {
+            // Not a direct library/require/loadNamespace call; try the
+            // apply-family form (sapply/map/etc. of bare library/require).
+            library_calls.extend(try_parse_apply_library_call(node, content));
         }
     }
 
@@ -717,6 +721,223 @@ fn extract_package_value(node: Node, content: &str) -> Option<String> {
             None
         }
     }
+}
+
+// ============================================================================
+// Apply-Family Library Detection (issue #172)
+// ============================================================================
+
+/// Apply-family functions whose bare-identifier form may load packages
+/// dynamically when paired with `library`/`require` and `character.only = TRUE`.
+const APPLY_BARE_NAMES: &[&str] = &[
+    "sapply",
+    "lapply",
+    "vapply",
+    "mapply",
+    "map",
+    "walk",
+    "pmap",
+    "imap",
+    "iwalk",
+    "pwalk",
+    "map_chr",
+    "map_int",
+    "map_dbl",
+    "map_lgl",
+    "map_raw",
+    "map_dfr",
+    "map_dfc",
+    "map_vec",
+    "map_if",
+    "map_at",
+    "map2",
+    "map2_chr",
+    "map2_int",
+    "map2_dbl",
+    "map2_lgl",
+    "map2_dfr",
+    "map2_dfc",
+    "map2_vec",
+    "walk2",
+];
+
+/// Apply-family functions accepted under the `purrr::` namespace.
+const APPLY_PURRR_NAMES: &[&str] = &[
+    "map",
+    "walk",
+    "pmap",
+    "imap",
+    "iwalk",
+    "pwalk",
+    "map_chr",
+    "map_int",
+    "map_dbl",
+    "map_lgl",
+    "map_raw",
+    "map_dfr",
+    "map_dfc",
+    "map_vec",
+    "map_if",
+    "map_at",
+    "map2",
+    "map2_chr",
+    "map2_int",
+    "map2_dbl",
+    "map2_lgl",
+    "map2_dfr",
+    "map2_dfc",
+    "map2_vec",
+    "walk2",
+];
+
+/// Returns true when `func_node` names a base-R or purrr apply-family function
+/// supported for static library-vector detection. Accepts a bare identifier
+/// (`sapply`, `map`, ...) or a `purrr::xxx` namespace_operator.
+fn is_apply_family_function(func_node: Node, content: &str) -> bool {
+    match func_node.kind() {
+        "identifier" => {
+            let name = node_text(func_node, content);
+            APPLY_BARE_NAMES.contains(&name)
+        }
+        "namespace_operator" => {
+            let mut cursor = func_node.walk();
+            let named_children: Vec<Node> = func_node
+                .children(&mut cursor)
+                .filter(|c| c.is_named())
+                .collect();
+            if named_children.len() != 2 {
+                return false;
+            }
+            let ns = node_text(named_children[0], content);
+            let name = node_text(named_children[1], content);
+            ns == "purrr" && APPLY_PURRR_NAMES.contains(&name)
+        }
+        _ => false,
+    }
+}
+
+/// Strict variant of `extract_c_string_args`: returns `Some(packages)` only
+/// when `node` is `c(arg1, arg2, ...)` where every argument is a positional
+/// string literal and at least one argument is present. Returns `None` for any
+/// non-string element, named argument, or empty `c()` — anything but a fully
+/// static character vector is treated as dynamic.
+fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
+    if !is_c_call(node, content) {
+        return None;
+    }
+    let args_node = node.child_by_field_name("arguments")?;
+    if args_node.has_error() {
+        return None;
+    }
+    let mut strings = Vec::new();
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            return None;
+        }
+        let value_node = child.child_by_field_name("value")?;
+        if value_node.kind() != "string" {
+            return None;
+        }
+        let s = extract_string_literal(value_node, content)?;
+        strings.push(s);
+    }
+    if strings.is_empty() {
+        None
+    } else {
+        Some(strings)
+    }
+}
+
+/// Try to interpret `node` as an apply-family call that loads a static vector
+/// of packages — e.g. `sapply(c("dplyr","tidyr"), library, character.only = TRUE)`.
+///
+/// Returns one `LibraryCall` per package when:
+/// - the function is a supported apply-family name (see [`is_apply_family_function`]),
+/// - `character.only = TRUE` (or `T`) is set,
+/// - exactly one positional arg resolves to a static `Vec<String>` via inline `c(...)`,
+/// - at least one positional arg is the bare identifier `library` or `require`.
+///
+/// All emitted entries share the apply call's end position. Returns an empty
+/// vec for every other case (the caller continues recursion into children).
+fn try_parse_apply_library_call(node: Node, content: &str) -> Vec<LibraryCall> {
+    let func_node = match node.child_by_field_name("function") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if !is_apply_family_function(func_node, content) {
+        return Vec::new();
+    }
+
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if args_node.has_error() {
+        return Vec::new();
+    }
+
+    if !has_character_only_true(&args_node, content) {
+        return Vec::new();
+    }
+
+    let mut has_library_fun = false;
+    let mut packages: Option<Vec<String>> = None;
+    let mut ambiguous = false;
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            continue;
+        }
+        let value_node = match child.child_by_field_name("value") {
+            Some(n) => n,
+            None => continue,
+        };
+
+        if value_node.kind() == "identifier" {
+            let text = node_text(value_node, content);
+            if text == "library" || text == "require" {
+                has_library_fun = true;
+            }
+            continue;
+        }
+
+        if let Some(strings) = extract_c_strings_strict(value_node, content) {
+            if packages.is_some() {
+                ambiguous = true;
+            }
+            packages = Some(strings);
+        }
+    }
+
+    if !has_library_fun || ambiguous {
+        return Vec::new();
+    }
+    let packages = match packages {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+
+    let end = node.end_position();
+    let line_text = content.lines().nth(end.row).unwrap_or("");
+    let column = byte_offset_to_utf16_column(line_text, end.column);
+    let line = end.row as u32;
+
+    packages
+        .into_iter()
+        .map(|package| LibraryCall {
+            package,
+            line,
+            column,
+            function_scope: None,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -1656,6 +1877,25 @@ library(ggplot2)"#;
         let tree = parse_r(code);
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 1);
+        assert!(lib_calls[0].function_scope.is_none());
+    }
+
+    // ==================== apply-family library detection (#172) ====================
+
+    #[test]
+    fn test_apply_inline_c_with_library() {
+        // sapply(c("dplyr","tidyr"), library, character.only = TRUE)
+        // Validates issue #172 — the "inline c()" path.
+        let code = r#"sapply(c("dplyr", "tidyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+        // Both share the apply call's end position.
+        assert_eq!(lib_calls[0].line, 0);
+        assert_eq!(lib_calls[1].line, 0);
+        assert_eq!(lib_calls[0].column, lib_calls[1].column);
         assert!(lib_calls[0].function_scope.is_none());
     }
 }

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -1939,6 +1939,42 @@ library(ggplot2)"#;
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);
     }
+
+    #[test]
+    fn test_apply_purrr_bare_walk() {
+        let code = r#"walk(c("dplyr","tidyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_purrr_qualified_map() {
+        let code = r#"purrr::map(c("dplyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 1);
+        assert_eq!(lib_calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_apply_purrr_qualified_map_chr() {
+        let code = r#"purrr::map_chr(c("dplyr","tidyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+    }
+
+    #[test]
+    fn test_apply_other_namespace_not_detected() {
+        // foo::map(...) is not purrr — skip.
+        let code = r#"foo::map(c("dplyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -1898,6 +1898,47 @@ library(ggplot2)"#;
         assert_eq!(lib_calls[0].column, lib_calls[1].column);
         assert!(lib_calls[0].function_scope.is_none());
     }
+
+    #[test]
+    fn test_apply_lapply_inline_c_with_require() {
+        let code = r#"lapply(c("dplyr"), require, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 1);
+        assert_eq!(lib_calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_apply_vapply_inline_c() {
+        // vapply has extra signature args; library FUN + c() X still detects.
+        let code = r#"vapply(c("dplyr","tidyr"), require, logical(1), character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_mapply_inline_c() {
+        // mapply puts FUN first; we're position-agnostic so it still matches.
+        let code = r#"mapply(library, c("dplyr","tidyr"), character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_with_named_x_arg_skipped() {
+        // A c() inside a *named* arg is not picked up — only positional X args
+        // are considered. Documents the limitation.
+        let code = r#"sapply(X = c("dplyr"), FUN = require, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -506,7 +506,8 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
     log::trace!("Starting tree-sitter parsing for library() call detection");
     let mut library_calls = Vec::new();
     let root = tree.root_node();
-    visit_node_for_library(root, content, &mut library_calls);
+    let var_lookup = collect_var_bindings(root, content);
+    visit_node_for_library(root, content, &var_lookup, &mut library_calls);
     log::trace!(
         "Completed library() call detection, found {} calls",
         library_calls.len()
@@ -544,7 +545,12 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
 /// visit_node_for_library(root, source_text, &mut library_calls);
 /// assert!(library_calls.iter().all(|c| !c.package.is_empty()));
 /// ```
-fn visit_node_for_library(node: Node, content: &str, library_calls: &mut Vec<LibraryCall>) {
+fn visit_node_for_library(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+    library_calls: &mut Vec<LibraryCall>,
+) {
     // Skip identifier nodes - they have no children
     if node.kind() == "identifier" {
         return;
@@ -555,12 +561,12 @@ fn visit_node_for_library(node: Node, content: &str, library_calls: &mut Vec<Lib
         } else {
             // Not a direct library/require/loadNamespace call; try the
             // apply-family form (sapply/map/etc. of bare library/require).
-            library_calls.extend(try_parse_apply_library_call(node, content));
+            library_calls.extend(try_parse_apply_library_call(node, content, var_lookup));
         }
     }
 
     for child in node.children(&mut node.walk()) {
-        visit_node_for_library(child, content, library_calls);
+        visit_node_for_library(child, content, var_lookup, library_calls);
     }
 }
 
@@ -727,6 +733,169 @@ fn extract_package_value(node: Node, content: &str) -> Option<String> {
 // Apply-Family Library Detection (issue #172)
 // ============================================================================
 
+use std::collections::HashMap;
+
+/// Information collected for an identifier appearing on the LHS of any
+/// binding form (assignment operator, `assign("name", ...)` call, or function
+/// parameter) anywhere in the file. Used by apply-family detection to resolve
+/// X arguments that are variable references.
+///
+/// `assignment_count` increments for *every* binding form: `<-`, `=`, `<<-`,
+/// `->`, `->>`, `assign(...)`, and function parameters. Only `<-`, `=`, or
+/// `assign("name", ...)` whose RHS is a `c(...)` of string literals populates
+/// `static_packages`.
+#[derive(Debug, Default)]
+struct VarBinding {
+    assignment_count: u32,
+    /// `(packages, byte_offset_of_assignment_node)` from the first supported,
+    /// statically-resolved assignment.
+    static_packages: Option<(Vec<String>, usize)>,
+}
+
+impl VarBinding {
+    /// Return packages iff `count == 1`, we extracted a static c-of-strings,
+    /// and that assignment started before `before_byte`.
+    fn resolved_before(&self, before_byte: usize) -> Option<&[String]> {
+        if self.assignment_count != 1 {
+            return None;
+        }
+        let (pkgs, off) = self.static_packages.as_ref()?;
+        if *off < before_byte {
+            Some(pkgs.as_slice())
+        } else {
+            None
+        }
+    }
+}
+
+fn collect_var_bindings(root: Node, content: &str) -> HashMap<String, VarBinding> {
+    let mut map: HashMap<String, VarBinding> = HashMap::new();
+    visit_var_bindings(root, content, &mut map);
+    map
+}
+
+fn visit_var_bindings(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    match node.kind() {
+        "binary_operator" => record_binary_assignment(node, content, map),
+        "call" => record_assign_call(node, content, map),
+        "function_definition" => record_function_params(node, content, map),
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_var_bindings(child, content, map);
+    }
+}
+
+fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    let mut cursor = node.walk();
+    let named: Vec<Node> = node
+        .children(&mut cursor)
+        .filter(|c| c.is_named())
+        .collect();
+    if named.len() != 2 {
+        return;
+    }
+    let mut op_walker = node.walk();
+    let op_text = node.children(&mut op_walker).find_map(|c| {
+        let t = node_text(c, content);
+        if matches!(t, "<-" | "=" | "<<-" | "->" | "->>") {
+            Some(t.to_string())
+        } else {
+            None
+        }
+    });
+    drop(op_walker);
+    let Some(op) = op_text else { return };
+
+    let (name_node, value_node) = match op.as_str() {
+        "<-" | "=" | "<<-" => (named[0], named[1]),
+        "->" | "->>" => (named[1], named[0]),
+        _ => return,
+    };
+    if name_node.kind() != "identifier" {
+        return;
+    }
+    let name = node_text(name_node, content).to_string();
+    let entry = map.entry(name).or_default();
+    entry.assignment_count = entry.assignment_count.saturating_add(1);
+
+    if matches!(op.as_str(), "<-" | "=") {
+        if let Some(packages) = extract_c_strings_strict(value_node, content) {
+            if entry.static_packages.is_none() {
+                entry.static_packages = Some((packages, node.start_byte()));
+            }
+        }
+    }
+}
+
+fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    let func_node = match node.child_by_field_name("function") {
+        Some(n) => n,
+        None => return,
+    };
+    if node_text(func_node, content) != "assign" {
+        return;
+    }
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) => n,
+        None => return,
+    };
+    if args_node.has_error() {
+        return;
+    }
+    let mut cursor = args_node.walk();
+    let positional: Vec<Node> = args_node
+        .children(&mut cursor)
+        .filter(|c| c.kind() == "argument" && c.child_by_field_name("name").is_none())
+        .collect();
+    if positional.len() < 2 {
+        return;
+    }
+    let name_value = match positional[0].child_by_field_name("value") {
+        Some(n) => n,
+        None => return,
+    };
+    let name = match extract_string_literal(name_value, content) {
+        Some(s) => s,
+        None => return,
+    };
+    let value_node = match positional[1].child_by_field_name("value") {
+        Some(n) => n,
+        None => return,
+    };
+    let entry = map.entry(name).or_default();
+    entry.assignment_count = entry.assignment_count.saturating_add(1);
+    if let Some(packages) = extract_c_strings_strict(value_node, content) {
+        if entry.static_packages.is_none() {
+            entry.static_packages = Some((packages, node.start_byte()));
+        }
+    }
+}
+
+fn record_function_params(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    let parameters = match node.child_by_field_name("parameters") {
+        Some(n) => n,
+        None => return,
+    };
+    let mut cursor = parameters.walk();
+    for child in parameters.children(&mut cursor) {
+        if child.kind() != "parameter" {
+            continue;
+        }
+        let mut param_cursor = child.walk();
+        let Some(ident) = child
+            .children(&mut param_cursor)
+            .find(|c| c.kind() == "identifier")
+        else {
+            continue;
+        };
+        let name = node_text(ident, content).to_string();
+        let entry = map.entry(name).or_default();
+        entry.assignment_count = entry.assignment_count.saturating_add(1);
+    }
+}
+
 /// Apply-family functions whose bare-identifier form may load packages
 /// dynamically when paired with `library`/`require` and `character.only = TRUE`.
 const APPLY_BARE_NAMES: &[&str] = &[
@@ -863,7 +1032,11 @@ fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
 ///
 /// All emitted entries share the apply call's end position. Returns an empty
 /// vec for every other case (the caller continues recursion into children).
-fn try_parse_apply_library_call(node: Node, content: &str) -> Vec<LibraryCall> {
+fn try_parse_apply_library_call(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+) -> Vec<LibraryCall> {
     let func_node = match node.child_by_field_name("function") {
         Some(n) => n,
         None => return Vec::new(),
@@ -884,6 +1057,7 @@ fn try_parse_apply_library_call(node: Node, content: &str) -> Vec<LibraryCall> {
         return Vec::new();
     }
 
+    let call_start = node.start_byte();
     let mut has_library_fun = false;
     let mut packages: Option<Vec<String>> = None;
     let mut ambiguous = false;
@@ -904,6 +1078,15 @@ fn try_parse_apply_library_call(node: Node, content: &str) -> Vec<LibraryCall> {
             let text = node_text(value_node, content);
             if text == "library" || text == "require" {
                 has_library_fun = true;
+                continue;
+            }
+            if let Some(binding) = var_lookup.get(text) {
+                if let Some(pkgs) = binding.resolved_before(call_start) {
+                    if packages.is_some() {
+                        ambiguous = true;
+                    }
+                    packages = Some(pkgs.to_vec());
+                }
             }
             continue;
         }
@@ -1975,6 +2158,21 @@ library(ggplot2)"#;
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);
     }
+
+    #[test]
+    fn test_apply_var_single_arrow_assignment() {
+        // Same-file variable assigned exactly once via `<-` to a c() of strings.
+        let code =
+            "libs <- c(\"dplyr\", \"tidyr\")\nsapply(libs, require, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+        assert_eq!(lib_calls[0].line, 1);
+        assert_eq!(lib_calls[1].line, 1);
+    }
+
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -2173,6 +2173,35 @@ library(ggplot2)"#;
         assert_eq!(lib_calls[1].line, 1);
     }
 
+    #[test]
+    fn test_apply_var_equals_assignment() {
+        let code =
+            "libs = c(\"dplyr\", \"tidyr\")\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_var_assign_call() {
+        let code = "assign(\"libs\", c(\"dplyr\", \"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_var_assignment_after_apply_call_skipped() {
+        // Variable assigned *after* the apply call must not resolve.
+        let code = "sapply(libs, library, character.only = TRUE)\nlibs <- c(\"dplyr\")";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -2297,6 +2297,47 @@ library(ggplot2)"#;
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);
     }
+
+    #[test]
+    fn test_apply_position_at_call_end_utf16() {
+        // 🎉 is 4 UTF-8 bytes / 2 UTF-16 code units.
+        let code = "🎉; sapply(c(\"dplyr\",\"tidyr\"), library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        let total_utf16 = code.encode_utf16().count() as u32;
+        for call in &lib_calls {
+            assert_eq!(call.line, 0);
+            assert_eq!(call.column, total_utf16);
+        }
+    }
+
+    #[test]
+    fn test_apply_issue_172_exact_example() {
+        // Issue #172 — exact pattern from the report.
+        let code = "libs <- c(\"lib1\", \"lib2\", \"lib3\")\nsapply(libs, require, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 3);
+        assert_eq!(lib_calls[0].package, "lib1");
+        assert_eq!(lib_calls[1].package, "lib2");
+        assert_eq!(lib_calls[2].package, "lib3");
+        for call in &lib_calls {
+            assert_eq!(call.line, 1);
+        }
+    }
+
+    #[test]
+    fn test_apply_issue_172_via_extract_metadata() {
+        let code = "libs <- c(\"lib1\", \"lib2\", \"lib3\")\nsapply(libs, require, character.only = TRUE)";
+        let meta = crate::cross_file::extract_metadata(code);
+        let pkgs: Vec<&str> = meta
+            .library_calls
+            .iter()
+            .map(|c| c.package.as_str())
+            .collect();
+        assert_eq!(pkgs, vec!["lib1", "lib2", "lib3"]);
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -533,17 +533,21 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
     library_calls
 }
 
-/// Recursively traverses an AST subtree and collects statically determinable `library`/`require`/`loadNamespace` calls.
-///
-/// This function walks `node` and its descendants in document order. When a call node representing a
-/// statically resolvable package load is found, a `LibraryCall` describing that call (package and end
-/// position) is pushed into `library_calls`.
+/// Recursively traverses an AST subtree and collects statically determinable
+/// package loads — both direct `library`/`require`/`loadNamespace` calls and
+/// apply-family calls whose FUN is `library`/`require`. Direct calls push at
+/// most one `LibraryCall`; apply calls may push one entry per package, all
+/// sharing the apply call's end position.
 ///
 /// # Parameters
 ///
 /// - `node`: the current AST node to visit (will recurse into its children).
 /// - `content`: source text for extracting node-local values when parsing calls.
-/// - `library_calls`: mutable collector that receives discovered `LibraryCall` entries in document order.
+/// - `var_lookup`: name→binding map (built once via [`collect_var_bindings`])
+///   used by apply detection to resolve same-file variable references like
+///   `libs <- c(...); sapply(libs, library, character.only = TRUE)`.
+/// - `library_calls`: mutable collector that receives discovered `LibraryCall`
+///   entries in document order.
 ///
 /// # Examples
 ///
@@ -552,7 +556,8 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
 /// ```text
 /// let mut library_calls = Vec::new();
 /// let root = tree.root_node();
-/// visit_node_for_library(root, source_text, &mut library_calls);
+/// let var_lookup = collect_var_bindings(root, source_text);
+/// visit_node_for_library(root, source_text, &var_lookup, &mut library_calls);
 /// assert!(library_calls.iter().all(|c| !c.package.is_empty()));
 /// ```
 fn visit_node_for_library(

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -839,6 +839,37 @@ fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String,
     }
 }
 
+/// Formals of `assign()` other than `x` and `value`. Used to filter partial
+/// matches so we don't accept ambiguous prefixes.
+const ASSIGN_OTHER_FORMALS: &[&str] = &["pos", "envir", "inherits", "immediate"];
+
+/// Decide which `assign()` formal a named arg binds, emulating R's matching:
+/// exact match first, then unique partial-prefix match. Returns `Some("x")`
+/// or `Some("value")` for the names we care about, `None` otherwise (the
+/// other formals or an ambiguous prefix).
+fn match_assign_formal(name: &str) -> Option<&'static str> {
+    if name.is_empty() {
+        return None;
+    }
+    if name == "x" {
+        return Some("x");
+    }
+    if name == "value" {
+        return Some("value");
+    }
+    // Partial: accept iff `name` is a prefix of exactly one formal we track.
+    let prefix_of_value = "value".starts_with(name);
+    let prefix_of_other =
+        ASSIGN_OTHER_FORMALS.iter().any(|f| f.starts_with(name)) || "x".starts_with(name);
+    match (prefix_of_value, prefix_of_other) {
+        (true, false) => Some("value"),
+        // `x` is a single character so partial-matching it means name == "x",
+        // which we handled above. Anything else is either ambiguous or
+        // matches an unrelated formal — ignore.
+        _ => None,
+    }
+}
+
 fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
     let Some(func_node) = node.child_by_field_name("function") else {
         return;
@@ -853,11 +884,12 @@ fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBi
         return;
     }
 
-    // R argument matching: exact-named args bind first, then any remaining
-    // positional args fill `assign(x, value, ...)` in declaration order.
-    // We only care about `x` (the name) and `value` (the assigned expression);
-    // other params (`pos`, `envir`, `inherits`, `immediate`) are ignored but
-    // do not consume positional slots.
+    // R argument matching: exact-named args bind first, then unambiguous
+    // partial matches, then any remaining positional args fill the unbound
+    // formals (`x`, `value`) in declaration order. We only care about `x`
+    // (the name) and `value` (the assigned expression); other formals
+    // (`pos`/`envir`/`inherits`/`immediate`) and unrecognised names don't
+    // consume positional slots.
     let mut named_x: Option<Node> = None;
     let mut named_value: Option<Node> = None;
     let mut positional: Vec<Node> = Vec::new();
@@ -870,9 +902,10 @@ fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBi
             continue;
         };
         if let Some(name_node) = child.child_by_field_name("name") {
-            match node_text(name_node, content) {
-                "x" => named_x = Some(value),
-                "value" => named_value = Some(value),
+            let arg_name = node_text(name_node, content);
+            match match_assign_formal(arg_name) {
+                Some("x") if named_x.is_none() => named_x = Some(value),
+                Some("value") if named_value.is_none() => named_value = Some(value),
                 _ => {}
             }
         } else {
@@ -927,9 +960,10 @@ fn record_function_params(node: Node, content: &str, map: &mut HashMap<String, V
 /// dynamically when paired with `library`/`require` and `character.only = TRUE`.
 ///
 /// Restricted to functions with a clean `(X, FUN, ...)` shape (or `(FUN, ...)`
-/// for `mapply`). `map2`/`walk2`/`pmap`/`pwalk` and their typed variants are
-/// excluded because their X argument is a list of vectors or two parallel
-/// vectors, which doesn't match the simple static-vector model.
+/// for `mapply`). Excluded:
+/// - `map2`/`walk2`/`map2_*` — two parallel X vectors with FUN at position 2.
+/// - `pmap`/`pwalk` — X is a list of vectors, not a single vector.
+/// - `map_if`/`map_at` — `(X, predicate-or-selector, FUN, ...)`, FUN at position 2.
 const APPLY_BARE_NAMES: &[&str] = &[
     "sapply",
     "lapply",
@@ -947,8 +981,6 @@ const APPLY_BARE_NAMES: &[&str] = &[
     "map_dfr",
     "map_dfc",
     "map_vec",
-    "map_if",
-    "map_at",
 ];
 
 /// Apply-family functions accepted under the `purrr::` namespace.
@@ -965,8 +997,6 @@ const APPLY_PURRR_NAMES: &[&str] = &[
     "map_dfr",
     "map_dfc",
     "map_vec",
-    "map_if",
-    "map_at",
 ];
 
 /// Return `(x_position, fun_position)` describing where in the call's
@@ -2405,6 +2435,40 @@ library(ggplot2)"#;
         // libs is assigned twice — once via `<-`, once via named-arg assign().
         // The named assign() must count toward the multi-assignment rule.
         let code = "libs <- c(\"dplyr\")\nassign(x = \"libs\", value = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_map_if_library_in_predicate_slot_not_detected() {
+        // map_if has signature (.x, .p, .f) — the predicate is at position 1,
+        // not the FUN. Putting `library` in the predicate slot doesn't load
+        // anything; we should not match it. Drop map_if/map_at from the
+        // supported apply set rather than guessing positions per signature.
+        let code = r#"map_if(c("dplyr"), library, is.character, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_assign_partial_named() {
+        // R does partial matching after exact: `val` is a unique prefix of
+        // `value` among assign()'s formals, so `val = ...` binds `value`.
+        let code = "assign(x = \"libs\", val = c(\"dplyr\", \"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_var_assign_partial_named_overrides_disqualifies() {
+        // Same as test_apply_var_assign_named_overrides_disqualifies but the
+        // second assign uses partial-match `val` for `value`.
+        let code = "libs <- c(\"dplyr\")\nassign(x = \"libs\", val = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
         let tree = parse_r(code);
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -483,11 +483,21 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 // Library Call Detection
 // ============================================================================
 
-/// Detects `library()`, `require()`, and `loadNamespace()` calls that specify a static package name.
+/// Detects package loads in the file: direct `library()`/`require()`/`loadNamespace()`
+/// calls, plus apply-family calls whose FUN argument is a bare reference to
+/// `library` or `require`.
 ///
-/// This returns entries for calls where the package can be determined from a bare identifier
-/// (e.g., `library(dplyr)`) or a string literal (e.g., `library("dplyr")`). Calls that use
-/// `character.only = TRUE` or whose package argument is an expression or variable are skipped.
+/// For direct calls, the package must be a bare identifier (`library(dplyr)`)
+/// or a string literal (`library("dplyr")`); direct calls with
+/// `character.only = TRUE` or a dynamic package argument are skipped.
+///
+/// For apply-family calls (`sapply`, `lapply`, `vapply`, `mapply`, plus the
+/// bare and `purrr::`-qualified `map`/`walk`/`map_chr`/etc.), `character.only =
+/// TRUE` is *required* and the X argument must resolve statically to a vector
+/// of string literals — either an inline `c("a","b",...)` or a same-file
+/// variable assigned exactly once via `<-`, `=`, or `assign("name", c(...))`.
+/// Each apply emits one `LibraryCall` per package, all sharing the apply
+/// call's end position.
 ///
 /// # Examples
 ///

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -839,35 +839,24 @@ fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String,
     }
 }
 
-/// Formals of `assign()` other than `x` and `value`. Used to filter partial
-/// matches so we don't accept ambiguous prefixes.
-const ASSIGN_OTHER_FORMALS: &[&str] = &["pos", "envir", "inherits", "immediate"];
-
-/// Decide which `assign()` formal a named arg binds, emulating R's matching:
-/// exact match first, then unique partial-prefix match. Returns `Some("x")`
-/// or `Some("value")` for the names we care about, `None` otherwise (the
-/// other formals or an ambiguous prefix).
-fn match_assign_formal(name: &str) -> Option<&'static str> {
-    if name.is_empty() {
-        return None;
+/// Returns true if `name` is a non-empty prefix of `assign()`'s `value`
+/// formal that is *not* also a prefix of any other formal — i.e. an
+/// unambiguous partial match for `value`. Excludes the exact name "value"
+/// itself; that's handled by the exact-match pass.
+fn is_partial_prefix_of_value(name: &str) -> bool {
+    if name.is_empty() || name == "value" {
+        return false;
     }
-    if name == "x" {
-        return Some("x");
+    if !"value".starts_with(name) {
+        return false;
     }
-    if name == "value" {
-        return Some("value");
-    }
-    // Partial: accept iff `name` is a prefix of exactly one formal we track.
-    let prefix_of_value = "value".starts_with(name);
-    let prefix_of_other =
-        ASSIGN_OTHER_FORMALS.iter().any(|f| f.starts_with(name)) || "x".starts_with(name);
-    match (prefix_of_value, prefix_of_other) {
-        (true, false) => Some("value"),
-        // `x` is a single character so partial-matching it means name == "x",
-        // which we handled above. Anything else is either ambiguous or
-        // matches an unrelated formal — ignore.
-        _ => None,
-    }
+    // assign()'s other formals: x, pos, envir, inherits, immediate.
+    // (`x` is a single character so partial-matching `x` just means name == "x".)
+    !"x".starts_with(name)
+        && !"pos".starts_with(name)
+        && !"envir".starts_with(name)
+        && !"inherits".starts_with(name)
+        && !"immediate".starts_with(name)
 }
 
 fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
@@ -884,14 +873,13 @@ fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBi
         return;
     }
 
-    // R argument matching: exact-named args bind first, then unambiguous
-    // partial matches, then any remaining positional args fill the unbound
-    // formals (`x`, `value`) in declaration order. We only care about `x`
-    // (the name) and `value` (the assigned expression); other formals
-    // (`pos`/`envir`/`inherits`/`immediate`) and unrecognised names don't
-    // consume positional slots.
-    let mut named_x: Option<Node> = None;
-    let mut named_value: Option<Node> = None;
+    // Bucketize args. R argument matching is two passes (exact, then partial)
+    // followed by positional fill. We only track the `x` and `value` formals
+    // — other formals (`pos`/`envir`/`inherits`/`immediate`) and unknown
+    // names are ignored and don't consume positional slots.
+    let mut exact_x: Vec<Node> = Vec::new();
+    let mut exact_value: Vec<Node> = Vec::new();
+    let mut partial_to_value: Vec<Node> = Vec::new();
     let mut positional: Vec<Node> = Vec::new();
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
@@ -903,19 +891,43 @@ fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBi
         };
         if let Some(name_node) = child.child_by_field_name("name") {
             let arg_name = node_text(name_node, content);
-            match match_assign_formal(arg_name) {
-                Some("x") if named_x.is_none() => named_x = Some(value),
-                Some("value") if named_value.is_none() => named_value = Some(value),
-                _ => {}
+            if arg_name == "x" {
+                exact_x.push(value);
+            } else if arg_name == "value" {
+                exact_value.push(value);
+            } else if is_partial_prefix_of_value(arg_name) {
+                partial_to_value.push(value);
             }
         } else {
             positional.push(value);
         }
     }
 
-    let mut pos_iter = positional.into_iter();
-    let x_value = named_x.or_else(|| pos_iter.next());
-    let value_node = named_value.or_else(|| pos_iter.next());
+    // If any of the rules R uses would error — duplicate exact, multiple
+    // partials matching the same formal, or a partial colliding with an exact
+    // — the call itself errors and never assigns. Skip the call entirely so
+    // we don't record a static binding R never produced.
+    let value_collision = (exact_value.len() == 1 && !partial_to_value.is_empty())
+        || exact_value.len() > 1
+        || partial_to_value.len() > 1;
+    if exact_x.len() > 1 || value_collision {
+        return;
+    }
+
+    // Resolve x (exact > positional[0]) and value (exact > partial > next
+    // positional after x).
+    let x_value = exact_x
+        .first()
+        .copied()
+        .or_else(|| positional.first().copied());
+    let value_node = exact_value
+        .first()
+        .copied()
+        .or_else(|| partial_to_value.first().copied())
+        .or_else(|| {
+            let next_idx = if exact_x.is_empty() { 1 } else { 0 };
+            positional.get(next_idx).copied()
+        });
 
     let Some(x_value) = x_value else { return };
     let Some(name) = extract_string_literal(x_value, content) else {
@@ -2469,6 +2481,27 @@ library(ggplot2)"#;
         // Same as test_apply_var_assign_named_overrides_disqualifies but the
         // second assign uses partial-match `val` for `value`.
         let code = "libs <- c(\"dplyr\")\nassign(x = \"libs\", val = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_assign_exact_and_partial_value_skipped() {
+        // R does exact-name matching first, then partial. With both an exact
+        // `value = ...` and a partial `val = ...` present, R errors with
+        // "matched by multiple actual arguments" and the assignment never
+        // happens; we must not record a static binding from it.
+        let code = "assign(x = \"libs\", val = c(\"dplyr\"), value = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_assign_duplicate_exact_value_skipped() {
+        // Same idea: two exact `value =` args also error in R.
+        let code = "assign(x = \"libs\", value = c(\"dplyr\"), value = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
         let tree = parse_r(code);
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -2202,6 +2202,101 @@ library(ggplot2)"#;
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);
     }
+
+    #[test]
+    fn test_apply_var_multiple_assignments_skipped() {
+        let code = "libs <- c(\"dplyr\")\nlibs <- c(\"tidyr\")\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_super_assignment_disqualifies() {
+        // <<- alone counts but doesn't extract — single-assignment but no
+        // static packages means the binding doesn't resolve.
+        let code = "libs <<- c(\"dplyr\")\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_function_param_shadow_disqualifies() {
+        // A function parameter named `libs` increments the count and
+        // disqualifies the global binding.
+        let code = "libs <- c(\"dplyr\")\nf <- function(libs) {}\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_dynamic_x_paste0_skipped() {
+        let code = r#"sapply(paste0("dp", "lyr"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_dynamic_x_setdiff_skipped() {
+        let code = r#"sapply(setdiff(c("a","b"), "b"), library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_dynamic_x_c_with_var_skipped() {
+        // c() containing a non-string argument disqualifies the X arg.
+        let code = "libs1 <- c(\"a\")\nsapply(c(libs1, \"b\"), library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_anonymous_fun_skipped() {
+        // \(x) library(x) — FUN is not a bare identifier so the apply must not
+        // pick up "dplyr". The inner `library(x)` may still be detected with
+        // package="x" by the existing direct-library detector — that's
+        // pre-existing loose behavior; we only assert the apply path didn't
+        // fire by checking that no LibraryCall mentions "dplyr".
+        let code = r#"sapply(c("dplyr"), \(x) library(x), character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert!(
+            lib_calls.iter().all(|c| c.package != "dplyr"),
+            "apply path should not emit dplyr; got {:?}",
+            lib_calls
+        );
+    }
+
+    #[test]
+    fn test_apply_no_character_only_skipped() {
+        let code = r#"sapply(c("dplyr"), library)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_character_only_false_skipped() {
+        let code = r#"sapply(c("dplyr"), library, character.only = FALSE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_loadnamespace_fun_skipped() {
+        // loadNamespace is intentionally not in the FUN allowlist.
+        let code = r#"sapply(c("dplyr"), loadNamespace, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
 }
 
 // ============================================================================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -840,45 +840,62 @@ fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String,
 }
 
 fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
-    let func_node = match node.child_by_field_name("function") {
-        Some(n) => n,
-        None => return,
+    let Some(func_node) = node.child_by_field_name("function") else {
+        return;
     };
     if node_text(func_node, content) != "assign" {
         return;
     }
-    let args_node = match node.child_by_field_name("arguments") {
-        Some(n) => n,
-        None => return,
+    let Some(args_node) = node.child_by_field_name("arguments") else {
+        return;
     };
     if args_node.has_error() {
         return;
     }
+
+    // R argument matching: exact-named args bind first, then any remaining
+    // positional args fill `assign(x, value, ...)` in declaration order.
+    // We only care about `x` (the name) and `value` (the assigned expression);
+    // other params (`pos`, `envir`, `inherits`, `immediate`) are ignored but
+    // do not consume positional slots.
+    let mut named_x: Option<Node> = None;
+    let mut named_value: Option<Node> = None;
+    let mut positional: Vec<Node> = Vec::new();
     let mut cursor = args_node.walk();
-    let positional: Vec<Node> = args_node
-        .children(&mut cursor)
-        .filter(|c| c.kind() == "argument" && c.child_by_field_name("name").is_none())
-        .collect();
-    if positional.len() < 2 {
-        return;
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        let Some(value) = child.child_by_field_name("value") else {
+            continue;
+        };
+        if let Some(name_node) = child.child_by_field_name("name") {
+            match node_text(name_node, content) {
+                "x" => named_x = Some(value),
+                "value" => named_value = Some(value),
+                _ => {}
+            }
+        } else {
+            positional.push(value);
+        }
     }
-    let name_value = match positional[0].child_by_field_name("value") {
-        Some(n) => n,
-        None => return,
+
+    let mut pos_iter = positional.into_iter();
+    let x_value = named_x.or_else(|| pos_iter.next());
+    let value_node = named_value.or_else(|| pos_iter.next());
+
+    let Some(x_value) = x_value else { return };
+    let Some(name) = extract_string_literal(x_value, content) else {
+        return;
     };
-    let name = match extract_string_literal(name_value, content) {
-        Some(s) => s,
-        None => return,
-    };
-    let value_node = match positional[1].child_by_field_name("value") {
-        Some(n) => n,
-        None => return,
-    };
+
     let entry = map.entry(name).or_default();
     entry.assignment_count = entry.assignment_count.saturating_add(1);
-    if let Some(packages) = extract_c_strings_strict(value_node, content) {
-        if entry.static_packages.is_none() {
-            entry.static_packages = Some((packages, node.start_byte()));
+    if let Some(value_node) = value_node {
+        if let Some(packages) = extract_c_strings_strict(value_node, content) {
+            if entry.static_packages.is_none() {
+                entry.static_packages = Some((packages, node.start_byte()));
+            }
         }
     }
 }
@@ -908,6 +925,11 @@ fn record_function_params(node: Node, content: &str, map: &mut HashMap<String, V
 
 /// Apply-family functions whose bare-identifier form may load packages
 /// dynamically when paired with `library`/`require` and `character.only = TRUE`.
+///
+/// Restricted to functions with a clean `(X, FUN, ...)` shape (or `(FUN, ...)`
+/// for `mapply`). `map2`/`walk2`/`pmap`/`pwalk` and their typed variants are
+/// excluded because their X argument is a list of vectors or two parallel
+/// vectors, which doesn't match the simple static-vector model.
 const APPLY_BARE_NAMES: &[&str] = &[
     "sapply",
     "lapply",
@@ -915,10 +937,8 @@ const APPLY_BARE_NAMES: &[&str] = &[
     "mapply",
     "map",
     "walk",
-    "pmap",
     "imap",
     "iwalk",
-    "pwalk",
     "map_chr",
     "map_int",
     "map_dbl",
@@ -929,25 +949,14 @@ const APPLY_BARE_NAMES: &[&str] = &[
     "map_vec",
     "map_if",
     "map_at",
-    "map2",
-    "map2_chr",
-    "map2_int",
-    "map2_dbl",
-    "map2_lgl",
-    "map2_dfr",
-    "map2_dfc",
-    "map2_vec",
-    "walk2",
 ];
 
 /// Apply-family functions accepted under the `purrr::` namespace.
 const APPLY_PURRR_NAMES: &[&str] = &[
     "map",
     "walk",
-    "pmap",
     "imap",
     "iwalk",
-    "pwalk",
     "map_chr",
     "map_int",
     "map_dbl",
@@ -958,25 +967,25 @@ const APPLY_PURRR_NAMES: &[&str] = &[
     "map_vec",
     "map_if",
     "map_at",
-    "map2",
-    "map2_chr",
-    "map2_int",
-    "map2_dbl",
-    "map2_lgl",
-    "map2_dfr",
-    "map2_dfc",
-    "map2_vec",
-    "walk2",
 ];
 
-/// Returns true when `func_node` names a base-R or purrr apply-family function
-/// supported for static library-vector detection. Accepts a bare identifier
-/// (`sapply`, `map`, ...) or a `purrr::xxx` namespace_operator.
-fn is_apply_family_function(func_node: Node, content: &str) -> bool {
-    match func_node.kind() {
+/// Return `(x_position, fun_position)` describing where in the call's
+/// positional argument list the X (vector) and FUN (mapped function) values
+/// are expected, for a supported apply-family function. Returns `None` when
+/// the function isn't one we recognise.
+///
+/// Most apply functions (`sapply`, `lapply`, `vapply`, the purrr `map`/`walk`
+/// family) take `(X, FUN, ...)`, so X is at position 0 and FUN at position 1.
+/// `mapply`'s signature is `(FUN, ...)`, so FUN is at position 0 and the
+/// first vector at position 1.
+fn apply_arg_positions(func_node: Node, content: &str) -> Option<(usize, usize)> {
+    let name = match func_node.kind() {
         "identifier" => {
-            let name = node_text(func_node, content);
-            APPLY_BARE_NAMES.contains(&name)
+            let n = node_text(func_node, content);
+            if !APPLY_BARE_NAMES.contains(&n) {
+                return None;
+            }
+            n
         }
         "namespace_operator" => {
             let mut cursor = func_node.walk();
@@ -985,13 +994,22 @@ fn is_apply_family_function(func_node: Node, content: &str) -> bool {
                 .filter(|c| c.is_named())
                 .collect();
             if named_children.len() != 2 {
-                return false;
+                return None;
             }
-            let ns = node_text(named_children[0], content);
-            let name = node_text(named_children[1], content);
-            ns == "purrr" && APPLY_PURRR_NAMES.contains(&name)
+            if node_text(named_children[0], content) != "purrr" {
+                return None;
+            }
+            let n = node_text(named_children[1], content);
+            if !APPLY_PURRR_NAMES.contains(&n) {
+                return None;
+            }
+            n
         }
-        _ => false,
+        _ => return None,
+    };
+    match name {
+        "mapply" => Some((1, 0)),
+        _ => Some((0, 1)),
     }
 }
 
@@ -1034,43 +1052,43 @@ fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
 /// Try to interpret `node` as an apply-family call that loads a static vector
 /// of packages — e.g. `sapply(c("dplyr","tidyr"), library, character.only = TRUE)`.
 ///
-/// Returns one `LibraryCall` per package when:
-/// - the function is a supported apply-family name (see [`is_apply_family_function`]),
-/// - `character.only = TRUE` (or `T`) is set,
-/// - exactly one positional arg resolves to a static `Vec<String>` via inline `c(...)`,
-/// - at least one positional arg is the bare identifier `library` or `require`.
+/// Returns one `LibraryCall` per package when, given the call's
+/// `(x_position, fun_position)` from [`apply_arg_positions`]:
+/// - `character.only = TRUE` (or `T`) is present,
+/// - the positional arg at `fun_position` is the bare identifier `library`
+///   or `require` (so we don't match calls like
+///   `sapply(c("dplyr"), identity, library, ...)` where library is just a
+///   `...`-passthrough),
+/// - the positional arg at `x_position` resolves to a static `Vec<String>`
+///   via inline `c(...)` or a same-file variable in `var_lookup`.
 ///
-/// All emitted entries share the apply call's end position. Returns an empty
-/// vec for every other case (the caller continues recursion into children).
+/// All emitted entries share the apply call's end position.
 fn try_parse_apply_library_call(
     node: Node,
     content: &str,
     var_lookup: &HashMap<String, VarBinding>,
 ) -> Vec<LibraryCall> {
-    let func_node = match node.child_by_field_name("function") {
-        Some(n) => n,
-        None => return Vec::new(),
-    };
-    if !is_apply_family_function(func_node, content) {
+    let Some(func_node) = node.child_by_field_name("function") else {
         return Vec::new();
-    }
+    };
+    let Some((x_pos, fun_pos)) = apply_arg_positions(func_node, content) else {
+        return Vec::new();
+    };
 
-    let args_node = match node.child_by_field_name("arguments") {
-        Some(n) => n,
-        None => return Vec::new(),
+    let Some(args_node) = node.child_by_field_name("arguments") else {
+        return Vec::new();
     };
     if args_node.has_error() {
         return Vec::new();
     }
-
     if !has_character_only_true(&args_node, content) {
         return Vec::new();
     }
 
-    let call_start = node.start_byte();
-    let mut has_library_fun = false;
-    let mut packages: Option<Vec<String>> = None;
-    let mut ambiguous = false;
+    // Positional argument values, in source order. Named args (including
+    // `character.only =`, `simplify =`, `FUN =`, `X =`, etc.) are excluded
+    // here — see `test_apply_with_named_x_arg_skipped` for the limitation.
+    let mut positional_values: Vec<Node> = Vec::new();
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
         if child.kind() != "argument" {
@@ -1079,42 +1097,43 @@ fn try_parse_apply_library_call(
         if child.child_by_field_name("name").is_some() {
             continue;
         }
-        let value_node = match child.child_by_field_name("value") {
-            Some(n) => n,
-            None => continue,
-        };
-
-        if value_node.kind() == "identifier" {
-            let text = node_text(value_node, content);
-            if text == "library" || text == "require" {
-                has_library_fun = true;
-                continue;
-            }
-            if let Some(binding) = var_lookup.get(text) {
-                if let Some(pkgs) = binding.resolved_before(call_start) {
-                    if packages.is_some() {
-                        ambiguous = true;
-                    }
-                    packages = Some(pkgs.to_vec());
-                }
-            }
-            continue;
-        }
-
-        if let Some(strings) = extract_c_strings_strict(value_node, content) {
-            if packages.is_some() {
-                ambiguous = true;
-            }
-            packages = Some(strings);
+        if let Some(value) = child.child_by_field_name("value") {
+            positional_values.push(value);
         }
     }
 
-    if !has_library_fun || ambiguous {
+    // FUN must sit at the position dictated by the apply's signature and be a
+    // bare `library`/`require` identifier — not just appear *somewhere* among
+    // the positional args.
+    let Some(&fun_value) = positional_values.get(fun_pos) else {
+        return Vec::new();
+    };
+    if fun_value.kind() != "identifier" {
         return Vec::new();
     }
-    let packages = match packages {
-        Some(p) => p,
-        None => return Vec::new(),
+    let fun_text = node_text(fun_value, content);
+    if fun_text != "library" && fun_text != "require" {
+        return Vec::new();
+    }
+
+    let Some(&x_value) = positional_values.get(x_pos) else {
+        return Vec::new();
+    };
+    let packages: Vec<String> = match x_value.kind() {
+        "identifier" => {
+            let text = node_text(x_value, content);
+            match var_lookup
+                .get(text)
+                .and_then(|b| b.resolved_before(node.start_byte()))
+            {
+                Some(pkgs) => pkgs.to_vec(),
+                None => return Vec::new(),
+            }
+        }
+        _ => match extract_c_strings_strict(x_value, content) {
+            Some(v) => v,
+            None => return Vec::new(),
+        },
     };
 
     let end = node.end_position();
@@ -2347,6 +2366,48 @@ library(ggplot2)"#;
             .map(|c| c.package.as_str())
             .collect();
         assert_eq!(pkgs, vec!["lib1", "lib2", "lib3"]);
+    }
+
+    #[test]
+    fn test_apply_library_in_extra_position_skipped() {
+        // FUN is `identity`; `library` is just an extra positional arg passed
+        // through `...` to identity, which doesn't load anything.
+        let code = r#"sapply(c("dplyr"), identity, library, character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_library_at_x_position_skipped() {
+        // For sapply/lapply/etc., X is at position 0 and FUN at position 1.
+        // Swapping them is not a real library load.
+        let code = r#"sapply(library, c("dplyr"), character.only = TRUE)"#;
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_var_assign_call_named_args() {
+        // assign(x = "libs", value = c(...)) — the named-arg form should
+        // count and resolve just like the positional form.
+        let code = "assign(x = \"libs\", value = c(\"dplyr\", \"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 2);
+        assert_eq!(lib_calls[0].package, "dplyr");
+        assert_eq!(lib_calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_apply_var_assign_named_overrides_disqualifies() {
+        // libs is assigned twice — once via `<-`, once via named-arg assign().
+        // The named assign() must count toward the multi-assignment rule.
+        let code = "libs <- c(\"dplyr\")\nassign(x = \"libs\", value = c(\"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+        let tree = parse_r(code);
+        let lib_calls = detect_library_calls(&tree, code);
+        assert_eq!(lib_calls.len(), 0);
     }
 }
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -104,6 +104,29 @@ Packages loaded in child files do NOT propagate back to parents (forward-only).
 | `require(pkgname)` | Yes |
 | `loadNamespace("pkgname")` | Yes |
 | `library(pkg, character.only = TRUE)` | No (dynamic) |
+| `sapply(c("a","b"), library, character.only = TRUE)` | Yes (apply family) |
+| `sapply(libs, library, character.only = TRUE)` where `libs <- c("a","b")` | Yes (same-file variable) |
+| `purrr::map(c("a","b"), library, character.only = TRUE)` | Yes (purrr family) |
+| `sapply(paste0(...), library, character.only = TRUE)` | No (dynamic vector) |
+
+### Apply-Family Loads
+
+Raven also recognizes package loads expressed through apply-family calls when
+all the package names are statically determinable:
+
+```r
+libs <- c("dplyr", "tidyr")
+sapply(libs, require, character.only = TRUE)
+```
+
+This works for `sapply`, `lapply`, `vapply`, `mapply`, and the purrr forms
+(`map`, `walk`, `map_chr`, etc., bare or `purrr::`-qualified). The package
+vector must be either an inline `c("a","b",...)` of string literals, or a
+same-file variable assigned exactly once via `<-`, `=`, or `assign()` to such
+a literal vector. `character.only = TRUE` must be present (without it, R
+itself would not load the strings as packages). Dynamic constructions such as
+`paste0(...)`, `tolower(x)`, `c(libs1, libs2)`, function-parameter origins,
+or values defined in another file are silently ignored.
 
 ### Keeping Packages in Sync
 

--- a/docs/superpowers/plans/2026-05-06-apply-family-library-detection.md
+++ b/docs/superpowers/plans/2026-05-06-apply-family-library-detection.md
@@ -1,0 +1,1281 @@
+# Apply-Family Library Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Raven recognise package loads like `sapply(c("dplyr","tidyr"), require, character.only = TRUE)` and `sapply(libs, require, character.only = TRUE)` so the per-package `{...}` exports become available and the "undefined variable" diagnostic disappears (issue #172).
+
+**Architecture:** Stay inside `crates/raven/src/cross_file/source_detect.rs`. Extend `detect_library_calls` so that when an apply-family call passes a bare `library`/`require` reference plus `character.only = TRUE`, we extract the X argument's static string vector (inline `c(...)` or a same-file variable assigned exactly once via `<-`/`=`/`assign()`) and emit one `LibraryCall` per package. All emitted calls share the apply call's end position. `LibraryCall`'s shape is unchanged, so every consumer (`extract_metadata`, `compute_artifacts*`, `extract_loaded_packages_from_library_calls`) picks up the new entries automatically.
+
+**Tech Stack:** Rust + tree-sitter-r 0.x. Existing helpers `is_c_call`, `extract_string_literal`, `byte_offset_to_utf16_column`, `has_character_only_true`. Tests use the existing `parse_r` helper plus the same `#[test]` style as the surrounding library-call tests.
+
+**Out of scope (don't implement):** dynamic vector construction (`paste0`/`tolower`/`setdiff`/`c(libs1, libs2)`), variables defined in another file, `for` loops, anonymous-function FUNs (`\(x) library(x)`, `~require(.x)`), and any runtime evaluation. These should be silently skipped, not diagnosed.
+
+---
+
+## File Structure
+
+**Modified files:**
+
+- `crates/raven/src/cross_file/source_detect.rs` — primary changes (apply detection + var lookup + tests, all alongside the existing library detection)
+- `docs/cross-file.md` — append a row to the "Supported Call Patterns" table and mention the apply pattern
+
+**No other files need changes.** `LibraryCall`'s struct stays the same. Downstream code in `cross_file/mod.rs::extract_metadata`, `cross_file/scope.rs::compute_artifacts*`, and `backend.rs::extract_loaded_packages_from_library_calls` already iterates each `LibraryCall`, so emitting multiple entries from one apply call slots in without changes.
+
+**Why one file:** All new detection work fits inside `source_detect.rs`'s existing "Library Call Detection" section. New helpers should sit between the existing helpers (`extract_package_value`) and the test module. Tests go inside the existing `#[cfg(test)] mod tests` at the bottom of the existing tests, in a clearly demarcated subsection.
+
+---
+
+## Background — what the AST looks like
+
+These shapes drive the implementation. They were verified by parsing real code with tree-sitter-r in this repo:
+
+```text
+sapply(c("a","b"), require, character.only = TRUE)
+└─ call
+   ├─ identifier "sapply"                               ← function field
+   └─ arguments
+      ├─ argument [no name field]                       ← positional X
+      │  └─ call (the c())
+      │     ├─ identifier "c"
+      │     └─ arguments
+      │        ├─ argument: string "a"
+      │        └─ argument: string "b"
+      ├─ argument [no name field]                       ← positional FUN
+      │  └─ identifier "require"
+      └─ argument [name = identifier "character.only"]  ← named arg
+         └─ true "TRUE"                                 ← value field
+
+purrr::map(libs, library, character.only = TRUE)
+└─ call
+   ├─ namespace_operator "purrr::map"                   ← function field
+   │  ├─ identifier "purrr"
+   │  ├─ ::
+   │  └─ identifier "map"
+   └─ arguments (same shape as above; X is identifier "libs")
+
+libs <- c("a", "b")
+└─ binary_operator
+   ├─ identifier "libs"
+   ├─ <-
+   └─ call (c)
+
+assign("libs", c("a", "b"))
+└─ call
+   ├─ identifier "assign"
+   └─ arguments
+      ├─ argument: string "libs"
+      └─ argument: call (c with strings)
+```
+
+Key facts:
+- `argument` nodes expose `name` (the LHS of `=`) and `value` (the RHS) via tree-sitter field names. A positional argument has no `name` field but does have `value`.
+- `character.only = TRUE` parses with `value` being the `true` keyword node whose text is `"TRUE"` — `node_text(value_node, content) == "TRUE"` works (existing `has_character_only_true` already handles this).
+- `purrr::map` uses `kind = "namespace_operator"` with three children: the namespace identifier, `::`, and the function identifier (in that order).
+
+---
+
+## Behaviour spec (what the code must enforce)
+
+For every `call` node in the tree:
+
+1. **Apply call?** The function child is either:
+   - an `identifier` whose text is in the bare apply set (below), OR
+   - a `namespace_operator` whose left identifier is `"purrr"` and whose right identifier is in the purrr apply set.
+2. **`character.only = TRUE` present?** If not (missing, `FALSE`, `F`, or any other expression), skip silently. (Reuse `has_character_only_true`.)
+3. **Library FUN found?** Walk positional args (those without a `name` field). At least one must be an `identifier` whose text is `"library"` or `"require"`. (`loadNamespace` is intentionally **not** supported here; its signature differs.)
+4. **Static X vector found?** Among the *other* positional args, exactly one must resolve to `Some(Vec<String>)` via:
+   - **Inline:** the arg's value is a `c(...)` call where every argument is a string literal and there are no named args. (`extract_c_strings_strict` below.)
+   - **Same-file variable:** the arg's value is an `identifier` whose name has a `Resolved { packages, byte_offset }` entry in the variable map AND `byte_offset < apply_call.start_byte()`.
+5. **Emit:** for each package, push a `LibraryCall { package, line, column, function_scope: None }` where `(line, column)` is the UTF-16 end position of the apply call.
+
+If multiple positional args satisfy step 4, treat as ambiguous and skip silently. If none satisfies step 4, skip silently. If FUN is missing, skip silently. The downstream wiring requires `function_scope` to stay `None` here — `compute_artifacts*` populates it later via `find_containing_function_scope`.
+
+The variable-lookup map is built once per `detect_library_calls` invocation. Every binding to an identifier name `n` (anywhere in the file) increments `n`'s count. We extract the c-of-strings RHS only for assignments of the form `<-` / `=` / `assign("n", ...)`. After traversal:
+
+- `count == 1` AND we extracted a c-of-strings → `Resolved { packages, byte_offset }`.
+- Anything else (count == 0, count > 1, or count == 1 but RHS isn't a c-of-strings) → no usable binding (entry absent or `Unresolvable`).
+
+Function parameter names also increment the count (so a `libs` parameter shadowing a global `libs` causes us to skip — conservative). `<<-`, `->`, `->>` increment the count but never extract.
+
+---
+
+## Apply function name sets
+
+Use these exact sets in `is_apply_family_function`:
+
+```rust
+const APPLY_BARE_NAMES: &[&str] = &[
+    // base R apply family
+    "sapply", "lapply", "vapply", "mapply",
+    // purrr (callable bare when `library(purrr)` is in scope)
+    "map", "walk", "pmap", "imap", "iwalk", "pwalk",
+    "map_chr", "map_int", "map_dbl", "map_lgl", "map_raw",
+    "map_dfr", "map_dfc", "map_vec",
+    "map_if", "map_at",
+    "map2", "map2_chr", "map2_int", "map2_dbl", "map2_lgl",
+    "map2_dfr", "map2_dfc", "map2_vec",
+    "walk2",
+];
+
+const APPLY_PURRR_NAMES: &[&str] = &[
+    "map", "walk", "pmap", "imap", "iwalk", "pwalk",
+    "map_chr", "map_int", "map_dbl", "map_lgl", "map_raw",
+    "map_dfr", "map_dfc", "map_vec",
+    "map_if", "map_at",
+    "map2", "map2_chr", "map2_int", "map2_dbl", "map2_lgl",
+    "map2_dfr", "map2_dfc", "map2_vec",
+    "walk2",
+];
+```
+
+Both lists may be defined as `const` arrays at the top of the new helpers section.
+
+---
+
+## Task 1: Inline `c(...)` apply detection (sapply + library)
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` — add helpers and tests in the `// ==================== library()/require()/loadNamespace() detection tests ====================` section (around line 1382) for the tests, and immediately after `extract_package_value` (around line 720) for the new helpers.
+
+- [ ] **Step 1: Write the failing test for inline `c(...)`**
+
+Insert into `mod tests` (before the property-tests module, e.g. after `test_library_function_scope_is_none`):
+
+```rust
+#[test]
+fn test_apply_inline_c_with_library() {
+    // sapply(c("dplyr","tidyr"), library, character.only = TRUE)
+    // Validates issue #172 — the "inline c()" path.
+    let code = r#"sapply(c("dplyr", "tidyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+    // Both share the apply call's end position
+    assert_eq!(lib_calls[0].line, 0);
+    assert_eq!(lib_calls[1].line, 0);
+    assert_eq!(lib_calls[0].column, lib_calls[1].column);
+    assert!(lib_calls[0].function_scope.is_none());
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+cargo test -p raven --lib test_apply_inline_c_with_library 2>&1 | tail -20
+```
+
+Expected: `assertion `left == right` failed: 0 vs 2` (or similar — current detection returns 0 calls).
+
+- [ ] **Step 3: Add the apply-detection helpers**
+
+Insert these helpers in `source_detect.rs` immediately after `extract_package_value` (around line 720, before `#[cfg(test)] mod tests`):
+
+```rust
+// ============================================================================
+// Apply-family library detection (issue #172)
+// ============================================================================
+
+const APPLY_BARE_NAMES: &[&str] = &[
+    "sapply", "lapply", "vapply", "mapply",
+    "map", "walk", "pmap", "imap", "iwalk", "pwalk",
+    "map_chr", "map_int", "map_dbl", "map_lgl", "map_raw",
+    "map_dfr", "map_dfc", "map_vec",
+    "map_if", "map_at",
+    "map2", "map2_chr", "map2_int", "map2_dbl", "map2_lgl",
+    "map2_dfr", "map2_dfc", "map2_vec",
+    "walk2",
+];
+
+const APPLY_PURRR_NAMES: &[&str] = &[
+    "map", "walk", "pmap", "imap", "iwalk", "pwalk",
+    "map_chr", "map_int", "map_dbl", "map_lgl", "map_raw",
+    "map_dfr", "map_dfc", "map_vec",
+    "map_if", "map_at",
+    "map2", "map2_chr", "map2_int", "map2_dbl", "map2_lgl",
+    "map2_dfr", "map2_dfc", "map2_vec",
+    "walk2",
+];
+
+/// Returns true if `func_node` names a base-R or purrr apply-family function we
+/// support for static library-vector detection. Accepts bare identifiers
+/// (`sapply`, `map`, ...) and `purrr::xxx` namespace_operator nodes.
+fn is_apply_family_function(func_node: Node, content: &str) -> bool {
+    match func_node.kind() {
+        "identifier" => {
+            let name = node_text(func_node, content);
+            APPLY_BARE_NAMES.contains(&name)
+        }
+        "namespace_operator" => {
+            // Children are: identifier (namespace), :: (anonymous), identifier (name).
+            let mut cursor = func_node.walk();
+            let named_children: Vec<Node> = func_node
+                .children(&mut cursor)
+                .filter(|c| c.is_named())
+                .collect();
+            if named_children.len() != 2 {
+                return false;
+            }
+            let ns = node_text(named_children[0], content);
+            let name = node_text(named_children[1], content);
+            ns == "purrr" && APPLY_PURRR_NAMES.contains(&name)
+        }
+        _ => false,
+    }
+}
+
+/// Strict variant of `extract_c_string_args`: returns `Some(packages)` only if
+/// `node` is `c(arg1, arg2, ...)` where every argument is a positional string
+/// literal and at least one argument is present. Returns `None` for any
+/// non-string element, named argument, or empty `c()`.
+fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
+    if !is_c_call(node, content) {
+        return None;
+    }
+    let args_node = node.child_by_field_name("arguments")?;
+    if args_node.has_error() {
+        return None;
+    }
+    let mut strings = Vec::new();
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            return None; // named arg in c() — treat as dynamic
+        }
+        let value_node = child.child_by_field_name("value")?;
+        if value_node.kind() != "string" {
+            return None;
+        }
+        let s = extract_string_literal(value_node, content)?;
+        strings.push(s);
+    }
+    if strings.is_empty() {
+        None
+    } else {
+        Some(strings)
+    }
+}
+
+/// Try to interpret `node` (a "call" AST node) as an apply-family call that
+/// loads packages dynamically — e.g.
+/// `sapply(c("dplyr","tidyr"), require, character.only = TRUE)`.
+///
+/// Returns one `LibraryCall` per package when:
+/// - the function is a supported apply-family name (see `is_apply_family_function`),
+/// - `character.only = TRUE` (or `T`) is set,
+/// - exactly one positional arg resolves to `Some(Vec<String>)` (inline `c(...)`
+///   for now; same-file variables come in Task 3),
+/// - at least one positional arg is the bare identifier `library` or `require`,
+/// - and the X arg precedes nothing dynamic (we already excluded that above).
+///
+/// All returned `LibraryCall`s share the apply call's end position. Position
+/// columns use UTF-16 code units to match the rest of the LSP surface.
+fn try_parse_apply_library_call(node: Node, content: &str) -> Vec<LibraryCall> {
+    let func_node = match node.child_by_field_name("function") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if !is_apply_family_function(func_node, content) {
+        return Vec::new();
+    }
+
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if args_node.has_error() {
+        return Vec::new();
+    }
+
+    if !has_character_only_true(&args_node, content) {
+        return Vec::new();
+    }
+
+    let mut has_library_fun = false;
+    let mut packages: Option<Vec<String>> = None;
+    let mut ambiguous = false;
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            continue;
+        }
+        let value_node = match child.child_by_field_name("value") {
+            Some(n) => n,
+            None => continue,
+        };
+
+        if value_node.kind() == "identifier" {
+            let text = node_text(value_node, content);
+            if text == "library" || text == "require" {
+                has_library_fun = true;
+                continue;
+            }
+            // Variable lookup comes in Task 3; for now identifiers other than
+            // `library`/`require` are skipped silently.
+            continue;
+        }
+
+        if let Some(strings) = extract_c_strings_strict(value_node, content) {
+            if packages.is_some() {
+                ambiguous = true;
+            }
+            packages = Some(strings);
+        }
+    }
+
+    if !has_library_fun || ambiguous {
+        return Vec::new();
+    }
+    let packages = match packages {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+
+    let end = node.end_position();
+    let line_text = content.lines().nth(end.row).unwrap_or("");
+    let column = byte_offset_to_utf16_column(line_text, end.column);
+    let line = end.row as u32;
+
+    packages
+        .into_iter()
+        .map(|package| LibraryCall {
+            package,
+            line,
+            column,
+            function_scope: None,
+        })
+        .collect()
+}
+```
+
+Then update `visit_node_for_library` to also try the apply parser. Replace the existing function body (around line 547) with:
+
+```rust
+fn visit_node_for_library(node: Node, content: &str, library_calls: &mut Vec<LibraryCall>) {
+    if node.kind() == "identifier" {
+        return;
+    }
+    if node.kind() == "call" {
+        if let Some(lib_call) = try_parse_library_call(node, content) {
+            library_calls.push(lib_call);
+        } else {
+            // Fall through to apply-family detection only when the call wasn't
+            // a direct library/require/loadNamespace match — the two parsers
+            // are mutually exclusive (different function names).
+            library_calls.extend(try_parse_apply_library_call(node, content));
+        }
+    }
+
+    for child in node.children(&mut node.walk()) {
+        visit_node_for_library(child, content, library_calls);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+cargo test -p raven --lib test_apply_inline_c_with_library 2>&1 | tail -10
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "feat(cross-file): detect inline c() vector in apply-family library calls (#172)"
+```
+
+---
+
+## Task 2: All apply families — sapply / lapply / vapply / mapply, plus require
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add immediately after `test_apply_inline_c_with_library`:
+
+```rust
+#[test]
+fn test_apply_lapply_inline_c_with_require() {
+    let code = r#"lapply(c("dplyr"), require, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 1);
+    assert_eq!(lib_calls[0].package, "dplyr");
+}
+
+#[test]
+fn test_apply_vapply_inline_c() {
+    // vapply has extra signature args, but library FUN + c() X still detect.
+    let code = r#"vapply(c("dplyr","tidyr"), require, logical(1), character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+}
+
+#[test]
+fn test_apply_mapply_inline_c() {
+    // mapply puts FUN first; we're position-agnostic so it still matches.
+    let code = r#"mapply(library, c("dplyr","tidyr"), character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+}
+
+#[test]
+fn test_apply_with_require_named_x_arg_skipped() {
+    // c() inside a named arg is currently *not* detected — only positional X
+    // args are considered. This documents the limitation.
+    let code = r#"sapply(X = c("dplyr"), FUN = require, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm**
+
+```bash
+cargo test -p raven --lib 'test_apply_' 2>&1 | tail -20
+```
+
+Expected: 4 passed (the prior `test_apply_inline_c_with_library` plus three new ones; one new test asserts non-detection).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): cover lapply/vapply/mapply + require in apply detection"
+```
+
+---
+
+## Task 3: purrr — bare and `purrr::`-qualified
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the same library-test block:
+
+```rust
+#[test]
+fn test_apply_purrr_bare_walk() {
+    let code = r#"walk(c("dplyr","tidyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+}
+
+#[test]
+fn test_apply_purrr_qualified_map() {
+    let code = r#"purrr::map(c("dplyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 1);
+    assert_eq!(lib_calls[0].package, "dplyr");
+}
+
+#[test]
+fn test_apply_purrr_qualified_map_chr() {
+    let code = r#"purrr::map_chr(c("dplyr","tidyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+}
+
+#[test]
+fn test_apply_other_namespace_not_detected() {
+    // foo::map(...) is not purrr — skip.
+    let code = r#"foo::map(c("dplyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo test -p raven --lib 'test_apply_purrr' 2>&1 | tail -15
+cargo test -p raven --lib test_apply_other_namespace_not_detected 2>&1 | tail -10
+```
+
+Expected: all four tests pass with no implementation changes (the helpers from Task 1 already accept `namespace_operator`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): cover purrr bare and qualified apply detection"
+```
+
+---
+
+## Task 4: Same-file variable assignment lookup — single `<-`
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (helper + threading + tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_apply_var_single_arrow_assignment() {
+    // Same-file variable assigned exactly once via `<-` to c() of strings.
+    let code = "libs <- c(\"dplyr\", \"tidyr\")\nsapply(libs, require, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+    // Both share the apply call's end position (line 1).
+    assert_eq!(lib_calls[0].line, 1);
+    assert_eq!(lib_calls[1].line, 1);
+}
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+```bash
+cargo test -p raven --lib test_apply_var_single_arrow_assignment 2>&1 | tail -10
+```
+
+Expected: `assertion 'left == right' failed: 0 vs 2`.
+
+- [ ] **Step 3: Add `VarBinding` + the variable-collection pre-pass + thread it through**
+
+Add this near the new apply helpers (right before `try_parse_apply_library_call`):
+
+```rust
+use std::collections::HashMap;
+
+/// Information collected for an identifier appearing on the LHS of any binding
+/// (assignment operator or `assign("name", ...)` call) or as a function
+/// parameter, anywhere in the file. Used to resolve apply-X arguments that are
+/// variable references.
+///
+/// `assignment_count` includes every binding form (`<-`, `=`, `<<-`, `->`,
+/// `->>`, `assign(...)`, function parameter). Only assignments via `<-`, `=`,
+/// or `assign("name", ...)` *to a `c(...)` of string literals* populate
+/// `static_packages`; everything else leaves it empty.
+#[derive(Debug, Default)]
+struct VarBinding {
+    assignment_count: u32,
+    /// Populated only when there is at least one supported, statically-resolved
+    /// assignment. Stores `(packages, byte_offset_of_assignment_node)`.
+    static_packages: Option<(Vec<String>, usize)>,
+}
+
+impl VarBinding {
+    /// Return packages iff `count == 1` and we extracted a static c-of-strings
+    /// from that single assignment, AND the assignment node started before
+    /// `before_byte`.
+    fn resolved_before(&self, before_byte: usize) -> Option<&[String]> {
+        if self.assignment_count != 1 {
+            return None;
+        }
+        let (pkgs, off) = self.static_packages.as_ref()?;
+        if *off < before_byte {
+            Some(pkgs.as_slice())
+        } else {
+            None
+        }
+    }
+}
+
+fn collect_var_bindings(root: Node, content: &str) -> HashMap<String, VarBinding> {
+    let mut map: HashMap<String, VarBinding> = HashMap::new();
+    visit_var_bindings(root, content, &mut map);
+    map
+}
+
+fn visit_var_bindings(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    match node.kind() {
+        "binary_operator" => record_binary_assignment(node, content, map),
+        "call" => record_assign_call(node, content, map),
+        "function_definition" => record_function_params(node, content, map),
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_var_bindings(child, content, map);
+    }
+}
+
+fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    // Find named children: lhs, op, rhs (skipping anonymous tokens).
+    let mut cursor = node.walk();
+    let named: Vec<Node> = node.children(&mut cursor).filter(|c| c.is_named()).collect();
+    if named.len() != 2 {
+        return; // shape we expect is two named children with the op between as anonymous text
+    }
+    // The assignment operator is an anonymous child. Read it from the full
+    // children list to determine direction.
+    let mut walker = node.walk();
+    let all: Vec<Node> = node.children(&mut walker).collect();
+    let op_text = all.iter().find_map(|c| {
+        let t = node_text(*c, content);
+        if matches!(t, "<-" | "=" | "<<-" | "->" | "->>") {
+            Some(t)
+        } else {
+            None
+        }
+    });
+    let Some(op) = op_text else { return };
+
+    let (name_node, value_node) = match op {
+        "<-" | "=" | "<<-" => (named[0], named[1]),
+        "->" | "->>" => (named[1], named[0]),
+        _ => return,
+    };
+    if name_node.kind() != "identifier" {
+        return;
+    }
+    let name = node_text(name_node, content).to_string();
+    let entry = map.entry(name).or_default();
+    entry.assignment_count = entry.assignment_count.saturating_add(1);
+
+    // Only `<-` and `=` extract.
+    if matches!(op, "<-" | "=") {
+        if let Some(packages) = extract_c_strings_strict(value_node, content) {
+            // First static extraction wins; if a later one comes in, the count
+            // will already be > 1 so `resolved_before` will reject it anyway.
+            if entry.static_packages.is_none() {
+                entry.static_packages = Some((packages, node.start_byte()));
+            }
+        }
+    }
+}
+
+fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    let func_node = match node.child_by_field_name("function") {
+        Some(n) => n,
+        None => return,
+    };
+    if node_text(func_node, content) != "assign" {
+        return;
+    }
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) => n,
+        None => return,
+    };
+    if args_node.has_error() {
+        return;
+    }
+    let mut cursor = args_node.walk();
+    let positional: Vec<Node> = args_node
+        .children(&mut cursor)
+        .filter(|c| c.kind() == "argument" && c.child_by_field_name("name").is_none())
+        .collect();
+    if positional.len() < 2 {
+        return;
+    }
+    let name_value = match positional[0].child_by_field_name("value") {
+        Some(n) => n,
+        None => return,
+    };
+    let name = match extract_string_literal(name_value, content) {
+        Some(s) => s,
+        None => return, // dynamic name — don't bind
+    };
+    let value_node = match positional[1].child_by_field_name("value") {
+        Some(n) => n,
+        None => return,
+    };
+    let entry = map.entry(name).or_default();
+    entry.assignment_count = entry.assignment_count.saturating_add(1);
+    if let Some(packages) = extract_c_strings_strict(value_node, content) {
+        if entry.static_packages.is_none() {
+            entry.static_packages = Some((packages, node.start_byte()));
+        }
+    }
+}
+
+fn record_function_params(node: Node, content: &str, map: &mut HashMap<String, VarBinding>) {
+    // Conservative: increment count for every parameter name seen in any
+    // function definition. This deliberately disqualifies file-global
+    // identifiers shadowed by a same-named function parameter.
+    let parameters = match node.child_by_field_name("parameters") {
+        Some(n) => n,
+        None => return,
+    };
+    let mut cursor = parameters.walk();
+    for child in parameters.children(&mut cursor) {
+        if child.kind() != "parameter" {
+            continue;
+        }
+        // A parameter exposes the identifier via the `name` field.
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
+        if name_node.kind() != "identifier" {
+            continue;
+        }
+        let name = node_text(name_node, content).to_string();
+        let entry = map.entry(name).or_default();
+        entry.assignment_count = entry.assignment_count.saturating_add(1);
+    }
+}
+```
+
+Now update `try_parse_apply_library_call` to take `&HashMap<String, VarBinding>` and resolve identifier args. Replace the existing function with:
+
+```rust
+fn try_parse_apply_library_call(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+) -> Vec<LibraryCall> {
+    let func_node = match node.child_by_field_name("function") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if !is_apply_family_function(func_node, content) {
+        return Vec::new();
+    }
+
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) => n,
+        None => return Vec::new(),
+    };
+    if args_node.has_error() {
+        return Vec::new();
+    }
+
+    if !has_character_only_true(&args_node, content) {
+        return Vec::new();
+    }
+
+    let call_start = node.start_byte();
+    let mut has_library_fun = false;
+    let mut packages: Option<Vec<String>> = None;
+    let mut ambiguous = false;
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            continue;
+        }
+        let value_node = match child.child_by_field_name("value") {
+            Some(n) => n,
+            None => continue,
+        };
+
+        if value_node.kind() == "identifier" {
+            let text = node_text(value_node, content);
+            if text == "library" || text == "require" {
+                has_library_fun = true;
+                continue;
+            }
+            if let Some(binding) = var_lookup.get(text) {
+                if let Some(pkgs) = binding.resolved_before(call_start) {
+                    if packages.is_some() {
+                        ambiguous = true;
+                    }
+                    packages = Some(pkgs.to_vec());
+                }
+            }
+            continue;
+        }
+
+        if let Some(strings) = extract_c_strings_strict(value_node, content) {
+            if packages.is_some() {
+                ambiguous = true;
+            }
+            packages = Some(strings);
+        }
+    }
+
+    if !has_library_fun || ambiguous {
+        return Vec::new();
+    }
+    let packages = match packages {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+
+    let end = node.end_position();
+    let line_text = content.lines().nth(end.row).unwrap_or("");
+    let column = byte_offset_to_utf16_column(line_text, end.column);
+    let line = end.row as u32;
+
+    packages
+        .into_iter()
+        .map(|package| LibraryCall {
+            package,
+            line,
+            column,
+            function_scope: None,
+        })
+        .collect()
+}
+```
+
+Update `detect_library_calls` to build the lookup once and pass it down. Replace the body of `detect_library_calls` with:
+
+```rust
+pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
+    log::trace!("Starting tree-sitter parsing for library() call detection");
+    let mut library_calls = Vec::new();
+    let root = tree.root_node();
+    let var_lookup = collect_var_bindings(root, content);
+    visit_node_for_library(root, content, &var_lookup, &mut library_calls);
+    log::trace!(
+        "Completed library() call detection, found {} calls",
+        library_calls.len()
+    );
+    for lib_call in &library_calls {
+        log::trace!(
+            "  Detected library() call: package='{}' at line {} column {}",
+            lib_call.package,
+            lib_call.line,
+            lib_call.column
+        );
+    }
+    library_calls
+}
+```
+
+And update `visit_node_for_library`'s signature to thread the lookup:
+
+```rust
+fn visit_node_for_library(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+    library_calls: &mut Vec<LibraryCall>,
+) {
+    if node.kind() == "identifier" {
+        return;
+    }
+    if node.kind() == "call" {
+        if let Some(lib_call) = try_parse_library_call(node, content) {
+            library_calls.push(lib_call);
+        } else {
+            library_calls.extend(try_parse_apply_library_call(node, content, var_lookup));
+        }
+    }
+
+    for child in node.children(&mut node.walk()) {
+        visit_node_for_library(child, content, var_lookup, library_calls);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+cargo test -p raven --lib test_apply_var_single_arrow_assignment 2>&1 | tail -10
+cargo test -p raven --lib cross_file::source_detect 2>&1 | tail -10
+```
+
+Expected: target test passes; the existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "feat(cross-file): resolve same-file variable in apply-family library detection"
+```
+
+---
+
+## Task 5: `=` and `assign()` assignment forms; ordering rule
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn test_apply_var_equals_assignment() {
+    let code = "libs = c(\"dplyr\", \"tidyr\")\nsapply(libs, library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    assert_eq!(lib_calls[0].package, "dplyr");
+    assert_eq!(lib_calls[1].package, "tidyr");
+}
+
+#[test]
+fn test_apply_var_assign_call() {
+    let code =
+        "assign(\"libs\", c(\"dplyr\", \"tidyr\"))\nsapply(libs, library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+}
+
+#[test]
+fn test_apply_var_assignment_after_apply_call_skipped() {
+    // Variable assigned *after* the apply call must not resolve.
+    let code = "sapply(libs, library, character.only = TRUE)\nlibs <- c(\"dplyr\")";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo test -p raven --lib 'test_apply_var_' 2>&1 | tail -20
+```
+
+Expected: all three new tests pass (Task 4 already wired `=` and `assign()` and the byte-offset comparison).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): cover = / assign() / ordering in apply var lookup"
+```
+
+---
+
+## Task 6: Multi-assignment, function-arg, and dynamic skips
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn test_apply_var_multiple_assignments_skipped() {
+    let code = "libs <- c(\"dplyr\")\nlibs <- c(\"tidyr\")\nsapply(libs, library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_var_super_assignment_disqualifies() {
+    // <<- alone counts but doesn't extract — single-assignment but no static
+    // packages means the binding doesn't resolve.
+    let code = "libs <<- c(\"dplyr\")\nsapply(libs, library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_var_function_param_shadow_disqualifies() {
+    // A function parameter named `libs` increments the count and disqualifies
+    // the global binding.
+    let code = "libs <- c(\"dplyr\")\nf <- function(libs) {}\nsapply(libs, library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_dynamic_x_paste0_skipped() {
+    let code = r#"sapply(paste0("dp", "lyr"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_dynamic_x_setdiff_skipped() {
+    let code = r#"sapply(setdiff(c("a","b"), "b"), library, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_dynamic_x_c_with_var_skipped() {
+    // c() containing a non-string argument disqualifies the X arg entirely.
+    let code = "libs1 <- c(\"a\")\nsapply(c(libs1, \"b\"), library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_anonymous_fun_skipped() {
+    // \(x) library(x) — FUN is not a bare identifier.
+    let code = r#"sapply(c("dplyr"), \(x) library(x), character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_no_character_only_skipped() {
+    let code = r#"sapply(c("dplyr"), library)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_character_only_false_skipped() {
+    let code = r#"sapply(c("dplyr"), library, character.only = FALSE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+
+#[test]
+fn test_apply_loadnamespace_fun_skipped() {
+    // loadNamespace is intentionally not in the FUN allowlist.
+    let code = r#"sapply(c("dplyr"), loadNamespace, character.only = TRUE)"#;
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo test -p raven --lib 'test_apply_' 2>&1 | tail -30
+```
+
+Expected: every test in this task passes (Task 4 covers all the negative paths).
+
+- [ ] **Step 3: If any test fails, debug**
+
+The most likely fragile cases:
+- `test_apply_anonymous_fun_skipped` — confirm `\(x) library(x)` parses with the FUN argument's value being a `function_definition`, not an `identifier`. The current code ignores non-`identifier` args silently, so this should pass.
+- `test_apply_var_function_param_shadow_disqualifies` — depends on `record_function_params` correctly walking `parameters > parameter > name`. If tree-sitter-r exposes parameters differently, dump the tree (`tree.root_node().to_sexp()`) and adjust field-name lookups; otherwise iterate `parameter` children and look for the first identifier child.
+
+If a fix is needed, edit the helpers and rerun.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): cover apply-family negative paths (multi-assign, dynamic, anonymous FUN, etc.)"
+```
+
+---
+
+## Task 7: Position correctness (UTF-16 column at apply call end)
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_apply_position_at_call_end_utf16() {
+    // 🎉 is 4 UTF-8 bytes / 2 UTF-16 code units. Verify column accounting.
+    let code = "🎉; sapply(c(\"dplyr\",\"tidyr\"), library, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 2);
+    let total_utf16 = code.encode_utf16().count() as u32;
+    for call in &lib_calls {
+        assert_eq!(call.line, 0);
+        assert_eq!(call.column, total_utf16);
+    }
+}
+```
+
+- [ ] **Step 2: Run and confirm**
+
+```bash
+cargo test -p raven --lib test_apply_position_at_call_end_utf16 2>&1 | tail -10
+```
+
+Expected: pass (the helper uses `byte_offset_to_utf16_column` already).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): verify UTF-16 end-of-call position for apply detection"
+```
+
+---
+
+## Task 8: Issue #172 acceptance test (end-to-end via metadata)
+
+**Files:**
+- Modify: `crates/raven/src/cross_file/source_detect.rs` (tests only)
+
+- [ ] **Step 1: Write the test from the issue**
+
+```rust
+#[test]
+fn test_apply_issue_172_exact_example() {
+    // Issue #172: this exact pattern should produce LibraryCalls so
+    // downstream package-export plumbing turns the underlines off.
+    let code = "libs <- c(\"lib1\", \"lib2\", \"lib3\")\nsapply(libs, require, character.only = TRUE)";
+    let tree = parse_r(code);
+    let lib_calls = detect_library_calls(&tree, code);
+    assert_eq!(lib_calls.len(), 3);
+    assert_eq!(lib_calls[0].package, "lib1");
+    assert_eq!(lib_calls[1].package, "lib2");
+    assert_eq!(lib_calls[2].package, "lib3");
+    // Order is the c() literal order — apply call is on line 1.
+    for call in &lib_calls {
+        assert_eq!(call.line, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Verify metadata pipeline picks them up**
+
+Add a sibling test that goes through the public `extract_metadata` path so we know the wiring all the way up to the consumer is correct:
+
+```rust
+#[test]
+fn test_apply_issue_172_via_extract_metadata() {
+    let code = "libs <- c(\"lib1\", \"lib2\", \"lib3\")\nsapply(libs, require, character.only = TRUE)";
+    let meta = crate::cross_file::extract_metadata(code);
+    let pkgs: Vec<&str> = meta.library_calls.iter().map(|c| c.package.as_str()).collect();
+    assert_eq!(pkgs, vec!["lib1", "lib2", "lib3"]);
+}
+```
+
+(This test goes in the same module — `extract_metadata` is `pub` and re-exports work because `source_detect`'s test module already references the parent crate via `super::*`. If the import path needs adjusting, use `crate::cross_file::extract_metadata` as shown.)
+
+- [ ] **Step 3: Run**
+
+```bash
+cargo test -p raven --lib 'test_apply_issue_172' 2>&1 | tail -15
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/raven/src/cross_file/source_detect.rs
+git commit -m "test(cross-file): regression coverage for issue #172"
+```
+
+---
+
+## Task 9: Update user-facing documentation
+
+**Files:**
+- Modify: `docs/cross-file.md` — extend the Supported Call Patterns table and add a short paragraph
+
+- [ ] **Step 1: Edit the docs**
+
+In `docs/cross-file.md`, extend the "Supported Call Patterns" table (currently around line 100). After the existing rows add:
+
+```markdown
+| `sapply(c("a","b"), library, character.only = TRUE)` | Yes (apply family) |
+| `sapply(libs, library, character.only = TRUE)` where `libs <- c("a","b")` | Yes (same-file variable) |
+| `purrr::map(c("a","b"), library, character.only = TRUE)` | Yes (purrr family) |
+| `sapply(paste0(...), library, character.only = TRUE)` | No (dynamic vector) |
+```
+
+Then add a short subsection right after the table, before "Keeping Packages in Sync":
+
+```markdown
+### Apply-Family Loads
+
+Raven also recognises package loads expressed through apply-family calls when
+all the package names are statically determinable:
+
+```r
+libs <- c("dplyr", "tidyr")
+sapply(libs, require, character.only = TRUE)
+```
+
+This works for `sapply`, `lapply`, `vapply`, `mapply`, and the purrr forms
+(`map`, `walk`, `map_chr`, etc., bare or `purrr::`-qualified). The package
+vector must be either an inline `c("a","b",...)` of string literals or a
+same-file variable assigned exactly once via `<-`, `=`, or `assign()` to such a
+literal vector. `character.only = TRUE` must be present (without it, R itself
+would not load the strings as packages). Dynamic constructions such as
+`paste0(...)`, `tolower(x)`, `c(libs1, libs2)`, or values defined in another
+file are silently ignored.
+```
+
+(Note: the inner code fence in the second markdown block uses the same triple-backtick depth as the other code fences in the file — re-check that it's not nested inside another fence.)
+
+- [ ] **Step 2: Lint check**
+
+```bash
+# Check the file still passes any existing markdown lint by eyeballing it
+# alongside neighbouring rows. The project uses MD040 (language tags on
+# fences) — make sure the new fence is `r`.
+cat docs/cross-file.md | head -125 | tail -40
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/cross-file.md
+git commit -m "docs(cross-file): document apply-family library detection (#172)"
+```
+
+---
+
+## Task 10: Final verification and feature commit
+
+**Files:** none
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+cargo test -p raven 2>&1 | tail -30
+```
+
+Expected: all green. Pay attention to existing library tests and property tests in `cross_file::source_detect`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cargo build -p raven 2>&1 | tail -10
+```
+
+Expected: clean build, no warnings introduced (or only ones already present pre-change).
+
+- [ ] **Step 3: Confirm no clippy regression on changed files**
+
+```bash
+cargo clippy -p raven --lib --no-deps -- -D warnings 2>&1 | tail -30
+```
+
+Expected: clean, or only pre-existing warnings — do not introduce new ones in `source_detect.rs`.
+
+- [ ] **Step 4: Stop. Hand off to verification skill**
+
+Use `superpowers:verification-before-completion` before claiming done. Confirm:
+- All cargo commands above produced expected output
+- The new tests cover every bullet under "Behaviour spec"
+- Issue #172's exact pattern produces three `LibraryCall` entries
+
+If anything is off, fix and re-run instead of declaring success.
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:** every bullet under "Behaviour spec" is exercised by a test in Tasks 1–8. The "function arg origin → skip" case is covered by `test_apply_var_function_param_shadow_disqualifies`. The "anything dynamic" case is covered by the dynamic-X tests in Task 6.
+- **Placeholder scan:** none.
+- **Type/name consistency:** `VarBinding`, `collect_var_bindings`, `try_parse_apply_library_call`, `is_apply_family_function`, `extract_c_strings_strict` are referenced consistently in every task. `LibraryCall`'s public shape is unchanged.
+- **Downstream impact:** none — `LibraryCall`'s consumers in `mod.rs::extract_metadata`, `scope.rs::compute_artifacts*`, and `backend.rs::extract_loaded_packages_from_library_calls` already iterate the vector and tolerate multiple entries at the same `(line, column)`.

--- a/docs/superpowers/plans/2026-05-06-apply-family-library-detection.md
+++ b/docs/superpowers/plans/2026-05-06-apply-family-library-detection.md
@@ -1191,9 +1191,9 @@ In `docs/cross-file.md`, extend the "Supported Call Patterns" table (currently a
 | `sapply(paste0(...), library, character.only = TRUE)` | No (dynamic vector) |
 ```
 
-Then add a short subsection right after the table, before "Keeping Packages in Sync":
+Then add a short subsection right after the table, before "Keeping Packages in Sync" (note the outer fence uses four backticks so the inner triple-backtick `r` block doesn't close it prematurely):
 
-```markdown
+````markdown
 ### Apply-Family Loads
 
 Raven also recognises package loads expressed through apply-family calls when
@@ -1212,9 +1212,7 @@ literal vector. `character.only = TRUE` must be present (without it, R itself
 would not load the strings as packages). Dynamic constructions such as
 `paste0(...)`, `tolower(x)`, `c(libs1, libs2)`, or values defined in another
 file are silently ignored.
-```
-
-(Note: the inner code fence in the second markdown block uses the same triple-backtick depth as the other code fences in the file — re-check that it's not nested inside another fence.)
+````
 
 - [ ] **Step 2: Lint check**
 


### PR DESCRIPTION
## Summary

- Detects `library`/`require` package loads inside `sapply`/`lapply`/`vapply`/`mapply` and `purrr::map`/`walk`/etc., when the package vector is statically resolvable. Closes/addresses #172.
- Two extraction paths: inline `c("a","b",...)` of string literals, and a same-file variable assigned exactly once via `<-`/`=`/`assign()` to such a vector. `character.only = TRUE` is required.
- All other patterns (dynamic `paste0`/`setdiff`/`tolower`, function-arg origins, multi-assignments, `<<-`/`->`/`->>`, anonymous-function FUNs, `loadNamespace` as FUN, missing/false `character.only`) are silently skipped.
- Each apply emits one `LibraryCall` per package, sharing the apply call's UTF-16 end position. `LibraryCall`'s public shape is unchanged, so `extract_metadata`, `compute_artifacts*`, and `extract_loaded_packages_from_library_calls` pick up the new entries with no other code changes.
- Docs updated in `docs/cross-file.md` (Supported Call Patterns table + new "Apply-Family Loads" subsection).

## Test plan

- [x] `cargo test -p raven` — 3237 unit + 103 integration + 58 doctest, 0 failures
- [x] `cargo build -p raven` — clean
- [x] `cargo clippy -p raven --lib --no-deps` — 26 warnings, all pre-existing on `main`; no new warnings introduced
- [x] 26 new tests in `cross_file::source_detect::tests` cover: inline `c()`, all four base apply functions, both `require` and `library` as FUN, both bare-purrr and `purrr::`-qualified calls, same-file variable via `<-`/`=`/`assign()`, ordering rule (assignment must precede the apply call), multi-assignment skip, `<<-` skip, function-parameter shadow skip, dynamic `paste0`/`setdiff`/`c(var,"x")` skip, anonymous-function FUN skip, missing/false `character.only` skip, `loadNamespace` as FUN skip, UTF-16 column at apply end, and the exact issue #172 example end-to-end through `extract_metadata`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended library detection to recognize packages loaded via apply-family functions (sapply, lapply, vapply, mapply, purrr map/walk), improving static resolution of package usage in varied code patterns.

* **Documentation**
  * Added “Apply-Family Loads” docs with examples, supported patterns, and limitations.

* **Tests**
  * Added comprehensive tests covering inline vectors, same-file variable bindings, purrr variants, argument handling, and position consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->