### PR TITLE
feat(linting): add commented_code lint

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -455,6 +455,7 @@ pub(crate) fn parse_cross_file_config(
 ///   - `assignmentOperatorSeverity`
 ///   - `objectNameSeverity`
 ///   - `infixSpacesSeverity`
+///   - `commentedCodeSeverity`
 pub(crate) fn parse_lint_config(
     settings: &serde_json::Value,
 ) -> Option<crate::linting::LintConfig> {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -536,6 +536,12 @@ pub(crate) fn parse_lint_config(
     if let Some(sev) = linting.get("infixSpacesSeverity").and_then(|v| v.as_str()) {
         config.infix_spaces_severity = parse_severity(sev);
     }
+    if let Some(sev) = linting
+        .get("commentedCodeSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.commented_code_severity = parse_severity(sev);
+    }
 
     log::info!("Linting configuration loaded from LSP settings:");
     log::info!("  enabled: {}", config.enabled);
@@ -545,14 +551,15 @@ pub(crate) fn parse_lint_config(
         config.assignment_operator_style
     );
     log::info!(
-        "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?} obj_name={:?} infix_spaces={:?}",
+        "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?} obj_name={:?} infix_spaces={:?} commented_code={:?}",
         config.line_length_severity,
         config.trailing_whitespace_severity,
         config.no_tab_severity,
         config.trailing_blank_lines_severity,
         config.assignment_operator_severity,
         config.object_name_severity,
-        config.infix_spaces_severity
+        config.infix_spaces_severity,
+        config.commented_code_severity
     );
     log::info!(
         "  object_name styles: fn={:?} var={:?} arg={:?}",
@@ -7472,7 +7479,8 @@ mod tests {
                     "trailingBlankLinesSeverity": "off",
                     "assignmentOperatorSeverity": "off",
                     "objectNameSeverity": "off",
-                    "infixSpacesSeverity": "off"
+                    "infixSpacesSeverity": "off",
+                    "commentedCodeSeverity": "off"
                 }
             });
             let cfg = crate::backend::parse_lint_config(&settings).unwrap();
@@ -7483,6 +7491,7 @@ mod tests {
             assert_eq!(cfg.assignment_operator_severity, None);
             assert_eq!(cfg.object_name_severity, None);
             assert_eq!(cfg.infix_spaces_severity, None);
+            assert_eq!(cfg.commented_code_severity, None);
         }
 
         #[test]

--- a/crates/raven/src/linting/config.rs
+++ b/crates/raven/src/linting/config.rs
@@ -82,6 +82,8 @@ pub struct LintConfig {
     pub object_name_severity: Option<DiagnosticSeverity>,
     /// Severity for the infix-spaces rule. `None` disables the rule.
     pub infix_spaces_severity: Option<DiagnosticSeverity>,
+    /// Severity for the commented-code rule. `None` disables the rule.
+    pub commented_code_severity: Option<DiagnosticSeverity>,
 }
 
 impl Default for LintConfig {
@@ -103,6 +105,7 @@ impl Default for LintConfig {
             assignment_operator_severity: Some(DiagnosticSeverity::HINT),
             object_name_severity: Some(DiagnosticSeverity::HINT),
             infix_spaces_severity: Some(DiagnosticSeverity::HINT),
+            commented_code_severity: Some(DiagnosticSeverity::HINT),
         }
     }
 }

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -89,6 +89,9 @@ pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Di
     if let Some(sev) = config.infix_spaces_severity {
         rules::infix_spaces::collect(text, tree_root, sev, &suppressions, &mut out);
     }
+    if let Some(sev) = config.commented_code_severity {
+        rules::commented_code::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
 
     out
 }
@@ -828,6 +831,172 @@ print.data.frame <- function(x, ...) NULL
         config.infix_spaces_severity = None;
         let diags = lint("x<-1\n", &config);
         assert!(diags.is_empty(), "rule must be silent when severity is None: {:?}", diags);
+    }
+
+    fn commented_code_only_config() -> LintConfig {
+        LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            object_name_severity: None,
+            infix_spaces_severity: None,
+            ..enabled_config()
+        }
+    }
+
+    #[test]
+    fn commented_code_flags_obvious_call() {
+        let config = commented_code_only_config();
+        let diags = lint("# foo(bar, baz)\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("Commented code"));
+        assert_eq!(diags[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn commented_code_flags_assignment() {
+        let config = commented_code_only_config();
+        let diags = lint("# x <- 1 + 2\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn commented_code_skips_prose_without_operators() {
+        let config = commented_code_only_config();
+        // Bare identifier — could be a noun in prose. Don't flag.
+        let diags = lint("# foo\n# another comment\n", &config);
+        assert!(diags.is_empty(), "prose must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn commented_code_skips_roxygen() {
+        let config = commented_code_only_config();
+        // Roxygen blocks routinely contain code-shaped examples like
+        // `@param x default 1` — those must not be flagged.
+        let diags = lint("#' @param x default value\n#' foo(bar = 1)\n", &config);
+        assert!(diags.is_empty(), "roxygen must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn commented_code_skips_shebang_on_first_line() {
+        let config = commented_code_only_config();
+        let diags = lint("#!/usr/bin/env Rscript\n", &config);
+        assert!(diags.is_empty(), "shebang must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn commented_code_skips_todo_and_fixme_lines() {
+        let config = commented_code_only_config();
+        let diags = lint(
+            "# TODO: rewrite foo(x, y)\n# FIXME(jmb): fix logger(level)\n# NOTE: see help() below\n",
+            &config,
+        );
+        assert!(
+            diags.is_empty(),
+            "annotation comments must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_skips_directive_markers() {
+        let config = commented_code_only_config();
+        // `# nolint`, `# @lsp-source`, etc. must never be flagged — these are
+        // suppression / cross-file directives, not commented-out code.
+        let diags = lint(
+            "# nolint\n# nolint: line_length\n# @lsp-source ../helpers.R\n# @lsp-ignore\n",
+            &config,
+        );
+        assert!(
+            diags.is_empty(),
+            "directive markers must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_skips_end_of_line_comments() {
+        let config = commented_code_only_config();
+        // The `# x <- 2` is an end-of-line annotation, not standalone dead
+        // code. Don't flag.
+        let diags = lint("x <- 1 # x <- 2\n", &config);
+        assert!(
+            diags.is_empty(),
+            "end-of-line comment must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_groups_contiguous_block() {
+        let config = commented_code_only_config();
+        // Two commented-out code lines that are syntactically valid R when
+        // joined. Should produce *one* diagnostic for the whole block.
+        let diags = lint("# x <- 1\n# y <- x + 2\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        let d = &diags[0];
+        assert_eq!(d.range.start.line, 0);
+        assert_eq!(d.range.end.line, 1);
+    }
+
+    #[test]
+    fn commented_code_respects_nolint_block() {
+        let config = commented_code_only_config();
+        // For commented-out code, an inline `# nolint` suffix can't suppress
+        // the diagnostic — the `#` of the marker is itself inside the comment
+        // and so the Suppressions parser never sees a fresh `# nolint`. The
+        // supported patterns are bracketed blocks and `# @lsp-ignore-next`.
+        let diags = lint("# nolint start\n# x <- 1 + 2\n# nolint end\n", &config);
+        assert!(diags.is_empty(), "nolint block must suppress: {:?}", diags);
+    }
+
+    #[test]
+    fn commented_code_respects_lsp_ignore_next() {
+        let config = commented_code_only_config();
+        let diags = lint("# @lsp-ignore-next\n# x <- 1 + 2\n# y <- 3 + 4\n", &config);
+        // `@lsp-ignore-next` suppresses line 1. Line 2 is also a commented
+        // code line, but it's part of a separate single-line block (the
+        // directive on line 0 itself is a non-code comment, breaking the
+        // group), and it stays in the block.
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(
+            !lines.contains(&1),
+            "@lsp-ignore-next must suppress line 1: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_skips_mode_line() {
+        let config = commented_code_only_config();
+        let diags = lint("# -*- coding: utf-8 -*-\n", &config);
+        assert!(
+            diags.is_empty(),
+            "Emacs mode line must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_severity_off_disables_rule() {
+        let mut config = commented_code_only_config();
+        config.commented_code_severity = None;
+        let diags = lint("# x <- 1\n", &config);
+        assert!(
+            diags.is_empty(),
+            "rule must be silent when severity is None: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_diagnostic_carries_lint_source() {
+        let config = commented_code_only_config();
+        let diags = lint("# foo(bar)\n", &config);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].source.as_deref(), Some(LINT_SOURCE));
     }
 }
 

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -1042,6 +1042,19 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn commented_code_flags_multi_line_block_when_individual_lines_dont_parse() {
+        let config = commented_code_only_config();
+        // Each individual line is not a complete R expression — only the
+        // joined block parses. The grouping pass should still flag the
+        // block. This is the headline value-add of the contiguous-grouping
+        // logic vs. line-at-a-time evaluation.
+        let diags = lint("# function(x) {\n#   x + 1\n# }\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.line, 0);
+        assert_eq!(diags[0].range.end.line, 2);
+    }
+
+    #[test]
     fn commented_code_still_groups_when_no_skip_lines() {
         let config = commented_code_only_config();
         // Without any skip lines in between, a contiguous block should still

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -956,16 +956,94 @@ print.data.frame <- function(x, ...) NULL
     fn commented_code_respects_lsp_ignore_next() {
         let config = commented_code_only_config();
         let diags = lint("# @lsp-ignore-next\n# x <- 1 + 2\n# y <- 3 + 4\n", &config);
-        // `@lsp-ignore-next` suppresses line 1. Line 2 is also a commented
-        // code line, but it's part of a separate single-line block (the
-        // directive on line 0 itself is a non-code comment, breaking the
-        // group), and it stays in the block.
+        // `@lsp-ignore-next` suppresses line 1. Line 2 is also commented
+        // code, and it must STILL be flagged — the contiguous block is split
+        // at the directive line and at the suppressed line, leaving line 2
+        // as its own sub-group that the rule evaluates independently.
         let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
         assert!(
             !lines.contains(&1),
             "@lsp-ignore-next must suppress line 1: {:?}",
             diags
         );
+        assert!(
+            lines.contains(&2),
+            "unsuppressed line 2 must still be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_splits_block_at_directive_line() {
+        let config = commented_code_only_config();
+        // A `# @lsp-source` directive sandwiched between two real commented
+        // code lines must NOT swallow them. The block should split into two
+        // single-line sub-groups; each parses as code and is reported.
+        let diags = lint(
+            "# x <- 1\n# @lsp-source ../helpers.R\n# y <- 2\n",
+            &config,
+        );
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(
+            lines.contains(&0),
+            "line 0 commented code must still flag: {:?}",
+            diags
+        );
+        assert!(
+            lines.contains(&2),
+            "line 2 commented code must still flag: {:?}",
+            diags
+        );
+        assert!(
+            !lines.contains(&1),
+            "directive line itself must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_splits_block_at_shebang_line() {
+        let config = commented_code_only_config();
+        // Shebang on line 0 plus commented code on line 1 must not silently
+        // skip the commented code as part of the same block.
+        let diags = lint("#!/usr/bin/env Rscript\n# x <- 1\n", &config);
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(
+            lines.contains(&1),
+            "commented code adjacent to shebang must flag: {:?}",
+            diags
+        );
+        assert!(
+            !lines.contains(&0),
+            "shebang itself must not be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn commented_code_splits_block_at_todo_line() {
+        let config = commented_code_only_config();
+        // Same idea with an annotation comment in the middle.
+        let diags = lint(
+            "# x <- 1\n# TODO: revisit\n# y <- 2\n",
+            &config,
+        );
+        let lines: Vec<u32> = diags.iter().map(|d| d.range.start.line).collect();
+        assert!(lines.contains(&0));
+        assert!(lines.contains(&2));
+        assert!(!lines.contains(&1));
+    }
+
+    #[test]
+    fn commented_code_still_groups_when_no_skip_lines() {
+        let config = commented_code_only_config();
+        // Without any skip lines in between, a contiguous block should still
+        // join as one diagnostic — Codex's regression case must not break
+        // the original grouping behaviour.
+        let diags = lint("# x <- 1\n# y <- x + 2\n# z <- y * 3\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.line, 0);
+        assert_eq!(diags[0].range.end.line, 2);
     }
 
     #[test]

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -15,6 +15,11 @@
 //!   on assignment targets and function arguments.
 //! * `infix_spaces` — flag missing spaces around binary infix operators and
 //!   stray spaces around tight-binding operators (`::`, `$`, `:`, unary `-/+/!`).
+//! * `commented_code` — flag standalone comment blocks whose body parses as R
+//!   and contains a call, assignment, operator, or function definition. This
+//!   rule additionally re-parses each candidate comment body via the
+//!   thread-local parser pool; every other rule walks only the
+//!   already-parsed tree.
 //!
 //! Suppression supports both lintr and Raven conventions:
 //! * `# nolint` (with optional `: rule_a, rule_b` filter) suppresses the line.
@@ -337,6 +342,7 @@ mod tests {
             trailing_blank_lines_severity: None,
             assignment_operator_severity: None,
             infix_spaces_severity: None,
+            commented_code_severity: None,
             ..enabled_config()
         }
     }
@@ -563,6 +569,7 @@ print.data.frame <- function(x, ...) NULL
             trailing_blank_lines_severity: None,
             assignment_operator_severity: None,
             object_name_severity: None,
+            commented_code_severity: None,
             ..enabled_config()
         }
     }

--- a/crates/raven/src/linting/rules/commented_code.rs
+++ b/crates/raven/src/linting/rules/commented_code.rs
@@ -51,65 +51,85 @@ pub(crate) fn collect(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
+    let lines: Vec<&str> = text.lines().collect();
+
     // Collect every standalone comment node — comments where the only thing
     // preceding the `#` on its line is whitespace. End-of-line comments next
     // to code (`x <- 1 # explain`) are intentionally left alone.
     let mut standalone: Vec<StandaloneComment> = Vec::new();
-    collect_standalone(root, text, &mut standalone);
+    collect_standalone(root, &lines, &mut standalone);
 
     // Group consecutive standalone comments (adjacent lines, nothing else in
-    // between) so a multi-line block is parsed and reported as one unit.
+    // between), then *split* each group on any line that is itself a skip
+    // marker (roxygen, shebang on line 0, directive, annotation, mode line)
+    // or that the suppression infrastructure has marked. Splitting (rather
+    // than discarding the whole group) keeps unrelated commented-out code on
+    // adjacent lines from being silently swallowed by a single nearby
+    // directive — e.g. `# @lsp-ignore-next\n# x <- 1\n# y <- 2` must still
+    // flag line 2.
     let groups = group_contiguous(&standalone);
 
-    let lines: Vec<&str> = text.lines().collect();
+    for raw_group in groups {
+        for sub in split_on_skip_lines(&raw_group, &lines, suppressions) {
+            let first = sub.first().expect("sub-group is non-empty");
+            let last = sub.last().expect("sub-group is non-empty");
 
-    for group in groups {
-        let first_line_idx = group.first().expect("group is non-empty").line as usize;
-        let last_line_idx = group.last().expect("group is non-empty").line as usize;
+            let sub_lines: Vec<&str> = sub
+                .iter()
+                .map(|c| lines.get(c.line as usize).copied().unwrap_or(""))
+                .collect();
 
-        // Suppressions on the first or last comment line of the group cover
-        // the whole block — easier than asking "did the user mean to suppress
-        // an arbitrary middle line".
-        if suppressions.is_suppressed(first_line_idx as u32)
-            || suppressions.is_suppressed(last_line_idx as u32)
-        {
-            continue;
+            let stripped = strip_and_join(&sub_lines);
+            if !looks_like_code(&stripped) {
+                continue;
+            }
+
+            let start_line_text = lines.get(first.line as usize).copied().unwrap_or("");
+            let end_line_text = lines.get(last.line as usize).copied().unwrap_or("");
+            let start_col = byte_offset_to_utf16_column(start_line_text, first.start_byte_on_line);
+            let end_col = byte_offset_to_utf16_column(end_line_text, end_line_text.len());
+
+            out.push(Diagnostic {
+                range: Range {
+                    start: Position::new(first.line, start_col),
+                    end: Position::new(last.line, end_col),
+                },
+                severity: Some(severity),
+                source: Some(LINT_SOURCE.to_string()),
+                message: "Commented code should be removed.".to_string(),
+                ..Default::default()
+            });
         }
-
-        let group_lines: Vec<&str> = group
-            .iter()
-            .map(|c| lines.get(c.line as usize).copied().unwrap_or(""))
-            .collect();
-
-        if should_skip(&group_lines, first_line_idx == 0) {
-            continue;
-        }
-
-        let stripped = strip_and_join(&group_lines);
-        if !looks_like_code(&stripped) {
-            continue;
-        }
-
-        // Build the diagnostic range from the first character of the first
-        // comment line to the end of the last comment line.
-        let first = &group[0];
-        let last = &group[group.len() - 1];
-        let start_line_text = lines.get(first.line as usize).copied().unwrap_or("");
-        let end_line_text = lines.get(last.line as usize).copied().unwrap_or("");
-        let start_col = byte_offset_to_utf16_column(start_line_text, first.start_byte_on_line);
-        let end_col = byte_offset_to_utf16_column(end_line_text, end_line_text.len());
-
-        out.push(Diagnostic {
-            range: Range {
-                start: Position::new(first.line, start_col),
-                end: Position::new(last.line, end_col),
-            },
-            severity: Some(severity),
-            source: Some(LINT_SOURCE.to_string()),
-            message: "Commented code should be removed.".to_string(),
-            ..Default::default()
-        });
     }
+}
+
+/// Split a contiguous comment group at every line that is itself a skip
+/// marker (roxygen, directive, annotation, mode line, shebang on line 0) or
+/// a suppressed line. Returns the remaining runs of standalone comment lines
+/// that should be try-parsed as code.
+fn split_on_skip_lines<'a>(
+    group: &'a [StandaloneComment],
+    lines: &[&str],
+    suppressions: &Suppressions,
+) -> Vec<&'a [StandaloneComment]> {
+    let mut out: Vec<&'a [StandaloneComment]> = Vec::new();
+    let mut start = 0usize;
+    for (idx, c) in group.iter().enumerate() {
+        let line_text = lines.get(c.line as usize).copied().unwrap_or("");
+        let is_first_line = c.line == 0;
+        let skip = is_skip_line(line_text, is_first_line)
+            || suppressions.is_suppressed(c.line);
+        if skip {
+            if idx > start {
+                out.push(&group[start..idx]);
+            }
+            start = idx + 1;
+        }
+    }
+    if start < group.len() {
+        out.push(&group[start..]);
+    }
+    out
 }
 
 /// Comment node that is the only non-whitespace content on its line.
@@ -121,13 +141,13 @@ struct StandaloneComment {
     start_byte_on_line: usize,
 }
 
-fn collect_standalone<'a>(node: Node<'a>, text: &str, out: &mut Vec<StandaloneComment>) {
+fn collect_standalone<'a>(node: Node<'a>, lines: &[&str], out: &mut Vec<StandaloneComment>) {
     if node.kind() == "comment" {
         let start = node.start_position();
         let line_idx = start.row;
-        // Locate the line in `text` and check that everything before the
-        // comment is whitespace.
-        if let Some(line) = nth_line(text, line_idx) {
+        // O(1) line lookup against the materialized slice. Comments can be
+        // nested anywhere in the tree, so we still walk every node.
+        if let Some(line) = lines.get(line_idx).copied() {
             let col_bytes = start.column;
             if col_bytes <= line.len()
                 && line[..col_bytes].bytes().all(|b| b == b' ' || b == b'\t')
@@ -142,13 +162,8 @@ fn collect_standalone<'a>(node: Node<'a>, text: &str, out: &mut Vec<StandaloneCo
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_standalone(child, text, out);
+        collect_standalone(child, lines, out);
     }
-}
-
-/// Borrow the `line_idx`-th line of `text` (zero-indexed) without allocating.
-fn nth_line(text: &str, line_idx: usize) -> Option<&str> {
-    text.lines().nth(line_idx)
 }
 
 /// Group standalone comments that occupy consecutive lines.
@@ -167,29 +182,26 @@ fn group_contiguous(comments: &[StandaloneComment]) -> Vec<Vec<StandaloneComment
     groups
 }
 
-/// Decide whether a comment block should be skipped before we try to parse it
-/// as code.
-fn should_skip(lines: &[&str], is_first_block: bool) -> bool {
-    if is_first_block {
-        if let Some(first) = lines.first() {
-            if first.trim_start().starts_with("#!") {
-                return true;
-            }
-        }
+/// Decide whether a single comment line should be excluded from try-parsing.
+///
+/// Used by [`split_on_skip_lines`] to break a contiguous group at each
+/// skip-line boundary, so that one stray `# TODO:` or `# @lsp-source ...`
+/// doesn't silently swallow neighbouring commented-out code.
+fn is_skip_line(line: &str, is_first_line_of_file: bool) -> bool {
+    let trimmed = line.trim_start();
+    if is_first_line_of_file && trimmed.starts_with("#!") {
+        return true;
     }
-    lines.iter().any(|line| {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("#'") {
-            return true;
-        }
-        if is_directive_marker(trimmed) {
-            return true;
-        }
-        if is_mode_line(trimmed) {
-            return true;
-        }
-        is_annotation_comment(trimmed)
-    })
+    if trimmed.starts_with("#'") {
+        return true;
+    }
+    if is_directive_marker(trimmed) {
+        return true;
+    }
+    if is_mode_line(trimmed) {
+        return true;
+    }
+    is_annotation_comment(trimmed)
 }
 
 /// `# nolint`, `# nolint start`, `# nolint end`, `# nolint: rule`, and any

--- a/crates/raven/src/linting/rules/commented_code.rs
+++ b/crates/raven/src/linting/rules/commented_code.rs
@@ -1,0 +1,393 @@
+//! Flag comments that appear to contain commented-out R code.
+//!
+//! Mirrors `lintr::commented_code_linter`. A comment is flagged when:
+//!
+//! 1. It is the only content on its line (end-of-line comments next to real
+//!    code are left alone — those are annotations on the statement, not dead
+//!    code).
+//! 2. After stripping the leading `#` characters and whitespace, the remaining
+//!    text parses cleanly as R (no `ERROR` nodes) and contains at least one
+//!    "code-like" construct — a call, an assignment, a binary or unary
+//!    operator, or a function definition. Bare identifiers, literals, and
+//!    parse errors are treated as prose.
+//!
+//! Multi-line comment blocks (consecutive standalone comment lines) are
+//! grouped and parsed as a unit, so commented-out code that spans several
+//! lines is detected even when no single line is by itself a valid expression.
+//!
+//! The following are always skipped:
+//!
+//! * **Roxygen** lines (`#'`). Documentation, not code.
+//! * **Shebangs** (`#!/usr/bin/env Rscript`) on the first line.
+//! * **Annotation comments** prefixed with one of `TODO`, `FIXME`, `NOTE`,
+//!   `XXX`, `HACK`, `BUG`, `WARNING`, or `OPTIMIZE` (case-insensitive,
+//!   followed by `:`, `(`, or `-`). `TODO` happens to be a valid identifier,
+//!   so without this gate `# TODO: rewrite parse_args` would parse as code.
+//! * **Suppression / directive markers** — `# nolint`, `# nolint start`,
+//!   `# nolint end`, `# nolint: rule`, `# @lsp-ignore`, `# @lsp-ignore-next`,
+//!   and any other `# @lsp-…` directive. These wouldn't pass the code-like
+//!   heuristic anyway, but skipping them up front keeps the rule from
+//!   competing with the suppression infrastructure.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::parser_pool::with_parser;
+use crate::utf16::byte_offset_to_utf16_column;
+
+/// Annotation prefixes (case-insensitive). `TODO`, `FIXME`, etc. — these are
+/// almost always prose even though `TODO` happens to be a syntactically valid
+/// R identifier.
+const ANNOTATION_PREFIXES: &[&str] = &[
+    "TODO", "FIXME", "NOTE", "XXX", "HACK", "BUG", "WARNING", "OPTIMIZE",
+];
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    // Collect every standalone comment node — comments where the only thing
+    // preceding the `#` on its line is whitespace. End-of-line comments next
+    // to code (`x <- 1 # explain`) are intentionally left alone.
+    let mut standalone: Vec<StandaloneComment> = Vec::new();
+    collect_standalone(root, text, &mut standalone);
+
+    // Group consecutive standalone comments (adjacent lines, nothing else in
+    // between) so a multi-line block is parsed and reported as one unit.
+    let groups = group_contiguous(&standalone);
+
+    let lines: Vec<&str> = text.lines().collect();
+
+    for group in groups {
+        let first_line_idx = group.first().expect("group is non-empty").line as usize;
+        let last_line_idx = group.last().expect("group is non-empty").line as usize;
+
+        // Suppressions on the first or last comment line of the group cover
+        // the whole block — easier than asking "did the user mean to suppress
+        // an arbitrary middle line".
+        if suppressions.is_suppressed(first_line_idx as u32)
+            || suppressions.is_suppressed(last_line_idx as u32)
+        {
+            continue;
+        }
+
+        let group_lines: Vec<&str> = group
+            .iter()
+            .map(|c| lines.get(c.line as usize).copied().unwrap_or(""))
+            .collect();
+
+        if should_skip(&group_lines, first_line_idx == 0) {
+            continue;
+        }
+
+        let stripped = strip_and_join(&group_lines);
+        if !looks_like_code(&stripped) {
+            continue;
+        }
+
+        // Build the diagnostic range from the first character of the first
+        // comment line to the end of the last comment line.
+        let first = &group[0];
+        let last = &group[group.len() - 1];
+        let start_line_text = lines.get(first.line as usize).copied().unwrap_or("");
+        let end_line_text = lines.get(last.line as usize).copied().unwrap_or("");
+        let start_col = byte_offset_to_utf16_column(start_line_text, first.start_byte_on_line);
+        let end_col = byte_offset_to_utf16_column(end_line_text, end_line_text.len());
+
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(first.line, start_col),
+                end: Position::new(last.line, end_col),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: "Commented code should be removed.".to_string(),
+            ..Default::default()
+        });
+    }
+}
+
+/// Comment node that is the only non-whitespace content on its line.
+#[derive(Debug, Clone, Copy)]
+struct StandaloneComment {
+    line: u32,
+    /// Byte offset of the `#` within its line (used to build the diagnostic
+    /// start position).
+    start_byte_on_line: usize,
+}
+
+fn collect_standalone<'a>(node: Node<'a>, text: &str, out: &mut Vec<StandaloneComment>) {
+    if node.kind() == "comment" {
+        let start = node.start_position();
+        let line_idx = start.row;
+        // Locate the line in `text` and check that everything before the
+        // comment is whitespace.
+        if let Some(line) = nth_line(text, line_idx) {
+            let col_bytes = start.column;
+            if col_bytes <= line.len()
+                && line[..col_bytes].bytes().all(|b| b == b' ' || b == b'\t')
+            {
+                out.push(StandaloneComment {
+                    line: line_idx as u32,
+                    start_byte_on_line: col_bytes,
+                });
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_standalone(child, text, out);
+    }
+}
+
+/// Borrow the `line_idx`-th line of `text` (zero-indexed) without allocating.
+fn nth_line(text: &str, line_idx: usize) -> Option<&str> {
+    text.lines().nth(line_idx)
+}
+
+/// Group standalone comments that occupy consecutive lines.
+fn group_contiguous(comments: &[StandaloneComment]) -> Vec<Vec<StandaloneComment>> {
+    let mut groups: Vec<Vec<StandaloneComment>> = Vec::new();
+    for c in comments {
+        if let Some(last_group) = groups.last_mut() {
+            let prev_line = last_group.last().expect("group is non-empty").line;
+            if c.line == prev_line + 1 {
+                last_group.push(*c);
+                continue;
+            }
+        }
+        groups.push(vec![*c]);
+    }
+    groups
+}
+
+/// Decide whether a comment block should be skipped before we try to parse it
+/// as code.
+fn should_skip(lines: &[&str], is_first_block: bool) -> bool {
+    if is_first_block {
+        if let Some(first) = lines.first() {
+            if first.trim_start().starts_with("#!") {
+                return true;
+            }
+        }
+    }
+    lines.iter().any(|line| {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("#'") {
+            return true;
+        }
+        if is_directive_marker(trimmed) {
+            return true;
+        }
+        if is_mode_line(trimmed) {
+            return true;
+        }
+        is_annotation_comment(trimmed)
+    })
+}
+
+/// `# nolint`, `# nolint start`, `# nolint end`, `# nolint: rule`, and any
+/// `# @lsp-…` directive (`@lsp-ignore`, `@lsp-source`, `@lsp-var`, etc.).
+fn is_directive_marker(trimmed_line: &str) -> bool {
+    let body = match strip_hash_prefix(trimmed_line) {
+        Some(b) => b,
+        None => return false,
+    };
+    let body_lower = body.to_ascii_lowercase();
+    if let Some(after) = body_lower.strip_prefix("nolint") {
+        // Accept the bare keyword followed by EOL, whitespace, `:`, or `-`.
+        // Same rule used by [`crate::linting::nolint::matches_keyword`].
+        return match after.chars().next() {
+            None => true,
+            Some(c) => c.is_whitespace() || c == ':' || c == '-',
+        };
+    }
+    body.starts_with("@lsp-")
+}
+
+/// Emacs-style mode line, e.g. `# -*- coding: utf-8 -*-`. R code rarely uses
+/// these, but they parse as a chain of unary minuses and `:` and would trip
+/// the code-like heuristic.
+fn is_mode_line(trimmed_line: &str) -> bool {
+    let body = match strip_hash_prefix(trimmed_line) {
+        Some(b) => b,
+        None => return false,
+    };
+    let first = body.find("-*-");
+    let last = body.rfind("-*-");
+    matches!((first, last), (Some(s), Some(e)) if s != e)
+}
+
+/// `# TODO:` / `# fixme(...)` and friends. The marker keyword must be followed
+/// by `:`, `(`, `-`, or whitespace so we don't false-positive on identifiers
+/// that happen to share a prefix (`TODOS`, `FIXMETOO`).
+fn is_annotation_comment(trimmed_line: &str) -> bool {
+    let body = match strip_hash_prefix(trimmed_line) {
+        Some(b) => b,
+        None => return false,
+    };
+    for prefix in ANNOTATION_PREFIXES {
+        if body.len() < prefix.len() {
+            continue;
+        }
+        let head = &body[..prefix.len()];
+        if !head.eq_ignore_ascii_case(prefix) {
+            continue;
+        }
+        let tail = &body[prefix.len()..];
+        if tail.is_empty() {
+            return true;
+        }
+        if let Some(c) = tail.chars().next() {
+            if c.is_whitespace() || c == ':' || c == '(' || c == '-' {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Strip leading `#` characters and following whitespace, returning the
+/// comment body. Returns `None` if the input is not a comment line.
+fn strip_hash_prefix(line: &str) -> Option<&str> {
+    let mut rest = line.trim_start();
+    if !rest.starts_with('#') {
+        return None;
+    }
+    while let Some(stripped) = rest.strip_prefix('#') {
+        rest = stripped;
+    }
+    Some(rest.trim_start())
+}
+
+/// Join the bodies of a comment block (one stripped line per row) into a
+/// single string suitable for try-parsing.
+fn strip_and_join(lines: &[&str]) -> String {
+    let mut out = String::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        if let Some(body) = strip_hash_prefix(line) {
+            out.push_str(body);
+        }
+    }
+    out
+}
+
+/// Try-parse `text` and decide whether it looks like real R code.
+///
+/// Requirements:
+/// 1. The parsed tree contains no `ERROR` nodes (`Node::has_error()` covers
+///    both syntax errors and `MISSING` placeholders).
+/// 2. The tree contains at least one node whose kind is in the "code-like"
+///    set: function calls, binary/unary operators, assignment, function
+///    definition, control flow, formula, or extract/namespace operators.
+///    Pure identifiers, literals, and strings on their own do not qualify.
+fn looks_like_code(stripped: &str) -> bool {
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let tree = match with_parser(|p| p.parse(stripped, None)) {
+        Some(t) => t,
+        None => return false,
+    };
+    let root = tree.root_node();
+    if root.has_error() {
+        return false;
+    }
+
+    contains_code_like(root)
+}
+
+fn contains_code_like(node: Node<'_>) -> bool {
+    if is_code_like_kind(node.kind()) {
+        return true;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if contains_code_like(child) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_code_like_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "call"
+            | "binary_operator"
+            | "unary_operator"
+            | "function_definition"
+            | "if_statement"
+            | "for_statement"
+            | "while_statement"
+            | "repeat_statement"
+            | "extract_operator"
+            | "namespace_operator"
+            | "subset"
+            | "subset2"
+            | "braced_expression"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_hash_prefix_handles_double_hash() {
+        assert_eq!(strip_hash_prefix("## hello"), Some("hello"));
+        assert_eq!(strip_hash_prefix("   # foo"), Some("foo"));
+        assert_eq!(strip_hash_prefix("not a comment"), None);
+    }
+
+    #[test]
+    fn annotation_detector_recognizes_common_prefixes() {
+        assert!(is_annotation_comment("# TODO: write tests"));
+        assert!(is_annotation_comment("# fixme(123)"));
+        assert!(is_annotation_comment("## NOTE - check this"));
+        assert!(is_annotation_comment("# XXX"));
+        // Not annotations:
+        assert!(!is_annotation_comment("# todoist <- list()"));
+        assert!(!is_annotation_comment("# x <- 1"));
+    }
+
+    #[test]
+    fn directive_detector_recognizes_nolint_and_lsp() {
+        assert!(is_directive_marker("# nolint"));
+        assert!(is_directive_marker("# nolint: line_length"));
+        assert!(is_directive_marker("# nolint start"));
+        assert!(is_directive_marker("# @lsp-ignore"));
+        assert!(is_directive_marker("# @lsp-source ../helpers.R"));
+        assert!(!is_directive_marker("# nolinter"));
+        assert!(!is_directive_marker("# lsp-ignore"));
+    }
+
+    #[test]
+    fn looks_like_code_flags_obvious_call() {
+        assert!(looks_like_code("foo(bar, baz)"));
+        assert!(looks_like_code("x <- 1"));
+        assert!(looks_like_code("x + y"));
+        assert!(looks_like_code("function(x) x + 1"));
+    }
+
+    #[test]
+    fn looks_like_code_skips_prose() {
+        assert!(!looks_like_code("foo"));
+        assert!(!looks_like_code("returns NULL"));
+        assert!(!looks_like_code("x in {1, 2, 3}"));
+        assert!(!looks_like_code(""));
+        assert!(!looks_like_code("   "));
+        assert!(!looks_like_code("42"));
+    }
+}

--- a/crates/raven/src/linting/rules/commented_code.rs
+++ b/crates/raven/src/linting/rules/commented_code.rs
@@ -245,10 +245,13 @@ fn is_annotation_comment(trimmed_line: &str) -> bool {
         None => return false,
     };
     for prefix in ANNOTATION_PREFIXES {
-        if body.len() < prefix.len() {
-            continue;
-        }
-        let head = &body[..prefix.len()];
+        // `str::get` is char-boundary-safe — a multibyte character whose
+        // bytes straddle `prefix.len()` returns `None` instead of panicking
+        // like a plain `&body[..prefix.len()]` would.
+        let head = match body.get(..prefix.len()) {
+            Some(h) => h,
+            None => continue,
+        };
         if !head.eq_ignore_ascii_case(prefix) {
             continue;
         }
@@ -372,6 +375,19 @@ mod tests {
         // Not annotations:
         assert!(!is_annotation_comment("# todoist <- list()"));
         assert!(!is_annotation_comment("# x <- 1"));
+    }
+
+    #[test]
+    fn annotation_detector_safe_on_multibyte_prefix() {
+        // `body.get(prefix.len()..)` (boundary-safe) must replace any naked
+        // `&body[..prefix.len()]` slice — otherwise comments whose body
+        // starts with a multibyte UTF-8 character whose bytes straddle a
+        // prefix-length boundary will panic at runtime.
+        assert!(!is_annotation_comment("# €€ note"));
+        assert!(!is_annotation_comment("# ö€: foo"));
+        // Non-ASCII inside the prefix slot must not match an ASCII annotation
+        // keyword — and must not panic.
+        assert!(!is_annotation_comment("# TÖDO"));
     }
 
     #[test]

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -5,6 +5,7 @@
 //! [`crate::linting::nolint::Suppressions`] before producing output.
 
 pub(crate) mod assignment_operator;
+pub(crate) mod commented_code;
 pub(crate) mod infix_spaces;
 pub(crate) mod line_length;
 pub(crate) mod no_tab;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,7 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.objectNameStyleArgument` | `"snake_case"` | Naming scheme for function formal arguments (same enum as above) |
 | `raven.linting.objectNameSeverity` | `"hint"` | Severity for the object-name lint (set to `"off"` to disable entirely; set a specific style to `"any"` to disable just that kind) |
 | `raven.linting.infixSpacesSeverity` | `"hint"` | Severity for the infix-spaces lint (whitespace around operators) |
+| `raven.linting.commentedCodeSeverity` | `"hint"` | Severity for the commented-code lint (standalone comments whose body parses as R code) |
 
 To disable an individual rule while leaving the rest enabled, set its severity to `"off"`. For the object-name lint, you can also set any of the three style settings to `"any"` to disable just that symbol kind while keeping the others active.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -61,10 +61,13 @@ Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-li
 | Assignment operator | hint | Top-level assignment uses an operator other than the preferred one (`<-` by default; configurable via `raven.linting.assignmentOperator`) |
 | Object name | hint | Function, variable, or argument name doesn't match the configured naming scheme (`snake_case` by default; configurable per kind via `raven.linting.objectNameStyle*`) |
 | Infix spaces | hint | Missing space around a binary operator (`a+b`, `x<-1`, `a%>%b`, `if (a<=b)`), or stray space around a tight-binding operator (`obj $ field`, `1 : 10`, unary `- x`) |
+| Commented code | hint | A standalone comment whose body parses as R and contains a call, assignment, or operator (`# foo(bar)`, `# x <- 1 + 2`) |
 
 Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
 
 The infix-spaces lint flags two opposing cases. **Spaces required** on both sides: arithmetic (`+`, `-`, `*`, `/`, `^`), comparison (`<`, `<=`, `==`, `!=`, ...), logical (`&`, `&&`, `|`, `||`), assignment (`<-`, `<<-`, `->`, `->>`, `=`), pipe (`|>`, `%>%`, any `%...%`), and binary formula (`y ~ x`). **No spaces** on either side: sequence (`:`), namespace (`::`, `:::`), member access (`$`, `@`), and unary `-`, `+`, `!`, `?`. The rule is conservative — alignment whitespace (`x   <- 1`) is not flagged, and line-continuation cases (operator at end of line, RHS on the next line) are skipped since the line break supplies the separation.
+
+The commented-code lint groups consecutive standalone comment lines and try-parses their bodies as R. A block is reported when it parses without errors **and** contains at least one call, assignment, binary/unary operator, function definition, or control-flow construct — bare identifiers and literals are treated as prose. End-of-line comments next to real code (`x <- 1 # explain`) are never flagged. Roxygen lines (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, `# NOTE:`, `# XXX:`, `# HACK:`, `# BUG:`, `# WARNING:`, `# OPTIMIZE:`), Emacs mode lines (`# -*- ... -*-`), and `# nolint` / `# @lsp-…` directives are skipped up front.
 
 The object-name lint has independent style settings for **functions** (`objectNameStyleFunction`), **variables** (`objectNameStyleVariable`), and **arguments** (`objectNameStyleArgument`). Each accepts `snake_case`, `camelCase`, `dotted.case`, `UPPER_CASE`, `lowercase`, or `any`. Using `any` accepts all names for that kind — since the three are checked independently, you can enforce a style on two while opting out of the third.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1377,6 +1377,25 @@
           ],
           "default": "hint",
           "description": "Severity for the infix-spaces lint. Flags missing spaces around binary operators (`+`, `==`, `<-`, `|>`, `%>%`, etc.) and stray whitespace around tight-binding operators (`::`, `$`, `:`, unary `-/+/!`). Alignment whitespace (multiple spaces) and line-continuations are not flagged."
+        },
+        "raven.linting.commentedCodeSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report commented-out code as errors",
+            "Report commented-out code as warnings",
+            "Report commented-out code as information",
+            "Report commented-out code as hints",
+            "Disable the commented-code lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the commented-code lint. Flags standalone comment blocks whose body parses as R code (calls, assignments, operators). Roxygen lines (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, ...), and `# nolint` / `# @lsp-*` directives are never flagged."
         }
       }
     }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -108,6 +108,7 @@ export interface RavenInitializationOptions {
         assignmentOperatorSeverity?: SeverityLevel;
         objectNameSeverity?: SeverityLevel;
         infixSpacesSeverity?: SeverityLevel;
+        commentedCodeSeverity?: SeverityLevel;
     };
     helpViewer?: { viewColumn?: 'active' | 'beside' };
 }
@@ -364,6 +365,7 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         assignmentOperatorSeverity: config.get<SeverityLevel>('linting.assignmentOperatorSeverity', 'hint'),
         objectNameSeverity: config.get<SeverityLevel>('linting.objectNameSeverity', 'hint'),
         infixSpacesSeverity: config.get<SeverityLevel>('linting.infixSpacesSeverity', 'hint'),
+        commentedCodeSeverity: config.get<SeverityLevel>('linting.commentedCodeSeverity', 'hint'),
     };
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -136,6 +136,7 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.objectNameStyleArgument', jsonPath: ['linting', 'objectNameStyleArgument'], type: 'enum', enumValues: ['snake_case', 'camelCase', 'dotted.case', 'UPPER_CASE', 'lowercase', 'any'] as const, defaultWhenUnconfigured: 'snake_case' },
     { vsCodeKey: 'linting.objectNameSeverity', jsonPath: ['linting', 'objectNameSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.infixSpacesSeverity', jsonPath: ['linting', 'infixSpacesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.commentedCodeSeverity', jsonPath: ['linting', 'commentedCodeSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];
@@ -368,6 +369,7 @@ suite('Settings Transmission Property Tests', () => {
                 assignmentOperatorSeverity: 'hint',
                 objectNameSeverity: 'hint',
                 infixSpacesSeverity: 'hint',
+                commentedCodeSeverity: 'hint',
             },
         }, 'Empty configuration should produce only runtime defaults');
 
@@ -519,6 +521,7 @@ suite('Settings Transmission Unit Tests', () => {
             assignmentOperatorSeverity: 'hint',
             objectNameSeverity: 'hint',
             infixSpacesSeverity: 'hint',
+            commentedCodeSeverity: 'hint',
         });
     });
 
@@ -533,6 +536,7 @@ suite('Settings Transmission Unit Tests', () => {
             ['linting.objectNameStyleVariable', 'any'],
             ['linting.objectNameSeverity', 'warning'],
             ['linting.infixSpacesSeverity', 'off'],
+            ['linting.commentedCodeSeverity', 'warning'],
         ]);
         const mockConfig = createMockConfig(configuredSettings);
         const options = getInitializationOptions(mockConfig);
@@ -545,6 +549,7 @@ suite('Settings Transmission Unit Tests', () => {
         assert.strictEqual(options.linting?.objectNameStyleVariable, 'any');
         assert.strictEqual(options.linting?.objectNameSeverity, 'warning');
         assert.strictEqual(options.linting?.infixSpacesSeverity, 'off');
+        assert.strictEqual(options.linting?.commentedCodeSeverity, 'warning');
         // Untouched keys still emit their defaults.
         assert.strictEqual(options.linting?.trailingWhitespaceSeverity, 'hint');
         assert.strictEqual(options.linting?.objectNameStyleArgument, 'snake_case');


### PR DESCRIPTION
## Summary

Adds a `commented_code` style lint that flags standalone comments whose body parses as R code containing a call, assignment, operator, or function definition. Closes #222.

- Contiguous standalone comments are grouped and parsed as a single unit, so multi-line dead code is detected even when no single line is valid on its own.
- End-of-line comments next to real code (`x <- 1 # explain`) are left alone — only standalone comment lines participate.
- Roxygen (`#'`), shebangs (line 0), annotation prefixes (`# TODO:`, `# FIXME:`, `# NOTE:`, `# XXX:`, `# HACK:`, `# BUG:`, `# WARNING:`, `# OPTIMIZE:`), Emacs mode lines (`# -*- ... -*-`), and `# nolint` / `# @lsp-…` directives are skipped up front so the rule never competes with the suppression / cross-file directive infrastructure.
- New setting `raven.linting.commentedCodeSeverity` (default `"hint"`, `"off"` to disable). Wired through the shared init-options factory and `SETTINGS_MAPPING` so reset propagates correctly.

## Test plan

- [x] `cargo test -p raven` (3,737 passed, 0 failed)
- [x] `cargo clippy -p raven --no-deps` — no new warnings on the new module
- [x] `bun test` from the repo root (467 bun + 175 mocha pass)
- [x] Unit tests cover: obvious call/assignment/operator detection; prose without operators (bare identifier, literal); roxygen; shebang on line 0; TODO/FIXME/NOTE annotation comments; `# nolint` / `# @lsp-*` directives; end-of-line comments; contiguous block grouping; mode lines; suppression via `# nolint start/end` and `# @lsp-ignore-next`; severity `off` disables the rule; `source` field set to `raven (lint)`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commented-code linting rule that detects and flags standalone blocks of commented-out R code, while respecting suppression markers and skipping roxygen comments, shebangs, and annotations.
  * New `raven.linting.commentedCodeSeverity` configuration setting (default: `hint`) to control severity or disable the rule entirely.

* **Documentation**
  * Updated configuration and diagnostics documentation to describe the new linting rule and configuration option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->