### PR TITLE
feat(vscode): add quick inspection commands

### DIFF
--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -42,6 +42,21 @@ The selected program must be available on your PATH.
 | **Run Downward Lines** | Sends all lines from the current line to the end of the file (extending upward to include the full statement start). |
 | **Source File** | Runs `source("filepath", echo = TRUE)` in the R terminal. |
 
+### Quick Inspection Commands
+
+These commands wrap the word under the cursor (or the current selection) in a common inspection function and send it to the R terminal — one keystroke to check an object's shape. No default keybindings; bind them in `keybindings.json` or run them from the Command Palette.
+
+| Command | Sends to R |
+|---------|------------|
+| **Show nrow** | `nrow(<target>)` |
+| **Show length** | `length(<target>)` |
+| **Show head** | `head(<target>)` |
+| **Show head (transposed)** | `t(head(<target>))` |
+| **Show names** | `names(<target>)` |
+| **View** | `View(<target>)` |
+
+If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used.
+
 ## Editor Toolbar
 
 A toolbar button (▶) appears in the editor title bar for R files, providing quick access to all send commands. The menu is organized into two sections:

--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -57,6 +57,8 @@ These commands wrap the word under the cursor (or the current selection) in a co
 
 If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor is an R document (`.R`, `.r`, `.rmd`, `.qmd`, or an untitled buffer whose language is R).
 
+Single-line wrapped expressions go straight to the terminal via direct paste; if the wrapped expression spans multiple lines (because the selection did), it honors the user's `raven.sendToR.sendMethod` setting. This avoids writing a one-liner like `nrow(x)` to a temp file just because `tempfile` mode is configured for normal sends.
+
 ## Editor Toolbar
 
 A toolbar button (▶) appears in the editor title bar for R files, providing quick access to all send commands. The menu is organized into two sections:

--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -44,18 +44,18 @@ The selected program must be available on your PATH.
 
 ### Quick Inspection Commands
 
-These commands wrap the word under the cursor (or the current selection) in a common inspection function and send it to the R terminal — one keystroke to check an object's shape. No default keybindings; bind them in `keybindings.json` or run them from the Command Palette.
+These commands wrap the word under the cursor (or the current selection) in a common inspection function and send it to the R terminal — one keystroke to check an object's shape. They're registered under the **R** category, so typing `R:` in the Command Palette surfaces them all. No default keybindings; bind them in `keybindings.json` if you want shortcuts.
 
 | Command | Sends to R |
 |---------|------------|
-| **Show nrow** | `nrow(<target>)` |
-| **Show length** | `length(<target>)` |
-| **Show head** | `head(<target>)` |
-| **Show head (transposed)** | `t(head(<target>))` |
-| **Show names** | `names(<target>)` |
-| **View** | `View(<target>)` |
+| **R: Show nrow** | `nrow(<target>)` |
+| **R: Show length** | `length(<target>)` |
+| **R: Show head** | `head(<target>)` |
+| **R: Show head (transposed)** | `t(head(<target>))` |
+| **R: Show names** | `names(<target>)` |
+| **R: View** | `View(<target>)` |
 
-If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used.
+If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor is an R document (`.R`, `.r`, `.rmd`, `.qmd`, or an untitled buffer whose language is R).
 
 ## Editor Toolbar
 

--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -55,7 +55,7 @@ These commands wrap the word under the cursor (or the current selection) in a co
 | **R: Show names** | `names(<target>)` |
 | **R: View** | `View(<target>)` |
 
-If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor is an R document (`.R`, `.r`, `.rmd`, `.qmd`, or an untitled buffer whose language is R).
+If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor's language is R — typically `.R`/`.r` files and untitled buffers whose language has been set to R. R Markdown and Quarto documents claimed by other extensions (`languageId` of `rmd`, `quarto`, etc.) are not currently in scope.
 
 Single-line wrapped expressions go straight to the terminal via direct paste; if the wrapped expression spans multiple lines (because the selection did), it honors the user's `raven.sendToR.sendMethod` setting. This avoids writing a one-liner like `nrow(x)` to a temp file just because `tempfile` mode is configured for normal sends.
 

--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -44,16 +44,16 @@ The selected program must be available on your PATH.
 
 ### Quick Inspection Commands
 
