### PR TITLE
feat(vscode): add $testthat problem matcher for test failures

### DIFF
--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -52,6 +52,47 @@ In contrast, a function defined in `tests/testthat/test-helpers.R` is **not**
 visible to `R/helpers.R` — symbols in `R/` are visible from `tests/testthat/`,
 but not the other way around.
 
+### testthat problem matcher
+
+When you run `devtools::test()` or `testthat::test_file()`, the default
+progress reporter prints failure headers like:
+
+```text
+── Failure (test-helpers.R:12:3): process_data handles NAs ──
+Expected: 1
+Actual: 2
+```
+
+Raven contributes a `$testthat` problem matcher that parses those headers
+and surfaces each failing test in VS Code's Problems panel, with a
+clickable file:line link that jumps to the failing assertion.
+
+To wire it up, add a task to `.vscode/tasks.json` (or run it ad hoc via
+**Terminal → Run Task…**):
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "R: Test package",
+      "type": "shell",
+      "command": "Rscript",
+      "args": ["-e", "devtools::test()"],
+      "problemMatcher": "$testthat",
+      "group": "test"
+    }
+  ]
+}
+```
+
+The matcher captures both `── Failure (…) ──` and `── Error (…) ──`
+headers and resolves paths relative to `${workspaceFolder}/tests/testthat`,
+matching the directory testthat sets as the working directory while a
+test runs. The Problems-panel entry's message is the test name; the full
+expected/actual output stays in the terminal where you can read it
+alongside any other context the test printed.
+
 ### Roxygen Namespace Tags
 
 When roxygen is detected, Raven parses these tags from source:

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -54,13 +54,15 @@ but not the other way around.
 
 ### testthat problem matcher
 
-When you run `devtools::test()` or `testthat::test_file()`, the default
-progress reporter prints failure headers like:
+When you run `devtools::test()` or `testthat::test_dir()`, testthat's
+default progress reporter prints failure headers like:
 
 ```text
-── Failure (test-helpers.R:12:3): process_data handles NAs ──
-Expected: 1
-Actual: 2
+Failure ('test-helpers.R:12:3'): process_data handles NAs
+Expected 1 to equal 2.
+Differences:
+1/1 mismatches
+[1] 1 - 2 == -1
 ```
 
 Raven contributes a `$testthat` problem matcher that parses those headers
@@ -86,12 +88,17 @@ To wire it up, add a task to `.vscode/tasks.json` (or run it ad hoc via
 }
 ```
 
-The matcher captures both `── Failure (…) ──` and `── Error (…) ──`
-headers and resolves paths relative to `${workspaceFolder}/tests/testthat`,
-matching the directory testthat sets as the working directory while a
-test runs. The Problems-panel entry's message is the test name; the full
-expected/actual output stays in the terminal where you can read it
-alongside any other context the test printed.
+The matcher recognises `Failure (…)` / `Error (…)` headers from the
+default `ProgressReporter`, the `── Failure (…) ──` form from the
+`CompactProgressReporter`, and the all-caps `FAILURE: …` / `ERROR: …`
+shape that testthat's `LlmReporter` emits when running under an AI
+coding agent (`CLAUDECODE` / `AGENT` / `GEMINI_CLI` / `CURSOR_AGENT`).
+Paths resolve relative to `${workspaceFolder}/tests/testthat`, matching
+the directory testthat sets as the working directory while a test
+runs. The Problems-panel entry's message is the test name (when the
+reporter emits one); the full expected/actual output stays in the
+terminal where you can read it alongside any other context the test
+printed.
 
 ### Roxygen Namespace Tags
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -373,11 +373,11 @@
         ],
         "severity": "error",
         "pattern": {
-          "regexp": "^[-─]+\\s+(Failure|Error)\\s+\\((.+?):(\\d+)(?::(\\d+))?\\):\\s+(.+?)\\s+[-─]+\\s*$",
-          "file": 2,
-          "line": 3,
-          "column": 4,
-          "message": 5
+          "regexp": "^[-─]*\\s*(?:(Failure|Error)|(FAILURE|ERROR):)\\s+\\(?'([^':]+):(\\d+)(?::(\\d+))?'\\)?(?::\\s+(.+?))?\\s*[-─]*\\s*$",
+          "file": 3,
+          "line": 4,
+          "column": 5,
+          "message": 6
         }
       }
     ],

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -360,6 +360,27 @@
         "path": "./snippets/rmarkdown.json"
       }
     ],
