### PR TITLE
feat(linting): bundle of 9 lintr-equivalent style rules

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -440,7 +440,9 @@ pub(crate) fn parse_cross_file_config(
 /// Recognised keys:
 /// * `enabled` (bool) — master switch.
 /// * `lineLength` (number) — max line length; clamped to `[20, 10_000]`.
+/// * `objectLength` (number) — max identifier length; clamped to `[5, 1_000]`.
 /// * `assignmentOperator` (`"<-"` or `"="`) — preferred operator.
+/// * `stringDelimiter` (`"\""` or `"'"`) — preferred string delimiter.
 /// * `objectNameStyleFunction`, `objectNameStyleVariable`,
 ///   `objectNameStyleArgument` (string, one of `"snake_case" | "camelCase" |
 ///   "dotted.case" | "UPPER_CASE" | "lowercase" | "any"`) — naming scheme
@@ -456,6 +458,15 @@ pub(crate) fn parse_cross_file_config(
 ///   - `objectNameSeverity`
 ///   - `infixSpacesSeverity`
 ///   - `commentedCodeSeverity`
+///   - `quotesSeverity`
+///   - `commasSeverity`
+///   - `tAndFSymbolSeverity`
+///   - `semicolonSeverity`
+///   - `equalsNaSeverity`
+///   - `objectLengthSeverity`
+///   - `vectorLogicSeverity`
+///   - `functionLeftParenthesesSeverity`
+///   - `spacesInsideSeverity`
 pub(crate) fn parse_lint_config(
     settings: &serde_json::Value,
 ) -> Option<crate::linting::LintConfig> {
@@ -477,6 +488,11 @@ pub(crate) fn parse_lint_config(
         // is well below u32::MAX so the post-clamp cast is lossless.
         config.line_length = v.clamp(20, 10_000) as u32;
     }
+    if let Some(v) = linting.get("objectLength").and_then(|v| v.as_u64()) {
+        // Same clamp-first pattern as `lineLength`. The floor of 5 keeps
+        // single-letter conventions usable; the ceiling is well below u32::MAX.
+        config.object_length = v.clamp(5, 1_000) as u32;
+    }
     if let Some(op) = linting.get("assignmentOperator").and_then(|v| v.as_str()) {
         config.assignment_operator_style = match op {
             "=" => crate::linting::AssignmentOperatorStyle::Equals,
@@ -486,6 +502,18 @@ pub(crate) fn parse_lint_config(
                     "Unrecognised linting.assignmentOperator '{other}', defaulting to '<-'."
                 );
                 crate::linting::AssignmentOperatorStyle::LeftArrow
+            }
+        };
+    }
+    if let Some(d) = linting.get("stringDelimiter").and_then(|v| v.as_str()) {
+        config.string_delimiter = match d {
+            "\"" => crate::linting::StringDelimiter::Double,
+            "'" => crate::linting::StringDelimiter::Single,
+            other => {
+                log::warn!(
+                    "Unrecognised linting.stringDelimiter '{other}', defaulting to '\"'."
+                );
+                crate::linting::StringDelimiter::Double
             }
         };
     }
@@ -543,14 +571,55 @@ pub(crate) fn parse_lint_config(
     {
         config.commented_code_severity = parse_severity(sev);
     }
+    if let Some(sev) = linting.get("quotesSeverity").and_then(|v| v.as_str()) {
+        config.quotes_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting.get("commasSeverity").and_then(|v| v.as_str()) {
+        config.commas_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("tAndFSymbolSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.t_and_f_symbol_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting.get("semicolonSeverity").and_then(|v| v.as_str()) {
+        config.semicolon_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting.get("equalsNaSeverity").and_then(|v| v.as_str()) {
+        config.equals_na_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("objectLengthSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.object_length_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting.get("vectorLogicSeverity").and_then(|v| v.as_str()) {
+        config.vector_logic_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("functionLeftParenthesesSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.function_left_parentheses_severity = parse_severity(sev);
+    }
+    if let Some(sev) = linting
+        .get("spacesInsideSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.spaces_inside_severity = parse_severity(sev);
+    }
 
     log::info!("Linting configuration loaded from LSP settings:");
     log::info!("  enabled: {}", config.enabled);
     log::info!("  line_length: {}", config.line_length);
+    log::info!("  object_length: {}", config.object_length);
     log::info!(
         "  assignment_operator_style: {:?}",
         config.assignment_operator_style
     );
+    log::info!("  string_delimiter: {:?}", config.string_delimiter);
     log::info!(
         "  severities: line={:?} ws={:?} tab={:?} blank={:?} assign={:?} obj_name={:?} infix_spaces={:?} commented_code={:?}",
         config.line_length_severity,
@@ -561,6 +630,18 @@ pub(crate) fn parse_lint_config(
         config.object_name_severity,
         config.infix_spaces_severity,
         config.commented_code_severity
+    );
+    log::info!(
+        "  severities: quotes={:?} commas={:?} t_and_f={:?} semicolon={:?} equals_na={:?} object_length={:?} vector_logic={:?} function_left_paren={:?} spaces_inside={:?}",
+        config.quotes_severity,
+        config.commas_severity,
+        config.t_and_f_symbol_severity,
+        config.semicolon_severity,
+        config.equals_na_severity,
+        config.object_length_severity,
+        config.vector_logic_severity,
+        config.function_left_parentheses_severity,
+        config.spaces_inside_severity,
     );
     log::info!(
         "  object_name styles: fn={:?} var={:?} arg={:?}",

--- a/crates/raven/src/linting/config.rs
+++ b/crates/raven/src/linting/config.rs
@@ -16,6 +16,17 @@ pub enum AssignmentOperatorStyle {
     Equals,
 }
 
+/// Preferred string-literal delimiter. Mirrors `lintr::quotes_linter` /
+/// `lintr::single_quotes_linter` — the two map to the two enum variants here.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StringDelimiter {
+    /// Require `"..."` for string literals; flag `'...'`. Default.
+    #[default]
+    Double,
+    /// Require `'...'` for string literals; flag `"..."`.
+    Single,
+}
+
 /// Naming scheme used by the `object_name` lint.
 ///
 /// Mirrors `lintr::object_name_linter` styles. `Any` disables the check for a
@@ -52,8 +63,13 @@ pub struct LintConfig {
     /// Maximum allowed line length, measured in UTF-16 code units to align
     /// with how LSP positions are reported.
     pub line_length: u32,
+    /// Maximum allowed identifier length (object-length rule). Identifiers
+    /// longer than this are flagged. Measured in characters of the name.
+    pub object_length: u32,
     /// Preferred assignment operator style.
     pub assignment_operator_style: AssignmentOperatorStyle,
+    /// Preferred string-literal delimiter (used by the `quotes` rule).
+    pub string_delimiter: StringDelimiter,
     /// Required naming scheme for top-level functions (assignments whose RHS
     /// is a `function() ...` expression). Set to [`ObjectNameStyle::Any`] to
     /// disable just the function-name check while keeping variable and
@@ -84,6 +100,25 @@ pub struct LintConfig {
     pub infix_spaces_severity: Option<DiagnosticSeverity>,
     /// Severity for the commented-code rule. `None` disables the rule.
     pub commented_code_severity: Option<DiagnosticSeverity>,
+    /// Severity for the quotes rule (`lintr::quotes_linter`). `None` disables.
+    pub quotes_severity: Option<DiagnosticSeverity>,
+    /// Severity for the commas rule (`lintr::commas_linter`). `None` disables.
+    pub commas_severity: Option<DiagnosticSeverity>,
+    /// Severity for the `T`/`F` symbol rule (`lintr::T_and_F_symbol_linter`).
+    pub t_and_f_symbol_severity: Option<DiagnosticSeverity>,
+    /// Severity for the semicolon rule (`lintr::semicolon_linter`).
+    pub semicolon_severity: Option<DiagnosticSeverity>,
+    /// Severity for the `== NA` / `!= NA` rule (`lintr::equals_na_linter`).
+    pub equals_na_severity: Option<DiagnosticSeverity>,
+    /// Severity for the object-length rule (`lintr::object_length_linter`).
+    pub object_length_severity: Option<DiagnosticSeverity>,
+    /// Severity for the vector-logic rule (`lintr::vector_logic_linter`).
+    pub vector_logic_severity: Option<DiagnosticSeverity>,
+    /// Severity for the function-left-parentheses rule
+    /// (`lintr::function_left_parentheses_linter`).
+    pub function_left_parentheses_severity: Option<DiagnosticSeverity>,
+    /// Severity for the spaces-inside rule (`lintr::spaces_inside_linter`).
+    pub spaces_inside_severity: Option<DiagnosticSeverity>,
 }
 
 impl Default for LintConfig {
@@ -92,7 +127,9 @@ impl Default for LintConfig {
             // Conservative default: feature is opt-in until it stabilizes.
             enabled: false,
             line_length: 80,
+            object_length: 30,
             assignment_operator_style: AssignmentOperatorStyle::default(),
+            string_delimiter: StringDelimiter::default(),
             object_name_style_function: ObjectNameStyle::SnakeCase,
             object_name_style_variable: ObjectNameStyle::SnakeCase,
             object_name_style_argument: ObjectNameStyle::SnakeCase,
@@ -106,6 +143,15 @@ impl Default for LintConfig {
             object_name_severity: Some(DiagnosticSeverity::HINT),
             infix_spaces_severity: Some(DiagnosticSeverity::HINT),
             commented_code_severity: Some(DiagnosticSeverity::HINT),
+            quotes_severity: Some(DiagnosticSeverity::HINT),
+            commas_severity: Some(DiagnosticSeverity::HINT),
+            t_and_f_symbol_severity: Some(DiagnosticSeverity::HINT),
+            semicolon_severity: Some(DiagnosticSeverity::HINT),
+            equals_na_severity: Some(DiagnosticSeverity::HINT),
+            object_length_severity: Some(DiagnosticSeverity::HINT),
+            vector_logic_severity: Some(DiagnosticSeverity::HINT),
+            function_left_parentheses_severity: Some(DiagnosticSeverity::HINT),
+            spaces_inside_severity: Some(DiagnosticSeverity::HINT),
         }
     }
 }

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -18,9 +18,35 @@
 //! * `commented_code` — flag standalone comment blocks whose body parses as R
 //!   and contains a call, assignment, operator, or function definition. This
 //!   rule re-parses each candidate comment body via the thread-local parser
-//!   pool; every other rule walks only the already-parsed tree. The same
-//!   parser pool is also exercised by the suppression parser on the rare
-//!   commented-code line that carries an inline `# nolint` (see below).
+//!   pool. The same parser pool is also exercised by the suppression parser
+//!   on the rare commented-code line that carries an inline `# nolint` (see
+//!   below).
+//! * `quotes` — flag string literals not using the configured delimiter (`"`
+//!   or `'`). Raw strings are exempt.
+//! * `commas` — flag whitespace before `,` and missing whitespace after `,`
+//!   (newline after is fine).
+//! * `t_and_f_symbol` — flag bare `T` / `F` identifiers used as references to
+//!   `TRUE` / `FALSE`. Assignment targets, named arguments, formal
+//!   parameters, and `$` / `@` field names are exempt.
+//! * `semicolon` — flag `;` statement separators in source. Unlike the other
+//!   rules, this one byte-scans the raw source (skipping ranges that the AST
+//!   marks as `string` or `comment`) because tree-sitter-r does not emit `;`
+//!   as a node.
+//! * `equals_na` — flag `x == NA`, `x != NA`, and the typed `NA_*` variants
+//!   on either side.
+//! * `object_length` — flag identifier names longer than the configured
+//!   maximum length.
+//! * `vector_logic` — flag `&` / `|` in `if` / `while` conditions; call
+//!   boundaries stop the scan so `if (any(x & y))` is left alone.
+//! * `function_left_parentheses` — flag whitespace between `function`
+//!   (or `\`) and `(`.
+//! * `spaces_inside` — flag whitespace immediately inside `(`, `[`, `[[`
+//!   and their closers. Empty groupings and multi-line wrapping are exempt.
+//!
+//! Implementation note: every rule except `commented_code` and `semicolon`
+//! walks the already-parsed tree directly. `commented_code` re-parses each
+//! candidate comment body; `semicolon` byte-scans the source text using AST
+//! ranges only to skip strings and comments.
 //!
 //! Suppression supports both lintr and Raven conventions:
 //! * `# nolint` (with optional `: rule_a, rule_b` filter) suppresses the line.

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -41,7 +41,7 @@ mod rules;
 use tower_lsp::lsp_types::Diagnostic;
 use tree_sitter::Node;
 
-pub use self::config::{AssignmentOperatorStyle, LintConfig, ObjectNameStyle};
+pub use self::config::{AssignmentOperatorStyle, LintConfig, ObjectNameStyle, StringDelimiter};
 
 /// Source identifier set on every diagnostic produced by this module.
 ///
@@ -103,6 +103,47 @@ pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Di
     }
     if let Some(sev) = config.commented_code_severity {
         rules::commented_code::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.quotes_severity {
+        rules::quotes::collect(
+            text,
+            tree_root,
+            config.string_delimiter,
+            sev,
+            &suppressions,
+            &mut out,
+        );
+    }
+    if let Some(sev) = config.commas_severity {
+        rules::commas::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.t_and_f_symbol_severity {
+        rules::t_and_f_symbol::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.semicolon_severity {
+        rules::semicolon::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.equals_na_severity {
+        rules::equals_na::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.object_length_severity {
+        rules::object_length::collect(
+            text,
+            tree_root,
+            config.object_length,
+            sev,
+            &suppressions,
+            &mut out,
+        );
+    }
+    if let Some(sev) = config.vector_logic_severity {
+        rules::vector_logic::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.function_left_parentheses_severity {
+        rules::function_left_parentheses::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.spaces_inside_severity {
+        rules::spaces_inside::collect(text, tree_root, sev, &suppressions, &mut out);
     }
 
     out
@@ -245,12 +286,15 @@ mod tests {
             trailing_whitespace_severity: None,
             no_tab_severity: None,
             trailing_blank_lines_severity: None,
+            semicolon_severity: None,
             ..enabled_config()
         };
         // `y = x` inside the function body is a real assignment, not a named
         // argument — even though it lives transitively under an arguments
         // list. Regression: an earlier draft propagated a sticky
         // `inside_call_args` flag through descendants and suppressed this.
+        // Semicolon-severity is disabled in this fixture so the assertion can
+        // focus on the assignment-operator rule.
         let diags = lint("lapply(xs, function(x) { y = x; y })\n", &config);
         assert_eq!(
             diags.len(),
@@ -1133,6 +1177,533 @@ print.data.frame <- function(x, ...) NULL
         let diags = lint("# foo(bar)\n", &config);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].source.as_deref(), Some(LINT_SOURCE));
+    }
+
+    /// Builds a config with every existing rule disabled, leaving only the
+    /// rule under test enabled. Used by the per-rule sub-tests below — each
+    /// rule sets its own severity back on top of this baseline.
+    fn solo_config() -> LintConfig {
+        LintConfig {
+            line_length_severity: None,
+            trailing_whitespace_severity: None,
+            no_tab_severity: None,
+            trailing_blank_lines_severity: None,
+            assignment_operator_severity: None,
+            object_name_severity: None,
+            infix_spaces_severity: None,
+            commented_code_severity: None,
+            quotes_severity: None,
+            commas_severity: None,
+            t_and_f_symbol_severity: None,
+            semicolon_severity: None,
+            equals_na_severity: None,
+            object_length_severity: None,
+            vector_logic_severity: None,
+            function_left_parentheses_severity: None,
+            spaces_inside_severity: None,
+            ..enabled_config()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // quotes
+    // ------------------------------------------------------------------
+
+    fn quotes_only_config() -> LintConfig {
+        LintConfig {
+            quotes_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn quotes_flags_single_when_double_preferred() {
+        let config = quotes_only_config();
+        let diags = lint("x <- 'hi'\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("`'`"));
+        assert!(diags[0].message.contains("`\"`"));
+    }
+
+    #[test]
+    fn quotes_accepts_double() {
+        let config = quotes_only_config();
+        let diags = lint("x <- \"hi\"\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn quotes_skips_raw_strings() {
+        let config = quotes_only_config();
+        // Raw strings — both quote types are common because the body picks.
+        let diags = lint("x <- r'(hi)'\n", &config);
+        assert!(diags.is_empty(), "raw strings must not be flagged: {:?}", diags);
+    }
+
+    #[test]
+    fn quotes_single_mode_flags_double() {
+        let mut config = quotes_only_config();
+        config.string_delimiter = StringDelimiter::Single;
+        let diags = lint("x <- \"hi\"\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("`\"`"));
+        assert!(diags[0].message.contains("`'`"));
+    }
+
+    #[test]
+    fn quotes_respects_nolint() {
+        let config = quotes_only_config();
+        let diags = lint("x <- 'hi' # nolint\n", &config);
+        assert!(diags.is_empty(), "nolint must suppress: {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // commas
+    // ------------------------------------------------------------------
+
+    fn commas_only_config() -> LintConfig {
+        LintConfig {
+            commas_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn commas_flags_space_before() {
+        let config = commas_only_config();
+        let diags = lint("c(1 , 2)\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("before"));
+    }
+
+    #[test]
+    fn commas_flags_missing_space_after() {
+        let config = commas_only_config();
+        let diags = lint("c(1,2)\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("after"));
+    }
+
+    #[test]
+    fn commas_accepts_clean_spacing() {
+        let config = commas_only_config();
+        let diags = lint("c(1, 2, 3)\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn commas_allows_newline_after() {
+        let config = commas_only_config();
+        // A newline after the comma is fine — multi-line argument lists are
+        // common and shouldn't be reformatted.
+        let diags = lint("c(\n  1,\n  2\n)\n", &config);
+        assert!(diags.is_empty(), "newline-after-comma must pass: {:?}", diags);
+    }
+
+    #[test]
+    fn commas_flags_trailing_comma_before_close() {
+        // Matches `lintr::commas_linter(allow_trailing = FALSE)` — `a[1,]`
+        // has no whitespace after `,` so it's still flagged.
+        let config = commas_only_config();
+        let diags = lint("a[1,]\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn commas_in_parameters_are_also_checked() {
+        let config = commas_only_config();
+        // Tree-sitter treats `parameter` commas the same way; the rule walks
+        // them too.
+        let diags = lint("f <- function(a,b) a + b\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // T_and_F_symbol
+    // ------------------------------------------------------------------
+
+    fn t_and_f_only_config() -> LintConfig {
+        LintConfig {
+            t_and_f_symbol_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn t_and_f_flags_bare_t() {
+        let config = t_and_f_only_config();
+        let diags = lint("if (T) 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("TRUE"));
+    }
+
+    #[test]
+    fn t_and_f_flags_bare_f() {
+        let config = t_and_f_only_config();
+        let diags = lint("x <- F\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("FALSE"));
+    }
+
+    #[test]
+    fn t_and_f_accepts_true_false() {
+        let config = t_and_f_only_config();
+        let diags = lint("if (TRUE) 1\nx <- FALSE\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_skips_assignment_target() {
+        let config = t_and_f_only_config();
+        // `T <- 0` — the LHS itself is the assignment target, not a read.
+        let diags = lint("T <- 0\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_skips_named_argument() {
+        let config = t_and_f_only_config();
+        // `foo(T = TRUE)` — the `T` is a parameter label.
+        let diags = lint("foo(T = TRUE)\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_skips_extract_rhs() {
+        let config = t_and_f_only_config();
+        // `obj$T` — `T` is a field name on `obj`.
+        let diags = lint("x <- obj$T\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_flags_extract_lhs() {
+        let config = t_and_f_only_config();
+        // `T$foo` — `T` on the LHS *is* a read of the boolean.
+        let diags = lint("x <- T$foo\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_skips_formal_parameter() {
+        let config = t_and_f_only_config();
+        // `function(T) ...` — declaration of `T` as a parameter, not a read.
+        let diags = lint("f <- function(T) T + 1\n", &config);
+        // Only the *use* of `T` in the body is a read.
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // semicolon
+    // ------------------------------------------------------------------
+
+    fn semicolon_only_config() -> LintConfig {
+        LintConfig {
+            semicolon_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn semicolon_flags_separator() {
+        let config = semicolon_only_config();
+        let diags = lint("a; b\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.character, 1);
+    }
+
+    #[test]
+    fn semicolon_flags_trailing() {
+        let config = semicolon_only_config();
+        let diags = lint("a;\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn semicolon_flags_multiple_per_line() {
+        let config = semicolon_only_config();
+        let diags = lint("a; b; c\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn semicolon_ignores_strings_and_comments() {
+        let config = semicolon_only_config();
+        // `;` inside a string or comment is not a separator.
+        let diags = lint(
+            "x <- \"a;b\"\ny <- 1 # ;\n",
+            &config,
+        );
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // equals_na
+    // ------------------------------------------------------------------
+
+    fn equals_na_only_config() -> LintConfig {
+        LintConfig {
+            equals_na_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn equals_na_flags_x_eq_na() {
+        let config = equals_na_only_config();
+        let diags = lint("x == NA\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("is.na"));
+    }
+
+    #[test]
+    fn equals_na_flags_na_eq_x() {
+        let config = equals_na_only_config();
+        let diags = lint("NA == x\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn equals_na_flags_neq() {
+        let config = equals_na_only_config();
+        let diags = lint("x != NA\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn equals_na_flags_typed_na_variants() {
+        let config = equals_na_only_config();
+        let diags = lint(
+            "x == NA_integer_\nx == NA_real_\nx == NA_character_\nx == NA_complex_\n",
+            &config,
+        );
+        assert_eq!(diags.len(), 4, "got {:?}", diags);
+    }
+
+    #[test]
+    fn equals_na_does_not_flag_is_na() {
+        let config = equals_na_only_config();
+        let diags = lint("is.na(x)\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // object_length
+    // ------------------------------------------------------------------
+
+    fn object_length_only_config(max: u32) -> LintConfig {
+        LintConfig {
+            object_length: max,
+            object_length_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn object_length_flags_overlong_assignment_target() {
+        let config = object_length_only_config(5);
+        let diags = lint("longer_name <- 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("longer_name"));
+        assert!(diags[0].message.contains("11"));
+    }
+
+    #[test]
+    fn object_length_accepts_short_name() {
+        let config = object_length_only_config(5);
+        let diags = lint("ok <- 1\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn object_length_flags_overlong_parameter() {
+        let config = object_length_only_config(5);
+        let diags = lint("f <- function(longer_arg) 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("longer_arg"));
+    }
+
+    #[test]
+    fn object_length_does_not_count_leading_dot() {
+        // `.foo_bar` body is 7 chars; under max=7 a flagged-without-stripping
+        // implementation would mis-count `.foo_bar` as 8. We strip the dot,
+        // so `.foo_bar` is exactly the maximum and passes.
+        let config = object_length_only_config(7);
+        let diags = lint(".foo_bar <- 1\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn object_length_skips_backtick_names() {
+        let config = object_length_only_config(5);
+        let diags = lint("`a very long backtick name` <- 1\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn object_length_skips_compound_lhs() {
+        let config = object_length_only_config(5);
+        // `obj$longer_field <- 1` — assignment doesn't introduce a new symbol.
+        let diags = lint("obj$longer_field <- 1\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // vector_logic
+    // ------------------------------------------------------------------
+
+    fn vector_logic_only_config() -> LintConfig {
+        LintConfig {
+            vector_logic_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn vector_logic_flags_amp_in_if() {
+        let config = vector_logic_only_config();
+        let diags = lint("if (a & b) 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("&&"));
+    }
+
+    #[test]
+    fn vector_logic_flags_pipe_in_while() {
+        let config = vector_logic_only_config();
+        let diags = lint("while (a | b) 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("||"));
+    }
+
+    #[test]
+    fn vector_logic_accepts_double_operators() {
+        let config = vector_logic_only_config();
+        let diags = lint("if (a && b) 1\nwhile (a || b) 1\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn vector_logic_skips_inside_function_call() {
+        // `if (any(x & y))` — the `&` is evaluated inside `any()` on a
+        // vector, not on the condition itself.
+        let config = vector_logic_only_config();
+        let diags = lint("if (any(x & y)) 1\n", &config);
+        assert!(diags.is_empty(), "call boundary must stop scan: {:?}", diags);
+    }
+
+    #[test]
+    fn vector_logic_recurses_through_logical_operators() {
+        // `if (a & b || c)` — the `&` deep inside the condition is still
+        // flagged because the scan recurses through binary operators.
+        let config = vector_logic_only_config();
+        let diags = lint("if (a & b || c) 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // function_left_parentheses
+    // ------------------------------------------------------------------
+
+    fn flp_only_config() -> LintConfig {
+        LintConfig {
+            function_left_parentheses_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn flp_flags_space_after_function() {
+        let config = flp_only_config();
+        let diags = lint("f <- function (x) x\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("function"));
+    }
+
+    #[test]
+    fn flp_accepts_tight() {
+        let config = flp_only_config();
+        let diags = lint("f <- function(x) x\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn flp_flags_lambda_with_space() {
+        let config = flp_only_config();
+        let diags = lint("f <- \\ (x) x\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("\\"));
+    }
+
+    #[test]
+    fn flp_accepts_tight_lambda() {
+        let config = flp_only_config();
+        let diags = lint("f <- \\(x) x\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // spaces_inside
+    // ------------------------------------------------------------------
+
+    fn spaces_inside_only_config() -> LintConfig {
+        LintConfig {
+            spaces_inside_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn spaces_inside_flags_call_with_spaces() {
+        let config = spaces_inside_only_config();
+        let diags = lint("f( x )\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_accepts_tight_call() {
+        let config = spaces_inside_only_config();
+        let diags = lint("f(x)\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_allows_empty_call() {
+        let config = spaces_inside_only_config();
+        // `f()` and `f( )` are both fine — empty groupings are exempt.
+        let diags_empty = lint("f()\n", &config);
+        let diags_padded = lint("f(  )\n", &config);
+        assert!(diags_empty.is_empty(), "got {:?}", diags_empty);
+        assert!(diags_padded.is_empty(), "got {:?}", diags_padded);
+    }
+
+    #[test]
+    fn spaces_inside_flags_subset() {
+        let config = spaces_inside_only_config();
+        let diags = lint("a[ 1 ]\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_flags_subset2() {
+        let config = spaces_inside_only_config();
+        let diags = lint("a[[ 1 ]]\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_allows_multiline_wrapping() {
+        let config = spaces_inside_only_config();
+        // Multi-line argument layout — the leading/trailing newlines are not
+        // single-line whitespace, so no diagnostic.
+        let diags = lint("f(\n  1,\n  2\n)\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_flags_parenthesized_expression() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x <- ( 1 + 2 )\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
     }
 }
 

--- a/crates/raven/src/linting/rules/commas.rs
+++ b/crates/raven/src/linting/rules/commas.rs
@@ -1,0 +1,114 @@
+//! Enforce conventional spacing around `,` separators.
+//!
+//! Mirrors `lintr::commas_linter` defaults: every comma must be tight on the
+//! left (no whitespace before) and must be followed by whitespace (space, tab,
+//! or newline). Tree-sitter-r exposes commas as named `comma` children of
+//! `arguments` and `parameters` nodes, so the rule walks those parents and
+//! inspects each comma's neighbours in the raw text.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "comma" {
+        check_comma(node, text, severity, suppressions, out);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check_comma(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let bytes = text.as_bytes();
+    let start = node.start_byte();
+    let end = node.end_byte();
+
+    // Space before comma: look at the byte immediately before. Only flag a
+    // *single-line* space — a comma at column 0 (after a leading newline) is
+    // a multi-line continuation, not a style violation.
+    if start > 0 {
+        let prev = bytes[start - 1];
+        if prev == b' ' || prev == b'\t' {
+            emit(
+                node,
+                text,
+                severity,
+                suppressions,
+                "Unexpected whitespace before `,`.",
+                out,
+            );
+        }
+    }
+
+    // Missing space after comma: the next byte (if any) must be whitespace or
+    // newline. lintr's default `allow_trailing = FALSE` also flags a comma
+    // followed by a closing bracket (`a[1,]`), so we don't carve that out.
+    if end < bytes.len() {
+        let next = bytes[end];
+        let is_ws = matches!(next, b' ' | b'\t' | b'\n' | b'\r');
+        if !is_ws {
+            emit(
+                node,
+                text,
+                severity,
+                suppressions,
+                "Missing space after `,`.",
+                out,
+            );
+        }
+    }
+}
+
+fn emit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    message: &str,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = node.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, node.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, node.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(node.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: message.to_string(),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/equals_na.rs
+++ b/crates/raven/src/linting/rules/equals_na.rs
@@ -1,0 +1,93 @@
+//! Flag equality comparisons against `NA`.
+//!
+//! Mirrors `lintr::equals_na_linter`. `x == NA` is silently wrong: the result
+//! is itself `NA`, never `TRUE`/`FALSE`. The idiomatic check is `is.na(x)`.
+//! Applies to every typed `NA` token tree-sitter-r recognises (`NA`,
+//! `NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_`), both as `==`
+//! and `!=`, on either side.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "binary_operator" {
+        check(node, text, severity, suppressions, out);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(op) = node.child_by_field_name("operator") else {
+        return;
+    };
+    let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+    if op_text != "==" && op_text != "!=" {
+        return;
+    }
+    let lhs = node.child_by_field_name("lhs");
+    let rhs = node.child_by_field_name("rhs");
+    let na_side = if lhs.is_some_and(is_na_literal) {
+        lhs
+    } else if rhs.is_some_and(is_na_literal) {
+        rhs
+    } else {
+        return;
+    };
+    let Some(na) = na_side else {
+        return;
+    };
+    let line_no = op.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, op.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, op.end_position().column);
+    let na_text = text.get(na.start_byte()..na.end_byte()).unwrap_or("NA");
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(op.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!(
+            "Use `is.na(x)` instead of `x {op_text} {na_text}`; comparison with `NA` returns `NA`."
+        ),
+        ..Default::default()
+    });
+}
+
+/// True when the node is an `na` literal (`NA`, `NA_integer_`, …).
+fn is_na_literal(node: Node<'_>) -> bool {
+    node.kind() == "na"
+}

--- a/crates/raven/src/linting/rules/function_left_parentheses.rs
+++ b/crates/raven/src/linting/rules/function_left_parentheses.rs
@@ -1,0 +1,94 @@
+//! Flag whitespace between `function` (or `\`) and its parameter `(`.
+//!
+//! Mirrors `lintr::function_left_parentheses_linter`. `function (x) ...` and
+//! `\ (x) ...` are valid R but the tight `function(x) ...` / `\(x) ...` is
+//! the community convention. Tree-sitter-r exposes both forms as
+//! `function_definition` with a `name` field holding the `function` keyword
+//! (or `\`) and a `parameters` field holding the `(...)` block.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "function_definition" {
+        check(node, text, severity, suppressions, out);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(name) = node.child_by_field_name("name") else {
+        return;
+    };
+    let Some(params) = node.child_by_field_name("parameters") else {
+        return;
+    };
+    let gap_start = name.end_byte();
+    let gap_end = params.start_byte();
+    if gap_end <= gap_start {
+        return;
+    }
+    let gap = match text.get(gap_start..gap_end) {
+        Some(s) => s,
+        None => return,
+    };
+    if gap.is_empty() {
+        return;
+    }
+    // Any whitespace at all (spaces, tabs, or even newlines) is reported —
+    // the rule wants tight `function(`. Use the slice contents rather than a
+    // separate "any non-whitespace" check because a non-empty gap that's not
+    // whitespace would be a parse anomaly we shouldn't pretend to handle.
+    if !gap.chars().all(|c| c.is_whitespace()) {
+        return;
+    }
+    let keyword = text.get(name.start_byte()..name.end_byte()).unwrap_or("function");
+    let line_no = name.end_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, name.end_position().column);
+    let end_line = params.start_position().row as u32;
+    let end_line_text = text.lines().nth(end_line as usize).unwrap_or("");
+    let end_col = byte_offset_to_utf16_column(end_line_text, params.start_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(end_line, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("Remove whitespace between `{keyword}` and `(`."),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -5,10 +5,19 @@
 //! [`crate::linting::nolint::Suppressions`] before producing output.
 
 pub(crate) mod assignment_operator;
+pub(crate) mod commas;
 pub(crate) mod commented_code;
+pub(crate) mod equals_na;
+pub(crate) mod function_left_parentheses;
 pub(crate) mod infix_spaces;
 pub(crate) mod line_length;
 pub(crate) mod no_tab;
+pub(crate) mod object_length;
 pub(crate) mod object_name;
+pub(crate) mod quotes;
+pub(crate) mod semicolon;
+pub(crate) mod spaces_inside;
+pub(crate) mod t_and_f_symbol;
 pub(crate) mod trailing_blank_lines;
 pub(crate) mod trailing_whitespace;
+pub(crate) mod vector_logic;

--- a/crates/raven/src/linting/rules/object_length.rs
+++ b/crates/raven/src/linting/rules/object_length.rs
@@ -66,10 +66,9 @@ fn check_assignment(
         "->" | "->>" => node.child_by_field_name("rhs"),
         _ => return,
     };
-    // `=` inside an argument list is a named argument, not assignment.
-    if op_text == "=" && node.parent().is_some_and(|p| p.kind() == "argument") {
-        return;
-    }
+    // Note: tree-sitter-r parses `f(name = value)` as an `argument` node
+    // whose `=` is an internal token, not as a `binary_operator`. So named
+    // arguments never reach this branch and need no explicit guard.
     let Some(target) = target else {
         return;
     };
@@ -93,11 +92,13 @@ fn check_parameters(
     };
     let mut cursor = params.walk();
     for child in params.children(&mut cursor) {
-        let ident = match child.kind() {
-            "parameter" | "default_parameter" => child.child_by_field_name("name"),
-            _ => continue,
-        };
-        let Some(ident) = ident else {
+        // Tree-sitter-r exposes formal parameters as `parameter` nodes (whether
+        // or not they carry a default value), so this is the only kind we
+        // need to match. The `dots` token (`...`) is not a user-chosen name.
+        if child.kind() != "parameter" {
+            continue;
+        }
+        let Some(ident) = child.child_by_field_name("name") else {
             continue;
         };
         if ident.kind() != "identifier" {

--- a/crates/raven/src/linting/rules/object_length.rs
+++ b/crates/raven/src/linting/rules/object_length.rs
@@ -1,0 +1,163 @@
+//! Flag identifier names longer than the configured maximum.
+//!
+//! Mirrors `lintr::object_length_linter`. Length is measured in characters
+//! after stripping the same decorative leading-dot that `object_name` accepts
+//! ("hidden identifier" convention). Backtick-quoted names and non-ASCII
+//! identifiers are skipped — matching `object_name`'s carve-outs.
+//!
+//! Only positions that introduce a new symbol are checked:
+//! assignment targets (`<-`, `<<-`, top-level `=`, `->`, `->>`) and formal
+//! parameters of `function_definition`. Compound assignment targets like
+//! `obj$field <- ...` are skipped (the assignment doesn't introduce a new
+//! symbol name — only the LHS field does, and `object_name` already won't
+//! flag those for the same reason).
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    max_length: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, max_length, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    max_length: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    match node.kind() {
+        "binary_operator" => check_assignment(node, text, max_length, severity, suppressions, out),
+        "function_definition" => check_parameters(node, text, max_length, severity, suppressions, out),
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, max_length, severity, suppressions, out);
+    }
+}
+
+fn check_assignment(
+    node: Node<'_>,
+    text: &str,
+    max_length: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(op) = node.child_by_field_name("operator") else {
+        return;
+    };
+    let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+    let target = match op_text {
+        "<-" | "<<-" | "=" => node.child_by_field_name("lhs"),
+        "->" | "->>" => node.child_by_field_name("rhs"),
+        _ => return,
+    };
+    // `=` inside an argument list is a named argument, not assignment.
+    if op_text == "=" && node.parent().is_some_and(|p| p.kind() == "argument") {
+        return;
+    }
+    let Some(target) = target else {
+        return;
+    };
+    if target.kind() != "identifier" {
+        return;
+    }
+    let name = text.get(target.start_byte()..target.end_byte()).unwrap_or("");
+    check_name(target, name, max_length, text, severity, suppressions, out);
+}
+
+fn check_parameters(
+    node: Node<'_>,
+    text: &str,
+    max_length: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(params) = node.child_by_field_name("parameters") else {
+        return;
+    };
+    let mut cursor = params.walk();
+    for child in params.children(&mut cursor) {
+        let ident = match child.kind() {
+            "parameter" | "default_parameter" => child.child_by_field_name("name"),
+            _ => continue,
+        };
+        let Some(ident) = ident else {
+            continue;
+        };
+        if ident.kind() != "identifier" {
+            continue;
+        }
+        let name = text.get(ident.start_byte()..ident.end_byte()).unwrap_or("");
+        check_name(ident, name, max_length, text, severity, suppressions, out);
+    }
+}
+
+fn check_name(
+    name_node: Node<'_>,
+    name: &str,
+    max_length: u32,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if name.is_empty() || should_skip_name(name) {
+        return;
+    }
+    // Strip the optional leading `.` (hidden identifier convention) before
+    // measuring, matching `object_name`'s carve-out.
+    let body = match name.strip_prefix('.') {
+        Some(rest) if !rest.starts_with('.') && !rest.is_empty() => rest,
+        Some(_) => name,
+        None => name,
+    };
+    let len = body.chars().count() as u32;
+    if len <= max_length {
+        return;
+    }
+    let line_no = name_node.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, name_node.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, name_node.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(name_node.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!(
+            "Identifier `{name}` is {len} characters long; maximum is {max_length}."
+        ),
+        ..Default::default()
+    });
+}
+
+fn should_skip_name(name: &str) -> bool {
+    if name.starts_with('`') {
+        return true;
+    }
+    if !name.is_ascii() {
+        return true;
+    }
+    false
+}

--- a/crates/raven/src/linting/rules/quotes.rs
+++ b/crates/raven/src/linting/rules/quotes.rs
@@ -1,0 +1,123 @@
+//! Enforce a single string-literal delimiter (`"` or `'`).
+//!
+//! Mirrors `lintr::quotes_linter` / `lintr::single_quotes_linter` — the
+//! configured delimiter is required for every regular string literal. Raw
+//! strings (`r"(...)"`, `R'(...)'`, `r"---(...)---"`) are skipped: their outer
+//! quote choice is constrained by the body, not by user style.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::config::StringDelimiter;
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    delimiter: StringDelimiter,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, delimiter, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    delimiter: StringDelimiter,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "string" {
+        check_string(node, text, delimiter, severity, suppressions, out);
+        // Strings have no relevant descendants for this rule.
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, delimiter, severity, suppressions, out);
+    }
+}
+
+fn check_string(
+    node: Node<'_>,
+    text: &str,
+    delimiter: StringDelimiter,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let lit = match text.get(node.start_byte()..node.end_byte()) {
+        Some(s) => s,
+        None => return,
+    };
+    if is_raw_string(lit) {
+        return;
+    }
+    let first = match lit.as_bytes().first() {
+        Some(b) => *b,
+        None => return,
+    };
+    let (wanted, got) = match (delimiter, first) {
+        (StringDelimiter::Double, b'\'') => ('"', '\''),
+        (StringDelimiter::Single, b'"') => ('\'', '"'),
+        _ => return,
+    };
+    let line_no = node.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, node.start_position().column);
+    // End column is on the start line only if the string is single-line; for
+    // multi-line strings the end position spans rows, which the LSP supports
+    // natively via `Range::end.line`.
+    let end_line = node.end_position().row as u32;
+    let end_line_text = text.lines().nth(end_line as usize).unwrap_or("");
+    let end_col = byte_offset_to_utf16_column(end_line_text, node.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(end_line, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("String uses `{got}`; configured delimiter is `{wanted}`."),
+        ..Default::default()
+    });
+}
+
+/// Detect R raw-string literals: `r"(...)"`, `R"[...]"`, `r"---(...)---"` etc.
+/// They start with `r`/`R`, then a quote, then optional dashes, then `(` / `[`
+/// / `{`. We only need a minimal prefix check to skip the rule.
+fn is_raw_string(lit: &str) -> bool {
+    let bytes = lit.as_bytes();
+    if bytes.len() < 2 {
+        return false;
+    }
+    if bytes[0] != b'r' && bytes[0] != b'R' {
+        return false;
+    }
+    matches!(bytes[1], b'"' | b'\'')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_string_prefix_is_detected() {
+        assert!(is_raw_string("r\"(hi)\""));
+        assert!(is_raw_string("R\"[hi]\""));
+        assert!(is_raw_string("r'---(hi)---'"));
+        assert!(!is_raw_string("\"hi\""));
+        assert!(!is_raw_string("'hi'"));
+        // `r` alone (e.g. identifier) is not a raw string.
+        assert!(!is_raw_string("r"));
+        assert!(!is_raw_string(""));
+    }
+}

--- a/crates/raven/src/linting/rules/semicolon.rs
+++ b/crates/raven/src/linting/rules/semicolon.rs
@@ -1,0 +1,112 @@
+//! Flag `;` separators in source.
+//!
+//! Mirrors `lintr::semicolon_linter`. Tree-sitter-r does not emit `;` as a
+//! named or anonymous node — it's simply a separator the parser consumes
+//! between statements. To find them we scan the raw source byte-by-byte while
+//! using the tree to skip string-literal and comment ranges.
+//!
+//! Diagnostic anchor: the column of the `;` character itself, on the line it
+//! appears on. We emit one diagnostic per `;` so a line with two semicolons
+//! produces two.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let exclusions = collect_exclusions(root);
+    scan(text, &exclusions, severity, suppressions, out);
+}
+
+/// Sorted, non-overlapping byte ranges of strings and comments — places where
+/// a `;` is not a statement separator.
+fn collect_exclusions(root: Node<'_>) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out.sort_by_key(|&(s, _)| s);
+    out
+}
+
+fn walk(node: Node<'_>, out: &mut Vec<(usize, usize)>) {
+    if matches!(node.kind(), "string" | "comment") {
+        out.push((node.start_byte(), node.end_byte()));
+        // Don't descend into strings; a `;` inside a `string_content` is
+        // never a separator.
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk(child, out);
+    }
+}
+
+fn scan(
+    text: &str,
+    exclusions: &[(usize, usize)],
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let bytes = text.as_bytes();
+    let mut excl_idx = 0;
+    let mut line_starts = vec![0usize];
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    for (offset, &b) in bytes.iter().enumerate() {
+        if b != b';' {
+            continue;
+        }
+        // Advance past any exclusion ranges ending before this offset.
+        while excl_idx < exclusions.len() && exclusions[excl_idx].1 <= offset {
+            excl_idx += 1;
+        }
+        // If this `;` lies inside an exclusion range, skip it.
+        if excl_idx < exclusions.len() {
+            let (s, e) = exclusions[excl_idx];
+            if s <= offset && offset < e {
+                continue;
+            }
+        }
+        // Map byte offset → (line, column).
+        let line_no = match line_starts.binary_search(&offset) {
+            Ok(i) => i,
+            Err(i) => i - 1,
+        };
+        let line_start = line_starts[line_no];
+        let line_end = if line_no + 1 < line_starts.len() {
+            line_starts[line_no + 1] - 1
+        } else {
+            bytes.len()
+        };
+        let line_text = text.get(line_start..line_end).unwrap_or("");
+        let col_byte = offset - line_start;
+        let line_no_u32 = line_no as u32;
+        if suppressions.is_suppressed(line_no_u32) {
+            continue;
+        }
+        let start_col = byte_offset_to_utf16_column(line_text, col_byte);
+        let end_col = byte_offset_to_utf16_column(line_text, col_byte + 1);
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(line_no_u32, start_col),
+                end: Position::new(line_no_u32, end_col),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: "Avoid `;`; put each statement on its own line.".to_string(),
+            ..Default::default()
+        });
+    }
+}

--- a/crates/raven/src/linting/rules/spaces_inside.rs
+++ b/crates/raven/src/linting/rules/spaces_inside.rs
@@ -1,0 +1,184 @@
+//! Flag whitespace immediately inside `(...)`, `[...]`, `[[...]]` groupings.
+//!
+//! Mirrors `lintr::spaces_inside_linter`. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`
+//! all have stray space against the brackets. The community convention is
+//! tight: `f(x)`, `df[1]`, `mat[[i]]`. Empty groupings — `f()`, `f( )`,
+//! `mat[]`, `mat[ ]` — are left alone: there's no token next to the bracket
+//! to crowd, and forcing `f()` vs `f( )` is too pedantic for a hint.
+//!
+//! Applies to `call`, `subset`, `subset2`, and `parenthesized_expression`
+//! nodes. The `open` and `close` field positions are used to anchor the
+//! check; the interior content is the gap between `open` and the first
+//! non-whitespace child, and between the last non-whitespace child and
+//! `close`.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    match node.kind() {
+        "call" | "subset" | "subset2" => {
+            if let Some(args) = node.child_by_field_name("arguments") {
+                check_bracketed(args, text, severity, suppressions, out);
+            }
+        }
+        "parenthesized_expression" => check_bracketed(node, text, severity, suppressions, out),
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check_bracketed(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(open) = node.child_by_field_name("open") else {
+        return;
+    };
+    let Some(close) = node.child_by_field_name("close") else {
+        return;
+    };
+    let open_end = open.end_byte();
+    let close_start = close.start_byte();
+    if close_start <= open_end {
+        return;
+    }
+    // Empty grouping (only whitespace between brackets) — allowed.
+    let interior = match text.get(open_end..close_start) {
+        Some(s) => s,
+        None => return,
+    };
+    if interior.chars().all(|c| c.is_whitespace()) {
+        return;
+    }
+
+    // Find the byte offset of the first non-whitespace character (anchor for
+    // the "after open" check) and the last non-whitespace character (anchor
+    // for the "before close" check).
+    let first_non_ws_rel = interior
+        .char_indices()
+        .find(|&(_, c)| !c.is_whitespace())
+        .map(|(i, _)| i);
+    let last_non_ws_rel = interior
+        .char_indices()
+        .rev()
+        .find(|&(_, c)| !c.is_whitespace())
+        .map(|(i, c)| i + c.len_utf8());
+
+    if let Some(first_rel) = first_non_ws_rel {
+        let after_open = &interior[..first_rel];
+        if !after_open.is_empty() && !after_open.contains('\n') {
+            // Open bracket has *single-line* whitespace before the first
+            // real token — that's the violation. Multi-line wrapping is fine.
+            let open_text = text.get(open.start_byte()..open.end_byte()).unwrap_or("");
+            emit_after_open(
+                open,
+                open_text,
+                after_open.len(),
+                text,
+                severity,
+                suppressions,
+                out,
+            );
+        }
+    }
+    if let Some(last_rel) = last_non_ws_rel {
+        let before_close = &interior[last_rel..];
+        if !before_close.is_empty() && !before_close.contains('\n') {
+            let close_text = text.get(close.start_byte()..close.end_byte()).unwrap_or("");
+            emit_before_close(
+                close,
+                close_text,
+                before_close.len(),
+                text,
+                severity,
+                suppressions,
+                out,
+            );
+        }
+    }
+}
+
+fn emit_after_open(
+    open: Node<'_>,
+    open_text: &str,
+    ws_len: usize,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = open.end_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, open.end_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, open.end_position().column + ws_len);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(line_no, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("Remove whitespace after `{open_text}`."),
+        ..Default::default()
+    });
+}
+
+fn emit_before_close(
+    close: Node<'_>,
+    close_text: &str,
+    ws_len: usize,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = close.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let close_col = close.start_position().column;
+    let start_col_bytes = close_col.saturating_sub(ws_len);
+    let start_col = byte_offset_to_utf16_column(line_text, start_col_bytes);
+    let end_col = byte_offset_to_utf16_column(line_text, close_col);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(line_no, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("Remove whitespace before `{close_text}`."),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -75,7 +75,7 @@ fn is_excluded_position(ident: Node<'_>) -> bool {
                 .child_by_field_name("name")
                 .is_some_and(|name| name.id() == ident.id())
         }
-        "parameter" | "default_parameter" => {
+        "parameter" => {
             // Formal parameter name: `function(T) ...` — declaring, not reading.
             parent
                 .child_by_field_name("name")

--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -1,0 +1,128 @@
+//! Flag bare `T` / `F` identifiers used as references to `TRUE` / `FALSE`.
+//!
+//! Mirrors `lintr::T_and_F_symbol_linter`. `T` and `F` are normal identifiers
+//! in R, not reserved words, so `T <- 0` silently flips the meaning of any
+//! later code that reads `T`. Idiomatic R uses the reserved literals `TRUE`
+//! and `FALSE` instead.
+//!
+//! The rule walks `identifier` nodes whose text is exactly `T` or `F` and
+//! reports them, except in positions where the identifier doesn't actually
+//! reference the value:
+//!
+//! * **Assignment targets** (`T <- 0`, `0 -> T`, top-level `T = 0`). The user
+//!   is explicitly overwriting the name — that *is* the bug, but reporting it
+//!   on the LHS would be redundant with the other reads we already flag, so
+//!   matching lintr we skip the LHS itself.
+//! * **`$` / `@` RHS** (`obj$T`, `obj@F`). These are field names, not symbol
+//!   lookups in the calling scope.
+//! * **Named arguments** (`foo(T = TRUE)`) and **formal parameters**
+//!   (`function(T) ...`). The `T` here is a name in the local syntax, not a
+//!   reference to the boolean.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "identifier" {
+        let name = text.get(node.start_byte()..node.end_byte()).unwrap_or("");
+        if (name == "T" || name == "F") && !is_excluded_position(node) {
+            emit(node, name, text, severity, suppressions, out);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+/// True if the identifier is in a non-reference position — somewhere a `T`/`F`
+/// spelling doesn't read the boolean value.
+fn is_excluded_position(ident: Node<'_>) -> bool {
+    let Some(parent) = ident.parent() else {
+        return false;
+    };
+    match parent.kind() {
+        "binary_operator" => is_assignment_target(parent, ident),
+        "extract_operator" => {
+            // `$` / `@`: skip the RHS field name; LHS is a real reference.
+            parent
+                .child_by_field_name("rhs")
+                .is_some_and(|rhs| rhs.id() == ident.id())
+        }
+        "argument" => {
+            // Named argument: `foo(T = TRUE)` — `T` here is a parameter label.
+            parent
+                .child_by_field_name("name")
+                .is_some_and(|name| name.id() == ident.id())
+        }
+        "parameter" | "default_parameter" => {
+            // Formal parameter name: `function(T) ...` — declaring, not reading.
+            parent
+                .child_by_field_name("name")
+                .is_some_and(|name| name.id() == ident.id())
+        }
+        _ => false,
+    }
+}
+
+/// True iff this identifier is the assignment-target side of `binop`.
+fn is_assignment_target(binop: Node<'_>, ident: Node<'_>) -> bool {
+    let Some(op) = binop.child_by_field_name("operator") else {
+        return false;
+    };
+    let op_text = op.kind();
+    let target = match op_text {
+        "<-" | "<<-" | "=" => binop.child_by_field_name("lhs"),
+        "->" | "->>" => binop.child_by_field_name("rhs"),
+        _ => return false,
+    };
+    target.is_some_and(|t| t.id() == ident.id())
+}
+
+fn emit(
+    node: Node<'_>,
+    name: &str,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = node.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, node.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, node.end_position().column);
+    let preferred = if name == "T" { "TRUE" } else { "FALSE" };
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(node.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!("Use `{preferred}` instead of the symbol `{name}`."),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/vector_logic.rs
+++ b/crates/raven/src/linting/rules/vector_logic.rs
@@ -1,0 +1,104 @@
+//! Flag `&` / `|` in `if` / `while` conditions, where `&&` / `||` is expected.
+//!
+//! Mirrors `lintr::vector_logic_linter`. `if (x & y)` triggers a warning in
+//! R 4.3+ (`condition has length > 1`) and silently does the wrong thing on
+//! older R when either side returns a vector. Scalar short-circuit operators
+//! (`&&` / `||`) are the correct choice in scalar contexts.
+//!
+//! The scan walks the condition expression of each `if_statement` /
+//! `while_statement` and reports every `&` / `|` operator inside, recursively.
+//! Function-call boundaries stop the recursion: `if (any(x & y))` is fine
+//! because the `&` is evaluated inside `any()` on a vector, not on the
+//! condition itself. lintr applies the same carve-out.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if matches!(node.kind(), "if_statement" | "while_statement") {
+        if let Some(cond) = node.child_by_field_name("condition") {
+            scan_condition(cond, text, severity, suppressions, out);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn scan_condition(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    // Stop at call boundaries — the operands of a call are evaluated as a
+    // vector context independently of the surrounding scalar condition.
+    if matches!(node.kind(), "call" | "subset" | "subset2") {
+        return;
+    }
+    if node.kind() == "binary_operator" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+            if op_text == "&" || op_text == "|" {
+                let preferred = if op_text == "&" { "&&" } else { "||" };
+                emit(op, op_text, preferred, text, severity, suppressions, out);
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_condition(child, text, severity, suppressions, out);
+    }
+}
+
+fn emit(
+    op: Node<'_>,
+    op_text: &str,
+    preferred: &str,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = op.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, op.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, op.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(op.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        message: format!(
+            "Use `{preferred}` in `if` / `while` conditions; `{op_text}` is the vectorised form."
+        ),
+        ..Default::default()
+    });
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.semicolonSeverity` | `"hint"` | Severity for the semicolon lint (`;` separators in source) |
 | `raven.linting.equalsNaSeverity` | `"hint"` | Severity for the equals-NA lint (`x == NA`, `x != NA`, typed-`NA` variants) |
 | `raven.linting.objectLengthSeverity` | `"hint"` | Severity for the object-length lint |
-| `raven.linting.vectorLogicSeverity` | `"hint"` | Severity for the vector-logic lint (`&` / `|` in `if` / `while` conditions) |
+| `raven.linting.vectorLogicSeverity` | `"hint"` | Severity for the vector-logic lint (`&` / `\|` in `if` / `while` conditions) |
 | `raven.linting.functionLeftParenthesesSeverity` | `"hint"` | Severity for the function-left-parentheses lint (whitespace between `function` and `(`) |
 | `raven.linting.spacesInsideSeverity` | `"hint"` | Severity for the spaces-inside lint (whitespace inside `(`, `[`, `[[`) |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,9 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 |---|---|---|
 | `raven.linting.enabled` | `false` | Master switch for all lint diagnostics |
 | `raven.linting.lineLength` | `80` | Maximum line length (UTF-16 code units) |
+| `raven.linting.objectLength` | `30` | Maximum identifier length for the object-length lint |
 | `raven.linting.assignmentOperator` | `"<-"` | Preferred assignment operator (`"<-"` or `"="`) |
+| `raven.linting.stringDelimiter` | `"\""` | Preferred string-literal delimiter (`"\""` or `"'"`); used by the quotes lint |
 | `raven.linting.lineLengthSeverity` | `"hint"` | Severity for over-long lines (or `"off"`) |
 | `raven.linting.trailingWhitespaceSeverity` | `"hint"` | Severity for trailing whitespace |
 | `raven.linting.noTabSeverity` | `"hint"` | Severity for tab characters |
@@ -133,6 +135,15 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.objectNameSeverity` | `"hint"` | Severity for the object-name lint (set to `"off"` to disable entirely; set a specific style to `"any"` to disable just that kind) |
 | `raven.linting.infixSpacesSeverity` | `"hint"` | Severity for the infix-spaces lint (whitespace around operators) |
 | `raven.linting.commentedCodeSeverity` | `"hint"` | Severity for the commented-code lint (standalone comments whose body parses as R code) |
+| `raven.linting.quotesSeverity` | `"hint"` | Severity for the quotes lint (string-literal delimiter style) |
+| `raven.linting.commasSeverity` | `"hint"` | Severity for the commas lint (spacing around `,`) |
+| `raven.linting.tAndFSymbolSeverity` | `"hint"` | Severity for the T/F-symbol lint (bare `T` / `F` used as `TRUE` / `FALSE`) |
+| `raven.linting.semicolonSeverity` | `"hint"` | Severity for the semicolon lint (`;` separators in source) |
+| `raven.linting.equalsNaSeverity` | `"hint"` | Severity for the equals-NA lint (`x == NA`, `x != NA`, typed-`NA` variants) |
+| `raven.linting.objectLengthSeverity` | `"hint"` | Severity for the object-length lint |
+| `raven.linting.vectorLogicSeverity` | `"hint"` | Severity for the vector-logic lint (`&` / `|` in `if` / `while` conditions) |
+| `raven.linting.functionLeftParenthesesSeverity` | `"hint"` | Severity for the function-left-parentheses lint (whitespace between `function` and `(`) |
+| `raven.linting.spacesInsideSeverity` | `"hint"` | Severity for the spaces-inside lint (whitespace inside `(`, `[`, `[[`) |
 
 To disable an individual rule while leaving the rest enabled, set its severity to `"off"`. For the object-name lint, you can also set any of the three style settings to `"any"` to disable just that symbol kind while keeping the others active.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -60,8 +60,17 @@ Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-li
 | Trailing blank lines | hint | Blank lines at end of file, or missing final newline |
 | Assignment operator | hint | Top-level assignment uses an operator other than the preferred one (`<-` by default; configurable via `raven.linting.assignmentOperator`) |
 | Object name | hint | Function, variable, or argument name doesn't match the configured naming scheme (`snake_case` by default; configurable per kind via `raven.linting.objectNameStyle*`) |
+| Object length | hint | Identifier name exceeds `raven.linting.objectLength` characters (default 30; leading `.` not counted) |
 | Infix spaces | hint | Missing space around a binary operator (`a+b`, `x<-1`, `a%>%b`, `if (a<=b)`), or stray space around a tight-binding operator (`obj $ field`, `1 : 10`, unary `- x`) |
 | Commented code | hint | A standalone comment whose body parses as R and contains a call, assignment, or operator (`# foo(bar)`, `# x <- 1 + 2`) |
+| Quotes | hint | String literal not using the preferred delimiter (`raven.linting.stringDelimiter`; default `"`). Raw strings are exempt |
+| Commas | hint | Whitespace before `,` (`a , b`) or missing whitespace after `,` (`c(1,2)`). Newline after comma is fine |
+| `T` / `F` symbol | hint | Bare `T` / `F` used in reference position (use `TRUE` / `FALSE`). Skipped at assignment targets, named arguments, formal parameters, and `$`/`@` field names |
+| Semicolon | hint | `;` separator outside strings/comments (`a; b`, trailing `a;`) |
+| Equals NA | hint | `x == NA`, `x != NA`, or any typed-`NA` variant on either side. Use `is.na(x)` |
+| Vector logic | hint | `&` or `|` in an `if` / `while` condition (use `&&` / `||` for scalars). Scan stops at call boundaries |
+| Function left parentheses | hint | Whitespace between `function` (or `\`) and `(` (`function (x) ...`, `\ (x) ...`) |
+| Spaces inside | hint | Whitespace immediately inside `(`, `[`, or `[[` (`f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are exempt |
 
 Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -68,7 +68,7 @@ Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-li
 | `T` / `F` symbol | hint | Bare `T` / `F` used in reference position (use `TRUE` / `FALSE`). Skipped at assignment targets, named arguments, formal parameters, and `$`/`@` field names |
 | Semicolon | hint | `;` separator outside strings/comments (`a; b`, trailing `a;`) |
 | Equals NA | hint | `x == NA`, `x != NA`, or any typed-`NA` variant on either side. Use `is.na(x)` |
-| Vector logic | hint | `&` or `|` in an `if` / `while` condition (use `&&` / `||` for scalars). Scan stops at call boundaries |
+| Vector logic | hint | `&` or `\|` in an `if` / `while` condition (use `&&` / `\|\|` for scalars). Scan stops at call boundaries |
 | Function left parentheses | hint | Whitespace between `function` (or `\`) and `(` (`function (x) ...`, `\ (x) ...`) |
 | Spaces inside | hint | Whitespace immediately inside `(`, `[`, or `[[` (`f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are exempt |
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -92,6 +92,60 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 - **`lintr` equivalent:** `lintr::commented_code_linter()`.
 - Flags a standalone comment block (consecutive `#` lines) whose body parses as R and contains a call, assignment, operator, or function definition. Roxygen (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, `# NOTE:`, `# XXX:`, `# HACK:`, `# BUG:`, `# WARNING:`, `# OPTIMIZE:`), Emacs mode lines, and `# nolint` / `# @lsp-…` directives are skipped. End-of-line comments next to real code (`x <- 1 # explain`) are never flagged.
 
+### Quotes
+
+- **Raven:** `raven.linting.stringDelimiter` (default `"\""`, alternative `"'"`), `raven.linting.quotesSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::quotes_linter()` / `lintr::single_quotes_linter()` (the two map to the two settings above).
+- Raw strings (`r"(...)"`, `R'(...)'`, `r"---(...)---"`) are exempt — the outer quote is constrained by the body.
+
+### Commas
+
+- **Raven:** `raven.linting.commasSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::commas_linter()`.
+- Flags whitespace before `,` and missing whitespace after `,`. A newline after a comma is fine, so multi-line argument lists are not flagged. Matches `lintr`'s default `allow_trailing = FALSE` — a comma directly against a closing bracket (`a[1,]`) is still flagged.
+
+### T / F symbol
+
+- **Raven:** `raven.linting.tAndFSymbolSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::T_and_F_symbol_linter()`.
+- Flags bare `T` / `F` identifiers used as references to `TRUE` / `FALSE`. Assignment targets (`T <- 0`), named arguments (`foo(T = TRUE)`), formal parameters (`function(T) ...`), and `$` / `@` field names (`obj$T`) are exempt — those positions don't read the boolean.
+
+### Semicolon
+
+- **Raven:** `raven.linting.semicolonSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::semicolon_linter()`.
+- Flags `;` separators in source. `;` inside string literals or comments is left alone. One diagnostic per `;`.
+
+### Equals NA
+
+- **Raven:** `raven.linting.equalsNaSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::equals_na_linter()`.
+- Flags `x == NA`, `x != NA`, and the typed variants (`NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_`) on either side. The comparison always returns `NA`; use `is.na(x)` instead.
+
+### Object length
+
+- **Raven:** `raven.linting.objectLength` (default `30`), `raven.linting.objectLengthSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::object_length_linter(length = 30)`.
+- Flags assignment targets and formal parameters whose names exceed the configured length. An optional leading `.` (hidden identifier convention) is not counted. Backtick-quoted and non-ASCII names are exempt, matching `object_name`'s carve-outs.
+
+### Vector logic
+
+- **Raven:** `raven.linting.vectorLogicSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::vector_logic_linter()`.
+- Flags `&` or `|` in `if` / `while` conditions (where `&&` / `||` is the scalar short-circuit form). The scan recurses through nested logical operators but stops at call boundaries — `if (any(x & y))` is left alone because the `&` is evaluated on a vector inside `any()`.
+
+### Function left parentheses
+
+- **Raven:** `raven.linting.functionLeftParenthesesSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::function_left_parentheses_linter()`.
+- Flags whitespace between `function` (or the `\` lambda shorthand) and the parameter `(`. The community convention is tight: `function(x)` and `\(x)`.
+
+### Spaces inside
+
+- **Raven:** `raven.linting.spacesInsideSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::spaces_inside_linter()`.
+- Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Empty groupings (`f()`, `f( )`, `mat[]`) and multi-line wrapping are exempt — only single-line interior whitespace is flagged.
+
 ## Migrating from `.lintr`
 
 Raven does not read `.lintr` files — its rules are configured per VS Code settings instead. The table below maps the `lintr` linters covered by Raven to their Raven equivalents. For each `lintr` linter you currently enable, set the corresponding `raven.linting.*` keys; for ones not listed, see [Gaps vs `lintr`](#gaps-vs-lintr).
@@ -106,6 +160,15 @@ Raven does not read `.lintr` files — its rules are configured per VS Code sett
 | `object_name_linter(styles = c("snake_case"))` | `raven.linting.objectNameStyleFunction`, `raven.linting.objectNameStyleVariable`, `raven.linting.objectNameStyleArgument`, `raven.linting.objectNameSeverity` |
 | `infix_spaces_linter()` | `raven.linting.infixSpacesSeverity` |
 | `commented_code_linter()` | `raven.linting.commentedCodeSeverity` |
+| `quotes_linter()` / `single_quotes_linter()` | `raven.linting.stringDelimiter`, `raven.linting.quotesSeverity` |
+| `commas_linter()` | `raven.linting.commasSeverity` |
+| `T_and_F_symbol_linter()` | `raven.linting.tAndFSymbolSeverity` |
+| `semicolon_linter()` | `raven.linting.semicolonSeverity` |
+| `equals_na_linter()` | `raven.linting.equalsNaSeverity` |
+| `object_length_linter(length = N)` | `raven.linting.objectLength = N`, `raven.linting.objectLengthSeverity` |
+| `vector_logic_linter()` | `raven.linting.vectorLogicSeverity` |
+| `function_left_parentheses_linter()` | `raven.linting.functionLeftParenthesesSeverity` |
+| `spaces_inside_linter()` | `raven.linting.spacesInsideSeverity` |
 
 To disable a rule from a `.lintr` `linters_with_defaults(..., default = list())` setup, set its severity to `"off"`. To raise a rule that `lintr` would flag as a `warning`, raise its severity from `"hint"` to `"warning"`.
 
@@ -113,15 +176,14 @@ If you'd also like a starter `.lintr` for running `lintr` itself alongside Raven
 
 ## Gaps vs `lintr`
 
-`lintr` ships several dozen linters. Raven implements the eight in the table above. Common `lintr` linters that have **no Raven equivalent** include (non-exhaustive):
+`lintr` ships several dozen linters. Raven implements the ones in the table above. Common `lintr` linters that have **no Raven equivalent** include (non-exhaustive):
 
 - `object_usage_linter` — flags undefined globals inside function bodies via `codetools::checkUsage()`. Raven's [Undefined variable diagnostic](diagnostics.md#undefined-variables) covers similar ground at the file and `source()`-chain level (via static cross-file scope), but with different semantics: Raven's check is scope- and position-aware across `source()` chains, while `object_usage_linter` runs inside individual function bodies via R's own analyzer.
 - `cyclocomp_linter` — cyclomatic complexity.
-- `T_and_F_symbol_linter`, `quotes_linter`, `single_quotes_linter`.
-- `semicolon_linter`, `seq_linter`, `vector_logic_linter`, `equals_na_linter`.
-- `brace_linter`, `paren_body_linter`, `indentation_linter`, `function_left_parentheses_linter`, `spaces_inside_linter`, `spaces_left_parentheses_linter`, `commas_linter`.
+- `seq_linter`.
+- `brace_linter`, `paren_body_linter`, `indentation_linter`, `spaces_left_parentheses_linter`.
 - `pipe_continuation_linter`, `pipe_call_linter`.
-- `absolute_path_linter`, `object_length_linter`.
+- `absolute_path_linter`.
 
 If you rely on any of these, the recommended setup is to run `lintr` via the `REditorSupport (R)` extension alongside Raven — Raven's language server is designed to coexist with REditorSupport. See [below](#filling-the-gaps-with-lintr-itself).
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1396,6 +1396,197 @@
           ],
           "default": "hint",
           "description": "Severity for the commented-code lint. Flags standalone comment blocks whose body parses as R code (calls, assignments, operators). Roxygen lines (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, ...), and `# nolint` / `# @lsp-*` directives are never flagged."
+        },
+        "raven.linting.stringDelimiter": {
+          "type": "string",
+          "default": "\"",
+          "enum": [
+            "\"",
+            "'"
+          ],
+          "enumDescriptions": [
+            "Require double quotes (\"...\") for string literals.",
+            "Require single quotes ('...') for string literals."
+          ],
+          "description": "Preferred string-literal delimiter. Used by the quotes lint. Raw strings (r\"(...)\") are exempt."
+        },
+        "raven.linting.quotesSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report quote-style violations as errors",
+            "Report quote-style violations as warnings",
+            "Report quote-style violations as information",
+            "Report quote-style violations as hints",
+            "Disable the quotes lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the quotes lint. Flags string literals not using the configured `raven.linting.stringDelimiter`. Raw strings are exempt."
+        },
+        "raven.linting.commasSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report comma-spacing violations as errors",
+            "Report comma-spacing violations as warnings",
+            "Report comma-spacing violations as information",
+            "Report comma-spacing violations as hints",
+            "Disable the commas lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the commas lint. Flags whitespace before `,` and missing whitespace after `,`. A newline after `,` is fine."
+        },
+        "raven.linting.tAndFSymbolSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report `T`/`F` usage as errors",
+            "Report `T`/`F` usage as warnings",
+            "Report `T`/`F` usage as information",
+            "Report `T`/`F` usage as hints",
+            "Disable the T/F symbol lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the T/F-symbol lint. Flags bare `T` / `F` identifiers used as references to `TRUE` / `FALSE`. Assignment targets, named arguments, formal parameters, and `$`/`@` field names are exempt."
+        },
+        "raven.linting.semicolonSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report `;` separators as errors",
+            "Report `;` separators as warnings",
+            "Report `;` separators as information",
+            "Report `;` separators as hints",
+            "Disable the semicolon lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the semicolon lint. Flags `;` statement separators in source (outside strings and comments)."
+        },
+        "raven.linting.equalsNaSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report `== NA` / `!= NA` as errors",
+            "Report `== NA` / `!= NA` as warnings",
+            "Report `== NA` / `!= NA` as information",
+            "Report `== NA` / `!= NA` as hints",
+            "Disable the equals-NA lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the equals-NA lint. Flags `x == NA`, `x != NA` (and the typed `NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_` variants). Use `is.na(x)` instead."
+        },
+        "raven.linting.objectLength": {
+          "type": "integer",
+          "default": 30,
+          "minimum": 5,
+          "maximum": 1000,
+          "description": "Maximum allowed identifier length for the object-length lint. The leading `.` of hidden-identifier names is not counted; backtick-quoted and non-ASCII names are exempt."
+        },
+        "raven.linting.objectLengthSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report overlong identifiers as errors",
+            "Report overlong identifiers as warnings",
+            "Report overlong identifiers as information",
+            "Report overlong identifiers as hints",
+            "Disable the object-length lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the object-length lint. Flags assignment targets and formal parameters whose names exceed `raven.linting.objectLength` characters."
+        },
+        "raven.linting.vectorLogicSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report `&`/`|` in `if`/`while` conditions as errors",
+            "Report `&`/`|` in `if`/`while` conditions as warnings",
+            "Report `&`/`|` in `if`/`while` conditions as information",
+            "Report `&`/`|` in `if`/`while` conditions as hints",
+            "Disable the vector-logic lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the vector-logic lint. Flags `&` or `|` in `if` / `while` conditions (where `&&` / `||` is the scalar form). Function-call boundaries stop the scan, so `if (any(x & y))` is left alone."
+        },
+        "raven.linting.functionLeftParenthesesSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report space between `function` and `(` as errors",
+            "Report space between `function` and `(` as warnings",
+            "Report space between `function` and `(` as information",
+            "Report space between `function` and `(` as hints",
+            "Disable the function-left-parens lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the function-left-parentheses lint. Flags whitespace between `function` (or `\\`) and the parameter `(`."
+        },
+        "raven.linting.spacesInsideSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report whitespace inside brackets as errors",
+            "Report whitespace inside brackets as warnings",
+            "Report whitespace inside brackets as information",
+            "Report whitespace inside brackets as hints",
+            "Disable the spaces-inside lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the spaces-inside lint. Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are left alone."
         }
       }
     }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -97,7 +97,9 @@ export interface RavenInitializationOptions {
     linting?: {
         enabled?: boolean;
         lineLength?: number;
+        objectLength?: number;
         assignmentOperator?: "<-" | "=";
+        stringDelimiter?: "\"" | "'";
         objectNameStyleFunction?: ObjectNameStyle;
         objectNameStyleVariable?: ObjectNameStyle;
         objectNameStyleArgument?: ObjectNameStyle;
@@ -109,6 +111,15 @@ export interface RavenInitializationOptions {
         objectNameSeverity?: SeverityLevel;
         infixSpacesSeverity?: SeverityLevel;
         commentedCodeSeverity?: SeverityLevel;
+        quotesSeverity?: SeverityLevel;
+        commasSeverity?: SeverityLevel;
+        tAndFSymbolSeverity?: SeverityLevel;
+        semicolonSeverity?: SeverityLevel;
+        equalsNaSeverity?: SeverityLevel;
+        objectLengthSeverity?: SeverityLevel;
+        vectorLogicSeverity?: SeverityLevel;
+        functionLeftParenthesesSeverity?: SeverityLevel;
+        spacesInsideSeverity?: SeverityLevel;
     };
     helpViewer?: { viewColumn?: 'active' | 'beside' };
 }
@@ -354,7 +365,9 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
     options.linting = {
         enabled: config.get<boolean>('linting.enabled', false),
         lineLength: config.get<number>('linting.lineLength', 80),
+        objectLength: config.get<number>('linting.objectLength', 30),
         assignmentOperator: config.get<"<-" | "=">('linting.assignmentOperator', '<-'),
+        stringDelimiter: config.get<"\"" | "'">('linting.stringDelimiter', '"'),
         objectNameStyleFunction: config.get<ObjectNameStyle>('linting.objectNameStyleFunction', 'snake_case'),
         objectNameStyleVariable: config.get<ObjectNameStyle>('linting.objectNameStyleVariable', 'snake_case'),
         objectNameStyleArgument: config.get<ObjectNameStyle>('linting.objectNameStyleArgument', 'snake_case'),
@@ -366,6 +379,15 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         objectNameSeverity: config.get<SeverityLevel>('linting.objectNameSeverity', 'hint'),
         infixSpacesSeverity: config.get<SeverityLevel>('linting.infixSpacesSeverity', 'hint'),
         commentedCodeSeverity: config.get<SeverityLevel>('linting.commentedCodeSeverity', 'hint'),
+        quotesSeverity: config.get<SeverityLevel>('linting.quotesSeverity', 'hint'),
+        commasSeverity: config.get<SeverityLevel>('linting.commasSeverity', 'hint'),
+        tAndFSymbolSeverity: config.get<SeverityLevel>('linting.tAndFSymbolSeverity', 'hint'),
+        semicolonSeverity: config.get<SeverityLevel>('linting.semicolonSeverity', 'hint'),
+        equalsNaSeverity: config.get<SeverityLevel>('linting.equalsNaSeverity', 'hint'),
+        objectLengthSeverity: config.get<SeverityLevel>('linting.objectLengthSeverity', 'hint'),
+        vectorLogicSeverity: config.get<SeverityLevel>('linting.vectorLogicSeverity', 'hint'),
+        functionLeftParenthesesSeverity: config.get<SeverityLevel>('linting.functionLeftParenthesesSeverity', 'hint'),
+        spacesInsideSeverity: config.get<SeverityLevel>('linting.spacesInsideSeverity', 'hint'),
     };
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -125,7 +125,9 @@ const SETTINGS_MAPPING: Array<{
     // stale state active. Defaults below mirror package.json.
     { vsCodeKey: 'linting.enabled', jsonPath: ['linting', 'enabled'], type: 'boolean', defaultWhenUnconfigured: false },
     { vsCodeKey: 'linting.lineLength', jsonPath: ['linting', 'lineLength'], type: 'number', defaultWhenUnconfigured: 80 },
+    { vsCodeKey: 'linting.objectLength', jsonPath: ['linting', 'objectLength'], type: 'number', defaultWhenUnconfigured: 30 },
     { vsCodeKey: 'linting.assignmentOperator', jsonPath: ['linting', 'assignmentOperator'], type: 'enum', enumValues: ['<-', '='] as const, defaultWhenUnconfigured: '<-' },
+    { vsCodeKey: 'linting.stringDelimiter', jsonPath: ['linting', 'stringDelimiter'], type: 'enum', enumValues: ['"', "'"] as const, defaultWhenUnconfigured: '"' },
     { vsCodeKey: 'linting.lineLengthSeverity', jsonPath: ['linting', 'lineLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.trailingWhitespaceSeverity', jsonPath: ['linting', 'trailingWhitespaceSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.noTabSeverity', jsonPath: ['linting', 'noTabSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
@@ -137,6 +139,15 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.objectNameSeverity', jsonPath: ['linting', 'objectNameSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.infixSpacesSeverity', jsonPath: ['linting', 'infixSpacesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.commentedCodeSeverity', jsonPath: ['linting', 'commentedCodeSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.quotesSeverity', jsonPath: ['linting', 'quotesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.commasSeverity', jsonPath: ['linting', 'commasSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.tAndFSymbolSeverity', jsonPath: ['linting', 'tAndFSymbolSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.semicolonSeverity', jsonPath: ['linting', 'semicolonSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.equalsNaSeverity', jsonPath: ['linting', 'equalsNaSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.objectLengthSeverity', jsonPath: ['linting', 'objectLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.vectorLogicSeverity', jsonPath: ['linting', 'vectorLogicSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.functionLeftParenthesesSeverity', jsonPath: ['linting', 'functionLeftParenthesesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.spacesInsideSeverity', jsonPath: ['linting', 'spacesInsideSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];
@@ -358,7 +369,9 @@ suite('Settings Transmission Property Tests', () => {
             linting: {
                 enabled: false,
                 lineLength: 80,
+                objectLength: 30,
                 assignmentOperator: '<-',
+                stringDelimiter: '"',
                 objectNameStyleFunction: 'snake_case',
                 objectNameStyleVariable: 'snake_case',
                 objectNameStyleArgument: 'snake_case',
@@ -370,6 +383,15 @@ suite('Settings Transmission Property Tests', () => {
                 objectNameSeverity: 'hint',
                 infixSpacesSeverity: 'hint',
                 commentedCodeSeverity: 'hint',
+                quotesSeverity: 'hint',
+                commasSeverity: 'hint',
+                tAndFSymbolSeverity: 'hint',
+                semicolonSeverity: 'hint',
+                equalsNaSeverity: 'hint',
+                objectLengthSeverity: 'hint',
+                vectorLogicSeverity: 'hint',
+                functionLeftParenthesesSeverity: 'hint',
+                spacesInsideSeverity: 'hint',
             },
         }, 'Empty configuration should produce only runtime defaults');
 
@@ -510,7 +532,9 @@ suite('Settings Transmission Unit Tests', () => {
         assert.deepStrictEqual(options.linting, {
             enabled: false,
             lineLength: 80,
+            objectLength: 30,
             assignmentOperator: '<-',
+            stringDelimiter: '"',
             objectNameStyleFunction: 'snake_case',
             objectNameStyleVariable: 'snake_case',
             objectNameStyleArgument: 'snake_case',
@@ -522,6 +546,15 @@ suite('Settings Transmission Unit Tests', () => {
             objectNameSeverity: 'hint',
             infixSpacesSeverity: 'hint',
             commentedCodeSeverity: 'hint',
+            quotesSeverity: 'hint',
+            commasSeverity: 'hint',
+            tAndFSymbolSeverity: 'hint',
+            semicolonSeverity: 'hint',
+            equalsNaSeverity: 'hint',
+            objectLengthSeverity: 'hint',
+            vectorLogicSeverity: 'hint',
+            functionLeftParenthesesSeverity: 'hint',
+            spacesInsideSeverity: 'hint',
         });
     });
 


### PR DESCRIPTION
## Summary

Resolves #244. Adds native Raven implementations of nine commonly-requested `lintr` style rules in one bundle. Each rule is a self-contained AST/token check with low design risk; bundling them lets the issue close as a single PR.

Each rule:
- has its own `raven.linting.<rule>Severity` setting (default `"hint"`);
- honors `# nolint` / `# @lsp-ignore` markers via the shared `Suppressions` infrastructure;
- is wired through `LintConfig` → `parse_lint_config` → `package.json` + `initializationOptions.ts` + the `SETTINGS_MAPPING` test fixture.

## Rules added

- `quotes_linter` / `single_quotes_linter` — flag literals not using the configured delimiter. Setting: `raven.linting.stringDelimiter` (`"\"`" / `'`). Raw strings (`r"(...)"`) are exempt.
- `commas_linter` — flag space before `,` and missing space after `,`. Newline after is fine. Trailing `,]` is still flagged (matches lintr default `allow_trailing = FALSE`).
- `T_and_F_symbol_linter` — flag bare `T` / `F` in reference position. Assignment targets, named arguments, formal parameters, and `$`/`@` field names are exempt.
- `semicolon_linter` — flag `;` separators outside strings/comments. One diagnostic per `;`.
- `equals_na_linter` — flag `x == NA`, `x != NA`, and the typed `NA_integer_` / `NA_real_` / `NA_character_` / `NA_complex_` variants on either side.
- `object_length_linter` — flag identifiers longer than `raven.linting.objectLength` (default 30). Leading `.` not counted; backtick-quoted and non-ASCII names exempt (matches `object_name`'s carve-outs).
- `vector_logic_linter` — flag `&` / `|` in `if` / `while` conditions. Recursion stops at call boundaries (`any(x & y)` is left alone).
- `function_left_parentheses_linter` — flag whitespace between `function` (or `\` lambda) and `(`.
- `spaces_inside_linter` — flag whitespace immediately inside `(`, `[`, `[[` and their closers. Empty groupings (`f()`, `f( )`) and multi-line wrapping are exempt.

## Docs

- `docs/linting.md`: per-rule sections under "Settings reference by rule", rows in the `.lintr` migration table, removed implemented rules from "Gaps vs `lintr`".
- `docs/diagnostics.md`: rows in the Style Lints table.
- `docs/configuration.md`: rows in the Linting Settings table.

## Test plan

- [x] `cargo test -p raven` (debug + release with `--features test-support`) — all 3675 + 103 + 58 unit/integration tests pass
- [x] `bun test` — 467 pass / 0 fail across the workspace suite (Rust + VS Code Mocha integration)
- [x] New rules verified against positive, negative, and suppression cases (47 new tests)
- [x] Regression: existing `assignment_operator_flags_inside_function_body_passed_as_arg` test updated to disable `semicolon_severity` so the assertion stays scoped to the assignment-operator rule
- [x] `cargo clippy -p raven --tests` — no new warnings in the added rule files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 9 new lint rules (quotes delimiter, comma spacing, bare T/F, semicolons, NA comparisons, object identifier length, vector-logic, function-left-parentheses, spaces-inside).
  * Per-rule configurable severity levels and new settings for max identifier length, assignment-operator style, and string-delimiter preference.
  * Editor integration updated to expose these linting options and defaults.

* **Documentation**
  * Linting guides, diagnostics reference, and configuration docs updated to cover all new rules and settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/247)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->