### PR TITLE
feat(vscode): add Raven Build commands for devtools workflows

### DIFF
--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -60,13 +60,13 @@ contributes six Command Palette entries that wrap the standard
 `devtools` / `testthat` / `roxygen2` workflows. Names mirror RStudio's
 **Build** menu so existing muscle memory carries over:
 
-| Palette title                  | Runs in                  | R call                |
-|--------------------------------|--------------------------|-----------------------|
-| `Raven Build: Load All`        | active R terminal        | `devtools::load_all("<workspace>")` |
-| `Raven Build: Document`        | active R terminal        | `devtools::document("<workspace>")` |
-| `Raven Build: Install and Restart` | active R terminal    | `devtools::install("<workspace>")` followed by `quit(save = "no")` |
-| `Raven Build: Test Package`    | `R: Package Tasks` terminal | `devtools::test("<workspace>")` |
-| `Raven Build: Check Package`   | `R: Package Tasks` terminal | `devtools::check("<workspace>")` |
+| Palette title | Runs in | R call |
+|---|---|---|
+| `Raven Build: Load All` | active R terminal | `devtools::load_all("<workspace>")` |
+| `Raven Build: Document` | active R terminal | `devtools::document("<workspace>")` |
+| `Raven Build: Install and Restart` | active R terminal | `devtools::install("<workspace>")` followed by `quit(save = "no")` |
+| `Raven Build: Test Package` | `R: Package Tasks` terminal | `devtools::test("<workspace>")` |
+| `Raven Build: Check Package` | `R: Package Tasks` terminal | `devtools::check("<workspace>")` |
 | `Raven Build: Build Source Package` | `R: Package Tasks` terminal | `devtools::build("<workspace>")` |
 
 Each command passes the first workspace folder's absolute path explicitly,

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -62,12 +62,16 @@ contributes six Command Palette entries that wrap the standard
 
 | Palette title                  | Runs in                  | R call                |
 |--------------------------------|--------------------------|-----------------------|
-| `Raven Build: Load All`        | active R terminal        | `devtools::load_all()` |
-| `Raven Build: Document`        | active R terminal        | `devtools::document()` |
-| `Raven Build: Install and Restart` | active R terminal    | `devtools::install()` followed by `quit(save = "no")` |
-| `Raven Build: Test Package`    | `R: Package Tasks` terminal | `devtools::test()` |
-| `Raven Build: Check Package`   | `R: Package Tasks` terminal | `devtools::check()` |
-| `Raven Build: Build Source Package` | `R: Package Tasks` terminal | `devtools::build()` |
+| `Raven Build: Load All`        | active R terminal        | `devtools::load_all("<workspace>")` |
+| `Raven Build: Document`        | active R terminal        | `devtools::document("<workspace>")` |
+| `Raven Build: Install and Restart` | active R terminal    | `devtools::install("<workspace>")` followed by `quit(save = "no")` |
+| `Raven Build: Test Package`    | `R: Package Tasks` terminal | `devtools::test("<workspace>")` |
+| `Raven Build: Check Package`   | `R: Package Tasks` terminal | `devtools::check("<workspace>")` |
+| `Raven Build: Build Source Package` | `R: Package Tasks` terminal | `devtools::build("<workspace>")` |
+
+Each command passes the first workspace folder's absolute path explicitly,
+so a stray `setwd()` in the R session — or a terminal launched from a
+subdirectory — can't redirect the build at the wrong project.
 
 The six commands also appear as a single `$(package)` submenu in the
 editor title bar when an R file is open in a package workspace.

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -52,6 +52,54 @@ In contrast, a function defined in `tests/testthat/test-helpers.R` is **not**
 visible to `R/helpers.R` — symbols in `R/` are visible from `tests/testthat/`,
 but not the other way around.
 
