### PR TITLE
feat(outline): surface R Markdown / Quarto chunks and `# %%` cells

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -4155,6 +4155,17 @@ impl LanguageServer for Backend {
                     continue;
                 }
 
+                // Skip Rmd/Quarto files: they're routed to the LSP for the
+                // document outline (issue #227), but their prose/YAML would
+                // pollute the cross-file index if parsed as R. The workspace
+                // startup scan already excludes them via
+                // `is_stat_model_extension`; this keeps the watcher consistent.
+                let lower_path = uri.path().to_ascii_lowercase();
+                if lower_path.ends_with(".rmd") || lower_path.ends_with(".qmd") {
+                    log::trace!("Skipping watched Rmd/Quarto file change: {}", uri);
+                    continue;
+                }
+
                 match change.typ {
                     FileChangeType::CREATED | FileChangeType::CHANGED => {
                         // Invalidate disk-backed caches
@@ -4795,7 +4806,7 @@ impl LanguageServer for Backend {
                 Some(doc) => doc,
                 None => return Ok(None),
             };
-            if doc.file_type != crate::file_type::FileType::R {
+            if doc.file_type != crate::file_type::FileType::R || doc.is_rmd_document() {
                 return Ok(None);
             }
             let tree = match &doc.tree {
@@ -5024,6 +5035,13 @@ impl LanguageServer for Backend {
                 return Ok(None);
             }
         };
+
+        // Skip Rmd/Quarto: indentation rules designed for R syntax would
+        // produce surprising edits on prose, YAML, or non-R chunk content.
+        if doc.is_rmd_document() {
+            log::trace!("on_type_formatting: skipping Rmd/Quarto document {}", uri);
+            return Ok(None);
+        }
 
         // Get tree-sitter AST
         let tree = match doc.tree.as_ref() {

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -67,7 +67,10 @@ fn section_divider_re() -> &'static Regex {
     // Acts as a cell-END boundary when mixed with `# %%` cells.
     // Excludes roxygen `#'` lines.
     RE.get_or_init(|| {
-        Regex::new(r"^#+[^']?.*[-#+=*]{4,}\s*$").expect("section divider regex")
+        // `[^']` (mandatory, not `[^']?`) — without it, the character class
+        // could match zero chars and a roxygen line like `#' Title ----`
+        // would be misread as a divider.
+        Regex::new(r"^#+[^'].*[-#+=*]{4,}\s*$").expect("section divider regex")
     })
 }
 
@@ -390,6 +393,19 @@ mod tests {
         let chunks = detect(src, ChunkKind::R);
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].label, None);
+    }
+
+    #[test]
+    fn roxygen_line_does_not_end_cell() {
+        // A `#' @param x A value -----` line inside a cell must NOT be
+        // mistaken for a section divider — the divider regex must require a
+        // non-quote character right after the leading hashes.
+        let src = "# %% Setup\n#' @param x A value -----\nlibrary(x)\n# %% Next\ny <- 2";
+        let chunks = detect(src, ChunkKind::R);
+        assert_eq!(chunks.len(), 2);
+        // First cell should extend through line 2 (`library(x)`), not be
+        // truncated at the roxygen line.
+        assert_eq!(chunks[0].end_line, 2);
     }
 
     #[test]

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -1,0 +1,420 @@
+//! Code-chunk detection for R Markdown / Quarto fenced blocks and `.R` cell markers.
+//!
+//! Rust port of `editors/vscode/src/chunks/chunk-detector.ts`. Detection is
+//! text-based (no tree-sitter), so it works on documents whose body would
+//! otherwise be opaque to the R parser (prose, YAML, fenced non-R code).
+//!
+//! Used by `SymbolExtractor::extract_chunks` to surface chunk entries in the
+//! document outline. Kept aligned with the TypeScript detector so the two
+//! continue to produce the same `header_line` / `end_line` for any document.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Which detection path to use when scanning a document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkKind {
+    /// Rmd/Qmd fenced block (` ```{r ...} ` … ` ``` `).
+    Rmd,
+    /// `.R` cell marker (`# %%`).
+    R,
+}
+
+/// A detected chunk.
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    /// 0-based line index of the chunk header (fence or `# %%` line).
+    pub header_line: u32,
+    /// 0-based line index of the last content line (inclusive). For an Rmd
+    /// chunk this is one line above `closing_fence_line` when the fence is
+    /// present, or the last line of the file when unclosed.
+    pub end_line: u32,
+    /// 0-based line index of the closing fence (Rmd only). `None` for `.R`
+    /// cells and for unclosed Rmd chunks that run off the end of the file.
+    pub closing_fence_line: Option<u32>,
+    /// Language tag from the chunk header, lower-cased. `.R` cells are always
+    /// `"r"`.
+    pub language: String,
+    /// First bare identifier in the header (e.g. `setup` in
+    /// `{r setup, eval=FALSE}`), or — for `# %%` cells — the text after the
+    /// marker. `None` when no label is present.
+    pub label: Option<String>,
+}
+
+fn fence_header_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(`{3,}|~{3,})\s*\{([A-Za-z0-9_+.\-]+)([^}]*)\}\s*$")
+            .expect("fence header regex")
+    })
+}
+
+fn fence_close_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^(`{3,}|~{3,})\s*$").expect("fence close regex"))
+}
+
+fn cell_marker_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // `# %%` (any number of leading `#`), followed by EOL or whitespace.
+    // Excludes `# %%%` (3+ `%`) and `# %%inline-text`.
+    RE.get_or_init(|| Regex::new(r"^#+\s*%%(?:[^%\S\r\n].*|\s*)?$").expect("cell marker regex"))
+}
+
+fn section_divider_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // RStudio-style section divider: `# Title ====`, `# Setup ----`, etc.
+    // Acts as a cell-END boundary when mixed with `# %%` cells.
+    // Excludes roxygen `#'` lines.
+    RE.get_or_init(|| {
+        Regex::new(r"^#+[^']?.*[-#+=*]{4,}\s*$").expect("section divider regex")
+    })
+}
+
+/// Classify a document path (URI or file path) by extension. Falls back to
+/// [`ChunkKind::R`] for unknown extensions so behavior is predictable.
+pub fn classify_chunk_document(path_or_uri: &str) -> ChunkKind {
+    let lower = path_or_uri.to_ascii_lowercase();
+    if lower.ends_with(".rmd") || lower.ends_with(".qmd") {
+        ChunkKind::Rmd
+    } else {
+        ChunkKind::R
+    }
+}
+
+/// Detect all chunks in the document, in source order. `kind` controls which
+/// detection path runs.
+pub fn detect_chunks(text: &str, kind: ChunkKind) -> Vec<Chunk> {
+    let lines: Vec<&str> = text.lines().collect();
+    match kind {
+        ChunkKind::Rmd => detect_rmd_chunks(&lines),
+        ChunkKind::R => detect_r_cells(&lines),
+    }
+}
+
+fn detect_rmd_chunks(lines: &[&str]) -> Vec<Chunk> {
+    let mut chunks = Vec::new();
+    let header_re = fence_header_re();
+    let close_re = fence_close_re();
+
+    let mut i = 0usize;
+    while i < lines.len() {
+        let line = lines[i];
+        let Some(caps) = header_re.captures(line) else {
+            i += 1;
+            continue;
+        };
+
+        let fence = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        let lang = caps
+            .get(2)
+            .map(|m| m.as_str().to_ascii_lowercase())
+            .unwrap_or_default();
+        let header_rest = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+        let label = parse_header_label(header_rest);
+
+        let fence_char = fence.chars().next().unwrap_or('`');
+        let min_len = fence.len();
+        let mut closing_line: Option<u32> = None;
+        for j in (i + 1)..lines.len() {
+            if let Some(close_caps) = close_re.captures(lines[j]) {
+                let close = close_caps.get(1).map(|m| m.as_str()).unwrap_or("");
+                if close.starts_with(fence_char) && close.len() >= min_len {
+                    closing_line = Some(j as u32);
+                    break;
+                }
+            }
+        }
+
+        let header_line = i as u32;
+        let end_line = match closing_line {
+            Some(close) if close > 0 => close - 1,
+            Some(_) => header_line,
+            None => (lines.len().saturating_sub(1)) as u32,
+        };
+        let end_line = end_line.max(header_line);
+
+        chunks.push(Chunk {
+            header_line,
+            end_line,
+            closing_fence_line: closing_line,
+            language: lang,
+            label,
+        });
+
+        i = match closing_line {
+            Some(close) => (close as usize) + 1,
+            None => lines.len(),
+        };
+    }
+    chunks
+}
+
+fn detect_r_cells(lines: &[&str]) -> Vec<Chunk> {
+    let marker_re = cell_marker_re();
+    let divider_re = section_divider_re();
+
+    // Pass 1: enumerate cell markers and section dividers.
+    let mut markers: Vec<usize> = Vec::new();
+    let mut dividers: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if marker_re.is_match(line) {
+            markers.push(idx);
+        } else if divider_re.is_match(line) {
+            dividers.insert(idx);
+        }
+    }
+
+    // Pass 2: each marker is a cell that runs until the next marker, the next
+    // section divider, or EOF — whichever comes first.
+    let mut chunks = Vec::with_capacity(markers.len());
+    for (m, &header) in markers.iter().enumerate() {
+        let next_marker = markers
+            .get(m + 1)
+            .copied()
+            .unwrap_or(lines.len());
+        let mut end_line = next_marker.saturating_sub(1);
+        for i in (header + 1)..next_marker {
+            if dividers.contains(&i) {
+                end_line = i;
+                break;
+            }
+        }
+        let header_line = header as u32;
+        let end_line = (end_line as u32).max(header_line);
+        chunks.push(Chunk {
+            header_line,
+            end_line,
+            closing_fence_line: None,
+            language: "r".to_string(),
+            label: cell_label(lines[header]),
+        });
+    }
+    chunks
+}
+
+/// Extract the human-readable label from a `# %%` cell marker line.
+/// Returns `None` when the marker has no trailing text.
+fn cell_label(line: &str) -> Option<String> {
+    // Trim leading `#`s and whitespace, drop the `%%` token, then return the
+    // remainder (trimmed) as the label. Returns None when nothing remains.
+    let mut rest = line.trim_start();
+    while rest.starts_with('#') {
+        rest = &rest[1..];
+    }
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix("%%").unwrap_or(rest);
+    let label = rest.trim().trim_end_matches(|c: char| {
+        // Strip trailing decorative `-#+=*` runs (e.g. `# %% Setup ----`).
+        matches!(c, '-' | '#' | '+' | '=' | '*' | ' ' | '\t')
+    });
+    let label = label.trim();
+    if label.is_empty() {
+        None
+    } else {
+        Some(label.to_string())
+    }
+}
+
+/// Parse the body of a chunk header (everything between `{lang` and `}`) and
+/// return the optional label (first bare identifier).
+///
+/// Comma splitting respects nested brackets and quoted strings so that values
+/// like `fig.dim=c(5, 6)` or `lab="a,b"` don't trip the parser.
+fn parse_header_label(rest: &str) -> Option<String> {
+    let trimmed = rest.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Split on commas while keeping nested brackets and quoted strings intact.
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_quote: Option<char> = None;
+    let mut depth = 0i32;
+
+    let chars: Vec<char> = trimmed.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let ch = chars[i];
+        if let Some(q) = in_quote {
+            current.push(ch);
+            if ch == '\\' && i + 1 < chars.len() {
+                current.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
+            if ch == q {
+                in_quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        match ch {
+            '"' | '\'' => {
+                in_quote = Some(ch);
+                current.push(ch);
+            }
+            '(' | '[' | '{' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' | ']' | '}' => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                parts.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+        i += 1;
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+
+    for raw in parts {
+        let part = raw.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if part.contains('=') {
+            // key=value option, not the label.
+            continue;
+        }
+        return Some(part.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detect(text: &str, kind: ChunkKind) -> Vec<Chunk> {
+        detect_chunks(text, kind)
+    }
+
+    #[test]
+    fn classifies_rmd_qmd_extensions() {
+        assert_eq!(classify_chunk_document("/tmp/foo.Rmd"), ChunkKind::Rmd);
+        assert_eq!(classify_chunk_document("/tmp/foo.qmd"), ChunkKind::Rmd);
+        assert_eq!(classify_chunk_document("/tmp/foo.QMD"), ChunkKind::Rmd);
+        assert_eq!(classify_chunk_document("/tmp/foo.R"), ChunkKind::R);
+        assert_eq!(classify_chunk_document("/tmp/foo.r"), ChunkKind::R);
+        assert_eq!(classify_chunk_document("/tmp/foo.txt"), ChunkKind::R);
+    }
+
+    #[test]
+    fn detects_a_single_r_chunk() {
+        let src = "Some prose.\n\n```{r}\nx <- 1\nprint(x)\n```\n\nMore prose.";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].header_line, 2);
+        assert_eq!(chunks[0].closing_fence_line, Some(5));
+        assert_eq!(chunks[0].end_line, 4);
+        assert_eq!(chunks[0].language, "r");
+    }
+
+    #[test]
+    fn parses_label_from_header() {
+        let src = "```{r setup, eval=FALSE, fig.width=4}\nx <- 1\n```";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].label.as_deref(), Some("setup"));
+    }
+
+    #[test]
+    fn skips_options_when_picking_label() {
+        // First option is key=value, so the label is None (no bare token).
+        let src = "```{r, eval=FALSE}\n1\n```";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks[0].label, None);
+    }
+
+    #[test]
+    fn handles_unclosed_chunk_at_eof() {
+        let src = "```{r}\nx <- 1\nprint(x)";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].header_line, 0);
+        assert_eq!(chunks[0].closing_fence_line, None);
+        assert_eq!(chunks[0].end_line, 2);
+    }
+
+    #[test]
+    fn tracks_non_r_language_tag() {
+        let src = "```{python}\nprint('hi')\n```\n\n```{julia}\n1+1\n```";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].language, "python");
+        assert_eq!(chunks[1].language, "julia");
+    }
+
+    #[test]
+    fn tilde_fences_work() {
+        let src = "~~~{r}\nx <- 1\n~~~";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].closing_fence_line, Some(2));
+    }
+
+    #[test]
+    fn fence_close_requires_same_char_and_min_length() {
+        // 4-backtick opener; 3-backtick close should not match.
+        let src = "````{r}\nx <- 1\n```\n````";
+        let chunks = detect(src, ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].closing_fence_line, Some(3));
+    }
+
+    #[test]
+    fn detects_r_cells_basic() {
+        let src = "# %% Setup\nlibrary(dplyr)\n\n# %% Analysis\nx <- 1";
+        let chunks = detect(src, ChunkKind::R);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].header_line, 0);
+        assert_eq!(chunks[0].end_line, 2);
+        assert_eq!(chunks[0].label.as_deref(), Some("Setup"));
+        assert_eq!(chunks[1].header_line, 3);
+        assert_eq!(chunks[1].end_line, 4);
+        assert_eq!(chunks[1].label.as_deref(), Some("Analysis"));
+    }
+
+    #[test]
+    fn empty_cell_marker_has_no_label() {
+        let src = "# %%\nx <- 1";
+        let chunks = detect(src, ChunkKind::R);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].label, None);
+    }
+
+    #[test]
+    fn section_divider_ends_cell() {
+        let src = "# %% Setup\nlibrary(x)\n# Header ----\nx <- 1\n# %% Next\ny <- 2";
+        let chunks = detect(src, ChunkKind::R);
+        assert_eq!(chunks.len(), 2);
+        // The divider line itself is the last line of the first cell.
+        assert_eq!(chunks[0].end_line, 2);
+    }
+
+    #[test]
+    fn cell_marker_with_trailing_decoration_keeps_label() {
+        let src = "# %% Setup ----\nx <- 1";
+        let chunks = detect(src, ChunkKind::R);
+        assert_eq!(chunks[0].label.as_deref(), Some("Setup"));
+    }
+
+    #[test]
+    fn parenthesised_option_values_survive() {
+        let src = "```{r, fig.dim=c(5, 6), out.width=\"80%\"}\n1\n```";
+        let chunks = detect(src, ChunkKind::Rmd);
+        // We don't store options, but the header must still parse cleanly
+        // and produce one chunk without confusing the comma split.
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].language, "r");
+    }
+}

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -85,6 +85,23 @@ pub fn classify_chunk_document(path_or_uri: &str) -> ChunkKind {
     }
 }
 
