### PR TITLE
feat(chunks): R Markdown / Quarto chunk support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ User-facing:
 - `docs/indentation.md`
 - `docs/syntax-highlighting.md`
 - `docs/r-console.md`
+- `docs/chunks.md`
 - `docs/plot-viewer.md`
 - `docs/data-viewer.md`
 - `docs/help-viewer.md`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 ### R session integration
 
 - **[R console](docs/r-console.md)** — Interactive R console with statement detection and a temp-file fallback for large blocks; supports R, arf, and radian
+- **[Code chunks](docs/chunks.md)** — R Markdown / Quarto chunk detection with Run Chunk / Run Above / Run All commands, CodeLens buttons, navigation, and background highlighting; `# %%` cell support in `.R` files
 - **[Plot viewer](docs/plot-viewer.md)** — Plots render in a VS Code panel via [httpgd](https://nx10.dev/httpgd/), with history navigation, save (PNG/SVG/PDF), and theme-aware background
 - **[Data viewer](docs/data-viewer.md)** — `View(df)` opens a virtualized grid backed by Apache Arrow; viewport-based rendering keeps scrolling responsive on multi-million-row frames
 - **[Help viewer](docs/help-viewer.md)** — Scope-aware R help: hovering shows the function in scope at the cursor instead of falling through to a multi-package list when scope can't be inferred
@@ -62,6 +63,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 **R session integration:**
 
 - [R Console](docs/r-console.md) — Interactive console, send-to-R commands, send method
+- [Code Chunks](docs/chunks.md) — R Markdown / Quarto chunk commands, CodeLens, navigation, highlighting
 - [Plot Viewer](docs/plot-viewer.md) — httpgd-backed plot panel
 - [Data Viewer](docs/data-viewer.md) — Arrow-backed `View()` replacement
 - [Help Viewer](docs/help-viewer.md) — Scope-aware R help

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -5,7 +5,7 @@ Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delim
 This is the daily-driver workflow for `.Rmd` / `.qmd` users coming from RStudio or vscode-R.
 
 > [!NOTE]
-> Chunk commands require Raven's R console — they create or reuse the R terminal Raven manages. If `raven.rConsole.activation` is `disabled` (or `auto` defers to another R extension), the chunk commands are not registered. See [Coexistence](./coexistence.md).
+> Navigation commands (Go to Next/Previous Chunk, Select Current Chunk) and chunk background highlighting work regardless of `raven.rConsole.activation`. The **run** commands (Run Current Chunk, Run Above, Run All) and the `▷ Run Chunk` / `↥ Run Above` CodeLens buttons require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), the run commands and CodeLens are not registered. See [Coexistence](./coexistence.md).
 
 ## Chunk forms
 

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -1,0 +1,109 @@
+# R Code Chunks
+
+Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delimited cells in plain `.R` files. You can run a single chunk, every chunk above the cursor, or every chunk in the document; navigate forward and backward between chunks; and see a subtle background tint that makes chunks easy to scan.
+
+This is the daily-driver workflow for `.Rmd` / `.qmd` users coming from RStudio or vscode-R.
+
+> [!NOTE]
+> Chunk commands require Raven's R console — they create or reuse the R terminal Raven manages. If `raven.rConsole.activation` is `disabled` (or `auto` defers to another R extension), the chunk commands are not registered. See [Coexistence](./coexistence.md).
+
+## Chunk forms
+
+| Form | File types | Example header |
+|------|------------|----------------|
+| Fenced block | `.Rmd`, `.qmd` | ```` ```{r setup, eval=FALSE} ```` |
+| Cell marker | `.R` | `# %% Section 1` |
+
+Fenced blocks may use either backticks or tildes, and four-or-more-character fences nest naturally (so a chunk can contain a literal `` ``` ``).
+
+Only **R** chunks are sent to the R console. Chunks tagged with other languages (`{python}`, `{bash}`, `{julia}`, …) are still recognized for navigation and outline but not for execution.
+
+## Keyboard shortcuts
+
+| Mac | Windows/Linux | Action |
+|-----|---------------|--------|
+| `Cmd+Shift+Enter` | `Ctrl+Shift+Enter` | Run Current Chunk (in `.Rmd` / `.qmd`) |
+| `Cmd+Alt+P` | `Ctrl+Alt+P` | Run Above Chunks |
+| `Cmd+Alt+N` | `Ctrl+Alt+N` | Go to Next Chunk |
+| `Cmd+Alt+Shift+N` | `Ctrl+Alt+Shift+N` | Go to Previous Chunk |
+
+In `.R` files, `Cmd+Shift+Enter` keeps its usual meaning of **Source File** — to run a single cell, use the command palette or the CodeLens "Run Chunk" button.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| **Run Current Chunk** | Sends the chunk at the cursor to R. |
+| **Run Current Chunk and Move** | Runs the current chunk, then moves the cursor into the next R chunk. |
+| **Run Above Chunks** | Runs every R chunk that ends before the cursor. The current chunk is not included. |
+| **Run All Chunks** | Runs every R chunk in the document, top to bottom. |
+| **Go to Next Chunk** | Moves the cursor to the body of the next R chunk. |
+| **Go to Previous Chunk** | Moves the cursor to the body of the previous R chunk. |
+| **Select Current Chunk** | Selects the body of the chunk at the cursor (excludes header and closing fence). |
+
+CodeLens buttons appear on every R chunk header:
+
+```text
+▷ Run Chunk    ↥ Run Above
+```{r}
+…
+```
+
+Buttons for non-R languages are intentionally omitted.
+
+## Chunk options
+
+Raven parses the header inside `{…}` and recognizes:
+
+- The **label** — the first bare identifier (e.g. `setup` in `{r setup}`).
+- **Key-value options** — comma-separated `key=value` pairs.
+
+Two options affect Raven specifically:
+
+- `eval = FALSE` (or `eval = F`) — Raven dims the chunk's background tint to signal that it will not be evaluated by `knitr` or `quarto render`. The CodeLens still offers to run the chunk manually if you want.
+
+Every other option is preserved on the parsed chunk but Raven does not interpret it.
+
+## Highlighting
+
+Each R chunk gets a faint background tint via two themable colors:
+
+| Color id | Used for |
+|----------|----------|
+| `raven.chunk.activeBackground` | Default runnable R chunks. |
+| `raven.chunk.inactiveBackground` | Chunks with `eval = FALSE`. Lower opacity by default. |
+
+Customize them in `settings.json`:
+
+```jsonc
+{
+  "workbench.colorCustomizations": {
+    "raven.chunk.activeBackground": "#1f7fff10",
+    "raven.chunk.inactiveBackground": "#1f7fff05"
+  }
+}
+```
+
+Set `raven.chunks.highlight.enabled` to `false` to turn the background off entirely.
+
+## Plain `.R` cell mode
+
+A line matching `# %%`, `## %%`, `### %%`, … starts a new cell. The cell extends until the next marker (or end of file). This matches VS Code's native interactive-cell convention used by the Jupyter extension and several R notebook plugins.
+
+```r
+# %% Load
+library(dplyr)
+
+# %% Transform
+mtcars |>
+    group_by(cyl) |>
+    summarise(mean(mpg))
+```
+
+Run Current Chunk on any line inside a cell sends that cell to the R console.
+
+## Limitations
+
+- Knit and Quarto render commands are not yet implemented (tracked separately).
+- Nested chunks (the inner chunk inside an outer chunk's body) are not supported — the inner chunk header is treated as ordinary content of the outer chunk.
+- `eval = !my_condition` and other dynamic option expressions are read literally; Raven does not evaluate R to determine `eval`.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -118,6 +118,41 @@
         "category": "Raven"
       },
       {
+        "command": "raven.runCurrentChunk",
+        "title": "Run Current Chunk",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runCurrentChunkAndMove",
+        "title": "Run Current Chunk and Move",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runAboveChunks",
+        "title": "Run Above Chunks",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runAllChunks",
+        "title": "Run All Chunks",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.goToNextChunk",
+        "title": "Go to Next Chunk",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.goToPreviousChunk",
+        "title": "Go to Previous Chunk",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.selectCurrentChunk",
+        "title": "Select Current Chunk",
+        "category": "Raven"
+      },
+      {
         "command": "raven.scaffold.gitignore",
         "title": "Create .gitignore",
         "category": "Raven"
@@ -184,6 +219,30 @@
         "command": "raven.sourceFile",
         "key": "shift+ctrl+enter",
         "mac": "shift+cmd+enter",
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+      },
+      {
+        "command": "raven.runCurrentChunk",
+        "key": "ctrl+shift+enter",
+        "mac": "cmd+shift+enter",
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled && resourceExtname =~ /\\.(rmd|Rmd|qmd|QMD)$/"
+      },
+      {
+        "command": "raven.runAboveChunks",
+        "key": "ctrl+alt+p",
+        "mac": "cmd+alt+p",
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+      },
+      {
+        "command": "raven.goToNextChunk",
+        "key": "ctrl+alt+n",
+        "mac": "cmd+alt+n",
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+      },
+      {
+        "command": "raven.goToPreviousChunk",
+        "key": "ctrl+alt+shift+n",
+        "mac": "cmd+alt+shift+n",
         "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
       }
     ],
@@ -282,12 +341,28 @@
           "group": "1_run@3"
         },
         {
+          "command": "raven.runCurrentChunk",
+          "group": "2_chunk@1"
+        },
+        {
+          "command": "raven.runCurrentChunkAndMove",
+          "group": "2_chunk@2"
+        },
+        {
+          "command": "raven.runAboveChunks",
+          "group": "2_chunk@3"
+        },
+        {
+          "command": "raven.runAllChunks",
+          "group": "2_chunk@4"
+        },
+        {
           "command": "raven.sourceFile",
-          "group": "2_file@1"
+          "group": "3_file@1"
         },
         {
           "submenu": "raven.sendToR.terminal",
-          "group": "3_terminal"
+          "group": "4_terminal"
         }
       ],
       "raven.sendToR.terminal": [
@@ -478,6 +553,28 @@
         "editor.formatOnType": true
       }
     },
