### PR TITLE
fix: eliminate CodeQL open-redirect false positive in redirect-loop test

### DIFF
--- a/tests/bun/plot-http-download.test.ts
+++ b/tests/bun/plot-http-download.test.ts
@@ -69,9 +69,9 @@ describe('download_to_buffer', () => {
     });
 
     test('rejects when redirect chain exceeds max_redirects', async () => {
-        await start((req, res) => {
+        await start((_req, res) => {
             // Always redirect to itself; chain grows without bound.
-            res.writeHead(302, { location: req.url ?? '/loop' }).end();
+            res.writeHead(302, { location: '/loop' }).end();
         });
         await expect(
             download_to_buffer(`http://127.0.0.1:${port}/loop`, { max_redirects: 2 }),


### PR DESCRIPTION
## Summary

- Fixes CodeQL alert #15 (`js/server-side-unvalidated-url-redirection`)
- The flagged line was `res.writeHead(302, { location: req.url ?? '/loop' })` in a test-only ephemeral server — a false positive, since the server is bound to `127.0.0.1` on a random port and torn down after each test
- The test always calls the server at `/loop`, so `req.url` was always `'/loop'`; replacing it with the literal removes the data flow CodeQL flagged with no behavior change

## Test plan

- [x] All 7 tests in `tests/bun/plot-http-download.test.ts` still pass