### PR TITLE
vscode readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Raven — R language server and VS Code extension
+# Raven — R Extension & Language Server
 
-Raven is an R extension for VS Code, plus a standalone [language server](https://github.com/Microsoft/language-server-protocol) for other LSP-compatible editors (Zed, Neovim, and AI agents).
+R language support for VS Code with cross-file code intelligence (completions, diagnostics, navigation), an [R console](docs/r-console.md), and [plot](docs/plot-viewer.md), [data](docs/data-viewer.md), and [help](docs/help-viewer.md) viewers. The [language server](https://github.com/Microsoft/language-server-protocol) also runs standalone in [other editors](docs/editor-integrations.md).
 
-The language server analyzes your code in realtime. It completes variable and accessor names as you type, flags syntax errors and undefined variables, and lets you jump to where a variable or function is defined or list all the other places that your codebase references it. The VS Code extension bundles the language server alongside an integrated [R console](docs/r-console.md), [plot viewer](docs/plot-viewer.md), [data viewer](docs/data-viewer.md), and [help viewer](docs/help-viewer.md).
+The language server analyzes your code in realtime: it completes variable and accessor names as you type, flags syntax errors and undefined variables, and lets you jump to where a variable or function is defined or list all the other places that your codebase references it.
 
 Compared with [REditorSupport's R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), [Positron](https://github.com/posit-dev/positron), and RStudio, Raven's language server is the only one that traces `source()` chains, so completions, diagnostics, and navigation reflect the actual order of execution at each cursor position. Of those three, REditorSupport is the only other VS Code option; against REditorSupport specifically, Raven adds RStudio-style indentation on Enter without disturbing the surrounding code, sends large blocks of code to R faster, and uses a virtualized Arrow-backed data viewer that stays responsive on large frames.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Raven — R Extension & Language Server
+# Raven
 
-R language support for VS Code with cross-file code intelligence (completions, diagnostics, navigation), an [R console](docs/r-console.md), and [plot](docs/plot-viewer.md), [data](docs/data-viewer.md), and [help](docs/help-viewer.md) viewers. The [language server](https://github.com/Microsoft/language-server-protocol) also runs standalone in [other editors](docs/editor-integrations.md).
+Raven is an R language server with cross-file code intelligence (completions, diagnostics, navigation), plus a VS Code extension that adds an [R console](docs/r-console.md) and [plot](docs/plot-viewer.md), [data](docs/data-viewer.md), and [help](docs/help-viewer.md) viewers on top. The language server also runs in any LSP-compatible [editor](docs/editor-integrations.md).
 
 The language server analyzes your code in realtime: it completes variable and accessor names as you type, flags syntax errors and undefined variables, and lets you jump to where a variable or function is defined or list all the other places that your codebase references it.
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,10 +1,10 @@
-# Raven — R Extension for VS Code
+# Raven
 
-Raven is an R extension for VS Code, plus a standalone language server for other LSP-compatible editors.
+R language support for VS Code with cross-file code intelligence (completions, diagnostics, navigation), an [R console](https://github.com/jbearak/raven/blob/main/docs/r-console.md), and [plot](https://github.com/jbearak/raven/blob/main/docs/plot-viewer.md), [data](https://github.com/jbearak/raven/blob/main/docs/data-viewer.md), and [help](https://github.com/jbearak/raven/blob/main/docs/help-viewer.md) viewers.
 
-The extension integrates an R console, plot viewer, data viewer, and help viewer. Compared with [REditorSupport's R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), Raven sends large blocks of code to R reliably even over `tmux` and SSH, and uses a virtualized Arrow-backed data viewer that stays responsive on large frames.
+The language server analyzes your code in realtime: it completes variable and accessor names as you type, flags syntax errors and undefined variables, and lets you jump to where a variable or function is defined or list all the other places that your codebase references it.
 
-The language server brings cross-file code intelligence to R: completions, diagnostics, and navigation that follow `source()` chains across files and are aware of which packages are loaded at the cursor. We're not aware of another R language server that combines `source()`-chain tracing with position-aware package scope; if you know of one, we'd like to hear about it.
+Compared with [REditorSupport's R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), [Positron](https://github.com/posit-dev/positron), and RStudio, Raven's language server is the only one that traces `source()` chains, so completions, diagnostics, and navigation reflect the actual order of execution at each cursor position. Of those three, REditorSupport is the only other VS Code option; against REditorSupport specifically, Raven adds RStudio-style indentation on Enter without disturbing the surrounding code, sends large blocks of code to R faster, and uses a virtualized Arrow-backed data viewer that stays responsive on large frames.
 
 > [!NOTE]
 > If you already have the REditorSupport (R) extension installed, or you're using Positron, Raven's R-console features (R console, plot viewer, data viewer) step aside by default — see [Coexistence](#coexistence-with-vscode-r-and-positron) below. The language server and help viewer are unaffected.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # Raven
 
-R language support for VS Code with cross-file code intelligence (completions, diagnostics, navigation), an [R console](https://github.com/jbearak/raven/blob/main/docs/r-console.md), and [plot](https://github.com/jbearak/raven/blob/main/docs/plot-viewer.md), [data](https://github.com/jbearak/raven/blob/main/docs/data-viewer.md), and [help](https://github.com/jbearak/raven/blob/main/docs/help-viewer.md) viewers.
+R language support with cross-file code intelligence (completions, diagnostics, navigation), an [R console](https://github.com/jbearak/raven/blob/main/docs/r-console.md), and [plot](https://github.com/jbearak/raven/blob/main/docs/plot-viewer.md), [data](https://github.com/jbearak/raven/blob/main/docs/data-viewer.md), and [help](https://github.com/jbearak/raven/blob/main/docs/help-viewer.md) viewers.
 
 The language server analyzes your code in realtime: it completes variable and accessor names as you type, flags syntax errors and undefined variables, and lets you jump to where a variable or function is defined or list all the other places that your codebase references it.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raven-r",
   "displayName": "Raven - R Language Server",
-  "description": "Static R language server with cross-file awareness",
+  "description": "R language server with cross-file awareness, plus an R console and plot, data, and help viewers",
   "version": "0.5.1",
   "publisher": "jbearak",
   "license": "GPL-3.0",


### PR DESCRIPTION
- **README: rewrite opening to lead with capabilities**
- **README: lead with the language server, drop redundant scoping**
- **package.json: update marketplace description to match README**