+    "colors": [
+      {
+        "id": "raven.chunk.activeBackground",
+        "description": "Background color for runnable R code chunks in .Rmd / .qmd files and `# %%` cells in .R files.",
+        "defaults": {
+          "dark": "#ffffff0c",
+          "light": "#0000000a",
+          "highContrast": "#ffffff14",
+          "highContrastLight": "#0000001a"
+        }
+      },
+      {
+        "id": "raven.chunk.inactiveBackground",
+        "description": "Background color for R code chunks marked `eval = FALSE` (or `eval = F`). Should be subtler than the active background.",
+        "defaults": {
+          "dark": "#ffffff05",
+          "light": "#00000005",
+          "highContrast": "#ffffff0a",
+          "highContrastLight": "#0000000d"
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Raven",
@@ -1128,6 +1225,11 @@
           ],
           "default": "snake_case",
           "description": "Required naming scheme for function formal arguments."
+        },
+        "raven.chunks.highlight.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Highlight R code chunks in .Rmd / .qmd files (and `# %%` cells in .R files) with a background color. Disable to remove the background entirely."
         },
         "raven.linting.objectNameSeverity": {
           "type": "string",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -237,13 +237,13 @@
         "command": "raven.goToNextChunk",
         "key": "ctrl+alt+n",
         "mac": "cmd+alt+n",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+        "when": "editorTextFocus && editorLangId == r"
       },
       {
         "command": "raven.goToPreviousChunk",
         "key": "ctrl+alt+shift+n",
         "mac": "cmd+alt+shift+n",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+        "when": "editorTextFocus && editorLangId == r"
       }
     ],
     "submenus": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -225,7 +225,7 @@
         "command": "raven.runCurrentChunk",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled && resourceExtname =~ /\\.(rmd|Rmd|qmd|QMD)$/"
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled && resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/"
       },
       {
         "command": "raven.runAboveChunks",
@@ -404,7 +404,10 @@
           ".R",
           ".rmd",
           ".Rmd",
-          ".qmd"
+          ".RMD",
+          ".qmd",
+          ".Qmd",
+          ".QMD"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import {
-    classify_chunk_document,
+    classify_chunk_document_for_document,
     detect_chunks,
     has_chunk_anchor,
     is_runnable_chunk,
@@ -33,7 +33,7 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         document: vscode.TextDocument,
         _token: vscode.CancellationToken,
     ): vscode.CodeLens[] {
-        const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+        const kind = classify_chunk_document_for_document(document);
         // Fast path: plain `.R` files without `# %%` markers (and prose-only
         // `.Rmd` documents) skip the per-line scan entirely.
         if (!has_chunk_anchor(document.getText(), kind)) return [];

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -20,6 +20,10 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         this._on_did_change.fire();
     }
 
+    dispose(): void {
+        this._on_did_change.dispose();
+    }
+
     provideCodeLenses(
         document: vscode.TextDocument,
         _token: vscode.CancellationToken,
@@ -64,8 +68,10 @@ export function register_chunk_codelens(context: vscode.ExtensionContext): Chunk
             ],
             provider,
         ),
+        provider,
     );
     // Refresh lenses on document edits so they track newly added chunks.
+    // VS Code already coalesces CodeLens recomputation; we just fire the event.
     context.subscriptions.push(
         vscode.workspace.onDidChangeTextDocument(() => provider.refresh()),
     );

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+import {
+    classify_chunk_document,
+    detect_chunks,
+    is_runnable_chunk,
+} from './chunk-detector';
+
+/**
+ * CodeLens provider that places "Run Chunk | Run Above" buttons on every R chunk
+ * header in `.Rmd` / `.qmd` / `.R` documents.
+ *
+ * Non-R chunks (e.g. `{python}`, `{bash}`) are skipped — they aren't executable
+ * via the R console.
+ */
+class ChunkCodeLensProvider implements vscode.CodeLensProvider {
+    private readonly _on_did_change = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this._on_did_change.event;
+
+    refresh(): void {
+        this._on_did_change.fire();
+    }
+
+    provideCodeLenses(
+        document: vscode.TextDocument,
+        _token: vscode.CancellationToken,
+    ): vscode.CodeLens[] {
+        const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+        const lines: string[] = [];
+        for (let i = 0; i < document.lineCount; i++) lines.push(document.lineAt(i).text);
+        const chunks = detect_chunks(lines, kind);
+        const lenses: vscode.CodeLens[] = [];
+        let chunk_index = 0;
+        for (const c of chunks) {
+            chunk_index++;
+            if (!is_runnable_chunk(c)) continue;
+            const range = new vscode.Range(c.header_line, 0, c.header_line, 0);
+            const eval_suffix = c.is_eval_false ? ' (eval = FALSE)' : '';
+            lenses.push(new vscode.CodeLens(range, {
+                title: `▷ Run Chunk${eval_suffix}`,
+                command: 'raven.runCurrentChunkAt',
+                arguments: [document.uri, c.header_line],
+                tooltip: c.label
+                    ? `Run chunk "${c.label}" in the R console`
+                    : `Run chunk #${chunk_index} in the R console`,
+            }));
+            lenses.push(new vscode.CodeLens(range, {
+                title: '↥ Run Above',
+                command: 'raven.runAboveChunksAt',
+                arguments: [document.uri, c.header_line],
+                tooltip: 'Run every R chunk above this one',
+            }));
+        }
+        return lenses;
+    }
+}
+
+export function register_chunk_codelens(context: vscode.ExtensionContext): ChunkCodeLensProvider {
+    const provider = new ChunkCodeLensProvider();
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider(
+            [
+                { scheme: 'file', language: 'r' },
+                { scheme: 'untitled', language: 'r' },
+            ],
+            provider,
+        ),
+    );
+    // Refresh lenses on document edits so they track newly added chunks.
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument(() => provider.refresh()),
+    );
+    return provider;
+}

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -12,14 +12,18 @@ import {
  *
  * Non-R chunks (e.g. `{python}`, `{bash}`) are skipped — they aren't executable
  * via the R console.
+ *
+ * Lens invalidation is left to VS Code: the editor automatically re-calls
+ * `provideCodeLenses` (with internal debouncing) after document edits, visible-
+ * range changes, and selector-matching scope shifts. Because our lenses depend
+ * only on the document text, we don't fire `onDidChangeCodeLenses` ourselves —
+ * doing so on every keystroke would bypass VS Code's coalescing and trigger an
+ * immediate recompute per edit. The optional event is declared (and disposed)
+ * to keep the provider future-proof for cases that need external invalidation.
  */
 class ChunkCodeLensProvider implements vscode.CodeLensProvider {
     private readonly _on_did_change = new vscode.EventEmitter<void>();
     readonly onDidChangeCodeLenses = this._on_did_change.event;
-
-    refresh(): void {
-        this._on_did_change.fire();
-    }
 
     dispose(): void {
         this._on_did_change.dispose();
@@ -73,11 +77,6 @@ export function register_chunk_codelens(context: vscode.ExtensionContext): Chunk
             provider,
         ),
         provider,
-    );
-    // Refresh lenses on document edits so they track newly added chunks.
-    // VS Code already coalesces CodeLens recomputation; we just fire the event.
-    context.subscriptions.push(
-        vscode.workspace.onDidChangeTextDocument(() => provider.refresh()),
     );
     return provider;
 }

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
     classify_chunk_document,
     detect_chunks,
+    has_chunk_anchor,
     is_runnable_chunk,
 } from './chunk-detector';
 
