### PR TITLE
Harden send-to-R temp cleanup and restrict config scopes

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -22,6 +22,18 @@
     "onTerminalProfile:raven.rTerminal"
   ],
   "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Executable-path settings are read from user/global settings only in untrusted workspaces.",
+      "restrictedConfigurations": [
+        "raven.rTerminal.program",
+        "raven.server.path",
+        "raven.packages.rPath",
+        "raven.packages.additionalLibraryPaths"
+      ]
+    }
+  },
   "contributes": {
     "commands": [
       {
@@ -222,6 +234,7 @@
             "radian"
           ],
           "default": "R",
+          "scope": "machine-overridable",
           "description": "Program to use for the R terminal. 'R' is the standard R console; 'arf' and 'radian' are modern third-party R consoles (must be installed separately)."
         },
         "raven.sendToR.advanceCursorOnSend": {
@@ -232,6 +245,7 @@
         "raven.server.path": {
           "type": "string",
           "default": "",
+          "scope": "machine-overridable",
           "description": "Path to raven binary. If empty, uses bundled binary."
         },
         "raven.trace.server": {
@@ -505,11 +519,13 @@
             "type": "string"
           },
           "default": [],
+          "scope": "machine-overridable",
           "description": "Additional library paths to search for R packages. These paths are searched in addition to the default R library paths. Useful for projects with packages installed in non-standard locations or custom library directories."
         },
         "raven.packages.rPath": {
           "type": "string",
           "default": "",
+          "scope": "machine-overridable",
           "description": "Path to the R executable. If empty, Raven searches for R in the system PATH. Specify this setting if R is installed in a non-standard location or if you want to use a specific R installation."
         },
         "raven.packages.missingPackageSeverity": {

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -123,12 +123,13 @@ async function handle_terminal_send(mode: SendMode): Promise<void> {
 
 function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
     const tmp = create_temp_file(code);
-    // Have R unlink the file as part of consuming it, so cleanup is tied to
-    // execution rather than a wall-clock timer. The JS fallback below only
-    // runs if R never reaches the source() line (e.g. session crashed).
+    // Have R unlink the script's per-call directory as part of consuming it,
+    // so cleanup is tied to execution rather than a wall-clock timer. The JS
+    // fallback below only runs if R never reaches the source() line (e.g.
+    // session crashed).
     const path_literal = JSON.stringify(tmp);
     terminal.sendText(
-        `local({ .raven_src <- ${path_literal}; on.exit(unlink(.raven_src)); source(.raven_src, echo = TRUE) })`
+        `local({ .raven_src <- ${path_literal}; on.exit(unlink(dirname(.raven_src), recursive = TRUE)); source(.raven_src, echo = TRUE) })`
     );
     schedule_temp_file_cleanup(tmp);
 }

--- a/editors/vscode/src/send-to-r/temp-file.ts
+++ b/editors/vscode/src/send-to-r/temp-file.ts
@@ -6,11 +6,14 @@ import * as os from 'os';
 // the source() wrapper. This timer catches the case where R never reaches the
 // source line at all (session crashed before reading it).
 const CLEANUP_DELAY_MS = 120_000;
-let counter = 0;
 
 export function create_temp_file(content: string): string {
-    const tmp_dir = os.tmpdir();
-    const file_path = path.join(tmp_dir, `raven_send_${Date.now()}_${counter++}.R`);
+    // mkdtempSync creates a directory with mode 0o700 (POSIX) and an
+    // unpredictable random suffix, eliminating the symlink-race vector on
+    // legacy Linux kernels without fs.protected_symlinks. The script lives
+    // inside the per-call directory so callers (and R) can clean both up.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'raven_send_'));
+    const file_path = path.join(dir, 'src.R');
     fs.writeFileSync(file_path, content, { encoding: 'utf8', mode: 0o600 });
     return file_path;
 }
@@ -18,5 +21,6 @@ export function create_temp_file(content: string): string {
 export function schedule_temp_file_cleanup(file_path: string): void {
     setTimeout(() => {
         try { fs.unlinkSync(file_path); } catch {}
+        try { fs.rmdirSync(path.dirname(file_path)); } catch {}
     }, CLEANUP_DELAY_MS);
 }


### PR DESCRIPTION
## Summary
- Create per-send temp directories for `send to R` scripts using `mkdtempSync`, reducing symlink-race risk and keeping each script isolated.
- Clean up both the temp file and its parent directory, with the JS fallback now removing the per-call directory if R does not clean it up first.
- Update the R-related VS Code settings to be `machine-overridable` and restrict executable-path settings in untrusted workspaces to user/global scope only.

## Testing
- Not run (PR content only).
- Verified the diff updates cleanup logic in `temp-file.ts` and `commands.ts` consistently.
- Verified the new `untrustedWorkspaces` and `scope` entries are added in `package.json` for the affected settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for untrusted workspace configurations with restricted settings.
  * Enabled machine-level overrides for R terminal program, server path, and package library settings.

* **Bug Fixes**
  * Improved temporary file cleanup to prevent orphaned files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->