### PR TITLE
Add configurable send method and shell-validated R terminal fallback

### DIFF
--- a/docs/send-to-r.md
+++ b/docs/send-to-r.md
@@ -47,7 +47,7 @@ A toolbar button (▶) appears in the editor title bar for R files, providing qu
 - **Main commands** — Send code to the managed R (Raven) terminal. If no R terminal is open, one is created automatically.
 - **Terminal submenu** — Send code to whatever terminal is currently active in VS Code, regardless of type. This is useful for sending commands to R running inside `tmux`, a Docker container, or any other terminal session that isn't the extension's built-in R terminal.
 
-Selections and line ranges sent via the Terminal submenu are written to a temporary file and executed with `source()`, which avoids issues with large pastes over SSH or slow connections. **Terminal: Source File** runs `source()` directly against the document's saved path on disk (saving first if the buffer has unsaved changes).
+Code sent via the Terminal submenu follows the same send method as the main commands. By default, Raven pastes single-line code directly and writes multi-line code to a temporary file, executing it with `source()`. **Terminal: Source File** runs `source()` directly against the document's saved path on disk (saving first if the buffer has unsaved changes).
 
 ## Statement Detection
 
@@ -83,12 +83,28 @@ By default, the cursor advances to the next line after sending a single statemen
 
 **Configuration**: `raven.sendToR.advanceCursorOnSend` (default: `true`)
 
+## Send Method
+
+By default (`auto`), Raven pastes single-line code directly and writes multi-line code to a temporary file, executing it with `source()`. Override this with `raven.sendToR.sendMethod`:
+
+- **`paste`** — always pastes. For multi-line code, uses bracketed paste mode to deliver the block as a single unit.
+- **`tempfile`** — always writes to a temp file and runs `source()`. Use this for maximum consistency, or when even single-line paste is unreliable.
+
+**Why Raven defaults to temp files for multi-line code**
+
+When multi-line code is pasted, the terminal delivers characters to R's stdin faster than readline can process them, which can silently drop or corrupt lines. This affects the standard R console as well as arf and radian. Writing to a temp file sidesteps this entirely: R reads from disk rather than stdin, so there is no terminal paste-buffer race, no practical paste-size limit from stdin buffering, and no sensitivity to connection speed.
+
+`source(echo = TRUE)` also produces cleaner output: code is echoed line-by-line with `+` continuation prompts, matching how R normally displays interactive input.
+
+REditorSupport pastes directly for all code. If you prefer that behavior — for example, because you want raw paste output rather than `source()` echoing — set `raven.sendToR.sendMethod` to `"paste"`.
+
 ## Configuration Options
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `raven.rTerminal.program` | enum | `"R"` | Program for the R terminal: `"R"`, `"arf"`, or `"radian"` |
 | `raven.sendToR.advanceCursorOnSend` | boolean | `true` | Advance cursor to next line after sending a single statement |
+| `raven.sendToR.sendMethod` | enum | `"auto"` | How code is sent to R: `"auto"`, `"paste"`, or `"tempfile"` |
 
 ## Plot Viewer
 