@@ -29,6 +30,9 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         _token: vscode.CancellationToken,
     ): vscode.CodeLens[] {
         const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+        // Fast path: plain `.R` files without `# %%` markers (and prose-only
+        // `.Rmd` documents) skip the per-line scan entirely.
+        if (!has_chunk_anchor(document.getText(), kind)) return [];
         const lines: string[] = [];
         for (let i = 0; i < document.lineCount; i++) lines.push(document.lineAt(i).text);
         const chunks = detect_chunks(lines, kind);

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -1,0 +1,177 @@
+import * as vscode from 'vscode';
+import {
+    classify_chunk_document,
+    detect_chunks,
+    find_chunk_at_line,
+    chunks_above,
+    extract_chunk_code,
+    is_runnable_chunk,
+    Chunk,
+} from './chunk-detector';
+import { get_or_create_r_terminal } from '../send-to-r/r-terminal-manager';
+import { send_code, get_send_options } from '../send-to-r/send-code';
+
+type RunMode = 'current' | 'currentAndMove' | 'above' | 'all';
+
+function get_document_lines(document: vscode.TextDocument): string[] {
+    const lines: string[] = [];
+    for (let i = 0; i < document.lineCount; i++) {
+        lines.push(document.lineAt(i).text);
+    }
+    return lines;
+}
+
+function chunks_for_document(document: vscode.TextDocument): Chunk[] {
+    const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+    return detect_chunks(get_document_lines(document), kind);
+}
+
+function combined_code(lines: string[], chunks: Chunk[]): string {
+    const parts: string[] = [];
+    for (const c of chunks) {
+        if (!is_runnable_chunk(c)) continue;
+        const code = extract_chunk_code(lines, c);
+        if (code.trim().length > 0) parts.push(code);
+    }
+    return parts.join('\n');
+}
+
+async function send_to_r(code: string): Promise<void> {
+    if (code.trim().length === 0) return;
+    const terminal = await get_or_create_r_terminal();
+    terminal.show(true);
+    send_code(terminal, code, get_send_options());
+}
+
+function find_visible_editor(uri: vscode.Uri): vscode.TextEditor | undefined {
+    return vscode.window.visibleTextEditors.find(
+        (e) => e.document.uri.toString() === uri.toString(),
+    );
+}
+
+function move_cursor_to_next_chunk(
+    editor: vscode.TextEditor,
+    chunks: Chunk[],
+    current: Chunk,
+): void {
+    const next = chunks.find((c) => c.header_line > current.header_line && is_runnable_chunk(c));
+    if (!next) return;
+    const target_line = Math.min(next.header_line + 1, editor.document.lineCount - 1);
+    const pos = new vscode.Position(target_line, 0);
+    editor.selection = new vscode.Selection(pos, pos);
+    editor.revealRange(new vscode.Range(pos, pos));
+}
+
+async function run_chunk_at(
+    mode: RunMode,
+    document: vscode.TextDocument,
+    cursor_line: number,
+): Promise<void> {
+    const editor = find_visible_editor(document.uri);
+    const lines = get_document_lines(document);
+    const chunks = chunks_for_document(document);
+    if (chunks.length === 0) {
+        vscode.window.showInformationMessage('Raven: no R chunks found in this document.');
+        return;
+    }
+
+    if (mode === 'all') {
+        const code = combined_code(lines, chunks);
+        if (code.length === 0) {
+            vscode.window.showInformationMessage('Raven: no runnable R chunks to execute.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
+    if (mode === 'above') {
+        const above = chunks_above(chunks, cursor_line);
+        const code = combined_code(lines, above);
+        if (code.length === 0) {
+            vscode.window.showInformationMessage('Raven: no runnable chunks above the cursor.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
+    const current = find_chunk_at_line(chunks, cursor_line);
+    if (!current) {
+        vscode.window.showInformationMessage(
+            'Raven: cursor is not inside an R chunk. Place the cursor inside a ```{r} block or after a `# %%` marker.'
+        );
+        return;
+    }
+    if (!is_runnable_chunk(current)) {
+        vscode.window.showInformationMessage(
+            `Raven: current chunk language is "${current.language}" — only "r" chunks can be sent to the R console.`
+        );
+        return;
+    }
+    const code = extract_chunk_code(lines, current);
+    if (code.trim().length === 0) {
+        vscode.window.showInformationMessage('Raven: current chunk is empty.');
+        if (mode === 'currentAndMove' && editor) move_cursor_to_next_chunk(editor, chunks, current);
+        return;
+    }
+    await send_to_r(code);
+    if (mode === 'currentAndMove' && editor) move_cursor_to_next_chunk(editor, chunks, current);
+}
+
+async function run_chunk(mode: RunMode): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+    await run_chunk_at(mode, editor.document, editor.selection.active.line);
+}
+
+async function run_chunk_at_command(
+    mode: RunMode,
+    uri_or_arg: unknown,
+    line_arg: unknown,
+): Promise<void> {
+    const uri = uri_or_arg instanceof vscode.Uri ? uri_or_arg : null;
+    const line = typeof line_arg === 'number' ? line_arg : null;
+    if (uri === null || line === null) {
+        // Fall back to active editor when invoked without arguments (e.g. command palette).
+        await run_chunk(mode);
+        return;
+    }
+    let document: vscode.TextDocument;
+    try {
+        document = await vscode.workspace.openTextDocument(uri);
+    } catch {
+        await run_chunk(mode);
+        return;
+    }
+    await run_chunk_at(mode, document, line);
+}
+
+export function register_chunk_commands(context: vscode.ExtensionContext): void {
+    const handlers: Array<[string, RunMode]> = [
+        ['raven.runCurrentChunk', 'current'],
+        ['raven.runCurrentChunkAndMove', 'currentAndMove'],
+        ['raven.runAboveChunks', 'above'],
+        ['raven.runAllChunks', 'all'],
+    ];
+    for (const [id, mode] of handlers) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(id, () => run_chunk(mode))
+        );
+    }
+
+    // Positional variants used by CodeLens (header line is known up-front).
+    const positional: Array<[string, RunMode]> = [
+        ['raven.runCurrentChunkAt', 'current'],
+        ['raven.runAboveChunksAt', 'above'],
+    ];
+    for (const [id, mode] of positional) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(id, (uri: unknown, line: unknown) =>
+                run_chunk_at_command(mode, uri, line)
+            ),
+        );
+    }
+}
+
+export { chunks_for_document, get_document_lines };

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -38,9 +38,14 @@ function combined_code(lines: string[], chunks: Chunk[]): string {
 
 async function send_to_r(code: string): Promise<void> {
     if (code.trim().length === 0) return;
-    const terminal = await get_or_create_r_terminal();
-    terminal.show(true);
-    send_code(terminal, code, get_send_options());
+    try {
+        const terminal = await get_or_create_r_terminal();
+        terminal.show(true);
+        send_code(terminal, code, get_send_options());
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Raven: failed to send chunk to R — ${message}`);
+    }
 }
 
 function find_visible_editor(uri: vscode.Uri): vscode.TextEditor | undefined {
@@ -133,15 +138,21 @@ async function run_chunk_at_command(
     const uri = uri_or_arg instanceof vscode.Uri ? uri_or_arg : null;
     const line = typeof line_arg === 'number' ? line_arg : null;
     if (uri === null || line === null) {
-        // Fall back to active editor when invoked without arguments (e.g. command palette).
+        // Invoked without arguments (e.g. directly from the command palette).
+        // Fall back to the active editor's cursor.
         await run_chunk(mode);
         return;
     }
     let document: vscode.TextDocument;
     try {
         document = await vscode.workspace.openTextDocument(uri);
-    } catch {
-        await run_chunk(mode);
+    } catch (err) {
+        // Stale CodeLens: refuse to silently run a different chunk. Surface the
+        // failure so the user knows the click didn't take effect.
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(
+            `Raven: could not open chunk document (${message}). Try reopening the file.`
+        );
         return;
     }
     await run_chunk_at(mode, document, line);

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -5,6 +5,7 @@ import {
     find_chunk_at_line,
     chunks_above,
     extract_chunk_code,
+    has_chunk_anchor,
     is_runnable_chunk,
     Chunk,
 } from './chunk-detector';
@@ -23,6 +24,10 @@ function get_document_lines(document: vscode.TextDocument): string[] {
 
 function chunks_for_document(document: vscode.TextDocument): Chunk[] {
     const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+    // Fast path: skip the per-line scan when the document has no chunk anchors.
+    // For a plain `.R` file with no `# %%` markers this avoids materializing the
+    // line array AND running the marker regex on every keystroke.
+    if (!has_chunk_anchor(document.getText(), kind)) return [];
     return detect_chunks(get_document_lines(document), kind);
 }
 

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import {
-    classify_chunk_document,
+    classify_chunk_document_for_document,
     detect_chunks,
     find_chunk_at_line,
     chunks_above,
@@ -23,7 +23,7 @@ function get_document_lines(document: vscode.TextDocument): string[] {
 }
 
 function chunks_for_document(document: vscode.TextDocument): Chunk[] {
-    const kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+    const kind = classify_chunk_document_for_document(document);
     // Fast path: skip the per-line scan when the document has no chunk anchors.
     // For a plain `.R` file with no `# %%` markers this avoids materializing the
     // line array AND running the marker regex on every keystroke.

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -62,6 +62,26 @@ export function classify_chunk_document(file_name_or_uri: string): DocumentKind 
 }
 
 /**
+ * Classify a document by inspecting both its languageId and its URI. Used at
+ * the VS Code adapter layer (commands, CodeLens, decorations) where we have
+ * a full `TextDocument`. Checks languageId first so untitled buffers and
+ * environments with a dedicated `rmd` / `quarto` languageId classify correctly,
+ * then falls back to the extension-based check for saved files registered
+ * under our single `r` languageId.
+ *
+ * Today the extension registers only `r` (covering `.r` / `.R` / `.rmd` /
+ * `.Rmd` / `.RMD` / `.qmd` / `.Qmd` / `.QMD`); the languageId path remains
+ * forward-compatible should that ever change.
+ */
+export function classify_chunk_document_for_document(
+    document: { languageId: string; uri: { fsPath: string; path: string } },
+): DocumentKind {
+    const lang = document.languageId.toLowerCase();
+    if (lang === 'rmd' || lang === 'quarto') return 'rmd';
+    return classify_chunk_document(document.uri.fsPath || document.uri.path);
+}
+
+/**
  * Cheap substring screen for "does this document contain any chunk anchors?".
  * Lets callers skip the per-line detector loop on plain `.R` files that never
  * use cell markers and on prose-only `.Rmd` documents.

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -1,0 +1,244 @@
+/**
+ * Code-chunk detection for R Markdown / Quarto fenced blocks and `.R` cell markers.
+ *
+ * Pure functions (no VS Code dependency) — unit-testable from `tests/bun/`.
+ *
+ * Chunk forms supported:
+ *   - Rmd/Qmd fenced block: ```` ```{r ...} ```` … ```` ``` ```` (backticks or tildes,
+ *     fence must start at column 0; closing fence must use the same character and be
+ *     at least as long as the opener).
+ *   - `.R` cell marker: a line matching `/^#+\s*%%/` starts a new cell that extends
+ *     until the next marker or end-of-file.
+ *
+ * The `language` field is normalized to lower case. For `.R` cells it is always `'r'`.
+ */
+
+export type ChunkKind = 'rmd' | 'r';
+export type DocumentKind = ChunkKind;
+
+export interface Chunk {
+    /** 0-based line index of the chunk header (fence or `# %%` line). */
+    header_line: number;
+    /**
+     * 0-based line index of the last content line (inclusive).
+     * For an Rmd chunk, this is one line above `closing_fence_line` when the fence
+     * is present, or the last line of the file when unclosed.
+     * For a `.R` cell, this is the line above the next cell marker (or EOF).
+     */
+    end_line: number;
+    /**
+     * 0-based line index of the closing fence (Rmd only). `null` for `.R` cells and
+     * for unclosed Rmd chunks that run off the end of the file.
+     */
+    closing_fence_line: number | null;
+    /** Language tag from the chunk header, lower-cased. `.R` cells are always `'r'`. */
+    language: string;
+    /** Optional first identifier in the header (e.g. `setup` in `{r setup, eval=FALSE}`). */
+    label: string | null;
+    /** Parsed `key=value` options from the header (unquoted, trimmed). */
+    options: Record<string, string>;
+    /** True when `eval = FALSE` (or `F`) is present in the header options. */
+    is_eval_false: boolean;
+    /** Marker for which detection path produced this chunk. */
+    kind: ChunkKind;
+}
+
+const FENCE_HEADER_RE = /^(`{3,}|~{3,})\s*\{([A-Za-z0-9_+.\-]+)([^}]*)\}\s*$/;
+const FENCE_CLOSE_RE = /^(`{3,}|~{3,})\s*$/;
+const CELL_MARKER_RE = /^#+\s*%%/;
+
+/**
+ * Classify a document path (or URI string) by file extension.
+ * Falls back to `'r'` so behavior in unknown contexts is predictable.
+ */
+export function classify_chunk_document(file_name_or_uri: string): DocumentKind {
+    const lower = file_name_or_uri.toLowerCase();
+    if (lower.endsWith('.rmd') || lower.endsWith('.qmd')) return 'rmd';
+    return 'r';
+}
+
+/**
+ * Parse the body of a chunk header (everything between `{` and `}`, excluding the
+ * leading language tag). Returns the optional label (first bare identifier) and a
+ * map of `key=value` options. Values are returned unquoted and trimmed.
+ */
+function parse_header_options(rest: string): { label: string | null; options: Record<string, string> } {
+    const options: Record<string, string> = {};
+    let label: string | null = null;
+    const trimmed = rest.trim();
+    if (trimmed.length === 0) return { label, options };
+
+    // Split on commas, but respect simple quoted-string spans so a comma inside
+    // a quoted value doesn't shred the option list.
+    const parts: string[] = [];
+    let current = '';
+    let in_quote: '"' | "'" | null = null;
+    for (let i = 0; i < trimmed.length; i++) {
+        const ch = trimmed[i];
+        if (in_quote) {
+            current += ch;
+            if (ch === in_quote) in_quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'") {
+            in_quote = ch;
+            current += ch;
+            continue;
+        }
+        if (ch === ',') {
+            parts.push(current);
+            current = '';
+            continue;
+        }
+        current += ch;
+    }
+    if (current.length > 0) parts.push(current);
+
+    for (const raw of parts) {
+        const part = raw.trim();
+        if (part.length === 0) continue;
+        const eq = part.indexOf('=');
+        if (eq === -1) {
+            // Bare token: the first one is the label.
+            if (label === null) {
+                label = part;
+            }
+            continue;
+        }
+        const key = part.slice(0, eq).trim();
+        let value = part.slice(eq + 1).trim();
+        // Strip surrounding quotes for convenience.
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        }
+        if (key.length > 0) options[key] = value;
+    }
+
+    return { label, options };
+}
+
+function eval_false_from_options(options: Record<string, string>): boolean {
+    const raw = options.eval;
+    if (raw === undefined) return false;
+    const v = raw.trim().toUpperCase();
+    return v === 'F' || v === 'FALSE';
+}
+
+/**
+ * Detect all chunks in the document, in source order.
+ * `kind` controls which form to look for (caller decides via `classify_chunk_document`).
+ */
+export function detect_chunks(lines: string[], kind: DocumentKind): Chunk[] {
+    return kind === 'rmd' ? detect_rmd_chunks(lines) : detect_r_cells(lines);
+}
+
+function detect_rmd_chunks(lines: string[]): Chunk[] {
+    const chunks: Chunk[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const header_match = FENCE_HEADER_RE.exec(lines[i]);
+        if (!header_match) {
+            i++;
+            continue;
+        }
+        const fence = header_match[1];
+        const lang = header_match[2].toLowerCase();
+        const { label, options } = parse_header_options(header_match[3] ?? '');
+
+        // Find a matching closing fence (same char, at least as long).
+        const fence_char = fence[0];
+        const min_len = fence.length;
+        let closing_line: number | null = null;
+        for (let j = i + 1; j < lines.length; j++) {
+            const close_match = FENCE_CLOSE_RE.exec(lines[j]);
+            if (close_match && close_match[1][0] === fence_char && close_match[1].length >= min_len) {
+                closing_line = j;
+                break;
+            }
+        }
+        const end_line = closing_line !== null ? closing_line - 1 : lines.length - 1;
+        chunks.push({
+            header_line: i,
+            end_line: Math.max(end_line, i),
+            closing_fence_line: closing_line,
+            language: lang,
+            label,
+            options,
+            is_eval_false: eval_false_from_options(options),
+            kind: 'rmd',
+        });
+        i = closing_line !== null ? closing_line + 1 : lines.length;
+    }
+    return chunks;
+}
+
+function detect_r_cells(lines: string[]): Chunk[] {
+    const chunks: Chunk[] = [];
+    const marker_lines: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (CELL_MARKER_RE.test(lines[i])) marker_lines.push(i);
+    }
+    for (let m = 0; m < marker_lines.length; m++) {
+        const header_line = marker_lines[m];
+        const next_marker = m + 1 < marker_lines.length ? marker_lines[m + 1] : lines.length;
+        const end_line = Math.max(next_marker - 1, header_line);
+        chunks.push({
+            header_line,
+            end_line,
+            closing_fence_line: null,
+            language: 'r',
+            label: null,
+            options: {},
+            is_eval_false: false,
+            kind: 'r',
+        });
+    }
+    return chunks;
+}
+
+/**
+ * Find the chunk that contains a given 0-based line index, or `null` if the line
+ * is outside any chunk. The header line and (for Rmd) the closing fence line are
+ * considered "inside" the chunk.
+ */
+export function find_chunk_at_line(chunks: Chunk[], line: number): Chunk | null {
+    for (const c of chunks) {
+        const last = c.closing_fence_line ?? c.end_line;
+        if (line >= c.header_line && line <= last) return c;
+    }
+    return null;
+}
+
+/**
+ * Return chunks whose last line is strictly above the cursor line. When the cursor
+ * sits inside a chunk, that chunk is NOT included in the result.
+ */
+export function chunks_above(chunks: Chunk[], line: number): Chunk[] {
+    const out: Chunk[] = [];
+    for (const c of chunks) {
+        const last = c.closing_fence_line ?? c.end_line;
+        if (last < line) out.push(c);
+    }
+    return out;
+}
+
+/**
+ * Return the executable code inside the chunk, joined with `\n`.
+ * Excludes the header/fence lines.
+ */
+export function extract_chunk_code(lines: string[], chunk: Chunk): string {
+    const start = chunk.header_line + 1;
+    const end = chunk.end_line;
+    if (start > end) return '';
+    return lines.slice(start, end + 1).join('\n');
+}
+
+/**
+ * Whether the chunk's language is something Raven can run in R (i.e. R itself).
+ * Non-R language tags (python, julia, bash, …) are recognized for navigation/outline
+ * purposes but not sent to the R terminal.
+ */
+export function is_runnable_chunk(chunk: Chunk): boolean {
+    return chunk.language === 'r';
+}

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -45,7 +45,11 @@ export interface Chunk {
 
 const FENCE_HEADER_RE = /^(`{3,}|~{3,})\s*\{([A-Za-z0-9_+.\-]+)([^}]*)\}\s*$/;
 const FENCE_CLOSE_RE = /^(`{3,}|~{3,})\s*$/;
-const CELL_MARKER_RE = /^#+\s*%%/;
+// Cell marker: a comment line that starts with `# %%` (any number of leading `#`),
+// followed by end-of-line or whitespace. This avoids matching `# %%%` (three or
+// more `%`) or `# %%inline-text` which are not cell delimiters in VS Code's
+// interactive-cell convention.
+const CELL_MARKER_RE = /^#+\s*%%(?!%)(?:\s.*)?$/;
 
 /**
  * Classify a document path (or URI string) by file extension.
@@ -68,15 +72,22 @@ function parse_header_options(rest: string): { label: string | null; options: Re
     const trimmed = rest.trim();
     if (trimmed.length === 0) return { label, options };
 
-    // Split on commas, but respect simple quoted-string spans so a comma inside
-    // a quoted value doesn't shred the option list.
+    // Split on commas while keeping nested parens/brackets/braces and quoted
+    // strings intact, so values like `fig.dim=c(5, 6)` or `lab="a,b"` survive.
+    // Backslash-escaped quotes inside a quoted span are respected.
     const parts: string[] = [];
     let current = '';
     let in_quote: '"' | "'" | null = null;
+    let depth = 0;
     for (let i = 0; i < trimmed.length; i++) {
         const ch = trimmed[i];
         if (in_quote) {
             current += ch;
+            if (ch === '\\' && i + 1 < trimmed.length) {
+                current += trimmed[i + 1];
+                i++;
+                continue;
+            }
             if (ch === in_quote) in_quote = null;
             continue;
         }
@@ -85,7 +96,17 @@ function parse_header_options(rest: string): { label: string | null; options: Re
             current += ch;
             continue;
         }
-        if (ch === ',') {
+        if (ch === '(' || ch === '[' || ch === '{') {
+            depth++;
+            current += ch;
+            continue;
+        }
+        if (ch === ')' || ch === ']' || ch === '}') {
+            if (depth > 0) depth--;
+            current += ch;
+            continue;
+        }
+        if (ch === ',' && depth === 0) {
             parts.push(current);
             current = '';
             continue;

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -62,6 +62,21 @@ export function classify_chunk_document(file_name_or_uri: string): DocumentKind 
 }
 
 /**
+ * Cheap substring screen for "does this document contain any chunk anchors?".
+ * Lets callers skip the per-line detector loop on plain `.R` files that never
+ * use cell markers and on prose-only `.Rmd` documents.
+ *
+ * The screen is intentionally coarse: returning `true` only guarantees that an
+ * anchor character sequence is present somewhere in the text, not that any
+ * valid chunk will actually be detected. Use the result as a fast-path gate,
+ * not as authoritative chunk presence.
+ */
+export function has_chunk_anchor(text: string, kind: DocumentKind): boolean {
+    if (kind === 'r') return text.includes('%%');
+    return text.includes('```') || text.includes('~~~');
+}
+
+/**
  * Parse the body of a chunk header (everything between `{` and `}`, excluding the
  * leading language tag). Returns the optional label (first bare identifier) and a
  * map of `key=value` options. Values are returned unquoted and trimmed.

--- a/editors/vscode/src/chunks/chunk-highlighting.ts
+++ b/editors/vscode/src/chunks/chunk-highlighting.ts
@@ -1,0 +1,139 @@
+import * as vscode from 'vscode';
+import {
+    classify_chunk_document,
+    detect_chunks,
+    is_runnable_chunk,
+} from './chunk-detector';
+
+/**
+ * Manages per-editor background decoration for R chunk regions.
+ *
+ * Two decoration types are used:
+ *   - "active": chunks with `eval = TRUE` (the default).
+ *   - "inactive": chunks with `eval = FALSE`, rendered with reduced opacity so users
+ *     can see at a glance that these will not be evaluated by `knitr` / `quarto render`.
+ *
+ * The colors are themable via the `colorCustomizations` mechanism (see
+ * `register_chunk_decorations`).
+ */
+class ChunkDecorationManager {
+    private active_type: vscode.TextEditorDecorationType;
+    private inactive_type: vscode.TextEditorDecorationType;
+    private debounce_handle: NodeJS.Timeout | undefined;
+
+    constructor() {
+        this.active_type = this.create_decoration(false);
+        this.inactive_type = this.create_decoration(true);
+    }
+
+    private create_decoration(inactive: boolean): vscode.TextEditorDecorationType {
+        return vscode.window.createTextEditorDecorationType({
+            isWholeLine: true,
+            backgroundColor: new vscode.ThemeColor(
+                inactive ? 'raven.chunk.inactiveBackground' : 'raven.chunk.activeBackground',
+            ),
+            overviewRulerLane: vscode.OverviewRulerLane.Left,
+            overviewRulerColor: new vscode.ThemeColor(
+                inactive ? 'raven.chunk.inactiveBackground' : 'raven.chunk.activeBackground',
+            ),
+        });
+    }
+
+    update(editor: vscode.TextEditor | undefined): void {
+        if (!editor) return;
+        if (!is_chunk_capable_document(editor.document)) {
+            editor.setDecorations(this.active_type, []);
+            editor.setDecorations(this.inactive_type, []);
+            return;
+        }
+        if (!chunks_enabled()) {
+            editor.setDecorations(this.active_type, []);
+            editor.setDecorations(this.inactive_type, []);
+            return;
+        }
+        const kind = classify_chunk_document(editor.document.uri.fsPath || editor.document.uri.path);
+        const lines: string[] = [];
+        for (let i = 0; i < editor.document.lineCount; i++) lines.push(editor.document.lineAt(i).text);
+        const chunks = detect_chunks(lines, kind);
+        const active_ranges: vscode.Range[] = [];
+        const inactive_ranges: vscode.Range[] = [];
+        for (const c of chunks) {
+            if (!is_runnable_chunk(c)) continue;
+            const last = c.closing_fence_line ?? c.end_line;
+            const range = new vscode.Range(c.header_line, 0, last, 0);
+            (c.is_eval_false ? inactive_ranges : active_ranges).push(range);
+        }
+        editor.setDecorations(this.active_type, active_ranges);
+        editor.setDecorations(this.inactive_type, inactive_ranges);
+    }
+
+    update_visible(): void {
+        for (const editor of vscode.window.visibleTextEditors) {
+            this.update(editor);
+        }
+    }
+
+    /**
+     * Debounced refresh for rapid edits — VS Code coalesces editor-change events well,
+     * but Rmd documents in particular can be large, so we throttle to 75ms.
+     */
+    schedule_refresh(): void {
+        if (this.debounce_handle !== undefined) {
+            clearTimeout(this.debounce_handle);
+        }
+        this.debounce_handle = setTimeout(() => {
+            this.debounce_handle = undefined;
+            this.update_visible();
+        }, 75);
+    }
+
+    rebuild_decorations(): void {
+        this.active_type.dispose();
+        this.inactive_type.dispose();
+        this.active_type = this.create_decoration(false);
+        this.inactive_type = this.create_decoration(true);
+        this.update_visible();
+    }
+
+    dispose(): void {
+        if (this.debounce_handle !== undefined) clearTimeout(this.debounce_handle);
+        this.active_type.dispose();
+        this.inactive_type.dispose();
+    }
+}
+
+function chunks_enabled(): boolean {
+    const config = vscode.workspace.getConfiguration('raven.chunks');
+    return config.get<boolean>('highlight.enabled', true);
+}
+
+function is_chunk_capable_document(document: vscode.TextDocument): boolean {
+    if (document.languageId !== 'r') return false;
+    // For .R files we still draw highlight for `# %%` cells.
+    return true;
+}
+
+export function register_chunk_decorations(context: vscode.ExtensionContext): ChunkDecorationManager {
+    const manager = new ChunkDecorationManager();
+    context.subscriptions.push({ dispose: () => manager.dispose() });
+
+    manager.update_visible();
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor((editor) => manager.update(editor)),
+        vscode.window.onDidChangeVisibleTextEditors(() => manager.update_visible()),
+        vscode.workspace.onDidChangeTextDocument((event) => {
+            const active = vscode.window.activeTextEditor;
+            if (active && event.document.uri.toString() === active.document.uri.toString()) {
+                manager.schedule_refresh();
+            }
+        }),
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration('raven.chunks.highlight')) {
+                manager.rebuild_decorations();
+            }
+        }),
+    );
+
+    return manager;
+}