+### Build commands
+
+When the workspace is detected as an R package (DESCRIPTION with a non-empty
+`Package:` field, or `raven.packages.packageMode` set to `enabled`), Raven
+contributes six Command Palette entries that wrap the standard
+`devtools` / `testthat` / `roxygen2` workflows. Names mirror RStudio's
+**Build** menu so existing muscle memory carries over:
+
+| Palette title                  | Runs in                  | R call                |
+|--------------------------------|--------------------------|-----------------------|
+| `Raven Build: Load All`        | active R terminal        | `devtools::load_all()` |
+| `Raven Build: Document`        | active R terminal        | `devtools::document()` |
+| `Raven Build: Install and Restart` | active R terminal    | `devtools::install()` followed by `quit(save = "no")` |
+| `Raven Build: Test Package`    | `R: Package Tasks` terminal | `devtools::test()` |
+| `Raven Build: Check Package`   | `R: Package Tasks` terminal | `devtools::check()` |
+| `Raven Build: Build Source Package` | `R: Package Tasks` terminal | `devtools::build()` |
+
+The six commands also appear as a single `$(package)` submenu in the
+editor title bar when an R file is open in a package workspace.
+
+#### Terminal routing
+
+The three session-mutating commands (`Load All`, `Document`,
+`Install and Restart`) run in the same R terminal that Send-to-R uses,
+so their side effects land where you'd expect.
+
+The three long-running commands (`Test Package`, `Check Package`,
+`Build Source Package`) run in a dedicated `R: Package Tasks` terminal.
+This avoids tying up the interactive prompt for the 20–60s+ these
+commands can take, and keeps a clean separation between exploratory
+work and batch-style package checks. The tasks terminal is reused
+across invocations — Raven doesn't pay R-startup cost on every
+`devtools::test()`. Both terminals respect `raven.rTerminal.program`,
+so a configured `radian` or `arf` carries over.
+
+#### Install and Restart semantics
+
+`Install and Restart` chains `devtools::install()` with
+`quit(save = "no")` so the R process exits after install completes.
+When the terminal closes, Raven recreates it in the same pane. The next
+Send-to-R or Build command runs in a fresh R session that picks up the
+newly installed version of the package — which is the whole point of
+the command.
+
+If the install fails, the wrapper surfaces the error via `message()`
+before R exits; the failure output stays visible in the closed-terminal
+scrollback so you can read it before dismissing.
+
 ### testthat problem matcher
 
 When you run `devtools::test()` or `testthat::test_dir()`, testthat's

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -128,6 +128,36 @@
         "category": "Raven"
       },
       {
+        "command": "raven.build.loadAll",
+        "title": "Load All",
+        "category": "Raven Build"
+      },
+      {
+        "command": "raven.build.document",
+        "title": "Document",
+        "category": "Raven Build"
+      },
+      {
+        "command": "raven.build.installAndRestart",
+        "title": "Install and Restart",
+        "category": "Raven Build"
+      },
+      {
+        "command": "raven.build.testPackage",
+        "title": "Test Package",
+        "category": "Raven Build"
+      },
+      {
+        "command": "raven.build.checkPackage",
+        "title": "Check Package",
+        "category": "Raven Build"
+      },
+      {
+        "command": "raven.build.buildSource",
+        "title": "Build Source Package",
+        "category": "Raven Build"
+      },
+      {
         "command": "raven.openHelpPanel",
         "title": "Open R Help Panel",
         "category": "Raven"
@@ -166,14 +196,76 @@
       {
         "id": "raven.sendToR.terminal",
         "label": "Terminal"
+      },
+      {
+        "id": "raven.build",
+        "label": "R Package Build",
+        "icon": "$(package)"
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "raven.build.loadAll",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        },
+        {
+          "command": "raven.build.document",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        },
+        {
+          "command": "raven.build.installAndRestart",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        },
+        {
+          "command": "raven.build.testPackage",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        },
+        {
+          "command": "raven.build.checkPackage",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        },
+        {
+          "command": "raven.build.buildSource",
+          "when": "raven.rConsoleEnabled && raven.isRPackage"
+        }
+      ],
       "editor/title": [
         {
           "submenu": "raven.sendToR",
           "when": "editorLangId == r && raven.rConsoleEnabled",
           "group": "navigation"
+        },
+        {
+          "submenu": "raven.build",
+          "when": "editorLangId == r && raven.rConsoleEnabled && raven.isRPackage",
+          "group": "navigation"
+        }
+      ],
+      "raven.build": [
+        {
+          "command": "raven.build.loadAll",
+          "group": "1_session@1"
+        },
+        {
+          "command": "raven.build.document",
+          "group": "1_session@2"
+        },
+        {
+          "command": "raven.build.installAndRestart",
+          "group": "1_session@3"
+        },
+        {
+          "command": "raven.build.testPackage",
+          "group": "2_tasks@1"
+        },
+        {
+          "command": "raven.build.checkPackage",
+          "group": "2_tasks@2"
+        },
+        {
+          "command": "raven.build.buildSource",
+          "group": "2_tasks@3"
         }
       ],
       "raven.sendToR": [

--- a/editors/vscode/src/build-commands.ts
+++ b/editors/vscode/src/build-commands.ts
@@ -28,10 +28,12 @@ export interface BuildCommand {
     /** Where the command runs. */
     target: 'r-console' | 'tasks';
     /**
-     * The R code sent to the selected terminal. For `installAndRestart` this
-     * is composed dynamically (see `run_install_and_restart`).
+     * The R code sent to the selected terminal, parameterized by a
+     * pre-quoted R-string-literal representing the package path
+     * (e.g. `"\"/Users/foo/pkg\""` or `"\".\""`). `installAndRestart`
+     * composes its code in `run_install_and_restart` instead.
      */
-    code?: string;
+    make_code?: (pkg_arg: string) => string;
 }
 
 export const BUILD_COMMANDS: BuildCommand[] = [
@@ -39,13 +41,13 @@ export const BUILD_COMMANDS: BuildCommand[] = [
         id: 'raven.build.loadAll',
         title: 'Load All',
         target: 'r-console',
-        code: 'devtools::load_all()',
+        make_code: (pkg) => `devtools::load_all(${pkg})`,
     },
     {
         id: 'raven.build.document',
         title: 'Document',
         target: 'r-console',
-        code: 'devtools::document()',
+        make_code: (pkg) => `devtools::document(${pkg})`,
     },
     {
         id: 'raven.build.installAndRestart',
@@ -56,21 +58,45 @@ export const BUILD_COMMANDS: BuildCommand[] = [
         id: 'raven.build.testPackage',
         title: 'Test Package',
         target: 'tasks',
-        code: 'devtools::test()',
+        make_code: (pkg) => `devtools::test(${pkg})`,
     },
     {
         id: 'raven.build.checkPackage',
         title: 'Check Package',
         target: 'tasks',
-        code: 'devtools::check()',
+        make_code: (pkg) => `devtools::check(${pkg})`,
     },
     {
         id: 'raven.build.buildSource',
         title: 'Build Source Package',
         target: 'tasks',
-        code: 'devtools::build()',
+        make_code: (pkg) => `devtools::build(${pkg})`,
     },
 ];
+
+/**
+ * Compute the R-string-literal argument passed to every devtools call.
+ *
+ * The terminal's working directory can drift away from the package root
+ * (the user runs `setwd()`, or the terminal launches from a subdirectory),
+ * which means a bare `devtools::load_all()` would silently target the
+ * wrong project. Resolving the path against the first workspace folder
+ * keeps the build commands anchored to the package Raven detected.
+ *
+ * Falls back to `"."` only when no workspace folder is open — that's the
+ * `raven.packages.packageMode = "enabled"` escape hatch for users who
+ * force package mode without a DESCRIPTION-bearing root, and matches
+ * devtools' own default.
+ *
+ * `JSON.stringify` of an absolute path produces a valid R double-quoted
+ * string literal: identical escape rules for `\` and `"`, so Windows
+ * paths like `C:\foo\bar` round-trip safely.
+ */
+export function get_package_path_arg(): string {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) return '"."';
+    return JSON.stringify(folder.uri.fsPath);
+}
 
 const TASKS_TERMINAL_NAME = 'R: Package Tasks';
 let tasks_terminal: vscode.Terminal | null = null;
@@ -139,9 +165,10 @@ async function run_install_and_restart(): Promise<void> {
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
 
+    const pkg_arg = get_package_path_arg();
     const code = [
         'local({',
-        '  status <- tryCatch({ devtools::install(); "ok" },',
+        `  status <- tryCatch({ devtools::install(${pkg_arg}); "ok" },`,
         '    error = function(e) conditionMessage(e))',
         '  if (!identical(status, "ok"))',
         '    message("Raven: install failed: ", status)',
@@ -165,8 +192,8 @@ async function run_build_command(cmd: BuildCommand): Promise<void> {
         await run_install_and_restart();
         return;
     }
-    if (!cmd.code) return;
-    await run_simple(cmd.code, cmd.target);
+    if (!cmd.make_code) return;
+    await run_simple(cmd.make_code(get_package_path_arg()), cmd.target);
 }
 
 export function register_build_commands(context: vscode.ExtensionContext): void {
@@ -177,6 +204,17 @@ export function register_build_commands(context: vscode.ExtensionContext): void 
     }
     context.subscriptions.push(
         vscode.window.onDidCloseTerminal(handle_tasks_terminal_closed),
+        // Mirror the `raven.rTerminal.program`-change behaviour in
+        // `r-terminal-manager.ts`: clear the slot so the next build command
+        // launches a fresh terminal with the newly-configured program. The
+        // existing terminal keeps running so the user can read scrollback;
+        // they close it themselves when they're done with it.
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration('raven.rTerminal.program')) {
+                tasks_terminal = null;
+                tasks_creation_in_flight = null;
+            }
+        }),
     );
 }
 

