### PR TITLE
Show VS Code notification when httpgd is missing or outdated; fix install.packages breakage

### DIFF
--- a/editors/vscode/src/plot/index.ts
+++ b/editors/vscode/src/plot/index.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { PlotEvent, RSessionEvent, RSessionServer } from '../r-session-server';
+import { RSessionEvent, RSessionServer } from '../r-session-server';
 import { PlotViewerPanel } from './plot-viewer-panel';
 
 /**
@@ -110,15 +110,13 @@ export class PlotServices {
     }
 
     private on_server_event(event: RSessionEvent): void {
-        // PlotServices only handles plot-related events; the data viewer
-        // manager subscribes separately for view-data-requested.
-        if (event.type === 'view-data-requested') return;
-        const e = event as PlotEvent;
-        if (e.type === 'plot-available') {
-            const panel = this.get_or_create_panel(e.sessionId);
+        if (event.type === 'plot-available') {
+            const panel = this.get_or_create_panel(event.sessionId);
             panel.notifyPlotAvailable();
-        } else if (e.type === 'session-ended') {
-            this.panels.get(e.sessionId)?.notifySessionEnded();
+        } else if (event.type === 'session-ended') {
+            this.panels.get(event.sessionId)?.notifySessionEnded();
+        } else if (event.type === 'plot-warning') {
+            vscode.window.showWarningMessage(event.message);
         }
     }
 

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -350,7 +350,11 @@ local({
 
 # Plot bridge block — depends on httpgd. Independent of the data viewer
 # block above; if httpgd is missing, View() still works.
+# Skip entirely in non-interactive R processes (e.g. R CMD INSTALL subprocesses
+# spawned by install.packages): those inherit R_PROFILE_USER but must not load
+# or lock the httpgd namespace.
 local({
+    if (!interactive()) return(invisible(NULL))
     .raven_log <- function(msg) {
         message(paste0("Raven: ", msg))
     }
@@ -394,13 +398,29 @@ local({
 
     # 2. Verify httpgd >= 2.0.2 is available.
     if (!requireNamespace("httpgd", quietly = TRUE)) {
-        .raven_log("plots require the httpgd package. Install with: install.packages(\\"httpgd\\")")
+        .raven_msg <- "To view plots in VS Code, install the httpgd package: install.packages(\\"httpgd\\")"
+        .raven_log(.raven_msg)
+        .raven_post("/plot-warning", paste0(
+            "{",
+            "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
+            "\\"reason\\":\\"missing-httpgd\\",",
+            "\\"message\\":", .raven_json_str(.raven_msg),
+            "}"
+        ))
         return(invisible(NULL))
     }
     if (!(utils::packageVersion("httpgd") >= "2.0.2")) {
-        .raven_log(paste0(
-            "httpgd >= 2.0.2 is required (found ",
-            as.character(utils::packageVersion("httpgd")), "). Run: install.packages(\\"httpgd\\")"
+        .raven_msg <- paste0(
+            "To view plots in VS Code, update httpgd to >= 2.0.2 (installed: ",
+            as.character(utils::packageVersion("httpgd")), "): install.packages(\\"httpgd\\")"
+        )
+        .raven_log(.raven_msg)
+        .raven_post("/plot-warning", paste0(
+            "{",
+            "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
+            "\\"reason\\":\\"outdated-httpgd\\",",
+            "\\"message\\":", .raven_json_str(.raven_msg),
+            "}"
         ))
         return(invisible(NULL))
     }

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -507,6 +507,19 @@ local({
         .raven_original_device
     }
 
+    .raven_register_httpgd_retry <- function(.raven_original_device) {
+        # Retry after each R expression: initialize the plot bridge as soon as
+        # httpgd is available and new enough (e.g. after install.packages("httpgd")).
+        addTaskCallback(function(...) {
+            if (!requireNamespace("httpgd", quietly = TRUE)) return(TRUE)
+            if (!(utils::packageVersion("httpgd") >= "2.0.2")) return(TRUE)
+            # Remove the device wrapper now that httpgd is ready.
+            options(device = .raven_original_device)
+            .raven_init_httpgd()
+            FALSE
+        }, name = "raven-httpgd-pending")
+    }
+
     # 5. Verify httpgd >= 2.0.2 is available.
     if (!requireNamespace("httpgd", quietly = TRUE)) {
         # Console: full context. Popup: short enough to fit on one VS Code
@@ -516,16 +529,7 @@ local({
         # session start, to avoid overwhelming new users during setup.
         .raven_original_device <- .raven_deferred_warn(
             "To view R plots in VS Code: install.packages(\\"httpgd\\")", "missing-httpgd")
-        # Retry after each R expression: initialize the plot bridge as soon as
-        # httpgd is available (e.g. after install.packages("httpgd")).
-        addTaskCallback(function(...) {
-            if (!requireNamespace("httpgd", quietly = TRUE)) return(TRUE)
-            if (!(utils::packageVersion("httpgd") >= "2.0.2")) return(FALSE)
-            # Remove the device wrapper now that httpgd is ready.
-            options(device = .raven_original_device)
-            .raven_init_httpgd()
-            FALSE
-        }, name = "raven-httpgd-pending")
+        .raven_register_httpgd_retry(.raven_original_device)
         return(invisible(NULL))
     }
     if (!(utils::packageVersion("httpgd") >= "2.0.2")) {
@@ -533,8 +537,9 @@ local({
             "To view R plots in VS Code, update httpgd to >= 2.0.2 (installed: ",
             as.character(utils::packageVersion("httpgd")), "): install.packages(\\"httpgd\\")"
         ))
-        .raven_deferred_warn(
+        .raven_original_device <- .raven_deferred_warn(
             "To view R plots in VS Code, update httpgd: install.packages(\\"httpgd\\")", "outdated-httpgd")
+        .raven_register_httpgd_retry(.raven_original_device)
         return(invisible(NULL))
     }
 

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -466,29 +466,44 @@ local({
         invisible(NULL)
     }
 
-    # Helper: post a /plot-warning and then open the original graphics device.
-    # Installed as options(device=) so the VS Code popup fires on the first
-    # plot attempt rather than at session start, avoiding startup noise.
+    # Helper: defer the VS Code popup to the user's first plot attempt, and
+    # warn on every subsequent plot until httpgd is installed. Combines:
+    #   - A permanent PDF fallback in options(device=) so plot() never errors
+    #     with "no active device" — output is discarded since there's no UI
+    #     to render to until httpgd is available.
+    #   - Hooks on plot.new and grid.newpage so the warning fires on every
+    #     plot (base R + grid/ggplot2), not just the first.
+    # The VS Code popup is posted only on the first plot to avoid stacking
+    # notifications. Both the hook and the popup self-disable once httpgd
+    # becomes available, so installing it mid-session doesn't require a
+    # restart.
     .raven_deferred_warn <- function(msg, reason) {
         .raven_original_device <- getOption("device")
         options(device = function() {
-            # Self-remove before doing anything so re-entrant calls are safe.
-            options(device = .raven_original_device)
-            .raven_post("/plot-warning", paste0(
-                "{",
-                "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
-                "\\"reason\\":", .raven_json_str(reason), ",",
-                "\\"message\\":", .raven_json_str(msg),
-                "}"
-            ))
-            warning(msg, call. = FALSE)
-            # Try to open the original device; if that fails (e.g. the
-            # terminal has no native graphics device), fall back to a
-            # temporary PDF so R always has something to render to.
-            tryCatch(grDevices::dev.new(), error = function(e) {
-                try(grDevices::pdf(tempfile(fileext = ".pdf")), silent = TRUE)
-            })
+            try(grDevices::pdf(tempfile(fileext = ".pdf")), silent = TRUE)
         })
+        .raven_first_plot <- TRUE
+        .raven_warn_hook <- function(...) {
+            # Once httpgd is available, become a no-op so plots flow through
+            # to the VS Code panel normally.
+            if (requireNamespace("httpgd", quietly = TRUE) &&
+                utils::packageVersion("httpgd") >= "2.0.2") {
+                return(invisible(NULL))
+            }
+            if (.raven_first_plot) {
+                .raven_post("/plot-warning", paste0(
+                    "{",
+                    "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
+                    "\\"reason\\":", .raven_json_str(reason), ",",
+                    "\\"message\\":", .raven_json_str(msg),
+                    "}"
+                ))
+                .raven_first_plot <<- FALSE
+            }
+            warning(msg, call. = FALSE)
+        }
+        setHook("plot.new", .raven_warn_hook)
+        setHook("grid.newpage", .raven_warn_hook)
         .raven_original_device
     }
 

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -481,12 +481,10 @@ local({
                 "\\"message\\":", .raven_json_str(msg),
                 "}"
             ))
-            dev_fn <- if (is.function(.raven_original_device)) {
-                .raven_original_device
-            } else {
-                match.fun(.raven_original_device)
-            }
-            dev_fn()
+            # dev.new() reads getOption("device") internally, which is now
+            # restored to the original, so it opens the right device without
+            # needing to call the opener directly via match.fun.
+            grDevices::dev.new()
         })
         .raven_original_device
     }

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -396,7 +396,77 @@ local({
         paste0("\\"", x, "\\"")
     }
 
-    # 2. Verify httpgd >= 2.0.2 is available.
+    # 2. Start httpgd device, post session-ready, and register the
+    #    plot-available callback. Factored out so it can be called both at
+    #    startup and by the retry callback after install.packages("httpgd").
+    .raven_init_httpgd <- function() {
+        tryCatch({
+            httpgd::hgd(host = "127.0.0.1", port = 0, token = TRUE, silent = TRUE)
+        }, error = function(e) {
+            .raven_log(paste0("could not start httpgd: ", conditionMessage(e)))
+        })
+
+        .raven_details <- tryCatch(httpgd::hgd_details(), error = function(e) NULL)
+        if (is.null(.raven_details)) {
+            .raven_log("httpgd_details() unavailable; aborting plot bridge")
+            return(invisible(NULL))
+        }
+
+        .raven_session_id <- Sys.getenv("RAVEN_R_SESSION_ID")
+        if (!nzchar(.raven_session_id)) return(invisible(NULL))
+
+        # 3. POST session-ready.
+        .raven_post("/session-ready", paste0(
+            "{",
+            "\\"sessionId\\":", .raven_json_str(.raven_session_id), ",",
+            "\\"httpgdHost\\":", .raven_json_str(as.character(.raven_details$host)), ",",
+            "\\"httpgdPort\\":", as.integer(.raven_details$port), ",",
+            "\\"httpgdToken\\":", .raven_json_str(as.character(.raven_details$token)),
+            "}"
+        ))
+
+        # 4. addTaskCallback to push plot-available on state changes.
+        #    The hgd state function was removed in httpgd 2.0; query the /state
+        #    HTTP endpoint via httpgd::hgd_url(endpoint = "state") instead.
+        .raven_state <- list(hsize = -1L, upid = -1L)
+        addTaskCallback(function(...) {
+            tryCatch({
+                state_url <- httpgd::hgd_url(endpoint = "state")
+                body <- tryCatch({
+                    con <- url(state_url, open = "r")
+                    on.exit(close(con), add = TRUE)
+                    paste(readLines(con, warn = FALSE), collapse = "")
+                }, error = function(e) "")
+                hsize_match <- regmatches(body, regexpr('"hsize"\\\\s*:\\\\s*-?\\\\d+', body))
+                upid_match  <- regmatches(body, regexpr('"upid"\\\\s*:\\\\s*-?\\\\d+',  body))
+                if (length(hsize_match) == 1L && length(upid_match) == 1L) {
+                    hsize <- as.integer(sub('.*:\\\\s*', '', hsize_match))
+                    upid  <- as.integer(sub('.*:\\\\s*', '', upid_match))
+                    if (!is.na(hsize) && !is.na(upid) &&
+                        (hsize != .raven_state$hsize || upid != .raven_state$upid)) {
+                        .raven_state$hsize <<- hsize
+                        .raven_state$upid  <<- upid
+                        if (hsize > 0L) {
+                            .raven_post("/plot-available", paste0(
+                                "{",
+                                "\\"sessionId\\":", .raven_json_str(.raven_session_id), ",",
+                                "\\"hsize\\":", hsize, ",",
+                                "\\"upid\\":", upid,
+                                "}"
+                            ))
+                        }
+                    }
+                }
+            }, error = function(e) {
+                .raven_log(paste0("plot-available callback error: ", conditionMessage(e)))
+            })
+            TRUE
+        }, name = "raven-plot-bridge")
+
+        invisible(NULL)
+    }
+
+    # 5. Verify httpgd >= 2.0.2 is available.
     if (!requireNamespace("httpgd", quietly = TRUE)) {
         .raven_msg <- "To view plots in VS Code, install the httpgd package: install.packages(\\"httpgd\\")"
         .raven_log(.raven_msg)
@@ -407,6 +477,14 @@ local({
             "\\"message\\":", .raven_json_str(.raven_msg),
             "}"
         ))
+        # Retry after each R expression: initialize the plot bridge as soon as
+        # httpgd is available (e.g. after install.packages("httpgd")).
+        addTaskCallback(function(...) {
+            if (!requireNamespace("httpgd", quietly = TRUE)) return(TRUE)
+            if (!(utils::packageVersion("httpgd") >= "2.0.2")) return(FALSE)
+            .raven_init_httpgd()
+            FALSE
+        }, name = "raven-httpgd-pending")
         return(invisible(NULL))
     }
     if (!(utils::packageVersion("httpgd") >= "2.0.2")) {
@@ -425,72 +503,7 @@ local({
         return(invisible(NULL))
     }
 
-    # 3. Start httpgd device.
-    tryCatch({
-        httpgd::hgd(host = "127.0.0.1", port = 0, token = TRUE, silent = TRUE)
-    }, error = function(e) {
-        .raven_log(paste0("could not start httpgd: ", conditionMessage(e)))
-    })
-
-    .raven_details <- tryCatch(httpgd::hgd_details(), error = function(e) NULL)
-    if (is.null(.raven_details)) {
-        .raven_log("httpgd_details() unavailable; aborting plot bridge")
-        return(invisible(NULL))
-    }
-
-    .raven_session_id <- Sys.getenv("RAVEN_R_SESSION_ID")
-    if (!nzchar(.raven_session_id)) {
-        return(invisible(NULL))
-    }
-
-    # 4. POST session-ready.
-    .raven_post("/session-ready", paste0(
-        "{",
-        "\\"sessionId\\":", .raven_json_str(.raven_session_id), ",",
-        "\\"httpgdHost\\":", .raven_json_str(as.character(.raven_details$host)), ",",
-        "\\"httpgdPort\\":", as.integer(.raven_details$port), ",",
-        "\\"httpgdToken\\":", .raven_json_str(as.character(.raven_details$token)),
-        "}"
-    ))
-
-    # 5. addTaskCallback to push plot-available on state changes.
-    #    The hgd state function was removed in httpgd 2.0; query the /state
-    #    HTTP endpoint via httpgd::hgd_url(endpoint = "state") instead.
-    .raven_state <- list(hsize = -1L, upid = -1L)
-    addTaskCallback(function(...) {
-        tryCatch({
-            state_url <- httpgd::hgd_url(endpoint = "state")
-            body <- tryCatch({
-                con <- url(state_url, open = "r")
-                on.exit(close(con), add = TRUE)
-                paste(readLines(con, warn = FALSE), collapse = "")
-            }, error = function(e) "")
-            hsize_match <- regmatches(body, regexpr('"hsize"\\\\s*:\\\\s*-?\\\\d+', body))
-            upid_match  <- regmatches(body, regexpr('"upid"\\\\s*:\\\\s*-?\\\\d+',  body))
-            if (length(hsize_match) == 1L && length(upid_match) == 1L) {
-                hsize <- as.integer(sub('.*:\\\\s*', '', hsize_match))
-                upid  <- as.integer(sub('.*:\\\\s*', '', upid_match))
-                if (!is.na(hsize) && !is.na(upid) &&
-                    (hsize != .raven_state$hsize || upid != .raven_state$upid)) {
-                    .raven_state$hsize <<- hsize
-                    .raven_state$upid  <<- upid
-                    if (hsize > 0L) {
-                        .raven_post("/plot-available", paste0(
-                            "{",
-                            "\\"sessionId\\":", .raven_json_str(.raven_session_id), ",",
-                            "\\"hsize\\":", hsize, ",",
-                            "\\"upid\\":", upid,
-                            "}"
-                        ))
-                    }
-                }
-            }
-        }, error = function(e) {
-            .raven_log(paste0("plot-available callback error: ", conditionMessage(e)))
-        })
-        TRUE
-    }, name = "raven-plot-bridge")
-
+    .raven_init_httpgd()
     invisible(NULL)
 })
 `;

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -493,11 +493,13 @@ local({
 
     # 5. Verify httpgd >= 2.0.2 is available.
     if (!requireNamespace("httpgd", quietly = TRUE)) {
-        .raven_msg <- "To view plots in VS Code, install the httpgd package: install.packages(\\"httpgd\\")"
-        .raven_log(.raven_msg)
+        # Console: full context. Popup: short enough to fit on one VS Code
+        # notification line without the user needing to expand it.
+        .raven_log("To view R plots in VS Code, install the httpgd package: install.packages(\\"httpgd\\")")
         # Show the VS Code popup only when the user first tries to plot, not at
         # session start, to avoid overwhelming new users during setup.
-        .raven_original_device <- .raven_deferred_warn(.raven_msg, "missing-httpgd")
+        .raven_original_device <- .raven_deferred_warn(
+            "To view R plots: install.packages(\\"httpgd\\")", "missing-httpgd")
         # Retry after each R expression: initialize the plot bridge as soon as
         # httpgd is available (e.g. after install.packages("httpgd")).
         addTaskCallback(function(...) {
@@ -511,12 +513,12 @@ local({
         return(invisible(NULL))
     }
     if (!(utils::packageVersion("httpgd") >= "2.0.2")) {
-        .raven_msg <- paste0(
-            "To view plots in VS Code, update httpgd to >= 2.0.2 (installed: ",
+        .raven_log(paste0(
+            "To view R plots in VS Code, update httpgd to >= 2.0.2 (installed: ",
             as.character(utils::packageVersion("httpgd")), "): install.packages(\\"httpgd\\")"
-        )
-        .raven_log(.raven_msg)
-        .raven_deferred_warn(.raven_msg, "outdated-httpgd")
+        ))
+        .raven_deferred_warn(
+            "To view R plots, update httpgd: install.packages(\\"httpgd\\")", "outdated-httpgd")
         return(invisible(NULL))
     }
 

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -466,22 +466,45 @@ local({
         invisible(NULL)
     }
 
+    # Helper: post a /plot-warning and then open the original graphics device.
+    # Installed as options(device=) so the VS Code popup fires on the first
+    # plot attempt rather than at session start, avoiding startup noise.
+    .raven_deferred_warn <- function(msg, reason) {
+        .raven_original_device <- getOption("device")
+        options(device = function() {
+            # Self-remove before doing anything so re-entrant calls are safe.
+            options(device = .raven_original_device)
+            .raven_post("/plot-warning", paste0(
+                "{",
+                "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
+                "\\"reason\\":", .raven_json_str(reason), ",",
+                "\\"message\\":", .raven_json_str(msg),
+                "}"
+            ))
+            dev_fn <- if (is.function(.raven_original_device)) {
+                .raven_original_device
+            } else {
+                match.fun(.raven_original_device)
+            }
+            dev_fn()
+        })
+        .raven_original_device
+    }
+
     # 5. Verify httpgd >= 2.0.2 is available.
     if (!requireNamespace("httpgd", quietly = TRUE)) {
         .raven_msg <- "To view plots in VS Code, install the httpgd package: install.packages(\\"httpgd\\")"
         .raven_log(.raven_msg)
-        .raven_post("/plot-warning", paste0(
-            "{",
-            "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
-            "\\"reason\\":\\"missing-httpgd\\",",
-            "\\"message\\":", .raven_json_str(.raven_msg),
-            "}"
-        ))
+        # Show the VS Code popup only when the user first tries to plot, not at
+        # session start, to avoid overwhelming new users during setup.
+        .raven_original_device <- .raven_deferred_warn(.raven_msg, "missing-httpgd")
         # Retry after each R expression: initialize the plot bridge as soon as
         # httpgd is available (e.g. after install.packages("httpgd")).
         addTaskCallback(function(...) {
             if (!requireNamespace("httpgd", quietly = TRUE)) return(TRUE)
             if (!(utils::packageVersion("httpgd") >= "2.0.2")) return(FALSE)
+            # Remove the device wrapper now that httpgd is ready.
+            options(device = .raven_original_device)
             .raven_init_httpgd()
             FALSE
         }, name = "raven-httpgd-pending")
@@ -493,13 +516,7 @@ local({
             as.character(utils::packageVersion("httpgd")), "): install.packages(\\"httpgd\\")"
         )
         .raven_log(.raven_msg)
-        .raven_post("/plot-warning", paste0(
-            "{",
-            "\\"sessionId\\":", .raven_json_str(Sys.getenv("RAVEN_R_SESSION_ID")), ",",
-            "\\"reason\\":\\"outdated-httpgd\\",",
-            "\\"message\\":", .raven_json_str(.raven_msg),
-            "}"
-        ))
+        .raven_deferred_warn(.raven_msg, "outdated-httpgd")
         return(invisible(NULL))
     }
 

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -481,10 +481,10 @@ local({
                 "\\"message\\":", .raven_json_str(msg),
                 "}"
             ))
-            # dev.new() reads getOption("device") internally, which is now
-            # restored to the original, so it opens the right device without
-            # needing to call the opener directly via match.fun.
-            grDevices::dev.new()
+            warning(msg, call. = FALSE)
+            # dev.new() reads getOption("device") internally (now restored).
+            # Errors are suppressed: the warning above is the user signal.
+            tryCatch(grDevices::dev.new(), error = function(e) invisible(NULL))
         })
         .raven_original_device
     }

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -482,9 +482,12 @@ local({
                 "}"
             ))
             warning(msg, call. = FALSE)
-            # dev.new() reads getOption("device") internally (now restored).
-            # Errors are suppressed: the warning above is the user signal.
-            tryCatch(grDevices::dev.new(), error = function(e) invisible(NULL))
+            # Try to open the original device; if that fails (e.g. the
+            # terminal has no native graphics device), fall back to a
+            # temporary PDF so R always has something to render to.
+            tryCatch(grDevices::dev.new(), error = function(e) {
+                try(grDevices::pdf(tempfile(fileext = ".pdf")), silent = TRUE)
+            })
         })
         .raven_original_device
     }
@@ -497,7 +500,7 @@ local({
         # Show the VS Code popup only when the user first tries to plot, not at
         # session start, to avoid overwhelming new users during setup.
         .raven_original_device <- .raven_deferred_warn(
-            "To view R plots: install.packages(\\"httpgd\\")", "missing-httpgd")
+            "To view R plots in VS Code: install.packages(\\"httpgd\\")", "missing-httpgd")
         # Retry after each R expression: initialize the plot bridge as soon as
         # httpgd is available (e.g. after install.packages("httpgd")).
         addTaskCallback(function(...) {
@@ -516,7 +519,7 @@ local({
             as.character(utils::packageVersion("httpgd")), "): install.packages(\\"httpgd\\")"
         ))
         .raven_deferred_warn(
-            "To view R plots, update httpgd: install.packages(\\"httpgd\\")", "outdated-httpgd")
+            "To view R plots in VS Code, update httpgd: install.packages(\\"httpgd\\")", "outdated-httpgd")
         return(invisible(NULL))
     }
 

--- a/editors/vscode/src/r-session-server/index.ts
+++ b/editors/vscode/src/r-session-server/index.ts
@@ -5,13 +5,14 @@ import * as path from 'path';
 import {
     DataViewerWarningEvent,
     PlotEvent,
+    PlotWarningEvent,
     RSessionEvent,
     RSessionEventListener,
     SessionInfo,
     ViewDataEvent,
 } from './types';
 
-export type { DataViewerWarningEvent, PlotEvent, RSessionEvent, RSessionEventListener, SessionInfo, ViewDataEvent };
+export type { DataViewerWarningEvent, PlotEvent, PlotWarningEvent, RSessionEvent, RSessionEventListener, SessionInfo, ViewDataEvent };
 /** @deprecated Use {@link RSessionEventListener}. */
 export type PlotEventListener = RSessionEventListener;
 