--- a/editors/vscode/src/chunks/chunk-highlighting.ts
+++ b/editors/vscode/src/chunks/chunk-highlighting.ts
@@ -123,10 +123,15 @@ export function register_chunk_decorations(context: vscode.ExtensionContext): Ch
         vscode.window.onDidChangeActiveTextEditor((editor) => manager.update(editor)),
         vscode.window.onDidChangeVisibleTextEditors(() => manager.update_visible()),
         vscode.workspace.onDidChangeTextDocument((event) => {
-            const active = vscode.window.activeTextEditor;
-            if (active && event.document.uri.toString() === active.document.uri.toString()) {
-                manager.schedule_refresh();
-            }
+            // Refresh whenever the changed document is currently visible — that
+            // covers both the active editor and any split-view panes showing
+            // the same document, so decorations don't go stale when the user
+            // edits via a workspace edit or in another pane.
+            const document_uri = event.document.uri.toString();
+            const is_visible = vscode.window.visibleTextEditors.some(
+                (editor) => editor.document.uri.toString() === document_uri,
+            );
+            if (is_visible) manager.schedule_refresh();
         }),
         vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration('raven.chunks.highlight')) {

--- a/editors/vscode/src/chunks/chunk-highlighting.ts
+++ b/editors/vscode/src/chunks/chunk-highlighting.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import {
-    classify_chunk_document,
+    classify_chunk_document_for_document,
     detect_chunks,
     has_chunk_anchor,
     is_runnable_chunk,
@@ -52,7 +52,7 @@ class ChunkDecorationManager {
             editor.setDecorations(this.inactive_type, []);
             return;
         }
-        const kind = classify_chunk_document(editor.document.uri.fsPath || editor.document.uri.path);
+        const kind = classify_chunk_document_for_document(editor.document);
         // Fast path: avoid the per-line scan on `.R` files without `# %%`
         // markers and prose-only `.Rmd` documents. Still clears any stale
         // decorations from a prior state in case markers were just removed.
@@ -117,9 +117,12 @@ function chunks_enabled(): boolean {
 }
 
 function is_chunk_capable_document(document: vscode.TextDocument): boolean {
-    if (document.languageId !== 'r') return false;
-    // For .R files we still draw highlight for `# %%` cells.
-    return true;
+    // Accept our registered `r` languageId (which today covers `.r` / `.R` and
+    // `.Rmd` / `.qmd`), plus any sibling extension that contributes a dedicated
+    // `rmd` or `quarto` languageId. For `.R` files we still draw highlight for
+    // `# %%` cells.
+    const lang = document.languageId.toLowerCase();
+    return lang === 'r' || lang === 'rmd' || lang === 'quarto';
 }
 
 export function register_chunk_decorations(context: vscode.ExtensionContext): ChunkDecorationManager {

--- a/editors/vscode/src/chunks/chunk-highlighting.ts
+++ b/editors/vscode/src/chunks/chunk-highlighting.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
     classify_chunk_document,
     detect_chunks,
+    has_chunk_anchor,
     is_runnable_chunk,
 } from './chunk-detector';
 
@@ -52,6 +53,14 @@ class ChunkDecorationManager {
             return;
         }
         const kind = classify_chunk_document(editor.document.uri.fsPath || editor.document.uri.path);
+        // Fast path: avoid the per-line scan on `.R` files without `# %%`
+        // markers and prose-only `.Rmd` documents. Still clears any stale
+        // decorations from a prior state in case markers were just removed.
+        if (!has_chunk_anchor(editor.document.getText(), kind)) {
+            editor.setDecorations(this.active_type, []);
+            editor.setDecorations(this.inactive_type, []);
+            return;
+        }
         const lines: string[] = [];
         for (let i = 0; i < editor.document.lineCount; i++) lines.push(editor.document.lineAt(i).text);
         const chunks = detect_chunks(lines, kind);

--- a/editors/vscode/src/chunks/chunk-navigation.ts
+++ b/editors/vscode/src/chunks/chunk-navigation.ts
@@ -63,12 +63,19 @@ function select_current(): void {
         );
         return;
     }
-    // Select the content lines only (exclude the header and closing fence).
-    const start_line = Math.min(current.header_line + 1, editor.document.lineCount - 1);
-    const end_line = Math.max(start_line, current.end_line);
-    const start = new vscode.Position(start_line, 0);
-    const end_text = editor.document.lineAt(end_line).text;
-    const end = new vscode.Position(end_line, end_text.length);
+    // Empty chunk (no body lines): collapse the cursor to the end of the header
+    // rather than pretending we selected content. This avoids accidentally
+    // capturing the closing fence (Rmd) or cell-marker line (.R).
+    if (current.end_line <= current.header_line) {
+        const header_text = editor.document.lineAt(current.header_line).text;
+        const pos = new vscode.Position(current.header_line, header_text.length);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos));
+        return;
+    }
+    const start = new vscode.Position(current.header_line + 1, 0);
+    const end_text = editor.document.lineAt(current.end_line).text;
+    const end = new vscode.Position(current.end_line, end_text.length);
     editor.selection = new vscode.Selection(start, end);
     editor.revealRange(new vscode.Range(start, end));
 }

