### PR TITLE
feat(vscode): add R Markdown / Quarto snippets (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **[Syntax highlighting](docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
-- **[Snippets](docs/snippets.md)** — Built-in snippets for common R patterns (control flow, apply family, ggplot2 scaffolds, roxygen2 tags)
+- **[Snippets](docs/snippets.md)** — Built-in snippets for common R patterns (control flow, apply family, ggplot2 scaffolds, roxygen2 tags) plus R Markdown / Quarto chunk and YAML scaffolds
 
 ### R session integration
 

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -14,4 +14,12 @@ For the exact trigger list and expansion bodies, see `editors/vscode/snippets/r.
 
 ## R Markdown and Quarto
 
-Raven registers these snippets for VS Code's `r` language ID. That means plain R snippets also appear in `.rmd` and `.qmd` buffers, which is useful inside R chunks. R Markdown and Quarto chunk/YAML snippets are not included here.
+Raven registers snippets for VS Code's `r` language ID. Since `.rmd` and `.qmd` files are treated as R documents, both the plain R snippets above and an R Markdown / Quarto set are available in those buffers.
+
+The R Markdown / Quarto set covers:
+
+- Code chunks: `rchunk`, `rchunkopts`, `setupchunk`, `pychunk`, `sqlchunk`, `bashchunk`
+- YAML frontmatter: `rmdyaml`, `qyaml`
+- knitr helpers: `kable`, `incgraphics`, `inliner`
+
+For the exact trigger list and expansion bodies, see `editors/vscode/snippets/rmarkdown.json`.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -24,7 +24,7 @@ Compared with [REditorSupport's R extension](https://marketplace.visualstudio.co
 - **[Cross-file awareness](https://github.com/jbearak/raven/blob/main/docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
 - **[Directives](https://github.com/jbearak/raven/blob/main/docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **[Syntax highlighting](https://github.com/jbearak/raven/blob/main/docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
-- **[Snippets](https://github.com/jbearak/raven/blob/main/docs/snippets.md)** — Built-in snippets for common R patterns (control flow, apply family, ggplot2 scaffolds, roxygen2 tags)
+- **[Snippets](https://github.com/jbearak/raven/blob/main/docs/snippets.md)** — Built-in snippets for common R patterns (control flow, apply family, ggplot2 scaffolds, roxygen2 tags) plus R Markdown / Quarto chunk and YAML scaffolds
 
 ### R session integration
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -287,6 +287,10 @@
       {
         "language": "r",
         "path": "./snippets/r.json"
+      },
+      {
+        "language": "r",
+        "path": "./snippets/rmarkdown.json"
       }
     ],
     "configurationDefaults": {

--- a/editors/vscode/snippets/rmarkdown.json
+++ b/editors/vscode/snippets/rmarkdown.json
@@ -1,0 +1,98 @@
+{
+  "rmarkdown-r-chunk": {
+    "prefix": "rchunk",
+    "body": [
+      "```{r ${1:label}}",
+      "$0",
+      "```"
+    ],
+    "description": "R code chunk (R Markdown / Quarto)"
+  },
+  "rmarkdown-r-chunk-opts": {
+    "prefix": "rchunkopts",
+    "body": [
+      "```{r ${1:label}, echo = ${2:FALSE}, message = ${3:FALSE}, warning = ${4:FALSE}}",
+      "$0",
+      "```"
+    ],
+    "description": "R code chunk with common knitr options"
+  },
+  "rmarkdown-setup-chunk": {
+    "prefix": "setupchunk",
+    "body": [
+      "```{r setup, include = FALSE}",
+      "knitr::opts_chunk\\$set(echo = ${1:TRUE})",
+      "$0",
+      "```"
+    ],
+    "description": "knitr setup chunk"
+  },
+  "quarto-python-chunk": {
+    "prefix": "pychunk",
+    "body": [
+      "```{python}",
+      "$0",
+      "```"
+    ],
+    "description": "Python code chunk (Quarto)"
+  },
+  "quarto-sql-chunk": {
+    "prefix": "sqlchunk",
+    "body": [
+      "```{sql connection=${1:con}}",
+      "$0",
+      "```"
+    ],
+    "description": "SQL code chunk"
+  },
+  "quarto-bash-chunk": {
+    "prefix": "bashchunk",
+    "body": [
+      "```{bash}",
+      "$0",
+      "```"
+    ],
+    "description": "Bash code chunk"
+  },
+  "rmarkdown-yaml": {
+    "prefix": "rmdyaml",
+    "body": [
+      "---",
+      "title: \"${1:Title}\"",
+      "author: \"${2:Author}\"",
+      "date: \"`r format(Sys.time(), '%Y-%m-%d')`\"",
+      "output: ${3|html_document,pdf_document,word_document|}",
+      "---",
+      "$0"
+    ],
+    "description": "R Markdown YAML frontmatter"
+  },
+  "quarto-yaml": {
+    "prefix": "qyaml",
+    "body": [
+      "---",
+      "title: \"${1:Title}\"",
+      "author: \"${2:Author}\"",
+      "date: today",
+      "format: ${3|html,pdf,docx,revealjs|}",
+      "---",
+      "$0"
+    ],
+    "description": "Quarto YAML frontmatter"
+  },
+  "rmarkdown-include-graphics": {
+    "prefix": "incgraphics",
+    "body": "knitr::include_graphics(${0:\"path/to/img.png\"})",
+    "description": "knitr::include_graphics()"
+  },
+  "rmarkdown-kable": {
+    "prefix": "kable",
+    "body": "knitr::kable(${1:df}, caption = ${0:\"Caption\"})",
+    "description": "knitr::kable()"
+  },
+  "rmarkdown-inline-r": {
+    "prefix": "inliner",
+    "body": "`r ${0:expr}`",
+    "description": "Inline R expression"
+  }
+}