--- a/docs/superpowers/specs/2026-05-07-send-method-setting-design.md
+++ b/docs/superpowers/specs/2026-05-07-send-method-setting-design.md
@@ -1,0 +1,94 @@
+# Design: `raven.sendToR.sendMethod` setting
+
+**Date:** 2026-05-07
+**Status:** Approved, ready for implementation
+
+## Overview
+
+Add a `raven.sendToR.sendMethod` setting that lets users control whether Raven sends code to R via direct paste, bracketed paste, or a temp file. The default (`auto`) preserves current behavior.
+
+## Background
+
+Raven currently uses two different mechanisms depending on the code being sent:
+
+- **Single-line code** → `terminal.sendText()` (direct paste)
+- **Multi-line code** → writes to a temp file, then `source()`s it
+
+The tempfile path exists because pasting multi-line code over stdin can silently drop or corrupt lines — terminals deliver characters faster than R's readline can consume them. This affects the standard R console as well as arf and radian. `source(echo = TRUE)` also produces cleaner, more predictable output than a raw paste.
+
+REditorSupport pastes directly for all code. Users migrating from it may be surprised by the tempfile behavior, or may have specific reasons to prefer one mode.
+
+## Setting spec
+
+**Name:** `raven.sendToR.sendMethod`
+**Type:** enum
+**Default:** `"auto"`
+
+| Value | Single-line behavior | Multi-line behavior |
+|-------|---------------------|---------------------|
+| `"auto"` | `terminal.sendText()` | temp file + `source(echo = TRUE)` |
+| `"paste"` | `terminal.sendText()` | bracketed paste (`\x1b[200~`...`\x1b[201~`) |
+| `"tempfile"` | temp file + `source(echo = TRUE)` | temp file + `source(echo = TRUE)` |
+
+**Scope:** applies to both the Raven-managed terminal (`handle_send`) and the Terminal submenu (`handle_terminal_send`). The `sourceFile` command — which runs `source()` against the document's saved path — is unaffected in all modes.
+
+## Settings UI description (package.json)
+
+> Controls how Raven sends code to R. `auto` (default) pastes single-line code directly and uses a temp file for multi-line blocks. `paste` always pastes, using bracketed paste mode for multi-line code. `tempfile` always writes to a temp file and runs `source()`.
+
+## User-facing docs (docs/send-to-r.md)
+
+### Configuration table
+
+Add to the Configuration Options table:
+
+| `raven.sendToR.sendMethod` | enum | `"auto"` | How code is sent to R: `"auto"`, `"paste"`, or `"tempfile"` |
+
+### New subsection: "Send Method"
+
+Insert after the existing "Cursor Advancement" subsection.
+
+---
+
+By default (`auto`), Raven pastes single-line code directly and writes multi-line code to a temporary file, executing it with `source()`. Override this with `raven.sendToR.sendMethod`:
+
+- **`paste`** — always pastes. For multi-line code, uses bracketed paste mode to deliver the block as a single unit.
+- **`tempfile`** — always writes to a temp file and runs `source()`. Use this for maximum consistency, or when even single-line paste is unreliable.
+
+**Why Raven defaults to temp files for multi-line code**
+
+When multi-line code is pasted, the terminal delivers characters to R's stdin faster than readline can process them, which can silently drop or corrupt lines. This affects the standard R console as well as arf and radian. Writing to a temp file sidesteps this entirely: R reads from disk rather than stdin, so there is no buffering race, no size limit, and no sensitivity to connection speed.
+
+`source(echo = TRUE)` also produces cleaner output: code is echoed line-by-line with `+` continuation prompts, matching how R normally displays interactive input.
+
+REditorSupport pastes directly for all code. If you prefer that behavior — for example, because you want raw paste output rather than `source()` echoing — set `raven.sendToR.sendMethod` to `"paste"`.
+
+---
+
+## Implementation notes
+
+### commands.ts changes
+
+The dispatch logic in `handle_send` (line 86–91) and `handle_terminal_send` (line 112–121) needs to read the new setting and branch accordingly.
+
+```
+auto    + single-line  →  terminal.sendText(code)
+auto    + multi-line   →  send_via_tempfile(terminal, code)
+paste   + single-line  →  terminal.sendText(code)
+paste   + multi-line   →  terminal.sendText('\x1b[200~' + code + '\x1b[201~')
+tempfile + any         →  send_via_tempfile(terminal, code)
+```
+
+The `sourceFile` mode short-circuits before the dispatch point in both handlers and is unaffected.
+
+`sendMethod` is read directly from `vscode.workspace.getConfiguration('raven.sendToR')` in the command handlers — it is a client-side-only setting and does not go through `initializationOptions.ts`.
+
+### package.json changes
+
+Add `raven.sendToR.sendMethod` to the `contributes.configuration` block with enum values `["auto", "paste", "tempfile"]`, `enumDescriptions`, and `default: "auto"`.
+
+## Out of scope
+
+- No change to `sourceFile` behavior
+- No per-command override (one setting controls all send commands)
+- No separate setting for the Terminal submenu vs. the Raven terminal

--- a/docs/superpowers/specs/2026-05-07-send-method-setting-design.md
+++ b/docs/superpowers/specs/2026-05-07-send-method-setting-design.md
@@ -5,14 +5,16 @@
 
 ## Overview
 
-Add a `raven.sendToR.sendMethod` setting that lets users control whether Raven sends code to R via direct paste, bracketed paste, or a temp file. The default (`auto`) preserves current behavior.
+Add a `raven.sendToR.sendMethod` setting that lets users control whether Raven sends code to R via direct paste, bracketed paste, or a temp file. The default (`auto`) preserves the Raven-managed terminal behavior and normalizes the Terminal submenu to the same dispatch rule: direct paste for single-line code, temp file for multi-line code.
 
 ## Background
 
-Raven currently uses two different mechanisms depending on the code being sent:
+The Raven-managed terminal currently uses two different mechanisms depending on the code being sent:
 
 - **Single-line code** → `terminal.sendText()` (direct paste)
 - **Multi-line code** → writes to a temp file, then `source()`s it
