### PR TITLE
ci: run VS Code Mocha integration suite on PRs under Xvfb

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: VS Code Integration Tests
+name: Integration Tests
 
 on:
   push:
@@ -12,12 +12,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: vscode-integration-${{ github.ref }}
+  group: integration-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  vscode-integration:
-    name: VS Code Integration Tests
+  vscode-mocha:
+    name: VS Code Mocha Suite
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -90,11 +90,15 @@ jobs:
           restore-keys: |
             vscode-test-${{ runner.os }}-
 
-      - name: Place LSP binary for extension
+      # `vscode:prepublish` runs `bundle` (esbuild → `dist/extension.js`, the
+      # extension's `main` entry) and `copy-binary` (places the LSP binary at
+      # `bin/raven`). Both must exist before `vscode-test` activates the
+      # extension; `pretest` (below) only handles the test-side `tsc` build.
+      - name: Bundle extension and place LSP binary
         working-directory: editors/vscode
-        run: bun run copy-binary
+        run: bun run vscode:prepublish
 
-      - name: Compile extension and tests
+      - name: Compile tests
         working-directory: editors/vscode
         run: bun run pretest
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,8 +42,11 @@ jobs:
           restore-keys: |
             integration-cargo-${{ runner.os }}-
 
+      # `--features test-support` exposes `raven::test_utils`, which the
+      # `performance_budgets` integration test imports. Without the flag,
+      # the test binary fails to compile (E0433: cannot find `test_utils`).
       - name: Run cargo tests (release)
-        run: cargo test --release -p raven
+        run: cargo test --release -p raven --features test-support
 
   # Sibling job 2: the VS Code Mocha integration suite — runs the
   # extension under a real Electron host via `vscode-test`. Mirrors

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,7 +87,13 @@ jobs:
       # `ubuntu-latest` image. The `*t64` package names target Ubuntu 24.04
       # (current `ubuntu-latest`); they Provide the legacy names so this
       # block also works if the image rolls back to 22.04.
-      - name: Install Xvfb and Electron runtime deps
+      #
+      # R goes alongside so suites that drive the live R session (help,
+      # send-to-r, future knit / rmarkdown coverage) can run instead of
+      # skipping. `r-base-core` is the minimal install; tests that need
+      # specific packages (e.g. `arrow` for the data-viewer suite) still
+      # skip themselves when those packages aren't installed.
+      - name: Install Xvfb, Electron runtime deps, and R
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -101,7 +107,8 @@ jobs:
             libxkbcommon-x11-0 \
             libgbm1 \
             libsecret-1-0 \
-            xdg-utils
+            xdg-utils \
+            r-base-core
 
       - name: Build LSP binary (release)
         run: cargo build --release -p raven

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,6 +93,13 @@ jobs:
       # skipping. `r-base-core` is the minimal install; tests that need
       # specific packages (e.g. `arrow` for the data-viewer suite) still
       # skip themselves when those packages aren't installed.
+      #
+      # `r-cran-plyr` is needed by the cross-file LSP test
+      # (`lsp.test.ts: cross-file: sibling package propagation …`): the
+      # LSP's libpath scan must know `plyr` exports `ddply` before it can
+      # suppress the undefined-variable diagnostic that the test asserts
+      # against. Other widely-used CRAN packages can be added here as
+      # the suite grows.
       - name: Install Xvfb, Electron runtime deps, and R
         run: |
           sudo apt-get update
@@ -108,7 +115,8 @@ jobs:
             libgbm1 \
             libsecret-1-0 \
             xdg-utils \
-            r-base-core
+            r-base-core \
+            r-cran-plyr
 
       - name: Build LSP binary (release)
         run: cargo build --release -p raven

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Sibling job 1: the Rust test suite. Mirrors what `bun test` runs
+  # locally as the first half of `tests/bun/workspace-suite.test.ts`.
+  # Runs in release profile so its `target/` cache lines up with the
+  # release LSP binary that the Mocha suite builds — same cache key
+  # means whichever job finishes first warms the other on subsequent runs.
+  cargo:
+    name: Cargo Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: integration-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            integration-cargo-${{ runner.os }}-
+
+      - name: Run cargo tests (release)
+        run: cargo test --release -p raven
+
+  # Sibling job 2: the VS Code Mocha integration suite — runs the
+  # extension under a real Electron host via `vscode-test`. Mirrors
+  # the second half of the local `workspace-suite` invocation.
   vscode-mocha:
     name: VS Code Mocha Suite
     runs-on: ubuntu-latest
