### PR TITLE
vscode r coexistence docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ User-facing:
 - `docs/data-viewer.md`
 - `docs/help-viewer.md`
 - `docs/document-outline.md`
+- `docs/coexistence.md`
 - `docs/configuration.md`
 
 Maintainer/internal:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The language server analyzes your code in realtime: it completes variable and ac
 Compared with [REditorSupport's R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r), [Positron](https://github.com/posit-dev/positron), and RStudio, Raven's language server is the only one that traces `source()` chains, so completions, diagnostics, and navigation reflect the actual order of execution at each cursor position. Of those three, REditorSupport is the only other VS Code option; against REditorSupport specifically, Raven adds RStudio-style indentation on Enter without disturbing the surrounding code, sends large blocks of code to R faster, and uses a virtualized Arrow-backed data viewer that stays responsive on large frames.
 
 > [!NOTE]
-> If you already have the REditorSupport (R) extension installed, or you're using Positron, Raven's R-console features (R console, plot viewer, data viewer) step aside by default — see [Comparison: Coexistence](docs/comparison.md#coexistence). The language server and help viewer are unaffected.
+> If you already have the REditorSupport (R) extension installed, or you're using Positron, Raven's R-console features (R console, plot viewer, data viewer) step aside by default — see [Coexistence](docs/coexistence.md). The language server and help viewer are unaffected.
 
 > **Status:** Raven is under active development. It works well for day-to-day use but hasn't been widely announced yet. Bug reports and feedback are welcome!
 

--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -1,0 +1,35 @@
+# Coexistence with Other R Extensions
+
+Raven's VS Code extension includes both a **language server** (completions, diagnostics, navigation) and **R-session features** (R console, plot viewer, data viewer, help viewer). If you also use the [REditorSupport (R) extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) or [Positron](https://github.com/posit-dev/positron), Raven is designed to stay out of the way by default.
+
+## What steps aside and what doesn't
+
+Raven's **language server** and **help viewer** always activate — they don't overlap with a running R session.
+
+Raven's **R console**, **plot viewer**, and **data viewer** are the features that can overlap with another extension's R-session integration. The plot and data viewers are reached *through* Raven's R console: the R console boots a profile that overrides `View()` (data viewer) and starts httpgd (plot viewer). When Raven's R console isn't activated, neither of those viewers is wired up — `View(df)` and `plot(...)` go to whatever R session your other extension manages.
+
+## The `raven.rConsole.activation` setting
+
+The `raven.rConsole.activation` setting (default: `"auto"`) controls whether Raven's R console — and therefore its plot and data viewers — activates:
+
+- **`"auto"`** (default) — Raven's R-session features activate *unless* the REditorSupport (R) extension is enabled or VS Code is running as Positron. This keeps Raven out of the way when you already have R-session integration.
+- **`"enabled"`** — Always activate Raven's R-session features, even alongside other R extensions. You'll then be responsible for any keybinding or `View()`-override conflicts.
+- **`"disabled"`** — Never activate Raven's R-session features, even when no other R extension is present.
+
+The help viewer activates regardless of this setting. It shells out to R on demand to render Rd documentation as HTML, so it works whether or not Raven's R console is active — provided Raven can run the configured R executable.
+
+## Language servers: Raven alone vs. both
+
+Raven's language server traces `source()` chains across your project, so its completions, diagnostics, and navigation reflect actual execution order at the cursor position — including cross-file go-to-definition, find-references, and detection of circular dependencies and scope violations. It doesn't need a running R session.
+
+REditorSupport's language server provides [`lintr`](https://lintr.r-lib.org/) diagnostics, which covers a different surface than Raven's diagnostics: it catches style violations and certain correctness issues that Raven doesn't flag, while Raven catches cross-file scope problems that lintr doesn't see.
+
+If you want both, leave `r.lsp.enabled` at its default (`true`). Both language servers will run, with some overlap in completions and diagnostics.
+
+If you only need Raven's language intelligence and want REditorSupport solely for its R-session features, disable its language server so the two don't compete:
+
+```json
+"r.lsp.enabled": false
+```
+
+See [Editor Integrations](./editor-integrations.md) for setup details across editors.

--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -26,7 +26,11 @@ REditorSupport's language server provides [`lintr`](https://lintr.r-lib.org/) di
 
 If you want both, leave `r.lsp.enabled` at its default (`true`). Both language servers will run, with some overlap in completions and diagnostics.
 
-If you only need Raven's language intelligence and want REditorSupport solely for its R-session features, disable its language server so the two don't compete:
+If you don't need lintr, Raven can replace REditorSupport entirely. Raven's R-session features offer some advantages over REditorSupport's equivalents: the R console sends large blocks via a temp-file `source()` instead of line-by-line paste (faster and more reliable), and the data viewer stays responsive on multi-million-row frames (REditorSupport's data viewer serializes the entire frame to JSON and loads it into the webview at once, so it caps at 100 rows by default to avoid freezing VS Code). See [Comparison](./comparison.md#r-session-integration) for details.
+
+One reason to keep REditorSupport installed is its workspace viewer — a sidebar panel that introspects your active R session, showing live objects, their types, and dimensions. Raven doesn't have an equivalent. If you're interested in a workspace viewer or lintr integration in Raven, please [file an issue](https://github.com/jbearak/raven/issues) — I haven't built these because in nearly two decades of using R I haven't relied on either, but I'd consider them if there's interest.
+
+If you keep REditorSupport installed but don't need its language server (e.g. you only want the workspace viewer), you can disable it to avoid the overhead of running two LSPs:
 
 ```json
 "r.lsp.enabled": false

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -51,16 +51,4 @@ Raven takes a different approach. Its language server is a separate Rust process
 
 ## Coexistence
 
-Raven's data viewer and plot viewer are reached *through* its R console: the R console boots a profile that overrides `View()` (data viewer) and starts httpgd (plot viewer). When Raven's R console isn't activated, neither of those viewers is wired up — `View(df)` and `plot(...)` go to whatever R session your other extension manages.
-
-Raven's help viewer operates independently of the R console: it shells out to R on demand to render `Rd → HTML`, so it works whether or not Raven's R console is active. Help remains available independently of `raven.rConsole.activation`, provided Raven can run the configured R executable.
-
-With the default `raven.rConsole.activation: "auto"`, the R console (and therefore its plot and data viewers) steps aside automatically when the [REditorSupport (R) extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) is enabled or VS Code is running as Positron, so Raven stays out of the way of your existing R-session setup. Set the value explicitly to `"enabled"` if you want both extensions' R-session features active at once; you'll then be responsible for any keybinding or `View()`-override conflicts that result. Set `"disabled"` to never activate Raven's R-session features even when no other R extension is present.
-
-If you want to run REditorSupport's language server alongside Raven (for example, to use `lintr` diagnostics), keep its language-server feature off:
-
-```json
-"r.lsp.enabled": false
-```
-
-See [Editor Integrations](./editor-integrations.md) for setup details across editors.
+See [Coexistence with Other R Extensions](./coexistence.md) for how Raven's R-session features interact with the REditorSupport (R) extension and Positron, how `raven.rConsole.activation` works, and how to run REditorSupport's lintr alongside Raven.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -23,6 +23,11 @@ Compares Raven's language server against the language servers and code-intellige
 
 Among the R LSPs we've surveyed, Raven is the only one that traces `source()` chains across a project: it builds a dependency graph and resolves what's in scope at each cursor position based on the actual order of execution, rather than treating the workspace as one flat symbol set. That makes its completions, diagnostics, and navigation reflect actual execution order in multi-file scripted projects, including circular-dependency and scope-violation detection. The analysis is static; Raven does spawn R subprocesses on demand for package metadata (exports, NAMESPACE entries, function signatures), but it doesn't need a live R session to compute scope.
 
+### What REditorSupport's language server offers that Raven doesn't
+
+- **lintr diagnostics** — Style checks and correctness linters (e.g. `object_usage_linter`, `line_length_linter`, `trailing_whitespace_linter`) via the [`lintr`](https://lintr.r-lib.org/) package. Raven has no style linting.
+- **Session-aware completions** — When the session watcher is enabled, REditorSupport can complete symbols from the live R session's `globalenv()`, including column names from data frames that only exist at runtime. Raven's completions are purely static.
+
 ## R session integration
 
 Raven's VS Code extension also includes an R console, plot viewer, data viewer, and help viewer. The [REditorSupport (R) extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) provides equivalents (it's a long-standing, widely used extension), and Positron has its own first-party versions. We chose to build these features rather than rely on REditorSupport because they let us address specific limitations our team has run into — described below.
@@ -48,6 +53,15 @@ Raven's `View()` writes the frame to an Apache Arrow IPC (Feather v2) file, and 
 REditorSupport's hover is rendered server-side by [`languageserver`](https://github.com/REditorSupport/languageserver), which is itself an R package running inside its own R process. When the hover handler can't resolve a symbol from the in-file scope, it calls `workspace$get_help(token, package)`, which tries [`guess_namespace(topic)`](https://github.com/REditorSupport/languageserver/blob/master/R/workspace.R) against the language server's *workspace-flat* set of attached packages. That set is built by parsing `library()` / `require()` / `pacman::p_load()` calls out of source files and `library()`-ing the named packages inside the language server's own R process — but only for files the user has opened (`didOpen`), with one exception: if the project is an R package (has a `DESCRIPTION` file), `R/*.R` is also pre-scanned at startup. For an ordinary scripted project, `library()` calls in files the user hasn't opened are invisible to the hover; across files the user *has* opened, the package set is unioned without regard to where the cursor is. When `guess_namespace` doesn't return a single match, the handler falls through to `utils::help((topic))` with no `package` argument, which returns matches across **every** installed package — so hovering over `filter` in a script that's loaded `dplyr` can fall through to a multi-package result that includes `dplyr::filter`, `stats::filter`, and other same-named topics.
 
 Raven takes a different approach. Its language server is a separate Rust process that statically traces `library()` / `require()` calls in the file at the cursor and across the `source()` chain — including files the user hasn't opened — plus namespace qualifiers (`pkg::fn`) and `@lsp-*` directives, to compute which package is in scope at the cursor position. It then shows a single help link for that package. Raven does spawn R subprocesses to read package metadata (exports, NAMESPACE entries, function signatures), but the disambiguation logic itself is static — it doesn't depend on whether the user has opened, run, or attached anything. See [Help Viewer](./help-viewer.md).
+
+### What REditorSupport's VS Code extension offers that Raven doesn't
+
+- **Workspace viewer** — A sidebar panel that introspects the live R session, showing objects in `globalenv()` with their types and dimensions, plus attached and loaded namespaces. Objects can be viewed or removed directly from the panel.
+- **htmlwidget / Shiny viewer** — Interactive HTML output (plotly, DT, profvis, etc.) and Shiny apps render in VS Code webview panels.
+- **R Markdown support** — Chunk highlighting, chunk navigation, run-chunk / run-above CodeLens buttons, and R Markdown preview.
+- **List / environment viewer** — `View()` on lists and environments opens a collapsible tree view. Raven's `View()` only handles data frames and matrices.
+
+If you're interested in any of these, please [file an issue](https://github.com/jbearak/raven/issues) or submit a PR.
 
 ## Coexistence
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ Each accepts: `"error"`, `"warning"`, `"information"`, `"hint"`, or `"off"`.
 
 | Setting | Default | Description |
 |---|---|---|
-| `raven.rConsole.activation` | `"auto"` | When Raven's R console (and the plot and data viewers it powers) activates. `"enabled"`: always activate. `"disabled"`: never activate. `"auto"`: activate unless the REditorSupport (R) extension is enabled or VS Code is running as Positron. See [R Console](r-console.md) and [Comparison: Coexistence](comparison.md#coexistence). |
+| `raven.rConsole.activation` | `"auto"` | When Raven's R console (and the plot and data viewers it powers) activates. `"enabled"`: always activate. `"disabled"`: never activate. `"auto"`: activate unless the REditorSupport (R) extension is enabled or VS Code is running as Positron. See [R Console](r-console.md) and [Coexistence](coexistence.md). |
 
 ## Plot Settings
 

--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -23,7 +23,7 @@ than the size of the frame. See
 > `auto`). When the REditorSupport (R) extension is enabled or VS Code is
 > running as Positron, Raven's R console — and therefore the data viewer
 > — steps aside automatically. See
-> [Comparison: Coexistence](./comparison.md#coexistence) for details.
+> [Coexistence](./coexistence.md) for details.
 
 ## What it shows
 

--- a/docs/plot-viewer.md
+++ b/docs/plot-viewer.md
@@ -3,7 +3,7 @@
 Raven shows plots from its managed R terminal directly in VS Code via a built-in viewer panel. The viewer is backed by [httpgd](https://nx10.dev/httpgd/), a headless graphics device for R that exposes plots over a local HTTP/WebSocket server. Each R session gets its own plot panel with independent history, theme-aware backgrounds, and export to PNG, SVG, or PDF.
 
 > [!NOTE]
-> The plot viewer is reached through Raven's R console: it activates only when Raven's R console activates (`raven.rConsole.activation`, default: `auto`). When the REditorSupport (R) extension is enabled or VS Code is running as Positron, Raven's R console — and therefore the plot viewer — steps aside automatically. See [Comparison: Coexistence](./comparison.md#coexistence) for details.
+> The plot viewer is reached through Raven's R console: it activates only when Raven's R console activates (`raven.rConsole.activation`, default: `auto`). When the REditorSupport (R) extension is enabled or VS Code is running as Positron, Raven's R console — and therefore the plot viewer — steps aside automatically. See [Coexistence](./coexistence.md) for details.
 
 ## Prerequisites
 

--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -5,7 +5,7 @@ Raven provides an integrated R console inside VS Code, plus commands to send R c
 The R console is the entry point to Raven's [plot viewer](./plot-viewer.md) and [data viewer](./data-viewer.md): plots produced in this console render in a VS Code panel via httpgd, and `View(df)` opens Raven's data viewer instead of R's default. Raven's [help viewer](./help-viewer.md) works independently of the R console.
 
 > [!NOTE]
-> Whether the R console activates is controlled by `raven.rConsole.activation` (default: `auto`). When the REditorSupport (R) extension is enabled or VS Code is running as Positron, Raven's R console — and therefore its plot and data viewers — steps aside automatically to avoid disrupting your existing R-session setup. See [Comparison](./comparison.md#coexistence) for details.
+> Whether the R console activates is controlled by `raven.rConsole.activation` (default: `auto`). When the REditorSupport (R) extension is enabled or VS Code is running as Positron, Raven's R console — and therefore its plot and data viewers — steps aside automatically to avoid disrupting your existing R-session setup. See [Coexistence](./coexistence.md) for details.
 
 ## R Terminal Profile
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -59,7 +59,7 @@ Raven's R-console features (R console, plot viewer, data viewer) and REditorSupp
 
 Set `"enabled"` to override and run both extensions' R-session features at once — you'll then own any keybinding or `View()`-override conflicts.
 
-If you want to run vscode-R's language server alongside Raven (for example, to use its `lintr` diagnostics), keep its language-server feature off:
+REditorSupport's `lintr` diagnostics are provided by its language server. If you want lintr alongside Raven, leave `r.lsp.enabled` at its default (`true`) — both language servers will run, with some overlap in completions and diagnostics. If you don't need lintr and only want vscode-R for its R-session features, disable its language server:
 
 ```json
 "r.lsp.enabled": false

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -627,7 +627,7 @@
             "Activate Raven's R console, plot viewer, and data viewer unless the REditorSupport (R) extension is enabled or VS Code is running as Positron."
           ],
           "default": "auto",
-          "description": "Controls when Raven's R console (and the plot and data viewers it powers) activates. The help viewer is unaffected by this setting. See https://github.com/jbearak/raven/blob/main/docs/comparison.md#coexistence."
+          "description": "Controls when Raven's R console (and the plot and data viewers it powers) activates. The help viewer is unaffected by this setting. See https://github.com/jbearak/raven/blob/main/docs/coexistence.md."
         },
         "raven.plot.viewerColumn": {
           "type": "string",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -94,13 +94,13 @@
         "command": "raven.runLineOrSelection",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
-        "when": "editorTextFocus && editorLangId == r"
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
       },
       {
         "command": "raven.sourceFile",
         "key": "shift+ctrl+enter",
         "mac": "shift+cmd+enter",
-        "when": "editorTextFocus && editorLangId == r"
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
       }
     ],
     "submenus": [
@@ -118,7 +118,7 @@
       "editor/title": [
         {
           "submenu": "raven.sendToR",
-          "when": "editorLangId == r",
+          "when": "editorLangId == r && raven.rConsoleEnabled",
           "group": "navigation"
         }
       ],

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -43,6 +43,7 @@ function getInitializationOptions(): RavenInitializationOptions {
 }
 
 let client: LanguageClient;
+const R_CONSOLE_ENABLED_CONTEXT = 'raven.rConsoleEnabled';
 const WORD_SEPARATORS = "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?";
 const DOT_IN_WORD_LANGUAGE_IDS = ['r', 'jags'] as const;
 
@@ -178,6 +179,11 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
     // Positron, so Raven supplements rather than fights existing R-session
     // setups. The help viewer activates regardless and is wired above.
     const r_console_resolved = resolveRConsoleActivation();
+    void vscode.commands.executeCommand(
+        'setContext',
+        R_CONSOLE_ENABLED_CONTEXT,
+        r_console_resolved === 'enabled',
+    );
     let data_viewer_manager: DataViewerManager | undefined;
     if (r_console_resolved === 'enabled') {
         // Plot services (session server + viewer panel) for managed R terminals.

--- a/editors/vscode/src/r-console-activation.ts
+++ b/editors/vscode/src/r-console-activation.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
  * when the REditorSupport (R) extension is enabled or VS Code is
  * running as Positron, so Raven steps aside in environments where the
  * user already has R-session integration. See
- * docs/comparison.md#coexistence for the rationale.
+ * docs/coexistence.md for the rationale.
  */
 
 export type RConsoleActivation = 'enabled' | 'disabled' | 'auto';
@@ -78,7 +78,7 @@ export async function notifyAutoDisable(
     );
     if (choice === LEARN_MORE) {
         await vscode.env.openExternal(
-            vscode.Uri.parse('https://github.com/jbearak/raven/blob/main/docs/comparison.md#coexistence'),
+            vscode.Uri.parse('https://github.com/jbearak/raven/blob/main/docs/coexistence.md'),
         );
     } else if (choice === OPEN_SETTINGS) {
         await vscode.commands.executeCommand(

--- a/editors/vscode/src/test/r-console-activation.test.ts
+++ b/editors/vscode/src/test/r-console-activation.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
     isPositron,
@@ -61,5 +63,33 @@ suite('Raven R-console activation', () => {
         assert.strictEqual(isPositron('Visual Studio Code'), false);
         assert.strictEqual(isPositron('Cursor'), false);
         assert.strictEqual(isPositron('Code - OSS'), false);
+    });
+
+    test('R-console editor affordances are hidden unless the resolved activation context is enabled', () => {
+        const package_json_path = path.join(__dirname, '..', '..', 'package.json');
+        const package_json = JSON.parse(fs.readFileSync(package_json_path, 'utf8')) as {
+            contributes: {
+                keybindings: Array<{ command: string; when?: string }>;
+                menus: { 'editor/title': Array<{ submenu: string; when?: string }> };
+            };
+        };
+
+        const editor_menu = package_json.contributes.menus['editor/title']
+            .find(item => item.submenu === 'raven.sendToR');
+        assert.ok(editor_menu, 'editor/title should contribute the Send to R submenu');
+        assert.ok(
+            editor_menu.when?.includes('raven.rConsoleEnabled'),
+            'Send to R editor toolbar submenu must require the resolved R-console context key',
+        );
+
+        for (const command of ['raven.runLineOrSelection', 'raven.sourceFile']) {
+            const binding = package_json.contributes.keybindings
+                .find(item => item.command === command);
+            assert.ok(binding, `${command} should have a keybinding`);
+            assert.ok(
+                binding.when?.includes('raven.rConsoleEnabled'),
+                `${command} keybinding must require the resolved R-console context key`,
+            );
+        }
     });
 });


### PR DESCRIPTION
- **Hide R console toolbar when disabled**
- **Extract coexistence docs into standalone page**
- **Flesh out coexistence.md with rationale and fix lintr guidance**
- **Add what REditorSupport offers that Raven doesn't to comparison.md**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * R console-dependent commands (Run Line/Selection, Source File, Send to R) now conditionally appear based on R console activation state.

* **Documentation**
  * New guidance document explaining Raven's coexistence with REditorSupport (R) and Positron extensions.
  * Updated configuration documentation to reference coexistence guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/194)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->