### PR TITLE
Fix data viewer selection, copy, tooltips, and smoke-test coverage

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -79,10 +79,16 @@ same `View(mtcars)` opened tomorrow remembers the layout.
   column headers to select multiple contiguous columns.
 - Click a row-number gutter cell to select that row; click-drag across
   row headers to select multiple contiguous rows.
-- `Cmd/Ctrl+A` selects every row across all currently-visible columns.
+- Click the `#` corner cell (top-left) to select the whole table.
+- `Cmd/Ctrl+A` selects every row across all currently-visible columns
+  (equivalent to clicking `#`).
 - `Cmd/Ctrl+C` copies the selection as TSV. Copying respects the
   active Labels / Format / digits state — what you see is what you
   copy.
+- Column-header selections and whole-table selections (via `#` or
+  `Cmd/Ctrl+A`) include the column-name row when copied. Cell and
+  row-header selections copy data only, matching spreadsheet
+  conventions.
 - Right-click a cell, column header, or row header to show a Copy menu
   (which copies the current selection, or the right-clicked target if
   the click landed outside the selection). The platform's default

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -116,6 +116,10 @@ export type WebviewToExtension =
         labelsOn: boolean;
         formatOn: boolean;
         digits: number;
+        /** When true, prepend a tab-separated row of column names so the
+         *  paste lands with headers. Set by the webview for column /
+         *  select-all selections. */
+        includeHeader: boolean;
     };
 
 /** Hard cap on the number of cells the extension will materialize for a

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -333,7 +333,7 @@ export class DataViewerPanel {
 
         const tsv = render_tsv(
             got.rows, m.range.colIndices, this.columns, this.dictionaries,
-            m.labelsOn, m.formatOn, m.digits, resolved,
+            m.labelsOn, m.formatOn, m.digits, resolved, m.includeHeader,
         );
         try {
             await vscode.env.clipboard.writeText(tsv);

--- a/editors/vscode/src/data-viewer/tsv.ts
+++ b/editors/vscode/src/data-viewer/tsv.ts
@@ -23,8 +23,15 @@ export function render_tsv(
     formatOn: boolean,
     digits: number,
     resolvedLabels: ResolvedLabels = {},
+    includeHeader: boolean = false,
 ): string {
     const lines: string[] = [];
+    if (includeHeader) {
+        const header = colIndices
+            .map(i => sanitize(columns[i]?.name ?? ''))
+            .join('\t');
+        lines.push(header);
+    }
     for (const row of rows) {
         const parts: string[] = [];
         for (let j = 0; j < row.length; j++) {

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -148,9 +148,68 @@
             }
         };
         window.addEventListener('message', handler);
+        // macOS dispatches Cmd-A and Cmd-C through the Edit menu's responder
+        // chain rather than as a JS keydown event. Chromium responds by
+        // calling document.execCommand('selectAll') / firing a 'copy' event
+        // directly, so the window-level keydown listener never sees them.
+        // Catch both via the synthesized DOM events instead — this is what
+        // actually fires for Cmd shortcuts on macOS, while Ctrl shortcuts
+        // continue to flow through the keydown path.
+        document.addEventListener('selectionchange', onSelectionChange);
+        document.addEventListener('copy', onDocumentCopy);
         vscode.postMessage({ type: 'webviewReady' });
-        return () => window.removeEventListener('message', handler);
+        // Pull focus into the iframe so Cmd/Ctrl+A and Cmd/Ctrl+C reach the
+        // window-level keydown handler. Without this, the panel can mount
+        // without focus inside the iframe (e.g. opened via R's View() while
+        // the editor still has focus); keystrokes would then never reach
+        // our handler and Cmd+A would fall back to the browser's default
+        // "select all webview text" behavior.
+        focusViewport();
+        return () => {
+            window.removeEventListener('message', handler);
+            document.removeEventListener('selectionchange', onSelectionChange);
+            document.removeEventListener('copy', onDocumentCopy);
+        };
     });
+
+    /** Fires after Cmd-A / Edit > Select All (which Chromium implements via
+     *  document.execCommand('selectAll'), bypassing keydown on macOS).
+     *  When we observe the document gaining a body-spanning native
+     *  selection we suppress it and run our grid select-all instead.
+     *
+     *  A user-initiated drag-select keeps both endpoints inside the same
+     *  text node, so the containsNode(body) check only matches the
+     *  synthetic "select all". */
+    function onSelectionChange(): void {
+        const sel = window.getSelection?.();
+        if (!sel || sel.rangeCount === 0) return;
+        if (sel.isCollapsed) return;
+        const root = document.body;
+        if (!root) return;
+        if (!sel.containsNode(root, true)) return;
+        sel.removeAllRanges();
+        if (visibleCols.length > 0 && nrow > 0) {
+            selection.selectAll(nrow, visibleCols);
+            bumpSelection();
+        }
+    }
+
+    /** Fires for Cmd-C / Edit > Copy on macOS regardless of whether
+     *  keydown reached us. We always intercept and write our TSV to the
+     *  clipboard via the extension host (the webview can't access
+     *  navigator.clipboard reliably under the default CSP). */
+    function onDocumentCopy(e: ClipboardEvent): void {
+        if (!selection.rect()) return;
+        e.preventDefault();
+        copySelection();
+    }
+
+    /** Pull keyboard focus to the grid viewport so Cmd/Ctrl shortcuts
+     *  reach our window-level keydown handler. Called on mount and on
+     *  every pointer interaction inside the panel. */
+    function focusViewport(): void {
+        viewportEl?.focus({ preventScroll: true });
+    }
 
     function applyInitOrReplace(
         m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>,
@@ -275,9 +334,10 @@
 
     function onCellPointerDown(row: number, col: number, e: PointerEvent): void {
         if (e.button !== 0) return;
+        focusViewport();
         dragMode = 'cell';
         if (e.shiftKey) selection.focus(row, col);
-        else selection.anchor(row, col);
+        else selection.anchor(row, col, 'cells');
         bumpSelection();
     }
 
@@ -290,11 +350,12 @@
 
     function onColHeaderPointerDown(colIdx: number, e: PointerEvent): void {
         if (e.button !== 0) return;
+        focusViewport();
         dragMode = 'column';
         if (nrow === 0) return;
         if (e.shiftKey) selection.focus(nrow - 1, colIdx);
         else {
-            selection.anchor(0, colIdx);
+            selection.anchor(0, colIdx, 'columns');
             selection.focus(nrow - 1, colIdx);
         }
         bumpSelection();
@@ -310,15 +371,27 @@
 
     function onRowHeaderPointerDown(absRow: number, e: PointerEvent): void {
         if (e.button !== 0) return;
+        focusViewport();
         dragMode = 'row';
         if (visibleCols.length === 0) return;
         const minCol = visibleCols[0];
         const maxCol = visibleCols[visibleCols.length - 1];
         if (e.shiftKey) selection.focus(absRow, maxCol);
         else {
-            selection.anchor(absRow, minCol);
+            selection.anchor(absRow, minCol, 'rows');
             selection.focus(absRow, maxCol);
         }
+        bumpSelection();
+    }
+
+    /** Top-left corner cell ("#") behaves as the "select all" affordance,
+     *  matching spreadsheet conventions. Always sets selection kind to
+     *  'all' so a copy includes the column-header row. */
+    function onCornerPointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
+        focusViewport();
+        if (visibleCols.length === 0 || nrow === 0) return;
+        selection.selectAll(nrow, visibleCols);
         bumpSelection();
     }
 
@@ -366,6 +439,7 @@
                 colIndices,
             },
             labelsOn, formatOn, digits,