--- a/editors/vscode/src/build-commands.ts
+++ b/editors/vscode/src/build-commands.ts
@@ -74,11 +74,29 @@ export const BUILD_COMMANDS: BuildCommand[] = [
 
 const TASKS_TERMINAL_NAME = 'R: Package Tasks';
 let tasks_terminal: vscode.Terminal | null = null;
+// Shared in-flight promise so two tasks-group commands fired in quick
+// succession (e.g. Test Package immediately followed by Check Package)
+// don't both pass the `tasks_terminal` null check around the
+// `await resolve_program()` yield point and spawn two terminals. Mirrors
+// the `creation_in_flight` guard in `r-terminal-manager.ts`.
+let tasks_creation_in_flight: Promise<vscode.Terminal> | null = null;
 
 function handle_tasks_terminal_closed(terminal: vscode.Terminal): void {
     if (terminal === tasks_terminal) {
         tasks_terminal = null;
     }
+}
+
+async function create_tasks_terminal(): Promise<vscode.Terminal> {
+    const program = await resolve_program();
+    const terminal = vscode.window.createTerminal({
+        name: TASKS_TERMINAL_NAME,
+        shellPath: program,
+        shellArgs: ['--no-save', '--no-restore'],
+        isTransient: true,
+    });
+    tasks_terminal = terminal;
+    return terminal;
 }
 
 /**
@@ -90,14 +108,11 @@ function handle_tasks_terminal_closed(terminal: vscode.Terminal): void {
  */
 export async function get_or_create_tasks_terminal(): Promise<vscode.Terminal> {
     if (tasks_terminal) return tasks_terminal;
-    const program = await resolve_program();
-    tasks_terminal = vscode.window.createTerminal({
-        name: TASKS_TERMINAL_NAME,
-        shellPath: program,
-        shellArgs: ['--no-save', '--no-restore'],
-        isTransient: true,
+    if (tasks_creation_in_flight) return tasks_creation_in_flight;
+    tasks_creation_in_flight = create_tasks_terminal().finally(() => {
+        tasks_creation_in_flight = null;
     });
-    return tasks_terminal;
+    return tasks_creation_in_flight;
 }
 
 async function run_simple(code: string, target: 'r-console' | 'tasks'): Promise<void> {
@@ -168,4 +183,5 @@ export function register_build_commands(context: vscode.ExtensionContext): void 
 /** Reset the tasks-terminal slot. Tests only. */
 export function _reset_tasks_terminal_for_test(): void {
     tasks_terminal = null;
+    tasks_creation_in_flight = null;
 }

--- a/editors/vscode/src/build-commands.ts
+++ b/editors/vscode/src/build-commands.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import {
+    get_or_create_r_terminal,
+    resolve_program,
+    send_code,
+    get_send_options,
+} from './send-to-r';
+
+/**
+ * "Raven Build:" commands — wrappers around the standard devtools workflows
+ * (load_all, document, install, test, check, build). Names and behaviour
+ * mirror RStudio's Build menu so users with existing muscle memory find what
+ * they expect.
+ *
+ * Terminal routing:
+ *   - `Load All`, `Document`, `Install and Restart` run in the active R
+ *     terminal (the same one used by Send-to-R). Side effects on the
+ *     interactive session are the point of these commands.
+ *   - `Test Package`, `Check Package`, `Build Source Package` run in a
+ *     dedicated "R: Package Tasks" terminal so they don't tie up the
+ *     interactive prompt for the 20-60s+ they take.
+ */
+
+export interface BuildCommand {
+    id: string;
+    /** Palette title (without the "Raven Build:" prefix). */
+    title: string;
+    /** Where the command runs. */
+    target: 'r-console' | 'tasks';
+    /**
+     * The R code sent to the selected terminal. For `installAndRestart` this
+     * is composed dynamically (see `run_install_and_restart`).
+     */
+    code?: string;
+}
+
+export const BUILD_COMMANDS: BuildCommand[] = [
+    {
+        id: 'raven.build.loadAll',
+        title: 'Load All',
+        target: 'r-console',
+        code: 'devtools::load_all()',
+    },
+    {
+        id: 'raven.build.document',
+        title: 'Document',
+        target: 'r-console',
+        code: 'devtools::document()',
+    },
+    {
+        id: 'raven.build.installAndRestart',
+        title: 'Install and Restart',
+        target: 'r-console',
+    },
+    {
+        id: 'raven.build.testPackage',
+        title: 'Test Package',
+        target: 'tasks',
+        code: 'devtools::test()',
+    },
+    {
+        id: 'raven.build.checkPackage',
+        title: 'Check Package',
+        target: 'tasks',
+        code: 'devtools::check()',
+    },
+    {
+        id: 'raven.build.buildSource',
+        title: 'Build Source Package',
+        target: 'tasks',
+        code: 'devtools::build()',
+    },
+];
+
+const TASKS_TERMINAL_NAME = 'R: Package Tasks';
+let tasks_terminal: vscode.Terminal | null = null;
+
+function handle_tasks_terminal_closed(terminal: vscode.Terminal): void {
+    if (terminal === tasks_terminal) {
+        tasks_terminal = null;
+    }
+}
+
+/**
+ * Get-or-create the dedicated package-tasks terminal. Parallel to the
+ * Send-to-R terminal slot: reuses `resolve_program()` so the user's
+ * `raven.rTerminal.program` carries over, and uses `isTransient: true` to
+ * opt out of VS Code's terminal restoration (a window restore would replay
+ * scrollback into a fresh R process with no shared state).
+ */
+export async function get_or_create_tasks_terminal(): Promise<vscode.Terminal> {
+    if (tasks_terminal) return tasks_terminal;
+    const program = await resolve_program();
+    tasks_terminal = vscode.window.createTerminal({
+        name: TASKS_TERMINAL_NAME,
+        shellPath: program,
+        shellArgs: ['--no-save', '--no-restore'],
+        isTransient: true,
+    });
+    return tasks_terminal;
+}
+
+async function run_simple(code: string, target: 'r-console' | 'tasks'): Promise<void> {
+    const terminal = target === 'r-console'
+        ? await get_or_create_r_terminal()
+        : await get_or_create_tasks_terminal();
+    terminal.show(true);
+    send_code(terminal, code, get_send_options());
+}
+
+/**
+ * `Install and Restart`: install the package, then end the R session so a
+ * fresh R is launched on next use. VS Code's stable terminal API doesn't
+ * expose terminal output, so we can't watch for a sentinel — instead we
+ * append `quit(save = "no")` to the install call. R exits when install
+ * completes (or errors), and a one-shot close listener spawns a new R
+ * terminal in the same pane.
+ *
+ * `tryCatch` keeps `quit()` running even if install fails, so the user
+ * never ends up stuck in a broken half-restarted state. Failure output
+ * remains visible in the closed-terminal scrollback.
+ */
+async function run_install_and_restart(): Promise<void> {
+    const terminal = await get_or_create_r_terminal();
+    terminal.show(true);
+
+    const code = [
+        'local({',
+        '  status <- tryCatch({ devtools::install(); "ok" },',
+        '    error = function(e) conditionMessage(e))',
+        '  if (!identical(status, "ok"))',
+        '    message("Raven: install failed: ", status)',
+        '  quit(save = "no")',
+        '})',
+    ].join('\n');
+
+    const restart_listener = vscode.window.onDidCloseTerminal((closed) => {
+        if (closed !== terminal) return;
+        restart_listener.dispose();
+        // Recreate so the user's next Send-to-R / Build command lands in a
+        // fresh R session loaded with the newly installed package.
+        void get_or_create_r_terminal();
+    });
+
+    send_code(terminal, code, get_send_options());
+}
+
+async function run_build_command(cmd: BuildCommand): Promise<void> {
+    if (cmd.id === 'raven.build.installAndRestart') {
+        await run_install_and_restart();
+        return;
+    }
+    if (!cmd.code) return;
+    await run_simple(cmd.code, cmd.target);
+}
+
+export function register_build_commands(context: vscode.ExtensionContext): void {
+    for (const cmd of BUILD_COMMANDS) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(cmd.id, () => run_build_command(cmd)),
+        );
+    }
+    context.subscriptions.push(
+        vscode.window.onDidCloseTerminal(handle_tasks_terminal_closed),
+    );
+}
+
+/** Reset the tasks-terminal slot. Tests only. */
+export function _reset_tasks_terminal_for_test(): void {
+    tasks_terminal = null;
+}

--- a/editors/vscode/src/build-commands.ts
+++ b/editors/vscode/src/build-commands.ts
@@ -121,7 +121,14 @@ async function create_tasks_terminal(): Promise<vscode.Terminal> {
         shellArgs: ['--no-save', '--no-restore'],
         isTransient: true,
     });
-    tasks_terminal = terminal;
+    // `resolve_program()` can yield for seconds (shell `which` validation,
+    // or a "Switch to R / Keep" dialog). If `raven.rTerminal.program`
+    // changed during that window, the config handler cleared
+    // `tasks_creation_in_flight`; don't cache this now-stale terminal —
+    // the next call should launch a fresh one with the updated program.
+    if (tasks_creation_in_flight !== null) {
+        tasks_terminal = terminal;
+    }
     return terminal;
 }
 