@@ -120,6 +121,10 @@ export class RSessionServer {
             this.read_json_body(req, res, body => this.handle_data_viewer_warning(body, res));
             return;
         }
+        if (url === '/plot-warning') {
+            this.read_json_body(req, res, body => this.handle_plot_warning(body, res));
+            return;
+        }
         res.writeHead(404).end();
     }
 
@@ -142,6 +147,24 @@ export class RSessionServer {
             reason,
             message,
         });
+        res.writeHead(200).end();
+    }
+
+    private handle_plot_warning(body: unknown, res: http.ServerResponse): void {
+        if (!body || typeof body !== 'object') {
+            res.writeHead(400).end();
+            return;
+        }
+        const b = body as Record<string, unknown>;
+        const sessionId = typeof b.sessionId === 'string' ? b.sessionId : '';
+        const reason = (b.reason === 'missing-httpgd' || b.reason === 'outdated-httpgd')
+            ? b.reason : '';
+        const message = typeof b.message === 'string' ? b.message : '';
+        if (!sessionId || !reason || !message) {
+            res.writeHead(400).end();
+            return;
+        }
+        this.emit({ type: 'plot-warning', sessionId, reason, message });
         res.writeHead(200).end();
     }
 

--- a/editors/vscode/src/r-session-server/types.ts
+++ b/editors/vscode/src/r-session-server/types.ts
@@ -36,5 +36,12 @@ export type DataViewerWarningEvent = {
     message: string;
 };
 