+
+The Terminal submenu currently sends every non-`sourceFile` payload through a temp file. This design intentionally changes that path so `auto` means the same thing for both command groups.
 
 The tempfile path exists because pasting multi-line code over stdin can silently drop or corrupt lines — terminals deliver characters faster than R's readline can consume them. This affects the standard R console as well as arf and radian. `source(echo = TRUE)` also produces cleaner, more predictable output than a raw paste.
 
@@ -30,7 +32,7 @@ REditorSupport pastes directly for all code. Users migrating from it may be surp
 | `"paste"` | `terminal.sendText()` | bracketed paste (`\x1b[200~`...`\x1b[201~`) |
 | `"tempfile"` | temp file + `source(echo = TRUE)` | temp file + `source(echo = TRUE)` |
 
-**Scope:** applies to both the Raven-managed terminal (`handle_send`) and the Terminal submenu (`handle_terminal_send`). The `sourceFile` command — which runs `source()` against the document's saved path — is unaffected in all modes.
+**Scope:** applies to both the Raven-managed terminal (`handle_send`) and the Terminal submenu (`handle_terminal_send`). The `sourceFile` command — which runs `source()` against the document's saved path — is unaffected in all modes and must bypass `sendMethod` dispatch explicitly.
 
 ## Settings UI description (package.json)
 
@@ -57,7 +59,7 @@ By default (`auto`), Raven pastes single-line code directly and writes multi-lin
 
 **Why Raven defaults to temp files for multi-line code**
 
-When multi-line code is pasted, the terminal delivers characters to R's stdin faster than readline can process them, which can silently drop or corrupt lines. This affects the standard R console as well as arf and radian. Writing to a temp file sidesteps this entirely: R reads from disk rather than stdin, so there is no buffering race, no size limit, and no sensitivity to connection speed.
+When multi-line code is pasted, the terminal delivers characters to R's stdin faster than readline can process them, which can silently drop or corrupt lines. This affects the standard R console as well as arf and radian. Writing to a temp file sidesteps this entirely: R reads from disk rather than stdin, so there is no terminal paste-buffer race, no practical paste-size limit from stdin buffering, and no sensitivity to connection speed.
 
 `source(echo = TRUE)` also produces cleaner output: code is echoed line-by-line with `+` continuation prompts, matching how R normally displays interactive input.
 
@@ -69,23 +71,59 @@ REditorSupport pastes directly for all code. If you prefer that behavior — for
 
 ### commands.ts changes
 
-The dispatch logic in `handle_send` (line 86–91) and `handle_terminal_send` (line 112–121) needs to read the new setting and branch accordingly.
+The dispatch logic in `handle_send` and `handle_terminal_send` needs to read the new setting and branch accordingly. Both handlers should explicitly send `mode === "file"` payloads with `terminal.sendText(code)` and return before considering `sendMethod`; this prevents `sourceFile` from being routed through a temp file when `sendMethod` is `"tempfile"`.
 
-```
+For all non-file sends:
+
+```text
 auto    + single-line  →  terminal.sendText(code)
 auto    + multi-line   →  send_via_tempfile(terminal, code)
 paste   + single-line  →  terminal.sendText(code)
 paste   + multi-line   →  terminal.sendText('\x1b[200~' + code + '\x1b[201~')
