### PR TITLE
feat(linting): indentation lint rule (lintr::indentation_linter)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c08839d2-1358-42c2-b429-8635f7630c86","pid":80223,"procStart":"Fri May 15 18:51:22 2026","acquiredAt":1778874252468}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c08839d2-1358-42c2-b429-8635f7630c86","pid":80223,"procStart":"Fri May 15 18:51:22 2026","acquiredAt":1778874252468}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/raven.exe
 
 # Claude Code local settings (but keep plans and rules)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .superpowers/
 .claude/worktrees
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Raven's sister project [Sight](https://github.com/jbearak/sight) implements a la
 - **[Go-to-definition](docs/go-to-definition.md)** — Jump to definitions across file boundaries
 - **[Find references](docs/find-references.md)** — Locate all usages of a symbol across your project
 - **[Hover](docs/hover.md)** — Symbol info including source file and package origin
-- **[Diagnostics](docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages, plus opt-in [style/lint rules](docs/linting.md) (line length, trailing whitespace, trailing blank lines, tabs, assignment operator, object names, infix spaces, commented code)
+- **[Diagnostics](docs/diagnostics.md)** — Undefined variable detection that understands sourced files and loaded packages, plus opt-in [style/lint rules](docs/linting.md) (line length, trailing whitespace, trailing blank lines, tabs, assignment operator, object names, infix spaces, commented code, indentation)
 - **[Document outline](docs/document-outline.md)** — Hierarchical view with sections, classes, and nested functions
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -441,6 +441,8 @@ pub(crate) fn parse_cross_file_config(
 /// * `enabled` (bool) — master switch.
 /// * `lineLength` (number) — max line length; clamped to `[20, 10_000]`.
 /// * `objectLength` (number) — max identifier length; clamped to `[5, 1_000]`.
+/// * `indentationUnit` (number) — spaces per indent level for the
+///   indentation lint; clamped to `[1, 8]`.
 /// * `assignmentOperator` (`"<-"` or `"="`) — preferred operator.
 /// * `stringDelimiter` (`"\""` or `"'"`) — preferred string delimiter.
 /// * `objectNameStyleFunction`, `objectNameStyleVariable`,
@@ -467,6 +469,7 @@ pub(crate) fn parse_cross_file_config(
 ///   - `vectorLogicSeverity`
 ///   - `functionLeftParenthesesSeverity`
 ///   - `spacesInsideSeverity`
+///   - `indentationSeverity`
 pub(crate) fn parse_lint_config(
     settings: &serde_json::Value,
 ) -> Option<crate::linting::LintConfig> {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -493,6 +493,12 @@ pub(crate) fn parse_lint_config(
         // single-letter conventions usable; the ceiling is well below u32::MAX.
         config.object_length = v.clamp(5, 1_000) as u32;
     }
+    if let Some(v) = linting.get("indentationUnit").and_then(|v| v.as_u64()) {
+        // Same clamp-first pattern. Floors at 1 because zero-space indents
+        // wouldn't be visually distinguishable; ceiling matches the `tab_size`
+        // bound used by the on-type indentation provider.
+        config.indentation_unit = v.clamp(1, 8) as u32;
+    }
     if let Some(op) = linting.get("assignmentOperator").and_then(|v| v.as_str()) {
         config.assignment_operator_style = match op {
             "=" => crate::linting::AssignmentOperatorStyle::Equals,
@@ -610,6 +616,12 @@ pub(crate) fn parse_lint_config(
     {
         config.spaces_inside_severity = parse_severity(sev);
     }
+    if let Some(sev) = linting
+        .get("indentationSeverity")
+        .and_then(|v| v.as_str())
+    {
+        config.indentation_severity = parse_severity(sev);
+    }
 
     log::info!("Linting configuration loaded from LSP settings:");
     log::info!("  enabled: {}", config.enabled);
@@ -632,7 +644,7 @@ pub(crate) fn parse_lint_config(
         config.commented_code_severity
     );
     log::info!(
-        "  severities: quotes={:?} commas={:?} t_and_f={:?} semicolon={:?} equals_na={:?} object_length={:?} vector_logic={:?} function_left_paren={:?} spaces_inside={:?}",
+        "  severities: quotes={:?} commas={:?} t_and_f={:?} semicolon={:?} equals_na={:?} object_length={:?} vector_logic={:?} function_left_paren={:?} spaces_inside={:?} indentation={:?}",
         config.quotes_severity,
         config.commas_severity,
         config.t_and_f_symbol_severity,
@@ -642,7 +654,9 @@ pub(crate) fn parse_lint_config(
         config.vector_logic_severity,
         config.function_left_parentheses_severity,
         config.spaces_inside_severity,
+        config.indentation_severity,
     );
+    log::info!("  indentation_unit: {}", config.indentation_unit);
     log::info!(
         "  object_name styles: fn={:?} var={:?} arg={:?}",
         config.object_name_style_function,
@@ -7580,7 +7594,8 @@ mod tests {
                     "assignmentOperatorSeverity": "off",
                     "objectNameSeverity": "off",
                     "infixSpacesSeverity": "off",
-                    "commentedCodeSeverity": "off"
+                    "commentedCodeSeverity": "off",
+                    "indentationSeverity": "off"
                 }
             });
             let cfg = crate::backend::parse_lint_config(&settings).unwrap();
@@ -7592,6 +7607,24 @@ mod tests {
             assert_eq!(cfg.object_name_severity, None);
             assert_eq!(cfg.infix_spaces_severity, None);
             assert_eq!(cfg.commented_code_severity, None);
+            assert_eq!(cfg.indentation_severity, None);
+        }
+
+        #[test]
+        fn parse_lint_config_reads_indentation_unit_and_clamps() {
+            let settings = json!({ "linting": { "indentationUnit": 4 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.indentation_unit, 4);
+
+            // Above the ceiling is clamped down to 8.
+            let settings = json!({ "linting": { "indentationUnit": 99 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.indentation_unit, 8);
+
+            // Zero is clamped up to 1 (the floor).
+            let settings = json!({ "linting": { "indentationUnit": 0 } });
+            let cfg = crate::backend::parse_lint_config(&settings).unwrap();
+            assert_eq!(cfg.indentation_unit, 1);
         }
 
         #[test]

--- a/crates/raven/src/linting/config.rs
+++ b/crates/raven/src/linting/config.rs
@@ -66,6 +66,9 @@ pub struct LintConfig {
     /// Maximum allowed identifier length (object-length rule). Identifiers
     /// longer than this are flagged. Measured in characters of the name.
     pub object_length: u32,
+    /// Number of spaces per indentation level used by the indentation rule
+    /// (`lintr::indentation_linter`). Defaults to 2 to match `lintr`.
+    pub indentation_unit: u32,
     /// Preferred assignment operator style.
     pub assignment_operator_style: AssignmentOperatorStyle,
     /// Preferred string-literal delimiter (used by the `quotes` rule).
@@ -119,6 +122,8 @@ pub struct LintConfig {
     pub function_left_parentheses_severity: Option<DiagnosticSeverity>,
     /// Severity for the spaces-inside rule (`lintr::spaces_inside_linter`).
     pub spaces_inside_severity: Option<DiagnosticSeverity>,
+    /// Severity for the indentation rule (`lintr::indentation_linter`).
+    pub indentation_severity: Option<DiagnosticSeverity>,
 }
 
 impl Default for LintConfig {
@@ -128,6 +133,7 @@ impl Default for LintConfig {
             enabled: false,
             line_length: 80,
             object_length: 30,
+            indentation_unit: 2,
             assignment_operator_style: AssignmentOperatorStyle::default(),
             string_delimiter: StringDelimiter::default(),
             object_name_style_function: ObjectNameStyle::SnakeCase,
@@ -152,6 +158,7 @@ impl Default for LintConfig {
             vector_logic_severity: Some(DiagnosticSeverity::HINT),
             function_left_parentheses_severity: Some(DiagnosticSeverity::HINT),
             spaces_inside_severity: Some(DiagnosticSeverity::HINT),
+            indentation_severity: Some(DiagnosticSeverity::HINT),
         }
     }
 }

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -42,6 +42,9 @@
 //!   (or `\`) and `(`.
 //! * `spaces_inside` — flag whitespace immediately inside `(`, `[`, `[[`
 //!   and their closers. Empty groupings and multi-line wrapping are exempt.
+//! * `indentation` — flag lines whose leading whitespace doesn't match the
+//!   expected indent for their AST scope. Lintr's tidy-default hanging indent
+//!   for braced blocks, multi-line argument lists, and continuation lines.
 //!
 //! Implementation note: every rule except `commented_code` and `semicolon`
 //! walks the already-parsed tree directly. `commented_code` re-parses each
@@ -170,6 +173,16 @@ pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Di
     }
     if let Some(sev) = config.spaces_inside_severity {
         rules::spaces_inside::collect(text, tree_root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = config.indentation_severity {
+        rules::indentation::collect(
+            text,
+            tree_root,
+            config.indentation_unit,
+            sev,
+            &suppressions,
+            &mut out,
+        );
     }
 
     out
@@ -1227,6 +1240,7 @@ print.data.frame <- function(x, ...) NULL
             vector_logic_severity: None,
             function_left_parentheses_severity: None,
             spaces_inside_severity: None,
+            indentation_severity: None,
             ..enabled_config()
         }
     }
@@ -1730,6 +1744,39 @@ print.data.frame <- function(x, ...) NULL
         let config = spaces_inside_only_config();
         let diags = lint("x <- ( 1 + 2 )\n", &config);
         assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    // ------------------------------------------------------------------
+    // indentation
+    // ------------------------------------------------------------------
+
+    fn indentation_only_config() -> LintConfig {
+        LintConfig {
+            indentation_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        }
+    }
+
+    #[test]
+    fn indentation_dispatcher_flags_misindented_block_line() {
+        let config = indentation_only_config();
+        let diags = lint("f <- function() {\nx <- 1\n}\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.line, 1);
+        assert!(diags[0].message.contains("should be 2 spaces"));
+    }
+
+    #[test]
+    fn indentation_dispatcher_honors_configured_unit() {
+        let config = LintConfig {
+            indentation_unit: 4,
+            ..indentation_only_config()
+        };
+        // 4 spaces is correct under indent_unit=4; 2 spaces is wrong.
+        assert!(lint("f <- function() {\n    x <- 1\n}\n", &config).is_empty());
+        let diags = lint("f <- function() {\n  x <- 1\n}\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("should be 4 spaces"));
     }
 }
 

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -43,13 +43,17 @@
 //! * `spaces_inside` — flag whitespace immediately inside `(`, `[`, `[[`
 //!   and their closers. Empty groupings and multi-line wrapping are exempt.
 //! * `indentation` — flag lines whose leading whitespace doesn't match the
-//!   expected indent for their AST scope. Lintr's tidy-default hanging indent
-//!   for braced blocks, multi-line argument lists, and continuation lines.
+//!   expected indent for their AST scope. Implements lintr's tidy-default
+//!   hanging indent for braced blocks, multi-line argument lists, and
+//!   continuation lines; also accepts the on-type formatter's aligned style
+//!   for argument lists that carry content on the opener line.
 //!
-//! Implementation note: every rule except `commented_code` and `semicolon`
-//! walks the already-parsed tree directly. `commented_code` re-parses each
-//! candidate comment body; `semicolon` byte-scans the source text using AST
-//! ranges only to skip strings and comments.
+//! Implementation note: most rules walk the already-parsed tree directly.
+//! `commented_code` re-parses each candidate comment body; `semicolon`
+//! byte-scans the source text using AST ranges only to skip strings and
+//! comments. `indentation` walks the tree to compute per-line scope
+//! expectations and also scans line text to count leading whitespace and
+//! detect mixed tabs.
 //!
 //! Suppression supports both lintr and Raven conventions:
 //! * `# nolint` (with optional `: rule_a, rule_b` filter) suppresses the line.
@@ -433,6 +437,7 @@ mod tests {
             assignment_operator_severity: None,
             infix_spaces_severity: None,
             commented_code_severity: None,
+            indentation_severity: None,
             ..enabled_config()
         }
     }
@@ -660,6 +665,7 @@ print.data.frame <- function(x, ...) NULL
             assignment_operator_severity: None,
             object_name_severity: None,
             commented_code_severity: None,
+            indentation_severity: None,
             ..enabled_config()
         }
     }
@@ -939,6 +945,7 @@ print.data.frame <- function(x, ...) NULL
             assignment_operator_severity: None,
             object_name_severity: None,
             infix_spaces_severity: None,
+            indentation_severity: None,
             ..enabled_config()
         }
     }

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -609,6 +609,43 @@ mod tests {
     }
 
     #[test]
+    fn parenthesized_expression_hanging_indent_passes() {
+        // Plain `(expr)` (parenthesized_expression, not a call) routes through
+        // the same set_bracketed path as call arguments. Inner content hangs
+        // one unit beyond the line of `(`; the inner `a + b` continuation
+        // adds another unit on top of that.
+        let text = "x <- (\n  a +\n    b\n)\n";
+        assert!(lint(text, 2).is_empty(), "got {:?}", lint(text, 2));
+    }
+
+    #[test]
+    fn parenthesized_expression_inner_misindented_flagged() {
+        // `b` continues `a +` and must indent one unit beyond `a`'s line
+        // (line indent 2 → expected 4). Writing it at 2 is wrong.
+        let text = "x <- (\n  a +\n  b\n)\n";
+        let diags = lint(text, 2);
+        assert!(
+            diags.iter().any(|d| d.range.start.line == 2),
+            "expected continuation diagnostic on line 2; got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn parenthesized_expression_closing_paren_aligns_with_opener_line() {
+        // The closing `)` on its own line aligns with the line of the `(`.
+        let aligned = "x <- (\n  a\n)\n";
+        let misaligned = "x <- (\n  a\n  )\n";
+        assert!(lint(aligned, 2).is_empty());
+        let diags = lint(misaligned, 2);
+        assert!(
+            diags.iter().any(|d| d.range.start.line == 2),
+            "expected misalignment diagnostic on line 2; got {:?}",
+            diags
+        );
+    }
+
+    #[test]
     fn mixed_pipe_and_arithmetic_chain_accepts_hanging_and_subchain_aligned() {
         // `f() |> g() + y + z` chains across pipe and arithmetic. The
         // hanging form (2) and the chain-start column (which lines up with

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -23,11 +23,15 @@
 //! * `binary_operator` — when the operator's RHS lives on a later line than
 //!   the LHS, those continuation lines indent one [`indent_unit`] beyond the
 //!   line where the LHS starts. The on-type formatter additionally aligns
-//!   such lines with the chain's first non-whitespace column (i.e.
-//!   `node.start_position().column`); when that column is to the right of
-//!   the hanging indent, the linter accepts it as an alternative so its
-//!   verdict doesn't disagree with the formatter's output. Nested binary
-//!   operators may push the expectation deeper (lintr's "tidy" default).
+//!   such lines with the binop's own start column (the column of its
+//!   leftmost token); when that column is to the right of the hanging indent,
+//!   the linter accepts it as an alternative so its verdict doesn't disagree
+//!   with the formatter's output. (The smart-indent provider may walk to a
+//!   sub-chain root for some mixed pipe/arithmetic chains via
+//!   `find_chain_start_from_ast`; the linter currently approximates this
+//!   with `node.start_position().column`, which agrees in the common cases
+//!   exercised by the test suite.) Nested binary operators may push the
+//!   expectation deeper (lintr's "tidy" default).
 //!
 //! Lines skipped without checks:
 //! * Suppressed lines (`# nolint`, `# nolint start/end`, `# @lsp-ignore`,

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -1,0 +1,523 @@
+//! Flag lines whose leading whitespace doesn't match the expected indent.
+//!
+//! Mirrors `lintr::indentation_linter()` with the default "tidy" hanging-indent
+//! style. The rule walks the parse tree once, builds a per-line expected indent
+//! from the AST scopes it crosses (braced blocks, multi-line argument lists,
+//! continuation lines under a binary operator), and reports any line whose
+//! actual leading-space count doesn't satisfy that expectation.
+//!
+//! Scopes and their expected indents:
+//! * `braced_expression` — inner lines indent one [`indent_unit`] beyond the
+//!   line of the opening `{`. A `}` that starts its own line aligns with the
+//!   opening `{`'s line; a `}` trailing other code is left to the inner-line
+//!   rule.
+//! * Bracketed groups (`call` / `subset` / `subset2` arguments, and
+//!   `parenthesized_expression`) — when the opener is followed by content on
+//!   the same line (e.g. `foo(a,`), continuation lines may either align with
+//!   the column after the opener (`opener_col + 1`) or hang one
+//!   [`indent_unit`] below the opener's line; both are accepted to match the
+//!   community-common aligned style. When the opener stands alone at end of
+//!   line (`foo(`), only the hanging form is accepted.
+//! * `binary_operator` — when the operator's RHS lives on a later line than
+//!   the LHS, those continuation lines must indent one [`indent_unit`] beyond
+//!   the line where the LHS starts. Nested binary operators may push that
+//!   expectation deeper (lintr's "tidy" hanging-indent default).
+//!
+//! Lines skipped without checks:
+//! * Suppressed lines (`# nolint`, `# nolint start/end`, `# @lsp-ignore`,
+//!   `# @lsp-ignore-next`).
+//! * Blank lines.
+//! * Lines whose leading whitespace contains any tab — those belong to the
+//!   `no_tab` rule.
+//! * Lines that start strictly inside a multi-line string literal.
+//! * Top-level lines with no enclosing multi-line scope expect indent 0.
+
+use std::collections::{HashMap, HashSet};
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::LINT_SOURCE;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    indent_unit: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.is_empty() {
+        return;
+    }
+
+    let mut string_interior: HashSet<u32> = HashSet::new();
+    collect_string_interior_lines(root, &mut string_interior);
+
+    let mut expectations: HashMap<u32, Expected> = HashMap::new();
+    set_expectations(root, &lines, indent_unit, &mut expectations);
+
+    for (idx, line_text) in lines.iter().enumerate() {
+        let line_no = idx as u32;
+        if suppressions.is_suppressed(line_no) {
+            continue;
+        }
+        if line_text.trim().is_empty() {
+            continue;
+        }
+        if string_interior.contains(&line_no) {
+            continue;
+        }
+        if has_tab_in_leading(line_text) {
+            continue;
+        }
+
+        let actual = leading_space_count(line_text);
+        let expected = expectations
+            .get(&line_no)
+            .cloned()
+            .unwrap_or_else(Expected::top_level);
+
+        if expected.is_acceptable(actual) {
+            continue;
+        }
+
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(line_no, 0),
+                end: Position::new(line_no, actual),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            message: expected.message(actual),
+            ..Default::default()
+        });
+    }
+}
+
+/// Acceptable indent values for a single line.
+///
+/// Most lines have a single acceptable indent, but multi-line argument lists
+/// whose opener carries content on the same line accept either the aligned
+/// column or the hanging indent (lintr's tidy default for argument lists).
+#[derive(Clone)]
+struct Expected {
+    primary: u32,
+    alternatives: Vec<u32>,
+}
+
+impl Expected {
+    fn single(value: u32) -> Self {
+        Self {
+            primary: value,
+            alternatives: Vec::new(),
+        }
+    }
+
+    fn top_level() -> Self {
+        Self::single(0)
+    }
+
+    fn with_alternative(primary: u32, alternative: u32) -> Self {
+        if primary == alternative {
+            Self::single(primary)
+        } else {
+            Self {
+                primary,
+                alternatives: vec![alternative],
+            }
+        }
+    }
+
+    fn is_acceptable(&self, actual: u32) -> bool {
+        actual == self.primary || self.alternatives.contains(&actual)
+    }
+
+    fn message(&self, actual: u32) -> String {
+        if self.alternatives.is_empty() {
+            format!(
+                "Indentation should be {} spaces, not {}.",
+                self.primary, actual
+            )
+        } else {
+            let mut options: Vec<u32> = std::iter::once(self.primary)
+                .chain(self.alternatives.iter().copied())
+                .collect();
+            options.sort_unstable();
+            options.dedup();
+            let listed = options
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(" or ");
+            format!("Indentation should be {listed} spaces, not {actual}.")
+        }
+    }
+}
+
+/// Walk the tree once, recording an expected indent for each line covered by
+/// a multi-line scope. We visit the parent before its children so that nested
+/// (innermost) scopes overwrite their ancestor's expectation — the inner scope
+/// is what the line actually sits in.
+fn set_expectations(
+    node: Node<'_>,
+    lines: &[&str],
+    indent_unit: u32,
+    out: &mut HashMap<u32, Expected>,
+) {
+    match node.kind() {
+        "braced_expression" => set_braced(node, lines, indent_unit, out),
+        "call" | "subset" | "subset2" => {
+            if let Some(args) = node.child_by_field_name("arguments") {
+                set_bracketed(args, lines, indent_unit, out);
+            }
+        }
+        "parenthesized_expression" => set_bracketed(node, lines, indent_unit, out),
+        "binary_operator" => set_binary_operator(node, lines, indent_unit, out),
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        set_expectations(child, lines, indent_unit, out);
+    }
+}
+
+fn set_braced(
+    node: Node<'_>,
+    lines: &[&str],
+    indent_unit: u32,
+    out: &mut HashMap<u32, Expected>,
+) {
+    let Some(opener) = node.child_by_field_name("open") else {
+        return;
+    };
+    let Some(closer) = node.child_by_field_name("close") else {
+        return;
+    };
+
+    let opener_line = opener.start_position().row as u32;
+    let closer_line = closer.start_position().row as u32;
+    if opener_line >= closer_line {
+        return;
+    }
+
+    let opener_indent = leading_whitespace_count(line_text(lines, opener_line));
+    let inner_indent = opener_indent.saturating_add(indent_unit);
+    let closer_col = closer.start_position().column as u32;
+
+    for line in (opener_line + 1)..=closer_line {
+        let text = line_text(lines, line);
+        let leading_ws = leading_whitespace_count(text);
+        let expected = if line == closer_line && closer_col == leading_ws {
+            Expected::single(opener_indent)
+        } else {
+            Expected::single(inner_indent)
+        };
+        out.insert(line, expected);
+    }
+}
+
+fn set_bracketed(
+    node: Node<'_>,
+    lines: &[&str],
+    indent_unit: u32,
+    out: &mut HashMap<u32, Expected>,
+) {
+    let Some(opener) = node.child_by_field_name("open") else {
+        return;
+    };
+    let Some(closer) = node.child_by_field_name("close") else {
+        return;
+    };
+
+    let opener_line = opener.start_position().row as u32;
+    let closer_line = closer.start_position().row as u32;
+    if opener_line >= closer_line {
+        return;
+    }
+
+    let opener_line_text = line_text(lines, opener_line);
+    let opener_indent = leading_whitespace_count(opener_line_text);
+    let opener_end_col = opener.end_position().column as u32;
+    let after_opener = opener_line_text
+        .get(opener_end_col as usize..)
+        .unwrap_or("");
+    let has_content_after_opener = after_opener.chars().any(|c| !c.is_whitespace());
+
+    let primary = opener_indent.saturating_add(indent_unit);
+    let aligned = opener_end_col;
+    let closer_col = closer.start_position().column as u32;
+
+    for line in (opener_line + 1)..=closer_line {
+        let text = line_text(lines, line);
+        let leading_ws = leading_whitespace_count(text);
+        let expected = if line == closer_line && closer_col == leading_ws {
+            Expected::single(opener_indent)
+        } else if has_content_after_opener {
+            Expected::with_alternative(primary, aligned)
+        } else {
+            Expected::single(primary)
+        };
+        out.insert(line, expected);
+    }
+}
+
+fn set_binary_operator(
+    node: Node<'_>,
+    lines: &[&str],
+    indent_unit: u32,
+    out: &mut HashMap<u32, Expected>,
+) {
+    let start_line = node.start_position().row as u32;
+    let end_line = node.end_position().row as u32;
+    if start_line >= end_line {
+        return;
+    }
+
+    let opener_indent = leading_whitespace_count(line_text(lines, start_line));
+    let expected = Expected::single(opener_indent.saturating_add(indent_unit));
+
+    for line in (start_line + 1)..=end_line {
+        out.insert(line, expected.clone());
+    }
+}
+
+/// Collect line numbers that start strictly inside a multi-line string. For a
+/// string spanning rows `[r1, r2]` with `r2 > r1`, lines `r1 + 1 ..= r2` start
+/// inside the string and are skipped by the linter.
+fn collect_string_interior_lines(node: Node<'_>, set: &mut HashSet<u32>) {
+    if node.kind() == "string" {
+        let start = node.start_position().row as u32;
+        let end = node.end_position().row as u32;
+        if end > start {
+            for line in (start + 1)..=end {
+                set.insert(line);
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_string_interior_lines(child, set);
+    }
+}
+
+fn line_text<'a>(lines: &'a [&'a str], line: u32) -> &'a str {
+    lines.get(line as usize).copied().unwrap_or("")
+}
+
+fn leading_space_count(line: &str) -> u32 {
+    line.chars().take_while(|c| *c == ' ').count() as u32
+}
+
+fn leading_whitespace_count(line: &str) -> u32 {
+    line.chars().take_while(|c| c.is_whitespace()).count() as u32
+}
+
+fn has_tab_in_leading(line: &str) -> bool {
+    line.chars()
+        .take_while(|c| c.is_whitespace())
+        .any(|c| c == '\t')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser_pool::with_parser;
+
+    fn lint(text: &str, indent_unit: u32) -> Vec<Diagnostic> {
+        let tree = with_parser(|p| p.parse(text, None)).expect("parse must succeed");
+        let suppressions = crate::linting::nolint::Suppressions::from_text(text);
+        let mut out = Vec::new();
+        collect(
+            text,
+            tree.root_node(),
+            indent_unit,
+            DiagnosticSeverity::HINT,
+            &suppressions,
+            &mut out,
+        );
+        out
+    }
+
+    #[test]
+    fn function_body_correctly_indented_passes() {
+        let text = "f <- function() {\n  x <- 1\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn function_body_underindented_flagged() {
+        let text = "f <- function() {\nx <- 1\n}\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 1);
+        assert!(diags[0].message.contains("should be 2 spaces"));
+    }
+
+    #[test]
+    fn function_body_overindented_flagged() {
+        let text = "f <- function() {\n    x <- 1\n}\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 1);
+        assert!(diags[0].message.contains("should be 2 spaces"));
+    }
+
+    #[test]
+    fn nested_braces_each_level_one_unit_deeper() {
+        let text = "{\n  if (x) {\n    y <- 1\n  }\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn nested_braces_inner_wrong_flagged() {
+        let text = "{\n  if (x) {\n  y <- 1\n  }\n}\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 2);
+    }
+
+    #[test]
+    fn closing_brace_aligned_with_opener() {
+        let text = "{\n  x <- 1\n  }\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 2);
+        assert!(diags[0].message.contains("should be 0 spaces"));
+    }
+
+    #[test]
+    fn continuation_after_binary_operator() {
+        let text = "x <- 1 +\n  2\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn continuation_underindented_flagged() {
+        let text = "x <- 1 +\n2\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn pipe_continuation_indented() {
+        let text = "x |>\n  f()\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_call_hanging_indent_passes() {
+        let text = "foo(\n  a,\n  b\n)\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_call_closing_paren_aligned() {
+        let text = "foo(\n  a,\n  b\n  )\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 3);
+        assert!(diags[0].message.contains("should be 0 spaces"));
+    }
+
+    #[test]
+    fn multi_line_call_aligned_with_first_arg_accepted() {
+        let text = "foo(a,\n    b)\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_call_hanging_when_opener_alone_accepted() {
+        let text = "foo(\n  a\n)\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_call_misaligned_flagged() {
+        let text = "foo(a,\n  b)\n";
+        // 2 is the hanging alternative (opener_indent + unit); 4 is aligned.
+        // Both are acceptable, so no diagnostic.
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_call_wrong_indent_flagged() {
+        let text = "foo(a,\n b)\n";
+        // 1 is neither aligned (4) nor hanging (2).
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("2 or 4"));
+    }
+
+    #[test]
+    fn if_else_block_passes() {
+        let text = "if (x) {\n  a\n} else {\n  b\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn multi_line_string_skipped() {
+        let text = "x <- \"hello\nworld\"\n";
+        // Line 1 starts inside the string; should not be flagged.
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn line_with_tab_in_indent_skipped() {
+        let text = "f <- function() {\n\tx <- 1\n}\n";
+        // Line 1 uses a tab — no_tab handles it; indentation rule stays silent.
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn suppression_nolint_silences_diagnostic() {
+        let text = "f <- function() {\nx <- 1 # nolint\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn suppression_lsp_ignore_next_silences_diagnostic() {
+        // The marker comment must itself be at the correct indent — the
+        // `# @lsp-ignore-next` only suppresses the *following* source line, so
+        // a marker placed at column 0 inside a braced block would (correctly)
+        // be flagged on its own line.
+        let text = "f <- function() {\n  # @lsp-ignore-next\nx <- 1\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn top_level_lines_expect_zero_indent() {
+        let text = "  x <- 1\n";
+        let diags = lint(text, 2);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range.start.line, 0);
+        assert!(diags[0].message.contains("should be 0 spaces"));
+    }
+
+    #[test]
+    fn empty_braced_block_no_diagnostics() {
+        let text = "f <- function() {\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn blank_lines_inside_block_not_flagged() {
+        let text = "f <- function() {\n\n  x\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn configurable_indent_unit_four() {
+        let text = "f <- function() {\n    x <- 1\n}\n";
+        assert!(lint(text, 4).is_empty());
+
+        let wrong = "f <- function() {\n  x <- 1\n}\n";
+        let diags = lint(wrong, 4);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("should be 4 spaces"));
+    }
+}

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -605,6 +605,18 @@ mod tests {
     }
 
     #[test]
+    fn mixed_pipe_and_arithmetic_chain_accepts_hanging_and_subchain_aligned() {
+        // `f() |> g() + y + z` chains across pipe and arithmetic. The
+        // hanging form (2) and the chain-start column (which lines up with
+        // `f()` because the binop node spans from there) must both be
+        // accepted to avoid disagreeing with the on-type formatter.
+        let hanging = "x <- f() |>\n  g() + y +\n  z\n";
+        let aligned = "x <- f() |>\n     g() + y +\n     z\n";
+        assert!(lint(hanging, 2).is_empty(), "hanging style should pass");
+        assert!(lint(aligned, 2).is_empty(), "subchain-aligned style should pass");
+    }
+
+    #[test]
     fn function_definition_parameters_closing_paren_aligns_with_function() {
         // The closing `)` of the parameter list sits on its own line and
         // should align with the line of the `function` keyword.

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -11,17 +11,23 @@
 //!   line of the opening `{`. A `}` that starts its own line aligns with the
 //!   opening `{`'s line; a `}` trailing other code is left to the inner-line
 //!   rule.
-//! * Bracketed groups (`call` / `subset` / `subset2` arguments, and
-//!   `parenthesized_expression`) — when the opener is followed by content on
-//!   the same line (e.g. `foo(a,`), continuation lines may either align with
-//!   the column after the opener (`opener_col + 1`) or hang one
-//!   [`indent_unit`] below the opener's line; both are accepted to match the
-//!   community-common aligned style. When the opener stands alone at end of
-//!   line (`foo(`), only the hanging form is accepted.
+//! * Bracketed groups (`call` / `subset` / `subset2` arguments,
+//!   `parenthesized_expression`, and `function_definition` parameter lists)
+//!   — when the opener is followed by code on the same line (e.g. `foo(a,`),
+//!   continuation lines may either align with the column after the opener
+//!   (`opener_col + 1`) or hang one [`indent_unit`] below the opener's line;
+//!   both are accepted to match the community-common aligned style. A
+//!   trailing `#` comment after the opener doesn't count as content (so
+//!   `foo( # note` is treated like `foo(`, hanging-only). When the opener
+//!   stands alone at end of line, only the hanging form is accepted.
 //! * `binary_operator` — when the operator's RHS lives on a later line than
-//!   the LHS, those continuation lines must indent one [`indent_unit`] beyond
-//!   the line where the LHS starts. Nested binary operators may push that
-//!   expectation deeper (lintr's "tidy" hanging-indent default).
+//!   the LHS, those continuation lines indent one [`indent_unit`] beyond the
+//!   line where the LHS starts. The on-type formatter additionally aligns
+//!   such lines with the chain's first non-whitespace column (i.e.
+//!   `node.start_position().column`); when that column is to the right of
+//!   the hanging indent, the linter accepts it as an alternative so its
+//!   verdict doesn't disagree with the formatter's output. Nested binary
+//!   operators may push the expectation deeper (lintr's "tidy" default).
 //!
 //! Lines skipped without checks:
 //! * Suppressed lines (`# nolint`, `# nolint start/end`, `# @lsp-ignore`,
@@ -174,6 +180,11 @@ fn set_expectations(
                 set_bracketed(args, lines, indent_unit, out);
             }
         }
+        "function_definition" => {
+            if let Some(params) = node.child_by_field_name("parameters") {
+                set_bracketed(params, lines, indent_unit, out);
+            }
+        }
         "parenthesized_expression" => set_bracketed(node, lines, indent_unit, out),
         "binary_operator" => set_binary_operator(node, lines, indent_unit, out),
         _ => {}
@@ -245,7 +256,14 @@ fn set_bracketed(
     let after_opener = opener_line_text
         .get(opener_end_col as usize..)
         .unwrap_or("");
-    let has_content_after_opener = after_opener.chars().any(|c| !c.is_whitespace());
+    // A trailing `# comment` after the opener doesn't count as "content on
+    // the same line" — `foo( # note` is morally the same as `foo(`, so only
+    // the hanging form should be accepted. The smart-indent provider strips
+    // comments before making the same decision; do likewise here so we don't
+    // silently accept aligned-style indent in code where the opener carries
+    // no code argument.
+    let has_content_after_opener =
+        first_non_whitespace_is_code(after_opener);
 
     let primary = opener_indent.saturating_add(indent_unit);
     let aligned = opener_end_col;
@@ -278,7 +296,20 @@ fn set_binary_operator(
     }
 
     let opener_indent = leading_whitespace_count(line_text(lines, start_line));
-    let expected = Expected::single(opener_indent.saturating_add(indent_unit));
+    let hanging = opener_indent.saturating_add(indent_unit);
+    // The on-type formatter (see `calculate_indentation` for
+    // `AfterContinuationOperator`) places continuation lines at
+    // `max(chain_start_col, line_indent + tab_size)`. When the chain start
+    // column (the leftmost column of the binop's LHS) sits to the right of
+    // the hanging indent — typically because the chain is the RHS of a
+    // wider assignment such as `result <- foo() +` — we accept both forms
+    // so the linter doesn't disagree with the formatter's output.
+    let chain_start_col = node.start_position().column as u32;
+    let expected = if chain_start_col > hanging {
+        Expected::with_alternative(hanging, chain_start_col)
+    } else {
+        Expected::single(hanging)
+    };
 
     for line in (start_line + 1)..=end_line {
         out.insert(line, expected.clone());
@@ -320,6 +351,18 @@ fn has_tab_in_leading(line: &str) -> bool {
     line.chars()
         .take_while(|c| c.is_whitespace())
         .any(|c| c == '\t')
+}
+
+/// True when the first non-whitespace character in `s` is a code token rather
+/// than a `#` that starts a comment. Used to decide whether the opener of a
+/// bracketed group carries real content on its line — `foo( # note` should
+/// be treated as `foo(`, not as `foo(a`.
+fn first_non_whitespace_is_code(s: &str) -> bool {
+    match s.chars().find(|c| !c.is_whitespace()) {
+        None => false,
+        Some('#') => false,
+        Some(_) => true,
+    }
 }
 
 #[cfg(test)]
@@ -519,5 +562,60 @@ mod tests {
         let diags = lint(wrong, 4);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("should be 4 spaces"));
+    }
+
+    #[test]
+    fn chain_start_col_accepted_as_alternative() {
+        // The on-type formatter aligns `bar()` with `foo()` (column 10 —
+        // `result <- ` is 10 chars wide) because the chain starts there.
+        // The linter must also accept the hanging indent (2). Both must
+        // pass without diagnostics.
+        let aligned = "result <- foo() +\n          bar()\n";
+        let hanging = "result <- foo() +\n  bar()\n";
+        assert!(lint(aligned, 2).is_empty(), "aligned style should pass");
+        assert!(lint(hanging, 2).is_empty(), "hanging style should pass");
+    }
+
+    #[test]
+    fn comment_after_opener_does_not_unlock_aligned_style() {
+        // `foo( # note` opens like `foo(` — only the hanging form (2) is
+        // allowed; alignment to column after the opener (5) is not, because
+        // there's no code argument on the opener line to align to.
+        let hanging_ok = "foo( # note\n  a\n)\n";
+        let aligned_bad = "foo( # note\n     a\n)\n";
+        assert!(lint(hanging_ok, 2).is_empty());
+        let diags = lint(aligned_bad, 2);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn function_definition_parameters_hanging_indent() {
+        let text = "f <- function(\n  x,\n  y\n) {\n  x + y\n}\n";
+        assert!(lint(text, 2).is_empty());
+    }
+
+    #[test]
+    fn function_definition_parameters_misindented_flagged() {
+        let text = "f <- function(\nx,\n  y\n) {\n  x + y\n}\n";
+        let diags = lint(text, 2);
+        // Only the `x,` line is mis-indented (0 instead of 2).
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn function_definition_parameters_closing_paren_aligns_with_function() {
+        // The closing `)` of the parameter list sits on its own line and
+        // should align with the line of the `function` keyword.
+        let aligned = "f <- function(\n  x\n) {\n  x\n}\n";
+        let misaligned = "f <- function(\n  x\n  ) {\n  x\n}\n";
+        assert!(lint(aligned, 2).is_empty());
+        let diags = lint(misaligned, 2);
+        assert!(
+            diags.iter().any(|d| d.range.start.line == 2),
+            "expected diagnostic on line 2 (the misindented `)`); got {:?}",
+            diags
+        );
     }
 }

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod commas;
 pub(crate) mod commented_code;
 pub(crate) mod equals_na;
 pub(crate) mod function_left_parentheses;
+pub(crate) mod indentation;
 pub(crate) mod infix_spaces;
 pub(crate) mod line_length;
 pub(crate) mod no_tab;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,7 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.enabled` | `false` | Master switch for all lint diagnostics |
 | `raven.linting.lineLength` | `80` | Maximum line length (UTF-16 code units) |
 | `raven.linting.objectLength` | `30` | Maximum identifier length for the object-length lint |
+| `raven.linting.indentationUnit` | `2` | Spaces per indent level used by the indentation lint (clamped to `1..=8`) |
 | `raven.linting.assignmentOperator` | `"<-"` | Preferred assignment operator (`"<-"` or `"="`) |
 | `raven.linting.stringDelimiter` | `"\""` | Preferred string-literal delimiter (`"\""` or `"'"`); used by the quotes lint |
 | `raven.linting.lineLengthSeverity` | `"hint"` | Severity for over-long lines (or `"off"`) |
@@ -144,6 +145,7 @@ Native style/lint diagnostics. Off by default; opt in with `raven.linting.enable
 | `raven.linting.vectorLogicSeverity` | `"hint"` | Severity for the vector-logic lint (`&` / `\|` in `if` / `while` conditions) |
 | `raven.linting.functionLeftParenthesesSeverity` | `"hint"` | Severity for the function-left-parentheses lint (whitespace between `function` and `(`) |
 | `raven.linting.spacesInsideSeverity` | `"hint"` | Severity for the spaces-inside lint (whitespace inside `(`, `[`, `[[`) |
+| `raven.linting.indentationSeverity` | `"hint"` | Severity for the indentation lint (lines whose leading whitespace doesn't match the expected indent for their AST scope) |
 
 To disable an individual rule while leaving the rest enabled, set its severity to `"off"`. For the object-name lint, you can also set any of the three style settings to `"any"` to disable just that symbol kind while keeping the others active.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -71,6 +71,7 @@ Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-li
 | Vector logic | hint | `&` or `\|` in an `if` / `while` condition (use `&&` / `\|\|` for scalars). Scan stops at call boundaries |
 | Function left parentheses | hint | Whitespace between `function` (or `\`) and `(` (`function (x) ...`, `\ (x) ...`) |
 | Spaces inside | hint | Whitespace immediately inside `(`, `[`, or `[[` (`f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are exempt |
+| Indentation | hint | Leading whitespace doesn't match the expected indent for the line's AST scope (braced blocks, multi-line argument lists, continuation lines). Configurable indent unit via `raven.linting.indentationUnit` (default 2) |
 
 Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -146,6 +146,13 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 - **`lintr` equivalent:** `lintr::spaces_inside_linter()`.
 - Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Empty groupings (`f()`, `f( )`, `mat[]`) and multi-line wrapping are exempt — only single-line interior whitespace is flagged.
 
+### Indentation
+
+- **Raven:** `raven.linting.indentationUnit` (default `2`, clamped to `1..=8`), `raven.linting.indentationSeverity` (default `"hint"`).
+- **`lintr` equivalent:** `lintr::indentation_linter()` with its tidy-default hanging style.
+- Flags lines whose leading whitespace doesn't match the indent expected by the AST scope the line sits in: braced blocks (one unit deeper than the line of `{`); multi-line argument lists (either aligned with the column after the opener — `foo(a,\n    b)` — or hanging one unit deeper than the opener's line); continuation lines under a binary operator (one unit deeper than the line where the chain starts). A closing delimiter (`)`, `]`, `]]`, `}`) that begins its own line aligns with the line of its opener.
+- Skipped without checks: blank lines, lines whose leading whitespace contains any tab (left to the `no_tab` rule), and lines that start strictly inside a multi-line string. Suppression markers behave as on every other rule.
+
 ## Migrating from `.lintr`
 
 Raven does not read `.lintr` files — its rules are configured per VS Code settings instead. The table below maps the `lintr` linters covered by Raven to their Raven equivalents. For each `lintr` linter you currently enable, set the corresponding `raven.linting.*` keys; for ones not listed, see [Gaps vs `lintr`](#gaps-vs-lintr).
@@ -169,6 +176,7 @@ Raven does not read `.lintr` files — its rules are configured per VS Code sett
 | `vector_logic_linter()` | `raven.linting.vectorLogicSeverity` |
 | `function_left_parentheses_linter()` | `raven.linting.functionLeftParenthesesSeverity` |
 | `spaces_inside_linter()` | `raven.linting.spacesInsideSeverity` |
+| `indentation_linter(indent = N)` | `raven.linting.indentationUnit = N`, `raven.linting.indentationSeverity` |
 
 To disable a rule from a `.lintr` `linters_with_defaults(..., default = list())` setup, set its severity to `"off"`. To raise a rule that `lintr` would flag as a `warning`, raise its severity from `"hint"` to `"warning"`.
 
@@ -181,7 +189,7 @@ If you'd also like a starter `.lintr` for running `lintr` itself alongside Raven
 - `object_usage_linter` — flags undefined globals inside function bodies via `codetools::checkUsage()`. Raven's [Undefined variable diagnostic](diagnostics.md#undefined-variables) covers similar ground at the file and `source()`-chain level (via static cross-file scope), but with different semantics: Raven's check is scope- and position-aware across `source()` chains, while `object_usage_linter` runs inside individual function bodies via R's own analyzer.
 - `cyclocomp_linter` — cyclomatic complexity.
 - `seq_linter`.
-- `brace_linter`, `paren_body_linter`, `indentation_linter`, `spaces_left_parentheses_linter`.
+- `brace_linter`, `paren_body_linter`, `spaces_left_parentheses_linter`.
 - `pipe_continuation_linter`, `pipe_call_linter`.
 - `absolute_path_linter`.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1587,6 +1587,32 @@
           ],
           "default": "hint",
           "description": "Severity for the spaces-inside lint. Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are left alone."
+        },
+        "raven.linting.indentationUnit": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 8,
+          "description": "Number of spaces per indent level used by the indentation lint. Mirrors `lintr::indentation_linter()`'s `indent` parameter."
+        },
+        "raven.linting.indentationSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report mis-indented lines as errors",
+            "Report mis-indented lines as warnings",
+            "Report mis-indented lines as information",
+            "Report mis-indented lines as hints",
+            "Disable the indentation lint"
+          ],
+          "default": "hint",
+          "description": "Severity for the indentation lint. Flags lines whose leading whitespace doesn't match the expected indent given their AST scope (braced blocks, multi-line argument lists, continuation lines)."
         }
       }
     }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -98,6 +98,7 @@ export interface RavenInitializationOptions {
         enabled?: boolean;
         lineLength?: number;
         objectLength?: number;
+        indentationUnit?: number;
         assignmentOperator?: "<-" | "=";
         stringDelimiter?: "\"" | "'";
         objectNameStyleFunction?: ObjectNameStyle;
@@ -120,6 +121,7 @@ export interface RavenInitializationOptions {
         vectorLogicSeverity?: SeverityLevel;
         functionLeftParenthesesSeverity?: SeverityLevel;
         spacesInsideSeverity?: SeverityLevel;
+        indentationSeverity?: SeverityLevel;
     };
     helpViewer?: { viewColumn?: 'active' | 'beside' };
 }
@@ -366,6 +368,7 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         enabled: config.get<boolean>('linting.enabled', false),
         lineLength: config.get<number>('linting.lineLength', 80),
         objectLength: config.get<number>('linting.objectLength', 30),
+        indentationUnit: config.get<number>('linting.indentationUnit', 2),
         assignmentOperator: config.get<"<-" | "=">('linting.assignmentOperator', '<-'),
         stringDelimiter: config.get<"\"" | "'">('linting.stringDelimiter', '"'),
         objectNameStyleFunction: config.get<ObjectNameStyle>('linting.objectNameStyleFunction', 'snake_case'),
@@ -388,6 +391,7 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         vectorLogicSeverity: config.get<SeverityLevel>('linting.vectorLogicSeverity', 'hint'),
         functionLeftParenthesesSeverity: config.get<SeverityLevel>('linting.functionLeftParenthesesSeverity', 'hint'),
         spacesInsideSeverity: config.get<SeverityLevel>('linting.spacesInsideSeverity', 'hint'),
+        indentationSeverity: config.get<SeverityLevel>('linting.indentationSeverity', 'hint'),
     };
 
     const helpViewerColumn = getExplicitSetting<'active' | 'beside'>(config, 'help.viewerColumn');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -126,6 +126,7 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.enabled', jsonPath: ['linting', 'enabled'], type: 'boolean', defaultWhenUnconfigured: false },
     { vsCodeKey: 'linting.lineLength', jsonPath: ['linting', 'lineLength'], type: 'number', defaultWhenUnconfigured: 80 },
     { vsCodeKey: 'linting.objectLength', jsonPath: ['linting', 'objectLength'], type: 'number', defaultWhenUnconfigured: 30 },
+    { vsCodeKey: 'linting.indentationUnit', jsonPath: ['linting', 'indentationUnit'], type: 'number', defaultWhenUnconfigured: 2 },
     { vsCodeKey: 'linting.assignmentOperator', jsonPath: ['linting', 'assignmentOperator'], type: 'enum', enumValues: ['<-', '='] as const, defaultWhenUnconfigured: '<-' },
     { vsCodeKey: 'linting.stringDelimiter', jsonPath: ['linting', 'stringDelimiter'], type: 'enum', enumValues: ['"', "'"] as const, defaultWhenUnconfigured: '"' },
     { vsCodeKey: 'linting.lineLengthSeverity', jsonPath: ['linting', 'lineLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
@@ -148,6 +149,7 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.vectorLogicSeverity', jsonPath: ['linting', 'vectorLogicSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.functionLeftParenthesesSeverity', jsonPath: ['linting', 'functionLeftParenthesesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.spacesInsideSeverity', jsonPath: ['linting', 'spacesInsideSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'linting.indentationSeverity', jsonPath: ['linting', 'indentationSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     // Help viewer settings
     { vsCodeKey: 'help.viewerColumn', jsonPath: ['helpViewer', 'viewColumn'], type: 'enum', enumValues: ['active', 'beside'] as const },
 ];
@@ -370,6 +372,7 @@ suite('Settings Transmission Property Tests', () => {
                 enabled: false,
                 lineLength: 80,
                 objectLength: 30,
+                indentationUnit: 2,
                 assignmentOperator: '<-',
                 stringDelimiter: '"',
                 objectNameStyleFunction: 'snake_case',
@@ -392,6 +395,7 @@ suite('Settings Transmission Property Tests', () => {
                 vectorLogicSeverity: 'hint',
                 functionLeftParenthesesSeverity: 'hint',
                 spacesInsideSeverity: 'hint',
+                indentationSeverity: 'hint',
             },
         }, 'Empty configuration should produce only runtime defaults');
 
@@ -533,6 +537,7 @@ suite('Settings Transmission Unit Tests', () => {
             enabled: false,
             lineLength: 80,
             objectLength: 30,
+            indentationUnit: 2,
             assignmentOperator: '<-',
             stringDelimiter: '"',
             objectNameStyleFunction: 'snake_case',
@@ -555,6 +560,7 @@ suite('Settings Transmission Unit Tests', () => {
             vectorLogicSeverity: 'hint',
             functionLeftParenthesesSeverity: 'hint',
             spacesInsideSeverity: 'hint',
+            indentationSeverity: 'hint',
         });
     });
 


### PR DESCRIPTION
Closes #243.

## Summary

- Adds a native indentation lint rule that walks the tree-sitter R AST and flags lines whose leading whitespace doesn't match the indent expected for the scope they sit in.
- Handles braced blocks, multi-line argument lists (call args, subset, subset2, parenthesized expressions, and `function()` parameter lists), continuation lines under multi-line binary operators, and own-line closing delimiters.
- Configurable via `raven.linting.indentationUnit` (default 2, clamped to 1..=8) and `raven.linting.indentationSeverity` (default `"hint"`).
- Removes `indentation_linter` from the "Gaps vs lintr" list in `docs/linting.md`.

## Design notes

- Two indent forms are accepted for bracketed groups whose opener carries content on the same line: aligned with the column after the opener (`foo(a,\n    b)`) and hanging one unit deeper than the opener's line (`foo(a,\n  b)`).
- For `binary_operator` continuation lines, the on-type formatter's chain-start column is accepted as an alternative when it sits to the right of the hanging indent — this is required so the linter doesn't disagree with code RStudio's on-type formatter just produced.
- Trailing `# comment` after the opener doesn't unlock the aligned alternative (matches the smart-indent provider).
- Lines skipped without checks: blank lines, lines with tabs in leading whitespace (left to the `no_tab` rule), and lines that start strictly inside a multi-line string. Suppression markers behave as on every other rule.

## Test plan

- [x] All 199 linting unit/integration tests pass (`cargo test -p raven --lib linting::`).
- [x] Full Rust test suite passes — debug and release with `--features test-support` (3707 lib tests + 103 + 58 integration).
- [x] VS Code extension typecheck and compile pass.
- [x] `parse_lint_config` tests cover the new `indentationSeverity` "off" path and the `indentationUnit` clamping (1..=8).
- [x] `editors/vscode/src/test/settings.test.ts` SETTINGS_MAPPING and named-value tests updated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indentation linting rule to detect indentation inconsistencies based on code structure. Configurable with indentationUnit (1–8 spaces per level) and indentationSeverity severity setting.

* **Documentation**
  * Added configuration documentation and diagnostic reference for the indentation rule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/248)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->