--- a/editors/vscode/src/chunks/chunk-navigation.ts
+++ b/editors/vscode/src/chunks/chunk-navigation.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import { chunks_for_document } from './chunk-commands';
+import { Chunk, find_chunk_at_line } from './chunk-detector';
+
+function move_to_line(editor: vscode.TextEditor, line: number): void {
+    const safe = Math.max(0, Math.min(line, editor.document.lineCount - 1));
+    const text = editor.document.lineAt(safe).text;
+    const column = Math.min(editor.selection.active.character, text.length);
+    const pos = new vscode.Position(safe, column);
+    editor.selection = new vscode.Selection(pos, pos);
+    editor.revealRange(new vscode.Range(pos, pos));
+}
+
+function go_to_next(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+    const chunks = chunks_for_document(editor.document);
+    if (chunks.length === 0) return;
+    const cursor = editor.selection.active.line;
+    const next = chunks.find((c) => c.header_line > cursor);
+    if (!next) {
+        vscode.window.setStatusBarMessage('Raven: already at the last chunk.', 2000);
+        return;
+    }
+    // Place the cursor one line below the header (i.e. inside the chunk body) when possible.
+    const target = next.header_line + 1 <= next.end_line ? next.header_line + 1 : next.header_line;
+    move_to_line(editor, target);
+}
+
+function go_to_previous(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+    const chunks = chunks_for_document(editor.document);
+    if (chunks.length === 0) return;
+    const cursor = editor.selection.active.line;
+    // Find the last chunk whose header is strictly above the cursor's current header.
+    const current = find_chunk_at_line(chunks, cursor);
+    const reference_header = current ? current.header_line : cursor;
+    let prev: Chunk | null = null;
+    for (const c of chunks) {
+        if (c.header_line < reference_header) prev = c;
+        else break;
+    }
+    if (!prev) {
+        vscode.window.setStatusBarMessage('Raven: already at the first chunk.', 2000);
+        return;
+    }
+    const target = prev.header_line + 1 <= prev.end_line ? prev.header_line + 1 : prev.header_line;
+    move_to_line(editor, target);
+}
+
+function select_current(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+    const chunks = chunks_for_document(editor.document);
+    if (chunks.length === 0) return;
+    const cursor = editor.selection.active.line;
+    const current = find_chunk_at_line(chunks, cursor);
+    if (!current) {
+        vscode.window.setStatusBarMessage(
+            'Raven: cursor is not inside a chunk.',
+            2000,
+        );
+        return;
+    }
+    // Select the content lines only (exclude the header and closing fence).
+    const start_line = Math.min(current.header_line + 1, editor.document.lineCount - 1);
+    const end_line = Math.max(start_line, current.end_line);
+    const start = new vscode.Position(start_line, 0);
+    const end_text = editor.document.lineAt(end_line).text;
+    const end = new vscode.Position(end_line, end_text.length);
+    editor.selection = new vscode.Selection(start, end);
+    editor.revealRange(new vscode.Range(start, end));
+}
+
+export function register_chunk_navigation(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('raven.goToNextChunk', go_to_next),
+        vscode.commands.registerCommand('raven.goToPreviousChunk', go_to_previous),
+        vscode.commands.registerCommand('raven.selectCurrentChunk', select_current),
+    );
+}

--- a/editors/vscode/src/chunks/index.ts
+++ b/editors/vscode/src/chunks/index.ts
@@ -5,15 +5,37 @@ import { register_chunk_navigation } from './chunk-navigation';
 import { register_chunk_decorations } from './chunk-highlighting';
 
 /**
- * Register every chunk-related contribution: commands, CodeLens provider,
- * navigation commands, and background decorations. Callers must invoke this
- * during extension activation regardless of `raven.rConsole.activation` —
- * navigation and CodeLens still make sense even when there is no R terminal.
- * The run-chunk commands themselves create/reuse the terminal on demand.
+ * Register chunk features that do NOT need an R terminal:
+ *
+ *   - Navigation commands (`raven.goToNextChunk`, `raven.goToPreviousChunk`,
+ *     `raven.selectCurrentChunk`).
+ *   - Background-tint decorations.
+ *
+ * These are safe to enable regardless of `raven.rConsole.activation` so users
+ * who coexist with REditorSupport or Positron still get the visual aids and
+ * cursor-motion commands when reading `.Rmd` / `.qmd` notebooks.
  */
-export function register_chunks(context: vscode.ExtensionContext): void {
-    register_chunk_commands(context);
-    register_chunk_codelens(context);
+export function register_chunks_navigation_and_highlight(
+    context: vscode.ExtensionContext,
+): void {
     register_chunk_navigation(context);
     register_chunk_decorations(context);
+}
+
+/**
+ * Register chunk features that DO need an R terminal:
+ *
+ *   - Run commands (`raven.runCurrentChunk` and friends, plus the positional
+ *     variants the CodeLens invokes).
+ *   - The `▷ Run Chunk` / `↥ Run Above` CodeLens provider.
+ *
+ * Callers must only invoke this when Raven's R console is enabled (i.e. inside
+ * the `r_console_resolved === 'enabled'` branch of `activate()`), otherwise
+ * `get_or_create_r_terminal()` has no terminal manager to consult.
+ */
+export function register_chunks_with_terminal(
+    context: vscode.ExtensionContext,
+): void {
+    register_chunk_commands(context);
+    register_chunk_codelens(context);
 }

--- a/editors/vscode/src/chunks/index.ts
+++ b/editors/vscode/src/chunks/index.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { register_chunk_commands } from './chunk-commands';
+import { register_chunk_codelens } from './chunk-codelens';
+import { register_chunk_navigation } from './chunk-navigation';
+import { register_chunk_decorations } from './chunk-highlighting';
+
+/**
+ * Register every chunk-related contribution: commands, CodeLens provider,
+ * navigation commands, and background decorations. Callers must invoke this
+ * during extension activation regardless of `raven.rConsole.activation` —
+ * navigation and CodeLens still make sense even when there is no R terminal.
+ * The run-chunk commands themselves create/reuse the terminal on demand.
+ */
+export function register_chunks(context: vscode.ExtensionContext): void {
+    register_chunk_commands(context);
+    register_chunk_codelens(context);
+    register_chunk_navigation(context);
+    register_chunk_decorations(context);
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -160,7 +160,7 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
             { scheme: 'untitled', language: 'stan' },
         ],
         synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{r,R,rmd,Rmd,qmd,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}'),
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{r,R,rmd,Rmd,RMD,qmd,Qmd,QMD,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}'),
         },
         outputChannel: outputChannel,
         initializationOptions: getInitializationOptions,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -28,6 +28,7 @@ import {
     get_or_create_r_terminal,
 } from './send-to-r';
 import { register_build_commands } from './build-commands';
