### PR TITLE
docs: add syntax highlighting page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ User-facing:
 - `docs/directives.md`
 - `docs/diagnostics.md`
 - `docs/indentation.md`
+- `docs/syntax-highlighting.md`
 - `docs/r-console.md`
 - `docs/plot-viewer.md`
 - `docs/data-viewer.md`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **Syntax highlighting** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
+- **[Syntax Highlighting](docs/syntax_highlighting.md)** — LSP semantic tokens for R, plus JAGS and Stan grammars
 
 ### R session integration
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **[Syntax Highlighting](docs/syntax_highlighting.md)** — LSP semantic tokens for R, plus JAGS and Stan grammars
+- **[Syntax highlighting](docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 
 ### R session integration
 
@@ -53,6 +53,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - [Find References](docs/find-references.md) — Cross-file reference finding
 - [Document Outline](docs/document-outline.md) — Hierarchical symbol view
 - [Smart Indentation](docs/indentation.md) — AST-aware indentation styles
+- [Syntax Highlighting](docs/syntax-highlighting.md) — LSP semantic tokens for R, plus JAGS and Stan grammars
 
 **R session integration:**
 

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,6 +1,6 @@
 # Syntax Highlighting
 
-Raven contributes syntax highlighting in three distinct ways: LSP semantic tokens for R function names, plus TextMate grammars for JAGS and Stan. For R, Raven augments whatever TextMate grammar is already loaded rather than replacing it. For JAGS and Stan, Raven ships the grammar itself because VS Code doesn't bundle one.
+Raven contributes syntax highlighting in two ways: LSP semantic tokens for R function names, plus TextMate grammars for JAGS and Stan. For R, Raven augments whatever TextMate grammar is already loaded rather than replacing it. For JAGS and Stan, Raven ships the grammar itself because VS Code doesn't bundle one.
 
 ## R
 
@@ -19,7 +19,7 @@ VS Code ships a built-in R grammar. It covers roxygen comments, line comments, s
 
 That grammar isn't maintained by Microsoft directly. It's a periodic sync of [REditorSupport/vscode-R-syntax](https://github.com/REditorSupport/vscode-R-syntax): VS Code's `extensions/r/package.json` has a single `update-grammar` script that runs `vscode-grammar-updater` against the REditorSupport source, and the generated file's header points readers back to the upstream repo for fixes. The two are the same grammar, with the built-in trailing upstream by however many commits have landed since the last sync.
 
-The one capability the upstream extension adds that VS Code doesn't bundle is **R Markdown**. [`REditorSupport.r-syntax`](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax) registers a separate `rmd` language with a markdown-aware grammar: `.Rmd` files are parsed as markdown with R code chunks, and 30+ embedded languages (Python, SQL, C, CSS, etc.) are recognized inside their respective fenced blocks. Without it, VS Code treats `.Rmd` as plain R source — you lose markdown headings, prose styling, and embedded-language highlighting inside code chunks.
+The one capability the upstream extension adds that VS Code doesn't bundle is **R Markdown**. [`REditorSupport.r-syntax`](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax) registers a separate `rmd` language with a Markdown-aware grammar: `.Rmd` files are parsed as Markdown with R code chunks, and 30+ embedded languages (Python, SQL, C, CSS, etc.) are recognized inside their respective fenced blocks. Without it, VS Code treats `.Rmd` as plain R source — you lose Markdown headings, prose styling, and embedded-language highlighting inside code chunks.
 
 ## JAGS and Stan
 

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -1,0 +1,53 @@
+# Syntax Highlighting
+
+Raven contributes syntax highlighting in three distinct ways: LSP semantic tokens for R function names, plus TextMate grammars for JAGS and Stan. For R, Raven augments whatever TextMate grammar is already loaded rather than replacing it. For JAGS and Stan, Raven ships the grammar itself because VS Code doesn't bundle one.
+
+## R
+
+Raven emits LSP semantic tokens for R function names. The token legend contains one entry — the standard LSP `function` token type — and Raven emits it for:
+
+- Function-definition names (identifiers assigned a `function(...)` value, with `<-`, `=`, `<<-`, `->`, or `->>`).
+- Function-call heads, including namespace-qualified calls like `pkg::fn()`.
+
+This is intentionally narrow. The goal is to catch call and definition sites reliably via the tree-sitter AST, then let the TextMate grammar handle everything else (comments, strings, numbers, operators, roxygen tags, constants, storage types, brackets). Semantic tokens augment the grammar; they don't replace it.
+
+Raven isn't the only R language server that emits semantic tokens — the one bundled with the full `REditorSupport.r` extension (distinct from the grammar-only `REditorSupport.r-syntax` discussed below) also does, with broader coverage. See [Coexistence](./coexistence.md) if you're running both.
+
+### VS Code's built-in R grammar vs. REditorSupport.r-syntax
+
+VS Code ships a built-in R grammar. It covers roxygen comments, line comments, strings (including raw strings), numeric and imaginary literals, `TRUE`/`FALSE`/`NULL`/`NA*`/`Inf`/`NaN`, the full operator set (`<-`, `->`, `|>`, `%...%`, `:::`, `@`, etc.), control-flow keywords, storage types, brackets, and function-call highlighting for base-package functions (`base`, `graphics`, `grDevices`, `methods`, `stats`, `utils`).
+
+That grammar isn't maintained by Microsoft directly. It's a periodic sync of [REditorSupport/vscode-R-syntax](https://github.com/REditorSupport/vscode-R-syntax): VS Code's `extensions/r/package.json` has a single `update-grammar` script that runs `vscode-grammar-updater` against the REditorSupport source, and the generated file's header points readers back to the upstream repo for fixes. The two are the same grammar, with the built-in trailing upstream by however many commits have landed since the last sync.
+
+The one capability the upstream extension adds that VS Code doesn't bundle is **R Markdown**. [`REditorSupport.r-syntax`](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax) registers a separate `rmd` language with a markdown-aware grammar: `.Rmd` files are parsed as markdown with R code chunks, and 30+ embedded languages (Python, SQL, C, CSS, etc.) are recognized inside their respective fenced blocks. Without it, VS Code treats `.Rmd` as plain R source — you lose markdown headings, prose styling, and embedded-language highlighting inside code chunks.
+
+## JAGS and Stan
+
+VS Code doesn't bundle grammars for JAGS or Stan, so Raven ships its own TextMate grammars for both languages. There are no LSP semantic tokens for these files — highlighting comes entirely from the grammar.
+
+### JAGS
+
+Registered for `.jags`, `.Jags`, `.JAGS`, `.bugs`, `.Bugs`, `.BUGS`. The grammar recognizes:
+
+- **Comments** — `#` to end of line.
+- **Strings** — double-quoted, with `\\`-style escapes.
+- **Block keywords** — `model`, `data`.
+- **Control flow** — `for`, `in`, `if`, `else`.
+- **Distributions** — `dnorm`, `dbern`, `dgamma`, `dunif`, `dpois`, `dbin`, `dbeta`, `dexp`, `dt`, `dweib`, `dlnorm`, `dchisqr`, `dlogis`, `dmulti`, `ddirch`, `dwish`, `dmnorm`, `dmt`, `dinterval`, `dcat`.
+- **Math functions** — `abs`, `sqrt`, `log`, `exp`, `pow`, `sin`, `cos`, `sum`, `prod`, `min`, `max`, `mean`, `sd`, `inverse`, `logit`, `probit`, `cloglog`, `ilogit`, `phi`, `step`, `equals`, `round`, `trunc`, `inprod`, `interp.lin`, `logfact`, `loggam`, `rank`, `sort`, `ifelse`, `T`.
+- **Numeric literals** — integer, decimal, and scientific notation.
+- **Operators** — `<-`, `~`, `&&`, `||`, comparisons (`==`, `!=`, `<=`, `>=`), and arithmetic (`+`, `-`, `*`, `/`, `^`).
+
+### Stan
+
+Registered for `.stan`, `.Stan`, `.STAN`. The grammar recognizes:
+
+- **Comments** — `//` line comments and `/* ... */` block comments.
+- **Strings** — double-quoted, with `\\`-style escapes.
+- **Block keywords** — `functions`, `data`, `transformed data`, `parameters`, `transformed parameters`, `model`, `generated quantities`.
+- **Type keywords** — `int`, `real`, `vector`, `row_vector`, `matrix`, `simplex`, `unit_vector`, `ordered`, `positive_ordered`, `corr_matrix`, `cov_matrix`, `cholesky_factor_corr`, `cholesky_factor_cov`, `void`, `array`, `complex`, `complex_vector`, `complex_row_vector`, `complex_matrix`, `tuple`.
+- **Constraint keywords** — `lower`, `upper`, `offset`, `multiplier`.
+- **Control flow** — `for`, `in`, `while`, `if`, `else`, `return`, `break`, `continue`, `print`, `reject`, `profile`.
+- **Distribution-suffix functions** — any identifier ending in `_lpdf`, `_lpmf`, `_lcdf`, `_lccdf`, or `_rng`, so user-defined and library-defined density/sampling functions both highlight consistently.
+- **Numeric literals** — integer, decimal, and scientific notation.
+- **Operators** — `<-`, `~`, `&&`, `||`, comparisons, arithmetic, and the Stan-specific `'` (transpose), `%` (mod), `!`, `?`, `:`.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -24,7 +24,7 @@ Compared with [REditorSupport's R extension](https://marketplace.visualstudio.co
 - **[Smart indentation](https://github.com/jbearak/raven/blob/main/docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](https://github.com/jbearak/raven/blob/main/docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](https://github.com/jbearak/raven/blob/main/docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **[Syntax highlighting](https://github.com/jbearak/raven/blob/main/docs/syntax_highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
+- **[Syntax highlighting](https://github.com/jbearak/raven/blob/main/docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 
 ### R session integration
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -24,7 +24,7 @@ Compared with [REditorSupport's R extension](https://marketplace.visualstudio.co
 - **[Smart indentation](https://github.com/jbearak/raven/blob/main/docs/indentation.md)** — Context-aware auto-indent with RStudio-style alignment
 - **[Cross-file awareness](https://github.com/jbearak/raven/blob/main/docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](https://github.com/jbearak/raven/blob/main/docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
-- **Syntax highlighting** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
+- **[Syntax highlighting](https://github.com/jbearak/raven/blob/main/docs/syntax_highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 
 ### R session integration
 


### PR DESCRIPTION
  Document Raven's three syntax-highlighting contributions:

  - LSP semantic tokens for R function names (narrow, intentionally
    additive to the TextMate grammar). Acknowledge that
    REditorSupport.r's
    bundled language server also emits semantic tokens, with broader
    coverage.
  - VS Code's built-in R grammar vs. REditorSupport.r-syntax: explain
    that the built-in is a periodic sync of the REditorSupport upstream
    minus R Markdown, and conditionally recommend installing r-syntax
    for .Rmd users.
  - Raven's JAGS and Stan TextMate grammars: enumerate covered
    categories (keywords, distributions, types, operators, etc.).

  Link the new page from both READMEs: the feature bullet and the
  Documentation section in the root README, and the feature bullet
  in editors/vscode/README.md (absolute GitHub URL for Marketplace
  resolvability).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive syntax highlighting documentation explaining LSP semantic tokens for R function names and TextMate grammars for JAGS and Stan languages.
  * Updated feature lists in README files for clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->