### PR TITLE
feat(linting): infix_spaces lint for whitespace around operators

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -454,6 +454,7 @@ pub(crate) fn parse_cross_file_config(
 ///   - `trailingBlankLinesSeverity`
 ///   - `assignmentOperatorSeverity`
 ///   - `objectNameSeverity`
+///   - `infixSpacesSeverity`
 pub(crate) fn parse_lint_config(
     settings: &serde_json::Value,
 ) -> Option<crate::linting::LintConfig> {
@@ -532,6 +533,9 @@ pub(crate) fn parse_lint_config(
     if let Some(sev) = linting.get("objectNameSeverity").and_then(|v| v.as_str()) {
         config.object_name_severity = parse_severity(sev);
     }
+    if let Some(sev) = linting.get("infixSpacesSeverity").and_then(|v| v.as_str()) {
+        config.infix_spaces_severity = parse_severity(sev);
+    }
 
     log::info!("Linting configuration loaded from LSP settings:");
     log::info!("  enabled: {}", config.enabled);
@@ -541,13 +545,14 @@ pub(crate) fn parse_lint_config(
         config.assignment_operator_style
     );
     log::info!(
-        "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?} obj_name={:?}",
+        "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?} obj_name={:?} infix_spaces={:?}",
         config.line_length_severity,
         config.trailing_whitespace_severity,
         config.no_tab_severity,
         config.trailing_blank_lines_severity,
         config.assignment_operator_severity,
-        config.object_name_severity
+        config.object_name_severity,
+        config.infix_spaces_severity
     );
     log::info!(
         "  object_name styles: fn={:?} var={:?} arg={:?}",
@@ -7466,7 +7471,8 @@ mod tests {
                     "noTabSeverity": "off",
                     "trailingBlankLinesSeverity": "off",
                     "assignmentOperatorSeverity": "off",
-                    "objectNameSeverity": "off"
+                    "objectNameSeverity": "off",
+                    "infixSpacesSeverity": "off"
                 }
             });
             let cfg = crate::backend::parse_lint_config(&settings).unwrap();
@@ -7476,6 +7482,7 @@ mod tests {
             assert_eq!(cfg.trailing_blank_lines_severity, None);
             assert_eq!(cfg.assignment_operator_severity, None);
             assert_eq!(cfg.object_name_severity, None);
+            assert_eq!(cfg.infix_spaces_severity, None);
         }
 
         #[test]

--- a/crates/raven/src/linting/config.rs
+++ b/crates/raven/src/linting/config.rs
@@ -80,6 +80,8 @@ pub struct LintConfig {
     /// Severity for the object-name rule. `None` disables the rule entirely;
     /// per-kind `Any` styles disable individual checks while still running.
     pub object_name_severity: Option<DiagnosticSeverity>,
+    /// Severity for the infix-spaces rule. `None` disables the rule.
+    pub infix_spaces_severity: Option<DiagnosticSeverity>,
 }
 
 impl Default for LintConfig {
@@ -100,6 +102,7 @@ impl Default for LintConfig {
             trailing_blank_lines_severity: Some(DiagnosticSeverity::HINT),
             assignment_operator_severity: Some(DiagnosticSeverity::HINT),
             object_name_severity: Some(DiagnosticSeverity::HINT),
+            infix_spaces_severity: Some(DiagnosticSeverity::HINT),
         }
     }
 }

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -620,6 +620,27 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn infix_spaces_flags_at_op_with_spaces() {
+        let config = infix_spaces_only_config();
+        // `obj @ slot` (S4 slot access) is also `extract_operator`.
+        let diags = lint("x <- obj @ slot\n", &config);
+        assert!(!diags.is_empty(), "stray space around `@` must be flagged");
+        assert!(diags.iter().all(|d| d.message.contains("`@`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_unary_not_with_space() {
+        let config = infix_spaces_only_config();
+        // Unary `!` should be tight against its operand.
+        let diags = lint("y <- ! x\n", &config);
+        let unary_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("unary") && d.message.contains("`!`"))
+            .collect();
+        assert_eq!(unary_diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
     fn infix_spaces_flags_sequence_op_with_spaces() {
         let config = infix_spaces_only_config();
         // `1 : 10` — spaces around `:` are wrong for the sequence operator.

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -333,6 +333,7 @@ mod tests {
             no_tab_severity: None,
             trailing_blank_lines_severity: None,
             assignment_operator_severity: None,
+            infix_spaces_severity: None,
             ..enabled_config()
         }
     }
@@ -672,12 +673,51 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn infix_spaces_does_not_flag_function_default_argument() {
+        let config = infix_spaces_only_config();
+        // tree-sitter-r parses formal-parameter defaults like `x=1` as a
+        // `parameter` node (operator `=` is a direct child), not as a
+        // `binary_operator`. The rule must therefore leave both spaced and
+        // unspaced defaults alone.
+        let no_space = lint("f <- function(x=1) x\n", &config);
+        let with_space = lint("f <- function(x = 1) x\n", &config);
+        assert!(
+            no_space.is_empty(),
+            "function(x=1) defaults must not be flagged: {:?}",
+            no_space
+        );
+        assert!(
+            with_space.is_empty(),
+            "function(x = 1) defaults must not be flagged: {:?}",
+            with_space
+        );
+    }
+
+    #[test]
     fn infix_spaces_does_not_flag_line_continuation() {
         let config = infix_spaces_only_config();
         // Operator at end of line, RHS on the next line — the newline supplies
         // the separation, so neither side should be flagged.
         let diags = lint("x <- a +\n  b\n", &config);
         assert!(diags.is_empty(), "line-continuation `+` must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_handles_comment_before_operand() {
+        // Regression: ensures `child_by_field_name("rhs")` (rather than
+        // positional walking) picks the real operand even when a comment
+        // node intervenes between the operator and its operand.
+        let config = infix_spaces_only_config();
+        // A comment between `<-` and `1` is uncommon but legal R. The rule
+        // should still be able to evaluate the gap consistently — and since
+        // the comment forces a newline before `1`, `gap_text` returns `None`
+        // (line-continuation case), so no diagnostic should be produced.
+        let diags = lint("x <- # comment\n  1\n", &config);
+        assert!(
+            diags.is_empty(),
+            "comment-then-newline gap must not produce diagnostics: {:?}",
+            diags
+        );
     }
 
     #[test]

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -13,6 +13,8 @@
 //! * `assignment_operator` — enforce `<-` (or `=`) for top-level assignment.
 //! * `object_name` — enforce a naming scheme (snake_case, camelCase, etc.)
 //!   on assignment targets and function arguments.
+//! * `infix_spaces` — flag missing spaces around binary infix operators and
+//!   stray spaces around tight-binding operators (`::`, `$`, `:`, unary `-/+/!`).
 //!
 //! Suppression supports both lintr and Raven conventions:
 //! * `# nolint` (with optional `: rule_a, rule_b` filter) suppresses the line.
@@ -83,6 +85,9 @@ pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Di
             &suppressions,
             &mut out,
         );
+    }
+    if let Some(sev) = config.infix_spaces_severity {
+        rules::infix_spaces::collect(text, tree_root, sev, &suppressions, &mut out);
     }
 
     out
@@ -544,6 +549,224 @@ print.data.frame <- function(x, ...) NULL
         for d in &diags {
             assert_eq!(d.source.as_deref(), Some(LINT_SOURCE));
         }
+    }
+
+    fn infix_spaces_only_config() -> LintConfig {
+        LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            object_name_severity: None,
+            ..enabled_config()
+        }
+    }
+
+    #[test]
+    fn infix_spaces_flags_missing_spaces_around_plus() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x <- 1+2\n", &config);
+        assert_eq!(diags.len(), 2, "expected 2 diagnostics (before+after), got {:?}", diags);
+        for d in &diags {
+            assert!(d.message.contains("space"), "msg: {}", d.message);
+            assert!(d.message.contains("`+`"), "msg: {}", d.message);
+        }
+    }
+
+    #[test]
+    fn infix_spaces_flags_only_missing_side() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x <- 1 +2\n", &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("after"));
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_correct_spacing() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x <- a + b * c / d ^ e\n", &config);
+        assert!(diags.is_empty(), "expected no diagnostics, got {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_alignment_whitespace() {
+        // Multiple spaces around an operator are allowed — alignment is a
+        // common pattern and collapsing it would be more annoying than helpful.
+        let config = infix_spaces_only_config();
+        let diags = lint("x   <-   1\n", &config);
+        assert!(diags.is_empty(), "alignment spaces must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_flags_namespace_op_with_spaces() {
+        let config = infix_spaces_only_config();
+        // `pkg :: fun` shouldn't have spaces around `::`. But tree-sitter-r
+        // only parses `pkg::fun` as `namespace_operator` when the operator is
+        // tight — verify it's a no-op when written that way.
+        let diags = lint("x <- pkg::fun()\n", &config);
+        assert!(diags.is_empty(), "tight `::` must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_flags_extract_op_with_spaces() {
+        let config = infix_spaces_only_config();
+        // `obj $ field` has stray whitespace around `$`. tree-sitter-r still
+        // recognises this as `extract_operator`.
+        let diags = lint("x <- obj $ field\n", &config);
+        assert!(!diags.is_empty(), "stray space around `$` must be flagged");
+        assert!(diags.iter().all(|d| d.message.contains("`$`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_sequence_op_with_spaces() {
+        let config = infix_spaces_only_config();
+        // `1 : 10` — spaces around `:` are wrong for the sequence operator.
+        let diags = lint("xs <- 1 : 10\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+        assert!(diags.iter().all(|d| d.message.contains("`:`")));
+    }
+
+    #[test]
+    fn infix_spaces_tight_sequence_is_ok() {
+        let config = infix_spaces_only_config();
+        let diags = lint("xs <- 1:10\n", &config);
+        assert!(diags.is_empty(), "tight `:` must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_flags_unary_minus_with_space() {
+        let config = infix_spaces_only_config();
+        // `- x` has a space after the unary minus — should be flagged.
+        let diags = lint("y <- - x\n", &config);
+        let unary_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("unary"))
+            .collect();
+        assert_eq!(unary_diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_tight_unary_minus_is_ok() {
+        let config = infix_spaces_only_config();
+        let diags = lint("y <- -x\n", &config);
+        assert!(diags.is_empty(), "tight unary `-` must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_binary_minus() {
+        let config = infix_spaces_only_config();
+        // `a - b` with binary minus and spaces — fine.
+        let diags = lint("y <- a - b\n", &config);
+        assert!(diags.is_empty(), "binary `-` with spaces must pass: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_named_argument() {
+        let config = infix_spaces_only_config();
+        // tree-sitter-r parses `name=value` inside a call as an `argument`
+        // node, never a `binary_operator`. The infix-spaces rule must never
+        // touch named arguments — they are an unrelated syntactic form.
+        let diags = lint("f(name=value)\n", &config);
+        assert!(diags.is_empty(), "named arguments must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_line_continuation() {
+        let config = infix_spaces_only_config();
+        // Operator at end of line, RHS on the next line — the newline supplies
+        // the separation, so neither side should be flagged.
+        let diags = lint("x <- a +\n  b\n", &config);
+        assert!(diags.is_empty(), "line-continuation `+` must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_flags_custom_percent_op_with_missing_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x <- a%>%b\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+        assert!(diags.iter().all(|d| d.message.contains("`%>%`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_assignment_without_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x<-1\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+        assert!(diags.iter().all(|d| d.message.contains("`<-`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_comparison_without_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("if (a<=b) NULL\n", &config);
+        assert_eq!(diags.len(), 2);
+        assert!(diags.iter().all(|d| d.message.contains("`<=`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_logical_without_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("if (a&&b) NULL\n", &config);
+        assert_eq!(diags.len(), 2);
+        assert!(diags.iter().all(|d| d.message.contains("`&&`")));
+    }
+
+    #[test]
+    fn infix_spaces_flags_formula_without_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("m <- lm(y~x)\n", &config);
+        let tilde_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("`~`"))
+            .collect();
+        assert_eq!(tilde_diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_unary_formula() {
+        let config = infix_spaces_only_config();
+        // `~ x` and `~x` are both acceptable formula-head forms. The rule
+        // should not touch unary `~` either way.
+        let no_space = lint("f(~x)\n", &config);
+        let with_space = lint("f(~ x)\n", &config);
+        assert!(no_space.is_empty(), "unary `~x` must pass: {:?}", no_space);
+        assert!(
+            with_space.is_empty(),
+            "unary `~ x` must pass: {:?}",
+            with_space
+        );
+    }
+
+    #[test]
+    fn infix_spaces_does_not_flag_pipe_with_spaces() {
+        let config = infix_spaces_only_config();
+        let diags = lint("xs |> length()\n", &config);
+        assert!(diags.is_empty(), "pipe with spaces must pass: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_respects_nolint() {
+        let config = infix_spaces_only_config();
+        let diags = lint("x <- 1+2 # nolint\n", &config);
+        assert!(diags.is_empty(), "nolint must suppress: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_respects_lsp_ignore_next() {
+        let config = infix_spaces_only_config();
+        let diags = lint("# @lsp-ignore-next\nx <- 1+2\ny <- 3+4\n", &config);
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(!lines.contains(&1), "@lsp-ignore-next must suppress line 1: {:?}", diags);
+        assert!(lines.contains(&2), "unsuppressed line 2 must still flag: {:?}", diags);
+    }
+
+    #[test]
+    fn infix_spaces_severity_off_disables_rule() {
+        let mut config = infix_spaces_only_config();
+        config.infix_spaces_severity = None;
+        let diags = lint("x<-1\n", &config);
+        assert!(diags.is_empty(), "rule must be silent when severity is None: {:?}", diags);
     }
 }
 

--- a/crates/raven/src/linting/rules/infix_spaces.rs
+++ b/crates/raven/src/linting/rules/infix_spaces.rs
@@ -102,7 +102,7 @@ fn check_binary(
         None => return,
     };
     let style = classify_binary(op_text);
-    let Some((lhs, rhs)) = lhs_and_rhs(node, op) else {
+    let Some((lhs, rhs)) = lhs_and_rhs(node) else {
         return;
     };
 
@@ -144,7 +144,7 @@ fn check_tight_binary(
         Some(s) => s,
         None => return,
     };
-    let Some((lhs, rhs)) = lhs_and_rhs(node, op) else {
+    let Some((lhs, rhs)) = lhs_and_rhs(node) else {
         return;
     };
 
@@ -196,7 +196,7 @@ fn check_unary(
     if !matches!(op_text, "-" | "+" | "!" | "?") {
         return;
     }
-    let Some(operand) = unary_operand(node, op) else {
+    let Some(operand) = node.child_by_field_name("rhs") else {
         return;
     };
     let gap = gap_text(text, op.end_byte(), operand.start_byte());
@@ -227,31 +227,13 @@ fn gap_text(text: &str, start: usize, end: usize) -> Option<&str> {
 }
 
 /// Resolve the left- and right-hand-side nodes of a `binary_operator`,
-/// `namespace_operator`, or `extract_operator` by finding the non-extra
-/// children flanking the operator token.
-fn lhs_and_rhs<'tree>(
-    node: Node<'tree>,
-    op: Node<'tree>,
-) -> Option<(Node<'tree>, Node<'tree>)> {
-    let mut cursor = node.walk();
-    let children: Vec<_> = node
-        .children(&mut cursor)
-        .filter(|c| c.is_named() || c.id() == op.id())
-        .collect();
-    let idx = children.iter().position(|c| c.id() == op.id())?;
-    let lhs = children.get(idx.checked_sub(1)?)?;
-    let rhs = children.get(idx + 1)?;
-    Some((*lhs, *rhs))
-}
-
-/// Resolve the operand node of a `unary_operator` (the named sibling that
-/// follows the operator token).
-fn unary_operand<'tree>(node: Node<'tree>, op: Node<'tree>) -> Option<Node<'tree>> {
-    let mut cursor = node.walk();
-    let found = node
-        .children(&mut cursor)
-        .find(|child| child.is_named() && child.id() != op.id() && child.start_byte() >= op.end_byte());
-    found
+/// `namespace_operator`, or `extract_operator`. Tree-sitter-r exposes both as
+/// the `lhs` and `rhs` fields, matching the pattern used elsewhere in the
+/// codebase (`object_name.rs`, `extract_op.rs`, `qualified_resolve.rs`).
+fn lhs_and_rhs<'tree>(node: Node<'tree>) -> Option<(Node<'tree>, Node<'tree>)> {
+    let lhs = node.child_by_field_name("lhs")?;
+    let rhs = node.child_by_field_name("rhs")?;
+    Some((lhs, rhs))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/raven/src/linting/rules/infix_spaces.rs
+++ b/crates/raven/src/linting/rules/infix_spaces.rs
@@ -1,0 +1,285 @@
+//! Enforce conventional spacing around infix operators.
+//!
+//! Walks the tree-sitter AST and flags whitespace that disagrees with R's
+//! community style (matching `lintr::infix_spaces_linter` semantics):
+//!
+//! * Most binary operators (`+`, `-`, `*`, `/`, `^`, comparison, logical,
+//!   assignment, pipe, formula `~`, `%any%` user-defined operators) require at
+//!   least one space on each side.
+//! * Tight-binding operators (`:` sequence, `::`/`:::` namespace, `$`/`@`
+//!   member access) take no spaces on either side.
+//! * Unary `-`, `+`, `!`, and unary `?` take no space between the operator and
+//!   its operand.
+//!
+//! The rule is conservative: it only flags clearly wrong cases. It does *not*
+//! flag "extra" spaces around operators that require spaces — alignment whitespace
+//! is common (`x   <- 1`) and collapsing it would be more annoying than helpful.
+//! Line continuations — operator at end of line, operand on the next line — are
+//! left alone since the line break itself supplies the separation.
+//!
+//! Disambiguation between unary and binary forms is handled by tree-sitter:
+//! `-x` parses as a `unary_operator`, `a - b` as a `binary_operator`. Named
+//! arguments (`f(name = value)`) are parsed as `argument` nodes, never
+//! `binary_operator`, so they're naturally exempt.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    match node.kind() {
+        "binary_operator" => check_binary(node, text, severity, suppressions, out),
+        "namespace_operator" | "extract_operator" => {
+            check_tight_binary(node, text, severity, suppressions, out)
+        }
+        "unary_operator" => check_unary(node, text, severity, suppressions, out),
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+/// Required-spaces vs. no-spaces classification for `binary_operator` tokens.
+enum BinaryStyle {
+    /// At least one whitespace character on each side.
+    RequireSpaces,
+    /// No whitespace on either side.
+    NoSpaces,
+    /// Skip — handled by another rule or context-dependent.
+    Skip,
+}
+
+fn classify_binary(op_text: &str) -> BinaryStyle {
+    // The `%...%` family of user-defined infix operators always requires
+    // spaces. tree-sitter-r reports the operator text as the literal `%...%`
+    // form, so a simple prefix/suffix test is sufficient.
+    if op_text.starts_with('%') && op_text.ends_with('%') && op_text.len() >= 2 {
+        return BinaryStyle::RequireSpaces;
+    }
+
+    match op_text {
+        "+" | "-" | "*" | "/" | "^" | "<" | ">" | "<=" | ">=" | "==" | "!=" | "&" | "|" | "&&"
+        | "||" | "<-" | "<<-" | "->" | "->>" | "=" | "|>" | "~" => BinaryStyle::RequireSpaces,
+        ":" => BinaryStyle::NoSpaces,
+        _ => BinaryStyle::Skip,
+    }
+}
+
+fn check_binary(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(op) = node.child_by_field_name("operator") else {
+        return;
+    };
+    let op_text = match text.get(op.start_byte()..op.end_byte()) {
+        Some(s) => s,
+        None => return,
+    };
+    let style = classify_binary(op_text);
+    let Some((lhs, rhs)) = lhs_and_rhs(node, op) else {
+        return;
+    };
+
+    let left_gap = gap_text(text, lhs.end_byte(), op.start_byte());
+    let right_gap = gap_text(text, op.end_byte(), rhs.start_byte());
+
+    match style {
+        BinaryStyle::RequireSpaces => {
+            if left_gap.is_some_and(|g| g.is_empty()) {
+                report(text, op, "missing space before `", op_text, "`", severity, suppressions, out);
+            }
+            if right_gap.is_some_and(|g| g.is_empty()) {
+                report(text, op, "missing space after `", op_text, "`", severity, suppressions, out);
+            }
+        }
+        BinaryStyle::NoSpaces => {
+            if left_gap.is_some_and(|g| !g.is_empty()) {
+                report(text, op, "unexpected whitespace before `", op_text, "`", severity, suppressions, out);
+            }
+            if right_gap.is_some_and(|g| !g.is_empty()) {
+                report(text, op, "unexpected whitespace after `", op_text, "`", severity, suppressions, out);
+            }
+        }
+        BinaryStyle::Skip => {}
+    }
+}
+
+fn check_tight_binary(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(op) = node.child_by_field_name("operator") else {
+        return;
+    };
+    let op_text = match text.get(op.start_byte()..op.end_byte()) {
+        Some(s) => s,
+        None => return,
+    };
+    let Some((lhs, rhs)) = lhs_and_rhs(node, op) else {
+        return;
+    };
+
+    let left_gap = gap_text(text, lhs.end_byte(), op.start_byte());
+    let right_gap = gap_text(text, op.end_byte(), rhs.start_byte());
+
+    if left_gap.is_some_and(|g| !g.is_empty()) {
+        report(
+            text,
+            op,
+            "unexpected whitespace before `",
+            op_text,
+            "`",
+            severity,
+            suppressions,
+            out,
+        );
+    }
+    if right_gap.is_some_and(|g| !g.is_empty()) {
+        report(
+            text,
+            op,
+            "unexpected whitespace after `",
+            op_text,
+            "`",
+            severity,
+            suppressions,
+            out,
+        );
+    }
+}
+
+fn check_unary(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(op) = node.child_by_field_name("operator") else {
+        return;
+    };
+    let op_text = match text.get(op.start_byte()..op.end_byte()) {
+        Some(s) => s,
+        None => return,
+    };
+    // Only the no-space unary operators are flagged. Unary `~` (formula head,
+    // e.g. `~ x`) is left alone — both `~x` and `~ x` are idiomatic.
+    if !matches!(op_text, "-" | "+" | "!" | "?") {
+        return;
+    }
+    let Some(operand) = unary_operand(node, op) else {
+        return;
+    };
+    let gap = gap_text(text, op.end_byte(), operand.start_byte());
+    if gap.is_some_and(|g| !g.is_empty()) {
+        report(
+            text,
+            op,
+            "unexpected whitespace after unary `",
+            op_text,
+            "`",
+            severity,
+            suppressions,
+            out,
+        );
+    }
+}
+
+/// Return the text between byte offsets `start` and `end` only if it stays on
+/// a single line — i.e. contains no `\n`. Returning `None` for cross-line gaps
+/// lets callers skip the check (line-continuation case).
+fn gap_text(text: &str, start: usize, end: usize) -> Option<&str> {
+    let slice = text.get(start..end)?;
+    if slice.as_bytes().contains(&b'\n') {
+        None
+    } else {
+        Some(slice)
+    }
+}
+
+/// Resolve the left- and right-hand-side nodes of a `binary_operator`,
+/// `namespace_operator`, or `extract_operator` by finding the non-extra
+/// children flanking the operator token.
+fn lhs_and_rhs<'tree>(
+    node: Node<'tree>,
+    op: Node<'tree>,
+) -> Option<(Node<'tree>, Node<'tree>)> {
+    let mut cursor = node.walk();
+    let children: Vec<_> = node
+        .children(&mut cursor)
+        .filter(|c| c.is_named() || c.id() == op.id())
+        .collect();
+    let idx = children.iter().position(|c| c.id() == op.id())?;
+    let lhs = children.get(idx.checked_sub(1)?)?;
+    let rhs = children.get(idx + 1)?;
+    Some((*lhs, *rhs))
+}
+
+/// Resolve the operand node of a `unary_operator` (the named sibling that
+/// follows the operator token).
+fn unary_operand<'tree>(node: Node<'tree>, op: Node<'tree>) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    let found = node
+        .children(&mut cursor)
+        .find(|child| child.is_named() && child.id() != op.id() && child.start_byte() >= op.end_byte());
+    found
+}
+
+#[allow(clippy::too_many_arguments)]
+fn report(
+    text: &str,
+    op: Node<'_>,
+    prefix: &str,
+    op_text: &str,
+    suffix: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = op.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, op.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, op.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(op.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("{prefix}{op_text}{suffix}."),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -5,6 +5,7 @@
 //! [`crate::linting::nolint::Suppressions`] before producing output.
 
 pub(crate) mod assignment_operator;
+pub(crate) mod infix_spaces;
 pub(crate) mod line_length;
 pub(crate) mod no_tab;
 pub(crate) mod object_name;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,7 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.objectNameStyleVariable` | `"snake_case"` | Naming scheme for variables (same enum as above) |
 | `raven.linting.objectNameStyleArgument` | `"snake_case"` | Naming scheme for function formal arguments (same enum as above) |
 | `raven.linting.objectNameSeverity` | `"hint"` | Severity for the object-name lint (set to `"off"` to disable entirely; set a specific style to `"any"` to disable just that kind) |
+| `raven.linting.infixSpacesSeverity` | `"hint"` | Severity for the infix-spaces lint (whitespace around operators) |
 
 To disable an individual rule while leaving the rest enabled, set its severity to `"off"`. For the object-name lint, you can also set any of the three style settings to `"any"` to disable just that symbol kind while keeping the others active.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -60,8 +60,11 @@ Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-li
 | Trailing blank lines | hint | Blank lines at end of file, or missing final newline |
 | Assignment operator | hint | Top-level assignment uses an operator other than the preferred one (`<-` by default; configurable via `raven.linting.assignmentOperator`) |
 | Object name | hint | Function, variable, or argument name doesn't match the configured naming scheme (`snake_case` by default; configurable per kind via `raven.linting.objectNameStyle*`) |
+| Infix spaces | hint | Missing space around a binary operator (`a+b`, `x<-1`, `a%>%b`, `if (a<=b)`), or stray space around a tight-binding operator (`obj $ field`, `1 : 10`, unary `- x`) |
 
 Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
+
+The infix-spaces lint flags two opposing cases. **Spaces required** on both sides: arithmetic (`+`, `-`, `*`, `/`, `^`), comparison (`<`, `<=`, `==`, `!=`, ...), logical (`&`, `&&`, `|`, `||`), assignment (`<-`, `<<-`, `->`, `->>`, `=`), pipe (`|>`, `%>%`, any `%...%`), and binary formula (`y ~ x`). **No spaces** on either side: sequence (`:`), namespace (`::`, `:::`), member access (`$`, `@`), and unary `-`, `+`, `!`, `?`. The rule is conservative — alignment whitespace (`x   <- 1`) is not flagged, and line-continuation cases (operator at end of line, RHS on the next line) are skipped since the line break supplies the separation.
 
 The object-name lint has independent style settings for **functions** (`objectNameStyleFunction`), **variables** (`objectNameStyleVariable`), and **arguments** (`objectNameStyleArgument`). Each accepts `snake_case`, `camelCase`, `dotted.case`, `UPPER_CASE`, `lowercase`, or `any`. Using `any` accepts all names for that kind — since the three are checked independently, you can enforce a style on two while opting out of the third.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1358,6 +1358,25 @@
           ],
           "default": "hint",
           "description": "Severity for the object-name lint. Set to \"off\" to disable the rule entirely, or set individual styles to \"any\" to disable specific symbol kinds."
+        },
+        "raven.linting.infixSpacesSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report infix-spacing violations as errors",
+            "Report infix-spacing violations as warnings",
+            "Report infix-spacing violations as information",
+            "Report infix-spacing violations as hints",
+            "Disable the infix-spaces lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the infix-spaces lint. Flags missing spaces around binary operators (`+`, `==`, `<-`, `|>`, `%>%`, etc.) and stray whitespace around tight-binding operators (`::`, `$`, `:`, unary `-/+/!`). Alignment whitespace (multiple spaces) and line-continuations are not flagged."
         }
       }
     }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -107,6 +107,7 @@ export interface RavenInitializationOptions {
         trailingBlankLinesSeverity?: SeverityLevel;
         assignmentOperatorSeverity?: SeverityLevel;
         objectNameSeverity?: SeverityLevel;
+        infixSpacesSeverity?: SeverityLevel;
     };
     helpViewer?: { viewColumn?: 'active' | 'beside' };
 }
@@ -362,6 +363,7 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         trailingBlankLinesSeverity: config.get<SeverityLevel>('linting.trailingBlankLinesSeverity', 'hint'),
         assignmentOperatorSeverity: config.get<SeverityLevel>('linting.assignmentOperatorSeverity', 'hint'),
         objectNameSeverity: config.get<SeverityLevel>('linting.objectNameSeverity', 'hint'),
+        infixSpacesSeverity: config.get<SeverityLevel>('linting.infixSpacesSeverity', 'hint'),
     };
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -135,6 +135,7 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.objectNameStyleVariable', jsonPath: ['linting', 'objectNameStyleVariable'], type: 'enum', enumValues: ['snake_case', 'camelCase', 'dotted.case', 'UPPER_CASE', 'lowercase', 'any'] as const, defaultWhenUnconfigured: 'snake_case' },
     { vsCodeKey: 'linting.objectNameStyleArgument', jsonPath: ['linting', 'objectNameStyleArgument'], type: 'enum', enumValues: ['snake_case', 'camelCase', 'dotted.case', 'UPPER_CASE', 'lowercase', 'any'] as const, defaultWhenUnconfigured: 'snake_case' },
     { vsCodeKey: 'linting.objectNameSeverity', jsonPath: ['linting', 'objectNameSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.infixSpacesSeverity', jsonPath: ['linting', 'infixSpacesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];
@@ -366,6 +367,7 @@ suite('Settings Transmission Property Tests', () => {
                 trailingBlankLinesSeverity: 'hint',
                 assignmentOperatorSeverity: 'hint',
                 objectNameSeverity: 'hint',
+                infixSpacesSeverity: 'hint',
             },
         }, 'Empty configuration should produce only runtime defaults');
 
@@ -516,6 +518,7 @@ suite('Settings Transmission Unit Tests', () => {
             trailingBlankLinesSeverity: 'hint',
             assignmentOperatorSeverity: 'hint',
             objectNameSeverity: 'hint',
+            infixSpacesSeverity: 'hint',
         });
     });
 
@@ -529,6 +532,7 @@ suite('Settings Transmission Unit Tests', () => {
             ['linting.objectNameStyleFunction', 'camelCase'],
             ['linting.objectNameStyleVariable', 'any'],
             ['linting.objectNameSeverity', 'warning'],
+            ['linting.infixSpacesSeverity', 'off'],
         ]);
         const mockConfig = createMockConfig(configuredSettings);
         const options = getInitializationOptions(mockConfig);
@@ -540,6 +544,7 @@ suite('Settings Transmission Unit Tests', () => {
         assert.strictEqual(options.linting?.objectNameStyleFunction, 'camelCase');
         assert.strictEqual(options.linting?.objectNameStyleVariable, 'any');
         assert.strictEqual(options.linting?.objectNameSeverity, 'warning');
+        assert.strictEqual(options.linting?.infixSpacesSeverity, 'off');
         // Untouched keys still emit their defaults.
         assert.strictEqual(options.linting?.trailingWhitespaceSeverity, 'hint');
         assert.strictEqual(options.linting?.objectNameStyleArgument, 'snake_case');


### PR DESCRIPTION
Closes #221.

## Summary

- New AST-driven lint matching `lintr::infix_spaces_linter` semantics, implemented in `crates/raven/src/linting/rules/infix_spaces.rs`.
- Flags **missing spaces** around binary operators (`+`, `==`, `<-`, `|>`, `%>%`, `%any%`, formula `~`, etc.) and **stray whitespace** around tight-binding operators (`::`, `$`, `@`, `:`, unary `-`/`+`/`!`/`?`).
- Conservative by design: alignment whitespace (`x   <- 1`) and line-continuations (operator at end of line) are not flagged. Unary `~` (formula head) is left alone in either form. Named arguments are parsed as `argument` nodes by tree-sitter-r, never `binary_operator`, so the rule cannot misfire on them.
- Reuses the existing severity / suppression / nolint infrastructure: `# nolint`, `# nolint start/end`, `# @lsp-ignore`, `# @lsp-ignore-next` all suppress the new diagnostics.
- New setting `raven.linting.infixSpacesSeverity` (default `hint`, set to `off` to disable).

## Test plan

- [x] `cargo test -p raven --lib linting::tests::infix_spaces` — 23 new tests covering each operator category, unary disambiguation, line continuation, named arguments, alignment, formula, custom `%...%` ops, comparison/logical/assignment without spaces, and suppression markers.
- [x] `cargo test -p raven` — full crate test suite (3553 tests; one pre-existing flaky `completion_context::property_tests::prop_nested_call_random_position_inside_inner` proptest is unrelated to this change and fails the same way on `main`).
- [x] `cargo clippy -p raven --lib --tests` — clean for new code.
- [x] `bun run typecheck` — VS Code extension types clean.
- [x] `bun test` — 467 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "infix-spaces" lint rule to detect missing or stray spaces around infix operators, with configurable severity level.

* **Documentation**
  * Updated configuration documentation with the new `linting.infixSpacesSeverity` setting.
  * Added "infix-spaces" lint rule documentation describing behavior and exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/237)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->