+/// Classify a document using its `languageId` first, then its URI path.
+///
+/// Matches the client-side `classify_chunk_document_for_document` helper in
+/// `editors/vscode/src/chunks/chunk-detector.ts` so untitled buffers — which
+/// have no file extension — still classify correctly when the editor passes
+/// `languageId: "rmd" | "quarto"`.
+pub fn classify_chunk_document_for(language_id: Option<&str>, path_or_uri: &str) -> ChunkKind {
+    if let Some(lang) = language_id {
+        match lang.to_ascii_lowercase().as_str() {
+            "rmd" | "quarto" => return ChunkKind::Rmd,
+            "r" => return classify_chunk_document(path_or_uri),
+            _ => {}
+        }
+    }
+    classify_chunk_document(path_or_uri)
+}
+
 /// Detect all chunks in the document, in source order. `kind` controls which
 /// detection path runs.
 pub fn detect_chunks(text: &str, kind: ChunkKind) -> Vec<Chunk> {
@@ -309,6 +326,37 @@ mod tests {
         assert_eq!(classify_chunk_document("/tmp/foo.R"), ChunkKind::R);
         assert_eq!(classify_chunk_document("/tmp/foo.r"), ChunkKind::R);
         assert_eq!(classify_chunk_document("/tmp/foo.txt"), ChunkKind::R);
+    }
+
+    #[test]
+    fn classifies_untitled_buffers_by_language_id() {
+        // Untitled buffers have no extension, so `languageId` is the only
+        // signal we have for distinguishing Rmd/Quarto from plain R.
+        assert_eq!(
+            classify_chunk_document_for(Some("rmd"), "untitled:Untitled-1"),
+            ChunkKind::Rmd
+        );
+        assert_eq!(
+            classify_chunk_document_for(Some("quarto"), "untitled:Untitled-1"),
+            ChunkKind::Rmd
+        );
+        assert_eq!(
+            classify_chunk_document_for(Some("RMD"), "untitled:Untitled-1"),
+            ChunkKind::Rmd
+        );
+        assert_eq!(
+            classify_chunk_document_for(Some("r"), "untitled:Untitled-1"),
+            ChunkKind::R
+        );
+        assert_eq!(
+            classify_chunk_document_for(None, "/tmp/foo.Rmd"),
+            ChunkKind::Rmd
+        );
+        // languageId='r' on a .Rmd URI: trust the URI (matches the TS detector).
+        assert_eq!(
+            classify_chunk_document_for(Some("r"), "/tmp/foo.Rmd"),
+            ChunkKind::Rmd
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -17519,6 +17519,54 @@ result <- data %>% filter(x > 0)
     }
 
     #[test]
+    fn test_r_handlers_suppressed_for_rmd_documents() {
+        // Every R-only handler that was gated in the Rmd routing change
+        // (issue #227) should return an empty/no-op response for Rmd
+        // documents. Diagnostics and completion have their own tests; this
+        // covers the remaining sync handlers in one place.
+        use crate::state::{Document, WorldState};
+
+        let code = "Some prose.\n\n```{r}\nfn <- function(x) x\n```\n";
+        let uri = Url::parse("file:///doc.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let pos = Position::new(3, 0);
+
+        assert_eq!(
+            super::folding_range(&state, &uri),
+            Some(Vec::new()),
+            "folding_range"
+        );
+        assert_eq!(
+            super::selection_range(&state, &uri, vec![pos]),
+            Some(Vec::new()),
+            "selection_range"
+        );
+        assert!(
+            super::prepare_signature_help(&state, &uri, pos).is_none(),
+            "prepare_signature_help"
+        );
+        assert!(
+            super::goto_definition_with_cancel(
+                &state,
+                &uri,
+                pos,
+                &crate::handlers::DiagCancelToken::never(),
+            )
+            .is_none(),
+            "goto_definition"
+        );
+        assert_eq!(
+            super::references(&state, &uri, pos),
+            Some(Vec::new()),
+            "references"
+        );
+    }
+
+    #[test]
     fn test_completion_suppressed_for_rmd_documents() {
         use crate::state::{Document, WorldState};
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -17452,6 +17452,32 @@ result <- data %>% filter(x > 0)
     }
 
     #[test]
+    fn test_document_symbol_includes_chunks_for_qmd_uri() {
+        // Mirrors the .Rmd integration test for the `.qmd` branch of
+        // `classify_chunk_document`.
+        use crate::state::{Document, WorldState};
+
+        let code = "Some prose.\n\n```{r setup}\nx <- 1\n```\n";
+        let uri = Url::parse("file:///test.qmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+        let chunk = symbols
+            .iter()
+            .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
+            .expect("chunk entry");
+        assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
     fn test_document_symbol_includes_cells_for_r_uri() {
         use crate::state::{Document, WorldState};
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3157,6 +3157,11 @@ fn cross_file_base_exports(state: &WorldState) -> Arc<HashSet<String>> {
 
 pub fn folding_range(state: &WorldState, uri: &Url) -> Option<Vec<FoldingRange>> {
     let doc = state.get_document(uri)?;
+    // Folding on prose/YAML would surface garbage AST regions; chunk-aware
+    // folding for Rmd/Quarto is a future feature.
+    if doc.is_rmd_document() {
+        return Some(Vec::new());
+    }
     let tree = doc.tree.as_ref()?;
     let mut ranges = Vec::new();
 
@@ -3202,6 +3207,9 @@ pub fn selection_range(
     positions: Vec<Position>,
 ) -> Option<Vec<SelectionRange>> {
     let doc = state.get_document(uri)?;
+    if doc.is_rmd_document() {
+        return Some(Vec::new());
+    }
     let tree = doc.tree.as_ref()?;
 
     let text = doc.text();
@@ -9240,6 +9248,11 @@ pub fn completion(
     context: Option<CompletionContext>,
 ) -> Option<CompletionResponse> {
     let doc = state.get_document(uri)?;
+    // Suppress R-style completions on prose/YAML lines in Rmd/Quarto.
+    // Chunk-aware completion inside fenced R blocks is a follow-up to #230.
+    if doc.is_rmd_document() {
+        return None;
+    }
     let text = doc.text();
 
     // JAGS/Stan completion filtering
@@ -10350,7 +10363,7 @@ fn build_help_panel_link(topic: &str, package: &str) -> String {
 /// Returns `Some(Hover)` when information (definition, signature, package attribution, or help text) is available for the identifier at `position`, `None` when no useful hover content can be produced.
 pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<Hover> {
     let doc = state.get_document(uri)?;
-    if doc.file_type != FileType::R {
+    if doc.file_type != FileType::R || doc.is_rmd_document() {
         return None;
     }
     let tree = doc.tree.as_ref()?;
@@ -11112,6 +11125,9 @@ pub fn prepare_signature_help(
     position: Position,
 ) -> Option<SignatureHelpContext> {
     let doc = state.get_document(uri)?;
+    if doc.is_rmd_document() {
+        return None;
+    }
     let tree = doc.tree.as_ref()?;
     let text = doc.text();
 
@@ -11347,6 +11363,9 @@ pub fn goto_definition_with_cancel(
     let doc = state
         .get_document(uri)
         .or_else(|| state.workspace_index.get(uri))?;
+    if doc.is_rmd_document() {
+        return None;
+    }
     let tree = doc.tree.as_ref()?;
     let text = doc.text();
 
@@ -11691,6 +11710,9 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
     let doc = state
         .get_document(uri)
         .or_else(|| state.workspace_index.get(uri))?;
+    if doc.is_rmd_document() {
+        return Some(Vec::new());
+    }
     let text = doc.text();
 
     if doc.file_type == FileType::Stan {
@@ -17494,6 +17516,22 @@ result <- data %>% filter(x > 0)
             .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
             .expect("chunk entry");
         assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
+    fn test_completion_suppressed_for_rmd_documents() {
+        use crate::state::{Document, WorldState};
+
+        let code = "Some prose with `library(`\n\n```{r}\nx <-\n```\n";
+        let uri = Url::parse("file:///doc.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        // Position 0, char 25 — inside the prose `library(` fragment.
+        let result = super::completion(&state, &uri, Position::new(0, 25), None);
+        assert!(result.is_none(), "Rmd should yield no R completions on prose");
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -118,6 +118,10 @@ pub(crate) struct DiagnosticsSnapshot {
 
     // File type (from document, not URI — needed for untitled JAGS/Stan buffers)
     pub file_type: FileType,
+    /// Chunk-detection kind for the document, captured from the document so
+    /// that untitled Rmd/Quarto buffers (no file extension) still classify
+    /// correctly. Used to gate diagnostics for prose-bearing documents.
+    pub chunk_kind: crate::chunks::ChunkKind,
 
     /// STEP 1 (parent walk) cache shared across all `get_scope` calls in this
     /// snapshot's diagnostic pass. STEP 1 is position-invariant within one
@@ -253,6 +257,7 @@ impl DiagnosticsSnapshot {
             cycle_closing_snippet,
             package_library: state.package_library.clone(),
             file_type: doc.file_type,
+            chunk_kind: doc.chunk_kind,
             parent_prefix_cache: std::cell::RefCell::new(scope::ParentPrefixCache::new()),
             scope_contribution: state.package_state.scope_contribution().clone(),
         })
@@ -320,6 +325,14 @@ pub(crate) fn diagnostics_from_snapshot(
     // Use snapshot.file_type (from document) instead of URI-based detection,
     // so untitled buffers with languageId "jags"/"stan" are correctly identified.
     if snapshot.file_type != FileType::R {
+        return Some(Vec::new());
+    }
+
+    // Suppress diagnostics for R Markdown / Quarto documents. The tree-sitter
+    // R parser sees prose, YAML, and non-R fenced blocks as garbage, so every
+    // non-R line becomes a syntax error. The outline still works (see
+    // `document_symbol`); only the diagnostic noise is gated.
+    if snapshot.chunk_kind == crate::chunks::ChunkKind::Rmd {
         return Some(Vec::new());
     }
 
@@ -4058,6 +4071,13 @@ pub fn diagnostics(state: &WorldState, uri: &Url, cancel: &DiagCancelToken) -> V
     };
 
     if doc.tree.is_none() {
+        return Vec::new();
+    }
+
+    // Suppress diagnostics for R Markdown / Quarto documents — prose lines
+    // would otherwise surface as spurious syntax errors. See the matching
+    // guard in `diagnostics_from_snapshot`.
+    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd {
         return Vec::new();
     }
 
@@ -17474,6 +17494,29 @@ result <- data %>% filter(x > 0)
             .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
             .expect("chunk entry");
         assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
+    fn test_diagnostics_suppressed_for_rmd_documents() {
+        // The R tree-sitter parser sees prose as garbage. Gating prevents
+        // every non-R line from surfacing as a syntax error.
+        use crate::state::{Document, WorldState};
+
+        let prose_with_chunk = "# A heading\n\nSome prose with [a link](url).\n\n```{r}\nx <- 1\n```\n";
+        let uri = Url::parse("file:///doc.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.cross_file_config.diagnostics_enabled = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(prose_with_chunk, None, &uri));
+
+        let diags = super::diagnostics(&state, &uri, &DiagCancelToken::never());
+        assert!(
+            diags.is_empty(),
+            "Rmd documents should produce zero diagnostics, got {} ({:?})",
+            diags.len(),
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3548,11 +3548,10 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             let extractor = SymbolExtractor::new(&text, tree.root_node());
             let mut raw_symbols = extractor.extract_all();
             // Surface R Markdown / Quarto code chunks and `.R` `# %%` cells
-            // in the outline. Classification is URI-based: `.Rmd`/`.qmd`
-            // files get fenced chunks, anything else gets `# %%` cells (the
-            // detector finds nothing in plain `.R` files without markers).
-            let chunk_kind = crate::chunks::classify_chunk_document(uri.path());
-            raw_symbols.extend(extractor.extract_chunks(chunk_kind));
+            // in the outline. The Document carries the resolved kind so that
+            // untitled buffers (no file extension) still classify correctly
+            // via their `languageId`.
+            raw_symbols.extend(extractor.extract_chunks(doc.chunk_kind));
             raw_symbols
         }
     };
@@ -17464,6 +17463,34 @@ result <- data %>% filter(x > 0)
         state
             .documents
             .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+        let chunk = symbols
+            .iter()
+            .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
+            .expect("chunk entry");
+        assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
+    fn test_document_symbol_includes_chunks_for_untitled_rmd_buffer() {
+        // Untitled buffers have no extension to inspect. The `languageId`
+        // is the only signal we have for distinguishing Rmd/Quarto from
+        // plain R, so the Document must preserve that classification.
+        use crate::state::{Document, WorldState};
+
+        let code = "Some prose.\n\n```{r setup}\nx <- 1\n```\n";
+        let uri = Url::parse("untitled:Untitled-1").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state.documents.insert(
+            uri.clone(),
+            Document::new_with_language_id(code, None, &uri, Some("rmd")),
+        );
 
         let response = super::document_symbol(&state, &uri).expect("response");
         let symbols = match response {

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -1038,6 +1038,12 @@ pub enum DocumentSymbolKind {
     Interface,
     /// R code section comment (SymbolKind::MODULE)
     Module,
+    /// R Markdown / Quarto code chunk or `# %%` cell (SymbolKind::OBJECT).
+    ///
+    /// Kept distinct from `Module` so the outline filter (and clients that map
+    /// symbol kinds to icons) can include or exclude chunks separately from
+    /// section headers.
+    Chunk,
 }
 
 impl DocumentSymbolKind {
@@ -1072,6 +1078,7 @@ impl DocumentSymbolKind {
             Self::Method => SymbolKind::METHOD,
             Self::Interface => SymbolKind::INTERFACE,
             Self::Module => SymbolKind::MODULE,
+            Self::Chunk => SymbolKind::OBJECT,
         }
     }
 }
@@ -2079,6 +2086,81 @@ impl<'a> SymbolExtractor<'a> {
         sections.sort_by_key(|s| s.range.start.line);
 
         sections
+    }
+
+    /// Extract R Markdown / Quarto chunks (or `# %%` cells) as outline entries.
+    ///
+    /// Each chunk becomes a `RawSymbol` with:
+    /// - `name`: the chunk label if present (e.g. `setup` for `{r setup}` or
+    ///   the trailing text for `# %% Setup`), otherwise `Chunk #N` numbered by
+    ///   source order across the whole document.
+    /// - `detail`: the bracketed language tag for non-R chunks (e.g. `{python}`),
+    ///   `None` for R chunks and for `# %%` cells.
+    /// - `kind`: [`DocumentSymbolKind::Chunk`] (maps to `SymbolKind::OBJECT`),
+    ///   distinct from sections so the outline filter can include or exclude
+    ///   them separately.
+    /// - `range`: header line through the last content line of the chunk
+    ///   (closing fence line, when present, for Rmd chunks).
+    /// - `selection_range`: the header line itself.
+    pub fn extract_chunks(&self, kind: crate::chunks::ChunkKind) -> Vec<RawSymbol> {
+        let chunks = crate::chunks::detect_chunks(self.text, kind);
+        let lines: Vec<&str> = self.text.lines().collect();
+        let mut symbols = Vec::with_capacity(chunks.len());
+
+        for (idx, chunk) in chunks.iter().enumerate() {
+            let header_idx = chunk.header_line as usize;
+            let header_text = lines.get(header_idx).copied().unwrap_or("");
+            let header_end_utf16 = utf16_len(header_text);
+
+            // Range end is the closing fence (Rmd) or the last content line.
+            let range_end_line = chunk.closing_fence_line.unwrap_or(chunk.end_line);
+            let range_end_idx = range_end_line as usize;
+            let range_end_text = lines.get(range_end_idx).copied().unwrap_or("");
+            let range_end_char = utf16_len(range_end_text);
+
+            let range = Range {
+                start: Position {
+                    line: chunk.header_line,
+                    character: 0,
+                },
+                end: Position {
+                    line: range_end_line,
+                    character: range_end_char,
+                },
+            };
+            let selection_range = Range {
+                start: Position {
+                    line: chunk.header_line,
+                    character: 0,
+                },
+                end: Position {
+                    line: chunk.header_line,
+                    character: header_end_utf16,
+                },
+            };
+
+            let name = chunk
+                .label
+                .clone()
+                .unwrap_or_else(|| format!("Chunk #{}", idx + 1));
+            let detail = if chunk.language == "r" || chunk.language.is_empty() {
+                None
+            } else {
+                Some(format!("{{{}}}", chunk.language))
+            };
+
+            symbols.push(RawSymbol {
+                name,
+                kind: DocumentSymbolKind::Chunk,
+                range,
+                selection_range,
+                detail,
+                section_level: None,
+                children: Vec::new(),
+            });
+        }
+
+        symbols
     }
 
     /// Extract decorative banner and inline headings for JAGS and Stan files.
@@ -3464,7 +3546,13 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
         }
         FileType::R => {
             let extractor = SymbolExtractor::new(&text, tree.root_node());
-            let raw_symbols = extractor.extract_all();
+            let mut raw_symbols = extractor.extract_all();
+            // Surface R Markdown / Quarto code chunks and `.R` `# %%` cells
+            // in the outline. Classification is URI-based: `.Rmd`/`.qmd`
+            // files get fenced chunks, anything else gets `# %%` cells (the
+            // detector finds nothing in plain `.R` files without markers).
+            let chunk_kind = crate::chunks::classify_chunk_document(uri.path());
+            raw_symbols.extend(extractor.extract_chunks(chunk_kind));
             raw_symbols
         }
     };
@@ -17222,6 +17310,172 @@ result <- data %>% filter(x > 0)
 
         let section = symbols.iter().find(|s| s.name == "my_section").unwrap();
         assert!(matches!(section.kind, DocumentSymbolKind::Module));
+    }
+
+    // ========================================================================
+    // extract_chunks() unit tests
+    // ========================================================================
+
+    #[test]
+    fn test_extract_chunks_rmd_basic() {
+        let code = "Some prose.\n\n```{r}\nx <- 1\n```\n";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "Chunk #1");
+        assert_eq!(chunks[0].detail, None);
+        assert!(matches!(chunks[0].kind, DocumentSymbolKind::Chunk));
+        // Range covers the fenced block from opener through the closing fence.
+        assert_eq!(chunks[0].range.start.line, 2);
+        assert_eq!(chunks[0].range.end.line, 4);
+        // Selection range is the header line only.
+        assert_eq!(chunks[0].selection_range.start.line, 2);
+        assert_eq!(chunks[0].selection_range.end.line, 2);
+    }
+
+    #[test]
+    fn test_extract_chunks_uses_label_when_present() {
+        let code = "```{r setup, eval=FALSE}\nlibrary(dplyr)\n```";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "setup");
+    }
+
+    #[test]
+    fn test_extract_chunks_non_r_language_in_detail() {
+        let code = "```{python}\nprint('hi')\n```\n\n```{julia}\n1+1\n```";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].detail.as_deref(), Some("{python}"));
+        assert_eq!(chunks[1].detail.as_deref(), Some("{julia}"));
+    }
+
+    #[test]
+    fn test_extract_chunks_r_chunk_has_no_detail() {
+        // R chunks (and R cells) should not duplicate the language tag in
+        // detail — the outline's symbol kind already conveys "this is a chunk".
+        let code = "```{r setup}\n1\n```";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks[0].detail, None);
+    }
+
+    #[test]
+    fn test_extract_chunks_auto_numbers_unlabeled() {
+        let code = "```{r}\n1\n```\n\n```{r}\n2\n```\n\n```{r named}\n3\n```";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 3);
+        // Auto-numbering counts every chunk, not just unlabeled ones, so the
+        // third labeled chunk doesn't reset the counter.
+        assert_eq!(chunks[0].name, "Chunk #1");
+        assert_eq!(chunks[1].name, "Chunk #2");
+        assert_eq!(chunks[2].name, "named");
+    }
+
+    #[test]
+    fn test_extract_chunks_r_cells() {
+        let code = "# %% Setup\nlibrary(x)\n\n# %% Analysis\ny <- 2";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::R);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].name, "Setup");
+        assert_eq!(chunks[1].name, "Analysis");
+        // Cells never have a language detail since they're always R.
+        assert!(chunks.iter().all(|c| c.detail.is_none()));
+    }
+
+    #[test]
+    fn test_extract_chunks_unlabeled_cell_uses_chunk_n() {
+        let code = "# %%\nx <- 1\n# %%\ny <- 2";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::R);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].name, "Chunk #1");
+        assert_eq!(chunks[1].name, "Chunk #2");
+    }
+
+    #[test]
+    fn test_extract_chunks_unclosed_runs_to_eof() {
+        let code = "```{r}\nx <- 1\nprint(x)";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let chunks = extractor.extract_chunks(crate::chunks::ChunkKind::Rmd);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].range.start.line, 0);
+        // Without a closing fence, the range extends to the last content line.
+        assert_eq!(chunks[0].range.end.line, 2);
+    }
+
+    #[test]
+    fn test_chunk_lsp_kind_is_object() {
+        // Distinct from sections (MODULE) so clients can filter independently.
+        assert_eq!(DocumentSymbolKind::Chunk.to_lsp_kind(), SymbolKind::OBJECT);
+    }
+
+    #[test]
+    fn test_document_symbol_includes_chunks_for_rmd_uri() {
+        use crate::state::{Document, WorldState};
+
+        let code = "Some prose.\n\n```{r setup}\nx <- 1\n```\n";
+        let uri = Url::parse("file:///test.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        // The outline should include both the `x` assignment (R-parsed) and
+        // the `setup` chunk (text-detected). We don't pin the count because
+        // the parser may or may not surface `x` depending on how the prose
+        // confuses tree-sitter-r; the chunk entry is the contract.
+        let chunk = symbols
+            .iter()
+            .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
+            .expect("chunk entry");
+        assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
+    fn test_document_symbol_includes_cells_for_r_uri() {
+        use crate::state::{Document, WorldState};
+
+        let code = "# %% Setup\nlibrary(x)\n\n# %% Analysis\ny <- 2";
+        let uri = Url::parse("file:///test.R").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        let cell_names: Vec<&str> = symbols
+            .iter()
+            .filter(|s| s.kind == SymbolKind::OBJECT)
+            .map(|s| s.name.as_str())
+            .collect();
+        assert!(cell_names.contains(&"Setup"));
+        assert!(cell_names.contains(&"Analysis"));
     }
 
     // ========================================================================

--- a/crates/raven/src/lib.rs
+++ b/crates/raven/src/lib.rs
@@ -19,6 +19,7 @@ pub mod test_utils;
 // Transitive dependencies of the above modules:
 pub mod backend;
 pub mod builtins;
+pub mod chunks;
 pub mod completion_context;
 pub mod content_provider;
 pub mod document_store;

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -7,6 +7,7 @@
 
 mod backend;
 mod builtins;
+mod chunks;
 mod cli;
 mod completion_context;
 mod content_provider;

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -241,6 +241,17 @@ impl Document {
     pub fn text(&self) -> String {
         self.contents.to_string()
     }
+
+    /// True when the document is an R Markdown / Quarto document. The R
+    /// tree-sitter parser sees the prose/YAML/non-R portions as syntax
+    /// errors, so handlers that don't understand chunks should treat the
+    /// document as off-limits and return empty results.
+    ///
+    /// The document outline (`document_symbol`) is the exception — it
+    /// intentionally processes chunk markers via the text-based detector.
+    pub fn is_rmd_document(&self) -> bool {
+        self.chunk_kind == ChunkKind::Rmd
+    }
 }
 
 fn utf16_offset_to_char_offset(line_text: &str, utf16_offset: usize) -> usize {

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -138,6 +138,7 @@ use crate::cross_file::{
     CrossFileActivityState, CrossFileConfig, CrossFileFileCache, CrossFileRevalidationState,
     CrossFileWorkspaceIndex, DependencyGraph, MetadataCache,
 };
+use crate::chunks::{classify_chunk_document, classify_chunk_document_for, ChunkKind};
 use crate::document_store::DocumentStore;
 use crate::file_type::{file_type_from_language_id_or_uri, file_type_from_uri, FileType};
 use crate::package_library::PackageLibrary;
@@ -150,6 +151,11 @@ pub struct Document {
     pub tree: Option<Tree>,
     pub loaded_packages: Vec<String>,
     pub file_type: FileType,
+    /// Chunk-detection kind for the outline: `Rmd` for `.Rmd`/`.qmd` documents
+    /// and for untitled buffers whose `languageId` is `rmd`/`quarto`; `R`
+    /// (i.e. `# %%` cells) otherwise. Mirrors the client-side classifier in
+    /// `editors/vscode/src/chunks/chunk-detector.ts`.
+    pub chunk_kind: ChunkKind,
     pub version: Option<i32>,
     pub revision: u64,
 }
@@ -161,7 +167,9 @@ impl Document {
     }
 
     pub fn new_with_uri(text: &str, version: Option<i32>, uri: &Url) -> Self {
-        Self::new_with_file_type(text, version, file_type_from_uri(uri))
+        let mut doc = Self::new_with_file_type(text, version, file_type_from_uri(uri));
+        doc.chunk_kind = classify_chunk_document(uri.path());
+        doc
     }
 
     pub fn new_with_language_id(
@@ -170,11 +178,13 @@ impl Document {
         uri: &Url,
         language_id: Option<&str>,
     ) -> Self {
-        Self::new_with_file_type(
+        let mut doc = Self::new_with_file_type(
             text,
             version,
             file_type_from_language_id_or_uri(language_id, uri),
-        )
+        );
+        doc.chunk_kind = classify_chunk_document_for(language_id, uri.path());
+        doc
     }
 
     pub fn new_with_file_type(text: &str, version: Option<i32>, file_type: FileType) -> Self {
@@ -186,6 +196,9 @@ impl Document {
             tree,
             loaded_packages,
             file_type,
+            // Default to `# %%` cell detection; URI/languageId-aware
+            // constructors override this above.
+            chunk_kind: ChunkKind::R,
             version,
             revision: 0,
         }

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -18,6 +18,8 @@ Fenced blocks may use either backticks or tildes, and four-or-more-character fen
 
 Only **R** chunks are sent to the R console. Chunks tagged with other languages (`{python}`, `{bash}`, `{julia}`, …) are still recognized for navigation and outline but not for execution.
 
+Chunks also appear in the document outline (`Cmd/Ctrl+Shift+O`) as a distinct symbol kind, separate from section headers — see [Document Outline](./document-outline.md#r-markdown--quarto-chunks).
+
 ## Keyboard shortcuts
 
 | Mac | Windows/Linux | Action |

--- a/docs/document-outline.md
+++ b/docs/document-outline.md
@@ -103,7 +103,7 @@ These patterns are **not** recognized as sections:
 
 For `.Rmd` and `.qmd` files, every fenced code chunk gets its own outline entry. The label, if present, becomes the entry name; unlabeled chunks fall back to `Chunk #N` numbered in source order across the whole document. For non-R chunks (`{python}`, `{julia}`, ...) the language tag appears in the detail field.
 
-```rmd
+````rmd
 ```{r setup, include=FALSE}
 library(dplyr)
 ```
@@ -115,7 +115,7 @@ analysis(data)
 ```{python}
 print("hi")
 ```
-```
+````
 
 Outline view shows:
 

--- a/docs/document-outline.md
+++ b/docs/document-outline.md
@@ -8,6 +8,7 @@ The document outline appears in VS Code's **Outline** view (usually in the Explo
 
 - **Hierarchical symbol tree** - See nested functions, variables within sections, and class methods
 - **R code sections** - Organize your code with collapsible section headers (`# Section ----`)
+- **R Markdown / Quarto chunks** - Each ```` ```{r ...} ```` block (and `# %%` cell in plain `.R` files) appears as its own outline entry, distinct from section headers
 - **Rich symbol types** - Distinguish functions, constants, classes, and methods with distinct icons
 - **Quick navigation** - Click any symbol to jump to its definition
 - **JAGS/Stan model structure** - Navigate JAGS and Stan model files with blocks, decorative comment headings, and `for` loops
@@ -97,6 +98,48 @@ These patterns are **not** recognized as sections:
 # ----                (no text content)
 # Section --          (only 2 delimiters, need 4+)
 ```
+
+## R Markdown / Quarto Chunks
+
+For `.Rmd` and `.qmd` files, every fenced code chunk gets its own outline entry. The label, if present, becomes the entry name; unlabeled chunks fall back to `Chunk #N` numbered in source order across the whole document. For non-R chunks (`{python}`, `{julia}`, ...) the language tag appears in the detail field.
+
+```rmd
+```{r setup, include=FALSE}
+library(dplyr)
+```
+
+```{r}
+analysis(data)
+```
+
+```{python}
+print("hi")
+```
+```
+
+Outline view shows:
+
+```text
+setup
+Chunk #2
+Chunk #3        {python}
+```
+
+Chunks use a distinct symbol kind (`OBJECT`) so the outline filter can include or exclude them separately from section headers.
+
+### `# %%` cells in `.R` files
+
+Plain `.R` files use the VS Code interactive-cell convention: a `# %%` line starts a new cell that runs until the next marker, a section divider, or end of file. Any text after the marker is used as the label:
+
+```r
+# %% Setup
+library(dplyr)
+
+# %% Analysis
+fit_model(data)
+```
+
+Cells with no trailing text fall back to `Chunk #N`.
 
 ## Symbol Types
 
@@ -432,7 +475,7 @@ model <- fit_model(processed_data)
 
 ### Outline view is empty
 
-1. Verify the file extension is `.R`, `.jags`, `.bugs`, or `.stan`
+1. Verify the file extension is `.R`, `.Rmd`, `.qmd`, `.jags`, `.bugs`, or `.stan`
 2. Check that Raven is running (status bar shows "Raven")
 3. Reload VS Code: **Ctrl+Shift+P** → "Developer: Reload Window"
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -160,26 +160,32 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
     const outputChannel = vscode.window.createOutputChannel('Raven');
 
     const clientOptions: LanguageClientOptions = {
-        // Deliberate scope: the Rust tree-sitter parser is R-only, so the
-        // selector does NOT include the `rmd` / `quarto` language IDs.
-        // Subscribing to them would surface prose lines as syntax errors and
-        // diagnostics. Chunk-level LSP features inside `.Rmd` / `.qmd` are
-        // tracked as a follow-up to #230 and will need a more targeted flow
-        // (e.g. virtual-document injection per fenced R block).
+        // `rmd` and `quarto` are included so the document outline can surface
+        // chunk entries (issue #227). The server side gates diagnostics for
+        // these documents because the R tree-sitter parser would otherwise
+        // emit syntax errors on prose. Chunk-level LSP features inside R
+        // chunks (hover/completion/go-to-def) are tracked as a follow-up to
+        // #230 and will need a more targeted flow (e.g. virtual-document
+        // injection per fenced R block).
         documentSelector: [
             { scheme: 'file', language: 'r' },
             { scheme: 'untitled', language: 'r' },
+            { scheme: 'file', language: 'rmd' },
+            { scheme: 'untitled', language: 'rmd' },
+            { scheme: 'file', language: 'quarto' },
+            { scheme: 'untitled', language: 'quarto' },
             { scheme: 'file', language: 'jags' },
             { scheme: 'untitled', language: 'jags' },
             { scheme: 'file', language: 'stan' },
             { scheme: 'untitled', language: 'stan' },
         ],
         synchronize: {
-            // Matches the LSP `documentSelector` above: only the file extensions
-            // mapped to the `r` / `jags` / `stan` language IDs. `.Rmd` / `.qmd`
-            // are tracked under `rmd` / `quarto` and the server does not parse
-            // them, so they are intentionally omitted from this glob.
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.{r,R,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}'),
+            // Matches the LSP `documentSelector` above. `.Rmd` / `.qmd` are
+            // included so workspace file events for those documents reach the
+            // server too.
+            fileEvents: vscode.workspace.createFileSystemWatcher(
+                '**/*.{r,R,rmd,Rmd,RMD,qmd,Qmd,QMD,jags,Jags,JAGS,bugs,Bugs,BUGS,stan,Stan,STAN}',
+            ),
         },
         outputChannel: outputChannel,
         initializationOptions: getInitializationOptions,


### PR DESCRIPTION
Closes #227.

## What's in

- New text-based chunk detector `crates/raven/src/chunks.rs` — a faithful Rust port of `editors/vscode/src/chunks/chunk-detector.ts`. Detects:
  - ```` ```{r ...} ```` / `~~~{r ...}` fenced blocks (backticks **or** tildes, ≥3-char fences, matching close required).
  - `.R` `# %%` cell markers, with RStudio-style `# Title ----` dividers closing the cell.
- `SymbolExtractor::extract_chunks(kind)` emits a `RawSymbol` per chunk:
  - **name**: header label (`{r setup}` → `setup`, `# %% Setup` → `Setup`) or `Chunk #N` fallback.
  - **detail**: `{python}`, `{julia}`, … for non-R chunks; `None` for R chunks and `# %%` cells.
  - **kind**: new `DocumentSymbolKind::Chunk` → `SymbolKind::OBJECT`, distinct from sections (MODULE) so the outline filter can include/exclude chunks independently.
  - **range**: header line through the closing fence (Rmd) or last content line (cells / unclosed chunks).
  - **selection_range**: header line only.
- `document_symbol` calls `extract_chunks` for `FileType::R`, with URI-based classification: `.Rmd`/`.qmd` → fenced, anything else → `# %%` cells.

## Why option 1 (server-side AST)

The issue floated either re-implementing detection in Rust or adding an extension-to-server custom request. Option 1 — done here — keeps the outline self-contained and works for non-VS-Code LSP clients. Detection is text-based (the chunks already mostly live outside tree-sitter-r's grammar) so the two detectors can stay aligned line-for-line.

## Test plan

- [x] `cargo test -p raven` — 7373 tests, 0 failures (includes 13 new `chunks::tests::*`, 8 new `test_extract_chunks_*`, and 2 new `test_document_symbol_includes_*` end-to-end tests).
- [x] `cargo build --release -p raven` — clean.
- [x] `bun test tests/bun/chunk-detector.test.ts` — original 61 TS detector tests still pass.
- [x] `bun run typecheck` in `editors/vscode/` — clean.
- [ ] CI: full bun + cargo + vscode-test suites.
- [ ] Manual smoke: open a `.Rmd`, check the outline view for chunk entries with the right names and language tags.

## Out of scope

- Hooking chunk visibility into a new outline-filter setting. The new symbol kind already lets VS Code's built-in outline filter (`OUTLINE: Filter`) include/exclude chunks separately; a dedicated setting can land later if users ask for it.
- Surfacing `eval = FALSE` differently in the outline. The detector recognizes the option (and tests confirm headers parse cleanly), but the outline doesn't dim or annotate eval=FALSE chunks today.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * R code chunks and cells now appear as distinct entries in the document outline (Cmd/Ctrl+O)
  * Supports R Markdown/Quarto fenced chunks and `# %%` cell markers in plain R files
  * Labeled chunks show custom names; unlabeled chunks are auto-numbered ("Chunk #1", etc.)
  * Non-R chunk languages are shown as a detail in the outline

* **Documentation**
  * Docs updated to describe chunk/cell outline behavior and supported extensions (.Rmd, .qmd)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/240)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->