--- a/editors/vscode/src/test/snippets.test.ts
+++ b/editors/vscode/src/test/snippets.test.ts
@@ -172,9 +172,10 @@ suite('Snippet contributions', () => {
 
     test('placeholder grammar is well-formed in every snippet body', () => {
         // Matches:
-        //   ${N}          (placeholder, no default)
-        //   ${N:default}  (placeholder with default, non-nested)
-        //   $N            (bare tab stop)
+        //   ${N}            (placeholder, no default)
+        //   ${N:default}    (placeholder with default, non-nested)
+        //   ${N|opt1,opt2|} (choice placeholder)
+        //   $N              (bare tab stop)
         // Known limitation: the [^}]* default-group is non-recursive, so
         // tab-stop numbers that appear *inside* a nested ${...} default
         // are not collected. The "for" snippet does this intentionally —
@@ -182,7 +183,7 @@ suite('Snippet contributions', () => {
         // invisible to this regex. The balance check below still catches
         // malformed nesting. If a future snippet adds duplicate stops
         // inside nested defaults, this regex won't flag them.
-        const tabStopPattern = /\$\{(\d+)(?::([^}]*))?\}|\$(\d+)/g;
+        const tabStopPattern = /\$\{(\d+)(?::[^}]*)?\}|\$\{(\d+)\|[^}]*\|\}|\$(\d+)/g;
 
         for (const entry of loadSnippetContributions()) {
             const snippets = loadSnippets(entry.path);
@@ -204,7 +205,7 @@ suite('Snippet contributions', () => {
                 let match: RegExpExecArray | null;
                 tabStopPattern.lastIndex = 0;
                 while ((match = tabStopPattern.exec(body)) !== null) {
-                    const numStr = match[1] ?? match[3];
+                    const numStr = match[1] ?? match[2] ?? match[3];
                     if (numStr !== undefined) {
                         tabStopNumbers.push(parseInt(numStr, 10));
                     }

--- a/editors/vscode/src/test/snippets.test.ts
+++ b/editors/vscode/src/test/snippets.test.ts
@@ -9,12 +9,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 /**
- * Structural and placeholder-grammar tests for the R snippets file.
+ * Structural and placeholder-grammar tests for the snippet files
+ * registered in package.json's `contributes.snippets`.
  *
  * Pure file/JSON assertions — no `vscode` API needed beyond the harness.
- * Validates: JSON parses, every entry has the right shape, prefixes are
- * unique, placeholder syntax is well-formed, and package.json's
- * `contributes.snippets` points at the on-disk file.
+ * For each registered file we validate: JSON parses, every entry has
+ * the right shape, placeholder syntax is well-formed. Across all files
+ * registered for the same language we validate that prefixes are unique
+ * (VS Code silently overwrites duplicates).
  *
  * We intentionally do NOT snapshot exact body strings or assert a hard
  * count — both make routine edits churn-y without catching real bugs.
@@ -26,8 +28,6 @@ declare const test: Mocha.TestFunction;
 
 // __dirname at runtime is editors/vscode/out/test. Walk back to editors/vscode/.
 const vscodeRoot = path.resolve(__dirname, '..', '..');
-const snippetsRelativePath = './snippets/r.json';
-const snippetsAbsolutePath = path.join(vscodeRoot, 'snippets', 'r.json');
 const packageJsonPath = path.join(vscodeRoot, 'package.json');
 
 interface SnippetEntry {
@@ -38,9 +38,9 @@ interface SnippetEntry {
     description: string;
 }
 
-function loadSnippets(): Record<string, SnippetEntry> {
-    const raw = fs.readFileSync(snippetsAbsolutePath, 'utf8');
-    return JSON.parse(raw) as Record<string, SnippetEntry>;
+interface SnippetContribution {
+    language: string;
+    path: string;
 }
 
 function loadPackageJson(): Record<string, unknown> {
@@ -48,67 +48,129 @@ function loadPackageJson(): Record<string, unknown> {
     return JSON.parse(raw) as Record<string, unknown>;
 }
 
+function loadSnippetContributions(): SnippetContribution[] {
+    const pkg = loadPackageJson();
+    const contributes = pkg.contributes as Record<string, unknown> | undefined;
+    assert.ok(contributes, 'package.json must have a contributes section');
+    const snippetEntries = contributes.snippets as SnippetContribution[] | undefined;
+    assert.ok(
+        Array.isArray(snippetEntries) && snippetEntries.length > 0,
+        'package.json contributes.snippets must be a non-empty array',
+    );
+    return snippetEntries;
+}
+
+function loadSnippets(relativePath: string): Record<string, SnippetEntry> {
+    const absolutePath = path.resolve(vscodeRoot, relativePath);
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    return JSON.parse(raw) as Record<string, SnippetEntry>;
+}
+
 function bodyToString(body: string | string[]): string {
     return Array.isArray(body) ? body.join('\n') : body;
 }
 
-suite('R snippets', () => {
-    test('snippets file parses as JSON', () => {
-        assert.doesNotThrow(() => loadSnippets(), 'r.json must be valid JSON');
-    });
-
-    test('contains at least one snippet', () => {
-        const snippets = loadSnippets();
+suite('Snippet contributions', () => {
+    test('package.json registers at least one snippet file for the r language', () => {
+        const contributions = loadSnippetContributions();
+        const rEntries = contributions.filter((e) => e.language === 'r');
         assert.ok(
-            Object.keys(snippets).length > 0,
-            'r.json must define at least one snippet',
+            rEntries.length >= 1,
+            'At least one snippet file must be registered for language "r"',
         );
     });
 
-    test('every snippet has required fields with correct types', () => {
-        const snippets = loadSnippets();
-        for (const [name, entry] of Object.entries(snippets)) {
-            const prefixIsString = typeof entry.prefix === 'string' && entry.prefix.length > 0;
-            const prefixIsStringArray = Array.isArray(entry.prefix)
-                && entry.prefix.length > 0
-                && entry.prefix.every((p) => typeof p === 'string' && p.length > 0);
+    test('every registered snippets path resolves to an existing file', () => {
+        for (const entry of loadSnippetContributions()) {
+            const resolvedPath = path.resolve(vscodeRoot, entry.path);
             assert.ok(
-                prefixIsString || prefixIsStringArray,
-                `Snippet "${name}" must have a non-empty string or non-empty string-array prefix`,
-            );
-            const bodyIsString = typeof entry.body === 'string';
-            const bodyIsStringArray = Array.isArray(entry.body)
-                && entry.body.every((line) => typeof line === 'string');
-            assert.ok(
-                bodyIsString || bodyIsStringArray,
-                `Snippet "${name}" body must be a string or array of strings`,
-            );
-            assert.ok(
-                typeof entry.description === 'string' && entry.description.length > 0,
-                `Snippet "${name}" must have a non-empty string description`,
+                fs.existsSync(resolvedPath),
+                `Registered snippets file does not exist on disk: ${resolvedPath}`,
             );
         }
     });
 
-    test('prefixes are unique across all snippets', () => {
-        const snippets = loadSnippets();
-        const seen = new Map<string, string>(); // prefix -> first snippet name
-        for (const [name, entry] of Object.entries(snippets)) {
-            const prefixes = Array.isArray(entry.prefix) ? entry.prefix : [entry.prefix];
-            for (const prefix of prefixes) {
-                const prior = seen.get(prefix);
+    test('every registered snippets file parses as JSON', () => {
+        for (const entry of loadSnippetContributions()) {
+            assert.doesNotThrow(
+                () => loadSnippets(entry.path),
+                `${entry.path} must be valid JSON`,
+            );
+        }
+    });
+
+    test('every registered snippets file contains at least one snippet', () => {
+        for (const entry of loadSnippetContributions()) {
+            const snippets = loadSnippets(entry.path);
+            assert.ok(
+                Object.keys(snippets).length > 0,
+                `${entry.path} must define at least one snippet`,
+            );
+        }
+    });
+
+    test('every snippet has required fields with correct types', () => {
+        for (const entry of loadSnippetContributions()) {
+            const snippets = loadSnippets(entry.path);
+            for (const [name, snippet] of Object.entries(snippets)) {
+                const prefixIsString = typeof snippet.prefix === 'string' && snippet.prefix.length > 0;
+                const prefixIsStringArray = Array.isArray(snippet.prefix)
+                    && snippet.prefix.length > 0
+                    && snippet.prefix.every((p) => typeof p === 'string' && p.length > 0);
                 assert.ok(
-                    prior === undefined,
-                    `Prefix "${prefix}" is used by both "${prior}" and "${name}" — `
-                    + 'duplicates silently overwrite each other in VS Code',
+                    prefixIsString || prefixIsStringArray,
+                    `${entry.path}: Snippet "${name}" must have a non-empty string or non-empty string-array prefix`,
                 );
-                seen.set(prefix, name);
+                const bodyIsString = typeof snippet.body === 'string';
+                const bodyIsStringArray = Array.isArray(snippet.body)
+                    && snippet.body.every((line) => typeof line === 'string');
+                assert.ok(
+                    bodyIsString || bodyIsStringArray,
+                    `${entry.path}: Snippet "${name}" body must be a string or array of strings`,
+                );
+                assert.ok(
+                    typeof snippet.description === 'string' && snippet.description.length > 0,
+                    `${entry.path}: Snippet "${name}" must have a non-empty string description`,
+                );
+            }
+        }
+    });
+
+    test('prefixes are unique within each language across all registered files', () => {
+        // Group registered files by language and check the union of prefixes
+        // — when multiple files are registered for the same language they
+        // share a single trigger namespace at runtime, so any duplicate
+        // would silently shadow the other.
+        const contributions = loadSnippetContributions();
+        const byLanguage = new Map<string, SnippetContribution[]>();
+        for (const entry of contributions) {
+            const list = byLanguage.get(entry.language) ?? [];
+            list.push(entry);
+            byLanguage.set(entry.language, list);
+        }
+
+        for (const [language, entries] of byLanguage) {
+            const seen = new Map<string, { file: string; name: string }>();
+            for (const entry of entries) {
+                const snippets = loadSnippets(entry.path);
+                for (const [name, snippet] of Object.entries(snippets)) {
+                    const prefixes = Array.isArray(snippet.prefix) ? snippet.prefix : [snippet.prefix];
+                    for (const prefix of prefixes) {
+                        const prior = seen.get(prefix);
+                        assert.ok(
+                            prior === undefined,
+                            `Language "${language}": prefix "${prefix}" is used by both `
+                            + `"${prior?.name}" in ${prior?.file} and "${name}" in ${entry.path} — `
+                            + 'duplicates silently overwrite each other in VS Code',
+                        );
+                        seen.set(prefix, { file: entry.path, name });
+                    }
+                }
             }
         }
     });
 
     test('placeholder grammar is well-formed in every snippet body', () => {
-        const snippets = loadSnippets();
         // Matches:
         //   ${N}          (placeholder, no default)
         //   ${N:default}  (placeholder with default, non-nested)
@@ -122,86 +184,49 @@ suite('R snippets', () => {
         // inside nested defaults, this regex won't flag them.
         const tabStopPattern = /\$\{(\d+)(?::([^}]*))?\}|\$(\d+)/g;
 
-        for (const [name, entry] of Object.entries(snippets)) {
-            const body = bodyToString(entry.body);
+        for (const entry of loadSnippetContributions()) {
+            const snippets = loadSnippets(entry.path);
+            for (const [name, snippet] of Object.entries(snippets)) {
+                const body = bodyToString(snippet.body);
+                const label = `${entry.path}: Snippet "${name}"`;
 
-            // 1. No unterminated `${` — count must balance.
-            const openCount = (body.match(/\$\{/g) || []).length;
-            const closeAfterOpen = countBalancedClosers(body);
-            assert.strictEqual(
-                openCount,
-                closeAfterOpen,
-                `Snippet "${name}" has unbalanced \${...} placeholders`,
-            );
+                // 1. No unterminated `${` — count must balance.
+                const openCount = (body.match(/\$\{/g) || []).length;
+                const closeAfterOpen = countBalancedClosers(body);
+                assert.strictEqual(
+                    openCount,
+                    closeAfterOpen,
+                    `${label} has unbalanced \${...} placeholders`,
+                );
 
-            // 2. Collect tab-stop numbers found in the body.
-            const tabStopNumbers: number[] = [];
-            let match: RegExpExecArray | null;
-            tabStopPattern.lastIndex = 0;
-            while ((match = tabStopPattern.exec(body)) !== null) {
-                const numStr = match[1] ?? match[3];
-                if (numStr !== undefined) {
-                    tabStopNumbers.push(parseInt(numStr, 10));
+                // 2. Collect tab-stop numbers found in the body.
+                const tabStopNumbers: number[] = [];
+                let match: RegExpExecArray | null;
+                tabStopPattern.lastIndex = 0;
+                while ((match = tabStopPattern.exec(body)) !== null) {
+                    const numStr = match[1] ?? match[3];
+                    if (numStr !== undefined) {
+                        tabStopNumbers.push(parseInt(numStr, 10));
+                    }
                 }
+
+                // 3. At most one ${0} (or $0). Zero is allowed (cursor lands at body end).
+                const zeroCount = tabStopNumbers.filter((n) => n === 0).length;
+                assert.ok(
+                    zeroCount <= 1,
+                    `${label} has ${zeroCount} \${0} placeholders — at most one is allowed`,
+                );
+
+                // 4. No duplicate non-zero tab-stop numbers within one snippet.
+                const nonZero = tabStopNumbers.filter((n) => n !== 0);
+                const duplicates = nonZero.filter((n, i) => nonZero.indexOf(n) !== i);
+                assert.deepStrictEqual(
+                    duplicates,
+                    [],
+                    `${label} has duplicate tab-stop numbers: ${[...new Set(duplicates)].join(', ')}`,
+                );
             }
-
-            // 3. At most one ${0} (or $0). Zero is allowed (cursor lands at body end).
-            const zeroCount = tabStopNumbers.filter((n) => n === 0).length;
-            assert.ok(
-                zeroCount <= 1,
-                `Snippet "${name}" has ${zeroCount} \${0} placeholders — at most one is allowed`,
-            );
-
-            // 4. No duplicate non-zero tab-stop numbers within one snippet.
-            const nonZero = tabStopNumbers.filter((n) => n !== 0);
-            const duplicates = nonZero.filter((n, i) => nonZero.indexOf(n) !== i);
-            assert.deepStrictEqual(
-                duplicates,
-                [],
-                `Snippet "${name}" has duplicate tab-stop numbers: ${[...new Set(duplicates)].join(', ')}`,
-            );
         }
-    });
-
-    test('package.json registers the snippets file under the r language', () => {
-        const pkg = loadPackageJson();
-        const contributes = pkg.contributes as Record<string, unknown> | undefined;
-        assert.ok(contributes, 'package.json must have a contributes section');
-        const snippetEntries = contributes.snippets as Array<{ language?: string; path?: string }> | undefined;
-        assert.ok(
-            Array.isArray(snippetEntries),
-            'package.json contributes.snippets must be an array',
-        );
-        const rEntries = snippetEntries.filter((e) => e.language === 'r');
-        assert.strictEqual(
-            rEntries.length,
-            1,
-            'Exactly one snippet entry must be registered for language "r"',
-        );
-        assert.strictEqual(
-            rEntries[0].path,
-            snippetsRelativePath,
-            `R snippet entry must point at ${snippetsRelativePath}`,
-        );
-    });
-
-    test('registered snippets path resolves to an existing file', () => {
-        const pkg = loadPackageJson();
-        const contributes = pkg.contributes as Record<string, unknown> | undefined;
-        assert.ok(contributes, 'package.json must have a contributes section');
-        const snippetEntries = contributes.snippets as Array<{ language: string; path: string }> | undefined;
-        assert.ok(
-            Array.isArray(snippetEntries),
-            'package.json contributes.snippets must be an array',
-        );
-        const rEntry = snippetEntries.find((e) => e.language === 'r');
-        assert.ok(rEntry, 'No snippet entry found for r language');
-        // Path in package.json is relative to the extension root, which is vscodeRoot.
-        const resolvedPath = path.resolve(vscodeRoot, rEntry.path);
-        assert.ok(
-            fs.existsSync(resolvedPath),
-            `Registered snippets file does not exist on disk: ${resolvedPath}`,
-        );
     });
 });
 


### PR DESCRIPTION
## Summary

Closes [#204](https://github.com/jbearak/raven/issues/204). The existing `editors/vscode/snippets/r.json` already covered ~65 plain-R triggers (control flow, apply family, ggplot2 scaffolds, roxygen2 tags, etc.), so the remaining gap from the issue was the R Markdown / Quarto side. This PR fills that gap.

- New `editors/vscode/snippets/rmarkdown.json` with 11 triggers:
  - Chunks: `rchunk`, `rchunkopts`, `setupchunk`, `pychunk`, `sqlchunk`, `bashchunk`
  - YAML frontmatter: `rmdyaml`, `qyaml`
  - knitr helpers: `kable`, `incgraphics`, `inliner`
- Registered for VS Code's `r` language ID — `.rmd` and `.qmd` already resolve to `r`, so the snippets fire there alongside the plain-R set. When dedicated `rmd`/`quarto` languages land (see [#209](https://github.com/jbearak/raven/issues/209)), the registration can be retargeted with no other changes.
- `src/test/snippets.test.ts` is generalized to iterate every entry in `contributes.snippets`, validate JSON shape and placeholder grammar per file, and enforce prefix uniqueness across the union of files contributing to the same language (VS Code silently overwrites duplicates).
- `docs/snippets.md`, `README.md`, and `editors/vscode/README.md` updated to reflect the new triggers.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 116 passing, including 7 generalized `Snippet contributions` cases
- [ ] Manual: in a `.qmd` buffer, type `rchunk` / `qyaml` / `pychunk` → verify the snippet appears in IntelliSense and expands with the right tab stops
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VS Code extension now provides R Markdown/Quarto snippets: R, Python, SQL, Bash chunk scaffolds, YAML frontmatter templates, and helpers for graphics, tables, and inline R expressions.

* **Documentation**
  * Docs updated to list and explain the newly available R Markdown/Quarto snippets.

* **Tests**
  * Snippet test suite expanded to validate all registered snippet files and ensure unique, well-formed snippet prefixes and bodies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/215)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->