+import { register_chunks } from './chunks';
 import { register_r_package_detection } from './r-package-detection';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';
@@ -206,6 +207,7 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         register_send_to_r_commands(context);
         register_inspection_commands(context);
         register_build_commands(context);
+        register_chunks(context);
     }
 
     // Package-mode context key. The `raven.isRPackage` key gates the

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -28,7 +28,10 @@ import {
     get_or_create_r_terminal,
 } from './send-to-r';
 import { register_build_commands } from './build-commands';
-import { register_chunks } from './chunks';
+import {
+    register_chunks_navigation_and_highlight,
+    register_chunks_with_terminal,
+} from './chunks';
 import { register_r_package_detection } from './r-package-detection';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';
@@ -207,8 +210,13 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         register_send_to_r_commands(context);
         register_inspection_commands(context);
         register_build_commands(context);
-        register_chunks(context);
+        register_chunks_with_terminal(context);
     }
+
+    // Chunk navigation and highlighting work without an R terminal, so register
+    // them regardless of `raven.rConsole.activation` — REditorSupport / Positron
+    // users still get the visual aids and cursor-motion commands.
+    register_chunks_navigation_and_highlight(context);
 
     // Package-mode context key. The `raven.isRPackage` key gates the
     // Build commands' palette entries and editor-title submenu — every

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -48,11 +48,21 @@ const R_CELL_FIXTURE = [
     '',
 ].join('\n');
 