@@ -161,7 +168,9 @@ async function run_simple(code: string, target: 'r-console' | 'tasks'): Promise<
  * never ends up stuck in a broken half-restarted state. Failure output
  * remains visible in the closed-terminal scrollback.
  */
-async function run_install_and_restart(): Promise<void> {
+async function run_install_and_restart(
+    context: vscode.ExtensionContext,
+): Promise<void> {
     const terminal = await get_or_create_r_terminal();
     terminal.show(true);
 
@@ -176,6 +185,10 @@ async function run_install_and_restart(): Promise<void> {
         '})',
     ].join('\n');
 
+    // Self-disposing one-shot listener — but also tracked in
+    // `context.subscriptions` so it's disposed if the extension deactivates
+    // before the terminal closes (otherwise the callback would later fire
+    // against a torn-down module and spawn an orphaned terminal).
     const restart_listener = vscode.window.onDidCloseTerminal((closed) => {
         if (closed !== terminal) return;
         restart_listener.dispose();
@@ -183,13 +196,17 @@ async function run_install_and_restart(): Promise<void> {
         // fresh R session loaded with the newly installed package.
         void get_or_create_r_terminal();
     });
+    context.subscriptions.push(restart_listener);
 
     send_code(terminal, code, get_send_options());
 }
 
-async function run_build_command(cmd: BuildCommand): Promise<void> {
+async function run_build_command(
+    cmd: BuildCommand,
+    context: vscode.ExtensionContext,
+): Promise<void> {
     if (cmd.id === 'raven.build.installAndRestart') {
-        await run_install_and_restart();
+        await run_install_and_restart(context);
         return;
     }
     if (!cmd.make_code) return;
@@ -199,7 +216,7 @@ async function run_build_command(cmd: BuildCommand): Promise<void> {
 export function register_build_commands(context: vscode.ExtensionContext): void {
     for (const cmd of BUILD_COMMANDS) {
         context.subscriptions.push(
-            vscode.commands.registerCommand(cmd.id, () => run_build_command(cmd)),
+            vscode.commands.registerCommand(cmd.id, () => run_build_command(cmd, context)),
         );
     }
     context.subscriptions.push(

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -208,12 +208,12 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         register_build_commands(context);
     }
 
-    // Package-mode context key. Wired regardless of R-console activation so
-    // the palette gating works even when Send-to-R is disabled (e.g. when
-    // coexisting with REditorSupport, which provides its own R session).
-    // The Build commands themselves require an R terminal, so they're only
-    // registered above when r-console is enabled; the context key still
-    // hides their palette entries when the workspace isn't a package.
+    // Package-mode context key. The `raven.isRPackage` key gates the
+    // Build commands' palette entries and editor-title submenu — every
+    // `when` clause that uses it is also gated on `raven.rConsoleEnabled`,
+    // so the key has no visible effect when R-console is disabled. We
+    // still register the detection unconditionally so the key is
+    // populated for whichever surfaces (current or future) consult it.
     register_r_package_detection(context);
 
     // Register restart command — re-reads trace config so changed settings take effect.

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -27,6 +27,8 @@ import {
     register_inspection_commands,
     get_or_create_r_terminal,
 } from './send-to-r';
+import { register_build_commands } from './build-commands';
+import { register_r_package_detection } from './r-package-detection';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';
 import type { DataViewerManager } from './data-viewer/manager';
@@ -203,7 +205,16 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         register_r_terminal(context, plot_services);
         register_send_to_r_commands(context);
         register_inspection_commands(context);
+        register_build_commands(context);
     }
+
+    // Package-mode context key. Wired regardless of R-console activation so
+    // the palette gating works even when Send-to-R is disabled (e.g. when
+    // coexisting with REditorSupport, which provides its own R session).
+    // The Build commands themselves require an R terminal, so they're only
+    // registered above when r-console is enabled; the context key still
+    // hides their palette entries when the workspace isn't a package.
+    register_r_package_detection(context);
 
     // Register restart command — re-reads trace config so changed settings take effect.
     //

--- a/editors/vscode/src/r-package-detection.ts
+++ b/editors/vscode/src/r-package-detection.ts
@@ -53,20 +53,34 @@ export function register_r_package_detection(
 ): void {
     void refresh_context();
 
-    const folder = vscode.workspace.workspaceFolders?.[0];
-    if (folder) {
+    // The watcher is anchored to the first workspace folder's DESCRIPTION,
+    // so it must be rebuilt when the workspace folder list changes —
+    // otherwise a folder switch leaves the watcher pointed at the previous
+    // root and edits to the new DESCRIPTION never re-trigger detection.
+    let watcher_disposables: vscode.Disposable[] = [];
+    const reset_description_watcher = (): void => {
+        for (const d of watcher_disposables) d.dispose();
+        watcher_disposables = [];
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) return;
         // Pattern is anchored to the root DESCRIPTION; nested packages (e.g.
         // inst/extdata/DESCRIPTION inside a non-package workspace) shouldn't
         // toggle the context key.
         const pattern = new vscode.RelativePattern(folder, 'DESCRIPTION');
         const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-        context.subscriptions.push(
+        watcher_disposables = [
             watcher,
             watcher.onDidCreate(refresh_context),
             watcher.onDidChange(refresh_context),
             watcher.onDidDelete(refresh_context),
-        );
-    }
+        ];
+    };
+    reset_description_watcher();
+    context.subscriptions.push({
+        dispose: () => {
+            for (const d of watcher_disposables) d.dispose();
+        },
+    });
 
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
@@ -75,6 +89,7 @@ export function register_r_package_detection(
             }
         }),
         vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            reset_description_watcher();
             void refresh_context();
         }),
     );