-These commands wrap the word under the cursor (or the current selection) in a common inspection function and send it to the R terminal — one keystroke to check an object's shape. They're registered under the **R** category, so typing `R:` in the Command Palette surfaces them all. No default keybindings; bind them in `keybindings.json` if you want shortcuts.
+These commands wrap the word under the cursor (or the current selection) in a common inspection function and send it to the R terminal — one keystroke to check an object's shape. They're registered under the **Raven** category, so typing `Raven:` in the Command Palette surfaces them all. No default keybindings; bind them in `keybindings.json` if you want shortcuts.
 
 | Command | Sends to R |
 |---------|------------|
-| **R: Show nrow** | `nrow(<target>)` |
-| **R: Show length** | `length(<target>)` |
-| **R: Show head** | `head(<target>)` |
-| **R: Show head (transposed)** | `t(head(<target>))` |
-| **R: Show names** | `names(<target>)` |
-| **R: View** | `View(<target>)` |
+| **Raven: Show nrow** | `nrow(<target>)` |
+| **Raven: Show length** | `length(<target>)` |
+| **Raven: Show head** | `head(<target>)` |
+| **Raven: Show head (transposed)** | `t(head(<target>))` |
+| **Raven: Show names** | `names(<target>)` |
+| **Raven: View** | `View(<target>)` |
 
 If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor's language is R — typically `.R`/`.r` files and untitled buffers whose language has been set to R. R Markdown and Quarto documents claimed by other extensions (`languageId` of `rmd`, `quarto`, etc.) are not currently in scope.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -80,32 +80,32 @@
       {
         "command": "raven.inspect.nrow",
         "title": "Show nrow",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.inspect.length",
         "title": "Show length",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.inspect.head",
         "title": "Show head",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.inspect.headTransposed",
         "title": "Show head (transposed)",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.inspect.names",
         "title": "Show names",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.inspect.view",
         "title": "View",
-        "category": "R"
+        "category": "Raven"
       },
       {
         "command": "raven.openHelpPanel",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -78,6 +78,30 @@
         "title": "Raven: Terminal - Source File"
       },
       {
+        "command": "raven.inspect.nrow",
+        "title": "Raven: Show nrow"
+      },
+      {
+        "command": "raven.inspect.length",
+        "title": "Raven: Show length"
+      },
+      {
+        "command": "raven.inspect.head",
+        "title": "Raven: Show head"
+      },
+      {
+        "command": "raven.inspect.headTransposed",
+        "title": "Raven: Show head (transposed)"
+      },
+      {
+        "command": "raven.inspect.names",
+        "title": "Raven: Show names"
+      },
+      {
+        "command": "raven.inspect.view",
+        "title": "Raven: View"
+      },
+      {
         "command": "raven.openHelpPanel",
         "title": "Raven: Open R Help Panel"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,27 +79,33 @@
       },
       {
         "command": "raven.inspect.nrow",
-        "title": "Raven: Show nrow"
+        "title": "Show nrow",
+        "category": "R"
       },
       {
         "command": "raven.inspect.length",
-        "title": "Raven: Show length"
+        "title": "Show length",
+        "category": "R"
       },
       {
         "command": "raven.inspect.head",
-        "title": "Raven: Show head"
+        "title": "Show head",
+        "category": "R"
       },
       {
         "command": "raven.inspect.headTransposed",
-        "title": "Raven: Show head (transposed)"
+        "title": "Show head (transposed)",
+        "category": "R"
       },
       {
         "command": "raven.inspect.names",
-        "title": "Raven: Show names"
+        "title": "Show names",
+        "category": "R"
       },
       {
         "command": "raven.inspect.view",
-        "title": "Raven: View"
+        "title": "View",
+        "category": "R"
       },
       {
         "command": "raven.openHelpPanel",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -20,7 +20,12 @@ import {
     shouldTriggerDirectivePathSuggest,
     shouldTriggerNestedPathSuggest,
 } from './pathCompletionTriggers';
-import { register_r_terminal, register_send_to_r_commands, get_or_create_r_terminal } from './send-to-r';
+import {
+    register_r_terminal,
+    register_send_to_r_commands,
+    register_inspection_commands,
+    get_or_create_r_terminal,
+} from './send-to-r';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';
 import type { DataViewerManager } from './data-viewer/manager';
@@ -196,6 +201,7 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         // Register R terminal and send-to-R commands
         register_r_terminal(context, plot_services);
         register_send_to_r_commands(context);
+        register_inspection_commands(context);
     }
 
     // Register restart command — re-reads trace config so changed settings take effect.

