### PR TITLE
feat(linting): native style/lint diagnostics (#211)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Maintainer/internal:
 Code (authoritative for behavior):
 - Cross-file: `crates/raven/src/cross_file/` — see module docs in `scope.rs`, `revalidation.rs`, `dependency.rs` for `ScopeEvent`, `ScopeStream`, `ParentPrefixCache`, `compute_interface_hash`, `compute_affected_dependents_after_edit`, etc.
 - Indentation: `crates/raven/src/indentation/`
+- Linting (style/lint diagnostics): `crates/raven/src/linting/` — opt-in lintr-equivalent rules in Rust, gated by `state.lint_config`. Honors `# nolint` / `# nolint start/end` and `# @lsp-ignore` / `# @lsp-ignore-next`.
 - Packages: `crates/raven/src/package_library.rs`, `crates/raven/src/r_subprocess.rs`
 - Diagnostic collectors: `crates/raven/src/handlers.rs` — `is_structural_non_reference` predicate is the single source of truth for "structural identifier; not a reference".
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Go-to-definition](docs/go-to-definition.md)** — Jump to definitions across file boundaries
 - **[Find references](docs/find-references.md)** — Locate all usages of a symbol across your project
 - **[Hover](docs/hover.md)** — Symbol info including source file and package origin
-- **[Diagnostics](docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages
+- **[Diagnostics](docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages, plus opt-in style/lint rules (line length, trailing whitespace, tabs, assignment operator)
 - **[Document outline](docs/document-outline.md)** — Hierarchical view with sections, classes, and nested functions
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3736,12 +3736,13 @@ impl LanguageServer for Backend {
             // for the filesystem watcher). Diagnostic content is unaffected,
             // so don't force every open document to revalidate.
             //
-            // Future-proof: compare the entire config with watch fields
-            // reverted so any new diagnostic-affecting field is automatically
-            // covered without maintaining a manual exclusion list.
-            // Lint config affects diagnostic output, so a lint-config change
-            // must trigger a republish even if the watcher-only optimization
-            // would otherwise skip it.
+            // Coverage is automatic for every field on `CrossFileConfig`: we
+            // compare the entire struct with the watch fields reverted, so
+            // any new diagnostic-affecting field added to `CrossFileConfig`
+            // is picked up without touching this site. Config structs that
+            // live OUTSIDE `CrossFileConfig` (e.g. `LintConfig`) still need
+            // an explicit `*_changed` guard below — extend the chain when
+            // adding another such struct.
             let lint_config_changed = new_lint_config
                 .as_ref()
                 .map(|c| c != &state.lint_config)

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -463,7 +463,11 @@ pub(crate) fn parse_lint_config(
         config.enabled = v;
     }
     if let Some(v) = linting.get("lineLength").and_then(|v| v.as_u64()) {
-        config.line_length = (v as u32).clamp(20, 10_000);
+        // Clamp on u64 first; casting to u32 before clamping would wrap values
+        // above u32::MAX (e.g. u32::MAX + 5 becomes 4) into a small value and
+        // then clamp to the floor of 20 — silently bogus. The clamp ceiling
+        // is well below u32::MAX so the post-clamp cast is lossless.
+        config.line_length = v.clamp(20, 10_000) as u32;
     }
     if let Some(op) = linting.get("assignmentOperator").and_then(|v| v.as_str()) {
         config.assignment_operator_style = match op {
@@ -3735,7 +3739,16 @@ impl LanguageServer for Backend {
             // Future-proof: compare the entire config with watch fields
             // reverted so any new diagnostic-affecting field is automatically
             // covered without maintaining a manual exclusion list.
+            // Lint config affects diagnostic output, so a lint-config change
+            // must trigger a republish even if the watcher-only optimization
+            // would otherwise skip it.
+            let lint_config_changed = new_lint_config
+                .as_ref()
+                .map(|c| c != &state.lint_config)
+                .unwrap_or(false);
+
             let only_watch_changed = watch_settings_changed
+                && !lint_config_changed
                 && new_config
                     .as_ref()
                     .map(|c| {
@@ -7352,6 +7365,18 @@ mod tests {
             assert_eq!(cfg.line_length, 20);
 
             let settings = json!({ "linting": { "lineLength": 999_999 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.line_length, 10_000);
+        }
+
+        #[test]
+        fn parse_lint_config_clamps_before_u32_truncation() {
+            // Regression: casting `u64 as u32` before clamping wraps values
+            // above u32::MAX into a small number (u32::MAX + 5 -> 4), which
+            // then clamps to the floor of 20 instead of the ceiling of
+            // 10_000.
+            let oversized = (u32::MAX as u64) + 5;
+            let settings = json!({ "linting": { "lineLength": oversized } });
             let cfg = crate::backend::parse_lint_config(&settings).unwrap();
             assert_eq!(cfg.line_length, 10_000);
         }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -431,6 +431,96 @@ pub(crate) fn parse_cross_file_config(
     Ok(Some(config))
 }
 
+/// Parse linting configuration from LSP settings.
+///
+/// Reads the `linting` section and constructs a [`LintConfig`]. Returns
+/// `None` when the section is absent so callers can fall back to defaults
+/// without losing the "section never seen" signal.
+///
+/// Recognised keys:
+/// * `enabled` (bool) — master switch.
+/// * `lineLength` (number) — max line length; clamped to `[20, 10_000]`.
+/// * `assignmentOperator` (`"<-"` or `"="`) — preferred operator.
+/// * Per-rule severities (string, `"error" | "warning" | "information" |
+///   "hint" | "off"`):
+///   - `lineLengthSeverity`
+///   - `trailingWhitespaceSeverity`
+///   - `noTabSeverity`
+///   - `trailingBlankLinesSeverity`
+///   - `assignmentOperatorSeverity`
+pub(crate) fn parse_lint_config(
+    settings: &serde_json::Value,
+) -> Option<crate::linting::LintConfig> {
+    let linting = settings.get("linting")?;
+    if !linting.is_object() {
+        log::warn!("linting settings must be an object; ignoring.");
+        return None;
+    }
+
+    let mut config = crate::linting::LintConfig::default();
+
+    if let Some(v) = linting.get("enabled").and_then(|v| v.as_bool()) {
+        config.enabled = v;
+    }
+    if let Some(v) = linting.get("lineLength").and_then(|v| v.as_u64()) {
+        config.line_length = (v as u32).clamp(20, 10_000);
+    }
+    if let Some(op) = linting.get("assignmentOperator").and_then(|v| v.as_str()) {
+        config.assignment_operator_style = match op {
+            "=" => crate::linting::AssignmentOperatorStyle::Equals,
+            "<-" => crate::linting::AssignmentOperatorStyle::LeftArrow,
+            other => {
+                log::warn!(
+                    "Unrecognised linting.assignmentOperator '{other}', defaulting to '<-'."
+                );
+                crate::linting::AssignmentOperatorStyle::LeftArrow
+            }
+        };
+    }
+    if let Some(sev) = linting.get("lineLengthSeverity").and_then(|v| v.as_str()) {
+        config.line_length_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("trailingWhitespaceSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.trailing_whitespace_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting.get("noTabSeverity").and_then(|v| v.as_str()) {
+        config.no_tab_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("trailingBlankLinesSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.trailing_blank_lines_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("assignmentOperatorSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.assignment_operator_severity = parse_severity(sev);
+    }
+
+    log::info!("Linting configuration loaded from LSP settings:");
+    log::info!("  enabled: {}", config.enabled);
+    log::info!("  line_length: {}", config.line_length);
+    log::info!(
+        "  assignment_operator_style: {:?}",
+        config.assignment_operator_style
+    );
+    log::info!(
+        "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?}",
+        config.line_length_severity,
+        config.trailing_whitespace_severity,
+        config.no_tab_severity,
+        config.trailing_blank_lines_severity,
+        config.assignment_operator_severity
+    );
+
+    Some(config)
+}
+
 /// Parse indentation configuration from LSP settings.
 ///
 /// Reads the `indentation` section from a serde_json::Value and constructs a
@@ -1506,6 +1596,11 @@ impl LanguageServer for Backend {
             // Parse indentation configuration
             if let Some(config) = parse_indentation_config(init_options) {
                 state.indentation_config = config;
+            }
+
+            // Parse linting configuration
+            if let Some(config) = parse_lint_config(init_options) {
+                state.lint_config = config;
             }
         }
 
@@ -3573,6 +3668,9 @@ impl LanguageServer for Backend {
         // Parse indentation configuration if provided
         let new_indentation_config = parse_indentation_config(&params.settings);
 
+        // Parse linting configuration if provided
+        let new_lint_config = parse_lint_config(&params.settings);
+
         let (
             open_uris,
             scope_changed,
@@ -3708,6 +3806,11 @@ impl LanguageServer for Backend {
             // Apply new indentation config if parsed
             if let Some(config) = new_indentation_config {
                 state.indentation_config = config;
+            }
+
+            // Apply new linting config if parsed
+            if let Some(config) = new_lint_config {
+                state.lint_config = config;
             }
 
             // Apply new completion config if parsed, tracking trigger change
@@ -7214,6 +7317,85 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(cfg.packages_watch_debounce_ms, 5000);
+        }
+    }
+
+    // ============================================================================
+    // LintConfig Parsing Tests
+    // ============================================================================
+    mod lint_config_parsing {
+        use serde_json::json;
+
+        #[test]
+        fn parse_lint_config_returns_none_when_section_absent() {
+            let settings = json!({});
+            assert!(crate::backend::parse_lint_config(&settings).is_none());
+        }
+
+        #[test]
+        fn parse_lint_config_reads_master_switch_and_line_length() {
+            let settings = json!({
+                "linting": {
+                    "enabled": true,
+                    "lineLength": 120
+                }
+            });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert!(cfg.enabled);
+            assert_eq!(cfg.line_length, 120);
+        }
+
+        #[test]
+        fn parse_lint_config_clamps_line_length() {
+            let settings = json!({ "linting": { "lineLength": 1 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.line_length, 20);
+
+            let settings = json!({ "linting": { "lineLength": 999_999 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.line_length, 10_000);
+        }
+
+        #[test]
+        fn parse_lint_config_reads_assignment_operator_styles() {
+            let settings = json!({ "linting": { "assignmentOperator": "=" } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(
+                cfg.assignment_operator_style,
+                crate::linting::AssignmentOperatorStyle::Equals
+            );
+
+            let settings = json!({ "linting": { "assignmentOperator": "<-" } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(
+                cfg.assignment_operator_style,
+                crate::linting::AssignmentOperatorStyle::LeftArrow
+            );
+        }
+
+        #[test]
+        fn parse_lint_config_severities_off_disables_each_rule() {
+            let settings = json!({
+                "linting": {
+                    "lineLengthSeverity": "off",
+                    "trailingWhitespaceSeverity": "off",
+                    "noTabSeverity": "off",
+                    "trailingBlankLinesSeverity": "off",
+                    "assignmentOperatorSeverity": "off"
+                }
+            });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.line_length_severity, None);
+            assert_eq!(cfg.trailing_whitespace_severity, None);
+            assert_eq!(cfg.no_tab_severity, None);
+            assert_eq!(cfg.trailing_blank_lines_severity, None);
+            assert_eq!(cfg.assignment_operator_severity, None);
+        }
+
+        #[test]
+        fn parse_lint_config_non_object_returns_none() {
+            let settings = json!({ "linting": 42 });
+            assert!(crate::backend::parse_lint_config(&settings).is_none());
         }
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -90,6 +90,7 @@ pub(crate) struct DiagnosticsSnapshot {
     // Cross-file state (pre-collected)
     pub directive_meta: crate::cross_file::CrossFileMetadata,
     pub cross_file_config: crate::cross_file::config::CrossFileConfig,
+    pub lint_config: crate::linting::LintConfig,
     /// Trimmed dependency subgraph for the queried URI's neighborhood.
     /// Stored as `Arc` so concurrent fan-out revalidations share allocation
     /// instead of each cloning the trimmed graph from the cache payload.
@@ -240,6 +241,7 @@ impl DiagnosticsSnapshot {
             text,
             directive_meta,
             cross_file_config: state.cross_file_config.clone(),
+            lint_config: state.lint_config.clone(),
             cross_file_graph: trimmed_graph,
             workspace_folders: state.workspace_folders.clone(),
             base_exports,
@@ -326,6 +328,14 @@ pub(crate) fn diagnostics_from_snapshot(
     // Fast collectors (no scope resolution needed)
     collect_syntax_errors(snapshot.tree.root_node(), &snapshot.text, &mut diagnostics);
     collect_else_newline_errors(snapshot.tree.root_node(), &snapshot.text, &mut diagnostics);
+
+    // Style/lint diagnostics. Native Rust rules driven by `lint_config`; no R
+    // subprocess. `run_lints` short-circuits when the master switch is off.
+    diagnostics.extend(crate::linting::run_lints(
+        &snapshot.text,
+        snapshot.tree.root_node(),
+        &snapshot.lint_config,
+    ));
 
     // Cycle detection (uses pre-computed result from full graph, not trimmed subgraph)
     if let Some(severity) = snapshot.cross_file_config.circular_dependency_severity {

--- a/crates/raven/src/lib.rs
+++ b/crates/raven/src/lib.rs
@@ -30,6 +30,7 @@ pub mod help;
 pub mod indentation;
 pub mod jags_builtins;
 pub mod libpath_watcher;
+pub mod linting;
 pub mod namespace_parser;
 pub mod package_library;
 pub mod package_namespace;

--- a/crates/raven/src/linting/config.rs
+++ b/crates/raven/src/linting/config.rs
@@ -1,0 +1,63 @@
+//! Configuration for the lint subsystem.
+//!
+//! Defaults follow `lintr`'s most common settings: 80-character lines, `<-` for
+//! assignment, all rules disabled by default at the master switch so the
+//! feature stays opt-in until it stabilizes (per upstream issue #211).
+
+use tower_lsp::lsp_types::DiagnosticSeverity;
+
+/// Preferred assignment operator. Mirrors `lintr::assignment_linter`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AssignmentOperatorStyle {
+    /// Require `<-` for assignment; flag top-level `=` assignments.
+    #[default]
+    LeftArrow,
+    /// Require `=` for assignment; flag top-level `<-` assignments.
+    Equals,
+}
+
+/// Lint configuration.
+///
+/// `enabled` is the master switch (default off). Each rule has its own
+/// `Option<DiagnosticSeverity>` so individual rules can also be disabled by
+/// setting their severity to "off". `line_length` controls the threshold used
+/// by the line-length rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LintConfig {
+    /// Master switch. When `false`, [`crate::linting::run_lints`] returns an
+    /// empty vector regardless of per-rule severities.
+    pub enabled: bool,
+    /// Maximum allowed line length, measured in UTF-16 code units to align
+    /// with how LSP positions are reported.
+    pub line_length: u32,
+    /// Preferred assignment operator style.
+    pub assignment_operator_style: AssignmentOperatorStyle,
+    /// Severity for the line-length rule. `None` disables the rule.
+    pub line_length_severity: Option<DiagnosticSeverity>,
+    /// Severity for the trailing-whitespace rule. `None` disables the rule.
+    pub trailing_whitespace_severity: Option<DiagnosticSeverity>,
+    /// Severity for the no-tab rule. `None` disables the rule.
+    pub no_tab_severity: Option<DiagnosticSeverity>,
+    /// Severity for the trailing-blank-lines rule. `None` disables the rule.
+    pub trailing_blank_lines_severity: Option<DiagnosticSeverity>,
+    /// Severity for the assignment-operator rule. `None` disables the rule.
+    pub assignment_operator_severity: Option<DiagnosticSeverity>,
+}
+
+impl Default for LintConfig {
+    fn default() -> Self {
+        Self {
+            // Conservative default: feature is opt-in until it stabilizes.
+            enabled: false,
+            line_length: 80,
+            assignment_operator_style: AssignmentOperatorStyle::default(),
+            // Default severities mirror lintr's "style" tier — surface as
+            // hints so they don't crowd the Problems pane.
+            line_length_severity: Some(DiagnosticSeverity::HINT),
+            trailing_whitespace_severity: Some(DiagnosticSeverity::HINT),
+            no_tab_severity: Some(DiagnosticSeverity::HINT),
+            trailing_blank_lines_severity: Some(DiagnosticSeverity::HINT),
+            assignment_operator_severity: Some(DiagnosticSeverity::HINT),
+        }
+    }
+}

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -7,7 +7,8 @@
 //! Scope:
 //! * `line_length` — flag lines wider than the configured maximum.
 //! * `trailing_whitespace` — trailing spaces/tabs at end of line.
-//! * `no_tab` — leading or interior tab characters.
+//! * `no_tab` — one diagnostic per line that contains a tab, anchored at
+//!   the first tab on that line.
 //! * `trailing_blank_lines` — blank lines at the very end of the file.
 //! * `assignment_operator` — enforce `<-` (or `=`) for top-level assignment.
 //!

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -1,0 +1,265 @@
+//! Native style/lint diagnostics.
+//!
+//! Implements a small set of `lintr`-equivalent rules natively against the
+//! tree-sitter AST and raw text. No R subprocess; rules run in microseconds on
+//! the already-parsed tree.
+//!
+//! Scope:
+//! * `line_length` — flag lines wider than the configured maximum.
+//! * `trailing_whitespace` — trailing spaces/tabs at end of line.
+//! * `no_tab` — leading or interior tab characters.
+//! * `trailing_blank_lines` — blank lines at the very end of the file.
+//! * `assignment_operator` — enforce `<-` (or `=`) for top-level assignment.
+//!
+//! Suppression follows lintr conventions: `# nolint` suppresses the line, and
+//! `# nolint start` / `# nolint end` brackets suppress a region.
+
+pub mod config;
+mod nolint;
+mod rules;
+
+use tower_lsp::lsp_types::Diagnostic;
+use tree_sitter::Node;
+
+pub use self::config::{AssignmentOperatorStyle, LintConfig};
+
+/// Source identifier set on every diagnostic produced by this module.
+///
+/// Lets clients (and tests) distinguish lint diagnostics from cross-file or
+/// syntax diagnostics, and gives the user a recognizable badge in the editor.
+pub const LINT_SOURCE: &str = "raven (lint)";
+
+/// Run all enabled lint rules against the given document.
+///
+/// `text` is the document text and `tree_root` is the tree-sitter root node.
+/// Returns an empty `Vec` when `config.enabled` is false; individual rules are
+/// gated by their per-rule severity inside [`LintConfig`].
+pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Diagnostic> {
+    if !config.enabled {
+        return Vec::new();
+    }
+
+    let suppressions = nolint::Suppressions::from_text(text);
+    let mut out = Vec::new();
+
+    if let Some(sev) = config.line_length_severity {
+        rules::line_length::collect(text, config.line_length, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.trailing_whitespace_severity {
+        rules::trailing_whitespace::collect(text, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.no_tab_severity {
+        rules::no_tab::collect(text, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.trailing_blank_lines_severity {
+        rules::trailing_blank_lines::collect(text, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.assignment_operator_severity {
+        rules::assignment_operator::collect(
+            text,
+            tree_root,
+            config.assignment_operator_style,
+            sev,
+            &suppressions,
+            &mut out,
+        );
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser_pool::with_parser;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+
+    fn enabled_config() -> LintConfig {
+        LintConfig {
+            enabled: true,
+            ..LintConfig::default()
+        }
+    }
+
+    fn lint(text: &str, config: &LintConfig) -> Vec<Diagnostic> {
+        let tree = with_parser(|p| p.parse(text, None)).expect("parse must succeed");
+        run_lints(text, tree.root_node(), config)
+    }
+
+    #[test]
+    fn master_switch_off_returns_empty() {
+        let mut config = enabled_config();
+        config.enabled = false;
+        let diags = lint("x  \n", &config);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn line_length_flags_only_overlong_lines() {
+        let config = LintConfig {
+            line_length: 10,
+            ..enabled_config()
+        };
+        let diags = lint("short\nthis line is much too long\nshort\n", &config);
+        let line_lints: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("characters long"))
+            .collect();
+        assert_eq!(line_lints.len(), 1);
+        assert_eq!(line_lints[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn trailing_whitespace_is_flagged() {
+        let config = LintConfig {
+            line_length_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("x <- 1   \n", &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("Trailing whitespace"));
+        assert_eq!(diags[0].range.start.character, 6);
+    }
+
+    #[test]
+    fn no_tab_flags_first_run_per_line() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("\t\tx <- 1\n", &config);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.character, 0);
+        assert_eq!(diags[0].range.end.character, 2);
+    }
+
+    #[test]
+    fn trailing_blank_lines_flag_multiple() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("x <- 1\n\n\n", &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("trailing blank"));
+    }
+
+    #[test]
+    fn missing_final_newline_is_flagged() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("x <- 1", &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("end with a newline"));
+    }
+
+    #[test]
+    fn assignment_operator_flags_top_level_equals_when_left_arrow_preferred() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("x = 1\n", &config);
+        let assign_lints: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("assignment"))
+            .collect();
+        assert_eq!(assign_lints.len(), 1);
+    }
+
+    #[test]
+    fn assignment_operator_ignores_named_arguments() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        // `n = 5` inside a call is a named argument, not assignment.
+        let diags = lint("rnorm(n = 5)\n", &config);
+        assert!(diags.is_empty(), "named-argument `=` must not be flagged");
+    }
+
+    #[test]
+    fn assignment_operator_equals_style_flags_left_arrow() {
+        let config = LintConfig {
+            assignment_operator_style: AssignmentOperatorStyle::Equals,
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        let diags = lint("x <- 1\n", &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("Use `=`"));
+    }
+
+    #[test]
+    fn nolint_line_suppresses_diagnostics_on_that_line() {
+        let config = LintConfig {
+            line_length: 10,
+            line_length_severity: Some(DiagnosticSeverity::HINT),
+            trailing_whitespace_severity: Some(DiagnosticSeverity::HINT),
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        // Overlong + trailing whitespace, but suppressed.
+        let diags = lint("this line is very long   # nolint\n", &config);
+        assert!(diags.is_empty(), "nolint comment must suppress lints");
+    }
+
+    #[test]
+    fn nolint_block_suppresses_a_range() {
+        let config = LintConfig {
+            line_length: 5,
+            line_length_severity: Some(DiagnosticSeverity::HINT),
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            ..enabled_config()
+        };
+        let src = "longline_outside\n# nolint start\nlongline_inside_a\nlongline_inside_b\n# nolint end\nlongline_after\n";
+        let diags = lint(src, &config);
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(lines.contains(&0));
+        assert!(!lines.contains(&2));
+        assert!(!lines.contains(&3));
+        assert!(lines.contains(&5));
+    }
+
+    #[test]
+    fn diagnostics_carry_lint_source() {
+        let config = LintConfig {
+            line_length: 5,
+            ..enabled_config()
+        };
+        let diags = lint("longline\n", &config);
+        assert!(!diags.is_empty());
+        for d in &diags {
+            assert_eq!(d.source.as_deref(), Some(LINT_SOURCE));
+        }
+    }
+}
+

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -11,8 +11,11 @@
 //! * `trailing_blank_lines` — blank lines at the very end of the file.
 //! * `assignment_operator` — enforce `<-` (or `=`) for top-level assignment.
 //!
-//! Suppression follows lintr conventions: `# nolint` suppresses the line, and
-//! `# nolint start` / `# nolint end` brackets suppress a region.
+//! Suppression supports both lintr and Raven conventions:
+//! * `# nolint` (with optional `: rule_a, rule_b` filter) suppresses the line.
+//! * `# nolint start` / `# nolint end` brackets a region.
+//! * `# @lsp-ignore` suppresses the line it appears on.
+//! * `# @lsp-ignore-next` suppresses the *following* source line.
 
 pub mod config;
 mod nolint;

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -202,6 +202,58 @@ mod tests {
     }
 
     #[test]
+    fn assignment_operator_flags_inside_function_body_passed_as_arg() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        // `y = x` inside the function body is a real assignment, not a named
+        // argument — even though it lives transitively under an arguments
+        // list. Regression: an earlier draft propagated a sticky
+        // `inside_call_args` flag through descendants and suppressed this.
+        let diags = lint("lapply(xs, function(x) { y = x; y })\n", &config);
+        assert_eq!(
+            diags.len(),
+            1,
+            "expected exactly one assignment-operator lint for `y = x`, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn assignment_operator_flags_inside_braced_block_passed_as_arg() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        // `{ y = 1 }` is a braced expression evaluated as the argument; the
+        // inner `y = 1` is a real assignment, not a named argument.
+        let diags = lint("f({ y = 1 })\n", &config);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn assignment_operator_flags_inside_if_body_passed_as_arg() {
+        let config = LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            ..enabled_config()
+        };
+        // `y = 1` is the body of an `if` used as an argument — a real
+        // assignment evaluated when the call runs.
+        let diags = lint("f(if (cond) y = 1)\n", &config);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
     fn assignment_operator_equals_style_flags_left_arrow() {
         let config = LintConfig {
             assignment_operator_style: AssignmentOperatorStyle::Equals,

--- a/crates/raven/src/linting/nolint.rs
+++ b/crates/raven/src/linting/nolint.rs
@@ -131,7 +131,7 @@ fn classify(after_hash: &str) -> Option<NolintMarker> {
         .trim_start_matches(|c: char| c == '#' || c.is_whitespace())
         .to_ascii_lowercase();
 
-    if let Some(rest) = trimmed.strip_prefix("nolint") {
+    if let Some(rest) = matches_keyword(&trimmed, "nolint") {
         let rest = rest.trim_start();
         return if rest.starts_with("start") {
             Some(NolintMarker::Start)
@@ -144,12 +144,12 @@ fn classify(after_hash: &str) -> Option<NolintMarker> {
         };
     }
 
-    if let Some(rest) = trimmed.strip_prefix("@lsp-ignore") {
-        // Match `-next`, `:next`, or bare `next` after the marker so all of
+    if let Some(rest) = matches_keyword(&trimmed, "@lsp-ignore") {
+        // Match `-next`, `:next`, or whitespace+`next` after the marker so
         // `@lsp-ignore-next`, `@lsp-ignore: next`, and `@lsp-ignore next`
-        // resolve to NextLine. Anything else is a same-line ignore.
-        let rest = rest
-            .trim_start_matches(|c: char| c == ':' || c == '-' || c.is_whitespace());
+        // all resolve to NextLine. Anything else on the same line is a
+        // same-line ignore.
+        let rest = rest.trim_start_matches(|c: char| c == ':' || c == '-' || c.is_whitespace());
         return if rest.starts_with("next") {
             Some(NolintMarker::NextLine)
         } else {
@@ -158,6 +158,29 @@ fn classify(after_hash: &str) -> Option<NolintMarker> {
     }
 
     None
+}
+
+/// Match `keyword` as a word in `haystack`: the keyword must appear as a
+/// prefix and the next character (if any) must be a non-identifier byte. This
+/// prevents `nolinter` or `@lsp-ignored` from matching `nolint` /
+/// `@lsp-ignore` — mirroring the strictness of the directive parser at
+/// `cross_file/directive.rs` for `# @lsp-ignore`.
+fn matches_keyword<'a>(haystack: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = haystack.strip_prefix(keyword)?;
+    match rest.as_bytes().first() {
+        // EOL, whitespace, colon, or `-` (used by `@lsp-ignore-next` and
+        // `# nolint:`). Anything else means we matched the middle of an
+        // unrelated word.
+        None => Some(rest),
+        Some(b) => {
+            let c = *b as char;
+            if c.is_whitespace() || c == ':' || c == '-' {
+                Some(rest)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -218,5 +241,19 @@ mod tests {
         assert!(!s.is_suppressed(0));
         assert!(s.is_suppressed(1));
         assert!(!s.is_suppressed(2));
+    }
+
+    #[test]
+    fn typo_lsp_ignored_does_not_suppress() {
+        // `@lsp-ignored` must not be parsed as `@lsp-ignore` — otherwise a
+        // typo silently swallows the lint instead of producing it.
+        let s = Suppressions::from_text("x = 1 # @lsp-ignored\n");
+        assert!(!s.is_suppressed(0));
+    }
+
+    #[test]
+    fn typo_nolinter_does_not_suppress() {
+        let s = Suppressions::from_text("x = 1 # nolinter\n");
+        assert!(!s.is_suppressed(0));
     }
 }

--- a/crates/raven/src/linting/nolint.rs
+++ b/crates/raven/src/linting/nolint.rs
@@ -1,0 +1,222 @@
+//! Lint suppression parsing.
+//!
+//! Recognised markers:
+//! * `# nolint` (or `# nolint: rule_a, rule_b`) — lintr-style line-level
+//!   suppression on the same source line.
+//! * `# nolint start` / `# nolint end` — lintr-style block suppression,
+//!   inclusive of the start and end lines.
+//! * `# @lsp-ignore` — Raven's own line marker; behaves like `# nolint`.
+//! * `# @lsp-ignore-next` — Raven's own marker that suppresses the *following*
+//!   source line.
+//!
+//! Rule-name filters (the `: rule_a, rule_b` suffix on `# nolint`) are
+//! recognised but ignored for now — line-level suppression applies to every
+//! rule. The shape of `Suppressions` is intentionally rule-agnostic so a
+//! future revision can match per rule without an API break.
+
+use std::collections::HashSet;
+
+/// Pre-computed line-suppression set for a document.
+#[derive(Debug, Default)]
+pub(crate) struct Suppressions {
+    suppressed_lines: HashSet<u32>,
+}
+
+impl Suppressions {
+    /// Parse `# nolint` markers out of `text`.
+    pub(crate) fn from_text(text: &str) -> Self {
+        let mut suppressed = HashSet::new();
+        let mut in_block = false;
+        let mut block_start: Option<u32> = None;
+
+        for (idx, line) in text.lines().enumerate() {
+            let line_no = idx as u32;
+            let marker = find_marker(line);
+
+            match marker {
+                Some(NolintMarker::Start) => {
+                    if !in_block {
+                        in_block = true;
+                        block_start = Some(line_no);
+                    }
+                }
+                Some(NolintMarker::End) => {
+                    if in_block {
+                        let start = block_start.unwrap_or(line_no);
+                        for l in start..=line_no {
+                            suppressed.insert(l);
+                        }
+                        in_block = false;
+                        block_start = None;
+                    }
+                }
+                Some(NolintMarker::Line) => {
+                    suppressed.insert(line_no);
+                }
+                Some(NolintMarker::NextLine) => {
+                    suppressed.insert(line_no + 1);
+                }
+                None => {}
+            }
+
+            if in_block {
+                suppressed.insert(line_no);
+            }
+        }
+
+        // Unterminated `nolint start` — treat as suppressing to EOF, matching
+        // lintr's behavior so a missing `end` doesn't silently lose coverage.
+        if in_block {
+            if let Some(start) = block_start {
+                let total_lines = text.lines().count() as u32;
+                for l in start..total_lines {
+                    suppressed.insert(l);
+                }
+            }
+        }
+
+        Self {
+            suppressed_lines: suppressed,
+        }
+    }
+
+    /// Is the given zero-indexed line suppressed?
+    pub(crate) fn is_suppressed(&self, line: u32) -> bool {
+        self.suppressed_lines.contains(&line)
+    }
+}
+
+enum NolintMarker {
+    Line,
+    Start,
+    End,
+    /// `# @lsp-ignore-next` — suppresses the line *after* the marker.
+    NextLine,
+}
+
+/// Scan a line for a `# nolint` marker (with optional `start`/`end` suffix).
+///
+/// Returns `None` if the marker doesn't appear, or if the `#` is inside a
+/// string literal. String detection is intentionally simple — it tracks
+/// single and double quotes within the same line. R lacks multi-line strings
+/// in the common case, so this is good enough for an unobtrusive linter.
+fn find_marker(line: &str) -> Option<NolintMarker> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\\' && (in_single || in_double) {
+            i += 2;
+            continue;
+        }
+        if !in_single && b == b'"' {
+            in_double = !in_double;
+        } else if !in_double && b == b'\'' {
+            in_single = !in_single;
+        } else if !in_single && !in_double && b == b'#' {
+            return classify(&line[i + 1..]);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn classify(after_hash: &str) -> Option<NolintMarker> {
+    // Strip an arbitrary run of leading whitespace and additional `#` chars
+    // (people sometimes write `## nolint`).
+    let trimmed = after_hash
+        .trim_start_matches(|c: char| c == '#' || c.is_whitespace())
+        .to_ascii_lowercase();
+
+    if let Some(rest) = trimmed.strip_prefix("nolint") {
+        let rest = rest.trim_start();
+        return if rest.starts_with("start") {
+            Some(NolintMarker::Start)
+        } else if rest.starts_with("end") {
+            Some(NolintMarker::End)
+        } else {
+            // Either bare `# nolint` or `# nolint: rule_a, rule_b`. Either way
+            // it is a line-level suppression for now.
+            Some(NolintMarker::Line)
+        };
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("@lsp-ignore") {
+        // Match `-next`, `:next`, or bare `next` after the marker so all of
+        // `@lsp-ignore-next`, `@lsp-ignore: next`, and `@lsp-ignore next`
+        // resolve to NextLine. Anything else is a same-line ignore.
+        let rest = rest
+            .trim_start_matches(|c: char| c == ':' || c == '-' || c.is_whitespace());
+        return if rest.starts_with("next") {
+            Some(NolintMarker::NextLine)
+        } else {
+            Some(NolintMarker::Line)
+        };
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_marker_suppresses_only_its_line() {
+        let s = Suppressions::from_text("x = 1\ny = 2 # nolint\nz = 3\n");
+        assert!(!s.is_suppressed(0));
+        assert!(s.is_suppressed(1));
+        assert!(!s.is_suppressed(2));
+    }
+
+    #[test]
+    fn block_marker_suppresses_inclusive_range() {
+        let s = Suppressions::from_text("a\n# nolint start\nb\nc\n# nolint end\nd\n");
+        assert!(!s.is_suppressed(0));
+        assert!(s.is_suppressed(1));
+        assert!(s.is_suppressed(2));
+        assert!(s.is_suppressed(3));
+        assert!(s.is_suppressed(4));
+        assert!(!s.is_suppressed(5));
+    }
+
+    #[test]
+    fn unterminated_block_extends_to_eof() {
+        let s = Suppressions::from_text("a\n# nolint start\nb\nc\n");
+        assert!(!s.is_suppressed(0));
+        assert!(s.is_suppressed(1));
+        assert!(s.is_suppressed(2));
+        assert!(s.is_suppressed(3));
+    }
+
+    #[test]
+    fn marker_inside_string_does_not_suppress() {
+        // `#` is inside a string literal — must not be parsed as a comment.
+        let s = Suppressions::from_text("x <- \"# nolint\"\n");
+        assert!(!s.is_suppressed(0));
+    }
+
+    #[test]
+    fn rule_filter_suffix_is_recognized() {
+        let s = Suppressions::from_text("x = 1 # nolint: line_length, no_tab\n");
+        assert!(s.is_suppressed(0));
+    }
+
+    #[test]
+    fn lsp_ignore_suppresses_current_line() {
+        let s = Suppressions::from_text("x = 1 # @lsp-ignore\ny = 2\n");
+        assert!(s.is_suppressed(0));
+        assert!(!s.is_suppressed(1));
+    }
+
+    #[test]
+    fn lsp_ignore_next_suppresses_following_line() {
+        let s = Suppressions::from_text("# @lsp-ignore-next\nx = 1\ny = 2\n");
+        assert!(!s.is_suppressed(0));
+        assert!(s.is_suppressed(1));
+        assert!(!s.is_suppressed(2));
+    }
+}

--- a/crates/raven/src/linting/rules/assignment_operator.rs
+++ b/crates/raven/src/linting/rules/assignment_operator.rs
@@ -1,10 +1,12 @@
 //! Enforce a single assignment operator at top-level.
 //!
 //! Walks the tree-sitter AST for `binary_operator` nodes whose `operator`
-//! field is `<-` or `=`. The rule only fires on assignments outside argument
-//! lists — using `=` inside a `call`'s argument list is named-argument
-//! syntax, not assignment, and must not be flagged. This matches
-//! `lintr::assignment_linter`'s default behavior.
+//! field is `<-` or `=`. A `=` whose `binary_operator` lives *directly* under
+//! an `argument` node is named-argument syntax (`f(name = value)`) and is
+//! never reported. Assignments inside nested expressions — function bodies,
+//! braced blocks, control flow — are reported normally even when they appear
+//! inside an argument list. This matches `lintr::assignment_linter`'s default
+//! behavior.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use tree_sitter::Node;
@@ -22,7 +24,7 @@ pub(crate) fn collect(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    visit(root, text, style, severity, suppressions, out, false);
+    visit(root, text, style, severity, suppressions, out);
 }
 
 fn visit(
@@ -32,15 +34,11 @@ fn visit(
     severity: DiagnosticSeverity,
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
-    inside_call_args: bool,
 ) {
     if node.kind() == "binary_operator" {
         if let Some(op_node) = node.child_by_field_name("operator") {
             let op_text = node_text(op_node, text);
-            // Named arguments in calls use `=` and must not be reported as
-            // assignment-style violations.
-            let is_named_arg = inside_call_args && op_text == "=";
-            if !is_named_arg {
+            if !is_named_argument(node, op_text) {
                 let bad = match style {
                     AssignmentOperatorStyle::LeftArrow => op_text == "=",
                     AssignmentOperatorStyle::Equals => op_text == "<-",
@@ -79,18 +77,26 @@ fn visit(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let child_inside_args =
-            inside_call_args || matches!(node.kind(), "arguments" | "argument");
-        visit(
-            child,
-            text,
-            style,
-            severity,
-            suppressions,
-            out,
-            child_inside_args,
-        );
+        visit(child, text, style, severity, suppressions, out);
     }
+}
+
+/// True if the given `binary_operator` node represents a named argument like
+/// `name = value` inside a call. Tree-sitter-r wraps each top-level
+/// expression in a call's argument list in an `argument` node, so a named
+/// argument's `=` `binary_operator` has `argument` as its direct parent.
+///
+/// Anything nested deeper — assignments inside a function body
+/// (`lapply(xs, function(x) { y = x; y })`), inside a braced block
+/// (`f({ y = 1 })`), or inside control flow (`f(if (cond) y = 1)`) — is a
+/// real assignment and must be reported.
+fn is_named_argument(binop: Node<'_>, op_text: &str) -> bool {
+    if op_text != "=" {
+        return false;
+    }
+    binop
+        .parent()
+        .is_some_and(|p| p.kind() == "argument")
 }
 
 fn node_text<'a>(node: Node<'_>, text: &'a str) -> &'a str {

--- a/crates/raven/src/linting/rules/assignment_operator.rs
+++ b/crates/raven/src/linting/rules/assignment_operator.rs
@@ -1,0 +1,100 @@
+//! Enforce a single assignment operator at top-level.
+//!
+//! Walks the tree-sitter AST for `binary_operator` nodes whose `operator`
+//! field is `<-` or `=`. The rule only fires on assignments outside argument
+//! lists — using `=` inside a `call`'s argument list is named-argument
+//! syntax, not assignment, and must not be flagged. This matches
+//! `lintr::assignment_linter`'s default behavior.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::config::AssignmentOperatorStyle;
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    style: AssignmentOperatorStyle,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, style, severity, suppressions, out, false);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    style: AssignmentOperatorStyle,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+    inside_call_args: bool,
+) {
+    if node.kind() == "binary_operator" {
+        if let Some(op_node) = node.child_by_field_name("operator") {
+            let op_text = node_text(op_node, text);
+            // Named arguments in calls use `=` and must not be reported as
+            // assignment-style violations.
+            let is_named_arg = inside_call_args && op_text == "=";
+            if !is_named_arg {
+                let bad = match style {
+                    AssignmentOperatorStyle::LeftArrow => op_text == "=",
+                    AssignmentOperatorStyle::Equals => op_text == "<-",
+                };
+                if bad {
+                    let line_no = op_node.start_position().row as u32;
+                    if !suppressions.is_suppressed(line_no) {
+                        let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+                        let start_col = byte_offset_to_utf16_column(
+                            line_text,
+                            op_node.start_position().column,
+                        );
+                        let end_col =
+                            byte_offset_to_utf16_column(line_text, op_node.end_position().column);
+                        let preferred = match style {
+                            AssignmentOperatorStyle::LeftArrow => "<-",
+                            AssignmentOperatorStyle::Equals => "=",
+                        };
+                        out.push(Diagnostic {
+                            range: Range {
+                                start: Position::new(line_no, start_col),
+                                end: Position::new(op_node.end_position().row as u32, end_col),
+                            },
+                            severity: Some(severity),
+                            source: Some(LINT_SOURCE.to_string()),
+                            message: format!(
+                                "Use `{preferred}` for assignment instead of `{op_text}`."
+                            ),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let child_inside_args =
+            inside_call_args || matches!(node.kind(), "arguments" | "argument");
+        visit(
+            child,
+            text,
+            style,
+            severity,
+            suppressions,
+            out,
+            child_inside_args,
+        );
+    }
+}
+
+fn node_text<'a>(node: Node<'_>, text: &'a str) -> &'a str {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    text.get(start..end).unwrap_or("")
+}

--- a/crates/raven/src/linting/rules/line_length.rs
+++ b/crates/raven/src/linting/rules/line_length.rs
@@ -1,0 +1,38 @@
+//! Flag lines wider than the configured maximum.
+//!
+//! Width is measured in UTF-16 code units to align with LSP positions. Tabs
+//! count as one unit, matching `lintr::line_length_linter`'s convention.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+
+pub(crate) fn collect(
+    text: &str,
+    max_len: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    for (idx, line) in text.lines().enumerate() {
+        let line_no = idx as u32;
+        if suppressions.is_suppressed(line_no) {
+            continue;
+        }
+        let width: u32 = line.chars().map(|c| c.len_utf16() as u32).sum();
+        if width <= max_len {
+            continue;
+        }
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(line_no, max_len),
+                end: Position::new(line_no, width),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: format!("Line is {width} characters long; limit is {max_len}."),
+            ..Default::default()
+        });
+    }
+}

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -1,0 +1,11 @@
+//! Individual lint rules.
+//!
+//! Each rule is a small module exposing a `collect(...)` function that pushes
+//! diagnostics into a `&mut Vec<Diagnostic>`. Rules consult the shared
+//! [`crate::linting::nolint::Suppressions`] before producing output.
+
+pub(crate) mod assignment_operator;
+pub(crate) mod line_length;
+pub(crate) mod no_tab;
+pub(crate) mod trailing_blank_lines;
+pub(crate) mod trailing_whitespace;

--- a/crates/raven/src/linting/rules/no_tab.rs
+++ b/crates/raven/src/linting/rules/no_tab.rs
@@ -1,0 +1,45 @@
+//! Flag tab characters in source.
+//!
+//! Reports one diagnostic per line that contains a tab, anchored at the first
+//! tab on that line. The diagnostic range covers the contiguous run of tabs
+//! so that "fix" actions or selection-aware tooling can target it cleanly.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    for (idx, line) in text.lines().enumerate() {
+        let line_no = idx as u32;
+        if suppressions.is_suppressed(line_no) {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let Some(start) = bytes.iter().position(|&b| b == b'\t') else {
+            continue;
+        };
+        let mut end = start;
+        while end < bytes.len() && bytes[end] == b'\t' {
+            end += 1;
+        }
+        let start_col = byte_offset_to_utf16_column(line, start);
+        let end_col = byte_offset_to_utf16_column(line, end);
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(line_no, start_col),
+                end: Position::new(line_no, end_col),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: "Tab character; use spaces.".to_string(),
+            ..Default::default()
+        });
+    }
+}

--- a/crates/raven/src/linting/rules/trailing_blank_lines.rs
+++ b/crates/raven/src/linting/rules/trailing_blank_lines.rs
@@ -1,0 +1,74 @@
+//! Flag trailing blank lines at end of file.
+//!
+//! lintr also flags a missing terminal newline. We match that: a file that
+//! doesn't end with `\n` is reported, and so is one with one-or-more blank
+//! lines after the last non-blank line.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+
+pub(crate) fn collect(
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if text.is_empty() {
+        return;
+    }
+
+    // Detect a missing trailing newline.
+    if !text.ends_with('\n') {
+        let last_line_idx = text.lines().count().saturating_sub(1) as u32;
+        if !suppressions.is_suppressed(last_line_idx) {
+            let last = text.lines().next_back().unwrap_or("");
+            let col: u32 = last.chars().map(|c| c.len_utf16() as u32).sum();
+            out.push(Diagnostic {
+                range: Range {
+                    start: Position::new(last_line_idx, col),
+                    end: Position::new(last_line_idx, col),
+                },
+                severity: Some(severity),
+                source: Some(LINT_SOURCE.to_string()),
+                message: "File should end with a newline.".to_string(),
+                ..Default::default()
+            });
+        }
+        return;
+    }
+
+    // Count trailing blank lines.
+    let lines: Vec<&str> = text.lines().collect();
+    let mut trailing = 0usize;
+    for line in lines.iter().rev() {
+        if line.trim().is_empty() {
+            trailing += 1;
+        } else {
+            break;
+        }
+    }
+    if trailing == 0 {
+        return;
+    }
+    let first_blank = lines.len() - trailing;
+    let line_no = first_blank as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, 0),
+            end: Position::new(lines.len() as u32, 0),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: if trailing == 1 {
+            "Trailing blank line at end of file.".to_string()
+        } else {
+            format!("{trailing} trailing blank lines at end of file.")
+        },
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/trailing_whitespace.rs
+++ b/crates/raven/src/linting/rules/trailing_whitespace.rs
@@ -1,0 +1,37 @@
+//! Flag trailing spaces/tabs at end of line.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    for (idx, line) in text.lines().enumerate() {
+        let line_no = idx as u32;
+        if suppressions.is_suppressed(line_no) {
+            continue;
+        }
+        let trimmed = line.trim_end_matches([' ', '\t']);
+        if trimmed.len() == line.len() {
+            continue;
+        }
+        let start_col = byte_offset_to_utf16_column(line, trimmed.len());
+        let end_col = byte_offset_to_utf16_column(line, line.len());
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(line_no, start_col),
+                end: Position::new(line_no, end_col),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: "Trailing whitespace.".to_string(),
+            ..Default::default()
+        });
+    }
+}

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -20,6 +20,7 @@ mod help;
 mod indentation;
 mod jags_builtins;
 mod libpath_watcher;
+mod linting;
 mod namespace_parser;
 mod package_library;
 mod package_namespace;

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -531,6 +531,9 @@ pub struct WorldState {
     pub completion_config: CompletionConfig,
     /// Indentation configuration
     pub indentation_config: IndentationSettings,
+    /// Style/lint configuration.
+    /// Master switch defaults to off; opt in via `raven.linting.enabled`.
+    pub lint_config: crate::linting::LintConfig,
     pub cross_file_meta: MetadataCache,
     pub cross_file_graph: DependencyGraph,
     pub cross_file_revalidation: CrossFileRevalidationState,
@@ -657,6 +660,7 @@ impl WorldState {
             symbol_config: SymbolConfig::default(),
             completion_config: CompletionConfig::default(),
             indentation_config: IndentationSettings::default(),
+            lint_config: crate::linting::LintConfig::default(),
             cross_file_meta: MetadataCache::new(),
             cross_file_graph: DependencyGraph::new(),
             cross_file_revalidation: CrossFileRevalidationState::new(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,23 @@ Raven sets `editor.formatOnType` to `true` for R files by default (lowest-priori
 
 See [Smart Indentation](indentation.md) for details.
 
+## Linting Settings
+
+Native style/lint diagnostics. Off by default; opt in with `raven.linting.enabled`. Implemented in Rust against the tree-sitter AST — no `lintr` install required. All rules default to severity `hint` so they don't crowd the Problems pane. See [Style Lints](diagnostics.md#style-lints) for the full rule list and suppression conventions.
+
+| Setting | Default | Description |
+|---|---|---|
+| `raven.linting.enabled` | `false` | Master switch for all lint diagnostics |
+| `raven.linting.lineLength` | `80` | Maximum line length (UTF-16 code units) |
+| `raven.linting.assignmentOperator` | `"<-"` | Preferred assignment operator (`"<-"` or `"="`) |
+| `raven.linting.lineLengthSeverity` | `"hint"` | Severity for over-long lines (or `"off"`) |
+| `raven.linting.trailingWhitespaceSeverity` | `"hint"` | Severity for trailing whitespace |
+| `raven.linting.noTabSeverity` | `"hint"` | Severity for tab characters |
+| `raven.linting.trailingBlankLinesSeverity` | `"hint"` | Severity for blank lines or missing newline at end of file |
+| `raven.linting.assignmentOperatorSeverity` | `"hint"` | Severity for mismatched assignment operator |
+
+To disable an individual rule while leaving the rest enabled, set its severity to `"off"`.
+
 ## Server Settings
 
 | Setting | Default | Description |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -48,6 +48,26 @@ Raven checks whether each symbol reference has a visible definition — either i
 | Ambiguous parent | warning | Multiple parents source this file and auto-inference can't determine which to use |
 | Redundant directive | hint | `@lsp-source` directive for a file already sourced via `source()` on the same line |
 
+### Style Lints
+
+Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-lib.org/)). Implemented in Rust against the tree-sitter AST — no R or `lintr` install required. Off by default; enable with `raven.linting.enabled` and tune per rule via the `raven.linting.*` severities. All rules default to severity `hint` so they don't crowd the Problems pane.
+
+| Diagnostic | Default Severity | Trigger |
+|---|---|---|
+| Line length | hint | Line exceeds `raven.linting.lineLength` (default 80 UTF-16 code units) |
+| Trailing whitespace | hint | Spaces or tabs at end of line |
+| Tab character | hint | Tab character anywhere in source |
+| Trailing blank lines | hint | Blank lines at end of file, or missing final newline |
+| Assignment operator | hint | Top-level assignment uses an operator other than the preferred one (`<-` by default; configurable via `raven.linting.assignmentOperator`) |
+
+Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
+
+**Suppression:** lint diagnostics honor the `lintr` conventions in addition to Raven's own:
+
+- `# nolint` on a line suppresses lints on that line (rule-name filters like `# nolint: line_length` are accepted; for now, all rules are suppressed on suppressed lines).
+- `# nolint start` / `# nolint end` brackets a region.
+- The standard `# @lsp-ignore` and `# @lsp-ignore-next` markers also apply to lint diagnostics.
+
 ## Suppression
 
 ### Per-Line: @lsp-ignore

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -945,6 +945,126 @@
           "minimum": 0,
           "maximum": 15,
           "description": "Initial digits used by the data viewer's Format toggle."
+        },
+        "raven.linting.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable native style/lint diagnostics. When on, Raven reports a small set of lintr-equivalent rules (line length, trailing whitespace, tabs, assignment operator, trailing blank lines) directly from its tree-sitter AST — no R or lintr install required. Individual rules can still be disabled via their per-rule severity settings."
+        },
+        "raven.linting.lineLength": {
+          "type": "integer",
+          "default": 80,
+          "minimum": 20,
+          "maximum": 10000,
+          "description": "Maximum allowed line length for the line-length lint. Width is measured in UTF-16 code units. Set raven.linting.lineLengthSeverity to \"off\" to disable the rule without affecting other lints."
+        },
+        "raven.linting.assignmentOperator": {
+          "type": "string",
+          "default": "<-",
+          "enum": [
+            "<-",
+            "="
+          ],
+          "enumDescriptions": [
+            "Require `<-` for assignment; flag top-level `=` assignments.",
+            "Require `=` for assignment; flag top-level `<-` assignments."
+          ],
+          "description": "Preferred assignment operator. The lint never flags `=` inside argument lists (named arguments)."
+        },
+        "raven.linting.lineLengthSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report long lines as errors",
+            "Report long lines as warnings",
+            "Report long lines as information",
+            "Report long lines as hints",
+            "Disable the line-length lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the line-length lint. Set to \"off\" to disable the rule."
+        },
+        "raven.linting.trailingWhitespaceSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report trailing whitespace as errors",
+            "Report trailing whitespace as warnings",
+            "Report trailing whitespace as information",
+            "Report trailing whitespace as hints",
+            "Disable the trailing-whitespace lint"
+          ],
+          "default": "hint",
+          "description": "Severity for trailing whitespace at end of line. Set to \"off\" to disable the rule."
+        },
+        "raven.linting.noTabSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report tab characters as errors",
+            "Report tab characters as warnings",
+            "Report tab characters as information",
+            "Report tab characters as hints",
+            "Disable the no-tab lint"
+          ],
+          "default": "hint",
+          "description": "Severity for tab characters in source. Set to \"off\" to disable the rule."
+        },
+        "raven.linting.trailingBlankLinesSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report trailing blank lines as errors",
+            "Report trailing blank lines as warnings",
+            "Report trailing blank lines as information",
+            "Report trailing blank lines as hints",
+            "Disable the trailing-blank-lines lint"
+          ],
+          "default": "hint",
+          "description": "Severity for trailing blank lines and missing final newline at end of file. Set to \"off\" to disable the rule."
+        },
+        "raven.linting.assignmentOperatorSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report mismatched assignment operator as errors",
+            "Report mismatched assignment operator as warnings",
+            "Report mismatched assignment operator as information",
+            "Report mismatched assignment operator as hints",
+            "Disable the assignment-operator lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the assignment-operator lint. Set to \"off\" to disable the rule."
         }
       }
     }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -328,51 +328,21 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         options.indentation = { style: indentationStyle };
     }
 
-    const lintingEnabled = getExplicitSetting<boolean>(config, 'linting.enabled');
-    const lintingLineLength = getExplicitSetting<number>(config, 'linting.lineLength');
-    const lintingAssignmentOperator = getExplicitSetting<"<-" | "=">(config, 'linting.assignmentOperator');
-    const lintingLineLengthSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.lineLengthSeverity');
-    const lintingTrailingWhitespaceSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.trailingWhitespaceSeverity');
-    const lintingNoTabSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.noTabSeverity');
-    const lintingTrailingBlankLinesSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.trailingBlankLinesSeverity');
-    const lintingAssignmentOperatorSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.assignmentOperatorSeverity');
-
-    if (
-        lintingEnabled !== undefined ||
-        lintingLineLength !== undefined ||
-        lintingAssignmentOperator !== undefined ||
-        lintingLineLengthSeverity !== undefined ||
-        lintingTrailingWhitespaceSeverity !== undefined ||
-        lintingNoTabSeverity !== undefined ||
-        lintingTrailingBlankLinesSeverity !== undefined ||
-        lintingAssignmentOperatorSeverity !== undefined
-    ) {
-        options.linting = {};
-        if (lintingEnabled !== undefined) {
-            options.linting.enabled = lintingEnabled;
-        }
-        if (lintingLineLength !== undefined) {
-            options.linting.lineLength = lintingLineLength;
-        }
-        if (lintingAssignmentOperator !== undefined) {
-            options.linting.assignmentOperator = lintingAssignmentOperator;
-        }
-        if (lintingLineLengthSeverity !== undefined) {
-            options.linting.lineLengthSeverity = lintingLineLengthSeverity;
-        }
-        if (lintingTrailingWhitespaceSeverity !== undefined) {
-            options.linting.trailingWhitespaceSeverity = lintingTrailingWhitespaceSeverity;
-        }
-        if (lintingNoTabSeverity !== undefined) {
-            options.linting.noTabSeverity = lintingNoTabSeverity;
-        }
-        if (lintingTrailingBlankLinesSeverity !== undefined) {
-            options.linting.trailingBlankLinesSeverity = lintingTrailingBlankLinesSeverity;
-        }
-        if (lintingAssignmentOperatorSeverity !== undefined) {
-            options.linting.assignmentOperatorSeverity = lintingAssignmentOperatorSeverity;
-        }
-    }
+    // Linting settings: always emit the full section using each setting's
+    // package.json default. Otherwise, resetting an explicitly-configured key
+    // (e.g. via VS Code's "Reset Setting") would omit it from the payload,
+    // and the server treats absent keys as "preserve current value" — so the
+    // previous state would persist until restart.
+    options.linting = {
+        enabled: config.get<boolean>('linting.enabled', false),
+        lineLength: config.get<number>('linting.lineLength', 80),
+        assignmentOperator: config.get<"<-" | "=">('linting.assignmentOperator', '<-'),
+        lineLengthSeverity: config.get<SeverityLevel>('linting.lineLengthSeverity', 'hint'),
+        trailingWhitespaceSeverity: config.get<SeverityLevel>('linting.trailingWhitespaceSeverity', 'hint'),
+        noTabSeverity: config.get<SeverityLevel>('linting.noTabSeverity', 'hint'),
+        trailingBlankLinesSeverity: config.get<SeverityLevel>('linting.trailingBlankLinesSeverity', 'hint'),
+        assignmentOperatorSeverity: config.get<SeverityLevel>('linting.assignmentOperatorSeverity', 'hint'),
+    };
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');
     if (helpViewerColumn !== undefined) {

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -82,6 +82,16 @@ export interface RavenInitializationOptions {
     indentation?: {
         style?: "rstudio" | "rstudio-minus" | "off";
     };
+    linting?: {
+        enabled?: boolean;
+        lineLength?: number;
+        assignmentOperator?: "<-" | "=";
+        lineLengthSeverity?: SeverityLevel;
+        trailingWhitespaceSeverity?: SeverityLevel;
+        noTabSeverity?: SeverityLevel;
+        trailingBlankLinesSeverity?: SeverityLevel;
+        assignmentOperatorSeverity?: SeverityLevel;
+    };
     helpViewer?: { viewColumn?: 'active' | 'beside' };
 }
 
@@ -316,6 +326,52 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
     const indentationStyle = getExplicitSetting<"rstudio" | "rstudio-minus" | "off">(config, 'indentation.style');
     if (indentationStyle !== undefined) {
         options.indentation = { style: indentationStyle };
+    }
+
+    const lintingEnabled = getExplicitSetting<boolean>(config, 'linting.enabled');
+    const lintingLineLength = getExplicitSetting<number>(config, 'linting.lineLength');
+    const lintingAssignmentOperator = getExplicitSetting<"<-" | "=">(config, 'linting.assignmentOperator');
+    const lintingLineLengthSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.lineLengthSeverity');
+    const lintingTrailingWhitespaceSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.trailingWhitespaceSeverity');
+    const lintingNoTabSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.noTabSeverity');
+    const lintingTrailingBlankLinesSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.trailingBlankLinesSeverity');
+    const lintingAssignmentOperatorSeverity = getExplicitSetting<SeverityLevel>(config, 'linting.assignmentOperatorSeverity');
+
+    if (
+        lintingEnabled !== undefined ||
+        lintingLineLength !== undefined ||
+        lintingAssignmentOperator !== undefined ||
+        lintingLineLengthSeverity !== undefined ||
+        lintingTrailingWhitespaceSeverity !== undefined ||
+        lintingNoTabSeverity !== undefined ||
+        lintingTrailingBlankLinesSeverity !== undefined ||
+        lintingAssignmentOperatorSeverity !== undefined
+    ) {
+        options.linting = {};
+        if (lintingEnabled !== undefined) {
+            options.linting.enabled = lintingEnabled;
+        }
+        if (lintingLineLength !== undefined) {
+            options.linting.lineLength = lintingLineLength;
+        }
+        if (lintingAssignmentOperator !== undefined) {
+            options.linting.assignmentOperator = lintingAssignmentOperator;
+        }
+        if (lintingLineLengthSeverity !== undefined) {
+            options.linting.lineLengthSeverity = lintingLineLengthSeverity;
+        }
+        if (lintingTrailingWhitespaceSeverity !== undefined) {
+            options.linting.trailingWhitespaceSeverity = lintingTrailingWhitespaceSeverity;
+        }
+        if (lintingNoTabSeverity !== undefined) {
+            options.linting.noTabSeverity = lintingNoTabSeverity;
+        }
+        if (lintingTrailingBlankLinesSeverity !== undefined) {
+            options.linting.trailingBlankLinesSeverity = lintingTrailingBlankLinesSeverity;
+        }
+        if (lintingAssignmentOperatorSeverity !== undefined) {
+            options.linting.assignmentOperatorSeverity = lintingAssignmentOperatorSeverity;
+        }
     }
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -120,15 +120,17 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'completion.triggerOnOpenParen', jsonPath: ['completion', 'triggerOnOpenParen'], type: 'boolean' },
     // Indentation settings
     { vsCodeKey: 'indentation.style', jsonPath: ['indentation', 'style'], type: 'enum', enumValues: ['rstudio', 'rstudio-minus', 'off'] as const },
-    // Linting settings
-    { vsCodeKey: 'linting.enabled', jsonPath: ['linting', 'enabled'], type: 'boolean' },
-    { vsCodeKey: 'linting.lineLength', jsonPath: ['linting', 'lineLength'], type: 'number' },
-    { vsCodeKey: 'linting.assignmentOperator', jsonPath: ['linting', 'assignmentOperator'], type: 'enum', enumValues: ['<-', '='] as const },
-    { vsCodeKey: 'linting.lineLengthSeverity', jsonPath: ['linting', 'lineLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
-    { vsCodeKey: 'linting.trailingWhitespaceSeverity', jsonPath: ['linting', 'trailingWhitespaceSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
-    { vsCodeKey: 'linting.noTabSeverity', jsonPath: ['linting', 'noTabSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
-    { vsCodeKey: 'linting.trailingBlankLinesSeverity', jsonPath: ['linting', 'trailingBlankLinesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
-    { vsCodeKey: 'linting.assignmentOperatorSeverity', jsonPath: ['linting', 'assignmentOperatorSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    // Linting settings — always emitted using each key's package.json default
+    // so that resetting a key propagates to the server instead of leaving
+    // stale state active. Defaults below mirror package.json.
+    { vsCodeKey: 'linting.enabled', jsonPath: ['linting', 'enabled'], type: 'boolean', defaultWhenUnconfigured: false },
+    { vsCodeKey: 'linting.lineLength', jsonPath: ['linting', 'lineLength'], type: 'number', defaultWhenUnconfigured: 80 },
+    { vsCodeKey: 'linting.assignmentOperator', jsonPath: ['linting', 'assignmentOperator'], type: 'enum', enumValues: ['<-', '='] as const, defaultWhenUnconfigured: '<-' },
+    { vsCodeKey: 'linting.lineLengthSeverity', jsonPath: ['linting', 'lineLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.trailingWhitespaceSeverity', jsonPath: ['linting', 'trailingWhitespaceSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.noTabSeverity', jsonPath: ['linting', 'noTabSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.trailingBlankLinesSeverity', jsonPath: ['linting', 'trailingBlankLinesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.assignmentOperatorSeverity', jsonPath: ['linting', 'assignmentOperatorSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];
@@ -347,6 +349,16 @@ suite('Settings Transmission Property Tests', () => {
             diagnostics: {
                 enabled: true,
             },
+            linting: {
+                enabled: false,
+                lineLength: 80,
+                assignmentOperator: '<-',
+                lineLengthSeverity: 'hint',
+                trailingWhitespaceSeverity: 'hint',
+                noTabSeverity: 'hint',
+                trailingBlankLinesSeverity: 'hint',
+                assignmentOperatorSeverity: 'hint',
+            },
         }, 'Empty configuration should produce only runtime defaults');
 
     });
@@ -470,6 +482,48 @@ suite('Settings Transmission Unit Tests', () => {
         assert.strictEqual(options.crossFile?.onDemandIndexing?.enabled, false);
         assert.strictEqual(options.crossFile?.onDemandIndexing?.maxTransitiveDepth, 5);
         assert.strictEqual(options.crossFile?.onDemandIndexing?.maxQueueSize, 100);
+    });
+
+    /**
+     * Regression: resetting an explicitly-configured lint setting must
+     * propagate to the server as the package.json default, not be silently
+     * omitted. If a key were omitted, the server treats absence as "preserve
+     * the previous value" — so a user who toggled `linting.enabled` on and
+     * later reset it would still have linting active until restart.
+     */
+    test('lint settings always emit (reset propagates as default)', () => {
+        const mockConfig = createMockConfig(new Map<string, unknown>());
+        const options = getInitializationOptions(mockConfig);
+        // Whole linting block populated with package.json defaults.
+        assert.deepStrictEqual(options.linting, {
+            enabled: false,
+            lineLength: 80,
+            assignmentOperator: '<-',
+            lineLengthSeverity: 'hint',
+            trailingWhitespaceSeverity: 'hint',
+            noTabSeverity: 'hint',
+            trailingBlankLinesSeverity: 'hint',
+            assignmentOperatorSeverity: 'hint',
+        });
+    });
+
+    test('lint settings forward explicit values', () => {
+        const configuredSettings = new Map<string, unknown>([
+            ['linting.enabled', true],
+            ['linting.lineLength', 120],
+            ['linting.assignmentOperator', '='],
+            ['linting.lineLengthSeverity', 'warning'],
+            ['linting.assignmentOperatorSeverity', 'off'],
+        ]);
+        const mockConfig = createMockConfig(configuredSettings);
+        const options = getInitializationOptions(mockConfig);
+        assert.strictEqual(options.linting?.enabled, true);
+        assert.strictEqual(options.linting?.lineLength, 120);
+        assert.strictEqual(options.linting?.assignmentOperator, '=');
+        assert.strictEqual(options.linting?.lineLengthSeverity, 'warning');
+        assert.strictEqual(options.linting?.assignmentOperatorSeverity, 'off');
+        // Untouched keys still emit their defaults.
+        assert.strictEqual(options.linting?.trailingWhitespaceSeverity, 'hint');
     });
 
     /**

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -120,6 +120,15 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'completion.triggerOnOpenParen', jsonPath: ['completion', 'triggerOnOpenParen'], type: 'boolean' },
     // Indentation settings
     { vsCodeKey: 'indentation.style', jsonPath: ['indentation', 'style'], type: 'enum', enumValues: ['rstudio', 'rstudio-minus', 'off'] as const },
+    // Linting settings
+    { vsCodeKey: 'linting.enabled', jsonPath: ['linting', 'enabled'], type: 'boolean' },
+    { vsCodeKey: 'linting.lineLength', jsonPath: ['linting', 'lineLength'], type: 'number' },
+    { vsCodeKey: 'linting.assignmentOperator', jsonPath: ['linting', 'assignmentOperator'], type: 'enum', enumValues: ['<-', '='] as const },
+    { vsCodeKey: 'linting.lineLengthSeverity', jsonPath: ['linting', 'lineLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    { vsCodeKey: 'linting.trailingWhitespaceSeverity', jsonPath: ['linting', 'trailingWhitespaceSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    { vsCodeKey: 'linting.noTabSeverity', jsonPath: ['linting', 'noTabSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    { vsCodeKey: 'linting.trailingBlankLinesSeverity', jsonPath: ['linting', 'trailingBlankLinesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    { vsCodeKey: 'linting.assignmentOperatorSeverity', jsonPath: ['linting', 'assignmentOperatorSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];


### PR DESCRIPTION
Closes #211 (initial slice).

## Summary

Adds an opt-in, native Rust style/lint subsystem under `crates/raven/src/linting/`. Rules run against the already-parsed tree-sitter tree; no R or `lintr` install required, no subprocess overhead.

Initial rule set covers the high-value, purely syntactic rules from the issue's proposed scope:

| Rule | lintr equivalent | Behavior |
|---|---|---|
| Line length | `line_length_linter` | Flag lines wider than `raven.linting.lineLength` (default 80 UTF-16 code units) |
| Trailing whitespace | `trailing_whitespace_linter` | Spaces/tabs at end of line |
| No tab | `no_tab_linter` | Tab characters anywhere in source |
| Trailing blank lines | `trailing_blank_lines_linter` | Trailing blanks or missing final newline |
| Assignment operator | `assignment_linter` | Flags top-level `=`/`<-` when other style preferred. Never flags named-arg `=` |

Three rules from the issue's table are deferred to a follow-up since they need more design work (`object_name_linter` style schemes, `infix_spaces_linter` whitespace-around-operator rules with the operator categorisation lintr uses, `commented_code_linter`). The current PR is focused, keeps the diff reviewable, and ships a useful baseline.

## Configuration

Master switch `raven.linting.enabled` defaults to `false` (per issue's "off initially, on once stable"). Each rule has its own severity (default `"hint"`); set to `"off"` to disable a rule individually.

Settings:

- `raven.linting.enabled`
- `raven.linting.lineLength`
- `raven.linting.assignmentOperator` (`"<-"` | `"="`)
- `raven.linting.lineLengthSeverity`
- `raven.linting.trailingWhitespaceSeverity`
- `raven.linting.noTabSeverity`
- `raven.linting.trailingBlankLinesSeverity`
- `raven.linting.assignmentOperatorSeverity`

Wired through all three sync points: `editors/vscode/package.json` (schema), `editors/vscode/src/initializationOptions.ts` (init payload), and `editors/vscode/src/test/settings.test.ts` (SETTINGS_MAPPING) — matching the invariant called out in AGENTS.md.

## Suppression

Honors both lintr and Raven conventions:

- `# nolint` (with optional `: rule, rule` filter — captured but currently coarse)
- `# nolint start` / `# nolint end`
- `# @lsp-ignore` / `# @lsp-ignore-next`

Markers inside string literals are ignored.

## Diagnostics integration

Lint diagnostics flow through the existing `DiagnosticsSnapshot` plumbing; `run_lints` short-circuits when the master switch is off, so there's no measurable cost when disabled. Diagnostics carry `source: "raven (lint)"` so clients (and tests) can distinguish them from cross-file or syntax diagnostics.

## Test plan

- [x] `cargo test -p raven --lib` — 3492 pass (19 new linting unit tests + 6 new backend config-parsing tests)
- [x] `bunx mocha --ui tdd editors/vscode/out/test/settings.test.js` — 27 pass (new `raven.linting.*` settings included in property/unit coverage)
- [x] `cargo clippy -p raven --no-deps --lib` — no new warnings from this change
- [x] Verified each rule fires (and doesn't fire) in the relevant unit tests:
  - Named-argument `=` is not flagged
  - Master-switch-off returns empty
  - `# nolint` / `# nolint start`/`end` / `# @lsp-ignore[-next]` all suppress correctly
  - Markers inside string literals are not treated as suppressions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in native style/lint diagnostics: line length, trailing whitespace, tabs, trailing blank lines, and assignment-operator style.
  * Suppression markers supported: `# nolint`, `# nolint start/end`, `# @lsp-ignore`, and `# @lsp-ignore-next`.
  * Configurable per-rule severities and options exposed via editor/extension settings.

* **Documentation**
  * Docs and README updated with linting settings, rule descriptions, suppression semantics, and defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/219)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->