### PR TITLE
feat(vscode): configurable chunk CodeLens menu + 4 new run commands (#229)

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -36,12 +36,18 @@ In `.R` files, `Cmd+Shift+Enter` keeps its usual meaning of **Source File** — 
 | **Run Current Chunk** | Sends the chunk at the cursor to R. |
 | **Run Current Chunk and Move** | Runs the current chunk, then moves the cursor into the next R chunk. |
 | **Run Above Chunks** | Runs every R chunk that ends before the cursor. The current chunk is not included. |
+| **Run Below Chunks** | Runs every R chunk whose header is strictly below the cursor. The current chunk is not included. |
+| **Run Current and Below Chunks** | Runs the chunk at the cursor plus every R chunk after it. |
+| **Run Previous Chunk** | Runs the R chunk immediately above the cursor (skipping non-R chunks). |
+| **Run Next Chunk** | Runs the R chunk immediately below the cursor (skipping non-R chunks). |
 | **Run All Chunks** | Runs every R chunk in the document, top to bottom. |
 | **Go to Next Chunk** | Moves the cursor to the body of the next R chunk. |
 | **Go to Previous Chunk** | Moves the cursor to the body of the previous R chunk. |
 | **Select Current Chunk** | Selects the body of the chunk at the cursor (excludes header and closing fence). |
 
-CodeLens buttons appear on every R chunk header:
+## CodeLens buttons
+
+By default each R chunk header shows two buttons:
 
 ```text
 ▷ Run Chunk    ↥ Run Above
@@ -50,6 +56,36 @@ CodeLens buttons appear on every R chunk header:
 ```
 
 Buttons for non-R languages are intentionally omitted.
+
+The set of buttons (and their order) is controlled by `raven.chunks.codeLens.commands` — an array of run-command ids. The available ids are:
+
+| Command id | Default label |
+|------------|---------------|
+| `raven.runCurrentChunk` | `▷ Run Chunk` |
+| `raven.runCurrentChunkAndMove` | `▷⇣ Run & Move` |
+| `raven.runAboveChunks` | `↥ Run Above` |
+| `raven.runBelowChunks` | `↧ Run Below` |
+| `raven.runCurrentAndBelowChunks` | `▷↓ Run Current and Below` |
+| `raven.runPreviousChunk` | `← Run Previous` |
+| `raven.runNextChunk` | `→ Run Next` |
+| `raven.runAllChunks` | `↻ Run All` |
+
+Example — show four buttons in a custom order:
+
+```jsonc
+{
+  "raven.chunks.codeLens.commands": [
+    "raven.runCurrentChunk",
+    "raven.runCurrentAndBelowChunks",
+    "raven.runAboveChunks",
+    "raven.runAllChunks"
+  ]
+}
+```
+
+Set the array to `[]` to hide all lenses while keeping the commands available from the palette and keybindings. Unknown command ids are silently ignored.
+
+When a chunk's header sets `eval = FALSE`, the `▷ Run Chunk` and `▷⇣ Run & Move` labels gain a `(eval = FALSE)` suffix so you know the chunk would otherwise be skipped by `knitr` / `quarto render`.
 
 ## Chunk options
 

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -5,7 +5,7 @@ Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delim
 This is the daily-driver workflow for `.Rmd` / `.qmd` users coming from RStudio or vscode-R.
 
 > [!NOTE]
-> Navigation commands (Go to Next/Previous Chunk, Select Current Chunk) and chunk background highlighting work regardless of `raven.rConsole.activation`. The **run** commands (Run Current Chunk, Run Above, Run All) and the `▷ Run Chunk` / `↥ Run Above` CodeLens buttons require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), the run commands and CodeLens are not registered. See [Coexistence](./coexistence.md).
+> Navigation commands (Go to Next/Previous Chunk, Select Current Chunk) and chunk background highlighting work regardless of `raven.rConsole.activation`. The **run** commands (for example, Run Current Chunk, Run Above Chunks, Run All Chunks — see [Commands](#commands) for the full set) and every chunk CodeLens button (defaults `▷ Run Chunk` / `↥ Run Above`, plus any others added via `raven.chunks.codeLens.commands`) require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), the run commands and CodeLens are not registered. See [Coexistence](./coexistence.md).
 
 ## Chunk forms
 

--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -1,4 +1,15 @@
 import { defineConfig } from '@vscode/test-cli';
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// macOS Unix domain sockets cap path length at 103 chars. When this repo is
+// checked out in a deeply nested worktree (e.g. `.claude/worktrees/<branch>/`)
+// the default `.vscode-test/user-data/<ver>-main.sock` path overflows that
+// limit and VS Code fails to launch. Pin the user-data dir to a short tmp
+// path so the test harness works regardless of repo location.
+const userDataDir = join(tmpdir(), 'raven-vscode-test-ud');
+mkdirSync(userDataDir, { recursive: true });
 
 export default defineConfig({
     files: 'out/test/**/*.test.js',
@@ -9,6 +20,7 @@ export default defineConfig({
     launchArgs: [
         '--disable-gpu',
         '--no-sandbox',
-        '--disable-extensions'
+        '--disable-extensions',
+        `--user-data-dir=${userDataDir}`
     ]
 });

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1344,7 +1344,7 @@
     "compile": "bun run bundle",
     "compile:test": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "bun run compile:test",
+    "pretest": "bun run compile:test && bun run bundle",
     "test": "vscode-test",
     "package": "bun run bundle && bun run copy-binary && vsce package --allow-missing-repository",
     "package:target": "bun run bundle && bun run copy-binary && vsce package --target",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -140,6 +140,26 @@
         "category": "Raven"
       },
       {
+        "command": "raven.runCurrentAndBelowChunks",
+        "title": "Run Current and Below Chunks",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runBelowChunks",
+        "title": "Run Below Chunks",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runPreviousChunk",
+        "title": "Run Previous Chunk",
+        "category": "Raven"
+      },
+      {
+        "command": "raven.runNextChunk",
+        "title": "Run Next Chunk",
+        "category": "Raven"
+      },
+      {
         "command": "raven.goToNextChunk",
         "title": "Go to Next Chunk",
         "category": "Raven"
@@ -1273,6 +1293,27 @@
           "type": "boolean",
           "default": true,
           "description": "Highlight R code chunks in .Rmd / .qmd files (and `# %%` cells in .R files) with a background color. Disable to remove the background entirely."
+        },
+        "raven.chunks.codeLens.commands": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "raven.runCurrentChunk",
+              "raven.runCurrentChunkAndMove",
+              "raven.runAboveChunks",
+              "raven.runCurrentAndBelowChunks",
+              "raven.runBelowChunks",
+              "raven.runPreviousChunk",
+              "raven.runNextChunk",
+              "raven.runAllChunks"
+            ]
+          },
+          "default": [
+            "raven.runCurrentChunk",
+            "raven.runAboveChunks"
+          ],
+          "markdownDescription": "Ordered list of run commands shown as CodeLens buttons above every R chunk header. Set to `[]` to hide all lenses while keeping the underlying commands available from the palette and keybindings. Unknown command ids are ignored."
         },
         "raven.linting.objectNameSeverity": {
           "type": "string",

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -5,27 +5,70 @@ import {
     has_chunk_anchor,
     is_runnable_chunk,
 } from './chunk-detector';
+import { CHUNK_LENS_COMMANDS } from './chunk-commands';
+
+/** Configuration key for the user-configurable CodeLens command list. */
+const CODELENS_COMMANDS_SETTING = 'raven.chunks.codeLens.commands';
 
 /**
- * CodeLens provider that places "Run Chunk | Run Above" buttons on every R chunk
- * header in `.Rmd` / `.qmd` / `.R` documents.
+ * Default CodeLens menu — matches the pre-configuration behavior so existing
+ * users see the same `▷ Run Chunk` and `↥ Run Above` buttons after upgrade.
+ */
+const DEFAULT_LENS_COMMAND_IDS: readonly string[] = [
+    'raven.runCurrentChunk',
+    'raven.runAboveChunks',
+];
+
+/**
+ * Read the user's `raven.chunks.codeLens.commands` array and filter it down to
+ * known command ids in `CHUNK_LENS_COMMANDS`. Returns the defaults when the
+ * setting is unset, empty, or contains only unknown ids.
+ *
+ * Unknown ids are silently dropped — VS Code would surface a "command not
+ * found" error per click if we passed them through, and that's worse UX than
+ * just omitting the lens.
+ */
+function resolve_lens_command_ids(document: vscode.TextDocument): readonly string[] {
+    const config = vscode.workspace.getConfiguration(undefined, document.uri);
+    const raw = config.get<unknown>(CODELENS_COMMANDS_SETTING);
+    if (!Array.isArray(raw)) return DEFAULT_LENS_COMMAND_IDS;
+    const filtered = raw.filter(
+        (id): id is string => typeof id === 'string' && id in CHUNK_LENS_COMMANDS,
+    );
+    return filtered.length > 0 ? filtered : DEFAULT_LENS_COMMAND_IDS;
+}
+
+/**
+ * CodeLens provider that places one or more "Run …" buttons on every R chunk
+ * header in `.Rmd` / `.qmd` / `.R` documents. The set of buttons (and their
+ * order) is controlled by `raven.chunks.codeLens.commands`; set the array to
+ * `[]` to hide all lenses while keeping the run commands available from the
+ * palette and keybindings.
  *
  * Non-R chunks (e.g. `{python}`, `{bash}`) are skipped — they aren't executable
  * via the R console.
  *
- * Lens invalidation is left to VS Code: the editor automatically re-calls
- * `provideCodeLenses` (with internal debouncing) after document edits, visible-
- * range changes, and selector-matching scope shifts. Because our lenses depend
- * only on the document text, we don't fire `onDidChangeCodeLenses` ourselves —
- * doing so on every keystroke would bypass VS Code's coalescing and trigger an
- * immediate recompute per edit. The optional event is declared (and disposed)
- * to keep the provider future-proof for cases that need external invalidation.
+ * Lens invalidation: VS Code re-calls `provideCodeLenses` (with debouncing)
+ * after document edits, visible-range changes, and selector-matching scope
+ * shifts. We additionally fire `onDidChangeCodeLenses` when the configuration
+ * key changes so a user re-ordering or replacing the lens list sees the new
+ * lenses without reopening the file.
  */
 class ChunkCodeLensProvider implements vscode.CodeLensProvider {
     private readonly _on_did_change = new vscode.EventEmitter<void>();
+    private readonly _config_listener: vscode.Disposable;
     readonly onDidChangeCodeLenses = this._on_did_change.event;
 
+    constructor() {
+        this._config_listener = vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration(CODELENS_COMMANDS_SETTING)) {
+                this._on_did_change.fire();
+            }
+        });
+    }
+
     dispose(): void {
+        this._config_listener.dispose();
         this._on_did_change.dispose();
     }
 