--- a/editors/vscode/src/send-to-r/commands.ts
+++ b/editors/vscode/src/send-to-r/commands.ts
@@ -5,8 +5,7 @@ import {
     get_downward_bounds,
 } from './statement-detector';
 import { get_or_create_r_terminal } from './r-terminal-manager';
-import { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
-import { choose_send_transport, SendMethod } from './send-method';
+import { send_code, get_send_options } from './send-code';
 
 type SendMode = 'statement' | 'upward' | 'downward' | 'file';
 
@@ -120,62 +119,6 @@ async function handle_terminal_send(mode: SendMode): Promise<void> {
     if (advance_to_line !== null) {
         advance_cursor(editor, advance_to_line);
     }
-}
-
-interface SendOptions {
-    sendMethod: SendMethod;
-    autoTempFileThresholdLines: number;
-}
-
-function get_send_options(): SendOptions {
-    const config = vscode.workspace.getConfiguration('raven.sendToR');
-    return {
-        sendMethod: config.get<SendMethod>('sendMethod', 'auto'),
-        autoTempFileThresholdLines: config.get<number>('autoTempFileThresholdLines', 25),
-    };
-}
-
-function send_code(
-    terminal: vscode.Terminal,
-    code: string,
-    options: SendOptions,
-): void {
-    const transport = choose_send_transport(
-        code,
-        options.sendMethod,
-        options.autoTempFileThresholdLines,
-    );
-    switch (transport) {
-        case 'direct-paste':
-            terminal.sendText(code);
-            return;
-        case 'bracketed-paste':
-            send_via_bracketed_paste(terminal, code);
-            return;
-        case 'tempfile':
-            send_via_tempfile(terminal, code);
-            return;
-    }
-}
-
-function send_via_bracketed_paste(
-    terminal: vscode.Terminal,
-    code: string,
-): void {
-    terminal.sendText('\x1b[200~' + code + '\x1b[201~');
-}
-
-function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
-    const tmp = create_temp_file(code);
-    // Have R unlink the script's per-call directory as part of consuming it,
-    // so cleanup is tied to execution rather than a wall-clock timer. The JS
-    // fallback below only runs if R never reaches the source() line (e.g.
-    // session crashed).
-    const path_literal = JSON.stringify(tmp);
-    terminal.sendText(
-        `local({ .raven_src <- ${path_literal}; on.exit(unlink(dirname(.raven_src), recursive = TRUE)); source(.raven_src, echo = TRUE) })`
-    );
-    schedule_temp_file_cleanup(tmp);
 }
 
 export function register_send_to_r_commands(

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -1,5 +1,11 @@
 export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-manager';
 export { register_send_to_r_commands } from './commands';
+export {
+    register_inspection_commands,
+    get_inspection_target,
+    INSPECTION_COMMANDS,
+} from './inspect-commands';
+export type { InspectionCommand } from './inspect-commands';
 export { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
 export {
     detect_r_statement,

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -1,5 +1,7 @@
 export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-manager';
 export { register_send_to_r_commands } from './commands';
+export { send_code, get_send_options } from './send-code';
+export type { SendOptions } from './send-code';
 export {
     register_inspection_commands,
     get_inspection_target,

--- a/editors/vscode/src/send-to-r/inspect-commands.ts
+++ b/editors/vscode/src/send-to-r/inspect-commands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { get_or_create_r_terminal } from './r-terminal-manager';
+import { send_code, get_send_options } from './send-code';
 
 export interface InspectionCommand {
     id: string;
@@ -75,7 +76,16 @@ export function register_inspection_commands(
                 const code = cmd.wrap(target);
                 const terminal = await get_or_create_r_terminal();
                 terminal.show(true);
-                terminal.sendText(code);
+                // Single-line wrapped expressions are always pasted directly:
+                // routing them through send_code would let `tempfile` mode
+                // write a one-liner like `nrow(x)` to disk, which is silly.
+                // Multi-line wrapped expressions (from a multi-line selection)
+                // honor the user's raven.sendToR.sendMethod setting.
+                if (code.includes('\n')) {
+                    send_code(terminal, code, get_send_options());
+                } else {
+                    terminal.sendText(code);
+                }
             })
         );
     }

--- a/editors/vscode/src/send-to-r/inspect-commands.ts
+++ b/editors/vscode/src/send-to-r/inspect-commands.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import { get_or_create_r_terminal } from './r-terminal-manager';
+
+export interface InspectionCommand {
+    id: string;
+    title: string;
+    wrap: (expr: string) => string;
+}
+
+export const INSPECTION_COMMANDS: InspectionCommand[] = [
+    {
+        id: 'raven.inspect.nrow',
+        title: 'Raven: Show nrow',
+        wrap: (e) => `nrow(${e})`,
+    },
+    {
+        id: 'raven.inspect.length',
+        title: 'Raven: Show length',
+        wrap: (e) => `length(${e})`,
+    },
+    {
+        id: 'raven.inspect.head',
+        title: 'Raven: Show head',
+        wrap: (e) => `head(${e})`,
+    },
+    {
+        id: 'raven.inspect.headTransposed',
+        title: 'Raven: Show head (transposed)',
+        wrap: (e) => `t(head(${e}))`,
+    },
+    {
+        id: 'raven.inspect.names',
+        title: 'Raven: Show names',
+        wrap: (e) => `names(${e})`,
+    },
+    {
+        id: 'raven.inspect.view',
+        title: 'Raven: View',
+        wrap: (e) => `View(${e})`,
+    },
+];
+
+export function get_inspection_target(editor: vscode.TextEditor): string | null {
+    const selection = editor.selection;
+    if (!selection.isEmpty) {
+        const text = editor.document.getText(selection).trim();
+        return text.length > 0 ? text : null;
+    }
+    const range = editor.document.getWordRangeAtPosition(selection.active);
+    if (!range) return null;
+    const text = editor.document.getText(range).trim();
+    return text.length > 0 ? text : null;
+}
+
+export function register_inspection_commands(
+    context: vscode.ExtensionContext
+): void {
+    for (const cmd of INSPECTION_COMMANDS) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(cmd.id, async () => {
+                const editor = vscode.window.activeTextEditor;
+                if (!editor) {
+                    vscode.window.showInformationMessage(
+                        'Open an R file to use quick inspection commands.'
+                    );
+                    return;
+                }
+                const target = get_inspection_target(editor);
+                if (!target) {
+                    vscode.window.showInformationMessage(
+                        'Place the cursor on an R identifier or select an expression.'
+                    );
+                    return;
+                }
+                const code = cmd.wrap(target);
+                const terminal = await get_or_create_r_terminal();
+                terminal.show(true);
+                terminal.sendText(code);
+            })
+        );
+    }
+}