@@ -33,9 +65,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: vscode-integration-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: integration-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            vscode-integration-cargo-${{ runner.os }}-
+            integration-cargo-${{ runner.os }}-
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,103 @@
+name: VS Code Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vscode-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vscode-integration:
+    name: VS Code Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: vscode-integration-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            vscode-integration-cargo-${{ runner.os }}-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      # Electron (the runtime VS Code uses for integration tests) needs an
+      # X server plus a handful of native libs that aren't in the default
+      # `ubuntu-latest` image. The `*t64` package names target Ubuntu 24.04
+      # (current `ubuntu-latest`); they Provide the legacy names so this
+      # block also works if the image rolls back to 22.04.
+      - name: Install Xvfb and Electron runtime deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            xvfb \
+            libnss3 \
+            libatk-bridge2.0-0t64 \
+            libatk1.0-0t64 \
+            libgtk-3-0t64 \
+            libasound2t64 \
+            libdrm2 \
+            libxkbcommon-x11-0 \
+            libgbm1 \
+            libsecret-1-0 \
+            xdg-utils
+
+      - name: Build LSP binary (release)
+        run: cargo build --release -p raven
+
+      # The extension uses `package-lock.json` (no `bun.lockb`), so `npm ci`
+      # gives us a reproducible install. The test scripts themselves still
+      # run under Bun (matching the local `bun run test` invocation used by
+      # `tests/bun/workspace-suite.test.ts`).
+      - name: Install VS Code extension dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      # `vscode-test` downloads a VS Code build (~150 MB) on first run.
+      # Caching it on the .vscode-test.mjs hash keeps PR feedback fast and
+      # invalidates the cache when the pinned VS Code version changes.
+      - name: Cache VS Code download
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: editors/vscode/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('editors/vscode/.vscode-test.mjs') }}
+          restore-keys: |
+            vscode-test-${{ runner.os }}-
+
+      - name: Place LSP binary for extension
+        working-directory: editors/vscode
+        run: bun run copy-binary
+
+      - name: Compile extension and tests
+        working-directory: editors/vscode
+        run: bun run pretest
+
+      - name: Run integration tests under Xvfb
+        working-directory: editors/vscode
+        run: xvfb-run -a bun run test

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -1,4 +1,8 @@
 import * as assert from 'assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
 
 const CHUNK_COMMANDS = [
@@ -48,20 +52,33 @@ const R_CELL_FIXTURE = [
     '',
 ].join('\n');
 
+const TEMP_FIXTURE_FILES: string[] = [];
+
 /**
- * Open an untitled buffer with the supplied content. The `language` argument
- * controls how the chunk detector classifies the document:
- *   - `'rmd'` (default) — RMarkdown / Quarto fenced-block mode; required to
- *     test fixtures that use ```{r} fences. Even though our extension only
- *     registers the `r` languageId for saved files, the chunk classifier
- *     also accepts `'rmd'` / `'quarto'` languageIds so untitled test buffers
- *     can stand in for RMarkdown documents without writing a temp file.
- *   - `'r'` — plain R / `# %%` cell-marker mode.
+ * Open a document with the supplied content for the chunk detector:
+ *   - `'rmd'` (default) — RMarkdown / Quarto fenced-block mode. Written
+ *     to a temp `.rmd` file so the chunk classifier's URI-extension path
+ *     reliably classifies it as `'rmd'`. An untitled buffer with
+ *     `language: 'rmd'` would also work in principle (the classifier
+ *     accepts the `'rmd'` languageId), but VS Code does not always
+ *     preserve unregistered languageIds across platforms — the extension
+ *     only contributes `'r'`, and on Linux VS Code 1.120 the languageId
+ *     gets coerced away from `'rmd'`, breaking classification.
+ *   - `'r'` — plain R / `# %%` cell-marker mode. Uses an untitled buffer
+ *     because the extension registers the `'r'` languageId, so it
+ *     survives the round-trip.
  */
 async function open_doc(
     content: string,
     language: 'rmd' | 'r' = 'rmd',
 ): Promise<vscode.TextEditor> {
+    if (language === 'rmd') {
+        const tmp = path.join(os.tmpdir(), `raven-chunks-${randomUUID()}.rmd`);
+        fs.writeFileSync(tmp, content);
+        TEMP_FIXTURE_FILES.push(tmp);
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmp));
+        return vscode.window.showTextDocument(doc);
+    }
     const doc = await vscode.workspace.openTextDocument({ language, content });
     return vscode.window.showTextDocument(doc);
 }