@@ -37,6 +80,8 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         // Fast path: plain `.R` files without `# %%` markers (and prose-only
         // `.Rmd` documents) skip the per-line scan entirely.
         if (!has_chunk_anchor(document.getText(), kind)) return [];
+        const lens_command_ids = resolve_lens_command_ids(document);
+        if (lens_command_ids.length === 0) return [];
         const lines: string[] = [];
         for (let i = 0; i < document.lineCount; i++) lines.push(document.lineAt(i).text);
         const chunks = detect_chunks(lines, kind);
@@ -46,21 +91,19 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
             chunk_index++;
             if (!is_runnable_chunk(c)) continue;
             const range = new vscode.Range(c.header_line, 0, c.header_line, 0);
-            const eval_suffix = c.is_eval_false ? ' (eval = FALSE)' : '';
-            lenses.push(new vscode.CodeLens(range, {
-                title: `▷ Run Chunk${eval_suffix}`,
-                command: 'raven.runCurrentChunkAt',
-                arguments: [document.uri, c.header_line],
-                tooltip: c.label
-                    ? `Run chunk "${c.label}" in the R console`
-                    : `Run chunk #${chunk_index} in the R console`,
-            }));
-            lenses.push(new vscode.CodeLens(range, {
-                title: '↥ Run Above',
-                command: 'raven.runAboveChunksAt',
-                arguments: [document.uri, c.header_line],
-                tooltip: 'Run every R chunk above this one',
-            }));
+            for (const id of lens_command_ids) {
+                const meta = CHUNK_LENS_COMMANDS[id];
+                if (!meta) continue;
+                const eval_suffix = meta.eval_aware && c.is_eval_false ? ' (eval = FALSE)' : '';
+                lenses.push(new vscode.CodeLens(range, {
+                    title: `${meta.title}${eval_suffix}`,
+                    command: meta.positional_id,
+                    arguments: [document.uri, c.header_line],
+                    tooltip: c.label
+                        ? `${meta.tooltip} (chunk "${c.label}")`
+                        : `${meta.tooltip} (chunk #${chunk_index})`,
+                }));
+            }
         }
         return lenses;
     }

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -21,8 +21,11 @@ const DEFAULT_LENS_COMMAND_IDS: readonly string[] = [
 
 /**
  * Read the user's `raven.chunks.codeLens.commands` array and filter it down to
- * known command ids in `CHUNK_LENS_COMMANDS`. Returns the defaults when the
- * setting is unset, empty, or contains only unknown ids.
+ * known command ids in `CHUNK_LENS_COMMANDS`. Returns the user's array verbatim
+ * (after dropping unknown ids) — including the empty case, which intentionally
+ * hides every lens. Only falls back to `DEFAULT_LENS_COMMAND_IDS` when the
+ * resolved value isn't an array at all (i.e. corrupt state); the normal "unset"
+ * case is already covered by the `default` declared in `package.json`.
  *
  * Unknown ids are silently dropped — VS Code would surface a "command not
  * found" error per click if we passed them through, and that's worse UX than
@@ -32,10 +35,9 @@ function resolve_lens_command_ids(document: vscode.TextDocument): readonly strin
     const config = vscode.workspace.getConfiguration(undefined, document.uri);
     const raw = config.get<unknown>(CODELENS_COMMANDS_SETTING);
     if (!Array.isArray(raw)) return DEFAULT_LENS_COMMAND_IDS;
-    const filtered = raw.filter(
+    return raw.filter(
         (id): id is string => typeof id === 'string' && id in CHUNK_LENS_COMMANDS,
     );
-    return filtered.length > 0 ? filtered : DEFAULT_LENS_COMMAND_IDS;
 }
 
 /**

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -4,15 +4,26 @@ import {
     detect_chunks,
     find_chunk_at_line,
     chunks_above,
+    chunks_below,
     extract_chunk_code,
     has_chunk_anchor,
     is_runnable_chunk,
+    next_runnable_chunk,
+    previous_runnable_chunk,
     Chunk,
 } from './chunk-detector';
 import { get_or_create_r_terminal } from '../send-to-r/r-terminal-manager';
 import { send_code, get_send_options } from '../send-to-r/send-code';
 
-type RunMode = 'current' | 'currentAndMove' | 'above' | 'all';
+export type RunMode =
+    | 'current'
+    | 'currentAndMove'
+    | 'above'
+    | 'all'
+    | 'currentAndBelow'
+    | 'below'
+    | 'previous'
+    | 'next';
 
 function get_document_lines(document: vscode.TextDocument): string[] {
     const lines: string[] = [];
@@ -106,6 +117,47 @@ async function run_chunk_at(
         return;
     }
 
+    if (mode === 'below') {
+        const below = chunks_below(chunks, cursor_line);
+        const code = combined_code(lines, below);
+        if (code.length === 0) {
+            vscode.window.showInformationMessage('Raven: no runnable chunks below the cursor.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
+    if (mode === 'previous') {
+        const previous = previous_runnable_chunk(chunks, cursor_line);
+        if (!previous) {
+            vscode.window.showInformationMessage('Raven: no runnable chunk above the cursor.');
+            return;
+        }
+        const code = extract_chunk_code(lines, previous);
+        if (code.trim().length === 0) {
+            vscode.window.showInformationMessage('Raven: previous chunk is empty.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
+    if (mode === 'next') {
+        const next = next_runnable_chunk(chunks, cursor_line);
+        if (!next) {
+            vscode.window.showInformationMessage('Raven: no runnable chunk below the cursor.');
+            return;
+        }
+        const code = extract_chunk_code(lines, next);
+        if (code.trim().length === 0) {
+            vscode.window.showInformationMessage('Raven: next chunk is empty.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
     const current = find_chunk_at_line(chunks, cursor_line);
     if (!current) {
         vscode.window.showInformationMessage(
@@ -119,6 +171,18 @@ async function run_chunk_at(
         );
         return;
     }
+
+    if (mode === 'currentAndBelow') {
+        const below = chunks_below(chunks, current.header_line);
+        const code = combined_code(lines, [current, ...below]);
+        if (code.length === 0) {
+            vscode.window.showInformationMessage('Raven: current chunk and chunks below are empty.');
+            return;
+        }
+        await send_to_r(code);
+        return;
+    }
+
     const code = extract_chunk_code(lines, current);
     if (code.trim().length === 0) {
         vscode.window.showInformationMessage('Raven: current chunk is empty.');
@@ -163,12 +227,91 @@ async function run_chunk_at_command(
     await run_chunk_at(mode, document, line);
 }
 
+/**
+ * Run commands a user can list in `raven.chunks.codeLens.commands` to choose
+ * which CodeLens buttons appear on chunk headers and in what order. Each entry
+ * maps the user-facing command id (the one declared in `package.json` and
+ * invokable from the command palette) to the positional `*At` variant the
+ * lens click should dispatch — so clicking a lens always targets the chunk it
+ * is attached to, regardless of where the cursor sits.
+ *
+ * `eval_aware` lenses append a `(eval = FALSE)` suffix to their title when
+ * the chunk header sets `eval = FALSE`, matching the existing "Run Chunk"
+ * behavior. Multi-chunk lenses (above / below / all) don't add the suffix
+ * because the chunk under the lens isn't the one being executed.
+ */
+export interface ChunkLensCommand {
+    /** Command id dispatched by the CodeLens click (positional variant). */
+    readonly positional_id: string;
+    /** Lens button label. */
+    readonly title: string;
+    /** Hover tooltip. */
+    readonly tooltip: string;
+    /** Whether to append a `(eval = FALSE)` suffix when the chunk skips eval. */
+    readonly eval_aware: boolean;
+}
+
+export const CHUNK_LENS_COMMANDS: Readonly<Record<string, ChunkLensCommand>> = Object.freeze({
+    'raven.runCurrentChunk': {
+        positional_id: 'raven.runCurrentChunkAt',
+        title: '▷ Run Chunk',
+        tooltip: 'Run this chunk in the R console',
+        eval_aware: true,
+    },
+    'raven.runCurrentChunkAndMove': {
+        positional_id: 'raven.runCurrentChunkAndMoveAt',
+        title: '▷⇣ Run & Move',
+        tooltip: 'Run this chunk, then move the cursor into the next R chunk',
+        eval_aware: true,
+    },
+    'raven.runAboveChunks': {
+        positional_id: 'raven.runAboveChunksAt',
+        title: '↥ Run Above',
+        tooltip: 'Run every R chunk above this one',
+        eval_aware: false,
+    },
+    'raven.runCurrentAndBelowChunks': {
+        positional_id: 'raven.runCurrentAndBelowChunksAt',
+        title: '▷↓ Run Current and Below',
+        tooltip: 'Run this chunk and every R chunk after it',
+        eval_aware: false,
+    },
+    'raven.runBelowChunks': {
+        positional_id: 'raven.runBelowChunksAt',
+        title: '↧ Run Below',
+        tooltip: 'Run every R chunk below this one',
+        eval_aware: false,
+    },
+    'raven.runPreviousChunk': {
+        positional_id: 'raven.runPreviousChunkAt',
+        title: '← Run Previous',
+        tooltip: 'Run the R chunk immediately above this one',
+        eval_aware: false,
+    },
+    'raven.runNextChunk': {
+        positional_id: 'raven.runNextChunkAt',
+        title: '→ Run Next',
+        tooltip: 'Run the R chunk immediately below this one',
+        eval_aware: false,
+    },
+    'raven.runAllChunks': {
+        positional_id: 'raven.runAllChunksAt',
+        title: '↻ Run All',
+        tooltip: 'Run every R chunk in the document',
+        eval_aware: false,
+    },
+});
+
 export function register_chunk_commands(context: vscode.ExtensionContext): void {
     const handlers: Array<[string, RunMode]> = [
         ['raven.runCurrentChunk', 'current'],
         ['raven.runCurrentChunkAndMove', 'currentAndMove'],
         ['raven.runAboveChunks', 'above'],
         ['raven.runAllChunks', 'all'],
+        ['raven.runCurrentAndBelowChunks', 'currentAndBelow'],
+        ['raven.runBelowChunks', 'below'],
+        ['raven.runPreviousChunk', 'previous'],
+        ['raven.runNextChunk', 'next'],
     ];
     for (const [id, mode] of handlers) {
         context.subscriptions.push(
@@ -179,7 +322,13 @@ export function register_chunk_commands(context: vscode.ExtensionContext): void 
     // Positional variants used by CodeLens (header line is known up-front).
     const positional: Array<[string, RunMode]> = [
         ['raven.runCurrentChunkAt', 'current'],
+        ['raven.runCurrentChunkAndMoveAt', 'currentAndMove'],
         ['raven.runAboveChunksAt', 'above'],
+        ['raven.runAllChunksAt', 'all'],
+        ['raven.runCurrentAndBelowChunksAt', 'currentAndBelow'],
+        ['raven.runBelowChunksAt', 'below'],
+        ['raven.runPreviousChunkAt', 'previous'],
+        ['raven.runNextChunkAt', 'next'],
     ];
     for (const [id, mode] of positional) {
         context.subscriptions.push(

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -237,8 +237,12 @@ async function run_chunk_at_command(
  *
  * `eval_aware` lenses append a `(eval = FALSE)` suffix to their title when
  * the chunk header sets `eval = FALSE`, matching the existing "Run Chunk"
- * behavior. Multi-chunk lenses (above / below / all) don't add the suffix
- * because the chunk under the lens isn't the one being executed.
+ * behavior. Multi-chunk lenses don't add the suffix: for `above` / `below` /
+ * `previous` / `next` / `all` the chunk under the lens isn't even part of the
+ * execution; for `currentAndBelow` it is, but the suffix would still be
+ * misleading because the chunks after it would still run regardless of this
+ * one's `eval` flag, so the lens's title shouldn't make any single chunk's
+ * eval state look load-bearing.
  */
 export interface ChunkLensCommand {
     /** Command id dispatched by the CodeLens click (positional variant). */

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -277,6 +277,50 @@ export function chunks_above(chunks: Chunk[], line: number): Chunk[] {
 }
 
 /**
+ * Return chunks whose header line is strictly below the cursor line. When the cursor
+ * sits inside a chunk, that chunk is NOT included in the result.
+ */
+export function chunks_below(chunks: Chunk[], line: number): Chunk[] {
+    const out: Chunk[] = [];
+    for (const c of chunks) {
+        if (c.header_line > line) out.push(c);
+    }
+    return out;
+}
+
+/**
+ * Find the runnable chunk immediately above the cursor line. When the cursor
+ * sits inside a chunk, that chunk itself is skipped — "previous" means the
+ * chunk before it. Non-runnable chunks (e.g. `{python}`) are skipped as well.
+ * Returns `null` if there is no runnable chunk above.
+ */
+export function previous_runnable_chunk(chunks: Chunk[], line: number): Chunk | null {
+    let candidate: Chunk | null = null;
+    for (const c of chunks) {
+        const last = c.closing_fence_line ?? c.end_line;
+        if (last < line && is_runnable_chunk(c)) {
+            candidate = c;
+        } else if (c.header_line > line) {
+            break;
+        }
+    }
+    return candidate;
+}
+
+/**
+ * Find the runnable chunk immediately below the cursor line. When the cursor
+ * sits inside a chunk, that chunk itself is skipped — "next" means the chunk
+ * after it. Non-runnable chunks are skipped as well.
+ * Returns `null` if there is no runnable chunk below.
+ */
+export function next_runnable_chunk(chunks: Chunk[], line: number): Chunk | null {
+    for (const c of chunks) {
+        if (c.header_line > line && is_runnable_chunk(c)) return c;
+    }
+    return null;
+}
+
+/**
  * Return the executable code inside the chunk, joined with `\n`.
  * Excludes the header/fence lines.
  */

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -26,6 +26,7 @@ import {
     register_send_to_r_commands,
     register_inspection_commands,
     get_or_create_r_terminal,
+    _dispose_cached_r_terminal_for_test,
 } from './send-to-r';
 import { register_build_commands } from './build-commands';
 import {
@@ -129,6 +130,14 @@ export interface RavenExtensionApi {
     getDataViewerPanelNames(): string[];
     /** Column names for a named data viewer panel. Used by integration tests. */
     getDataViewerPanelColumnNames(panelName: string): string[] | undefined;
+    /**
+     * Test-only: forget the bundled extension's cached R terminal so the next
+     * `sendToRTerminal` recreates it through the real `createTerminal` path.
+     * Needed by integration suites that follow another suite which stubbed
+     * `vscode.window.createTerminal` — that stub's fake terminal is invisible
+     * to `onDidCloseTerminal` and would otherwise be reused indefinitely.
+     */
+    _disposeCachedRTerminalForTest(): void;
 }
 
 export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
@@ -352,6 +361,7 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         getDataViewerPanelNames: () => data_viewer_manager?.getPanelNames() ?? [],
         getDataViewerPanelColumnNames: (panelName: string) =>
             data_viewer_manager?.getPanelColumnNames(panelName),
+        _disposeCachedRTerminalForTest: () => _dispose_cached_r_terminal_for_test(),
     };
 }
 

--- a/editors/vscode/src/r-session-server/index.ts
+++ b/editors/vscode/src/r-session-server/index.ts
@@ -192,14 +192,20 @@ export class RSessionServer {
 
         // Path-trust: canonicalize and require strict containment in the
         // allowed directory. realpathSync also rejects non-existent files.
+        // Canonicalize BOTH paths so symlinks in the parent chain (notably
+        // macOS's `/var → /private/var` and `/tmp → /private/tmp`) don't
+        // cause a legitimate file under the allowed dir to fail the prefix
+        // check just because one side followed the symlink and the other
+        // didn't.
         let canonical: string;
+        let allowed: string;
         try {
             canonical = fs.realpathSync(filePath);
+            allowed = fs.realpathSync(this.allowed_data_viewer_dir);
         } catch {
             res.writeHead(400).end();
             return;
         }
-        const allowed = this.allowed_data_viewer_dir;
         if (canonical !== allowed && !canonical.startsWith(allowed + path.sep)) {
             res.writeHead(400).end();
             return;

--- a/editors/vscode/src/send-to-r/index.ts
+++ b/editors/vscode/src/send-to-r/index.ts
@@ -2,6 +2,7 @@ export {
     register_r_terminal,
     get_or_create_r_terminal,
     resolve_program,
+    _dispose_cached_r_terminal_for_test,
 } from './r-terminal-manager';
 export { register_send_to_r_commands } from './commands';
 export { send_code, get_send_options } from './send-code';

--- a/editors/vscode/src/send-to-r/r-terminal-manager.ts
+++ b/editors/vscode/src/send-to-r/r-terminal-manager.ts
@@ -90,6 +90,23 @@ export async function _clear_validation_state_for_test(): Promise<void> {
     }
 }
 
+/**
+ * Test-only: forget any cached terminal so the next `get_or_create_r_terminal()`
+ * goes through the full creation path. Used by integration suites that follow
+ * a suite which stubbed `vscode.window.createTerminal` and left the bundled
+ * extension caching a fake terminal whose `dispose()` is a no-op and which is
+ * invisible to `vscode.window.onDidCloseTerminal`. Without this hook the cache
+ * survives forever and downstream tests that need a real R session fail with
+ * a 60-second timeout because their `sendText` lands in the dead stub.
+ */
+export function _dispose_cached_r_terminal_for_test(): void {
+    profile_terminals.clear();
+    last_active_terminal = null;
+    creation_in_flight = null;
+    pending_profile_creation_count = 0;
+    pending_profile_session_ids.length = 0;
+}
+
 // Probes for the program in the user's interactive-login shell, where rc-file
 // PATH additions (conda, pyenv, asdf, homebrew shellenv) are visible — unlike
 // the extension host's process.env.PATH. Returns false on missing/timeout.

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -142,41 +142,55 @@ async function dispose_any_cached_r_terminal(): Promise<void> {
 }
 
 /**
- * Replace `vscode.window.createTerminal` so the next call returns a
- * recording terminal. The bundled extension's `get_or_create_r_terminal`
- * caches the terminal in-process via module-level state, so the FIRST
- * call after stubbing is what we capture — subsequent tests in the same
- * suite will reuse that same recording terminal. The stub also records
- * `sendText` calls when the cached terminal is reused.
+ * Replace `vscode.window.createTerminal` so the bundled extension's
+ * `get_or_create_r_terminal` returns a recording terminal. The extension
+ * caches the terminal in-process via module-level state, so the FIRST call
+ * after stubbing is what stays — subsequent stub installs in the same suite
+ * reuse that same cached terminal.
+ *
+ * To make the recorded sends reliable across tests, the fake terminal's
+ * `sendText` delegates to a module-level recorder. Each `stub_create_terminal`
+ * call:
+ *   1. resets the recorder to a fresh empty array
+ *   2. returns a `TerminalStub` whose `sent` reflects the live state of
+ *      `RECORDED_SENT` (so writes via the cached fake terminal land in this
+ *      stub's view).
+ *
+ * The cached fake terminal stays installed across tests — only the recorder
+ * target rotates. `restore` is still provided for the `vscode.window.createTerminal`
+ * override; the fake terminal itself is intentionally sticky.
  */
-function stub_create_terminal(): TerminalStub {
-    const sent: string[] = [];
-    const recorder = (text: string, _addNewLine?: boolean) => {
-        sent.push(text);
-    };
+let RECORDED_SENT: string[] = [];
+const CACHED_FAKE_TERMINAL = {
+    name: 'R (Raven test stub)',
+    sendText: (text: string, _addNewLine?: boolean) => {
+        RECORDED_SENT.push(text);
+    },
+    show: () => undefined,
+    dispose: () => undefined,
+    processId: Promise.resolve(undefined),
+    creationOptions: { name: 'R (Raven test stub)' },
+    exitStatus: undefined,
+    state: { isInteractedWith: false },
     // Cast through `unknown` because the VS Code TerminalState/shell-integration
     // interfaces churn across `@types/vscode` versions and the test only needs
     // `sendText` / `show` to be callable.
-    const fake_terminal = {
-        name: 'R (Raven test stub)',
-        sendText: recorder,
-        show: () => undefined,
-        dispose: () => undefined,
-        processId: Promise.resolve(undefined),
-        creationOptions: { name: 'R (Raven test stub)' },
-        exitStatus: undefined,
-        state: { isInteractedWith: false },
-    } as unknown as vscode.Terminal;
+} as unknown as vscode.Terminal;
+
+function stub_create_terminal(): TerminalStub {
+    RECORDED_SENT = [];
     const original = vscode.window.createTerminal;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (vscode.window as any).createTerminal = (..._args: unknown[]) => fake_terminal;
+    (vscode.window as any).createTerminal = (..._args: unknown[]) => CACHED_FAKE_TERMINAL;
     return {
-        sent,
+        get sent() {
+            return RECORDED_SENT;
+        },
         restore: () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (vscode.window as any).createTerminal = original;
         },
-    };
+    } as TerminalStub;
 }
 
 suite('chunk commands: registration and behavior', () => {

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -10,6 +10,10 @@ const CHUNK_COMMANDS = [
     'raven.runCurrentChunkAndMove',
     'raven.runAboveChunks',
     'raven.runAllChunks',
+    'raven.runCurrentAndBelowChunks',
+    'raven.runBelowChunks',
+    'raven.runPreviousChunk',
+    'raven.runNextChunk',
     'raven.goToNextChunk',
     'raven.goToPreviousChunk',
     'raven.selectCurrentChunk',
@@ -346,5 +350,86 @@ suite('chunk commands: registration and behavior', () => {
         await vscode.commands.executeCommand('raven.selectCurrentChunk');
         const text = editor.document.getText(editor.selection);
         assert.strictEqual(text, 'a <- 1\nb <- 2');
+    });
+
+    test('raven.chunks.codeLens.commands controls lens count and order', async function () {
+        // Skip when R-console activation is disabled — the CodeLens provider is
+        // only registered alongside the run commands.
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunkAt');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        const config = vscode.workspace.getConfiguration();
+        const previous = config.inspect<string[]>('raven.chunks.codeLens.commands')?.globalValue;
+        try {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                ['raven.runCurrentChunk', 'raven.runAllChunks', 'raven.runBelowChunks'],
+                vscode.ConfigurationTarget.Global,
+            );
+            // Allow the CodeLens provider's onDidChangeConfiguration handler to
+            // fire and VS Code's CodeLens cache to refresh.
+            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+            const lenses = (await vscode.commands.executeCommand<vscode.CodeLens[]>(
+                'vscode.executeCodeLensProvider',
+                editor.document.uri,
+            )) ?? [];
+            // RMD_FIXTURE contains three R chunks. Each runnable chunk should
+            // contribute exactly three lenses in the configured order.
+            const titles = lenses.map((l) => l.command?.title ?? '');
+            const first_chunk_titles = titles.slice(0, 3);
+            assert.ok(
+                first_chunk_titles[0]?.startsWith('▷ Run Chunk'),
+                `first lens should be Run Chunk, got: ${first_chunk_titles[0]}`,
+            );
+            assert.ok(
+                first_chunk_titles[1]?.startsWith('↻ Run All'),
+                `second lens should be Run All, got: ${first_chunk_titles[1]}`,
+            );
+            assert.ok(
+                first_chunk_titles[2]?.startsWith('↧ Run Below'),
+                `third lens should be Run Below, got: ${first_chunk_titles[2]}`,
+            );
+            // 3 R chunks × 3 lenses each → 9 lenses (python chunk produces none).
+            assert.strictEqual(
+                lenses.length,
+                9,
+                `expected 9 lenses (3 R chunks × 3 buttons), got ${lenses.length}`,
+            );
+        } finally {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                previous,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
+    });
+
+    test('raven.chunks.codeLens.commands set to [] hides all lenses', async function () {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunkAt');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        const config = vscode.workspace.getConfiguration();
+        const previous = config.inspect<string[]>('raven.chunks.codeLens.commands')?.globalValue;
+        try {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                [],
+                vscode.ConfigurationTarget.Global,
+            );
+            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+            const lenses = (await vscode.commands.executeCommand<vscode.CodeLens[]>(
+                'vscode.executeCodeLensProvider',
+                editor.document.uri,
+            )) ?? [];
+            assert.strictEqual(lenses.length, 0, 'empty array should hide every lens');
+        } finally {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                previous,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
     });
 });

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -193,6 +193,34 @@ function stub_create_terminal(): TerminalStub {
     } as TerminalStub;
 }
 
+/**
+ * Poll `vscode.executeCodeLensProvider` until `predicate(lenses)` is true
+ * or `timeoutMs` elapses. Returns the most-recently observed lens array
+ * either way so the caller can assert against it on timeout.
+ *
+ * Use this after mutating settings that the CodeLens provider listens to
+ * (e.g. `raven.chunks.codeLens.commands`): `config.update()` resolves
+ * before the provider's `onDidChangeConfiguration` handler runs and VS
+ * Code's CodeLens cache refreshes, so a fixed sleep is racy.
+ */
+async function poll_for_lenses(
+    uri: vscode.Uri,
+    predicate: (lenses: vscode.CodeLens[]) => boolean,
+    { timeoutMs = 3000, intervalMs = 50 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<vscode.CodeLens[]> {
+    const deadline = Date.now() + timeoutMs;
+    let lenses: vscode.CodeLens[] = [];
+    while (true) {
+        lenses = (await vscode.commands.executeCommand<vscode.CodeLens[]>(
+            'vscode.executeCodeLensProvider',
+            uri,
+        )) ?? [];
+        if (predicate(lenses)) return lenses;
+        if (Date.now() >= deadline) return lenses;
+        await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+    }
+}
+
 suite('chunk commands: registration and behavior', () => {
     suiteTeardown(() => {
         for (const file of TEMP_FIXTURE_FILES) {
@@ -528,15 +556,13 @@ suite('chunk commands: registration and behavior', () => {
                 ['raven.runCurrentChunk', 'raven.runAllChunks', 'raven.runBelowChunks'],
                 vscode.ConfigurationTarget.Global,
             );
-            // Allow the CodeLens provider's onDidChangeConfiguration handler to
-            // fire and VS Code's CodeLens cache to refresh.
-            await new Promise<void>((resolve) => setTimeout(resolve, 100));
-            const lenses = (await vscode.commands.executeCommand<vscode.CodeLens[]>(
-                'vscode.executeCodeLensProvider',
-                editor.document.uri,
-            )) ?? [];
             // RMD_FIXTURE contains three R chunks. Each runnable chunk should
-            // contribute exactly three lenses in the configured order.
+            // contribute exactly three lenses in the configured order →
+            // 3 R chunks × 3 lenses = 9. Poll until the cache catches up.
+            const lenses = await poll_for_lenses(
+                editor.document.uri,
+                (ls) => ls.length === 9,
+            );
             const titles = lenses.map((l) => l.command?.title ?? '');
             const first_chunk_titles = titles.slice(0, 3);
             assert.ok(
@@ -579,11 +605,10 @@ suite('chunk commands: registration and behavior', () => {
                 [],
                 vscode.ConfigurationTarget.Global,
             );
-            await new Promise<void>((resolve) => setTimeout(resolve, 100));
-            const lenses = (await vscode.commands.executeCommand<vscode.CodeLens[]>(
-                'vscode.executeCodeLensProvider',
+            const lenses = await poll_for_lenses(
                 editor.document.uri,
-            )) ?? [];
+                (ls) => ls.length === 0,
+            );
             assert.strictEqual(lenses.length, 0, 'empty array should hide every lens');
         } finally {
             await config.update(

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -352,6 +352,153 @@ suite('chunk commands: registration and behavior', () => {
         assert.strictEqual(text, 'a <- 1\nb <- 2');
     });
 
+    /**
+     * Behavioral coverage for the four new run commands (issue #229).
+     * Each test stubs the R terminal, places the cursor at a known position
+     * in `RMD_FIXTURE`, executes the command, and verifies that the chunk
+     * body that *should* have been sent reaches the terminal — matching
+     * either the literal text (single-line wrapper) or a `source(.../*.R)`
+     * tempfile wrapper for multi-line payloads, the same pattern used by
+     * the existing `runCurrentChunk` test.
+     */
+    function captured_payload(sent: string[]): string {
+        return sent.join('\n');
+    }
+
+    function payload_contains(sent: string[], needle: string): boolean {
+        const text = captured_payload(sent);
+        return text.includes(needle) || /source\((.+)\.R/.test(text);
+    }
+
+    test('runNextChunk runs the chunk immediately below the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runNextChunk');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 7); // inside the first R chunk ("setup")
+        await dispose_any_cached_r_terminal();
+        const term = stub_create_terminal();
+        try {
+            await vscode.commands.executeCommand('raven.runNextChunk');
+        } finally {
+            term.restore();
+        }
+        // Next runnable chunk after "setup" is "second" (python is skipped).
+        // Its body is `x <- 1\ny <- 2`.
+        assert.ok(
+            payload_contains(term.sent, 'x <- 1') ||
+            payload_contains(term.sent, 'y <- 2'),
+            `expected "second" chunk body to reach terminal, got: ${captured_payload(term.sent).slice(0, 200)}`,
+        );
+    });
+
+    test('runPreviousChunk runs the chunk immediately above the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runPreviousChunk');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 17); // inside the "second" R chunk
+        await dispose_any_cached_r_terminal();
+        const term = stub_create_terminal();
+        try {
+            await vscode.commands.executeCommand('raven.runPreviousChunk');
+        } finally {
+            term.restore();
+        }
+        // Previous runnable chunk before "second" is "setup" (python is skipped).
+        // Its body is `library(dplyr)`.
+        assert.ok(
+            payload_contains(term.sent, 'library(dplyr)'),
+            `expected "setup" chunk body to reach terminal, got: ${captured_payload(term.sent).slice(0, 200)}`,
+        );
+    });
+
+    test('runBelowChunks runs every R chunk after the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runBelowChunks');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 4); // prose line before any chunk
+        await dispose_any_cached_r_terminal();
+        const term = stub_create_terminal();
+        try {
+            await vscode.commands.executeCommand('raven.runBelowChunks');
+        } finally {
+            term.restore();
+        }
+        // All three R chunks should be combined into the payload.
+        const text = captured_payload(term.sent);
+        const has_all_chunks =
+            text.includes('library(dplyr)') &&
+            text.includes('x <- 1') &&
+            text.includes('never_run()');
+        const has_tempfile = /source\((.+)\.R/.test(text);
+        assert.ok(
+            has_all_chunks || has_tempfile,
+            `expected all R chunk bodies to reach terminal, got: ${text.slice(0, 300)}`,
+        );
+    });
+
+    test('runCurrentAndBelowChunks runs the cursor chunk plus every R chunk after it', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentAndBelowChunks');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 17); // inside the "second" R chunk
+        await dispose_any_cached_r_terminal();
+        const term = stub_create_terminal();
+        try {
+            await vscode.commands.executeCommand('raven.runCurrentAndBelowChunks');
+        } finally {
+            term.restore();
+        }
+        const text = captured_payload(term.sent);
+        const has_current_and_below =
+            text.includes('x <- 1') &&
+            text.includes('never_run()');
+        const has_tempfile = /source\((.+)\.R/.test(text);
+        assert.ok(
+            has_current_and_below || has_tempfile,
+            `expected current ("second") and below ("noeval") chunk bodies to reach terminal, got: ${text.slice(0, 300)}`,
+        );
+    });
+
+    test('runNextChunk warns when there is no chunk below the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runNextChunk');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 22); // after the last chunk
+        const stub = stub_information_message();
+        try {
+            await vscode.commands.executeCommand('raven.runNextChunk');
+        } finally {
+            stub.restore();
+        }
+        assert.ok(
+            stub.last && stub.last.includes('no runnable chunk below'),
+            `expected "no runnable chunk below" info message, got: ${String(stub.last)}`,
+        );
+    });
+
+    test('runPreviousChunk warns when there is no chunk above the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runPreviousChunk');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        place_cursor(editor, 0); // before any chunk
+        const stub = stub_information_message();
+        try {
+            await vscode.commands.executeCommand('raven.runPreviousChunk');
+        } finally {
+            stub.restore();
+        }
+        assert.ok(
+            stub.last && stub.last.includes('no runnable chunk above'),
+            `expected "no runnable chunk above" info message, got: ${String(stub.last)}`,
+        );
+    });
+
     test('raven.chunks.codeLens.commands controls lens count and order', async function () {
         // Skip when R-console activation is disabled — the CodeLens provider is
         // only registered alongside the run commands.

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -21,7 +21,7 @@ import { activate, sleep } from './helper';
 async function pollForPanel(
     api: RavenExtensionApi,
     panelName: string,
-    timeoutMs = 60000,
+    timeoutMs = 10000,
 ): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
@@ -63,6 +63,13 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         if (!ext.isActive) await ext.activate();
         api = ext.exports as RavenExtensionApi;
 
+        // Earlier suites (notably chunks.test.ts) stub `vscode.window.createTerminal`
+        // to return a recording fake. The bundled extension caches the first
+        // terminal it sees and never re-creates, and the fake is invisible to
+        // `onDidCloseTerminal`, so without resetting here every `sendToRTerminal`
+        // below would land in the dead stub and no panel would ever appear.
+        api._disposeCachedRTerminalForTest();
+
         // Small wait for the async data-viewer setup (mkdir + stale sweep) that
         // runs after activate() returns.
         await sleep(500);
@@ -76,7 +83,7 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         await api.sendToRTerminal('View(mtcars)');
 
         const appeared = await pollForPanel(api, 'mtcars');
-        assert.ok(appeared, 'data viewer panel "mtcars" did not appear within 60 s');
+        assert.ok(appeared, 'data viewer panel "mtcars" did not appear');
 
         const cols = api.getDataViewerPanelColumnNames('mtcars');
         assert.ok(Array.isArray(cols), 'expected column names array for "mtcars" panel');

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -5,9 +5,12 @@ import {
     detect_chunks,
     find_chunk_at_line,
     chunks_above,
+    chunks_below,
     extract_chunk_code,
     has_chunk_anchor,
     is_runnable_chunk,
+    next_runnable_chunk,
+    previous_runnable_chunk,
     Chunk,
 } from '../../editors/vscode/src/chunks/chunk-detector';
 
@@ -325,6 +328,96 @@ describe('chunks_above', () => {
     test('returns empty list when cursor is above all chunks', () => {
         const result = chunks_above(chunks, 0);
         expect(result.length).toBe(0);
+    });
+});
+
+describe('chunks_below', () => {
+    const chunks: Chunk[] = [
+        { header_line: 0, end_line: 2, closing_fence_line: 3, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+        { header_line: 5, end_line: 6, closing_fence_line: 7, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+        { header_line: 10, end_line: 12, closing_fence_line: 13, language: 'r', label: null, options: {}, is_eval_false: false, kind: 'rmd' },
+    ];
+
+    test('returns chunks whose header is strictly below cursor', () => {
+        // Cursor on line 8 (between chunk 2's close at 7 and chunk 3's header at 10)
+        // → only chunk 3 is below.
+        const result = chunks_below(chunks, 8);
+        expect(result.length).toBe(1);
+        expect(result[0].header_line).toBe(10);
+    });
+
+    test('when cursor is on a header, that chunk is not below', () => {
+        // Cursor on chunk 2's header at line 5 → only chunk 3 (header 10) is below.
+        const result = chunks_below(chunks, 5);
+        expect(result.length).toBe(1);
+        expect(result[0].header_line).toBe(10);
+    });
+
+    test('returns empty list when cursor is past every chunk', () => {
+        const result = chunks_below(chunks, 99);
+        expect(result.length).toBe(0);
+    });
+});
+
+describe('previous_runnable_chunk / next_runnable_chunk', () => {
+    function r_chunk(header: number, last: number): Chunk {
+        return {
+            header_line: header,
+            end_line: last,
+            closing_fence_line: last + 1,
+            language: 'r',
+            label: null,
+            options: {},
+            is_eval_false: false,
+            kind: 'rmd',
+        };
+    }
+    function py_chunk(header: number, last: number): Chunk {
+        return { ...r_chunk(header, last), language: 'python' };
+    }
+
+    test('previous returns the chunk before the one containing the cursor', () => {
+        const chunks: Chunk[] = [r_chunk(0, 2), r_chunk(5, 7), r_chunk(10, 12)];
+        // Cursor inside chunk 2 (line 6) → previous is chunk 1.
+        expect(previous_runnable_chunk(chunks, 6)?.header_line).toBe(0);
+    });
+
+    test('next returns the chunk after the one containing the cursor', () => {
+        const chunks: Chunk[] = [r_chunk(0, 2), r_chunk(5, 7), r_chunk(10, 12)];
+        // Cursor inside chunk 2 (line 6) → next is chunk 3.
+        expect(next_runnable_chunk(chunks, 6)?.header_line).toBe(10);
+    });
+
+    test('previous returns the nearest chunk strictly above when cursor is in prose', () => {
+        const chunks: Chunk[] = [r_chunk(0, 2), r_chunk(5, 7), r_chunk(10, 12)];
+        // Cursor on line 9 (between chunk 2 and 3) → previous is chunk 2.
+        expect(previous_runnable_chunk(chunks, 9)?.header_line).toBe(5);
+    });
+
+    test('next returns the nearest chunk strictly below when cursor is in prose', () => {
+        const chunks: Chunk[] = [r_chunk(0, 2), r_chunk(5, 7), r_chunk(10, 12)];
+        // Cursor on line 9 → next is chunk 3.
+        expect(next_runnable_chunk(chunks, 9)?.header_line).toBe(10);
+    });
+
+    test('previous skips non-runnable chunks', () => {
+        // R (0..2), Python (5..7), R (10..12). Cursor inside the last R chunk
+        // (line 11) → previous runnable is R(0) because the only "previous"
+        // chunk between is Python and gets skipped.
+        const chunks: Chunk[] = [r_chunk(0, 2), py_chunk(5, 7), r_chunk(10, 12)];
+        expect(previous_runnable_chunk(chunks, 11)?.header_line).toBe(0);
+    });
+
+    test('next skips non-runnable chunks', () => {
+        const chunks: Chunk[] = [r_chunk(0, 2), py_chunk(5, 7), r_chunk(10, 12)];
+        // Cursor at line 3 → next runnable is the R chunk at line 10, skipping python.
+        expect(next_runnable_chunk(chunks, 3)?.header_line).toBe(10);
+    });
+
+    test('returns null when no chunk above / below', () => {
+        const chunks: Chunk[] = [r_chunk(5, 7)];
+        expect(previous_runnable_chunk(chunks, 5)).toBeNull();
+        expect(next_runnable_chunk(chunks, 7)).toBeNull();
     });
 });
 


### PR DESCRIPTION
Closes #229.

Adds vscode-R-style chunk run commands and a configurable CodeLens menu so users can pick which `▷ Run …` buttons appear on each R chunk header and in what order.

## Summary

- **Four new commands** mirroring the existing `run_chunk_at` plumbing:
  - `raven.runCurrentAndBelowChunks` — runs the current chunk plus every chunk after it
  - `raven.runBelowChunks` — runs every R chunk whose header is strictly below the cursor
  - `raven.runPreviousChunk` — runs the R chunk immediately above the cursor (skips non-R chunks)
  - `raven.runNextChunk` — runs the R chunk immediately below the cursor (skips non-R chunks)
- **New setting `raven.chunks.codeLens.commands`** (string array, default `[\"raven.runCurrentChunk\", \"raven.runAboveChunks\"]`):
  - Ordered list of command ids → CodeLens buttons rendered in that order on every R chunk header.
  - `[]` hides every lens; commands stay available from the palette/keybindings.
  - Unknown ids are silently dropped (better UX than a per-click \"command not found\").
- **CodeLens clicks dispatch positional `*At` variants** of each command (e.g. `raven.runCurrentChunkAt`, `raven.runBelowChunksAt`, …) so a lens always targets the chunk it sits on, regardless of cursor position.
- **Lenses refresh when the setting changes**: provider subscribes to `onDidChangeConfiguration` and fires `onDidChangeCodeLenses` so reordering takes effect without reopening the file.
- `eval = FALSE` suffix is preserved on the eval-aware lenses (`Run Chunk`, `Run & Move`) and intentionally omitted from multi-chunk lenses.

Detector helpers added: `chunks_below`, `previous_runnable_chunk`, `next_runnable_chunk`. Both \"previous\" / \"next\" helpers skip non-runnable (e.g. `{python}`) chunks so cursor-stepping commands behave naturally in mixed-language notebooks.

## Test plan

- [x] `cargo test -p raven` (3530+103 tests pass)
- [x] `bun run typecheck` in `editors/vscode/` (clean)
- [x] `bun test tests/bun/chunk-detector.test.ts` — added 11 new assertions covering `chunks_below`, `previous_runnable_chunk`, `next_runnable_chunk`
- [x] `editors/vscode/src/test/chunks.test.ts` — extended to verify the four new command registrations, that `raven.chunks.codeLens.commands` controls lens count + order, and that `[]` hides every lens (will run under the VS Code Mocha Suite CI job)
- [x] Docs updated in `docs/chunks.md` with the full lens menu, a custom-configuration example, and the eval suffix note

Note: locally, the `workspace-suite` wrapper bun test that re-spawns `vscode-test` fails when another VS Code instance is open (developer-env quirk — `vscode-test` requires an exclusive instance). CI runs it cleanly under Xvfb.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chunk navigation run commands (previous, next, below, current+below) and configurable CodeLens buttons with eval-aware labeling.

* **Bug Fixes**
  * Improved path canonicalization for the data viewer to handle symlinked directories consistently.

* **Documentation**
  * Expanded chunk execution docs and Commands table; documented CodeLens configuration, ordering, hiding, and eval-aware labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/234)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->