### PR TITLE
docs: add dedicated Go-to-Definition page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 ### Code intelligence
 
 - **[Completions](docs/completion.md)** — Symbols, packages, and function parameters — across files
-- **Go-to-definition** — Jump to definitions across file boundaries
+- **[Go-to-definition](docs/go-to-definition.md)** — Jump to definitions across file boundaries
 - **[Find references](docs/find-references.md)** — Locate all usages of a symbol across your project
 - **Hover** — Symbol info including source file and package origin
 - **[Diagnostics](docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages
@@ -50,6 +50,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - [Directives](docs/directives.md) — All `@lsp-*` directive syntax
 - [Diagnostics](docs/diagnostics.md) — What's reported and how to suppress
 - [Completions](docs/completion.md) — What's offered and scope rules
+- [Go-to-Definition](docs/go-to-definition.md) — Cross-file navigation, `$`/`@` members, declared symbols
 - [Find References](docs/find-references.md) — Cross-file reference finding
 - [Document Outline](docs/document-outline.md) — Hierarchical symbol view
 - [Smart Indentation](docs/indentation.md) — AST-aware indentation styles

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -40,6 +40,4 @@ The maximum number of results is configurable via `raven.symbols.workspaceMaxRes
 
 ## Go-to-Definition
 
-Go-to-definition (Cmd-click / F12) navigates to the symbol's definition, following `source()` chains across files. If a symbol is defined in a sourced file, Raven jumps directly to that file and line.
-
-For `$` member access (`foo$bar`), go-to-definition resolves `bar` as a member of `foo` — see [$ and @ Member Resolution](cross-file.md#-and--member-resolution).
+Go-to-definition is the reverse of find references — it navigates to a symbol's definition rather than listing its usages. See [Go-to-Definition](go-to-definition.md).

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -1,0 +1,98 @@
+# Go-to-Definition
+
+Go-to-definition (Cmd-click, Ctrl-click on Windows/Linux, or F12) navigates to where a symbol is defined. Raven follows `source()` chains across files and respects the cross-file dependency graph, so it works whether the definition is in the current file, a sourced sibling, or a parent script.
+
+## What You Can Jump To
+
+| At the cursor | Jumps to |
+|---|---|
+| Variable or function identifier | The most recent in-scope assignment (same file or sourced file) |
+| RHS of `$` or `@` (`foo$bar`) | The member assignment or constructor-literal field — see [$ and @ Member Resolution](#-and--member-resolution) |
+| Symbol declared via `@lsp-var` / `@lsp-func` | The directive line itself — see [Declared Symbols](#declared-symbols) |
+| File path inside `source()` or a path directive | The referenced file, opened at line 0 |
+| Identifier in `.stan`, `.jags`, or `.bugs` files | First definition (or first occurrence as a fallback for data inputs) |
+
+## Position-Aware Resolution
+
+Raven only navigates to definitions that are visible at the cursor's position according to R's execution order. If you cmd-click a variable before its assignment in the same file, Raven won't jump to the later assignment:
+
+```r
+x  # no jump — x isn't defined yet
+x <- 1
+x  # jumps to the line above
+```
+
+Inside function bodies, global definitions are hoisted (R's late-binding semantics), so a function can cmd-click a helper defined below it at file scope. Function-local variables stay strictly positional. See [Global Symbol Hoisting](cross-file.md#global-symbol-hoisting).
+
+## Cross-File Navigation
+
+When a symbol is defined in a sourced file, cmd-click opens that file and places the cursor on the definition:
+
+```r
+# main.R
+source("utils.R")
+result <- helper_function(42)  # cmd-click jumps into utils.R
+```
+
+```r
+# utils.R
+helper_function <- function(x) { x * 2 }  # ← jump target
+```
+
+Raven follows both `source()` calls and [forward directives](directives.md#forward-directives) (`@lsp-source`, `@lsp-run`, `@lsp-include`). Backward directives (`@lsp-sourced-by`) bring the parent file's symbols into scope, so cmd-clicking a parent-defined symbol in a child file works too.
+
+If no definition is found in the dependency graph, Raven falls back to other open documents and the workspace index so you can still navigate to reasonable candidates during project-wide exploration.
+
+## `$` and `@` Member Resolution
+
+When you cmd-click the RHS of `$` or `@` (e.g. `config$host`), Raven resolves it as a member of the LHS — not as a free variable. It searches for:
+
+- Member assignments: `config$host <- …`, `config[["host"]] <- …`, `object@slot <- …`
+- Constructor literals: named arguments in `list()`, `data.frame()`, `tibble()`, `c()`, S4 `new()`, etc.
+
+If multiple candidates exist across the dependency graph, Raven tie-breaks by graph distance (closer wins). Cmd-clicking on `$` or `@` itself (the punctuation) does nothing — only identifiers are navigable.
+
+For the full scope rules, see [$ and @ Member Resolution](cross-file.md#-and--member-resolution) in the cross-file doc.
+
+## Declared Symbols
+
+Symbols declared via [`@lsp-var` or `@lsp-func`](directives.md#declaration-directives) are navigable. Cmd-click jumps to the directive line at column 0. If the same name is declared more than once in the providing file, Raven jumps to the **first declaration by line number**:
+
+```r
+# @lsp-var config   ← jump target (first declaration)
+load("config.RData")
+# @lsp-var config   ← later duplicate, not used
+use(config)
+```
+
+This is the same rule the [diagnostics](diagnostics.md) and [completion](completion.md) subsystems use to identify the canonical declaration site.
+
+## File Path Navigation
+
+Inside `source()` strings and path-taking directives, cmd-click navigates to the referenced file. Path resolution follows the standard Raven rules:
+
+- `source()` calls and forward directives respect `@lsp-cd`.
+- Backward directives (`@lsp-sourced-by`, `@lsp-run-by`, `@lsp-included-by`) resolve relative to the file's own directory and ignore `@lsp-cd`.
+- Workspace-root fallback applies to AST-detected `source()` calls only, and only when no working directory is in effect.
+
+See [Cross-File Awareness](cross-file.md#automatic-source-detection) and [Directives](directives.md#working-directory-directives) for details.
+
+## Package Exports
+
+Cmd-click on a symbol that comes from an installed package (e.g. `dplyr::mutate` after `library(dplyr)`) does **not** navigate. Package exports are tracked for completions, diagnostics, and hover, but Raven doesn't currently open installed package sources. Use hover to see the `{package}` attribution instead.
+
+## JAGS and Stan
+
+For `.stan`, `.jags`, and `.bugs` files, Raven provides best-effort go-to-definition within the current file:
+
+- **Stan** — jumps to the declaration of a variable or function.
+- **JAGS** — jumps to the first assignment, or falls back to the first occurrence when the symbol is a data input or constant with no assignment in the file. Built-in keywords, distributions, and functions are excluded from the fallback.
+
+Cross-file navigation is not supported for these languages.
+
+## Related
+
+- [Find References](find-references.md) — the reverse operation: list every usage of a symbol
+- [Cross-File & Package Awareness](cross-file.md) — how the dependency graph and scope model work
+- [Directives](directives.md) — `@lsp-source`, `@lsp-sourced-by`, `@lsp-var`, `@lsp-func`, and friends
+- [Completions](completion.md) — position-aware scope used for `$` member and symbol completions

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -88,7 +88,7 @@ For `.stan`, `.jags`, and `.bugs` files, Raven provides best-effort go-to-defini
 - **Stan** — jumps to the declaration of a variable or function.
 - **JAGS** — jumps to the first assignment, or falls back to the first occurrence when the symbol is a data input or constant with no assignment in the file. Built-in keywords, distributions, and functions are excluded from the fallback.
 
-Cross-file navigation is not supported for these languages.
+Identifier resolution is file-local — Raven doesn't build a cross-file scope graph for these languages. File-path navigation (e.g. cmd-click on a path in `@lsp-sourced-by`) still works normally.
 
 ## Related
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -14,7 +14,7 @@ Compared with [REditorSupport's R extension](https://marketplace.visualstudio.co
 ### Code intelligence
 
 - **[Completions](https://github.com/jbearak/raven/blob/main/docs/completion.md)** — Symbols, packages, and function parameters — across files
-- **Go-to-definition** — Jump to definitions across file boundaries
+- **[Go-to-definition](https://github.com/jbearak/raven/blob/main/docs/go-to-definition.md)** — Jump to definitions across file boundaries
 - **[Find references](https://github.com/jbearak/raven/blob/main/docs/find-references.md)** — Locate all usages of a symbol across your project
 - **Hover** — Symbol info including source file and package origin
 - **[Diagnostics](https://github.com/jbearak/raven/blob/main/docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages


### PR DESCRIPTION
- New docs/go-to-definition.md covering position-aware resolution,
  cross-file navigation, $/@ member resolution, declared symbols,
  file path navigation, package-export limitation, and JAGS/Stan.
- README.md and editors/vscode/README.md: link the feature bullet
  to the new page; add index entry under Code intelligence.
- find-references.md: shrink the Go-to-Definition section to a
  one-line pointer so the two pages do not duplicate content.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive go-to-definition documentation page covering cross-file navigation, position-aware symbol resolution, and special handling for member access.
  * Enhanced existing documentation with improved cross-references and clearer feature positioning.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/198)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->