-export type RSessionEvent = PlotEvent | ViewDataEvent | DataViewerWarningEvent;
+export type PlotWarningEvent = {
+    type: 'plot-warning';
+    sessionId: string;
+    reason: 'missing-httpgd' | 'outdated-httpgd';
+    message: string;
+};
+
+export type RSessionEvent = PlotEvent | ViewDataEvent | DataViewerWarningEvent | PlotWarningEvent;
 export type RSessionEventListener = (event: RSessionEvent) => void;

--- a/tests/bun/plot-bootstrap-content.test.ts
+++ b/tests/bun/plot-bootstrap-content.test.ts
@@ -19,6 +19,34 @@ describe('generate_profile_source', () => {
         expect(src).toMatch(/packageVersion\("httpgd"\) >= "2\.0\.2"/);
     });
 
+    test('retries plot bridge initialization after outdated httpgd is updated', () => {
+        const retry_helper = src.match(
+            /\.raven_register_httpgd_retry <- function\(\.raven_original_device\) \{[\s\S]*?\n    \}/,
+        )?.[0];
+        const outdated_branch = src.match(
+            /if \(!\(utils::packageVersion\("httpgd"\) >= "2\.0\.2"\)\) \{[\s\S]*?return\(invisible\(NULL\)\)\n    \}/,
+        )?.[0];
+
+        expect(retry_helper).toBeDefined();
+        expect(retry_helper).toContain('addTaskCallback(function(...)');
+        expect(retry_helper).toContain(
+            'if (!(utils::packageVersion("httpgd") >= "2.0.2")) return(TRUE)',
+        );
+        expect(retry_helper).toContain(
+            'options(device = .raven_original_device)',
+        );
+        expect(retry_helper).toContain('.raven_init_httpgd()');
+        expect(retry_helper).toContain('name = "raven-httpgd-pending"');
+
+        expect(outdated_branch).toBeDefined();
+        expect(outdated_branch).toContain(
+            '.raven_original_device <- .raven_deferred_warn',
+        );
+        expect(outdated_branch).toContain(
+            '.raven_register_httpgd_retry(.raven_original_device)',
+        );
+    });
+
     test('starts httpgd::hgd with localhost host and ephemeral port', () => {
         expect(src).toMatch(/httpgd::hgd\(/);
         expect(src).toMatch(/host = "127\.0\.0\.1"/);

--- a/tests/bun/plot-bootstrap-r-integration.test.ts
+++ b/tests/bun/plot-bootstrap-r-integration.test.ts
@@ -17,6 +17,7 @@ async function r_with_httpgd_available(): Promise<boolean> {
             cmd: [
                 R_BIN,
                 '--vanilla',
+                '--slave',
                 '--quiet',
                 '-e',
                 'cat(requireNamespace("httpgd", quietly = TRUE) && utils::packageVersion("httpgd") >= "2.0.2")',
@@ -117,11 +118,10 @@ describe('R bootstrap end-to-end (real R subprocess)', () => {
             const proc = spawn({
                 cmd: [
                     R_BIN,
+                    '--interactive',
                     '--quiet',
                     '--no-save',
                     '--no-restore',
-                    '-e',
-                    'invisible(NULL)',
                 ],
                 cwd: tmp,
                 env: {
@@ -132,9 +132,12 @@ describe('R bootstrap end-to-end (real R subprocess)', () => {
                     RAVEN_SESSION_TOKEN: 'test-token-deadbeef',
                     RAVEN_R_SESSION_ID: 'test-session-id-1',
                 },
+                stdin: 'pipe',
                 stdout: 'pipe',
                 stderr: 'pipe',
             });
+            proc.stdin.write('invisible(NULL)\nq("no")\n');
+            proc.stdin.end();
             // Wait for the /session-ready POST before tearing down the
             // capture server, instead of a flaky fixed-timer sleep.
             const ready = await cap.waitForRequest(

--- a/tests/bun/plot-bootstrap-r-integration.test.ts
+++ b/tests/bun/plot-bootstrap-r-integration.test.ts
@@ -17,7 +17,7 @@ async function r_with_httpgd_available(): Promise<boolean> {
             cmd: [
                 R_BIN,
                 '--vanilla',
-                '--slave',
+                '--no-echo',
                 '--quiet',
                 '-e',
                 'cat(requireNamespace("httpgd", quietly = TRUE) && utils::packageVersion("httpgd") >= "2.0.2")',


### PR DESCRIPTION
## What changed

When a Raven-managed R terminal starts without httpgd installed (or with an outdated version), the bootstrap profile previously only logged to the R console — easy to miss in startup noise.

### User-visible improvements

- **Clearer message wording**: both warning messages are reworded from `"plots require the httpgd package…"` to `"To view plots in VS Code, install/update the httpgd package…"`.
- **VS Code notification popup**: after printing to the R console, the bootstrap POSTs to a new `/plot-warning` endpoint on the loopback `RSessionServer`. `PlotServices` handles the event and calls `vscode.window.showWarningMessage`, so a popup appears in VS Code alongside the console message. Both the missing-httpgd and outdated-httpgd cases are covered.

### Bug fix: `install.packages("httpgd")` was broken from a Raven terminal

`install.packages` spawns child R processes that inherit `R_PROFILE_USER` (set by Raven to point to the bootstrap profile). Those child processes sourced the bootstrap, called `httpgd::hgd()`, and locked the httpgd namespace — causing `code2LazyLoadDB` to fail with `"namespace must not be already loaded"`. The `addTaskCallback` also fired during compilation, producing `"Device is not a unigd device"` errors.

Fix: added `if (!interactive()) return(invisible(NULL))` as the first line of the plot bridge `local({})`. R CMD INSTALL subprocesses are non-interactive, so the block exits immediately with no httpgd load and no task callback registered. Interactive Raven terminals are unaffected.

## Files changed

| File | Change |
|------|--------|
| `r-session-server/types.ts` | Add `PlotWarningEvent` type; extend `RSessionEvent` union |
| `r-session-server/index.ts` | Add `/plot-warning` route and `handle_plot_warning` handler |
| `plot/index.ts` | Handle `plot-warning` in `on_server_event`; remove now-redundant `PlotEvent` cast |
| `plot/r-bootstrap-profile.ts` | Reword messages; add `/plot-warning` POSTs; guard block with `interactive()` |

## Testing

- With httpgd missing: open a Raven R terminal → R console shows updated message; VS Code shows a warning popup.
- With httpgd outdated (< 2.0.2): same behavior with the version-specific message.
- With httpgd ≥ 2.0.2: no popup, plots work normally.
- `install.packages("httpgd")` from a Raven terminal now succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plot warning notifications displayed in VS Code for missing or outdated httpgd.
  * Implemented automatic retry mechanism to detect when httpgd becomes available after an update.

* **Bug Fixes**
  * Improved handling of missing or outdated plot rendering libraries with graceful fallback to PDF device.
  * Deferred user notifications until first plot attempt instead of immediate popups.

* **Tests**
  * Added tests for bootstrap initialization and plot-related edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/189)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->