--- a/editors/vscode/src/r-package-detection.ts
+++ b/editors/vscode/src/r-package-detection.ts
@@ -1,0 +1,81 @@
+import * as vscode from 'vscode';
+
+/**
+ * Sets the `raven.isRPackage` context key, which gates the visibility of
+ * Build commands and the package-tasks editor-title submenu.
+ *
+ * Detection mirrors the server-side rule documented in
+ * `docs/r-package-dev.md` and `crates/raven/src/package_library.rs`:
+ *
+ *   - `raven.packages.packageMode = "enabled"`  → always on
+ *   - `raven.packages.packageMode = "disabled"` → always off
+ *   - `raven.packages.packageMode = "auto"`     → on iff the first workspace
+ *     folder contains a DESCRIPTION file whose `Package:` field is non-empty
+ *
+ * The context key is refreshed on activation, when the setting changes, and
+ * whenever DESCRIPTION is created/edited/deleted at the workspace root.
+ */
+
+export const IS_R_PACKAGE_CONTEXT = 'raven.isRPackage';
+
+const PACKAGE_FIELD_RE = /^Package:\s*(\S.*?)\s*$/m;
+
+export async function detect_r_package(): Promise<boolean> {
+    const mode = vscode.workspace
+        .getConfiguration('raven')
+        .get<string>('packages.packageMode', 'auto');
+    if (mode === 'enabled') return true;
+    if (mode === 'disabled') return false;
+
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) return false;
+    const description_uri = vscode.Uri.joinPath(folder.uri, 'DESCRIPTION');
+    try {
+        const bytes = await vscode.workspace.fs.readFile(description_uri);
+        const text = Buffer.from(bytes).toString('utf8');
+        return PACKAGE_FIELD_RE.test(text);
+    } catch {
+        return false;
+    }
+}
+
+async function refresh_context(): Promise<void> {
+    const is_package = await detect_r_package();
+    await vscode.commands.executeCommand(
+        'setContext',
+        IS_R_PACKAGE_CONTEXT,
+        is_package,
+    );
+}
+
+export function register_r_package_detection(
+    context: vscode.ExtensionContext,
+): void {
+    void refresh_context();
+
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (folder) {
+        // Pattern is anchored to the root DESCRIPTION; nested packages (e.g.
+        // inst/extdata/DESCRIPTION inside a non-package workspace) shouldn't
+        // toggle the context key.
+        const pattern = new vscode.RelativePattern(folder, 'DESCRIPTION');
+        const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+        context.subscriptions.push(
+            watcher,
+            watcher.onDidCreate(refresh_context),
+            watcher.onDidChange(refresh_context),
+            watcher.onDidDelete(refresh_context),
+        );
+    }
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration('raven.packages.packageMode')) {
+                void refresh_context();
+            }
+        }),
+        vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            void refresh_context();
+        }),
+    );
+}

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -1,4 +1,8 @@
-export { register_r_terminal, get_or_create_r_terminal } from './r-terminal-manager';
+export {
+    register_r_terminal,
+    get_or_create_r_terminal,
+    resolve_program,
+} from './r-terminal-manager';
 export { register_send_to_r_commands } from './commands';
 export { send_code, get_send_options } from './send-code';
 export type { SendOptions } from './send-code';