-tempfile + any         →  send_via_tempfile(terminal, code)
+tempfile + any non-file → send_via_tempfile(terminal, code)
 ```
 
-The `sourceFile` mode short-circuits before the dispatch point in both handlers and is unaffected.
+Extract the dispatch decision into a small testable helper rather than duplicating the matrix in both handlers. One acceptable shape:
+
+```ts
+type SendMethod = 'auto' | 'paste' | 'tempfile';
+type SendTransport = 'direct-paste' | 'bracketed-paste' | 'tempfile';
+
+function choose_send_transport(code: string, sendMethod: SendMethod): SendTransport {
+    // Implements the non-file matrix above.
+}
+```
+
+The command handlers remain responsible for the `mode === "file"` short-circuit, because `sourceFile` is a command-mode rule rather than a code-shape rule.
+
+Add a `send_via_bracketed_paste(terminal, code)` helper for multi-line `"paste"` sends. It should use bracketed paste delimiters:
+
+```ts
+terminal.sendText('\x1b[200~' + code + '\x1b[201~');
+```
+
+Use `terminal.sendText`'s default execution behavior unless implementation testing shows that an explicit trailing newline or `shouldExecute` value is needed.
 
 `sendMethod` is read directly from `vscode.workspace.getConfiguration('raven.sendToR')` in the command handlers — it is a client-side-only setting and does not go through `initializationOptions.ts`.
 
 ### package.json changes
 
 Add `raven.sendToR.sendMethod` to the `contributes.configuration` block with enum values `["auto", "paste", "tempfile"]`, `enumDescriptions`, and `default: "auto"`.
+
+### Tests and verification
+
+Add automated tests for the pure dispatch helper covering:
+
+- `"auto"` + single-line → direct paste
+- `"auto"` + multi-line → temp file
+- `"paste"` + single-line → direct paste
+- `"paste"` + multi-line → bracketed paste
+- `"tempfile"` + single-line → temp file
+- `"tempfile"` + multi-line → temp file
+
+Also add or update handler-level coverage, if practical, to verify that `mode === "file"` bypasses the helper and always sends the computed `source("path", echo = TRUE)` command directly.
+
+Manual smoke testing should verify that multi-line `"paste"` sends work with standard R. Best-effort verification with arf and radian is desirable because the docs name them as supported consoles.
 
 ## Out of scope
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -241,6 +241,21 @@
           "default": true,
           "description": "Advance cursor to the next line after sending a single statement to R."
         },
+        "raven.sendToR.sendMethod": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "paste",
+            "tempfile"
+          ],
+          "enumDescriptions": [
+            "Paste single-line code directly and use a temporary file for multi-line blocks.",
+            "Paste code directly. Multi-line blocks use bracketed paste mode.",
+            "Write code to a temporary file and run source() for both single-line and multi-line sends."
+          ],
+          "default": "auto",
+          "description": "Controls how Raven sends code to R. 'auto' pastes single-line code directly and uses a temp file for multi-line blocks. 'paste' always pastes, using bracketed paste mode for multi-line code. 'tempfile' always writes to a temp file and runs source()."
+        },
         "raven.server.path": {
           "type": "string",
           "default": "",

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -6,6 +6,7 @@ import {
 } from './statement-detector';
 import { get_or_create_r_terminal } from './r-terminal-manager';
 import { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
+import { choose_send_transport, SendMethod } from './send-method';
 
 type SendMode = 'statement' | 'upward' | 'downward' | 'file';
 
@@ -83,10 +84,10 @@ async function handle_send(mode: SendMode): Promise<void> {
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
 
-    if (code.includes('\n')) {
-        send_via_tempfile(terminal, code);
-    } else {
+    if (mode === 'file') {
         terminal.sendText(code);
+    } else {
+        send_code(terminal, code, get_send_method());
     }
 
     if (advance_to_line !== null) {
@@ -113,12 +114,43 @@ async function handle_terminal_send(mode: SendMode): Promise<void> {
     if (mode === 'file') {
         terminal.sendText(code);
     } else {
-        send_via_tempfile(terminal, code);
+        send_code(terminal, code, get_send_method());
     }
 
     if (advance_to_line !== null) {
         advance_cursor(editor, advance_to_line);
     }
+}
+
+function get_send_method(): SendMethod {
+    return vscode.workspace
+        .getConfiguration('raven.sendToR')
+        .get<SendMethod>('sendMethod', 'auto');
+}
+
+function send_code(
+    terminal: vscode.Terminal,
+    code: string,
+    sendMethod: SendMethod,
+): void {
+    switch (choose_send_transport(code, sendMethod)) {
+        case 'direct-paste':
+            terminal.sendText(code);
+            return;
+        case 'bracketed-paste':
+            send_via_bracketed_paste(terminal, code);
+            return;
+        case 'tempfile':
+            send_via_tempfile(terminal, code);
+            return;
+    }
+}
+
+function send_via_bracketed_paste(
+    terminal: vscode.Terminal,
+    code: string,
+): void {
+    terminal.sendText('\x1b[200~' + code + '\x1b[201~');
 }
 
 function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
@@ -150,7 +182,7 @@ export function register_send_to_r_commands(
         );
     }
 
-    // Terminal submenu: send to active terminal via tempfile
+    // Terminal submenu: send to active terminal using the configured send method.
     const terminal_commands: Array<[string, SendMode]> = [
         ['raven.terminal.runLineOrSelection', 'statement'],
         ['raven.terminal.runUpwardLines', 'upward'],

--- a/editors/vscode/src/send-to-r/send-method.ts
+++ b/editors/vscode/src/send-to-r/send-method.ts
@@ -1,0 +1,26 @@
+export type SendMethod = 'auto' | 'paste' | 'tempfile';
+export type SendTransport = 'direct-paste' | 'bracketed-paste' | 'tempfile';
+
+export function choose_send_transport(
+    code: string,
+    sendMethod: SendMethod,
+): SendTransport {
+    const normalized = sendMethod === 'paste' || sendMethod === 'tempfile'
+        ? sendMethod
+        : 'auto';
+
+    if (normalized === 'tempfile') {
+        return 'tempfile';
+    }
+
+    const is_multiline = code.includes('\n');
+    if (normalized === 'paste' && is_multiline) {
+        return 'bracketed-paste';
+    }
+
+    if (normalized === 'auto' && is_multiline) {
+        return 'tempfile';
+    }
+
+    return 'direct-paste';
+}

--- a/tests/bun/send-method.test.ts
+++ b/tests/bun/send-method.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  choose_send_transport,
+  type SendMethod,
+} from "../../editors/vscode/src/send-to-r/send-method";
+
+describe("choose_send_transport", () => {
+  const cases: Array<{
+    name: string;
+    code: string;
+    sendMethod: SendMethod;
+    expected: string;
+  }> = [
+    {
+      name: "auto sends single-line code by direct paste",
+      code: "x <- 1",
+      sendMethod: "auto",
+      expected: "direct-paste",
+    },
+    {
+      name: "auto sends multi-line code via temp file",
+      code: "x <- 1\ny <- 2",
+      sendMethod: "auto",
+      expected: "tempfile",
+    },
+    {
+      name: "paste sends single-line code by direct paste",
+      code: "x <- 1",
+      sendMethod: "paste",
+      expected: "direct-paste",
+    },
+    {
+      name: "paste sends multi-line code by bracketed paste",
+      code: "x <- 1\ny <- 2",
+      sendMethod: "paste",
+      expected: "bracketed-paste",
+    },
+    {
+      name: "tempfile sends single-line code via temp file",
+      code: "x <- 1",
+      sendMethod: "tempfile",
+      expected: "tempfile",
+    },
+    {
+      name: "tempfile sends multi-line code via temp file",
+      code: "x <- 1\ny <- 2",
+      sendMethod: "tempfile",
+      expected: "tempfile",
+    },
+  ];
+
+  for (const { name, code, sendMethod, expected } of cases) {
+    test(name, () => {
+      expect(choose_send_transport(code, sendMethod)).toBe(expected);
+    });
+  }
+
+  test("unknown send method falls back to auto", () => {
+    expect(choose_send_transport("x <- 1", "bogus" as SendMethod)).toBe(
+      "direct-paste",
+    );
+    expect(choose_send_transport("x <- 1\ny <- 2", "bogus" as SendMethod)).toBe(
+      "tempfile",
+    );
+  });
+});

--- a/tests/bun/vscode-config.test.ts
+++ b/tests/bun/vscode-config.test.ts
@@ -101,3 +101,25 @@ test("VS Code package metadata activates on JAGS and Stan languages", () => {
   expect(pkg.activationEvents).toContain("onLanguage:jags");
   expect(pkg.activationEvents).toContain("onLanguage:stan");
 });
+
+test("VS Code package metadata exposes send method setting", () => {
+  const packageJsonPath = path.join(
+    import.meta.dir,
+    "..",
+    "..",
+    "editors",
+    "vscode",
+    "package.json",
+  );
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const setting =
+    pkg.contributes.configuration.properties["raven.sendToR.sendMethod"];
+
+  expect(setting).toMatchObject({
+    type: "string",
+    enum: ["auto", "paste", "tempfile"],
+    default: "auto",
+  });
+  expect(setting.enumDescriptions).toHaveLength(3);
+  expect(setting.description).toContain("Controls how Raven sends code to R");
+});


### PR DESCRIPTION
## Summary
- Added `raven.sendToR.sendMethod` with `auto`, `paste`, and `tempfile` modes for both the Raven terminal and the Terminal submenu.
- Kept `sourceFile` behavior unchanged while making the send-path selection explicit and testable.
- Added shell-based validation for `raven.rTerminal.program`, with per-machine success persistence and per-session suppression after a user chooses to keep the current program.
- Updated docs for the new send-method setting and clarified that `raven.packages.rPath` must point to vanilla `R`, not `radian` or `arf`.

## Testing
- Not run.
- Added unit coverage for the send-method transport matrix in `tests/bun/send-method.test.ts`.
- Added config-schema coverage for `raven.sendToR.sendMethod` in `tests/bun/vscode-config.test.ts`.
- Added VS Code extension coverage for `raven.rTerminal.program` validation, persistence, and fallback behavior in `editors/vscode/src/test/send-to-r/terminal-program-fallback.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `raven.sendToR.sendMethod` configuration option with three modes (`auto`, `paste`, `tempfile`) to customize how code is transmitted to R, optimizing handling of single-line and multi-line code.

* **Documentation**
  * Enhanced documentation detailing send method behavior, terminal submenu handling, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->