### PR TITLE
feat(vscode): split r/rmd/quarto language IDs

### DIFF
--- a/docs/r-console.md
+++ b/docs/r-console.md
@@ -55,7 +55,7 @@ These commands wrap the word under the cursor (or the current selection) in a co
 | **Raven: Show names** | `names(<target>)` |
 | **Raven: View** | `View(<target>)` |
 
-If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands only run when the active editor's language is R — typically `.R`/`.r` files and untitled buffers whose language has been set to R. R Markdown and Quarto documents claimed by other extensions (`languageId` of `rmd`, `quarto`, etc.) are not currently in scope.
+If a selection is active, the entire selection is used as the target — handy for expressions like `df$col` or `subset(df, x > 0)`. Otherwise the word at the cursor is used. The commands run when the active editor's language is `r`, `rmd`, or `quarto` — placing the cursor on an R identifier inside an R chunk inside a `.Rmd` / `.qmd` file is the intended use; placing it on a prose word will send something to R that R will reject.
 
 Single-line wrapped expressions go straight to the terminal via direct paste; if the wrapped expression spans multiple lines (because the selection did), it honors the user's `raven.sendToR.sendMethod` setting. This avoids writing a one-liner like `nrow(x)` to a temp file just because `tempfile` mode is configured for normal sends.
 

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -14,9 +14,9 @@ For the exact trigger list and expansion bodies, see `editors/vscode/snippets/r.
 
 ## R Markdown and Quarto
 
-Raven contributes dedicated `rmd` and `quarto` language IDs for `.Rmd` and `.qmd` files. Each language ID gets its own snippet set; plain-R snippets are only registered under the `r` language ID, so they do not appear inside `.Rmd` / `.qmd` buffers (they will surface inside an R chunk only if another extension provides Markdown injection that switches the languageId to `r` within the chunk).
+Raven contributes dedicated `rmd` and `quarto` language IDs for `.Rmd` and `.qmd` files. Both also register the plain-R snippets from `r.json`, so `for` / `fun` / `if` etc. still expand inside `.Rmd` / `.qmd` buffers — typically what you want when the cursor sits inside an R chunk.
 
-The R Markdown set (`rmd`) covers:
+The R Markdown set (`rmd`) adds:
 
 - Code chunks: `rchunk`, `rchunkopts`, `setupchunk`, `pychunk`, `sqlchunk`, `bashchunk`
 - YAML frontmatter: `rmdyaml`

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -14,12 +14,14 @@ For the exact trigger list and expansion bodies, see `editors/vscode/snippets/r.
 
 ## R Markdown and Quarto
 
-Raven registers snippets for VS Code's `r` language ID. Since `.rmd` and `.qmd` files are treated as R documents, both the plain R snippets above and an R Markdown / Quarto set are available in those buffers.
+Raven contributes dedicated `rmd` and `quarto` language IDs for `.Rmd` and `.qmd` files. Each language ID gets its own snippet set; plain-R snippets are only registered under the `r` language ID, so they do not appear inside `.Rmd` / `.qmd` buffers (they will surface inside an R chunk only if another extension provides Markdown injection that switches the languageId to `r` within the chunk).
 
-The R Markdown / Quarto set covers:
+The R Markdown set (`rmd`) covers:
 
 - Code chunks: `rchunk`, `rchunkopts`, `setupchunk`, `pychunk`, `sqlchunk`, `bashchunk`
-- YAML frontmatter: `rmdyaml`, `qyaml`
+- YAML frontmatter: `rmdyaml`
 - knitr helpers: `kable`, `incgraphics`, `inliner`
 