-async function open_rmd(content: string): Promise<vscode.TextEditor> {
-    const doc = await vscode.workspace.openTextDocument({
-        language: 'r',
-        content,
-    });
+/**
+ * Open an untitled buffer with the supplied content. The `language` argument
+ * controls how the chunk detector classifies the document:
+ *   - `'rmd'` (default) — RMarkdown / Quarto fenced-block mode; required to
+ *     test fixtures that use ```{r} fences. Even though our extension only
+ *     registers the `r` languageId for saved files, the chunk classifier
+ *     also accepts `'rmd'` / `'quarto'` languageIds so untitled test buffers
+ *     can stand in for RMarkdown documents without writing a temp file.
+ *   - `'r'` — plain R / `# %%` cell-marker mode.
+ */
+async function open_doc(
+    content: string,
+    language: 'rmd' | 'r' = 'rmd',
+): Promise<vscode.TextEditor> {
+    const doc = await vscode.workspace.openTextDocument({ language, content });
     return vscode.window.showTextDocument(doc);
 }
 
@@ -166,7 +176,7 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('goToNextChunk places cursor inside the next R chunk body', async () => {
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 0); // before any chunk
         await vscode.commands.executeCommand('raven.goToNextChunk');
         // First chunk header is line 6 ("```{r setup, ...}"), body starts at line 7.
@@ -181,7 +191,7 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('goToPreviousChunk walks chunks in reverse', async () => {
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the second R chunk body
         await vscode.commands.executeCommand('raven.goToPreviousChunk');
         // Previous chunk is python at line 12 → body line 13.
@@ -189,7 +199,7 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('selectCurrentChunk selects only the body of the chunk under the cursor', async () => {
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the "second" R chunk
         await vscode.commands.executeCommand('raven.selectCurrentChunk');
         const text = editor.document.getText(editor.selection);
@@ -200,7 +210,7 @@ suite('chunk commands: registration and behavior', () => {
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunk');
         if (r_console_disabled) return; // command not registered in this env
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 4); // prose line, not in a chunk
         const stub = stub_information_message();
         try {
@@ -218,7 +228,7 @@ suite('chunk commands: registration and behavior', () => {
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunk');
         if (r_console_disabled) return;
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 13); // inside the python chunk
         const stub = stub_information_message();
         try {
@@ -236,7 +246,7 @@ suite('chunk commands: registration and behavior', () => {
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunk');
         if (r_console_disabled) return;
-        const editor = await open_rmd('x <- 1\nprint(x)\n');
+        const editor = await open_doc('x <- 1\nprint(x)\n', 'r');
         place_cursor(editor, 0);
         const stub = stub_information_message();
         try {
@@ -254,7 +264,7 @@ suite('chunk commands: registration and behavior', () => {
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunk');
         if (r_console_disabled) return;
-        const editor = await open_rmd(RMD_FIXTURE);
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the "second" R chunk
         const term = stub_create_terminal();
         try {
@@ -280,7 +290,7 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('# %% cell mode in .R: selectCurrentChunk grabs the cell body', async () => {
-        const editor = await open_rmd(R_CELL_FIXTURE);
+        const editor = await open_doc(R_CELL_FIXTURE, 'r');
         place_cursor(editor, 1); // inside cell "one"
         await vscode.commands.executeCommand('raven.selectCurrentChunk');
         const text = editor.document.getText(editor.selection);

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -1,0 +1,289 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+const CHUNK_COMMANDS = [
+    'raven.runCurrentChunk',
+    'raven.runCurrentChunkAndMove',
+    'raven.runAboveChunks',
+    'raven.runAllChunks',
+    'raven.goToNextChunk',
+    'raven.goToPreviousChunk',
+    'raven.selectCurrentChunk',
+] as const;
+
+const RMD_FIXTURE = [
+    '---',
+    'title: example',
+    '---',
+    '',
+    'Some prose.',
+    '',
+    '```{r setup, include=FALSE}',
+    'library(dplyr)',
+    '```',
+    '',
+    'More prose.',
+    '',
+    '```{python}',
+    'print("not r")',
+    '```',
+    '',
+    '```{r second}',
+    'x <- 1',
+    'y <- 2',
+    '```',
+    '',
+    '```{r noeval, eval=FALSE}',
+    'never_run()',
+    '```',
+    '',
+].join('\n');
+
+const R_CELL_FIXTURE = [
+    '# %% one',
+    'a <- 1',
+    'b <- 2',
+    '# %% two',
+    'c <- 3',
+    '',
+].join('\n');
+
+async function open_rmd(content: string): Promise<vscode.TextEditor> {
+    const doc = await vscode.workspace.openTextDocument({
+        language: 'r',
+        content,
+    });
+    return vscode.window.showTextDocument(doc);
+}
+
+function place_cursor(editor: vscode.TextEditor, line: number, char = 0): void {
+    const pos = new vscode.Position(line, char);
+    editor.selection = new vscode.Selection(pos, pos);
+}
+
+interface MessageStub {
+    last: string | undefined;
+    restore(): void;
+}
+
+function stub_information_message(): MessageStub {
+    const original = vscode.window.showInformationMessage;
+    const result: MessageStub = {
+        last: undefined,
+        restore: () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (vscode.window as any).showInformationMessage = original;
+        },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vscode.window as any).showInformationMessage = (msg: string) => {
+        result.last = msg;
+        return Promise.resolve(undefined);
+    };
+    return result;
+}
+
+interface TerminalStub {
+    sent: string[];
+    restore(): void;
+}
+
+/**
+ * Replace `vscode.window.createTerminal` so the next call returns a
+ * recording terminal. The bundled extension's `get_or_create_r_terminal`
+ * caches the terminal in-process via module-level state, so the FIRST
+ * call after stubbing is what we capture — subsequent tests in the same
+ * suite will reuse that same recording terminal. The stub also records
+ * `sendText` calls when the cached terminal is reused.
+ */
+function stub_create_terminal(): TerminalStub {
+    const sent: string[] = [];
+    const recorder = (text: string, _addNewLine?: boolean) => {
+        sent.push(text);
+    };
+    // Cast through `unknown` because the VS Code TerminalState/shell-integration
+    // interfaces churn across `@types/vscode` versions and the test only needs
+    // `sendText` / `show` to be callable.
+    const fake_terminal = {
+        name: 'R (Raven test stub)',
+        sendText: recorder,
+        show: () => undefined,
+        dispose: () => undefined,
+        processId: Promise.resolve(undefined),
+        creationOptions: { name: 'R (Raven test stub)' },
+        exitStatus: undefined,
+        state: { isInteractedWith: false },
+    } as unknown as vscode.Terminal;
+    const original = vscode.window.createTerminal;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vscode.window as any).createTerminal = (..._args: unknown[]) => fake_terminal;
+    return {
+        sent,
+        restore: () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (vscode.window as any).createTerminal = original;
+        },
+    };
+}
+
+suite('chunk commands: registration and behavior', () => {
+    test('every chunk command is registered in VS Code', async () => {
+        // Skip when R-console activation is disabled (REditorSupport / Positron):
+        // the run / CodeLens-positional commands aren't registered then. The
+        // three navigation commands always are.
+        const all = new Set(await vscode.commands.getCommands(true));
+        const r_console_disabled = !all.has('raven.runLineOrSelection');
+        const expected = r_console_disabled
+            ? ['raven.goToNextChunk', 'raven.goToPreviousChunk', 'raven.selectCurrentChunk']
+            : CHUNK_COMMANDS;
+        for (const cmd of expected) {
+            assert.ok(
+                all.has(cmd),
+                `expected chunk command "${cmd}" to be registered`,
+            );
+        }
+    });
+
+    test('package.json declares every chunk command under the Raven category', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../package.json') as {
+            contributes: {
+                commands: Array<{ command: string; title: string; category?: string }>;
+            };
+        };
+        const declared = new Map(
+            pkg.contributes.commands.map((c) => [c.command, c]),
+        );
+        for (const cmd of CHUNK_COMMANDS) {
+            const entry = declared.get(cmd);
+            assert.ok(entry, `package.json must declare ${cmd}`);
+            assert.strictEqual(
+                entry.category,
+                'Raven',
+                `${cmd} must be under the Raven category`,
+            );
+        }
+    });
+
+    test('goToNextChunk places cursor inside the next R chunk body', async () => {
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 0); // before any chunk
+        await vscode.commands.executeCommand('raven.goToNextChunk');
+        // First chunk header is line 6 ("```{r setup, ...}"), body starts at line 7.
+        assert.strictEqual(editor.selection.active.line, 7);
+
+        await vscode.commands.executeCommand('raven.goToNextChunk');
+        // Second runnable chunk header is the python one at 12, but navigation walks
+        // every chunk regardless of language — the next chunk is python at 12, so
+        // cursor lands on line 13 (body of the python chunk). That's intentional:
+        // navigation is language-agnostic.
+        assert.strictEqual(editor.selection.active.line, 13);
+    });
+
+    test('goToPreviousChunk walks chunks in reverse', async () => {
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 17); // inside the second R chunk body
+        await vscode.commands.executeCommand('raven.goToPreviousChunk');
+        // Previous chunk is python at line 12 → body line 13.
+        assert.strictEqual(editor.selection.active.line, 13);
+    });
+
+    test('selectCurrentChunk selects only the body of the chunk under the cursor', async () => {
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 17); // inside the "second" R chunk
+        await vscode.commands.executeCommand('raven.selectCurrentChunk');
+        const text = editor.document.getText(editor.selection);
+        assert.strictEqual(text, 'x <- 1\ny <- 2');
+    });
+
+    test('runCurrentChunk warns when cursor is not inside a chunk', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunk');
+        if (r_console_disabled) return; // command not registered in this env
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 4); // prose line, not in a chunk
+        const stub = stub_information_message();
+        try {
+            await vscode.commands.executeCommand('raven.runCurrentChunk');
+        } finally {
+            stub.restore();
+        }
+        assert.ok(
+            stub.last && stub.last.includes('not inside an R chunk'),
+            `expected "not inside an R chunk" info message, got: ${String(stub.last)}`,
+        );
+    });
+
+    test('runCurrentChunk refuses non-R chunks', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunk');
+        if (r_console_disabled) return;
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 13); // inside the python chunk
+        const stub = stub_information_message();
+        try {
+            await vscode.commands.executeCommand('raven.runCurrentChunk');
+        } finally {
+            stub.restore();
+        }
+        assert.ok(
+            stub.last && stub.last.includes('python'),
+            `expected python-language info message, got: ${String(stub.last)}`,
+        );
+    });
+
+    test('runCurrentChunk on an empty (no chunks) document warns', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunk');
+        if (r_console_disabled) return;
+        const editor = await open_rmd('x <- 1\nprint(x)\n');
+        place_cursor(editor, 0);
+        const stub = stub_information_message();
+        try {
+            await vscode.commands.executeCommand('raven.runCurrentChunk');
+        } finally {
+            stub.restore();
+        }
+        assert.ok(
+            stub.last && stub.last.includes('no R chunks'),
+            `expected "no R chunks" info message, got: ${String(stub.last)}`,
+        );
+    });
+
+    test('runCurrentChunk sends the chunk body to the R terminal', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunk');
+        if (r_console_disabled) return;
+        const editor = await open_rmd(RMD_FIXTURE);
+        place_cursor(editor, 17); // inside the "second" R chunk
+        const term = stub_create_terminal();
+        try {
+            await vscode.commands.executeCommand('raven.runCurrentChunk');
+        } finally {
+            term.restore();
+        }
+        const combined = term.sent.join('\n');
+        // The send path may wrap multi-line payloads in bracketed paste markers or
+        // a tempfile source() wrapper. Either way, the original chunk body should
+        // appear somewhere in the captured text (with chunk-body lines preserved
+        // or referenced via a temp-file source path). To keep the assertion
+        // robust across send transports, just check that AT LEAST one of the
+        // chunk's distinctive identifiers made it to the terminal.
+        const observed_chunk_content =
+            combined.includes('x <- 1') ||
+            combined.includes('y <- 2') ||
+            /source\((.+)\.R/.test(combined);
+        assert.ok(
+            observed_chunk_content,
+            `expected chunk body to reach terminal, got: ${combined.slice(0, 200)}`,
+        );
+    });
+
+    test('# %% cell mode in .R: selectCurrentChunk grabs the cell body', async () => {
+        const editor = await open_rmd(R_CELL_FIXTURE);
+        place_cursor(editor, 1); // inside cell "one"
+        await vscode.commands.executeCommand('raven.selectCurrentChunk');
+        const text = editor.document.getText(editor.selection);
+        assert.strictEqual(text, 'a <- 1\nb <- 2');
+    });
+});

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -5,6 +5,7 @@ import {
     find_chunk_at_line,
     chunks_above,
     extract_chunk_code,
+    has_chunk_anchor,
     is_runnable_chunk,
     Chunk,
 } from '../../editors/vscode/src/chunks/chunk-detector';
@@ -356,6 +357,35 @@ describe('extract_chunk_code', () => {
         ].join('\n'));
         const chunks = detect_chunks(src, 'rmd');
         expect(extract_chunk_code(src, chunks[0])).toBe('');
+    });
+});
+
+describe('has_chunk_anchor', () => {
+    test('returns false for plain R code with no markers', () => {
+        const text = 'x <- 1\nprint(x)\n# comment\nfn <- function(a, b) a + b\n';
+        expect(has_chunk_anchor(text, 'r')).toBe(false);
+    });
+
+    test('returns true when an .R file contains `%%`', () => {
+        // Coarse: any `%%` in the text triggers the slow path. False positives
+        // are acceptable; the real regex confirms whether the line is a marker.
+        expect(has_chunk_anchor('# %% one\nx <- 1', 'r')).toBe(true);
+        expect(has_chunk_anchor('x <- "50%%"\n', 'r')).toBe(true);
+    });
+
+    test('returns false for prose-only Rmd / Qmd', () => {
+        const text = '# Title\n\nSome prose.\nNo fences here.\n';
+        expect(has_chunk_anchor(text, 'rmd')).toBe(false);
+    });
+
+    test('returns true when an Rmd document contains backtick or tilde fences', () => {
+        expect(has_chunk_anchor('```{r}\n1\n```\n', 'rmd')).toBe(true);
+        expect(has_chunk_anchor('~~~{r}\n1\n~~~\n', 'rmd')).toBe(true);
+    });
+
+    test('does not false-trigger on single backticks (inline code)', () => {
+        const text = 'Inline `r 1 + 1` math here.\n';
+        expect(has_chunk_anchor(text, 'rmd')).toBe(false);
     });
 });
 

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -1,0 +1,334 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    classify_chunk_document,
+    detect_chunks,
+    find_chunk_at_line,
+    chunks_above,
+    extract_chunk_code,
+    is_runnable_chunk,
+    Chunk,
+} from '../../editors/vscode/src/chunks/chunk-detector';
+
+function lines(text: string): string[] {
+    return text.split('\n');
+}
+
+describe('classify_chunk_document', () => {
+    test('treats .Rmd as rmd', () => {
+        expect(classify_chunk_document('/tmp/foo.Rmd')).toBe('rmd');
+        expect(classify_chunk_document('/tmp/foo.rmd')).toBe('rmd');
+    });
+
+    test('treats .qmd as rmd', () => {
+        expect(classify_chunk_document('/tmp/foo.qmd')).toBe('rmd');
+        expect(classify_chunk_document('/tmp/foo.QMD')).toBe('rmd');
+    });
+
+    test('treats .R / .r as r', () => {
+        expect(classify_chunk_document('/tmp/foo.R')).toBe('r');
+        expect(classify_chunk_document('/tmp/foo.r')).toBe('r');
+    });
+
+    test('falls back to r for unknown extensions', () => {
+        expect(classify_chunk_document('/tmp/foo.txt')).toBe('r');
+    });
+});
+
+describe('detect_chunks — Rmd/Qmd fenced blocks', () => {
+    test('detects a single ```{r} chunk', () => {
+        const src = lines([
+            'Some prose.',
+            '',
+            '```{r}',
+            'x <- 1',
+            'print(x)',
+            '```',
+            '',
+            'More prose.',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(2);
+        expect(chunks[0].closing_fence_line).toBe(5);
+        expect(chunks[0].end_line).toBe(4);
+        expect(chunks[0].language).toBe('r');
+        expect(chunks[0].is_eval_false).toBe(false);
+    });
+
+    test('parses header options including label and eval=FALSE', () => {
+        const src = lines([
+            '```{r setup, eval=FALSE, fig.width=4}',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('r');
+        expect(chunks[0].label).toBe('setup');
+        expect(chunks[0].options.eval).toBe('FALSE');
+        expect(chunks[0].options['fig.width']).toBe('4');
+        expect(chunks[0].is_eval_false).toBe(true);
+    });
+
+    test('recognizes eval = F as eval false', () => {
+        const src = lines([
+            '```{r, eval = F}',
+            '1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks[0].is_eval_false).toBe(true);
+    });
+
+    test('recognizes upper-case R language tag', () => {
+        const src = lines([
+            '```{R}',
+            '1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks[0].language).toBe('r');
+    });
+
+    test('detects non-R chunks (python, julia)', () => {
+        const src = lines([
+            '```{python}',
+            'pass',
+            '```',
+            '',
+            '```{julia}',
+            '1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(2);
+        expect(chunks[0].language).toBe('python');
+        expect(chunks[1].language).toBe('julia');
+    });
+
+    test('detects multiple chunks separated by prose', () => {
+        const src = lines([
+            '```{r}',
+            'a <- 1',
+            '```',
+            'Prose between.',
+            '```{r second}',
+            'b <- 2',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(2);
+        expect(chunks[0].header_line).toBe(0);
+        expect(chunks[1].header_line).toBe(4);
+        expect(chunks[1].label).toBe('second');
+    });
+
+    test('handles unclosed fence by extending to EOF', () => {
+        const src = lines([
+            '```{r}',
+            'x <- 1',
+            'y <- 2',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].closing_fence_line).toBeNull();
+        expect(chunks[0].end_line).toBe(2);
+    });
+
+    test('handles tilde fences', () => {
+        const src = lines([
+            '~~~{r}',
+            'x <- 1',
+            '~~~',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('r');
+    });
+
+    test('handles fences with more backticks (4+)', () => {
+        const src = lines([
+            '````{r}',
+            '```',
+            'inner backticks',
+            '```',
+            '````',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].closing_fence_line).toBe(4);
+    });
+
+    test('ignores indented fences (Pandoc-style is line-start)', () => {
+        // Two leading spaces — code-block indent in Pandoc treats this as a literal, not a fence.
+        const src = lines([
+            '  ```{r}',
+            '  x <- 1',
+            '  ```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        // We don't try to parse Pandoc semantics: just require the fence at column 0.
+        expect(chunks.length).toBe(0);
+    });
+
+    test('returns empty for documents with no fences', () => {
+        const src = lines(['# Title', 'Just prose.'].join('\n'));
+        expect(detect_chunks(src, 'rmd').length).toBe(0);
+    });
+
+    test('skips a chunk header inside another open chunk (no nesting)', () => {
+        // The inner ```{r} should not start a new chunk because we're already
+        // inside one (we close on a matching fence).
+        const src = lines([
+            '```{r}',
+            'x <- 1',
+            '```',
+            '```{r}',
+            'y <- 2',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks.length).toBe(2);
+    });
+});
+
+describe('detect_chunks — .R cell markers', () => {
+    test('detects # %% cells', () => {
+        const src = lines([
+            '# initial code',
+            'x <- 1',
+            '# %% First cell',
+            'a <- 1',
+            'b <- 2',
+            '# %% Second cell',
+            'c <- 3',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'r');
+        expect(chunks.length).toBe(2);
+        expect(chunks[0].header_line).toBe(2);
+        expect(chunks[0].end_line).toBe(4);
+        expect(chunks[0].language).toBe('r');
+        expect(chunks[1].header_line).toBe(5);
+        expect(chunks[1].end_line).toBe(6);
+    });
+
+    test('matches multiple-hash markers', () => {
+        const src = lines([
+            '### %% Heading-style',
+            'x <- 1',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'r');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(0);
+    });
+
+    test('returns empty for .R with no markers', () => {
+        const src = lines(['x <- 1', 'print(x)'].join('\n'));
+        expect(detect_chunks(src, 'r').length).toBe(0);
+    });
+
+    test('empty cell (no following content) is still a chunk', () => {
+        const src = lines(['# %%'].join('\n'));
+        const chunks = detect_chunks(src, 'r');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(0);
+        expect(chunks[0].end_line).toBe(0);
+    });
+});
+
+describe('find_chunk_at_line', () => {
+    const chunks: Chunk[] = [
+        { header_line: 2, end_line: 4, closing_fence_line: 5, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+        { header_line: 7, end_line: 9, closing_fence_line: 10, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+    ];
+
+    test('returns chunk when cursor is inside body', () => {
+        expect(find_chunk_at_line(chunks, 3)?.header_line).toBe(2);
+        expect(find_chunk_at_line(chunks, 8)?.header_line).toBe(7);
+    });
+
+    test('returns chunk when cursor is on header line', () => {
+        expect(find_chunk_at_line(chunks, 2)?.header_line).toBe(2);
+    });
+
+    test('returns chunk when cursor is on closing fence', () => {
+        expect(find_chunk_at_line(chunks, 5)?.header_line).toBe(2);
+    });
+
+    test('returns null when cursor is outside any chunk', () => {
+        expect(find_chunk_at_line(chunks, 0)).toBeNull();
+        expect(find_chunk_at_line(chunks, 6)).toBeNull();
+    });
+});
+
+describe('chunks_above', () => {
+    const chunks: Chunk[] = [
+        { header_line: 0, end_line: 2, closing_fence_line: 3, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+        { header_line: 5, end_line: 6, closing_fence_line: 7, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+        { header_line: 10, end_line: 12, closing_fence_line: 13, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+    ];
+
+    test('returns chunks whose closing position is strictly above cursor', () => {
+        // Cursor on line 8 (between chunk 2's close at 7 and chunk 3's header at 10)
+        // → chunks 1 and 2 are above.
+        const result = chunks_above(chunks, 8);
+        expect(result.length).toBe(2);
+    });
+
+    test('when cursor is inside a chunk, chunks above does not include the current chunk', () => {
+        // Cursor in chunk 2 (line 6) → only chunk 1 is above.
+        const result = chunks_above(chunks, 6);
+        expect(result.length).toBe(1);
+        expect(result[0].header_line).toBe(0);
+    });
+
+    test('returns empty list when cursor is above all chunks', () => {
+        const result = chunks_above(chunks, 0);
+        expect(result.length).toBe(0);
+    });
+});
+
+describe('extract_chunk_code', () => {
+    test('extracts content between fence lines, excluding fences', () => {
+        const src = lines([
+            'prose',
+            '```{r}',
+            'x <- 1',
+            'y <- 2',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(extract_chunk_code(src, chunks[0])).toBe('x <- 1\ny <- 2');
+    });
+
+    test('extracts content after cell marker', () => {
+        const src = lines([
+            '# %% one',
+            'x <- 1',
+            'y <- 2',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'r');
+        expect(extract_chunk_code(src, chunks[0])).toBe('x <- 1\ny <- 2');
+    });
+
+    test('returns empty for an empty chunk body', () => {
+        const src = lines([
+            '```{r}',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(extract_chunk_code(src, chunks[0])).toBe('');
+    });
+});
+
+describe('is_runnable_chunk', () => {
+    test('r chunks are runnable', () => {
+        const c: Chunk = { header_line: 0, end_line: 1, closing_fence_line: 2, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' };
+        expect(is_runnable_chunk(c)).toBe(true);
+    });
+
+    test('non-r chunks are not runnable', () => {
+        const c: Chunk = { header_line: 0, end_line: 1, closing_fence_line: 2, language: 'python', label: null, options: {}, is_eval_false: false, kind: 'rmd' };
+        expect(is_runnable_chunk(c)).toBe(false);
+    });
+});

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -70,6 +70,28 @@ describe('detect_chunks — Rmd/Qmd fenced blocks', () => {
         expect(chunks[0].is_eval_false).toBe(true);
     });
 
+    test('keeps parenthesised vector values intact when splitting options', () => {
+        const src = lines([
+            '```{r, fig.dim=c(5, 6), out.width="80%"}',
+            '1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        expect(chunks[0].options['fig.dim']).toBe('c(5, 6)');
+        expect(chunks[0].options['out.width']).toBe('80%');
+    });
+
+    test('respects escaped quotes inside option values', () => {
+        const src = lines([
+            '```{r, lab="say \\"hi\\""}',
+            '1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'rmd');
+        // The escape stays in the parsed value — Raven does not interpret R string escapes.
+        expect(chunks[0].options.lab).toBe('say \\"hi\\"');
+    });
+
     test('recognizes eval = F as eval false', () => {
         const src = lines([
             '```{r, eval = F}',
@@ -176,19 +198,21 @@ describe('detect_chunks — Rmd/Qmd fenced blocks', () => {
         expect(detect_chunks(src, 'rmd').length).toBe(0);
     });
 
-    test('skips a chunk header inside another open chunk (no nesting)', () => {
-        // The inner ```{r} should not start a new chunk because we're already
-        // inside one (we close on a matching fence).
+    test('treats a header inside an open chunk as content, not a new chunk', () => {
+        // Outer ```` ```` fence wraps an inner ``` ``` ``` fence header
+        // verbatim. We should see one outer chunk and no inner one — the
+        // detector resumes scanning AFTER the outer closing fence.
         const src = lines([
-            '```{r}',
+            '````{r outer}',
+            '```{r inner}',
             'x <- 1',
             '```',
-            '```{r}',
-            'y <- 2',
-            '```',
+            '````',
         ].join('\n'));
         const chunks = detect_chunks(src, 'rmd');
-        expect(chunks.length).toBe(2);
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].label).toBe('outer');
+        expect(chunks[0].closing_fence_line).toBe(4);
     });
 });
 
@@ -220,6 +244,20 @@ describe('detect_chunks — .R cell markers', () => {
         const chunks = detect_chunks(src, 'r');
         expect(chunks.length).toBe(1);
         expect(chunks[0].header_line).toBe(0);
+    });
+
+    test('does not match `# %%%` or `# %%inline` non-markers', () => {
+        const src = lines([
+            '# %%%',
+            'x <- 1',
+            '# %%not-a-cell',
+            'y <- 2',
+            '# %% real cell',
+            'z <- 3',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'r');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(4);
     });
 
     test('returns empty for .R with no markers', () => {

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
     classify_chunk_document,
+    classify_chunk_document_for_document,
     detect_chunks,
     find_chunk_at_line,
     chunks_above,
@@ -357,6 +358,29 @@ describe('extract_chunk_code', () => {
         ].join('\n'));
         const chunks = detect_chunks(src, 'rmd');
         expect(extract_chunk_code(src, chunks[0])).toBe('');
+    });
+});
+
+describe('classify_chunk_document_for_document', () => {
+    test('prefers languageId rmd / quarto over URI extension', () => {
+        const doc = { languageId: 'rmd', uri: { fsPath: '/tmp/untitled-1', path: '/tmp/untitled-1' } };
+        expect(classify_chunk_document_for_document(doc)).toBe('rmd');
+        const qdoc = { languageId: 'Quarto', uri: { fsPath: '', path: 'Untitled-1' } };
+        expect(classify_chunk_document_for_document(qdoc)).toBe('rmd');
+    });
+
+    test('falls back to URI extension for `r` languageId', () => {
+        const rmd = { languageId: 'r', uri: { fsPath: '/tmp/report.Rmd', path: '/tmp/report.Rmd' } };
+        expect(classify_chunk_document_for_document(rmd)).toBe('rmd');
+        const qmd = { languageId: 'r', uri: { fsPath: '/tmp/notes.qmd', path: '/tmp/notes.qmd' } };
+        expect(classify_chunk_document_for_document(qmd)).toBe('rmd');
+        const r = { languageId: 'r', uri: { fsPath: '/tmp/main.R', path: '/tmp/main.R' } };
+        expect(classify_chunk_document_for_document(r)).toBe('r');
+    });
+
+    test('returns r for an untitled buffer with languageId r and no extension', () => {
+        const doc = { languageId: 'r', uri: { fsPath: '', path: 'Untitled-1' } };
+        expect(classify_chunk_document_for_document(doc)).toBe('r');
     });
 });
 


### PR DESCRIPTION
Closes #209.

Adds R Markdown / Quarto code-chunk support to the VS Code extension, plus `# %%` cell support in plain `.R` files — the largest workflow gap vs. vscode-R for notebook-heavy users.

## What's in

### Phase 1 — Chunk detection + run commands
- Pure-function detector in `editors/vscode/src/chunks/chunk-detector.ts` handles:
  - Fenced blocks (backtick **and** tilde, ≥3-char fences with same-char ≥same-length close rule, so ` ```` ` outer fences wrap literal ` ``` ` inside).
  - Label + key/value option parsing with quoted-value handling.
  - `eval = FALSE` / `eval = F` recognition for highlight dimming.
  - `.R` `# %%` cell markers.
- Commands: `raven.runCurrentChunk`, `raven.runCurrentChunkAndMove`, `raven.runAboveChunks`, `raven.runAllChunks` — all reuse the existing `send_to_r` infrastructure.
- CodeLens lenses (`▷ Run Chunk`, `↥ Run Above`) appear on every R chunk header. Non-R languages (python, julia, …) are detected for navigation but not executed.

### Phase 2 — Navigation
- `raven.goToNextChunk`, `raven.goToPreviousChunk`, `raven.selectCurrentChunk`.
- Keybindings: `Cmd/Ctrl+Alt+N` / `Cmd/Ctrl+Alt+Shift+N`.

### Phase 3 — Highlighting
- `TextEditorDecorationType` background tint, two themable colors:
  - `raven.chunk.activeBackground`
  - `raven.chunk.inactiveBackground` (lower opacity; used for `eval = FALSE`)
- Debounced refresh on document/editor changes; `raven.chunks.highlight.enabled` toggle.

### Documentation
- New `docs/chunks.md`; index entries in `README.md` and `AGENTS.md` (`CLAUDE.md` follows the symlink).

## Architectural choices
- Implemented entirely client-side in the VS Code extension. The "r" language ID already claims `.rmd` / `.qmd` extensions, so no server-side language-id work was needed and there's no LSP wire-format change.
- Chunk run-commands are gated alongside the rest of send-to-R on `r_console_resolved === 'enabled'`, matching the existing pattern. Users running REditorSupport or Positron still get nothing they didn't already have.
- The `Cmd+Shift+Enter` chunk binding uses a stricter `when` clause (resource extension matches `.rmd|.Rmd|.qmd|.QMD`) so the existing **Source File** binding keeps the same chord in plain `.R` files.

## Test plan

- [x] Unit tests for the detector: 32 tests covering fenced blocks, tilde fences, ≥4-char fences, unclosed chunks, indented fences, header options (label, eval, fig.width), upper-case `{R}`, non-R languages, multi-chunk docs, `# %%` cells (single/multiple/empty), `find_chunk_at_line` (body, header, closing fence, outside), `chunks_above`, `extract_chunk_code`, `is_runnable_chunk`.
- [x] `bun test tests/bun/chunk-detector.test.ts` → 32 pass.
- [x] `bun run typecheck` clean in `editors/vscode/`.
- [x] `bun run bundle` succeeds.
- [x] `cargo build -p raven` clean.
- [ ] CI: full bun + cargo + vscode-test suites.
- [ ] Manual smoke (post-merge): open a `.Rmd`, run a chunk, run-above, navigate.

## Not in this PR (future work)

- Knit / Quarto render commands and live preview (Phase 4 of #209).
- Nested chunks (the issue calls out simple cases; full Pandoc semantics are out of scope).
- Server-side document-outline integration for chunks. Current document outline already surfaces section headers; adding chunk entries can ride on top of that later.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect, navigate, highlight, and execute R code chunks in R Markdown/Quarto and `# %%` cells in .R files
  * CodeLens buttons and commands to run current/above/all chunks, run-and-move, and move/select chunks
  * Keybindings and editor theme colors for chunk highlighting; setting to enable/disable highlights

* **Documentation**
  * Added detailed "Code Chunks" docs and updated README/AGENTS guidance

* **Tests**
  * Added unit and extension tests covering chunk detection, navigation, and execution behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->