+            includeHeader: selection.includesHeader(),
         };
         copyStatus = 'copying';
         copyStatusMsg = 'Copying...';
@@ -452,11 +526,11 @@
         if (!inRect) {
             switch (target.kind) {
                 case 'cell':
-                    selection.anchor(target.row, target.col);
+                    selection.anchor(target.row, target.col, 'cells');
                     break;
                 case 'column':
                     if (nrow > 0) {
-                        selection.anchor(0, target.col);
+                        selection.anchor(0, target.col, 'columns');
                         selection.focus(nrow - 1, target.col);
                     }
                     break;
@@ -464,7 +538,7 @@
                     if (visibleCols.length > 0) {
                         const minCol = visibleCols[0];
                         const maxCol = visibleCols[visibleCols.length - 1];
-                        selection.anchor(target.row, minCol);
+                        selection.anchor(target.row, minCol, 'rows');
                         selection.focus(target.row, maxCol);
                     }
                     break;
@@ -671,7 +745,11 @@
         <div class="grid" style="height: {cappedScrollHeight(totalGridHeight) + ROW_HEIGHT}px;">
             <!-- Header row (sticky top) -->
             <div class="header-row">
-                <div class="cell header rowname-col corner-cell" style="width: {rowColWidth};">#</div>
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div class="cell header rowname-col corner-cell"
+                     style="width: {rowColWidth};"
+                     title="Select all"
+                     onpointerdown={onCornerPointerDown}>#</div>
                 {#each visibleCols as colIdx (colIdx)}
                     {@const col = columns[colIdx]}
                     <div class="cell header col-header

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -763,7 +763,7 @@
                     >
                         <span class="col-name">{col.name}</span>
                         {#if col.variableLabel}
-                            <span class="col-tooltip" role="tooltip">{col.variableLabel}</span>
+                            <span class="col-tooltip" role="tooltip">{col.name}: {col.variableLabel}</span>
                         {/if}
                         <!-- svelte-ignore a11y_no_static_element_interactions -->
                         <div class="resize-handle"

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -757,11 +757,14 @@
                          data-grid-target="col-header"
                          data-col={colIdx}
                          style="width: {widthOf(colIdx)}px;"
-                         title={col.variableLabel ? `${col.name}: ${col.variableLabel}` : col.name}
+                         aria-label={col.variableLabel ? `${col.name}: ${col.variableLabel}` : col.name}
                          onpointerdown={(e) => onColHeaderPointerDown(colIdx, e)}
                          onpointerenter={(e) => onColHeaderPointerEnter(colIdx, e)}
                     >
-                        {col.name}
+                        <span class="col-name">{col.name}</span>
+                        {#if col.variableLabel}
+                            <span class="col-tooltip" role="tooltip">{col.variableLabel}</span>
+                        {/if}
                         <!-- svelte-ignore a11y_no_static_element_interactions -->
                         <div class="resize-handle"
                              onpointerdown={(e) => onResizeHandlePointerDown(colIdx, e)}></div>

--- a/editors/vscode/src/data-viewer/webview/selection-model.ts
+++ b/editors/vscode/src/data-viewer/webview/selection-model.ts
@@ -2,7 +2,13 @@
  *
  *  Tracks an anchor and focus cell. `selectAll` records both an
  *  explicit list of column indices (for non-contiguous visible
- *  columns) and a synthetic anchor/focus that spans them. */
+ *  columns) and a synthetic anchor/focus that spans them.
+ *
+ *  Each selection also carries a {@link SelectionKind} that records how
+ *  the selection began. `'columns'` and `'all'` selections include the
+ *  column-name row when copied — matching spreadsheet conventions where
+ *  clicking a column letter or the "select all" corner copies headers
+ *  along with the data. */
 
 export type Rect = {
     rowStart: number;
@@ -11,15 +17,23 @@ export type Rect = {
     colEnd: number;
 };
 
+export type SelectionKind = 'cells' | 'columns' | 'rows' | 'all';
+
 export class Selection {
     private a: { row: number; col: number } | null = null;
     private f: { row: number; col: number } | null = null;
     private explicitCols: number[] | null = null;
+    private k: SelectionKind = 'cells';
 
-    anchor(row: number, col: number): void {
+    /** Set the anchor/focus to a single point. `kind` records how the
+     *  selection began ('cells' for a cell click, 'columns' for a column
+     *  header click, 'rows' for a row-number click). Subsequent calls to
+     *  {@link focus} preserve the kind. */
+    anchor(row: number, col: number, kind: SelectionKind = 'cells'): void {
         this.a = { row, col };
         this.f = { row, col };
         this.explicitCols = null;
+        this.k = kind;
     }
 
     focus(row: number, col: number): void {
@@ -41,12 +55,14 @@ export class Selection {
         this.a = { row: 0, col: minCol };
         this.f = { row: nrow - 1, col: maxCol };
         this.explicitCols = [...visibleCols];
+        this.k = 'all';
     }
 
     clear(): void {
         this.a = null;
         this.f = null;
         this.explicitCols = null;
+        this.k = 'cells';
     }
 
     rect(): Rect | null {
@@ -64,5 +80,14 @@ export class Selection {
      *  caller derives from rect()'s [colStart, colEnd) span. */
     colIndices(): number[] | null {
         return this.explicitCols ? [...this.explicitCols] : null;
+    }
+
+    kind(): SelectionKind { return this.k; }
+
+    /** True iff a copy of this selection should prepend a column-header
+     *  row, matching spreadsheet behavior for column / select-all
+     *  selections. */
+    includesHeader(): boolean {
+        return this.k === 'columns' || this.k === 'all';
     }
 }

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -224,6 +224,44 @@ html, body, #root {
 .cell.col-header {
     cursor: default;
     position: relative;
+    /* Override .cell's overflow: hidden so the variable-label tooltip can
+       overflow below the header row. The column name still ellipses via
+       .col-name below. */
+    overflow: visible;
+}
+.cell.col-header > .col-name {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+/* Variable-label tooltip that appears on header hover. The native HTML
+   title attribute has a long delay (~700 ms) and renders as an OS tooltip
+   that's easy to miss in a dense grid; this CSS-driven tooltip is
+   immediate and theme-aware. */
+.col-tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 5;
+    margin-top: 2px;
+    max-width: 360px;
+    padding: 4px 8px;
+    background: var(--vscode-editorHoverWidget-background, #252526);
+    color: var(--vscode-editorHoverWidget-foreground, #cccccc);
+    border: 1px solid var(--vscode-editorHoverWidget-border, #454545);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 16px;
+    white-space: normal;
+    pointer-events: none;
+}
+.cell.col-header:hover > .col-tooltip {
+    display: block;
 }
 
 .resize-handle {

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -273,7 +273,7 @@ html, body, #root {
     cursor: default;
 }
 .cell.corner-cell {
-    cursor: default;
+    cursor: pointer;
 }
 .header-row .cell.rowname-col {
     z-index: 3; /* above sticky body cells */

--- a/tests/bun/data-viewer-panel-render-tsv.test.ts
+++ b/tests/bun/data-viewer-panel-render-tsv.test.ts
@@ -89,4 +89,43 @@ describe('render_tsv', () => {
         );
         expect(tsv).toBe('6');  // 5 + 1
     });
+
+    test('includeHeader prepends a tab-separated row of column names', () => {
+        const rows = [
+            [1, 1.5, 0, 1] as any,
+            [2, 2.25, 1, 2] as any,
+        ];
+        const tsv = render_tsv(
+            rows, [0, 1, 2, 3], cols, dictionaries, false, false, 3, {}, true,
+        );
+        expect(tsv).toBe('i\tv\tf\tlab\n1\t1.5\t1\t1\n2\t2.25\t2\t2');
+    });
+
+    test('includeHeader honors the colIndices order, not schema order', () => {
+        const rows = [[2.25, 1] as any];
+        // Copy columns in reverse: v then i.
+        const tsv = render_tsv(
+            rows, [1, 0], cols, dictionaries, false, false, 3, {}, true,
+        );
+        expect(tsv).toBe('v\ti\n2.25\t1');
+    });
+
+    test('includeHeader sanitizes tabs / newlines in column names', () => {
+        const dirty: ColumnSchema = {
+            name: 'has\ttab\nname', arrowType: 'Utf8', isInteger: false,
+            dictionaryShipped: false,
+        };
+        const rows = [['x'] as any];
+        const tsv = render_tsv(
+            rows, [0], [dirty], {}, false, false, 3, {}, true,
+        );
+        expect(tsv).toBe('has tab name\nx');
+    });
+
+    test('includeHeader on empty rows still emits the header line', () => {
+        const tsv = render_tsv(
+            [], [0, 1], cols, dictionaries, false, false, 3, {}, true,
+        );
+        expect(tsv).toBe('i\tv');
+    });
 });

--- a/tests/bun/data-viewer-selection-model.test.ts
+++ b/tests/bun/data-viewer-selection-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'bun:test';
+import { Selection } from '../../editors/vscode/src/data-viewer/webview/selection-model';
+
+describe('Selection.kind / includesHeader', () => {
+    test('default kind is cells; cells do not include header', () => {
+        const s = new Selection();
+        s.anchor(2, 3);
+        expect(s.kind()).toBe('cells');
+        expect(s.includesHeader()).toBe(false);
+    });
+
+    test('column anchor sets kind to columns and includes header', () => {
+        const s = new Selection();
+        s.anchor(0, 4, 'columns');
+        s.focus(99, 4);
+        expect(s.kind()).toBe('columns');
+        expect(s.includesHeader()).toBe(true);
+    });
+
+    test('row anchor sets kind to rows and does not include header', () => {
+        const s = new Selection();
+        s.anchor(7, 0, 'rows');
+        s.focus(7, 9);
+        expect(s.kind()).toBe('rows');
+        expect(s.includesHeader()).toBe(false);
+    });
+
+    test('selectAll sets kind to all and includes header', () => {
+        const s = new Selection();
+        s.selectAll(100, [0, 1, 2, 5]);
+        expect(s.kind()).toBe('all');
+        expect(s.includesHeader()).toBe(true);
+        expect(s.colIndices()).toEqual([0, 1, 2, 5]);
+    });
+
+    test('focus preserves kind from the most recent anchor', () => {
+        const s = new Selection();
+        s.anchor(0, 4, 'columns');
+        s.focus(50, 4); // drag-extend within columns mode
+        expect(s.kind()).toBe('columns');
+    });
+
+    test('a new cell anchor switches kind back to cells', () => {
+        const s = new Selection();
+        s.selectAll(10, [0, 1, 2]);
+        expect(s.kind()).toBe('all');
+        s.anchor(3, 1); // user clicks a cell
+        expect(s.kind()).toBe('cells');
+        expect(s.includesHeader()).toBe(false);
+    });
+
+    test('clear() resets kind to cells', () => {
+        const s = new Selection();
+        s.selectAll(5, [0, 1]);
+        s.clear();
+        expect(s.kind()).toBe('cells');
+        expect(s.rect()).toBeNull();
+    });
+
+    test('selectAll with no visible columns clears the selection', () => {
+        const s = new Selection();
+        s.anchor(0, 0, 'columns');
+        s.selectAll(10, []);
+        expect(s.rect()).toBeNull();
+        expect(s.kind()).toBe('cells');
+    });
+});

--- a/tests/manual/data-viewer-smoke.R
+++ b/tests/manual/data-viewer-smoke.R
@@ -96,23 +96,27 @@ View(copy_me)
 # labels on every column and non-trivial value-label sets on four columns —
 # the canonical real-world read_sav() stress test for the Labels toggle.
 if (requireNamespace("haven", quietly = TRUE)) {
-  f        <- system.file("files/electric.sav", package = "foreign")
-  electric <- haven::read_sav(f)
+  f <- system.file("files/electric.sav", package = "foreign")
+  if (!nzchar(f)) {
+    message("Skipping Western Electric section: electric.sav not found (foreign package missing?).")
+  } else {
+    electric <- haven::read_sav(f)
 
-  View(electric)
-  # Expected:
-  #   hover any column header  → tooltip shows the variable label
-  #                              (e.g. "FIRSTCHD: FIRST CHD EVENT",
-  #                               "VITAL10: STATUS AT TEN YEARS")
-  #   Labels toggle ON         → four columns swap codes for strings:
-  #     FIRSTCHD   1 → "NO CHD", 2 → "SUDDEN  DEATH", 3 → "NONFATALMI",
-  #                5 → "FATAL   MI",  6 → "OTHER   CHD"
-  #     DAYOFWK    1 → "SUNDAY" … 7 → "SATURDAY", 9 → "MISSING"
-  #     VITAL10    0 → "ALIVE", 1 → "DEAD"
-  #     FAMHXCVR   "Y" → "YES", "N" → "NO"
-  #   Labels toggle OFF        → raw codes reappear in all four columns
-  #   Remaining 9 columns (AGE, DBP58, CHOL58, …) carry variable labels only:
-  #     toggle has no visible effect; variable-label tooltip still works
+    View(electric)
+    # Expected:
+    #   hover any column header  → tooltip shows "<NAME>: <variable label>"
+    #                              (e.g. "FIRSTCHD: FIRST CHD EVENT",
+    #                               "VITAL10: STATUS AT TEN YEARS")
+    #   Labels toggle ON         → four columns swap codes for strings:
+    #     FIRSTCHD   1 → "NO CHD", 2 → "SUDDEN  DEATH", 3 → "NONFATALMI",
+    #                5 → "FATAL   MI",  6 → "OTHER   CHD"
+    #     DAYOFWK    1 → "SUNDAY" … 7 → "SATURDAY", 9 → "MISSING"
+    #     VITAL10    0 → "ALIVE", 1 → "DEAD"
+    #     FAMHXCVR   "Y" → "YES", "N" → "NO"
+    #   Labels toggle OFF        → raw codes reappear in all four columns
+    #   Remaining 9 columns (AGE, DBP58, CHOL58, …) carry variable labels only:
+    #     toggle has no visible effect; variable-label tooltip still works
+  }
 } else {
   message("Skipping Western Electric section: install 'haven' to run it.")
 }

--- a/tests/manual/data-viewer-smoke.R
+++ b/tests/manual/data-viewer-smoke.R
@@ -34,8 +34,8 @@ if (requireNamespace("haven", quietly = TRUE)) {
 
 # ── 2b. Synthetic haven_labelled (variable labels + value labels) ─────────────
 # Builds a tibble with explicit value labels so the Labels toggle has something
-# to swap in. Stand-in for a haven::read_sav / read_dta workflow without needing
-# a real .sav / .dta file on disk.
+# to swap in. Minimal controlled example — for a real-world .sav label
+# round-trip test see section 5 (Western Electric study, no download needed).
 if (requireNamespace("haven", quietly = TRUE)) {
   labelled_demo <- data.frame(
     id       = 1:6,
@@ -87,3 +87,32 @@ View(copy_me)
 # Paste into Excel / Google Sheets / LibreOffice Calc.
 # Expected: 5 tab-separated columns, 1000 data rows + 1 header row;
 #           booleans, dates, and decimals round-trip without mangling.
+
+
+# ── 5. Western Electric study via haven (real SPSS + value labels) ────────────
+# foreign::electric.sav is bundled with base-R's `foreign` package (always
+# present, no download). It is a real SPSS file from the Western Electric /
+# WCGS cardiovascular study: 240 participants × 13 columns, with variable
+# labels on every column and non-trivial value-label sets on four columns —
+# the canonical real-world read_sav() stress test for the Labels toggle.
+if (requireNamespace("haven", quietly = TRUE)) {
+  f        <- system.file("files/electric.sav", package = "foreign")
+  electric <- haven::read_sav(f)
+
+  View(electric)
+  # Expected:
+  #   hover any column header  → tooltip shows the variable label
+  #                              (e.g. "FIRSTCHD: FIRST CHD EVENT",
+  #                               "VITAL10: STATUS AT TEN YEARS")
+  #   Labels toggle ON         → four columns swap codes for strings:
+  #     FIRSTCHD   1 → "NO CHD", 2 → "SUDDEN  DEATH", 3 → "NONFATALMI",
+  #                5 → "FATAL   MI",  6 → "OTHER   CHD"
+  #     DAYOFWK    1 → "SUNDAY" … 7 → "SATURDAY", 9 → "MISSING"
+  #     VITAL10    0 → "ALIVE", 1 → "DEAD"
+  #     FAMHXCVR   "Y" → "YES", "N" → "NO"
+  #   Labels toggle OFF        → raw codes reappear in all four columns
+  #   Remaining 9 columns (AGE, DBP58, CHOL58, …) carry variable labels only:
+  #     toggle has no visible effect; variable-label tooltip still works
+} else {
+  message("Skipping Western Electric section: install 'haven' to run it.")
+}

--- a/tests/manual/data-viewer-smoke.R
+++ b/tests/manual/data-viewer-smoke.R
@@ -15,7 +15,7 @@ View(big)
 # install.packages("haven")   # if needed
 if (requireNamespace("haven", quietly = TRUE)) {
   # Downloads ~500 KB; skip if already cached.
-  url  <- "https://wwwn.cdc.gov/Nchs/Nhanes/2017-2018/DEMO_J.XPT"
+  url  <- "https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/2017/DataFiles/DEMO_J.xpt"
   dest <- tempfile(fileext = ".xpt")
   download.file(url, dest, mode = "wb")
   nhanes <- haven::read_xpt(dest)   # labelled vectors with variable-label attrs

--- a/tests/manual/data-viewer-smoke.R
+++ b/tests/manual/data-viewer-smoke.R
@@ -11,23 +11,53 @@ big <- as.data.frame(
 View(big)
 
 
-# ── 2. NHANES via haven (variable labels + Labels toggle) ─────────────────────
-# install.packages("haven")   # if needed
+# ── 2. NHANES via haven (variable labels only) ────────────────────────────────
+# SAS XPORT files carry variable labels but not value labels — those live in a
+# separate SAS format catalog (.sas7bcat) that NHANES doesn't ship. Use this
+# section to exercise variable labels; section 2b below exercises value labels.
 if (requireNamespace("haven", quietly = TRUE)) {
   # Downloads ~500 KB; skip if already cached.
   url  <- "https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/2017/DataFiles/DEMO_J.xpt"
   dest <- tempfile(fileext = ".xpt")
   download.file(url, dest, mode = "wb")
-  nhanes <- haven::read_xpt(dest)   # labelled vectors with variable-label attrs
-
-  str(nhanes[1:3])            # confirm <labelled> with label attr
+  nhanes <- haven::read_xpt(dest)
 
   View(nhanes)
   # Expected:
-  #   hover a column header  → tooltip shows variable label
-  #   Labels toggle ON       → numeric codes swap for label strings (e.g. 1 → "Male")
+  #   hover a column header  → tooltip shows "<NAME>: <variable label>"
+  #                            (e.g. "RIAGENDR: Gender")
+  #   Labels toggle ON       → no visible change (NHANES XPT has no value labels)
 } else {
   message("Skipping NHANES section: install 'haven' to run it.")
+}
+
+
+# ── 2b. Synthetic haven_labelled (variable labels + value labels) ─────────────
+# Builds a tibble with explicit value labels so the Labels toggle has something
+# to swap in. Stand-in for a haven::read_sav / read_dta workflow without needing
+# a real .sav / .dta file on disk.
+if (requireNamespace("haven", quietly = TRUE)) {
+  labelled_demo <- data.frame(
+    id       = 1:6,
+    sex      = haven::labelled(
+      c(1, 2, 1, 2, 1, 2),
+      labels = c(Male = 1, Female = 2),
+      label  = "Sex of the participant"
+    ),
+    handedness = haven::labelled(
+      c(1L, 2L, 1L, 3L, 2L, 1L),
+      labels = c(Right = 1L, Left = 2L, Ambidextrous = 3L),
+      label  = "Self-reported handedness"
+    ),
+    score    = c(0.71, 0.42, 0.85, 0.13, 0.66, 0.30)
+  )
+
+  View(labelled_demo)
+  # Expected:
+  #   hover "sex" header     → tooltip shows "sex: Sex of the participant"
+  #   Labels toggle ON       → sex column shows "Male" / "Female" instead of 1 / 2
+  #                            handedness shows "Right" / "Left" / "Ambidextrous"
+  #   Labels toggle OFF      → numeric codes are visible again
 }
 
 


### PR DESCRIPTION
## Summary

- **Selection & copy fixes**: column-header and corner-cell (`#`) selections now include the header row when copied (TSV paste lands with column names); `Cmd/Ctrl+A` and `Cmd+C` now work on macOS where Chromium routes these through `execCommand`/`copy` DOM events rather than `keydown`; pointer-down handlers call `focusViewport()` so keystrokes reliably reach the grid after View() opens.
- **Variable-label tooltip**: custom column-header tooltip shows `"<col>: <variable label>"` for haven-labelled and NHANES columns.
- **Smoke-test additions**: section 2b (synthetic `haven_labelled`) and section 5 (Western Electric/WCGS study via `foreign::electric.sav` — real SPSS file bundled with base R, no download, 240 rows × 13 cols, 4 columns with non-trivial value-label sets verified end-to-end through the arrow pipeline).

## What a reviewer should know

- The `includeHeader` flag is set by the webview based on selection *kind* (`'columns'` / `'all'`), not re-derived on the extension side — the source of truth for whether a header row belongs is whichever gesture initiated the selection.
- `onSelectionChange` / `onDocumentCopy` are mounted once in `onMount` and cleaned up in the return; they don't fire during normal cell drags because the native selection stays within a single text node.
- Section 5 of the smoke test uses `system.file("files/electric.sav", package = "foreign")` — `foreign` is part of base R, so this section runs anywhere `haven` is installed with no network access.

## Test plan

- [ ] Run `bun test tests/bun/data-viewer-*` — 147 tests pass
- [ ] Run `cd editors/vscode && bun run bundle` — clean build
- [ ] Section 2 (NHANES): hover headers → variable-label tooltip; Labels toggle has no visible effect
- [ ] Section 2b (synthetic): Labels ON swaps sex/handedness codes for strings; Labels OFF restores codes
- [ ] Section 5 (electric.sav): Labels ON swaps FIRSTCHD/DAYOFWK/VITAL10/FAMHXCVR codes; 9 numeric columns unaffected
- [ ] Section 4: Cmd/Ctrl+A → select all → Cmd/Ctrl+C → paste into spreadsheet → 5 columns + header row, 1000 data rows
- [ ] Column-header click → Cmd+C → paste includes column-name row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Column headers now display variable label tooltips
  - Enhanced copy behavior: column names are included when copying entire columns or tables
  - Improved macOS keyboard shortcut compatibility for Select All and Copy operations

* **Documentation**
  - Updated Data Viewer documentation clarifying selection and copy conventions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->