### PR TITLE
fix: pin fast-uri >=3.1.2 and diff >=8.0.3 to resolve npm audit vulnerabilities

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -2866,9 +2866,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3270,9 +3270,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -688,7 +688,9 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.3",
-    "uuid": ">=14.0.0"
+    "uuid": ">=14.0.0",
+    "fast-uri": ">=3.1.2",
+    "diff": ">=8.0.3"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.1",


### PR DESCRIPTION
## Summary

- Add `"fast-uri": ">=3.1.2"` to the npm overrides in `editors/vscode/package.json`, resolving two HIGH-severity CVEs (GHSA-q3j6-qgpj-74h6 and GHSA-v39h-62p7-jpjc) — path-traversal and host-confusion via percent-encoded URI segments. Pulled in transitively via `ajv` ← `@vscode/vsce`.
- Add `"diff": ">=8.0.3"` to the npm overrides, resolving a LOW-severity ReDoS CVE (GHSA-73rr-hh4g-fpgx) in `parsePatch`/`applyPatch`. Pulled in transitively via `mocha@11`. This also clears the two derivative LOW-severity flags on `mocha` and `@vscode/test-cli`.

After these changes `npm audit` reports **found 0 vulnerabilities**. The diff upgrade landed on 9.0.0 (satisfies `>=8.0.3`); TypeScript compilation passes cleanly.

Both GitHub Dependabot alerts were already resolved/dismissed — no action needed there.

## Test plan

- [ ] `cd editors/vscode && npm audit` → `found 0 vulnerabilities`
- [ ] `npm ls fast-uri` → fast-uri@3.1.2 or higher
- [ ] `npm ls diff` → diff@8.0.3 or higher
- [ ] `bun run compile:test` → no TypeScript errors