### PR TITLE
Add R function semantic tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
+ "streaming-iterator",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)
+- **Syntax highlighting** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 
 ### R session integration
 

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -33,6 +33,7 @@ indexmap = "2.2"
 regex = "1.10.0"
 rayon = "1.10"
 ropey = "1.6"
+streaming-iterator = "0.1"
 lru = "0.16"
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
 percent-encoding = "2"

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -576,6 +576,19 @@ fn build_completion_trigger_chars(trigger_on_open_paren: bool) -> Vec<String> {
     chars
 }
 
+fn semantic_tokens_capability() -> SemanticTokensServerCapabilities {
+    SemanticTokensOptions {
+        work_done_progress_options: WorkDoneProgressOptions::default(),
+        legend: SemanticTokensLegend {
+            token_types: vec![SemanticTokenType::FUNCTION],
+            token_modifiers: vec![],
+        },
+        range: None,
+        full: Some(SemanticTokensFullOptions::Bool(true)),
+    }
+    .into()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CancellableRequestKind {
     GotoDefinition,
@@ -1166,6 +1179,7 @@ impl LanguageServer for Backend {
                 document_on_type_formatting_provider: Some(
                     indentation::on_type_formatting_capability(),
                 ),
+                semantic_tokens_provider: Some(semantic_tokens_capability()),
                 execute_command_provider: Some(tower_lsp::lsp_types::ExecuteCommandOptions {
                     commands: vec![],
                     ..Default::default()
@@ -3532,6 +3546,17 @@ impl LanguageServer for Backend {
                 Err(tower_lsp::jsonrpc::Error::internal_error())
             }
         }
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let state = self.state.read().await;
+        Ok(
+            handlers::semantic_tokens_full(&state, &params.text_document.uri)
+                .map(SemanticTokensResult::Tokens),
+        )
     }
 
     /// Searches workspace symbols that match the provided query string.

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3552,11 +3552,25 @@ impl LanguageServer for Backend {
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
-        let state = self.state.read().await;
-        Ok(
-            handlers::semantic_tokens_full(&state, &params.text_document.uri)
-                .map(SemanticTokensResult::Tokens),
-        )
+        let (tree, text) = {
+            let state = self.state.read().await;
+            let doc = match state.get_document(&params.text_document.uri) {
+                Some(doc) => doc,
+                None => return Ok(None),
+            };
+            if doc.file_type != crate::file_type::FileType::R {
+                return Ok(None);
+            }
+            let tree = match &doc.tree {
+                Some(tree) => tree.clone(),
+                None => return Ok(None),
+            };
+            (tree, doc.text())
+        };
+
+        Ok(Some(SemanticTokensResult::Tokens(
+            handlers::semantic_tokens_full(&tree, &text),
+        )))
     }
 
     /// Searches workspace symbols that match the provided query string.

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3567,10 +3567,15 @@ impl LanguageServer for Backend {
             };
             (tree, doc.text())
         };
-
-        Ok(Some(SemanticTokensResult::Tokens(
-            handlers::semantic_tokens_full(&tree, &text),
-        )))
+        match tokio::task::spawn_blocking(move || handlers::semantic_tokens_full(&tree, &text))
+            .await
+        {
+            Ok(tokens) => Ok(Some(SemanticTokensResult::Tokens(tokens))),
+            Err(e) => {
+                log::trace!("semantic_tokens_full: spawn_blocking failed: {e}");
+                Err(tower_lsp::jsonrpc::Error::internal_error())
+            }
+        }
     }
 
     /// Searches workspace symbols that match the provided query string.

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -548,26 +548,20 @@ struct AbsoluteSemanticToken {
     length: u32,
 }
 
-/// Compute full-document semantic tokens for an open R document.
+/// Compute full-document semantic tokens for a parsed R syntax tree.
 ///
 /// Raven keeps this intentionally narrow: the legend contains only the standard
 /// LSP `function` token type, and this provider emits tokens for function
 /// definition names and function-call heads. The result augments VS Code's
 /// TextMate syntax highlighting rather than replacing it.
-pub fn semantic_tokens_full(state: &WorldState, uri: &Url) -> Option<SemanticTokens> {
-    let doc = state.get_document(uri)?;
-    if doc.file_type != FileType::R {
-        return None;
-    }
-
-    let tree = doc.tree.as_ref()?;
-    let text = doc.text();
-    Some(semantic_tokens_for_r_tree(tree.root_node(), &text))
+pub fn semantic_tokens_full(tree: &tree_sitter::Tree, text: &str) -> SemanticTokens {
+    semantic_tokens_for_r_tree(tree.root_node(), text)
 }
 
 fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {
     let mut absolute_tokens = Vec::new();
-    collect_r_function_semantic_tokens(root, text, &mut absolute_tokens);
+    let lines: Vec<&str> = text.lines().collect();
+    collect_r_function_semantic_tokens(root, text, &lines, &mut absolute_tokens);
     SemanticTokens {
         result_id: None,
         data: encode_semantic_tokens(absolute_tokens),
@@ -577,21 +571,22 @@ fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {
 fn collect_r_function_semantic_tokens(
     node: Node,
     text: &str,
+    lines: &[&str],
     tokens: &mut Vec<AbsoluteSemanticToken>,
 ) {
     if let Some(function_name) = function_definition_name_node(node, text) {
-        push_function_token(function_name, text, tokens);
+        push_function_token(function_name, lines, tokens);
     }
 
     if node.kind() == "call" {
         if let Some(callee) = call_callee_identifier(node) {
-            push_function_token(callee, text, tokens);
+            push_function_token(callee, lines, tokens);
         }
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_r_function_semantic_tokens(child, text, tokens);
+        collect_r_function_semantic_tokens(child, text, lines, tokens);
     }
 }
 
@@ -669,14 +664,14 @@ fn namespace_operator_member_identifier(node: Node) -> Option<Node> {
         .find(|child| child.kind() == "identifier")
 }
 
-fn push_function_token(node: Node, text: &str, tokens: &mut Vec<AbsoluteSemanticToken>) {
+fn push_function_token(node: Node, lines: &[&str], tokens: &mut Vec<AbsoluteSemanticToken>) {
     let start = node.start_position();
     let end = node.end_position();
     if start.row != end.row {
         return;
     }
 
-    let line_text = text.lines().nth(start.row).unwrap_or("");
+    let line_text = lines.get(start.row).copied().unwrap_or("");
     let start_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, start.column);
     let end_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, end.column);
     let length = end_utf16.saturating_sub(start_utf16);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -9,9 +9,12 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
 use regex::Regex;
+use streaming_iterator::StreamingIterator;
 use tower_lsp::lsp_types::*;
 use tree_sitter::Node;
 use tree_sitter::Point;
+use tree_sitter::Query;
+use tree_sitter::QueryCursor;
 
 use crate::content_provider::ContentProvider;
 use crate::cross_file::dependency::compute_inherited_working_directory;
@@ -560,7 +563,7 @@ pub fn semantic_tokens_full(tree: &tree_sitter::Tree, text: &str) -> SemanticTok
 
 fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {
     let mut absolute_tokens = Vec::new();
-    let lines: Vec<&str> = text.lines().collect();
+    let lines: Vec<&str> = text.split('\n').collect();
     collect_r_function_semantic_tokens(root, text, &lines, &mut absolute_tokens);
     SemanticTokens {
         result_id: None,
@@ -569,101 +572,68 @@ fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {
 }
 
 fn collect_r_function_semantic_tokens(
-    node: Node,
+    root: Node,
     text: &str,
     lines: &[&str],
     tokens: &mut Vec<AbsoluteSemanticToken>,
 ) {
-    if let Some(function_name) = function_definition_name_node(node, text) {
-        push_function_token(function_name, lines, tokens);
-    }
-
-    if node.kind() == "call" {
-        if let Some(callee) = call_callee_identifier(node) {
-            push_function_token(callee, lines, tokens);
+    let mut cursor = QueryCursor::new();
+    let query = semantic_function_query();
+    let function_capture = capture_index(query, "function");
+    let value_capture = capture_index(query, "value");
+    let mut matches = cursor.matches(query, root, text.as_bytes());
+    while let Some(query_match) = {
+        matches.advance();
+        matches.get()
+    } {
+        match query_match.pattern_index {
+            0 | 1 => {
+                let mut function_node = None;
+                let mut value_node = None;
+                for capture in query_match.captures {
+                    if capture.index == function_capture {
+                        function_node = Some(capture.node);
+                    } else if capture.index == value_capture {
+                        value_node = Some(capture.node);
+                    }
+                }
+                if let (Some(function_node), Some(value_node)) = (function_node, value_node) {
+                    if value_is_function_definition(value_node) {
+                        push_function_token(function_node, lines, tokens);
+                    }
+                }
+            }
+            _ => {
+                for capture in query_match.captures {
+                    if capture.index == function_capture {
+                        push_function_token(capture.node, lines, tokens);
+                    }
+                }
+            }
         }
     }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_r_function_semantic_tokens(child, text, lines, tokens);
-    }
 }
 
-fn function_definition_name_node<'a>(node: Node<'a>, text: &str) -> Option<Node<'a>> {
-    if node.kind() != "binary_operator" && node.kind() != "right_assignment" {
-        return None;
-    }
-
-    let mut cursor = node.walk();
-    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
-    if children.len() < 3 {
-        return None;
-    }
-
-    let lhs = children[0];
-    let op = children[1];
-    let rhs = children[2];
-    let op_text = node_text(op, text);
-
-    if matches!(op_text, "<-" | "=" | "<<-")
-        && lhs.kind() == "identifier"
-        && contains_function_definition(rhs)
-    {
-        return Some(lhs);
-    }
-
-    if matches!(op_text, "->" | "->>")
-        && rhs.kind() == "identifier"
-        && contains_function_definition(lhs)
-    {
-        return Some(rhs);
-    }
-
-    None
+fn capture_index(query: &Query, name: &str) -> u32 {
+    query
+        .capture_names()
+        .iter()
+        .position(|capture_name| *capture_name == name)
+        .expect("semantic token query capture must exist") as u32
 }
 
-fn contains_function_definition(node: Node) -> bool {
+fn value_is_function_definition(node: Node) -> bool {
     if node.kind() == "function_definition" {
         return true;
     }
-
     if node.kind() != "parenthesized_expression" {
         return false;
     }
 
     let mut cursor = node.walk();
-    let has_function_definition = node
-        .children(&mut cursor)
-        .filter(|child| child.is_named())
-        .any(contains_function_definition);
-    has_function_definition
+    let contains_function_definition = node.children(&mut cursor).any(value_is_function_definition);
+    contains_function_definition
 }
-
-fn call_callee_identifier(node: Node) -> Option<Node> {
-    let mut cursor = node.walk();
-    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
-    let callee = children.first().copied()?;
-    if callee.kind() == "identifier" {
-        return Some(callee);
-    }
-    namespace_operator_member_identifier(callee)
-}
-
-fn namespace_operator_member_identifier(node: Node) -> Option<Node> {
-    if node.kind() != "namespace_operator" {
-        return None;
-    }
-
-    let mut cursor = node.walk();
-    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
-    children
-        .iter()
-        .rev()
-        .copied()
-        .find(|child| child.kind() == "identifier")
-}
-
 fn push_function_token(node: Node, lines: &[&str], tokens: &mut Vec<AbsoluteSemanticToken>) {
     let start = node.start_position();
     let end = node.end_position();
@@ -672,9 +642,10 @@ fn push_function_token(node: Node, lines: &[&str], tokens: &mut Vec<AbsoluteSema
     }
 
     let line_text = lines.get(start.row).copied().unwrap_or("");
-    let start_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, start.column);
-    let end_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, end.column);
-    let length = end_utf16.saturating_sub(start_utf16);
+    let Some((start_utf16, length)) = byte_span_to_utf16_span(line_text, start.column, end.column)
+    else {
+        return;
+    };
     if length == 0 {
         return;
     }
@@ -686,6 +657,70 @@ fn push_function_token(node: Node, lines: &[&str], tokens: &mut Vec<AbsoluteSema
     });
 }
 
+fn byte_span_to_utf16_span(line: &str, start_byte: usize, end_byte: usize) -> Option<(u32, u32)> {
+    if start_byte > end_byte || end_byte > line.len() {
+        return None;
+    }
+
+    if line.as_bytes()[..end_byte].is_ascii() {
+        return Some((start_byte as u32, (end_byte - start_byte) as u32));
+    }
+
+    let mut utf16_col: u32 = 0;
+    let mut start_utf16 = None;
+    let mut end_utf16 = None;
+
+    for (byte_idx, ch) in line.char_indices() {
+        if start_utf16.is_none() && byte_idx >= start_byte {
+            start_utf16 = Some(utf16_col);
+        }
+        if byte_idx >= end_byte {
+            end_utf16 = Some(utf16_col);
+            break;
+        }
+        utf16_col += ch.len_utf16() as u32;
+    }
+
+    let start_utf16 = start_utf16.unwrap_or(utf16_col);
+    let end_utf16 = end_utf16.unwrap_or(utf16_col);
+    Some((start_utf16, end_utf16.saturating_sub(start_utf16)))
+}
+
+fn semantic_function_query() -> &'static Query {
+    static QUERY: OnceLock<Query> = OnceLock::new();
+    QUERY.get_or_init(|| {
+        let language: tree_sitter::Language = tree_sitter_r::LANGUAGE.into();
+        Query::new(
+            &language,
+            r#"
+            (binary_operator
+              lhs: (identifier) @function
+              operator: [
+                "<-"
+                "="
+                "<<-"
+              ]
+              rhs: (_) @value)
+
+            (binary_operator
+              lhs: (_) @value
+              operator: [
+                "->"
+                "->>"
+              ]
+              rhs: (identifier) @function)
+
+            (call
+              function: (identifier) @function)
+
+            (call
+              function: (namespace_operator
+                rhs: (identifier) @function))
+            "#,
+        )
+        .expect("semantic token query must compile")
+    })
+}
 fn encode_semantic_tokens(mut absolute_tokens: Vec<AbsoluteSemanticToken>) -> Vec<SemanticToken> {
     absolute_tokens.sort_unstable();
     absolute_tokens.dedup();
@@ -12069,6 +12104,18 @@ mod tests {
     fn test_semantic_tokens_right_assigned_function_definitions() {
         let code = "(function(y) y) -> g\n(function(z) z) ->> h";
         assert_eq!(semantic_token_spans(code), vec![(0, 19, 1), (1, 20, 1)]);
+    }
+
+    #[test]
+    fn test_semantic_tokens_nested_parenthesized_function_definitions() {
+        let code = "f <- ((function(x) x))\n((function(y) y)) -> g";
+        assert_eq!(semantic_token_spans(code), vec![(0, 0, 1), (1, 21, 1)]);
+    }
+
+    #[test]
+    fn test_semantic_tokens_skip_function_definition_arguments() {
+        let code = "f <- wrapper(function(x) x)";
+        assert_eq!(semantic_token_spans(code), vec![(0, 5, 7)]);
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -534,6 +534,176 @@ fn is_delimiter_only(s: &str) -> bool {
 fn utf16_len(s: &str) -> u32 {
     s.chars().map(|c| c.len_utf16() as u32).sum()
 }
+// ============================================================================
+// Semantic Tokens
+// ============================================================================
+
+/// Token type index for `SemanticTokenType::FUNCTION` in Raven's semantic-token legend.
+const SEMANTIC_TOKEN_TYPE_FUNCTION: u32 = 0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct AbsoluteSemanticToken {
+    line: u32,
+    start: u32,
+    length: u32,
+}
+
+/// Compute full-document semantic tokens for an open R document.
+///
+/// Raven keeps this intentionally narrow: the legend contains only the standard
+/// LSP `function` token type, and this provider emits tokens for function
+/// definition names and function-call heads. The result augments VS Code's
+/// TextMate syntax highlighting rather than replacing it.
+pub fn semantic_tokens_full(state: &WorldState, uri: &Url) -> Option<SemanticTokens> {
+    let doc = state.get_document(uri)?;
+    if doc.file_type != FileType::R {
+        return None;
+    }
+
+    let tree = doc.tree.as_ref()?;
+    let text = doc.text();
+    Some(semantic_tokens_for_r_tree(tree.root_node(), &text))
+}
+
+fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {
+    let mut absolute_tokens = Vec::new();
+    collect_r_function_semantic_tokens(root, text, &mut absolute_tokens);
+    SemanticTokens {
+        result_id: None,
+        data: encode_semantic_tokens(absolute_tokens),
+    }
+}
+
+fn collect_r_function_semantic_tokens(
+    node: Node,
+    text: &str,
+    tokens: &mut Vec<AbsoluteSemanticToken>,
+) {
+    if let Some(function_name) = function_definition_name_node(node, text) {
+        push_function_token(function_name, text, tokens);
+    }
+
+    if node.kind() == "call" {
+        if let Some(callee) = call_callee_identifier(node) {
+            push_function_token(callee, text, tokens);
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_r_function_semantic_tokens(child, text, tokens);
+    }
+}
+
+fn function_definition_name_node<'a>(node: Node<'a>, text: &str) -> Option<Node<'a>> {
+    if node.kind() != "binary_operator" && node.kind() != "right_assignment" {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
+    if children.len() < 3 {
+        return None;
+    }
+
+    let lhs = children[0];
+    let op = children[1];
+    let rhs = children[2];
+    let op_text = node_text(op, text);
+
+    if matches!(op_text, "<-" | "=" | "<<-")
+        && lhs.kind() == "identifier"
+        && contains_function_definition(rhs)
+    {
+        return Some(lhs);
+    }
+
+    if matches!(op_text, "->" | "->>")
+        && rhs.kind() == "identifier"
+        && contains_function_definition(lhs)
+    {
+        return Some(rhs);
+    }
+
+    None
+}
+
+fn contains_function_definition(node: Node) -> bool {
+    if node.kind() == "function_definition" {
+        return true;
+    }
+
+    if node.kind() != "parenthesized_expression" {
+        return false;
+    }
+
+    let mut cursor = node.walk();
+    let has_function_definition = node
+        .children(&mut cursor)
+        .filter(|child| child.is_named())
+        .any(contains_function_definition);
+    has_function_definition
+}
+
+fn call_callee_identifier(node: Node) -> Option<Node> {
+    let mut cursor = node.walk();
+    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
+    let callee = children.first().copied()?;
+    (callee.kind() == "identifier").then_some(callee)
+}
+
+fn push_function_token(node: Node, text: &str, tokens: &mut Vec<AbsoluteSemanticToken>) {
+    let start = node.start_position();
+    let end = node.end_position();
+    if start.row != end.row {
+        return;
+    }
+
+    let line_text = text.lines().nth(start.row).unwrap_or("");
+    let start_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, start.column);
+    let end_utf16 = crate::utf16::byte_offset_to_utf16_column(line_text, end.column);
+    let length = end_utf16.saturating_sub(start_utf16);
+    if length == 0 {
+        return;
+    }
+
+    tokens.push(AbsoluteSemanticToken {
+        line: start.row as u32,
+        start: start_utf16,
+        length,
+    });
+}
+
+fn encode_semantic_tokens(mut absolute_tokens: Vec<AbsoluteSemanticToken>) -> Vec<SemanticToken> {
+    absolute_tokens.sort_unstable();
+    absolute_tokens.dedup();
+
+    let mut encoded = Vec::with_capacity(absolute_tokens.len());
+    let mut previous_line = 0;
+    let mut previous_start = 0;
+
+    for token in absolute_tokens {
+        let delta_line = token.line.saturating_sub(previous_line);
+        let delta_start = if delta_line == 0 {
+            token.start.saturating_sub(previous_start)
+        } else {
+            token.start
+        };
+
+        encoded.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length: token.length,
+            token_type: SEMANTIC_TOKEN_TYPE_FUNCTION,
+            token_modifiers_bitset: 0,
+        });
+
+        previous_line = token.line;
+        previous_start = token.start;
+    }
+
+    encoded
+}
 
 // ============================================================================
 // Banner-Style Section Helpers
@@ -11833,6 +12003,81 @@ mod tests {
             .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
         parser.parse(code, None).unwrap()
+    }
+
+    fn semantic_token_spans(code: &str) -> Vec<(u32, u32, u32)> {
+        let tree = parse_r_code(code);
+        let tokens = semantic_tokens_for_r_tree(tree.root_node(), code).data;
+        let mut spans = Vec::new();
+        let mut line = 0;
+        let mut start = 0;
+        for token in tokens {
+            line += token.delta_line;
+            start = if token.delta_line == 0 {
+                start + token.delta_start
+            } else {
+                token.delta_start
+            };
+            spans.push((line, start, token.length));
+        }
+        spans
+    }
+
+    #[test]
+    fn test_semantic_tokens_function_definition_and_call_heads() {
+        let code = "add <- function(x) x\nresult <- add(1) + mean(x)";
+        assert_eq!(
+            semantic_token_spans(code),
+            vec![
+                (0, 0, 3),  // add definition
+                (1, 10, 3), // add call
+                (1, 19, 4), // mean call
+            ]
+        );
+    }
+
+    #[test]
+    fn test_semantic_tokens_skip_plain_variable_assignments() {
+        let code = "x <- 1\ny <- x + 2";
+        assert!(semantic_token_spans(code).is_empty());
+    }
+
+    #[test]
+    fn test_semantic_tokens_right_assigned_function_definitions() {
+        let code = "(function(y) y) -> g\n(function(z) z) ->> h";
+        assert_eq!(semantic_token_spans(code), vec![(0, 19, 1), (1, 20, 1)]);
+    }
+
+    #[test]
+    fn test_semantic_tokens_encode_same_line_multiple_calls() {
+        let code = "a(); bc()";
+        let tree = parse_r_code(code);
+        let tokens = semantic_tokens_for_r_tree(tree.root_node(), code).data;
+        assert_eq!(
+            tokens,
+            vec![
+                SemanticToken {
+                    delta_line: 0,
+                    delta_start: 0,
+                    length: 1,
+                    token_type: SEMANTIC_TOKEN_TYPE_FUNCTION,
+                    token_modifiers_bitset: 0,
+                },
+                SemanticToken {
+                    delta_line: 0,
+                    delta_start: 5,
+                    length: 2,
+                    token_type: SEMANTIC_TOKEN_TYPE_FUNCTION,
+                    token_modifiers_bitset: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_semantic_tokens_use_utf16_columns() {
+        let code = "x <- \"😀\"; mean(1)";
+        assert_eq!(semantic_token_spans(code), vec![(0, 11, 4)]);
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -649,7 +649,24 @@ fn call_callee_identifier(node: Node) -> Option<Node> {
     let mut cursor = node.walk();
     let children = crate::parser_pool::non_extra_children(node, &mut cursor);
     let callee = children.first().copied()?;
-    (callee.kind() == "identifier").then_some(callee)
+    if callee.kind() == "identifier" {
+        return Some(callee);
+    }
+    namespace_operator_member_identifier(callee)
+}
+
+fn namespace_operator_member_identifier(node: Node) -> Option<Node> {
+    if node.kind() != "namespace_operator" {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    let children = crate::parser_pool::non_extra_children(node, &mut cursor);
+    children
+        .iter()
+        .rev()
+        .copied()
+        .find(|child| child.kind() == "identifier")
 }
 
 fn push_function_token(node: Node, text: &str, tokens: &mut Vec<AbsoluteSemanticToken>) {
@@ -12032,6 +12049,17 @@ mod tests {
                 (0, 0, 3),  // add definition
                 (1, 10, 3), // add call
                 (1, 19, 4), // mean call
+            ]
+        );
+    }
+    #[test]
+    fn test_semantic_tokens_namespace_qualified_call_heads() {
+        let code = "graphics::plot(1)\npkg:::internal(1)";
+        assert_eq!(
+            semantic_token_spans(code),
+            vec![
+                (0, 10, 4), // plot, not graphics
+                (1, 6, 8),  // internal, not pkg
             ]
         );
     }

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,6 +184,10 @@ Raven keeps `tower-lsp` at `.concurrency_level(1)` to preserve ordered text sync
 
 Interactive handlers that can spend noticeable time in cross-file scope resolution should use a request-scoped `DiagCancelToken` from the registry and poll it through long loops and scope helpers. Qualified-member go-to-definition threads this token through `goto_definition_with_cancel` → `resolve_qualified_member_with_cancel` → `get_cross_file_scope_with_cache`, including per-candidate validation. New interactive multi-position resolvers should follow the same pattern: keep a request-local `ParentPrefixCache`, pass the token into every scope lookup, and check the token between candidate batches while still preserving a single `WorldState` snapshot.
 
+### Semantic tokens
+
+Raven advertises full-document semantic tokens for R documents and currently emits the standard LSP `function` token type for function-definition names and call heads. The token legend order is part of the LSP contract: keep `SemanticTokenType::FUNCTION` at index 0 unless all encoded token-type indexes are updated together.
+
 ### On-demand background indexing
 
 On-demand indexing is used to index files that are not currently open in the editor, prioritizing:

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -24,7 +24,7 @@ Compared with [REditorSupport's R extension](https://marketplace.visualstudio.co
 - **[Smart indentation](https://github.com/jbearak/raven/blob/main/docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](https://github.com/jbearak/raven/blob/main/docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](https://github.com/jbearak/raven/blob/main/docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **Syntax highlighting** — JAGS and Stan (R highlighting is built into VS Code)
+- **Syntax highlighting** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 
 ### R session integration
 


### PR DESCRIPTION
## Summary
- Add full-document LSP semantic tokens for R function names.
- Advertise `semanticTokensProvider` and handle `textDocument/semanticTokens/full` in the Raven backend.
- Document R function-name semantic highlighting in the root and VS Code READMEs, plus a maintainer note for the token legend.

## Tests
- `cargo fmt --manifest-path /Users/jmb/repos/raven/Cargo.toml`
- `cargo test -p raven semantic_tokens`
- `cargo test -p raven`

## Artifacts
- Conversation: https://app.warp.dev/conversation/66f5a777-1ef8-4644-928c-ab1c88fa7074
- Plan: https://app.warp.dev/drive/notebook/Ufjh1Iug9OxSOGGfkfMceN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * R function names now receive enhanced syntax highlighting via LSP semantic tokens, providing improved visual distinction for both function definitions and function calls throughout your code.

* **Documentation**
  * Updated README and development documentation to describe the new R function name highlighting feature, including technical implementation details and maintenance guidelines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/195)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->