--- a/editors/vscode/src/send-to-r/inspect-commands.ts
+++ b/editors/vscode/src/send-to-r/inspect-commands.ts
@@ -10,32 +10,32 @@ export interface InspectionCommand {
 export const INSPECTION_COMMANDS: InspectionCommand[] = [
     {
         id: 'raven.inspect.nrow',
-        title: 'Raven: Show nrow',
+        title: 'Show nrow',
         wrap: (e) => `nrow(${e})`,
     },
     {
         id: 'raven.inspect.length',
-        title: 'Raven: Show length',
+        title: 'Show length',
         wrap: (e) => `length(${e})`,
     },
     {
         id: 'raven.inspect.head',
-        title: 'Raven: Show head',
+        title: 'Show head',
         wrap: (e) => `head(${e})`,
     },
     {
         id: 'raven.inspect.headTransposed',
-        title: 'Raven: Show head (transposed)',
+        title: 'Show head (transposed)',
         wrap: (e) => `t(head(${e}))`,
     },
     {
         id: 'raven.inspect.names',
-        title: 'Raven: Show names',
+        title: 'Show names',
         wrap: (e) => `names(${e})`,
     },
     {
         id: 'raven.inspect.view',
-        title: 'Raven: View',
+        title: 'View',
         wrap: (e) => `View(${e})`,
     },
 ];
@@ -59,7 +59,7 @@ export function register_inspection_commands(
         context.subscriptions.push(
             vscode.commands.registerCommand(cmd.id, async () => {
                 const editor = vscode.window.activeTextEditor;
-                if (!editor) {
+                if (!editor || editor.document.languageId !== 'r') {
                     vscode.window.showInformationMessage(
                         'Open an R file to use quick inspection commands.'
                     );

--- a/editors/vscode/src/send-to-r/send-code.ts
+++ b/editors/vscode/src/send-to-r/send-code.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+import { choose_send_transport, SendMethod } from './send-method';
+import { create_temp_file, schedule_temp_file_cleanup } from './temp-file';
+
+export interface SendOptions {
+    sendMethod: SendMethod;
+    autoTempFileThresholdLines: number;
+}
+
+export function get_send_options(): SendOptions {
+    const config = vscode.workspace.getConfiguration('raven.sendToR');
+    return {
+        sendMethod: config.get<SendMethod>('sendMethod', 'auto'),
+        autoTempFileThresholdLines: config.get<number>(
+            'autoTempFileThresholdLines',
+            25
+        ),
+    };
+}
+
+export function send_code(
+    terminal: vscode.Terminal,
+    code: string,
+    options: SendOptions,
+): void {
+    const transport = choose_send_transport(
+        code,
+        options.sendMethod,
+        options.autoTempFileThresholdLines,
+    );
+    switch (transport) {
+        case 'direct-paste':
+            terminal.sendText(code);
+            return;
+        case 'bracketed-paste':
+            send_via_bracketed_paste(terminal, code);
+            return;
+        case 'tempfile':
+            send_via_tempfile(terminal, code);
+            return;
+    }
+}
+
+function send_via_bracketed_paste(
+    terminal: vscode.Terminal,
+    code: string,
+): void {
+    terminal.sendText('\x1b[200~' + code + '\x1b[201~');
+}
+
+function send_via_tempfile(terminal: vscode.Terminal, code: string): void {
+    const tmp = create_temp_file(code);
+    // Have R unlink the script's per-call directory as part of consuming it,
+    // so cleanup is tied to execution rather than a wall-clock timer. The JS
+    // fallback below only runs if R never reaches the source() line (e.g.
+    // session crashed).
+    const path_literal = JSON.stringify(tmp);
+    terminal.sendText(
+        `local({ .raven_src <- ${path_literal}; on.exit(unlink(dirname(.raven_src), recursive = TRUE)); source(.raven_src, echo = TRUE) })`
+    );
+    schedule_temp_file_cleanup(tmp);
+}

--- a/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
+++ b/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
@@ -1,0 +1,102 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+    INSPECTION_COMMANDS,
+    get_inspection_target,
+} from '../../send-to-r/inspect-commands';
+
+suite('quick inspection commands', () => {
+    test('INSPECTION_COMMANDS wraps target in the documented R calls', () => {
+        const wraps = Object.fromEntries(
+            INSPECTION_COMMANDS.map((c) => [c.id, c.wrap('x')])
+        );
+        assert.strictEqual(wraps['raven.inspect.nrow'], 'nrow(x)');
+        assert.strictEqual(wraps['raven.inspect.length'], 'length(x)');
+        assert.strictEqual(wraps['raven.inspect.head'], 'head(x)');
+        assert.strictEqual(
+            wraps['raven.inspect.headTransposed'],
+            't(head(x))'
+        );
+        assert.strictEqual(wraps['raven.inspect.names'], 'names(x)');
+        assert.strictEqual(wraps['raven.inspect.view'], 'View(x)');
+    });
+
+    test('every inspection command is registered in VS Code', async () => {
+        const all = new Set(await vscode.commands.getCommands(true));
+        for (const cmd of INSPECTION_COMMANDS) {
+            assert.ok(
+                all.has(cmd.id),
+                `expected command "${cmd.id}" to be registered`
+            );
+        }
+    });
+
+    test('get_inspection_target returns the word at cursor when no selection', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'r',
+            content: 'my_data\n',
+        });
+        const editor = await vscode.window.showTextDocument(doc);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(0, 3),
+            new vscode.Position(0, 3)
+        );
+        assert.strictEqual(get_inspection_target(editor), 'my_data');
+    });
+
+    test('get_inspection_target returns the selection text when a range is selected', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'r',
+            content: 'df$col[1:5]\n',
+        });
+        const editor = await vscode.window.showTextDocument(doc);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 11)
+        );
+        assert.strictEqual(get_inspection_target(editor), 'df$col[1:5]');
+    });
+
+    test('get_inspection_target returns null when the cursor is not on a word', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'r',
+            content: '   \n',
+        });
+        const editor = await vscode.window.showTextDocument(doc);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(0, 1),
+            new vscode.Position(0, 1)
+        );
+        assert.strictEqual(get_inspection_target(editor), null);
+    });
+
+    test('get_inspection_target treats whitespace-only selection as no target', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'r',
+            content: '   x\n',
+        });
+        const editor = await vscode.window.showTextDocument(doc);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 2)
+        );
+        assert.strictEqual(get_inspection_target(editor), null);
+    });
+
+    test('INSPECTION_COMMANDS are advertised in package.json', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json') as {
+            contributes: { commands: Array<{ command: string; title: string }> };
+        };
+        const declared = new Map(
+            pkg.contributes.commands.map((c) => [c.command, c.title])
+        );
+        for (const cmd of INSPECTION_COMMANDS) {
+            assert.strictEqual(
+                declared.get(cmd.id),
+                cmd.title,
+                `package.json must declare ${cmd.id} with title "${cmd.title}"`
+            );
+        }
+    });
+});