+    "problemMatchers": [
+      {
+        "name": "testthat",
+        "label": "R testthat test failures",
+        "owner": "raven-testthat",
+        "source": "testthat",
+        "applyTo": "allDocuments",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}/tests/testthat"
+        ],
+        "severity": "error",
+        "pattern": {
+          "regexp": "^[-─]+\\s+(Failure|Error)\\s+\\((.+?):(\\d+)(?::(\\d+))?\\):\\s+(.+?)\\s+[-─]+\\s*$",
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "message": 5
+        }
+      }
+    ],
     "configurationDefaults": {
       "[r]": {
         "editor.formatOnType": true

--- a/editors/vscode/src/test/problemMatchers.test.ts
+++ b/editors/vscode/src/test/problemMatchers.test.ts
@@ -3,14 +3,28 @@
 /**
  * Structural tests for problem-matcher contributions in package.json.
  *
- * The $testthat matcher parses failure headers emitted by testthat's default
- * progress reporter so VS Code can surface failing tests in the Problems panel
- * with clickable file:line links.
+ * The $testthat matcher parses test-failure headers emitted by testthat 3.x.
+ * Three distinct reporters are in active use and the matcher must handle all
+ * three. Samples below were captured from `testthat 3.3.2` + `devtools 2.5.2`
+ * running against a temporary package with three failing tests.
  *
- * Tests are pure file/JSON assertions — they parse the regex out of
- * package.json and exercise it against captured testthat output samples,
- * which keeps the matcher honest without needing to spawn R or VS Code's
- * task runner.
+ *   ProgressReporter (default for `devtools::test()` / `testthat::test_dir()`):
+ *     Failure ('test-sample.R:2:3'): expect_equal mismatch
+ *     Error   ('test-sample.R:6:3'): error inside test
+ *
+ *   CompactProgressReporter:
+ *     ── Failure ('test-sample.R:2:3'): expect_equal mismatch ───────────────
+ *     ── Error   ('test-sample.R:6:3'): error inside test ───────────────────
+ *
+ *   LlmReporter — auto-selected when CLAUDECODE / AGENT / GEMINI_CLI /
+ *   CURSOR_AGENT env vars are set, so CI agents and reviewers running under
+ *   Claude / Gemini / Cursor see this form (not what end users get in
+ *   VS Code's terminal, but the matcher handles it for completeness):
+ *     FAILURE: 'test-sample.R:2:3' ----------------------
+ *     ERROR:   'test-sample.R:6:3' ------------------------
+ *
+ * Common shape: a single-quoted location `'file:line:col'`. Test name is
+ * absent in the LlmReporter form.
  */
 
 import * as assert from 'assert';
@@ -105,10 +119,10 @@ suite('problem matcher contributions', () => {
 
     test('pattern uses the documented capture-group indices', () => {
         const pattern = singlePattern(getTestthatMatcher());
-        assert.strictEqual(pattern.file, 2);
-        assert.strictEqual(pattern.line, 3);
-        assert.strictEqual(pattern.column, 4);
-        assert.strictEqual(pattern.message, 5);
+        assert.strictEqual(pattern.file, 3);
+        assert.strictEqual(pattern.line, 4);
+        assert.strictEqual(pattern.column, 5);
+        assert.strictEqual(pattern.message, 6);
     });
 
     test('regex compiles as a JavaScript RegExp', () => {
@@ -120,98 +134,191 @@ suite('problem matcher contributions', () => {
     });
 });
 
-suite('testthat regex captures', () => {
+interface ExpectedCapture {
+    file: string;
+    line: string;
+    column?: string;
+    message?: string;
+}
+
+suite('testthat regex captures (real reporter output)', () => {
     function regex(): RegExp {
         return new RegExp(singlePattern(getTestthatMatcher()).regexp);
     }
 
-    test('matches a standard testthat 3.x failure header', () => {
-        const sample = '── Failure (test-helpers.R:12:3): process_data handles NAs ──';
+    function expectMatch(sample: string, expected: ExpectedCapture): void {
         const m = sample.match(regex());
-        assert.ok(m, 'standard failure header must match');
-        assert.strictEqual(m[1], 'Failure');
-        assert.strictEqual(m[2], 'test-helpers.R');
-        assert.strictEqual(m[3], '12');
-        assert.strictEqual(m[4], '3');
-        assert.strictEqual(m[5], 'process_data handles NAs');
-    });
+        assert.ok(m, `expected match for: ${JSON.stringify(sample)}`);
+        const pattern = singlePattern(getTestthatMatcher());
+        assert.strictEqual(m[pattern.file!], expected.file, 'file capture');
+        assert.strictEqual(m[pattern.line!], expected.line, 'line capture');
+        assert.strictEqual(m[pattern.column!], expected.column, 'column capture');
+        assert.strictEqual(m[pattern.message!], expected.message, 'message capture');
+    }
 
-    test('matches an error header', () => {
-        const sample = '── Error (test-foo.R:50:1): boots when fed an empty frame ──';
-        const m = sample.match(regex());
-        assert.ok(m, 'error header must match');
-        assert.strictEqual(m[1], 'Error');
-        assert.strictEqual(m[2], 'test-foo.R');
-        assert.strictEqual(m[3], '50');
-        assert.strictEqual(m[4], '1');
-        assert.strictEqual(m[5], 'boots when fed an empty frame');
-    });
-
-    test('matches a header without an explicit column', () => {
-        const sample = '── Failure (test-foo.R:12): something ──';
-        const m = sample.match(regex());
-        assert.ok(m, 'header without column must still match');
-        assert.strictEqual(m[2], 'test-foo.R');
-        assert.strictEqual(m[3], '12');
-        assert.strictEqual(m[4], undefined, 'column should be unset when omitted');
-        assert.strictEqual(m[5], 'something');
-    });
-
-    test('matches an ASCII fallback header', () => {
-        const sample = '-- Failure (test-foo.R:1:1): plain ASCII fallback --';
-        const m = sample.match(regex());
-        assert.ok(m, 'ASCII fallback (-- ... --) must match');
-        assert.strictEqual(m[2], 'test-foo.R');
-        assert.strictEqual(m[5], 'plain ASCII fallback');
-    });
-
-    test('matches a header with extra leading dashes/spaces', () => {
-        const sample = '────── Failure (test-foo.R:9:1): wide rule ──────';
-        const m = sample.match(regex());
-        assert.ok(m, 'longer dash rules must still match');
-        assert.strictEqual(m[2], 'test-foo.R');
-        assert.strictEqual(m[5], 'wide rule');
-    });
-
-    test('matches a path containing dots and dashes', () => {
-        const sample = '── Failure (test-foo.bar.baz-2.R:3:7): odd-name ──';
-        const m = sample.match(regex());
-        assert.ok(m, 'paths with dots and dashes must match');
-        assert.strictEqual(m[2], 'test-foo.bar.baz-2.R');
-    });
-
-    test('rejects a header missing the leading rule', () => {
-        const sample = 'Failure (test-foo.R:12:3): without dashes';
-        assert.strictEqual(
-            sample.match(regex()),
-            null,
-            'header without leading dashes should not match the matcher',
-        );
-    });
-
-    test('rejects unrelated output', () => {
-        const samples = [
-            '',
-            '> devtools::test()',
-            '[ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]',
-            'Expected: 1',
-            'Backtrace:',
-        ];
-        for (const sample of samples) {
-            assert.strictEqual(
-                sample.match(regex()),
-                null,
-                `non-failure line should not match: ${JSON.stringify(sample)}`,
+    suite('ProgressReporter (default for devtools::test / testthat::test_dir)', () => {
+        test('failure header captures file, line, column, test name', () => {
+            expectMatch(
+                "Failure ('test-sample.R:2:3'): expect_equal mismatch",
+                {
+                    file: 'test-sample.R',
+                    line: '2',
+                    column: '3',
+                    message: 'expect_equal mismatch',
+                },
             );
-        }
+        });
+
+        test('error header captures file, line, column, test name', () => {
+            expectMatch(
+                "Error ('test-sample.R:6:3'): error inside test",
+                {
+                    file: 'test-sample.R',
+                    line: '6',
+                    column: '3',
+                    message: 'error inside test',
+                },
+            );
+        });
+
+        test('captures a verbose test name', () => {
+            expectMatch(
+                "Failure ('test-sample.R:10:3'): multi-line description that should be captured",
+                {
+                    file: 'test-sample.R',
+                    line: '10',
+                    column: '3',
+                    message: 'multi-line description that should be captured',
+                },
+            );
+        });
     });
 
-    test('does not match testthat skip headers (skips are not problems)', () => {
-        const sample = '── Skipped (test-foo.R:7:3): not on CI ──';
-        assert.strictEqual(
-            sample.match(regex()),
-            null,
-            'Skip headers should not produce diagnostics',
-        );
+    suite('CompactProgressReporter', () => {
+        test('failure header with surrounding box rule', () => {
+            expectMatch(
+                "── Failure ('test-sample.R:2:3'): expect_equal mismatch ────────────────────────",
+                {
+                    file: 'test-sample.R',
+                    line: '2',
+                    column: '3',
+                    message: 'expect_equal mismatch',
+                },
+            );
+        });
+
+        test('error header with surrounding box rule', () => {
+            expectMatch(
+                "── Error ('test-sample.R:6:3'): error inside test ──────────────────────────────",
+                {
+                    file: 'test-sample.R',
+                    line: '6',
+                    column: '3',
+                    message: 'error inside test',
+                },
+            );
+        });
+
+        test('ASCII fallback rule (cli.unicode=FALSE)', () => {
+            expectMatch(
+                "-- Failure ('test-sample.R:2:3'): expect_equal mismatch ----",
+                {
+                    file: 'test-sample.R',
+                    line: '2',
+                    column: '3',
+                    message: 'expect_equal mismatch',
+                },
+            );
+        });
+    });
+
+    suite('LlmReporter (CLAUDECODE/AGENT env active)', () => {
+        test('FAILURE: header captures file, line, column (no test name)', () => {
+            expectMatch(
+                "FAILURE: 'test-sample.R:2:3' ----------------------",
+                {
+                    file: 'test-sample.R',
+                    line: '2',
+                    column: '3',
+                    message: undefined,
+                },
+            );
+        });
+
+        test('ERROR: header captures file, line, column (no test name)', () => {
+            expectMatch(
+                "ERROR: 'test-sample.R:6:3' ------------------------",
+                {
+                    file: 'test-sample.R',
+                    line: '6',
+                    column: '3',
+                    message: undefined,
+                },
+            );
+        });
+    });
+
+    suite('Edge cases', () => {
+        test('header without column (srcref missing column info)', () => {
+            expectMatch(
+                "Failure ('test-sample.R:2'): no column captured",
+                {
+                    file: 'test-sample.R',
+                    line: '2',
+                    column: undefined,
+                    message: 'no column captured',
+                },
+            );
+        });
+
+        test('file path with hyphens and dots', () => {
+            expectMatch(
+                "Failure ('test-foo.bar.baz-2.R:1:1'): odd-name",
+                {
+                    file: 'test-foo.bar.baz-2.R',
+                    line: '1',
+                    column: '1',
+                    message: 'odd-name',
+                },
+            );
+        });
+
+        test('test name containing ASCII dashes', () => {
+            expectMatch(
+                "── Failure ('test-foo.R:9:1'): name with -- inside ──",
+                {
+                    file: 'test-foo.R',
+                    line: '9',
+                    column: '1',
+                    message: 'name with -- inside',
+                },
+            );
+        });
+    });
+
+    suite('Negative cases', () => {
+        const negatives = [
+            '',
+            'Expected 1 to equal 2.',
+            'Differences:',
+            '[ FAIL 3 | WARN 0 | SKIP 0 | PASS 0 ]',
+            '────────────────────────────────────────────────────────────────────────────────',
+            '✖ | 3        0 | sample',
+            '> devtools::test()',
+            'Some random text',
+            "── Skip ('test-foo.R:7:3'): not on CI ──",
+            "── Skipped ('test-foo.R:7:3'): not on CI ──",
+            "WARNING: 'test-foo.R:1:1' ----",
+            // Old (pre-3.0) testthat shape — not supported; verifies we don't
+            // accidentally fall back to the prior over-broad matcher.
+            '── Failure (test-foo.R:12:3): unquoted location ──',
+        ];
+
+        for (const sample of negatives) {
+            test(`rejects: ${JSON.stringify(sample)}`, () => {
+                const m = sample.match(regex());
+                assert.strictEqual(m, null);
+            });
+        }
     });
 });

--- a/editors/vscode/src/test/problemMatchers.test.ts
+++ b/editors/vscode/src/test/problemMatchers.test.ts
@@ -1,0 +1,217 @@
+/// <reference types="mocha" />
+
+/**
+ * Structural tests for problem-matcher contributions in package.json.
+ *
+ * The $testthat matcher parses failure headers emitted by testthat's default
+ * progress reporter so VS Code can surface failing tests in the Problems panel
+ * with clickable file:line links.
+ *
+ * Tests are pure file/JSON assertions — they parse the regex out of
+ * package.json and exercise it against captured testthat output samples,
+ * which keeps the matcher honest without needing to spawn R or VS Code's
+ * task runner.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+declare const suite: Mocha.SuiteFunction;
+declare const test: Mocha.TestFunction;
+
+const vscodeRoot = path.resolve(__dirname, '..', '..');
+const packageJsonPath = path.join(vscodeRoot, 'package.json');
+
+interface ProblemPattern {
+    regexp: string;
+    file?: number;
+    line?: number;
+    column?: number;
+    severity?: number;
+    message?: number;
+    code?: number;
+    location?: number;
+    endLine?: number;
+    endColumn?: number;
+    loop?: boolean;
+}
+
+interface ProblemMatcherContribution {
+    name?: string;
+    label?: string;
+    owner?: string;
+    source?: string;
+    applyTo?: string;
+    fileLocation?: string | [string, string];
+    severity?: string;
+    pattern: ProblemPattern | ProblemPattern[];
+}
+
+function loadProblemMatchers(): ProblemMatcherContribution[] {
+    const raw = fs.readFileSync(packageJsonPath, 'utf8');
+    const pkg = JSON.parse(raw) as {
+        contributes?: { problemMatchers?: ProblemMatcherContribution[] };
+    };
+    return pkg.contributes?.problemMatchers ?? [];
+}
+
+function getTestthatMatcher(): ProblemMatcherContribution {
+    const matchers = loadProblemMatchers();
+    const matcher = matchers.find((m) => m.name === 'testthat');
+    assert.ok(matcher, 'package.json must declare a problemMatcher named "testthat"');
+    return matcher;
+}
+
+function singlePattern(matcher: ProblemMatcherContribution): ProblemPattern {
+    assert.ok(
+        !Array.isArray(matcher.pattern),
+        'testthat matcher should declare a single-line pattern',
+    );
+    return matcher.pattern as ProblemPattern;
+}
+
+suite('problem matcher contributions', () => {
+    test('declares a testthat matcher with the expected top-level shape', () => {
+        const matcher = getTestthatMatcher();
+
+        assert.strictEqual(
+            matcher.owner,
+            'raven-testthat',
+            'owner must be a stable identifier so diagnostics are scoped to this matcher',
+        );
+        assert.strictEqual(
+            matcher.source,
+            'testthat',
+            'source should label diagnostics with their tool of origin',
+        );
+        assert.strictEqual(matcher.severity, 'error');
+        assert.ok(
+            Array.isArray(matcher.fileLocation),
+            'fileLocation must be a tuple [mode, baseDir]',
+        );
+        const [mode, base] = matcher.fileLocation as [string, string];
+        assert.strictEqual(
+            mode,
+            'relative',
+            'testthat reports paths relative to tests/testthat',
+        );
+        assert.strictEqual(
+            base,
+            '${workspaceFolder}/tests/testthat',
+            'base directory must point at tests/testthat under the workspace folder',
+        );
+    });
+
+    test('pattern uses the documented capture-group indices', () => {
+        const pattern = singlePattern(getTestthatMatcher());
+        assert.strictEqual(pattern.file, 2);
+        assert.strictEqual(pattern.line, 3);
+        assert.strictEqual(pattern.column, 4);
+        assert.strictEqual(pattern.message, 5);
+    });
+
+    test('regex compiles as a JavaScript RegExp', () => {
+        const pattern = singlePattern(getTestthatMatcher());
+        assert.doesNotThrow(
+            () => new RegExp(pattern.regexp),
+            `pattern.regexp must be a valid JS RegExp: ${pattern.regexp}`,
+        );
+    });
+});
+
+suite('testthat regex captures', () => {
+    function regex(): RegExp {
+        return new RegExp(singlePattern(getTestthatMatcher()).regexp);
+    }
+
+    test('matches a standard testthat 3.x failure header', () => {
+        const sample = '── Failure (test-helpers.R:12:3): process_data handles NAs ──';
+        const m = sample.match(regex());
+        assert.ok(m, 'standard failure header must match');
+        assert.strictEqual(m[1], 'Failure');
+        assert.strictEqual(m[2], 'test-helpers.R');
+        assert.strictEqual(m[3], '12');
+        assert.strictEqual(m[4], '3');
+        assert.strictEqual(m[5], 'process_data handles NAs');
+    });
+
+    test('matches an error header', () => {
+        const sample = '── Error (test-foo.R:50:1): boots when fed an empty frame ──';
+        const m = sample.match(regex());
+        assert.ok(m, 'error header must match');
+        assert.strictEqual(m[1], 'Error');
+        assert.strictEqual(m[2], 'test-foo.R');
+        assert.strictEqual(m[3], '50');
+        assert.strictEqual(m[4], '1');
+        assert.strictEqual(m[5], 'boots when fed an empty frame');
+    });
+
+    test('matches a header without an explicit column', () => {
+        const sample = '── Failure (test-foo.R:12): something ──';
+        const m = sample.match(regex());
+        assert.ok(m, 'header without column must still match');
+        assert.strictEqual(m[2], 'test-foo.R');
+        assert.strictEqual(m[3], '12');
+        assert.strictEqual(m[4], undefined, 'column should be unset when omitted');
+        assert.strictEqual(m[5], 'something');
+    });
+
+    test('matches an ASCII fallback header', () => {
+        const sample = '-- Failure (test-foo.R:1:1): plain ASCII fallback --';
+        const m = sample.match(regex());
+        assert.ok(m, 'ASCII fallback (-- ... --) must match');
+        assert.strictEqual(m[2], 'test-foo.R');
+        assert.strictEqual(m[5], 'plain ASCII fallback');
+    });
+
+    test('matches a header with extra leading dashes/spaces', () => {
+        const sample = '────── Failure (test-foo.R:9:1): wide rule ──────';
+        const m = sample.match(regex());
+        assert.ok(m, 'longer dash rules must still match');
+        assert.strictEqual(m[2], 'test-foo.R');
+        assert.strictEqual(m[5], 'wide rule');
+    });
+
+    test('matches a path containing dots and dashes', () => {
+        const sample = '── Failure (test-foo.bar.baz-2.R:3:7): odd-name ──';
+        const m = sample.match(regex());
+        assert.ok(m, 'paths with dots and dashes must match');
+        assert.strictEqual(m[2], 'test-foo.bar.baz-2.R');
+    });
+
+    test('rejects a header missing the leading rule', () => {
+        const sample = 'Failure (test-foo.R:12:3): without dashes';
+        assert.strictEqual(
+            sample.match(regex()),
+            null,
+            'header without leading dashes should not match the matcher',
+        );
+    });
+
+    test('rejects unrelated output', () => {
+        const samples = [
+            '',
+            '> devtools::test()',
+            '[ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]',
+            'Expected: 1',
+            'Backtrace:',
+        ];
+        for (const sample of samples) {
+            assert.strictEqual(
+                sample.match(regex()),
+                null,
+                `non-failure line should not match: ${JSON.stringify(sample)}`,
+            );
+        }
+    });
+
+    test('does not match testthat skip headers (skips are not problems)', () => {
+        const sample = '── Skipped (test-foo.R:7:3): not on CI ──';
+        assert.strictEqual(
+            sample.match(regex()),
+            null,
+            'Skip headers should not produce diagnostics',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a `$testthat` problem matcher (`contributes.problemMatchers`) that parses testthat 3.x progress-reporter failure headers — both `── Failure (file:line:col): name ──` and `── Error (…) ──` — so failing tests appear in the **Problems** panel with clickable file:line links.
- Paths resolve relative to `${workspaceFolder}/tests/testthat`, matching the directory testthat uses as its working directory while a test runs.
- Documents the matcher in `docs/r-package-dev.md` with a copy-pasteable `tasks.json` recipe.

Closes #206.

## Implementation notes

- Single-line pattern: captures `Failure|Error`, file, line, optional column, and the test name as the diagnostic message. Severity is fixed to `error`.
- Handles ASCII (`-- … --`) and box-drawing (`── … ──`) variants of the rule.
- Skip headers (`── Skipped (…) ──`) intentionally do not match — they're not problems.
- The matcher uses `severity: "error"` for both Failure and Error, matching the spec in #206. Promoting `Warning` headers can be added later if needed.

## Test plan

- [x] `cd editors/vscode && bun run compile:test` — TypeScript compiles
- [x] `bun test` (repo root) — all 406 tests pass, including the new 12 regex/contribution tests in `editors/vscode/src/test/problemMatchers.test.ts`
- [ ] Manual smoke test: open an R package in VS Code, add the documented `tasks.json` snippet, run the task, deliberately break a test, confirm the failure appears in the Problems panel with the correct file:line link
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `testthat` problem matcher for VS Code that parses R test failures/errors and shows results in the Problems panel with clickable file:line links.

* **Documentation**
  * Added a guide showing how to configure and run the matcher from a VS Code task, including path resolution details.

* **Tests**
  * Added unit tests validating the matcher across multiple reporter formats and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/217)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->