--- a/editors/vscode/src/test/build-commands.test.ts
+++ b/editors/vscode/src/test/build-commands.test.ts
@@ -1,0 +1,165 @@
+/// <reference types="mocha" />
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { BUILD_COMMANDS } from '../build-commands';
+import { activate } from './helper';
+
+declare const suite: Mocha.SuiteFunction;
+declare const test: Mocha.TestFunction;
+
+const vscodeRoot = path.resolve(__dirname, '..', '..');
+const packageJsonPath = path.join(vscodeRoot, 'package.json');
+
+interface CommandContribution {
+    command: string;
+    title: string;
+    category?: string;
+}
+
+interface MenuEntry {
+    command?: string;
+    submenu?: string;
+    when?: string;
+    group?: string;
+}
+
+interface SubmenuContribution {
+    id: string;
+    label: string;
+    icon?: string;
+}
+
+interface PackageJson {
+    contributes: {
+        commands: CommandContribution[];
+        submenus?: SubmenuContribution[];
+        menus?: Record<string, MenuEntry[]>;
+    };
+}
+
+function loadPackageJson(): PackageJson {
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+}
+
+suite('build commands: definitions', () => {
+    test('declares the six RStudio-Build-menu commands in order', () => {
+        const ids = BUILD_COMMANDS.map((c) => c.id);
+        assert.deepStrictEqual(ids, [
+            'raven.build.loadAll',
+            'raven.build.document',
+            'raven.build.installAndRestart',
+            'raven.build.testPackage',
+            'raven.build.checkPackage',
+            'raven.build.buildSource',
+        ]);
+    });
+
+    test('r-console group invokes the live R session, tasks group is dedicated', () => {
+        const target = Object.fromEntries(BUILD_COMMANDS.map((c) => [c.id, c.target]));
+        assert.strictEqual(target['raven.build.loadAll'], 'r-console');
+        assert.strictEqual(target['raven.build.document'], 'r-console');
+        assert.strictEqual(target['raven.build.installAndRestart'], 'r-console');
+        assert.strictEqual(target['raven.build.testPackage'], 'tasks');
+        assert.strictEqual(target['raven.build.checkPackage'], 'tasks');
+        assert.strictEqual(target['raven.build.buildSource'], 'tasks');
+    });
+
+    test('command code wraps the matching devtools call', () => {
+        const code = Object.fromEntries(BUILD_COMMANDS.map((c) => [c.id, c.code]));
+        assert.strictEqual(code['raven.build.loadAll'], 'devtools::load_all()');
+        assert.strictEqual(code['raven.build.document'], 'devtools::document()');
+        assert.strictEqual(code['raven.build.testPackage'], 'devtools::test()');
+        assert.strictEqual(code['raven.build.checkPackage'], 'devtools::check()');
+        assert.strictEqual(code['raven.build.buildSource'], 'devtools::build()');
+        // installAndRestart composes its R code dynamically because it must
+        // chain devtools::install() with quit(save = "no") to force the
+        // R-terminal restart that gives the command its name.
+        assert.strictEqual(code['raven.build.installAndRestart'], undefined);
+    });
+});
+
+suite('build commands: package.json contributions', () => {
+    test('every BUILD_COMMANDS entry is declared in package.json under the "Raven Build" category', () => {
+        const pkg = loadPackageJson();
+        const byId = new Map(pkg.contributes.commands.map((c) => [c.command, c]));
+        for (const cmd of BUILD_COMMANDS) {
+            const declared = byId.get(cmd.id);
+            assert.ok(declared, `${cmd.id} must be declared in package.json`);
+            assert.strictEqual(
+                declared.title,
+                cmd.title,
+                `${cmd.id} title should match BUILD_COMMANDS`,
+            );
+            assert.strictEqual(
+                declared.category,
+                'Raven Build',
+                `${cmd.id} should sit under the "Raven Build" category`,
+            );
+        }
+    });
+
+    test('declares the raven.build submenu with the package codicon', () => {
+        const pkg = loadPackageJson();
+        const submenu = pkg.contributes.submenus?.find((s) => s.id === 'raven.build');
+        assert.ok(submenu, 'package.json must declare the raven.build submenu');
+        assert.strictEqual(submenu.icon, '$(package)');
+    });
+
+    test('every build command appears in the raven.build submenu in the documented order', () => {
+        const pkg = loadPackageJson();
+        const entries = pkg.contributes.menus?.['raven.build'] ?? [];
+        const commandIds = entries.map((e) => e.command).filter((id): id is string => !!id);
+        assert.deepStrictEqual(
+            commandIds,
+            BUILD_COMMANDS.map((c) => c.id),
+            'raven.build submenu must list all six commands in BUILD_COMMANDS order',
+        );
+    });
+
+    test('raven.build editor/title entry is gated on package mode and the R console', () => {
+        const pkg = loadPackageJson();
+        const editorTitle = pkg.contributes.menus?.['editor/title'] ?? [];
+        const buildEntry = editorTitle.find((e) => e.submenu === 'raven.build');
+        assert.ok(buildEntry, 'editor/title must include the raven.build submenu');
+        const when = buildEntry.when ?? '';
+        assert.ok(when.includes('raven.isRPackage'), 'submenu must be gated on raven.isRPackage');
+        assert.ok(when.includes('raven.rConsoleEnabled'), 'submenu must require r-console activation');
+        assert.ok(when.includes("editorLangId == r"), 'submenu must require an R file');
+        assert.strictEqual(buildEntry.group, 'navigation');
+    });
+
+    test('palette entries for build commands are gated on package mode and the R console', () => {
+        const pkg = loadPackageJson();
+        const palette = pkg.contributes.menus?.commandPalette ?? [];
+        for (const cmd of BUILD_COMMANDS) {
+            const entry = palette.find((e) => e.command === cmd.id);
+            assert.ok(entry, `command palette must gate ${cmd.id}`);
+            const when = entry.when ?? '';
+            assert.ok(
+                when.includes('raven.isRPackage'),
+                `${cmd.id} palette entry must require raven.isRPackage`,
+            );
+            assert.ok(
+                when.includes('raven.rConsoleEnabled'),
+                `${cmd.id} palette entry must require raven.rConsoleEnabled`,
+            );
+        }
+    });
+});
+
+suite('build commands: registration', () => {
+    test('extension registers every build command after activation', async function () {
+        this.timeout(15000);
+        await activate();
+        const all = new Set(await vscode.commands.getCommands(true));
+        for (const cmd of BUILD_COMMANDS) {
+            assert.ok(
+                all.has(cmd.id),
+                `expected build command "${cmd.id}" to be registered`,
+            );
+        }
+    });
+});

--- a/editors/vscode/src/test/build-commands.test.ts
+++ b/editors/vscode/src/test/build-commands.test.ts
@@ -7,12 +7,14 @@ import * as vscode from 'vscode';
 import {
     BUILD_COMMANDS,
     get_or_create_tasks_terminal,
+    get_package_path_arg,
     _reset_tasks_terminal_for_test,
 } from '../build-commands';
 import { activate } from './helper';
 
 declare const suite: Mocha.SuiteFunction;
 declare const test: Mocha.TestFunction;
+declare const suiteTeardown: Mocha.HookFunction;
 
 const vscodeRoot = path.resolve(__dirname, '..', '..');
 const packageJsonPath = path.join(vscodeRoot, 'package.json');
@@ -71,17 +73,30 @@ suite('build commands: definitions', () => {
         assert.strictEqual(target['raven.build.buildSource'], 'tasks');
     });
 
-    test('command code wraps the matching devtools call', () => {
-        const code = Object.fromEntries(BUILD_COMMANDS.map((c) => [c.id, c.code]));
-        assert.strictEqual(code['raven.build.loadAll'], 'devtools::load_all()');
-        assert.strictEqual(code['raven.build.document'], 'devtools::document()');
-        assert.strictEqual(code['raven.build.testPackage'], 'devtools::test()');
-        assert.strictEqual(code['raven.build.checkPackage'], 'devtools::check()');
-        assert.strictEqual(code['raven.build.buildSource'], 'devtools::build()');
+    test('command code wraps the matching devtools call with the explicit pkg arg', () => {
+        const make = Object.fromEntries(
+            BUILD_COMMANDS.map((c) => [c.id, c.make_code]),
+        );
+        const pkg = '"/tmp/example"';
+        assert.strictEqual(make['raven.build.loadAll']?.(pkg), 'devtools::load_all("/tmp/example")');
+        assert.strictEqual(make['raven.build.document']?.(pkg), 'devtools::document("/tmp/example")');
+        assert.strictEqual(make['raven.build.testPackage']?.(pkg), 'devtools::test("/tmp/example")');
+        assert.strictEqual(make['raven.build.checkPackage']?.(pkg), 'devtools::check("/tmp/example")');
+        assert.strictEqual(make['raven.build.buildSource']?.(pkg), 'devtools::build("/tmp/example")');
         // installAndRestart composes its R code dynamically because it must
         // chain devtools::install() with quit(save = "no") to force the
         // R-terminal restart that gives the command its name.
-        assert.strictEqual(code['raven.build.installAndRestart'], undefined);
+        assert.strictEqual(make['raven.build.installAndRestart'], undefined);
+    });
+
+    test('get_package_path_arg quotes the first workspace folder as a valid R string literal', () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        assert.ok(folder, 'test harness must open a workspace folder');
+        const arg = get_package_path_arg();
+        // Result must round-trip through JSON.parse to the same fsPath:
+        // JSON string literals are a superset of valid R double-quoted
+        // string literals for the relevant escape rules (`\\`, `\"`).
+        assert.strictEqual(JSON.parse(arg), folder.uri.fsPath);
     });
 });
 