--- a/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
+++ b/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
@@ -83,20 +83,66 @@ suite('quick inspection commands', () => {
         assert.strictEqual(get_inspection_target(editor), null);
     });
 
-    test('INSPECTION_COMMANDS are advertised in package.json', () => {
+    test('INSPECTION_COMMANDS are advertised in package.json under the R category', () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const pkg = require('../../../package.json') as {
-            contributes: { commands: Array<{ command: string; title: string }> };
+            contributes: {
+                commands: Array<{
+                    command: string;
+                    title: string;
+                    category?: string;
+                }>;
+            };
         };
         const declared = new Map(
-            pkg.contributes.commands.map((c) => [c.command, c.title])
+            pkg.contributes.commands.map((c) => [c.command, c])
         );
         for (const cmd of INSPECTION_COMMANDS) {
+            const entry = declared.get(cmd.id);
+            assert.ok(entry, `package.json must declare ${cmd.id}`);
             assert.strictEqual(
-                declared.get(cmd.id),
+                entry.title,
                 cmd.title,
                 `package.json must declare ${cmd.id} with title "${cmd.title}"`
             );
+            assert.strictEqual(
+                entry.category,
+                'R',
+                `package.json must declare ${cmd.id} under the "R" category`
+            );
         }
+    });
+
+    test('command no-ops when active editor is not an R document', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'plaintext',
+            content: 'my_data\n',
+        });
+        const editor = await vscode.window.showTextDocument(doc);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(0, 3),
+            new vscode.Position(0, 3)
+        );
+
+        // Capture the info message rather than asserting on the terminal.
+        // The handler should fail closed (no terminal created) when the
+        // active document isn't R.
+        const original = vscode.window.showInformationMessage;
+        let last_message: string | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (vscode.window as any).showInformationMessage = (msg: string) => {
+            last_message = msg;
+            return Promise.resolve(undefined);
+        };
+        try {
+            await vscode.commands.executeCommand('raven.inspect.nrow');
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (vscode.window as any).showInformationMessage = original;
+        }
+        assert.ok(
+            last_message && last_message.includes('R file'),
+            `expected an info message about opening an R file, got: ${String(last_message)}`
+        );
     });
 });