@@ -137,6 +154,13 @@ function stub_create_terminal(): TerminalStub {
 }
 
 suite('chunk commands: registration and behavior', () => {
+    suiteTeardown(() => {
+        for (const file of TEMP_FIXTURE_FILES) {
+            try { fs.unlinkSync(file); } catch { /* best-effort */ }
+        }
+        TEMP_FIXTURE_FILES.length = 0;
+    });
+
     test('every chunk command is registered in VS Code', async () => {
         // Skip when R-console activation is disabled (REditorSupport / Positron):
         // the run / CodeLens-positional commands aren't registered then. The


### PR DESCRIPTION
Closes #231.

## Summary

Adds `.github/workflows/integration.yml`, a focused workflow that runs the VS Code Mocha integration suite (`editors/vscode/src/test/**/*.test.ts`) on every PR and `main` push, under `xvfb-run` on `ubuntu-latest`.

Until now, only `cargo test --release ... --test performance_budgets` ran in CI. The Mocha suite — which exercises `vscode.commands.executeCommand` round-trips, `window.activeTextEditor` interactions, language-id routing, terminal wiring, and untitled-buffer handling — was completely unenforced. PR #225 doubled the suite's size (the new chunks tests) and CodeRabbit caught a real bug there that CI would not have. This closes that gap.

## What the workflow does

1. Checkout + Rust + Node 24 + Bun + apt deps for Electron (Xvfb, libnss3, libgtk-3-0t64, libasound2t64, libgbm1, …).
2. `cargo build --release -p raven` — the extension's `getServerPath` resolves to `<extensionPath>/bin/raven`, so a real binary is required.
3. `npm ci` inside `editors/vscode/` — the extension uses `package-lock.json`; tests still run under Bun to match the local `bun run test` invocation in `tests/bun/workspace-suite.test.ts`.
4. `bun run copy-binary` → places the release binary at `editors/vscode/bin/raven`.
5. `bun run pretest` → `tsc` compile (fast-fail before VS Code download).
6. `xvfb-run -a bun run test` → `vscode-test` downloads VS Code (cached on the `.vscode-test.mjs` hash) and runs the Mocha suite.

## Design notes

- **Focused job, not bundled with cargo.** Keeps logs/timings clean and matches the issue's first sketch.
- **Caches.** Cargo registry + `target/`; npm cache via `setup-node`; `.vscode-test/` keyed on `.vscode-test.mjs` (so the cache invalidates when the pinned VS Code version changes).
- **Timeout 20 min** so a hung Electron can't burn an hour of runner time.
- **Concurrency** cancels in-progress runs for the same branch/PR (mirrors `perf.yml`).
- **`*t64` package names** target Ubuntu 24.04 (current `ubuntu-latest`) and Provide the legacy names so the block survives a rollback to 22.04.
- **No change** to `editors/vscode/.vscode-test.mjs` — its `--disable-gpu` / `--no-sandbox` `launchArgs` are already correct for headless Linux.

## Test plan

- [ ] First CI run succeeds end-to-end (binary builds, VS Code downloads, Mocha suite passes).
- [ ] Second CI run on this PR uses the cached VS Code download (look for `Cache restored` on the `.vscode-test` step, and a faster runtime).
- [ ] If the suite fails on a known-good commit, the failure logs are legible enough to debug locally (`xvfb-run -a bun run test` from `editors/vscode/`).

## Out of scope

- macOS / Windows runners (`vscode-test` supports them but Linux+Xvfb covers ~95% of regressions we'd actually catch).
- Splitting `.Rmd` / `.qmd` into separate languageIds (tracked in #230).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated VS Code extension integration testing to the continuous integration pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/232)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->