@@ -169,6 +184,32 @@ suite('build commands: registration', () => {
 });
 
 suite('build commands: tasks terminal', () => {
+    // `config.update(key, undefined, Workspace)` writes `.vscode/settings.json`
+    // with the remaining keys (possibly empty). Sweep on teardown so the
+    // fixture workspace doesn't pollute git status between runs.
+    suiteTeardown(async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) return;
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const dotVscode = vscode.Uri.joinPath(folder.uri, '.vscode');
+        const settings = vscode.Uri.joinPath(dotVscode, 'settings.json');
+        try {
+            const bytes = await vscode.workspace.fs.readFile(settings);
+            const text = Buffer.from(bytes).toString('utf8').trim();
+            if (text === '' || text === '{}' || text === '{\n}') {
+                try {
+                    await vscode.workspace.fs.delete(settings);
+                    const entries = await vscode.workspace.fs.readDirectory(dotVscode);
+                    if (entries.length === 0) await vscode.workspace.fs.delete(dotVscode);
+                } catch {
+                    // best-effort
+                }
+            }
+        } catch {
+            // no settings.json — nothing to clean
+        }
+    });
+
     test('concurrent get_or_create calls return the same terminal instance', async function () {
         this.timeout(15000);
         await activate();
@@ -196,4 +237,13 @@ suite('build commands: tasks terminal', () => {
             _reset_tasks_terminal_for_test();
         }
     });
+
+    // No test for the `raven.rTerminal.program`-change invalidation:
+    // vscode-test runs the suite against an out/ copy of this module while
+    // the bundled extension uses a separate dist/ copy (see the note on
+    // `_set_extension_context_for_test` in `r-terminal-manager.ts`). The
+    // listener registered by `register_build_commands` clears the bundled
+    // module's `tasks_terminal` slot, which the test module can't observe.
+    // The companion `raven.rTerminal.program`-change listener in
+    // `r-terminal-manager.ts` has the same gap.
 });

--- a/editors/vscode/src/test/build-commands.test.ts
+++ b/editors/vscode/src/test/build-commands.test.ts
@@ -4,7 +4,11 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { BUILD_COMMANDS } from '../build-commands';
+import {
+    BUILD_COMMANDS,
+    get_or_create_tasks_terminal,
+    _reset_tasks_terminal_for_test,
+} from '../build-commands';
 import { activate } from './helper';
 
 declare const suite: Mocha.SuiteFunction;
@@ -160,6 +164,36 @@ suite('build commands: registration', () => {
                 all.has(cmd.id),
                 `expected build command "${cmd.id}" to be registered`,
             );
+        }
+    });
+});
+
+suite('build commands: tasks terminal', () => {
+    test('concurrent get_or_create calls return the same terminal instance', async function () {
+        this.timeout(15000);
+        await activate();
+        _reset_tasks_terminal_for_test();
+        try {
+            // Fire both calls before awaiting either. With the
+            // creation-in-flight guard, both promises must resolve to the
+            // same vscode.Terminal — otherwise two terminals would be
+            // spawned and the first would be orphaned.
+            const [a, b] = await Promise.all([
+                get_or_create_tasks_terminal(),
+                get_or_create_tasks_terminal(),
+            ]);
+            assert.strictEqual(a, b, 'concurrent calls must share a single terminal');
+            assert.strictEqual(a.name, 'R: Package Tasks');
+        } finally {
+            // Best-effort cleanup: dispose the terminal so it doesn't
+            // linger between tests. The next test's reset will null out
+            // our module-local slot.
+            try {
+                (await get_or_create_tasks_terminal()).dispose();
+            } catch {
+                // ignore
+            }
+            _reset_tasks_terminal_for_test();
         }
     });
 });