-For the exact trigger list and expansion bodies, see `editors/vscode/snippets/rmarkdown.json`.
+The Quarto set (`quarto`) covers the same chunk and helper triggers, but `rchunk` / `rchunkopts` / `setupchunk` use the Quarto `#| key: value` option syntax, and the YAML snippet is `qyaml`.
+
+For the exact trigger list and expansion bodies, see `editors/vscode/snippets/rmarkdown.json` and `editors/vscode/snippets/quarto.json`.

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -19,7 +19,9 @@ VS Code ships a built-in R grammar. It covers roxygen comments, line comments, s
 
 That grammar isn't maintained by Microsoft directly. It's a periodic sync of [REditorSupport/vscode-R-syntax](https://github.com/REditorSupport/vscode-R-syntax): VS Code's `extensions/r/package.json` has a single `update-grammar` script that runs `vscode-grammar-updater` against the REditorSupport source, and the generated file's header points readers back to the upstream repo for fixes. The two are the same grammar, with the built-in trailing upstream by however many commits have landed since the last sync.
 
-The one capability the upstream extension adds that VS Code doesn't bundle is **R Markdown**. [`REditorSupport.r-syntax`](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax) registers a separate `rmd` language with a Markdown-aware grammar: `.Rmd` files are parsed as Markdown with R code chunks, and 30+ embedded languages (Python, SQL, C, CSS, etc.) are recognized inside their respective fenced blocks. Without it, VS Code treats `.Rmd` as plain R source — you lose Markdown headings, prose styling, and embedded-language highlighting inside code chunks.
+The one capability the upstream extension adds that VS Code doesn't bundle is **R Markdown**. [`REditorSupport.r-syntax`](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax) registers an `rmd` language with a Markdown-aware grammar: `.Rmd` files are parsed as Markdown with R code chunks, and 30+ embedded languages (Python, SQL, C, CSS, etc.) are recognized inside their respective fenced blocks.
+
+Raven contributes the `rmd` and `quarto` language IDs (for `.Rmd` / `.RMD` and `.qmd` / `.QMD` respectively) but does **not** ship a grammar for either. Without a sibling extension that supplies one — `REditorSupport.r-syntax` for `rmd`, [`quarto.quarto`](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) for `quarto` — VS Code falls back to plain-text rendering inside these documents. Install one (or both) to recover Markdown headings, prose styling, and embedded-language highlighting inside R chunks.
 
 ## R Package Development Files
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -549,7 +549,15 @@
       },
       {
         "language": "rmd",
+        "path": "./snippets/r.json"
+      },
+      {
+        "language": "rmd",
         "path": "./snippets/rmarkdown.json"
+      },
+      {
+        "language": "quarto",
+        "path": "./snippets/r.json"
       },
       {
         "language": "quarto",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -18,6 +18,8 @@
   ],
   "activationEvents": [
     "onLanguage:r",
+    "onLanguage:rmd",
+    "onLanguage:quarto",
     "onLanguage:jags",
     "onLanguage:stan",
     "onTerminalProfile:raven.rTerminal"
@@ -213,7 +215,7 @@
         "command": "raven.runLineOrSelection",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
       },
       {
         "command": "raven.sourceFile",
@@ -225,25 +227,25 @@
         "command": "raven.runCurrentChunk",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled && resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/"
+        "when": "editorTextFocus && (editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
       },
       {
         "command": "raven.runAboveChunks",
         "key": "ctrl+alt+p",
         "mac": "cmd+alt+p",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
       },
       {
         "command": "raven.goToNextChunk",
         "key": "ctrl+alt+n",
         "mac": "cmd+alt+n",
-        "when": "editorTextFocus && editorLangId == r"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto)"
       },
       {
         "command": "raven.goToPreviousChunk",
         "key": "ctrl+alt+shift+n",
         "mac": "cmd+alt+shift+n",
-        "when": "editorTextFocus && editorLangId == r"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto)"
       }
     ],
     "submenus": [
@@ -292,12 +294,12 @@
       "editor/title": [
         {
           "submenu": "raven.sendToR",
-          "when": "editorLangId == r && raven.rConsoleEnabled",
+          "when": "(editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled",
           "group": "navigation"
         },
         {
           "submenu": "raven.build",
-          "when": "editorLangId == r && raven.rConsoleEnabled && raven.isRPackage",
+          "when": "(editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled && raven.isRPackage",
           "group": "navigation"
         }
       ],
@@ -401,15 +403,33 @@
         ],
         "extensions": [
           ".r",
-          ".R",
+          ".R"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "rmd",
+        "aliases": [
+          "R Markdown",
+          "rmd"
+        ],
+        "extensions": [
           ".rmd",
           ".Rmd",
-          ".RMD",
+          ".RMD"
+        ]
+      },
+      {
+        "id": "quarto",
+        "aliases": [
+          "Quarto",
+          "quarto"
+        ],
+        "extensions": [
           ".qmd",
           ".Qmd",
           ".QMD"
-        ],
-        "configuration": "./language-configuration.json"
+        ]
       },
       {
         "id": "jags",
@@ -526,8 +546,12 @@
         "path": "./snippets/r.json"
       },
       {
-        "language": "r",
+        "language": "rmd",
         "path": "./snippets/rmarkdown.json"
+      },
+      {
+        "language": "quarto",
+        "path": "./snippets/quarto.json"
       }
     ],
     "problemMatchers": [
@@ -553,6 +577,12 @@
     ],
     "configurationDefaults": {
       "[r]": {
+        "editor.formatOnType": true
+      },
+      "[rmd]": {
+        "editor.formatOnType": true
+      },
+      "[quarto]": {
         "editor.formatOnType": true
       }
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -221,13 +221,13 @@
         "command": "raven.sourceFile",
         "key": "shift+ctrl+enter",
         "mac": "shift+cmd+enter",
-        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled"
+        "when": "editorTextFocus && editorLangId == r && raven.rConsoleEnabled && !(resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/)"
       },
       {
         "command": "raven.runCurrentChunk",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorTextFocus && (editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
+        "when": "editorTextFocus && raven.rConsoleEnabled && (editorLangId == rmd || editorLangId == quarto || (editorLangId == r && resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/))"
       },
       {
         "command": "raven.runAboveChunks",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -417,7 +417,8 @@
           ".rmd",
           ".Rmd",
           ".RMD"
-        ]
+        ],
+        "configuration": "./language-configuration.json"
       },
       {
         "id": "quarto",
@@ -429,7 +430,8 @@
           ".qmd",
           ".Qmd",
           ".QMD"
-        ]
+        ],
+        "configuration": "./language-configuration.json"
       },
       {
         "id": "jags",

--- a/editors/vscode/snippets/quarto.json
+++ b/editors/vscode/snippets/quarto.json
@@ -1,33 +1,40 @@
 {
-  "rmarkdown-r-chunk": {
+  "quarto-r-chunk": {
     "prefix": "rchunk",
     "body": [
-      "```{r ${1:label}}",
+      "```{r}",
+      "#| label: ${1:label}",
       "$0",
       "```"
     ],
-    "description": "R code chunk (R Markdown)"
+    "description": "R code chunk (Quarto)"
   },
-  "rmarkdown-r-chunk-opts": {
+  "quarto-r-chunk-opts": {
     "prefix": "rchunkopts",
     "body": [
-      "```{r ${1:label}, echo = ${2:FALSE}, message = ${3:FALSE}, warning = ${4:FALSE}}",
+      "```{r}",
+      "#| label: ${1:label}",
+      "#| echo: ${2|false,true|}",
+      "#| message: ${3|false,true|}",
+      "#| warning: ${4|false,true|}",
       "$0",
       "```"
     ],
-    "description": "R code chunk with common knitr options"
+    "description": "R code chunk with common Quarto options"
   },
-  "rmarkdown-setup-chunk": {
+  "quarto-setup-chunk": {
     "prefix": "setupchunk",
     "body": [
-      "```{r setup, include = FALSE}",
+      "```{r}",
+      "#| label: setup",
+      "#| include: false",
       "knitr::opts_chunk\\$set(echo = ${1:TRUE})",
       "$0",
       "```"
     ],
-    "description": "knitr setup chunk"
+    "description": "Quarto setup chunk"
   },
-  "rmarkdown-python-chunk": {
+  "quarto-python-chunk": {
     "prefix": "pychunk",
     "body": [
       "```{python}",
@@ -36,7 +43,7 @@
     ],
     "description": "Python code chunk"
   },
-  "rmarkdown-sql-chunk": {
+  "quarto-sql-chunk": {
     "prefix": "sqlchunk",
     "body": [
       "```{sql connection=${1:con}}",
@@ -45,7 +52,7 @@
     ],
     "description": "SQL code chunk"
   },
-  "rmarkdown-bash-chunk": {
+  "quarto-bash-chunk": {
     "prefix": "bashchunk",
     "body": [
       "```{bash}",
@@ -54,30 +61,30 @@
     ],
     "description": "Bash code chunk"
   },
-  "rmarkdown-yaml": {
-    "prefix": "rmdyaml",
+  "quarto-yaml": {
+    "prefix": "qyaml",
     "body": [
       "---",
       "title: \"${1:Title}\"",
       "author: \"${2:Author}\"",
-      "date: \"`r format(Sys.time(), '%Y-%m-%d')`\"",
-      "output: ${3|html_document,pdf_document,word_document|}",
+      "date: today",
+      "format: ${3|html,pdf,docx,revealjs|}",
       "---",
       "$0"
     ],
-    "description": "R Markdown YAML frontmatter"
+    "description": "Quarto YAML frontmatter"
   },
-  "rmarkdown-include-graphics": {
+  "quarto-include-graphics": {
     "prefix": "incgraphics",
     "body": "knitr::include_graphics(${0:\"path/to/img.png\"})",
     "description": "knitr::include_graphics()"
   },
-  "rmarkdown-kable": {
+  "quarto-kable": {
     "prefix": "kable",
     "body": "knitr::kable(${1:df}, caption = ${0:\"Caption\"})",
     "description": "knitr::kable()"
   },
-  "rmarkdown-inline-r": {
+  "quarto-inline-r": {
     "prefix": "inliner",
     "body": "`r ${0:expr}`",
     "description": "Inline R expression"

--- a/editors/vscode/src/autoCloseFix.ts
+++ b/editors/vscode/src/autoCloseFix.ts
@@ -7,6 +7,12 @@ let applying = false;
 
 const CLOSING_DELIMITERS = new Set([')', ']', '}']);
 
+// Languages where Raven applies the auto-close pair overtype fix. R code in
+// `.Rmd` / `.qmd` chunks benefits from the same correction; we accept the
+// minor cost of running the listener on prose lines (which never produce
+// duplicate-delimiter typing patterns in practice).
+const R_LIKE_LANGUAGES: ReadonlySet<string> = new Set(['r', 'rmd', 'quarto']);
+
 /**
  * Register a listener that fixes auto-closing pair overtype after
  * onTypeFormatting moves a closing delimiter to a new line.
@@ -17,7 +23,7 @@ const CLOSING_DELIMITERS = new Set([')', ']', '}']);
 export function registerAutoCloseFix(): vscode.Disposable {
     return vscode.workspace.onDidChangeTextDocument(async (e) => {
         if (applying) return;
-        if (e.document.languageId !== 'r') return;
+        if (!R_LIKE_LANGUAGES.has(e.document.languageId)) return;
         if (e.contentChanges.length !== 1) return;
 
         const change = e.contentChanges[0];

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -69,10 +69,17 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
 export function register_chunk_codelens(context: vscode.ExtensionContext): ChunkCodeLensProvider {
     const provider = new ChunkCodeLensProvider();
     context.subscriptions.push(
+        // Chunks live in `.R` files (via `# %%` cells) and in `.Rmd` / `.qmd`
+        // files (via fenced code blocks). After the language-ID split each
+        // file type uses its own `languageId`, so the selector lists all three.
         vscode.languages.registerCodeLensProvider(
             [
                 { scheme: 'file', language: 'r' },
                 { scheme: 'untitled', language: 'r' },
+                { scheme: 'file', language: 'rmd' },
+                { scheme: 'untitled', language: 'rmd' },
+                { scheme: 'file', language: 'quarto' },
+                { scheme: 'untitled', language: 'quarto' },
             ],
             provider,
         ),

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -64,14 +64,11 @@ export function classify_chunk_document(file_name_or_uri: string): DocumentKind 
 /**
  * Classify a document by inspecting both its languageId and its URI. Used at
  * the VS Code adapter layer (commands, CodeLens, decorations) where we have
- * a full `TextDocument`. Checks languageId first so untitled buffers and
- * environments with a dedicated `rmd` / `quarto` languageId classify correctly,
- * then falls back to the extension-based check for saved files registered
- * under our single `r` languageId.
- *
- * Today the extension registers only `r` (covering `.r` / `.R` / `.rmd` /
- * `.Rmd` / `.RMD` / `.qmd` / `.Qmd` / `.QMD`); the languageId path remains
- * forward-compatible should that ever change.
+ * a full `TextDocument`. Checks languageId first so untitled buffers — which
+ * have no file extension to inspect — classify correctly under our `rmd` /
+ * `quarto` language IDs, then falls back to the extension-based check as a
+ * safety net for environments where another extension has claimed the
+ * languageId for `.Rmd` / `.qmd` files.
  */
 export function classify_chunk_document_for_document(
     document: { languageId: string; uri: { fsPath: string; path: string } },

--- a/editors/vscode/src/chunks/chunk-highlighting.ts
+++ b/editors/vscode/src/chunks/chunk-highlighting.ts
@@ -117,10 +117,10 @@ function chunks_enabled(): boolean {
 }
 
 function is_chunk_capable_document(document: vscode.TextDocument): boolean {
-    // Accept our registered `r` languageId (which today covers `.r` / `.R` and
-    // `.Rmd` / `.qmd`), plus any sibling extension that contributes a dedicated
-    // `rmd` or `quarto` languageId. For `.R` files we still draw highlight for
-    // `# %%` cells.
+    // Accept the three language IDs Raven contributes: `r` (covering `.r` /
+    // `.R`, where chunks take the `# %%` cell form), `rmd` (covering `.Rmd`),
+    // and `quarto` (covering `.qmd`). A sibling extension that wins the
+    // `rmd` / `quarto` languageId race falls into the same branch by design.
     const lang = document.languageId.toLowerCase();
     return lang === 'r' || lang === 'rmd' || lang === 'quarto';
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -160,7 +160,11 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
             { scheme: 'untitled', language: 'stan' },
         ],
         synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{r,R,rmd,Rmd,RMD,qmd,Qmd,QMD,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}'),
+            // Matches the LSP `documentSelector` above: only the file extensions
+            // mapped to the `r` / `jags` / `stan` language IDs. `.Rmd` / `.qmd`
+            // are tracked under `rmd` / `quarto` and the server does not parse
+            // them, so they are intentionally omitted from this glob.
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{r,R,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}'),
         },
         outputChannel: outputChannel,
         initializationOptions: getInitializationOptions,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -151,6 +151,12 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
     const outputChannel = vscode.window.createOutputChannel('Raven');
 
     const clientOptions: LanguageClientOptions = {
+        // Deliberate scope: the Rust tree-sitter parser is R-only, so the
+        // selector does NOT include the `rmd` / `quarto` language IDs.
+        // Subscribing to them would surface prose lines as syntax errors and
+        // diagnostics. Chunk-level LSP features inside `.Rmd` / `.qmd` are
+        // tracked as a follow-up to #230 and will need a more targeted flow
+        // (e.g. virtual-document injection per fenced R block).
         documentSelector: [
             { scheme: 'file', language: 'r' },
             { scheme: 'untitled', language: 'r' },

--- a/editors/vscode/src/extensionHelpers.ts
+++ b/editors/vscode/src/extensionHelpers.ts
@@ -1,11 +1,15 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+// Set of language IDs and file extensions that Raven's language server
+// processes. `.Rmd` / `.qmd` are intentionally absent: those files use the
+// dedicated `rmd` / `quarto` language IDs and the LSP's document selector
+// is `r` only, so sending activity or watching their file events would be
+// noise. The chunk feature (which spans `.Rmd` / `.qmd`) has its own
+// language-aware wiring in `chunks/`.
 const R_DOCUMENT_LANGUAGE_IDS = new Set(['r', 'jags', 'stan']);
 const R_DOCUMENT_EXTENSIONS = new Set([
     '.r',
-    '.rmd',
-    '.qmd',
     '.jags',
     '.bugs',
     '.stan',

--- a/editors/vscode/src/send-to-r/inspect-commands.ts
+++ b/editors/vscode/src/send-to-r/inspect-commands.ts
@@ -8,6 +8,13 @@ export interface InspectionCommand {
     wrap: (expr: string) => string;
 }
 
+// Languages where the quick-inspect commands are available. R Markdown and
+// Quarto are included because R chunks inside them contain ordinary R
+// identifiers — the cursor-word path lets users inspect a variable without
+// hopping to a `.R` file. Outside a chunk the wrapped expression will
+// usually fail in R, which is acceptable user-responsibility.
+const INSPECTION_LANGUAGES: ReadonlySet<string> = new Set(['r', 'rmd', 'quarto']);
+
 export const INSPECTION_COMMANDS: InspectionCommand[] = [
     {
         id: 'raven.inspect.nrow',
@@ -60,9 +67,9 @@ export function register_inspection_commands(
         context.subscriptions.push(
             vscode.commands.registerCommand(cmd.id, async () => {
                 const editor = vscode.window.activeTextEditor;
-                if (!editor || editor.document.languageId !== 'r') {
+                if (!editor || !INSPECTION_LANGUAGES.has(editor.document.languageId)) {
                     vscode.window.showInformationMessage(
-                        'Open an R file to use quick inspection commands.'
+                        'Open an R, R Markdown, or Quarto file to use quick inspection commands.'
                     );
                     return;
                 }

--- a/editors/vscode/src/test/build-commands.test.ts
+++ b/editors/vscode/src/test/build-commands.test.ts
@@ -146,7 +146,15 @@ suite('build commands: package.json contributions', () => {
         const when = buildEntry.when ?? '';
         assert.ok(when.includes('raven.isRPackage'), 'submenu must be gated on raven.isRPackage');
         assert.ok(when.includes('raven.rConsoleEnabled'), 'submenu must require r-console activation');
-        assert.ok(when.includes("editorLangId == r"), 'submenu must require an R file');
+        // The submenu surfaces in the title bar for any of the three
+        // R-flavored language IDs (plain R, R Markdown, Quarto) since
+        // package vignettes and READMEs are commonly .Rmd / .qmd files.
+        assert.ok(
+            when.includes('editorLangId == r')
+                && when.includes('editorLangId == rmd')
+                && when.includes('editorLangId == quarto'),
+            `submenu must allow r / rmd / quarto language IDs, got: ${when}`,
+        );
         assert.strictEqual(buildEntry.group, 'navigation');
     });
 

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -56,17 +56,16 @@ const TEMP_FIXTURE_FILES: string[] = [];
 
 /**
  * Open a document with the supplied content for the chunk detector:
- *   - `'rmd'` (default) — RMarkdown / Quarto fenced-block mode. Written
- *     to a temp `.rmd` file so the chunk classifier's URI-extension path
- *     reliably classifies it as `'rmd'`. An untitled buffer with
- *     `language: 'rmd'` would also work in principle (the classifier
- *     accepts the `'rmd'` languageId), but VS Code does not always
- *     preserve unregistered languageIds across platforms — the extension
- *     only contributes `'r'`, and on Linux VS Code 1.120 the languageId
- *     gets coerced away from `'rmd'`, breaking classification.
+ *   - `'rmd'` (default) — R Markdown / Quarto fenced-block mode. Written
+ *     to a temp `.rmd` file so the URI-extension path of the classifier
+ *     fires reliably. The extension now contributes the `'rmd'` language
+ *     ID natively (so the languageId path would work too), but a real
+ *     `.rmd` file exercises both paths and sidesteps a Linux VS Code
+ *     1.120 quirk where untitled buffers can drop a freshly-contributed
+ *     languageId when the extension host hasn't loaded yet.
  *   - `'r'` — plain R / `# %%` cell-marker mode. Uses an untitled buffer
- *     because the extension registers the `'r'` languageId, so it
- *     survives the round-trip.
+ *     because `'r'` has been a registered languageId since day one and
+ *     reliably survives the round-trip.
  */
 async function open_doc(
     content: string,
@@ -113,6 +112,29 @@ function stub_information_message(): MessageStub {
 interface TerminalStub {
     sent: string[];
     restore(): void;
+}
+
+/**
+ * Names the bundled R terminal uses today (`r-terminal-manager.ts`
+ * `TERMINAL_NAME`). We dispose any pre-existing terminal with this name
+ * before installing the recording stub so the bundled extension's
+ * module-level cache doesn't hold a real terminal created by an earlier
+ * test suite (e.g. the data-viewer smoke tests).
+ */
+const RAVEN_R_TERMINAL_NAME = 'R (Raven)';
+
+async function dispose_any_cached_r_terminal(): Promise<void> {
+    const stale = vscode.window.terminals.filter(
+        (t) => t.name === RAVEN_R_TERMINAL_NAME,
+    );
+    if (stale.length === 0) return;
+    for (const t of stale) {
+        t.dispose();
+    }
+    // `dispose()` resolves before `onDidCloseTerminal` fires inside the
+    // bundled extension and clears its `last_active_terminal` cache, so
+    // wait a tick for that handler to run.
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
 }
 
 /**
@@ -290,6 +312,11 @@ suite('chunk commands: registration and behavior', () => {
         if (r_console_disabled) return;
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the "second" R chunk
+        // Dispose any R terminal a preceding test (e.g. data-viewer smoke
+        // tests, which surface `View()` panels and may create an R terminal
+        // in the process) left behind. Otherwise the bundled extension
+        // returns its cached real terminal and the stub never captures.
+        await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
             await vscode.commands.executeCommand('raven.runCurrentChunk');

--- a/editors/vscode/src/test/extensionHelpers.test.ts
+++ b/editors/vscode/src/test/extensionHelpers.test.ts
@@ -18,6 +18,12 @@ suite('Extension Helpers', () => {
         assert.strictEqual(isRDocument(makeUntitledDocument('r')), true);
         assert.strictEqual(isRDocument(makeUntitledDocument('jags')), true);
         assert.strictEqual(isRDocument(makeUntitledDocument('stan')), true);
+        // R Markdown and Quarto are tracked under their own language IDs but
+        // the LSP server does not parse them, so they intentionally do NOT
+        // count as "R documents" for activity-tracking / path-completion-
+        // trigger purposes.
+        assert.strictEqual(isRDocument(makeUntitledDocument('rmd')), false);
+        assert.strictEqual(isRDocument(makeUntitledDocument('quarto')), false);
         assert.strictEqual(isRDocument(makeUntitledDocument('plaintext')), false);
     });
 
@@ -31,9 +37,12 @@ suite('Extension Helpers', () => {
         });
 
         assert.strictEqual(isRDocument(makeFileDocument('/tmp/script.R')), true);
-        assert.strictEqual(isRDocument(makeFileDocument('/tmp/report.qmd')), true);
         assert.strictEqual(isRDocument(makeFileDocument('/tmp/model.BUGS')), true);
         assert.strictEqual(isRDocument(makeFileDocument('/tmp/model.StAn')), true);
+        // `.Rmd` and `.qmd` register under the dedicated `rmd` / `quarto`
+        // languages and are not LSP-tracked.
+        assert.strictEqual(isRDocument(makeFileDocument('/tmp/report.Rmd')), false);
+        assert.strictEqual(isRDocument(makeFileDocument('/tmp/report.qmd')), false);
         assert.strictEqual(isRDocument(makeFileDocument('/tmp/notes.txt')), false);
     });
 

--- a/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
+++ b/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
@@ -141,8 +141,8 @@ suite('quick inspection commands', () => {
             (vscode.window as any).showInformationMessage = original;
         }
         assert.ok(
-            last_message && last_message.includes('R file'),
-            `expected an info message about opening an R file, got: ${String(last_message)}`
+            last_message && /R Markdown|Quarto|R file|R, /.test(last_message),
+            `expected an info message about opening an R-flavored file, got: ${String(last_message)}`
         );
     });
 });


### PR DESCRIPTION
## Summary

Closes #230.

The extension currently uses one `r` language ID for `.R`, `.Rmd`, and `.qmd`. This PR splits the contribution into three so sibling extensions (R Markdown grammar, Quarto) can claim `.Rmd` / `.qmd` and so language-scoped settings can target each kind on its own:

- `r` — `.r`, `.R` (LSP-tracked, unchanged behavior)
- `rmd` — `.rmd`, `.Rmd`, `.RMD`
- `quarto` — `.qmd`, `.Qmd`, `.QMD`

### Key wiring choices

- LSP `documentSelector` stays `r`-only. The Rust tree-sitter parser is R-only and prose lines would surface as false diagnostics.
- File-watcher glob and `R_DOCUMENT_*` sets drop `.rmd` / `.qmd` (no LSP traffic = no need to send activity).
- Run / send-to-R / navigation keybindings, `editor/title` Send-to-R + Build submenus widen to all three language IDs.
- `Shift+Cmd+Enter` (Source File) stays scoped to `r`-only per the issue.
- Chunk CodeLens selector widened to all three IDs; autoCloseFix and quick-inspect commands widened to all three.
- Snippets: `rmarkdown.json` registered for `rmd`; new `quarto.json` for `quarto` (Quarto-style `#| key: value` chunk options + `qyaml`).
- `configurationDefaults`: mirror `[r]`'s `editor.formatOnType` for `[rmd]` and `[quarto]`.

### Grammar trade-off (called out in `docs/syntax-highlighting.md`)

Raven does not ship a grammar for `rmd` or `quarto`. Without a sibling extension (`REditorSupport.r-syntax` for `rmd`, `quarto.quarto` for `quarto`), `.Rmd` / `.qmd` files render as plain text. This is the intended outcome — treating prose as R was always wrong, and the issue defers a contributed grammar.

### Out of scope (still tracked separately)

- Knit / Quarto-render integration (#226)
- Outline integration (#227)
- Active-cell border + RStudio section dividers (#228)
- Extra run commands + configurable CodeLens list (#229)

## Test plan

- [x] `cargo test -p raven` — 0 failures
- [x] `bun test` from repo root — 449 pass, 0 fail (includes 167 vscode-test Mocha cases)
- [x] Typecheck (`bun run typecheck` in `editors/vscode`) clean
- [ ] Manual smoke: open a `.Rmd` file, confirm chunks highlight + CodeLens fire under the `rmd` language ID; confirm `Cmd+Shift+Enter` runs the current chunk
- [ ] Manual smoke: open a `.qmd` file, same checks under the `quarto` language ID
- [ ] Manual smoke: open a `.R` file, confirm `Shift+Cmd+Enter` (Source File) still works, `Cmd+Enter` (Run Line/Selection) works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support so chunk tooling, quick-inspection, editor commands, and snippets apply to R Markdown (.Rmd) and Quarto (.qmd) editors as well as plain R files.
  * Added dedicated Quarto snippets (YAML, chunk types, and helpers).

* **Documentation**
  * Clarified language ID registration, snippet coverage, and syntax-highlighting requirements for R, R Markdown, and Quarto.

* **Tests**
  * Updated tests to reflect and verify the broadened language support and menu/command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/233)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->