### PR DESCRIPTION
## Summary

Implements #207. Adds six commands that wrap the word under the cursor (or the current selection) in a common R inspection call and send it to the R terminal:

| Command | Sends to R |
|---|---|
| `Raven: Show nrow` | `nrow(<target>)` |
| `Raven: Show length` | `length(<target>)` |
| `Raven: Show head` | `head(<target>)` |
| `Raven: Show head (transposed)` | `t(head(<target>))` |
| `Raven: Show names` | `names(<target>)` |
| `Raven: View` | `View(<target>)` |

Each command reuses the existing `get_or_create_r_terminal` infrastructure. The handlers are exposed only via the Command Palette — no default keybindings, so users can bind them however they like.

Implementation lives in a new module `editors/vscode/src/send-to-r/inspect-commands.ts` to keep the command list and target-extraction logic small and testable.

## Test plan

- [x] `cargo build -p raven` succeeds
- [x] `cargo test -p raven` passes (58/58)
- [x] `bun run compile:test` (tsc) succeeds
- [x] Added unit tests for command registry, target extraction, and package.json registration
- [ ] VS Code integration tests: blocked locally by the documented Claude Code sandbox limitation around Electron; will run in CI

Closes #207
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick inspection commands for R: Show nrow, Show length, Show head, Show head (transposed), Show names, and View — wrap selection or word under cursor and send to the R console. Commands appear in the Command Palette with no default keybindings.

* **Documentation**
  * Quick Inspection Commands guide covering usage, language restrictions, and single- vs multi-line send behavior and configuration.

* **Tests**
  * Tests for command wrapping, registration, target selection, and R-file behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->