### PR TITLE
fix(vscode): re-check cancellation after awaiting plot env in terminal profile

### DIFF
--- a/editors/vscode/src/send-to-r/r-terminal-manager.ts
+++ b/editors/vscode/src/send-to-r/r-terminal-manager.ts
@@ -123,6 +123,9 @@ export function register_r_terminal(
             }
             const program = get_program();
             const plot_env = await get_plot_terminal_env();
+            if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
+            }
             const profile = new vscode.TerminalProfile({
                 name: TERMINAL_NAME,
                 shellPath: program,


### PR DESCRIPTION
## Summary

- Re-check the cancellation token after `await get_plot_terminal_env()` in `provideTerminalProfile` so a token that fires during the await throws a `CancellationError` instead of incrementing `pending_profile_creation_count` and pushing a session ID for a profile VS Code is about to discard.

## Why

PR #170 fixed a leak where `pending_profile_creation_count` could be incremented for cancelled profile requests, and addressed it by keeping the function synchronous after the cancellation check (commit `b8f24ce`). PR #176 then inserted `await get_plot_terminal_env()` between the cancellation check and the increment, reopening the gap. If the user dismisses the terminal picker during that brief await window, the counter stays inflated and the next R terminal that opens — even one created by an unrelated path — gets misclassified by `onDidOpenTerminal` as profile-spawned.

The await is short (config read + cached profile-write promise), so the window is small and the impact (one mis-attributed terminal, self-healing) is benign. But the invariant that PR #170's review explicitly established is that `provideTerminalProfile` must not bump the counter on a cancelled request, and adding more awaits later would compound the leak.

## Test plan

- [ ] `cd editors/vscode && npx tsc --noEmit` passes (verified locally)
- [ ] CI builds and tests pass