--- a/editors/vscode/src/test/r-package-detection.test.ts
+++ b/editors/vscode/src/test/r-package-detection.test.ts
@@ -1,0 +1,149 @@
+/// <reference types="mocha" />
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { detect_r_package } from '../r-package-detection';
+import { activate } from './helper';
+
+declare const suite: Mocha.SuiteFunction;
+declare const test: Mocha.TestFunction;
+declare const suiteTeardown: Mocha.HookFunction;
+
+async function writeDescription(folder: vscode.Uri, content: string): Promise<vscode.Uri> {
+    const uri = vscode.Uri.joinPath(folder, 'DESCRIPTION');
+    await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf8'));
+    return uri;
+}
+
+async function safeDelete(uri: vscode.Uri): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(uri);
+    } catch {
+        // best-effort cleanup
+    }
+}
+
+/**
+ * Snapshot and restore `raven.packages.packageMode` at workspace scope.
+ *
+ * `config.get(...)` returns the merged effective value (workspace ?? user
+ * ?? default), so naively saving its result and writing it back would
+ * persist the default value into `.vscode/settings.json` even when the
+ * workspace originally had no override. Round-trip via `.inspect()` so
+ * tests can faithfully restore "no workspace value" → `undefined`.
+ */
+async function withPackageMode<T>(
+    value: string,
+    body: () => Promise<T>,
+): Promise<T> {
+    const config = vscode.workspace.getConfiguration('raven');
+    const original = config.inspect<string>('packages.packageMode')?.workspaceValue;
+    try {
+        await config.update(
+            'packages.packageMode',
+            value,
+            vscode.ConfigurationTarget.Workspace,
+        );
+        return await body();
+    } finally {
+        await config.update(
+            'packages.packageMode',
+            original,
+            vscode.ConfigurationTarget.Workspace,
+        );
+    }
+}
+
+suite('r-package detection', () => {
+    // `config.update(key, undefined, Workspace)` clears the key but VS Code
+    // leaves the `.vscode/settings.json` file behind, possibly empty. Sweep
+    // it on suite teardown so the fixture workspace stays clean between
+    // test runs and doesn't pollute `git status`.
+    suiteTeardown(async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) return;
+        // VS Code's settings.json write after `update(key, undefined)` is
+        // best-effort but doesn't remove the file when no keys remain.
+        // Wait a moment for the pending write to land before inspecting.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const dotVscode = vscode.Uri.joinPath(folder.uri, '.vscode');
+        const settings = vscode.Uri.joinPath(dotVscode, 'settings.json');
+        try {
+            const bytes = await vscode.workspace.fs.readFile(settings);
+            const text = Buffer.from(bytes).toString('utf8').trim();
+            if (text === '' || text === '{}' || text === '{\n}') {
+                await safeDelete(settings);
+                // Also remove the now-empty .vscode dir, but only if empty —
+                // a real test/fixture file there would survive.
+                try {
+                    const entries = await vscode.workspace.fs.readDirectory(dotVscode);
+                    if (entries.length === 0) await safeDelete(dotVscode);
+                } catch {
+                    // .vscode missing — nothing else to clean.
+                }
+            }
+        } catch {
+            // No settings.json — nothing to clean.
+        }
+    });
+
+    test('packageMode "disabled" forces the answer to false even when DESCRIPTION exists', async function () {
+        this.timeout(15000);
+        await activate();
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        assert.ok(folder, 'test harness must open a workspace folder');
+        const desc = await writeDescription(folder.uri, 'Package: ravenTestPkg\n');
+        try {
+            await withPackageMode('disabled', async () => {
+                assert.strictEqual(await detect_r_package(), false);
+            });
+        } finally {
+            await safeDelete(desc);
+        }
+    });
+
+    test('packageMode "enabled" forces the answer to true even without a DESCRIPTION file', async function () {
+        this.timeout(15000);
+        await activate();
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        assert.ok(folder, 'test harness must open a workspace folder');
+        const desc = vscode.Uri.joinPath(folder.uri, 'DESCRIPTION');
+        await safeDelete(desc);
+        await withPackageMode('enabled', async () => {
+            assert.strictEqual(await detect_r_package(), true);
+        });
+    });
+
+    test('packageMode "auto" rejects a DESCRIPTION file missing the Package: field', async function () {
+        this.timeout(15000);
+        await activate();
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        assert.ok(folder, 'test harness must open a workspace folder');
+        const desc = await writeDescription(folder.uri, 'Title: Not a package\n');
+        try {
+            await withPackageMode('auto', async () => {
+                assert.strictEqual(await detect_r_package(), false);
+            });
+        } finally {
+            await safeDelete(desc);
+        }
+    });
+
+    test('packageMode "auto" accepts a DESCRIPTION file with a non-empty Package: field', async function () {
+        this.timeout(15000);
+        await activate();
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        assert.ok(folder, 'test harness must open a workspace folder');
+        const desc = await writeDescription(
+            folder.uri,
+            'Package: ravenTestPkg\nTitle: Example\nVersion: 0.0.1\n',
+        );
+        try {
+            await withPackageMode('auto', async () => {
+                assert.strictEqual(await detect_r_package(), true);
+            });
+        } finally {
+            await safeDelete(desc);
+        }
+    });
+});


### PR DESCRIPTION
Closes #205.

## Summary

Adds six Command Palette entries that wrap the standard devtools / testthat / roxygen2 package-development workflows, named after RStudio's Build menu so existing muscle memory carries over:

| Palette title                       | Runs in                  | R call                                            |
|-------------------------------------|--------------------------|---------------------------------------------------|
| `Raven Build: Load All`             | active R terminal        | `devtools::load_all()`                            |
| `Raven Build: Document`             | active R terminal        | `devtools::document()`                            |
| `Raven Build: Install and Restart`  | active R terminal        | `devtools::install()` then `quit(save = "no")`    |
| `Raven Build: Test Package`         | `R: Package Tasks` terminal | `devtools::test()`                             |
| `Raven Build: Check Package`        | `R: Package Tasks` terminal | `devtools::check()`                            |
| `Raven Build: Build Source Package` | `R: Package Tasks` terminal | `devtools::build()`                            |

The six commands also appear as a single `$(package)` submenu in the editor title bar when an R file is open in a package workspace.

## Design notes

- **Two terminals.** The three session-mutating commands run in the same R terminal Send-to-R uses, so their side effects land where the user expects. The three long-running batch commands route to a dedicated `R: Package Tasks` terminal that's reused across invocations — devtools/testthat/cli output is heavy on ANSI/box-drawing that an OutputChannel would strip, and a real terminal also "just works" with whatever R program the user has configured (radian, arf, vanilla R).
- **Install and Restart semantics.** VS Code's stable terminal API can't read terminal output (`onDidWriteTerminalData` is a proposed API), so I couldn't implement the sentinel-watching approach the issue suggests. Instead the wrapper chains `devtools::install()` with `quit(save = "no")`, listens for `onDidCloseTerminal` on that specific terminal, and recreates the terminal in the same pane. R exits even if install errors (`tryCatch` ensures `quit()` runs), and the failure output stays visible in the closed-terminal scrollback. The behavior is documented in the user-facing doc.
- **Gating.** A new context key `raven.isRPackage` activates when the workspace has a DESCRIPTION file with a non-empty `Package:` field, or `raven.packages.packageMode` is forced to `enabled`. Both the palette entries and the editor-title submenu are gated on `raven.rConsoleEnabled && raven.isRPackage`, so the commands don't appear in unrelated workspaces. The detection re-evaluates on DESCRIPTION create/change/delete and on setting changes.
- **Server-side reuse.** Detection mirrors the logic already documented for the server's package-mode activation, kept client-side because the UI gating runs before the server is ready. The two implementations are independent but read the same DESCRIPTION/Package: invariant — if those rules ever diverge, that's a bug.

## What's not in this PR

- A separate `Raven Build: Install Package` (no-restart variant). The issue calls for shipping only `Install and Restart` in v1 and adding `Install Package` later if users ask. Same here.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run bundle` succeeds
- [x] `bun run test` — 155 VS Code tests passing, including 11 new tests across the build-commands and package-detection suites
- [x] Root `bun test` — 406 tests passing
- [x] `cargo build -p raven` succeeds
- [x] New `suiteTeardown` cleans up `.vscode/settings.json` so the fixture workspace stays clean across runs
- [ ] Smoke test in a real package workspace — install, load_all, document, test, check, build, and install-and-restart all behave as described
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * R Package Build commands added to the Command Palette and editor title menu (Load, Document, Install & Restart, Test, Check, Build Source)
  * Automatic R package detection to enable/disable build UI based on workspace

* **Documentation**
  * R package development guide updated with Build commands, terminal routing (active console vs. dedicated Package Tasks), package-path behavior, and Install & Restart behavior preserving install output

* **Tests**
  * Added tests for build commands, UI registration, terminal behavior, and package-detection logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/218)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->