### PR TITLE
feat(scaffold): replace .lintr scaffold with linting-settings scaffold

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ These Command Palette entries write starter R config files to the first workspac
 | Command | File | Contents |
 |---|---|---|
 | `Raven: Create .gitignore` | `.gitignore` | Standard R ignores (`.Rhistory`, `.RData`, `.Rproj.user/`), OS files (`.DS_Store`, `Thumbs.db`), R Markdown/Quarto/`R CMD check` artifacts, local scratch dirs, and AI-tool user-local overrides |
-| `Raven: Create .lintr` | `.lintr` | `linters_with_defaults(line_length_linter(120))` |
+| `Raven: Create linting settings` | `.vscode/settings.json` | Every `raven.linting.*` key Raven understands, each prefaced with a `//` comment naming its `lintr` equivalent. Merges into an existing `settings.json` without disturbing unrelated keys or comments; prompts before overwriting an existing `raven.linting.*` block |
 
 ## R Console Activation
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -180,7 +180,9 @@ Raven does not read `.lintr` files — its rules are configured per VS Code sett
 
 To disable a rule from a `.lintr` `linters_with_defaults(..., default = list())` setup, set its severity to `"off"`. To raise a rule that `lintr` would flag as a `warning`, raise its severity from `"hint"` to `"warning"`.
 
-If you'd also like a starter `.lintr` for running `lintr` itself alongside Raven (see [below](#filling-the-gaps-with-lintr-itself)), run the **Raven: Create .lintr** command from the Command Palette ([Configuration § Scaffold Commands](configuration.md#scaffold-commands)). It writes a minimal `linters: linters_with_defaults(line_length_linter(120))` to the workspace root.
+If you'd like a starter `raven.linting.*` block scaffolded into `.vscode/settings.json` — every key Raven understands, each prefaced with a `//` comment naming its `lintr` equivalent — run the **Raven: Create linting settings** command from the Command Palette ([Configuration § Scaffold Commands](configuration.md#scaffold-commands)). It merges into an existing `settings.json` without disturbing unrelated keys or comments, and prompts before overwriting any pre-existing `raven.linting.*` values.
+
+If you also want to run `lintr` itself alongside Raven, see [below](#filling-the-gaps-with-lintr-itself) — that path needs a `.lintr` file, which Raven doesn't generate.
 
 ## Gaps vs `lintr`
 
@@ -201,7 +203,12 @@ The [REditorSupport (R) extension](https://marketplace.visualstudio.com/items?it
 
 1. Keep Raven installed and enabled.
 2. Install the REditorSupport (R) extension. Leave `r.lsp.enabled` at its default (`true`).
-3. Place a `.lintr` file at your project root. The **Raven: Create .lintr** command writes a starter (`linters: linters_with_defaults(line_length_linter(120))`).
+3. Place a `.lintr` file at your project root. Raven does not scaffold this file — its format is `lintr`'s own DSL and Raven doesn't read it. A minimal starter that mirrors the `lintr` default rule set with a 120-character line limit is one line:
+
+   ```r
+   linters: linters_with_defaults(line_length_linter(120))
+   ```
+
 4. Install `lintr` in the R session REditorSupport uses (`install.packages("lintr")`).
 
 REditorSupport's LSP will surface `lintr` diagnostics; Raven will continue to surface its own. Both sets will appear in the Problems pane and you can tell them apart by the `source` field (`raven (lint)` for Raven, `lintr` for REditorSupport). See [Coexistence § Language servers](coexistence.md#language-servers-raven-alone-vs-both) for the broader cross-extension model.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -180,8 +180,8 @@
         "category": "Raven"
       },
       {
-        "command": "raven.scaffold.lintr",
-        "title": "Create .lintr",
+        "command": "raven.scaffold.lintingSettings",
+        "title": "Create linting settings",
         "category": "Raven"
       },
       {

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -538,7 +538,7 @@ function stripSentineledLintingBlock(text: string): string {
  * `"editor.tabSize": 4, "raven.linting.foo": true` on a single line
  * would lose the unrelated key here, but VS Code's own formatters and
  * the Settings UI never produce that shape, so we don't try to handle
- * it.
+ * it. Tracked as a known limitation in https://github.com/jbearak/raven/issues/250.
  */
 function stripTopLevelLintingLines(text: string): string {
     const lineStarts = computeLineStarts(text);

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 
 /**
  * Templates and commands that scaffold R-specific workspace files
- * (`.gitignore`, `.lintr`). Written to the first workspace folder; if the
- * file already exists the user is prompted before it is overwritten.
+ * (`.gitignore`) and Raven configuration (`.vscode/settings.json`).
+ * Single-file writes prompt before overwriting; the linting-settings
+ * scaffold merges into an existing settings file and only prompts when
+ * it would overwrite existing `raven.linting.*` keys.
  */
 
 export const GITIGNORE_TEMPLATE = `# History files
@@ -55,10 +57,332 @@ scratch.R
 .cursorignore.local
 `;
 
-export const LINTR_TEMPLATE = `linters: linters_with_defaults(
-    line_length_linter(120)
-  )
-`;
+/**
+ * Ordered groups of `raven.linting.*` keys. Each group renders as a
+ * `// lintr: ...` heading followed by one or more key/value lines.
+ * The leading-group `comment` is shown above the very first group as
+ * the overview header. Keep the ordering stable so the file is easy
+ * to diff after running the scaffold a second time.
+ */
+interface LintingGroup {
+    comment: string;
+    entries: Array<{ key: string; value: unknown }>;
+}
+
+const LINTING_GROUPS: LintingGroup[] = [
+    {
+        comment: 'Master switch — enable Raven\'s native style/lint diagnostics.',
+        entries: [{ key: 'raven.linting.enabled', value: true }],
+    },
+    {
+        comment: 'lintr: line_length_linter(length = N)',
+        entries: [
+            { key: 'raven.linting.lineLength', value: 120 },
+            { key: 'raven.linting.lineLengthSeverity', value: 'hint' },
+        ],
+    },
+    {
+        comment: 'lintr: trailing_whitespace_linter()',
+        entries: [{ key: 'raven.linting.trailingWhitespaceSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: whitespace_linter() (no-tab portion)',
+        entries: [{ key: 'raven.linting.noTabSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: trailing_blank_lines_linter()',
+        entries: [{ key: 'raven.linting.trailingBlankLinesSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: assignment_linter()',
+        entries: [
+            { key: 'raven.linting.assignmentOperator', value: '<-' },
+            { key: 'raven.linting.assignmentOperatorSeverity', value: 'hint' },
+        ],
+    },
+    {
+        comment: 'lintr: object_name_linter(styles = ...)',
+        entries: [
+            { key: 'raven.linting.objectNameStyleFunction', value: 'snake_case' },
+            { key: 'raven.linting.objectNameStyleVariable', value: 'snake_case' },
+            { key: 'raven.linting.objectNameStyleArgument', value: 'snake_case' },
+            { key: 'raven.linting.objectNameSeverity', value: 'hint' },
+        ],
+    },
+    {
+        comment: 'lintr: infix_spaces_linter()',
+        entries: [{ key: 'raven.linting.infixSpacesSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: commented_code_linter()',
+        entries: [{ key: 'raven.linting.commentedCodeSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: quotes_linter() / single_quotes_linter()',
+        entries: [
+            { key: 'raven.linting.stringDelimiter', value: '"' },
+            { key: 'raven.linting.quotesSeverity', value: 'hint' },
+        ],
+    },
+    {
+        comment: 'lintr: commas_linter()',
+        entries: [{ key: 'raven.linting.commasSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: T_and_F_symbol_linter()',
+        entries: [{ key: 'raven.linting.tAndFSymbolSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: semicolon_linter()',
+        entries: [{ key: 'raven.linting.semicolonSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: equals_na_linter()',
+        entries: [{ key: 'raven.linting.equalsNaSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: object_length_linter(length = N)',
+        entries: [
+            { key: 'raven.linting.objectLength', value: 30 },
+            { key: 'raven.linting.objectLengthSeverity', value: 'hint' },
+        ],
+    },
+    {
+        comment: 'lintr: vector_logic_linter()',
+        entries: [{ key: 'raven.linting.vectorLogicSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: function_left_parentheses_linter()',
+        entries: [{ key: 'raven.linting.functionLeftParenthesesSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: spaces_inside_linter()',
+        entries: [{ key: 'raven.linting.spacesInsideSeverity', value: 'hint' }],
+    },
+    {
+        comment: 'lintr: indentation_linter(indent = N)',
+        entries: [
+            { key: 'raven.linting.indentationUnit', value: 2 },
+            { key: 'raven.linting.indentationSeverity', value: 'hint' },
+        ],
+    },
+];
+
+const LINTING_BLOCK_HEADER =
+    'Raven native style/lint diagnostics. Severities accept: "error",\n' +
+    '"warning", "information", "hint", or "off". Each group below names\n' +
+    'the lintr linter it mirrors. See docs/linting.md for details.';
+
+/**
+ * Format the linting-settings block (header + groups) at the given
+ * indentation, without surrounding braces. The final entry uses the
+ * supplied `trailingPunctuation` so the caller can distinguish the
+ * fresh-file case (no trailing comma — last property in the object)
+ * from the merge case (trailing comma — more properties may follow).
+ */
+function formatLintingBlock(indent: string, trailingPunctuation: '' | ','): string {
+    const lines: string[] = [];
+    for (const headerLine of LINTING_BLOCK_HEADER.split('\n')) {
+        lines.push(`${indent}// ${headerLine}`);
+    }
+
+    LINTING_GROUPS.forEach((group, groupIdx) => {
+        lines.push('');
+        lines.push(`${indent}// ${group.comment}`);
+        group.entries.forEach((entry, entryIdx) => {
+            const isLastEntryOfBlock =
+                groupIdx === LINTING_GROUPS.length - 1 &&
+                entryIdx === group.entries.length - 1;
+            const sep = isLastEntryOfBlock ? trailingPunctuation : ',';
+            lines.push(
+                `${indent}${JSON.stringify(entry.key)}: ${JSON.stringify(entry.value)}${sep}`,
+            );
+        });
+    });
+
+    return lines.join('\n');
+}
+
+/**
+ * The literal contents of a fresh `.vscode/settings.json` containing
+ * just the linting block. Exported for unit tests; the production path
+ * builds this via `buildLintingSettingsContent` so an existing file is
+ * merged rather than clobbered.
+ */
+export const LINTING_SETTINGS_TEMPLATE = `{\n${formatLintingBlock('  ', '')}\n}\n`;
+
+/**
+ * Strip `//` line comments and `/* ... *\/` block comments from JSONC
+ * text, preserving string contents and newlines (so line numbers in
+ * any downstream parse errors still line up). Trailing-comma stripping
+ * is left to the caller; this function only removes comments.
+ */
+function stripJsoncComments(text: string): string {
+    let out = '';
+    let i = 0;
+    let inString = false;
+    while (i < text.length) {
+        const c = text[i];
+        if (inString) {
+            out += c;
+            if (c === '\\' && i + 1 < text.length) {
+                out += text[i + 1];
+                i += 2;
+                continue;
+            }
+            if (c === '"') inString = false;
+            i++;
+            continue;
+        }
+        if (c === '"') {
+            inString = true;
+            out += c;
+            i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '/') {
+            while (i < text.length && text[i] !== '\n') i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '*') {
+            i += 2;
+            while (i + 1 < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+                if (text[i] === '\n') out += '\n';
+                i++;
+            }
+            i += 2;
+            continue;
+        }
+        out += c;
+        i++;
+    }
+    return out;
+}
+
+function stripTrailingCommas(text: string): string {
+    return text.replace(/,(\s*[}\]])/g, '$1');
+}
+
+/**
+ * Parse-with-comments helper that returns the list of top-level
+ * `raven.linting.*` keys present in a JSONC text, or `null` if the text
+ * has parse errors. An empty file returns an empty array.
+ */
+export function detectExistingLintingKeys(text: string): string[] | null {
+    if (text.trim().length === 0) return [];
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(stripTrailingCommas(stripJsoncComments(text)));
+    } catch {
+        return null;
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return [];
+    }
+    return Object.keys(parsed as Record<string, unknown>).filter((k) =>
+        k.startsWith('raven.linting.'),
+    );
+}
+
+/**
+ * Walk JSONC text and return the index of the `}` that closes the
+ * outermost object, or `-1` if none was found. Skips braces inside
+ * strings and comments.
+ */
+function findOutermostClosingBrace(text: string): number {
+    let depth = 0;
+    let inString = false;
+    let close = -1;
+    let i = 0;
+    while (i < text.length) {
+        const c = text[i];
+        if (inString) {
+            if (c === '\\' && i + 1 < text.length) {
+                i += 2;
+                continue;
+            }
+            if (c === '"') inString = false;
+            i++;
+            continue;
+        }
+        if (c === '"') {
+            inString = true;
+            i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '/') {
+            while (i < text.length && text[i] !== '\n') i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '*') {
+            i += 2;
+            while (i + 1 < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++;
+            i += 2;
+            continue;
+        }
+        if (c === '{') {
+            depth++;
+            i++;
+            continue;
+        }
+        if (c === '}') {
+            depth--;
+            if (depth === 0) close = i;
+            i++;
+            continue;
+        }
+        i++;
+    }
+    return close;
+}
+
+/**
+ * Remove lines whose sole content is a top-level `raven.linting.*` key
+ * declaration. `raven.linting.*` values are all scalars (boolean, int,
+ * string) so single-line removal is safe.
+ */
+function stripExistingLintingLines(text: string): string {
+    return text.replace(/^[ \t]*"raven\.linting\.[^"]+"[ \t]*:[^\n]*\n?/gm, '');
+}
+
+/**
+ * Build the JSONC content to write to `.vscode/settings.json`. If
+ * `existing` is `undefined` or whitespace-only, returns the fresh
+ * template. Otherwise removes any prior `raven.linting.*` keys and
+ * inserts a freshly formatted block immediately before the outermost
+ * closing brace, preserving all unrelated keys and comments.
+ */
+export function buildLintingSettingsContent(existing: string | undefined): string {
+    if (existing === undefined || existing.trim().length === 0) {
+        return LINTING_SETTINGS_TEMPLATE;
+    }
+    const withoutLinting = stripExistingLintingLines(existing);
+    const closeIdx = findOutermostClosingBrace(withoutLinting);
+    if (closeIdx === -1) {
+        return LINTING_SETTINGS_TEMPLATE;
+    }
+
+    const before = withoutLinting.slice(0, closeIdx);
+    const after = withoutLinting.slice(closeIdx);
+    const trimmedBefore = before.replace(/[ \t\n\r]+$/, '');
+
+    const openBraceIdx = trimmedBefore.lastIndexOf('{');
+    const hasExistingProps =
+        openBraceIdx !== -1 && trimmedBefore.slice(openBraceIdx + 1).trim().length > 0;
+    const endsWithComma = trimmedBefore.endsWith(',');
+
+    let prefix: string;
+    if (!hasExistingProps) {
+        prefix = trimmedBefore + '\n';
+    } else if (endsWithComma) {
+        prefix = trimmedBefore + '\n';
+    } else {
+        prefix = trimmedBefore + ',\n';
+    }
+
+    const block = formatLintingBlock('  ', '');
+    return `${prefix}${block}\n${after}`;
+}
 
 /**
  * Return the first workspace folder, or surface a message and return
@@ -138,6 +462,72 @@ async function runScaffoldCommand(fileName: string, content: string): Promise<vo
     }
 }
 
+/**
+ * Merge a Raven linting-settings block into `.vscode/settings.json`,
+ * creating the file (and the `.vscode/` directory) if absent. If the
+ * file already contains any `raven.linting.*` keys, prompt before
+ * overwriting them; unrelated keys and comments are preserved.
+ */
+async function runLintingSettingsScaffold(
+    folder: vscode.WorkspaceFolder,
+): Promise<vscode.Uri | undefined> {
+    const vscodeDir = vscode.Uri.joinPath(folder.uri, '.vscode');
+    const settingsUri = vscode.Uri.joinPath(vscodeDir, 'settings.json');
+    const displayName = '.vscode/settings.json';
+
+    let existing: string | undefined;
+    try {
+        const bytes = await vscode.workspace.fs.readFile(settingsUri);
+        existing = Buffer.from(bytes).toString('utf8');
+    } catch {
+        existing = undefined;
+    }
+
+    if (existing !== undefined) {
+        const existingKeys = detectExistingLintingKeys(existing);
+        if (existingKeys === null) {
+            void vscode.window.showErrorMessage(
+                `Raven: ${displayName} has JSON parse errors; fix them and re-run this command.`,
+            );
+            return undefined;
+        }
+        if (existingKeys.length > 0) {
+            const label =
+                existingKeys.length === 1
+                    ? '1 raven.linting.* setting'
+                    : `${existingKeys.length} raven.linting.* settings`;
+            const choice = await vscode.window.showWarningMessage(
+                `${label} already in ${displayName}. Overwrite the raven.linting.* block? Other keys and comments will be preserved.`,
+                { modal: true },
+                'Overwrite',
+            );
+            if (choice !== 'Overwrite') {
+                return undefined;
+            }
+        }
+    }
+
+    const newContent = buildLintingSettingsContent(existing);
+
+    try {
+        await vscode.workspace.fs.createDirectory(vscodeDir);
+    } catch {
+        // directory may already exist; createDirectory is best-effort
+    }
+
+    await vscode.workspace.fs.writeFile(settingsUri, Buffer.from(newContent, 'utf8'));
+
+    const doc = await vscode.workspace.openTextDocument(settingsUri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    void vscode.window.setStatusBarMessage(
+        `Raven: ${existing === undefined ? 'created' : 'updated'} ${displayName}`,
+        3000,
+    );
+
+    return settingsUri;
+}
+
 export function registerScaffoldCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand('raven.scaffold.gitignore', () =>
@@ -146,8 +536,16 @@ export function registerScaffoldCommands(context: vscode.ExtensionContext): void
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('raven.scaffold.lintr', () =>
-            runScaffoldCommand('.lintr', LINTR_TEMPLATE),
-        ),
+        vscode.commands.registerCommand('raven.scaffold.lintingSettings', async () => {
+            const folder = getTargetWorkspaceFolder();
+            if (!folder) return;
+            try {
+                await runLintingSettingsScaffold(folder);
+            } catch (err) {
+                void vscode.window.showErrorMessage(
+                    `Raven: failed to update .vscode/settings.json: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }),
     );
 }

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -275,24 +275,51 @@ function stripTrailingCommas(text: string): string {
 }
 
 /**
- * Parse-with-comments helper that returns the list of top-level
- * `raven.linting.*` keys present in a JSONC text, or `null` if the text
- * has parse errors. An empty file returns an empty array.
+ * Result of parsing JSONC settings text for our purposes:
+ *   - `parseError`: text was not valid JSONC at all (caller should bail).
+ *   - `nonObjectRoot`: parsed fine but the root isn't a JSON object
+ *     (e.g. an array, scalar, or `null`). Can't safely merge into it.
+ *   - `object`: parsed as a JSON object — `keys` lists the top-level
+ *     `raven.linting.*` keys present (may be empty).
  */
-export function detectExistingLintingKeys(text: string): string[] | null {
-    if (text.trim().length === 0) return [];
+type LintingParseResult =
+    | { kind: 'parseError' }
+    | { kind: 'nonObjectRoot' }
+    | { kind: 'object'; keys: string[] };
+
+function parseLintingKeys(text: string): LintingParseResult {
+    if (text.trim().length === 0) return { kind: 'object', keys: [] };
     let parsed: unknown;
     try {
         parsed = JSON.parse(stripTrailingCommas(stripJsoncComments(text)));
     } catch {
-        return null;
+        return { kind: 'parseError' };
     }
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        return [];
+        return { kind: 'nonObjectRoot' };
     }
-    return Object.keys(parsed as Record<string, unknown>).filter((k) =>
-        k.startsWith('raven.linting.'),
-    );
+    return {
+        kind: 'object',
+        keys: Object.keys(parsed as Record<string, unknown>).filter((k) =>
+            k.startsWith('raven.linting.'),
+        ),
+    };
+}
+
+/**
+ * Parse-with-comments helper that returns the list of top-level
+ * `raven.linting.*` keys present in a JSONC text, or `null` if the text
+ * has parse errors **or** is valid JSON whose root isn't an object.
+ * An empty file returns an empty array.
+ *
+ * Kept in this collapsed shape (string[] | null) because the test suite
+ * uses it as a parse-success signal; the scaffold command path uses
+ * the richer `parseLintingKeys` discriminator to distinguish parse
+ * errors from a non-object root.
+ */
+export function detectExistingLintingKeys(text: string): string[] | null {
+    const result = parseLintingKeys(text);
+    return result.kind === 'object' ? result.keys : null;
 }
 
 /**
@@ -348,26 +375,135 @@ function findOutermostClosingBrace(text: string): number {
 }
 
 /**
+ * Compute the offsets, line by line, at which a given character index
+ * falls. Used by the sentinel walker to map char-positions back to line
+ * indices without re-scanning the whole text per lookup.
+ */
+function computeLineStarts(text: string): number[] {
+    const starts: number[] = [0];
+    for (let i = 0; i < text.length; i++) {
+        if (text[i] === '\n') starts.push(i + 1);
+    }
+    return starts;
+}
+
+function lineIndexOfPos(lineStarts: number[], pos: number): number {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >>> 1;
+        if (lineStarts[mid] <= pos) lo = mid;
+        else hi = mid - 1;
+    }
+    return lo;
+}
+
+/**
+ * Find the line indices of our sentinel-begin / sentinel-end markers,
+ * skipping any matches that fall inside a JSONC `/* ... *\/` block
+ * comment (line-comment matches are kept — those are exactly what we
+ * emit). Returns `null` if either marker is missing or appears on the
+ * wrong side of the other.
+ */
+function findSentinelLineRange(text: string): { begin: number; end: number } | null {
+    const lineStarts = computeLineStarts(text);
+    const sentinelLines: { begin: number | null; end: number | null } = {
+        begin: null,
+        end: null,
+    };
+
+    let i = 0;
+    let inString = false;
+    let inBlockComment = false;
+    let lineConsumed = -1; // last line we've already classified
+
+    function maybeRecord(pos: number) {
+        const lineIdx = lineIndexOfPos(lineStarts, pos);
+        if (lineIdx <= lineConsumed) return;
+        const lineStart = lineStarts[lineIdx];
+        const lineEnd =
+            lineIdx + 1 < lineStarts.length ? lineStarts[lineIdx + 1] - 1 : text.length;
+        const lineText = text.slice(lineStart, lineEnd).trim();
+        if (lineText === LINTING_SENTINEL_BEGIN && sentinelLines.begin === null) {
+            sentinelLines.begin = lineIdx;
+        } else if (
+            lineText === LINTING_SENTINEL_END &&
+            sentinelLines.begin !== null &&
+            sentinelLines.end === null &&
+            lineIdx > sentinelLines.begin
+        ) {
+            sentinelLines.end = lineIdx;
+        }
+        lineConsumed = lineIdx;
+    }
+
+    while (i < text.length) {
+        const c = text[i];
+        if (inBlockComment) {
+            if (c === '*' && text[i + 1] === '/') {
+                inBlockComment = false;
+                i += 2;
+                continue;
+            }
+            i++;
+            continue;
+        }
+        if (inString) {
+            if (c === '\\' && i + 1 < text.length) {
+                i += 2;
+                continue;
+            }
+            if (c === '"') inString = false;
+            i++;
+            continue;
+        }
+        if (c === '"') {
+            inString = true;
+            i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '/') {
+            // A line comment outside of a block comment — this is where
+            // our sentinels live. Classify the line.
+            maybeRecord(i);
+            while (i < text.length && text[i] !== '\n') i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '*') {
+            inBlockComment = true;
+            i += 2;
+            continue;
+        }
+        i++;
+    }
+
+    if (sentinelLines.begin === null || sentinelLines.end === null) return null;
+    return { begin: sentinelLines.begin, end: sentinelLines.end };
+}
+
+/**
  * Strip the entire sentinel-delimited block we manage, including the
  * inner `// lintr: ...` headers and key lines. If either sentinel is
- * missing, returns the input unchanged. Matches whole-line sentinels
- * after trimming whitespace; a sentinel-shaped string embedded inside a
- * string literal won't be matched (the wrapping `"` survives the trim).
+ * missing — or appears only inside a block comment — returns the input
+ * unchanged.
  */
 function stripSentineledLintingBlock(text: string): string {
+    const range = findSentinelLineRange(text);
+    if (!range) return text;
     const lines = text.split('\n');
-    const begin = lines.findIndex((l) => l.trim() === LINTING_SENTINEL_BEGIN);
-    if (begin === -1) return text;
-    const end = lines.findIndex((l, i) => i > begin && l.trim() === LINTING_SENTINEL_END);
-    if (end === -1) return text;
-    lines.splice(begin, end - begin + 1);
+    lines.splice(range.begin, range.end - range.begin + 1);
     return lines.join('\n');
 }
 
 /**
- * Remove lines whose sole content is a top-level `raven.linting.*` key
- * declaration. `raven.linting.*` values are all scalars (boolean, int,
- * string) so single-line removal is safe.
+ * Remove lines whose sole content is a **top-level** `raven.linting.*`
+ * key declaration. `raven.linting.*` values are all scalars (boolean,
+ * int, string) so single-line removal is safe.
+ *
+ * Walks the text tracking string/comment state and brace/bracket depth
+ * so a nested key (e.g. inside a `[r]` language override block where
+ * the user might write `"[r]": { "raven.linting.lineLength": 120 }`)
+ * is left untouched.
  *
  * Assumes the VS Code convention of one key per line. A user who puts
  * `"editor.tabSize": 4, "raven.linting.foo": true` on a single line
@@ -375,8 +511,161 @@ function stripSentineledLintingBlock(text: string): string {
  * the Settings UI never produce that shape, so we don't try to handle
  * it.
  */
-function stripExistingLintingLines(text: string): string {
-    return text.replace(/^[ \t]*"raven\.linting\.[^"]+"[ \t]*:[^\n]*\n?/gm, '');
+function stripTopLevelLintingLines(text: string): string {
+    const lineStarts = computeLineStarts(text);
+    const linesToStrip = new Set<number>();
+
+    let depth = 0;
+    let inString = false;
+    let inBlockComment = false;
+    let i = 0;
+
+    while (i < text.length) {
+        const c = text[i];
+        if (inBlockComment) {
+            if (c === '*' && text[i + 1] === '/') {
+                inBlockComment = false;
+                i += 2;
+                continue;
+            }
+            i++;
+            continue;
+        }
+        if (inString) {
+            if (c === '\\' && i + 1 < text.length) {
+                i += 2;
+                continue;
+            }
+            if (c === '"') inString = false;
+            i++;
+            continue;
+        }
+        if (c === '"') {
+            // String-literal start. If we're at depth 1, this could be a
+            // top-level property key; check whether it matches our pattern
+            // and is followed by `:` (ignoring whitespace/comments).
+            if (depth === 1) {
+                const match = /^"raven\.linting\.[^"\\]+"/.exec(text.slice(i));
+                if (match) {
+                    const afterKey = i + match[0].length;
+                    let j = afterKey;
+                    // Skip whitespace and same-line comments looking for `:`.
+                    while (j < text.length) {
+                        const ch = text[j];
+                        if (ch === ' ' || ch === '\t') {
+                            j++;
+                            continue;
+                        }
+                        if (ch === '/' && text[j + 1] === '/') {
+                            while (j < text.length && text[j] !== '\n') j++;
+                            break;
+                        }
+                        if (ch === '/' && text[j + 1] === '*') {
+                            j += 2;
+                            while (
+                                j + 1 < text.length &&
+                                !(text[j] === '*' && text[j + 1] === '/')
+                            )
+                                j++;
+                            j += 2;
+                            continue;
+                        }
+                        break;
+                    }
+                    if (j < text.length && text[j] === ':') {
+                        linesToStrip.add(lineIndexOfPos(lineStarts, i));
+                    }
+                }
+            }
+            inString = true;
+            i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '/') {
+            while (i < text.length && text[i] !== '\n') i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '*') {
+            inBlockComment = true;
+            i += 2;
+            continue;
+        }
+        if (c === '{' || c === '[') {
+            depth++;
+            i++;
+            continue;
+        }
+        if (c === '}' || c === ']') {
+            depth--;
+            i++;
+            continue;
+        }
+        i++;
+    }
+
+    if (linesToStrip.size === 0) return text;
+
+    const lines = text.split('\n');
+    const kept: string[] = [];
+    for (let li = 0; li < lines.length; li++) {
+        if (!linesToStrip.has(li)) kept.push(lines[li]);
+    }
+    return kept.join('\n');
+}
+
+/**
+ * Append a `,` after the last non-comment, non-whitespace character of
+ * `text`. If the trailing content is a `//` line comment or a `/* *\/`
+ * block comment, the comma is inserted *before* the comment so the
+ * file remains valid JSONC. No-op if the last significant character is
+ * already `,`, `{`, or `[` (i.e. no separator needed).
+ */
+function appendCommaIfNeeded(text: string): string {
+    let lastSig = -1;
+    let i = 0;
+    let inString = false;
+
+    while (i < text.length) {
+        const c = text[i];
+        if (inString) {
+            if (c === '\\' && i + 1 < text.length) {
+                lastSig = i + 1;
+                i += 2;
+                continue;
+            }
+            lastSig = i;
+            if (c === '"') inString = false;
+            i++;
+            continue;
+        }
+        if (c === '"') {
+            inString = true;
+            lastSig = i;
+            i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '/') {
+            while (i < text.length && text[i] !== '\n') i++;
+            continue;
+        }
+        if (c === '/' && text[i + 1] === '*') {
+            i += 2;
+            while (i + 1 < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++;
+            i += 2;
+            continue;
+        }
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+            i++;
+            continue;
+        }
+        lastSig = i;
+        i++;
+    }
+
+    if (lastSig === -1) return text;
+    const lastChar = text[lastSig];
+    if (lastChar === ',' || lastChar === '{' || lastChar === '[') return text;
+    return text.slice(0, lastSig + 1) + ',' + text.slice(lastSig + 1);
 }
 
 /**
@@ -384,40 +673,51 @@ function stripExistingLintingLines(text: string): string {
  * managed block this scaffold owns. Used by the scaffold command to
  * decide whether to prompt: keys inside our block are safe to overwrite
  * silently on a re-run, but keys *outside* it are user-managed and need
- * confirmation.
+ * confirmation. Returns `null` for parse errors or a non-object root.
  */
 export function detectUserManagedLintingKeys(text: string): string[] | null {
     return detectExistingLintingKeys(stripSentineledLintingBlock(text));
 }
 
 /**
+ * Same as `detectUserManagedLintingKeys`, but returns the richer result
+ * shape so callers can distinguish a JSON parse error from a non-object
+ * root (e.g. the file contains `[1, 2, 3]`). The scaffold command path
+ * uses this; tests use the simpler `string[] | null` flavour above.
+ */
+export function classifyUserManagedLintingKeys(text: string): LintingParseResult {
+    return parseLintingKeys(stripSentineledLintingBlock(text));
+}
+
+/**
  * Build the JSONC content to write to `.vscode/settings.json`. If
  * `existing` is `undefined` or whitespace-only, returns the fresh
  * template. Otherwise strips any prior sentinel-managed block and any
- * stray `raven.linting.*` keys, then inserts a freshly formatted block
- * immediately before the outermost closing brace — preserving all
- * unrelated keys and comments.
+ * top-level `raven.linting.*` keys, then inserts a freshly formatted
+ * block immediately before the outermost closing brace — preserving
+ * all unrelated keys and comments.
+ *
+ * Returns `null` if the existing content can't safely be merged into
+ * (parse error, or root isn't a JSON object). Callers must surface
+ * that to the user rather than overwriting their file.
  */
-export function buildLintingSettingsContent(existing: string | undefined): string {
+export function buildLintingSettingsContent(existing: string | undefined): string | null {
     if (existing === undefined || existing.trim().length === 0) {
         return LINTING_SETTINGS_TEMPLATE;
     }
+
     const afterSentinelStrip = stripSentineledLintingBlock(existing);
-    const fullyStripped = stripExistingLintingLines(afterSentinelStrip);
+    const classification = parseLintingKeys(afterSentinelStrip);
+    if (classification.kind !== 'object') return null;
+
+    const fullyStripped = stripTopLevelLintingLines(afterSentinelStrip);
     const closeIdx = findOutermostClosingBrace(fullyStripped);
-    if (closeIdx === -1) {
-        return LINTING_SETTINGS_TEMPLATE;
-    }
+    if (closeIdx === -1) return null;
 
     const before = fullyStripped.slice(0, closeIdx);
     const after = fullyStripped.slice(closeIdx);
     const trimmedBefore = before.replace(/[ \t\n\r]+$/, '');
-
-    const openBraceIdx = trimmedBefore.lastIndexOf('{');
-    const hasExistingProps =
-        openBraceIdx !== -1 && trimmedBefore.slice(openBraceIdx + 1).trim().length > 0;
-    const needsComma = hasExistingProps && !trimmedBefore.endsWith(',');
-    const prefix = trimmedBefore + (needsComma ? ',\n' : '\n');
+    const prefix = appendCommaIfNeeded(trimmedBefore) + '\n';
 
     return `${prefix}${formatLintingBlock('  ')}\n${after}`;
 }
@@ -526,13 +826,20 @@ async function runLintingSettingsScaffold(
         // earlier run of this same scaffold, so it's safe to regenerate
         // them silently. Only user-authored `raven.linting.*` keys
         // (anything outside the sentinel range) trigger the prompt.
-        const userManagedKeys = detectUserManagedLintingKeys(existing);
-        if (userManagedKeys === null) {
+        const classification = classifyUserManagedLintingKeys(existing);
+        if (classification.kind === 'parseError') {
             void vscode.window.showErrorMessage(
                 `Raven: ${displayName} has JSON parse errors; fix them and re-run this command.`,
             );
             return undefined;
         }
+        if (classification.kind === 'nonObjectRoot') {
+            void vscode.window.showErrorMessage(
+                `Raven: ${displayName} is valid JSON but its root isn't a JSON object — refusing to overwrite. Move the file aside (or wrap its contents in \`{}\`) and re-run this command.`,
+            );
+            return undefined;
+        }
+        const userManagedKeys = classification.keys;
         if (userManagedKeys.length > 0) {
             const label =
                 userManagedKeys.length === 1
@@ -550,6 +857,13 @@ async function runLintingSettingsScaffold(
     }
 
     const newContent = buildLintingSettingsContent(existing);
+    if (newContent === null) {
+        // Classification above should have caught this — defensive only.
+        void vscode.window.showErrorMessage(
+            `Raven: could not safely merge into ${displayName}.`,
+        );
+        return undefined;
+    }
 
     try {
         await vscode.workspace.fs.createDirectory(vscodeDir);

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -174,32 +174,43 @@ const LINTING_BLOCK_HEADER =
     'the lintr linter it mirrors. See docs/linting.md for details.';
 
 /**
- * Format the linting-settings block (header + groups) at the given
- * indentation, without surrounding braces. The final entry uses the
- * supplied `trailingPunctuation` so the caller can distinguish the
- * fresh-file case (no trailing comma — last property in the object)
- * from the merge case (trailing comma — more properties may follow).
+ * Sentinel markers that delimit the block this scaffold manages. A
+ * re-run of the scaffold strips the full sentinel range (including the
+ * per-group `// lintr: ...` headers) before inserting a fresh block, so
+ * a previously scaffolded file stays clean instead of accumulating
+ * orphaned header comments. The markers are intentionally long and
+ * stable so an accidental match against a user-authored comment is
+ * unlikely.
  */
-function formatLintingBlock(indent: string, trailingPunctuation: '' | ','): string {
+export const LINTING_SENTINEL_BEGIN =
+    '// >>> raven.linting.* (managed by "Raven: Create linting settings")';
+export const LINTING_SENTINEL_END = '// <<< raven.linting.*';
+
+/**
+ * Format the linting-settings block (sentinels + header + groups) at
+ * the given indentation, without surrounding braces. Every entry — even
+ * the last one — emits a trailing comma; the sentinel-end comment line
+ * (and possibly more existing keys after our block in the merge case)
+ * follows, so the comma is always correct in JSONC.
+ */
+function formatLintingBlock(indent: string): string {
     const lines: string[] = [];
+    lines.push(`${indent}${LINTING_SENTINEL_BEGIN}`);
     for (const headerLine of LINTING_BLOCK_HEADER.split('\n')) {
         lines.push(`${indent}// ${headerLine}`);
     }
 
-    LINTING_GROUPS.forEach((group, groupIdx) => {
+    for (const group of LINTING_GROUPS) {
         lines.push('');
         lines.push(`${indent}// ${group.comment}`);
-        group.entries.forEach((entry, entryIdx) => {
-            const isLastEntryOfBlock =
-                groupIdx === LINTING_GROUPS.length - 1 &&
-                entryIdx === group.entries.length - 1;
-            const sep = isLastEntryOfBlock ? trailingPunctuation : ',';
+        for (const entry of group.entries) {
             lines.push(
-                `${indent}${JSON.stringify(entry.key)}: ${JSON.stringify(entry.value)}${sep}`,
+                `${indent}${JSON.stringify(entry.key)}: ${JSON.stringify(entry.value)},`,
             );
-        });
-    });
+        }
+    }
 
+    lines.push(`${indent}${LINTING_SENTINEL_END}`);
     return lines.join('\n');
 }
 
@@ -209,7 +220,7 @@ function formatLintingBlock(indent: string, trailingPunctuation: '' | ','): stri
  * builds this via `buildLintingSettingsContent` so an existing file is
  * merged rather than clobbered.
  */
-export const LINTING_SETTINGS_TEMPLATE = `{\n${formatLintingBlock('  ', '')}\n}\n`;
+export const LINTING_SETTINGS_TEMPLATE = `{\n${formatLintingBlock('  ')}\n}\n`;
 
 /**
  * Strip `//` line comments and `/* ... *\/` block comments from JSONC
@@ -337,51 +348,78 @@ function findOutermostClosingBrace(text: string): number {
 }
 
 /**
+ * Strip the entire sentinel-delimited block we manage, including the
+ * inner `// lintr: ...` headers and key lines. If either sentinel is
+ * missing, returns the input unchanged. Matches whole-line sentinels
+ * after trimming whitespace; a sentinel-shaped string embedded inside a
+ * string literal won't be matched (the wrapping `"` survives the trim).
+ */
+function stripSentineledLintingBlock(text: string): string {
+    const lines = text.split('\n');
+    const begin = lines.findIndex((l) => l.trim() === LINTING_SENTINEL_BEGIN);
+    if (begin === -1) return text;
+    const end = lines.findIndex((l, i) => i > begin && l.trim() === LINTING_SENTINEL_END);
+    if (end === -1) return text;
+    lines.splice(begin, end - begin + 1);
+    return lines.join('\n');
+}
+
+/**
  * Remove lines whose sole content is a top-level `raven.linting.*` key
  * declaration. `raven.linting.*` values are all scalars (boolean, int,
  * string) so single-line removal is safe.
+ *
+ * Assumes the VS Code convention of one key per line. A user who puts
+ * `"editor.tabSize": 4, "raven.linting.foo": true` on a single line
+ * would lose the unrelated key here, but VS Code's own formatters and
+ * the Settings UI never produce that shape, so we don't try to handle
+ * it.
  */
 function stripExistingLintingLines(text: string): string {
     return text.replace(/^[ \t]*"raven\.linting\.[^"]+"[ \t]*:[^\n]*\n?/gm, '');
 }
 
 /**
+ * Like `detectExistingLintingKeys`, but ignores keys inside the sentinel-
+ * managed block this scaffold owns. Used by the scaffold command to
+ * decide whether to prompt: keys inside our block are safe to overwrite
+ * silently on a re-run, but keys *outside* it are user-managed and need
+ * confirmation.
+ */
+export function detectUserManagedLintingKeys(text: string): string[] | null {
+    return detectExistingLintingKeys(stripSentineledLintingBlock(text));
+}
+
+/**
  * Build the JSONC content to write to `.vscode/settings.json`. If
  * `existing` is `undefined` or whitespace-only, returns the fresh
- * template. Otherwise removes any prior `raven.linting.*` keys and
- * inserts a freshly formatted block immediately before the outermost
- * closing brace, preserving all unrelated keys and comments.
+ * template. Otherwise strips any prior sentinel-managed block and any
+ * stray `raven.linting.*` keys, then inserts a freshly formatted block
+ * immediately before the outermost closing brace — preserving all
+ * unrelated keys and comments.
  */
 export function buildLintingSettingsContent(existing: string | undefined): string {
     if (existing === undefined || existing.trim().length === 0) {
         return LINTING_SETTINGS_TEMPLATE;
     }
-    const withoutLinting = stripExistingLintingLines(existing);
-    const closeIdx = findOutermostClosingBrace(withoutLinting);
+    const afterSentinelStrip = stripSentineledLintingBlock(existing);
+    const fullyStripped = stripExistingLintingLines(afterSentinelStrip);
+    const closeIdx = findOutermostClosingBrace(fullyStripped);
     if (closeIdx === -1) {
         return LINTING_SETTINGS_TEMPLATE;
     }
 
-    const before = withoutLinting.slice(0, closeIdx);
-    const after = withoutLinting.slice(closeIdx);
+    const before = fullyStripped.slice(0, closeIdx);
+    const after = fullyStripped.slice(closeIdx);
     const trimmedBefore = before.replace(/[ \t\n\r]+$/, '');
 
     const openBraceIdx = trimmedBefore.lastIndexOf('{');
     const hasExistingProps =
         openBraceIdx !== -1 && trimmedBefore.slice(openBraceIdx + 1).trim().length > 0;
-    const endsWithComma = trimmedBefore.endsWith(',');
+    const needsComma = hasExistingProps && !trimmedBefore.endsWith(',');
+    const prefix = trimmedBefore + (needsComma ? ',\n' : '\n');
 
-    let prefix: string;
-    if (!hasExistingProps) {
-        prefix = trimmedBefore + '\n';
-    } else if (endsWithComma) {
-        prefix = trimmedBefore + '\n';
-    } else {
-        prefix = trimmedBefore + ',\n';
-    }
-
-    const block = formatLintingBlock('  ', '');
-    return `${prefix}${block}\n${after}`;
+    return `${prefix}${formatLintingBlock('  ')}\n${after}`;
 }
 
 /**
@@ -484,18 +522,22 @@ async function runLintingSettingsScaffold(
     }
 
     if (existing !== undefined) {
-        const existingKeys = detectExistingLintingKeys(existing);
-        if (existingKeys === null) {
+        // Keys inside our sentinel-managed block were produced by an
+        // earlier run of this same scaffold, so it's safe to regenerate
+        // them silently. Only user-authored `raven.linting.*` keys
+        // (anything outside the sentinel range) trigger the prompt.
+        const userManagedKeys = detectUserManagedLintingKeys(existing);
+        if (userManagedKeys === null) {
             void vscode.window.showErrorMessage(
                 `Raven: ${displayName} has JSON parse errors; fix them and re-run this command.`,
             );
             return undefined;
         }
-        if (existingKeys.length > 0) {
+        if (userManagedKeys.length > 0) {
             const label =
-                existingKeys.length === 1
+                userManagedKeys.length === 1
                     ? '1 raven.linting.* setting'
-                    : `${existingKeys.length} raven.linting.* settings`;
+                    : `${userManagedKeys.length} raven.linting.* settings`;
             const choice = await vscode.window.showWarningMessage(
                 `${label} already in ${displayName}. Overwrite the raven.linting.* block? Other keys and comments will be preserved.`,
                 { modal: true },

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -291,12 +291,18 @@ function stripTrailingCommas(text: string): string {
  *   - `parseError`: text was not valid JSONC at all (caller should bail).
  *   - `nonObjectRoot`: parsed fine but the root isn't a JSON object
  *     (e.g. an array, scalar, or `null`). Can't safely merge into it.
+ *   - `unsupportedValue`: a top-level `raven.linting.*` key has a non-
+ *     scalar value (object or array). All declared `raven.linting.*`
+ *     settings are scalars (`boolean | number | string`); a non-scalar
+ *     value would likely span multiple lines, and the line-based
+ *     stripper isn't equipped to delete a multi-line value cleanly.
  *   - `object`: parsed as a JSON object — `keys` lists the top-level
  *     `raven.linting.*` keys present (may be empty).
  */
 type LintingParseResult =
     | { kind: 'parseError' }
     | { kind: 'nonObjectRoot' }
+    | { kind: 'unsupportedValue'; key: string }
     | { kind: 'object'; keys: string[] };
 
 function parseLintingKeys(text: string): LintingParseResult {
@@ -312,12 +318,21 @@ function parseLintingKeys(text: string): LintingParseResult {
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
         return { kind: 'nonObjectRoot' };
     }
-    return {
-        kind: 'object',
-        keys: Object.keys(parsed as Record<string, unknown>).filter((k) =>
-            k.startsWith('raven.linting.'),
-        ),
-    };
+    const obj = parsed as Record<string, unknown>;
+    const keys: string[] = [];
+    for (const k of Object.keys(obj)) {
+        if (!k.startsWith('raven.linting.')) continue;
+        const v = obj[k];
+        // raven.linting.* values are scalars (`boolean | number | string`).
+        // If the user wrote an object/array there, `stripTopLevelLintingLines`
+        // — which deletes a single physical line per key — would orphan the
+        // continuation lines and corrupt the file. Refuse to merge.
+        if (v !== null && typeof v === 'object') {
+            return { kind: 'unsupportedValue', key: k };
+        }
+        keys.push(k);
+    }
+    return { kind: 'object', keys };
 }
 
 /**
@@ -850,6 +865,12 @@ async function runLintingSettingsScaffold(
         if (classification.kind === 'nonObjectRoot') {
             void vscode.window.showErrorMessage(
                 `Raven: ${displayName} is valid JSON but its root isn't a JSON object — refusing to overwrite. Move the file aside (or wrap its contents in \`{}\`) and re-run this command.`,
+            );
+            return undefined;
+        }
+        if (classification.kind === 'unsupportedValue') {
+            void vscode.window.showErrorMessage(
+                `Raven: ${displayName} sets ${classification.key} to a non-scalar value (object or array). All raven.linting.* settings are scalars (boolean, number, or string); please correct the value before re-running this command.`,
             );
             return undefined;
         }

--- a/editors/vscode/src/scaffold.ts
+++ b/editors/vscode/src/scaffold.ts
@@ -227,8 +227,14 @@ export const LINTING_SETTINGS_TEMPLATE = `{\n${formatLintingBlock('  ')}\n}\n`;
  * text, preserving string contents and newlines (so line numbers in
  * any downstream parse errors still line up). Trailing-comma stripping
  * is left to the caller; this function only removes comments.
+ *
+ * Returns `null` if the input contains an unterminated block comment.
+ * Without this guard, the comment-stripper would silently drop the
+ * rest of the file and any subsequent `JSON.parse` would succeed on
+ * the truncated prefix — leading the scaffold to write back invalid
+ * JSONC (a `/*` with nothing closing it).
  */
-function stripJsoncComments(text: string): string {
+function stripJsoncComments(text: string): string | null {
     let out = '';
     let i = 0;
     let inString = false;
@@ -257,10 +263,16 @@ function stripJsoncComments(text: string): string {
         }
         if (c === '/' && text[i + 1] === '*') {
             i += 2;
-            while (i + 1 < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+            let closed = false;
+            while (i + 1 < text.length) {
+                if (text[i] === '*' && text[i + 1] === '/') {
+                    closed = true;
+                    break;
+                }
                 if (text[i] === '\n') out += '\n';
                 i++;
             }
+            if (!closed) return null;
             i += 2;
             continue;
         }
@@ -289,9 +301,11 @@ type LintingParseResult =
 
 function parseLintingKeys(text: string): LintingParseResult {
     if (text.trim().length === 0) return { kind: 'object', keys: [] };
+    const stripped = stripJsoncComments(text);
+    if (stripped === null) return { kind: 'parseError' };
     let parsed: unknown;
     try {
-        parsed = JSON.parse(stripTrailingCommas(stripJsoncComments(text)));
+        parsed = JSON.parse(stripTrailingCommas(stripped));
     } catch {
         return { kind: 'parseError' };
     }

--- a/editors/vscode/src/test/scaffold.test.ts
+++ b/editors/vscode/src/test/scaffold.test.ts
@@ -299,6 +299,27 @@ suite('scaffold linting-settings merge', () => {
         assert.strictEqual(buildLintingSettingsContent('{ this is not json'), null);
     });
 
+    test('returns null when a raven.linting.* key has a non-scalar (object) value', () => {
+        // raven.linting.* values are scalars; an object value would span
+        // multiple lines, and the line-based stripper can't safely delete
+        // a multi-line value. We refuse to merge instead.
+        const existing = `{
+  "raven.linting.foo": {
+    "nested": 1
+  }
+}
+`;
+        assert.strictEqual(buildLintingSettingsContent(existing), null);
+    });
+
+    test('returns null when a raven.linting.* key has a non-scalar (array) value', () => {
+        const existing = `{
+  "raven.linting.bar": [1, 2, 3]
+}
+`;
+        assert.strictEqual(buildLintingSettingsContent(existing), null);
+    });
+
     test('returns null for an unterminated block comment', () => {
         // An unterminated `/*` used to slip through the comment stripper
         // silently, producing apparently-valid JSON and an invalid output.

--- a/editors/vscode/src/test/scaffold.test.ts
+++ b/editors/vscode/src/test/scaffold.test.ts
@@ -173,8 +173,14 @@ suite('scaffold linting-settings merge', () => {
         assert.strictEqual(buildLintingSettingsContent('   \n\t\n'), LINTING_SETTINGS_TEMPLATE);
     });
 
+    function mergeOrThrow(input: string | undefined): string {
+        const merged = buildLintingSettingsContent(input);
+        assert.ok(merged !== null, 'buildLintingSettingsContent should not return null for this input');
+        return merged;
+    }
+
     test('inserts block into an empty object preserving formatting', () => {
-        const merged = buildLintingSettingsContent('{\n}\n');
+        const merged = mergeOrThrow('{\n}\n');
         assert.ok(merged.startsWith('{\n'), 'should retain the opening brace line');
         assert.ok(merged.trimEnd().endsWith('}'), 'should retain the closing brace');
         const keys = detectExistingLintingKeys(merged) ?? [];
@@ -189,7 +195,7 @@ suite('scaffold linting-settings merge', () => {
   "files.autoSave": "onFocusChange"
 }
 `;
-        const merged = buildLintingSettingsContent(existing);
+        const merged = mergeOrThrow(existing);
         assert.ok(
             merged.includes('"editor.tabSize": 4'),
             'unrelated key must be preserved',
@@ -215,7 +221,7 @@ suite('scaffold linting-settings merge', () => {
   "editor.tabSize": 2
 }
 `;
-        const merged = buildLintingSettingsContent(existing);
+        const merged = mergeOrThrow(existing);
         const enabledOccurrences = merged.match(/"raven\.linting\.enabled"/g) ?? [];
         assert.strictEqual(
             enabledOccurrences.length,
@@ -242,8 +248,59 @@ suite('scaffold linting-settings merge', () => {
         );
     });
 
+    test('inserts comma before a trailing line comment on the last property', () => {
+        const existing = `{
+  "editor.tabSize": 4 // explanatory comment
+}
+`;
+        const merged = mergeOrThrow(existing);
+        // The new comma must come BEFORE the user's trailing `//` comment so
+        // the file is still valid JSONC (otherwise the comma sits inside
+        // the comment text).
+        assert.ok(
+            /"editor\.tabSize":\s*4,\s*\/\/ explanatory comment/.test(merged),
+            `expected the inserted comma to land before the trailing comment; got:\n${merged}`,
+        );
+        const stripped = merged
+            .replace(/\/\/[^\n]*/g, '')
+            .replace(/,(\s*[}\]])/g, '$1');
+        const parsed = JSON.parse(stripped) as Record<string, unknown>;
+        assert.strictEqual(parsed['editor.tabSize'], 4);
+        assert.strictEqual(parsed['raven.linting.enabled'], true);
+    });
+
+    test('leaves a nested raven.linting.* key inside an [r] override untouched', () => {
+        const existing = `{
+  "editor.tabSize": 2,
+  "[r]": {
+    "raven.linting.lineLength": 100
+  }
+}
+`;
+        const merged = mergeOrThrow(existing);
+        // The nested key under [r] is a language-scoped override; it must
+        // survive the merge intact (top-level keys may be stripped).
+        assert.ok(
+            /"\[r\]"\s*:\s*\{\s*"raven\.linting\.lineLength":\s*100/.test(merged),
+            `expected the nested [r] override to survive; got:\n${merged}`,
+        );
+        // And the top-level block was still inserted.
+        assert.ok(
+            merged.includes('"raven.linting.enabled": true'),
+            'the top-level block must still be inserted',
+        );
+    });
+
+    test('returns null for a non-object root (e.g. array)', () => {
+        assert.strictEqual(buildLintingSettingsContent('[1, 2, 3]'), null);
+    });
+
+    test('returns null for a parse-error file', () => {
+        assert.strictEqual(buildLintingSettingsContent('{ this is not json'), null);
+    });
+
     test('re-running on a sentineled file does not duplicate the block or its lintr comments', () => {
-        const merged = buildLintingSettingsContent(LINTING_SETTINGS_TEMPLATE);
+        const merged = mergeOrThrow(LINTING_SETTINGS_TEMPLATE);
 
         const beginCount = (merged.match(new RegExp(escapeRegex(LINTING_SENTINEL_BEGIN), 'g')) ?? [])
             .length;
@@ -276,7 +333,7 @@ suite('scaffold linting-settings merge', () => {
   "files.autoSave": "onFocusChange"
 }
 `;
-        const merged = buildLintingSettingsContent(previous);
+        const merged = mergeOrThrow(previous);
         assert.ok(merged.includes('"editor.tabSize": 4'), 'unrelated keys must survive');
         assert.ok(
             merged.includes('"files.autoSave": "onFocusChange"'),
@@ -298,6 +355,30 @@ suite('scaffold linting-settings merge', () => {
         );
     });
 
+    test('ignores sentinel-shaped lines that sit inside a block comment', () => {
+        // The sentinels here are inside a /* ... */ block comment, so they
+        // should NOT trigger the sentinel-strip path. The file has no real
+        // raven.linting.* keys, so the merge just appends a fresh block.
+        const existing = `{
+  /*
+   ${LINTING_SENTINEL_BEGIN}
+   ${LINTING_SENTINEL_END}
+   notes about future config
+  */
+  "editor.tabSize": 4
+}
+`;
+        const merged = mergeOrThrow(existing);
+        assert.ok(
+            merged.includes('notes about future config'),
+            'the user-authored block comment must survive',
+        );
+        // The new block adds its own sentinels — exactly one begin/end pair.
+        const beginCount = (merged.match(new RegExp(escapeRegex(LINTING_SENTINEL_BEGIN), 'g')) ?? [])
+            .length;
+        assert.strictEqual(beginCount, 2, 'one sentinel inside the block comment plus one from the new block');
+    });
+
     test('output parses as valid JSON after comment + trailing-comma stripping', () => {
         const existing = `{
   "editor.tabSize": 4,
@@ -305,7 +386,7 @@ suite('scaffold linting-settings merge', () => {
   "raven.linting.enabled": false
 }
 `;
-        const merged = buildLintingSettingsContent(existing);
+        const merged = mergeOrThrow(existing);
         const stripped = merged
             .replace(/\/\/[^\n]*/g, '')
             .replace(/,(\s*[}\]])/g, '$1');

--- a/editors/vscode/src/test/scaffold.test.ts
+++ b/editors/vscode/src/test/scaffold.test.ts
@@ -6,8 +6,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
     GITIGNORE_TEMPLATE,
-    LINTR_TEMPLATE,
+    LINTING_SETTINGS_TEMPLATE,
+    buildLintingSettingsContent,
     createScaffoldFile,
+    detectExistingLintingKeys,
 } from '../scaffold';
 import { activate } from './helper';
 
@@ -29,6 +31,19 @@ function loadCommandContributions(): CommandContribution[] {
         contributes?: { commands?: CommandContribution[] };
     };
     return pkg.contributes?.commands ?? [];
+}
+
+function loadLintingSettingKeys(): string[] {
+    const raw = fs.readFileSync(packageJsonPath, 'utf8');
+    const pkg = JSON.parse(raw) as {
+        contributes?: {
+            configuration?: { properties?: Record<string, unknown> };
+        };
+    };
+    const properties = pkg.contributes?.configuration?.properties ?? {};
+    return Object.keys(properties)
+        .filter((k) => k.startsWith('raven.linting.'))
+        .sort();
 }
 
 suite('scaffold templates', () => {
@@ -68,27 +83,193 @@ suite('scaffold templates', () => {
         );
     });
 
-    test('.lintr template wraps line_length_linter inside linters_with_defaults', () => {
+    test('linting-settings template ends with a newline', () => {
         assert.ok(
-            /linters\s*:\s*linters_with_defaults\s*\(/.test(LINTR_TEMPLATE),
-            '.lintr template must set `linters:` to a linters_with_defaults() call',
-        );
-        assert.ok(
-            /line_length_linter\(\s*120\s*\)/.test(LINTR_TEMPLATE),
-            '.lintr template must enable line_length_linter(120)',
+            LINTING_SETTINGS_TEMPLATE.endsWith('\n'),
+            'linting-settings template should end with a trailing newline',
         );
     });
 
-    test('.lintr template ends with a newline', () => {
-        assert.ok(
-            LINTR_TEMPLATE.endsWith('\n'),
-            '.lintr template should end with a trailing newline',
+    test('linting-settings template parses as valid JSON (comments stripped)', () => {
+        const stripped = LINTING_SETTINGS_TEMPLATE.replace(/\/\/[^\n]*/g, '').replace(
+            /,(\s*[}\]])/g,
+            '$1',
         );
+        const parsed = JSON.parse(stripped) as Record<string, unknown>;
+        assert.strictEqual(parsed['raven.linting.enabled'], true);
+        assert.strictEqual(parsed['raven.linting.lineLength'], 120);
+        assert.strictEqual(parsed['raven.linting.indentationUnit'], 2);
+        assert.strictEqual(parsed['raven.linting.objectLength'], 30);
+    });
+
+    test('linting-settings template covers every raven.linting.* configuration key', () => {
+        const declared = loadLintingSettingKeys();
+        const present = (detectExistingLintingKeys(LINTING_SETTINGS_TEMPLATE) ?? []).sort();
+        assert.deepStrictEqual(
+            present,
+            declared,
+            'every raven.linting.* configuration key must appear in the scaffold template',
+        );
+    });
+
+    test('linting-settings template names lintr equivalents in comments', () => {
+        for (const expected of [
+            'line_length_linter',
+            'trailing_whitespace_linter',
+            'whitespace_linter',
+            'trailing_blank_lines_linter',
+            'assignment_linter',
+            'object_name_linter',
+            'infix_spaces_linter',
+            'commented_code_linter',
+            'quotes_linter',
+            'commas_linter',
+            'T_and_F_symbol_linter',
+            'semicolon_linter',
+            'equals_na_linter',
+            'object_length_linter',
+            'vector_logic_linter',
+            'function_left_parentheses_linter',
+            'spaces_inside_linter',
+            'indentation_linter',
+        ]) {
+            assert.ok(
+                LINTING_SETTINGS_TEMPLATE.includes(expected),
+                `linting-settings template must mention lintr's ${expected} in a comment`,
+            );
+        }
+    });
+});
+
+suite('scaffold linting-settings merge', () => {
+    test('returns fresh template when existing content is undefined', () => {
+        assert.strictEqual(buildLintingSettingsContent(undefined), LINTING_SETTINGS_TEMPLATE);
+    });
+
+    test('returns fresh template when existing content is whitespace-only', () => {
+        assert.strictEqual(buildLintingSettingsContent('   \n\t\n'), LINTING_SETTINGS_TEMPLATE);
+    });
+
+    test('inserts block into an empty object preserving formatting', () => {
+        const merged = buildLintingSettingsContent('{\n}\n');
+        assert.ok(merged.startsWith('{\n'), 'should retain the opening brace line');
+        assert.ok(merged.trimEnd().endsWith('}'), 'should retain the closing brace');
+        const keys = detectExistingLintingKeys(merged) ?? [];
+        assert.ok(keys.includes('raven.linting.enabled'));
+        assert.ok(keys.includes('raven.linting.indentationSeverity'));
+    });
+
+    test('preserves unrelated keys and comments when merging', () => {
+        const existing = `{
+  // editor settings I care about
+  "editor.tabSize": 4,
+  "files.autoSave": "onFocusChange"
+}
+`;
+        const merged = buildLintingSettingsContent(existing);
+        assert.ok(
+            merged.includes('"editor.tabSize": 4'),
+            'unrelated key must be preserved',
+        );
+        assert.ok(
+            merged.includes('"files.autoSave": "onFocusChange"'),
+            'unrelated key must be preserved',
+        );
+        assert.ok(
+            merged.includes('// editor settings I care about'),
+            'unrelated comments must be preserved',
+        );
+        assert.ok(
+            merged.includes('"raven.linting.enabled": true'),
+            'the new block must be inserted',
+        );
+    });
+
+    test('overwrites existing raven.linting.* keys without duplicating them', () => {
+        const existing = `{
+  "raven.linting.enabled": false,
+  "raven.linting.lineLength": 200,
+  "editor.tabSize": 2
+}
+`;
+        const merged = buildLintingSettingsContent(existing);
+        const enabledOccurrences = merged.match(/"raven\.linting\.enabled"/g) ?? [];
+        assert.strictEqual(
+            enabledOccurrences.length,
+            1,
+            'raven.linting.enabled must appear exactly once after merge',
+        );
+        const lineLengthOccurrences = merged.match(/"raven\.linting\.lineLength"/g) ?? [];
+        assert.strictEqual(
+            lineLengthOccurrences.length,
+            1,
+            'raven.linting.lineLength must appear exactly once after merge',
+        );
+        assert.ok(
+            merged.includes('"raven.linting.enabled": true'),
+            'merged value must reflect the new scaffold default (true)',
+        );
+        assert.ok(
+            merged.includes('"raven.linting.lineLength": 120'),
+            'merged value must reflect the new scaffold default (120)',
+        );
+        assert.ok(
+            merged.includes('"editor.tabSize": 2'),
+            'unrelated keys must survive overwrite',
+        );
+    });
+
+    test('output parses as valid JSON after comment + trailing-comma stripping', () => {
+        const existing = `{
+  "editor.tabSize": 4,
+  // a stray comment
+  "raven.linting.enabled": false
+}
+`;
+        const merged = buildLintingSettingsContent(existing);
+        const stripped = merged
+            .replace(/\/\/[^\n]*/g, '')
+            .replace(/,(\s*[}\]])/g, '$1');
+        const parsed = JSON.parse(stripped) as Record<string, unknown>;
+        assert.strictEqual(parsed['editor.tabSize'], 4);
+        assert.strictEqual(parsed['raven.linting.enabled'], true);
+    });
+});
+
+suite('detectExistingLintingKeys', () => {
+    test('returns an empty array for empty input', () => {
+        assert.deepStrictEqual(detectExistingLintingKeys(''), []);
+    });
+
+    test('finds raven.linting.* keys and skips others', () => {
+        const text = `{
+  "editor.tabSize": 2,
+  "raven.linting.enabled": true,
+  "raven.linting.lineLength": 120,
+  "raven.crossFile.indexWorkspace": true
+}`;
+        const keys = (detectExistingLintingKeys(text) ?? []).sort();
+        assert.deepStrictEqual(keys, [
+            'raven.linting.enabled',
+            'raven.linting.lineLength',
+        ]);
+    });
+
+    test('returns null on JSON parse errors', () => {
+        assert.strictEqual(detectExistingLintingKeys('{ this is not json'), null);
+    });
+
+    test('ignores raven.linting.* keys inside string values and comments', () => {
+        const text = `{
+  // "raven.linting.enabled": true (just a comment, not a real key)
+  "editor.label": "say \\"raven.linting.foo\\""
+}`;
+        assert.deepStrictEqual(detectExistingLintingKeys(text), []);
     });
 });
 
 suite('scaffold package.json contributions', () => {
-    test('declares raven.scaffold.gitignore and raven.scaffold.lintr commands', () => {
+    test('declares raven.scaffold.gitignore and raven.scaffold.lintingSettings commands', () => {
         const commands = loadCommandContributions();
         const byId = new Map(commands.map((c) => [c.command, c]));
 
@@ -105,17 +286,22 @@ suite('scaffold package.json contributions', () => {
             'raven.scaffold.gitignore must be under the Raven category',
         );
 
-        const lintr = byId.get('raven.scaffold.lintr');
-        assert.ok(lintr, 'raven.scaffold.lintr must be declared');
+        const linting = byId.get('raven.scaffold.lintingSettings');
+        assert.ok(linting, 'raven.scaffold.lintingSettings must be declared');
         assert.strictEqual(
-            lintr.title,
-            'Create .lintr',
-            'raven.scaffold.lintr must use the short title',
+            linting.title,
+            'Create linting settings',
+            'raven.scaffold.lintingSettings must use the short title',
         );
         assert.strictEqual(
-            lintr.category,
+            linting.category,
             'Raven',
-            'raven.scaffold.lintr must be under the Raven category',
+            'raven.scaffold.lintingSettings must be under the Raven category',
+        );
+
+        assert.ok(
+            !byId.has('raven.scaffold.lintr'),
+            'the legacy raven.scaffold.lintr command must no longer be declared',
         );
     });
 });
@@ -151,8 +337,21 @@ suite('scaffold integration', () => {
             'raven.scaffold.gitignore must be registered after activation',
         );
         assert.ok(
-            all.includes('raven.scaffold.lintr'),
-            'raven.scaffold.lintr must be registered after activation',
+            all.includes('raven.scaffold.lintingSettings'),
+            'raven.scaffold.lintingSettings must be registered after activation',
+        );
+        assert.ok(
+            !all.includes('raven.scaffold.lintr'),
+            'the legacy raven.scaffold.lintr command must no longer be registered',
         );
     });
+
+    // We intentionally don't drive `runLintingSettingsScaffold` end-to-end in
+    // an integration test: the production path calls `showTextDocument` on
+    // `.vscode/settings.json`, which leaves the file open in an editor and
+    // confuses the workspace-configuration writes that the `r-package
+    // detection` suite performs later in the same VS Code session. The merge
+    // logic itself is fully exercised by the `scaffold linting-settings
+    // merge` and `detectExistingLintingKeys` suites above, and command
+    // registration is covered by the test directly above this comment.
 });

--- a/editors/vscode/src/test/scaffold.test.ts
+++ b/editors/vscode/src/test/scaffold.test.ts
@@ -6,10 +6,13 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
     GITIGNORE_TEMPLATE,
+    LINTING_SENTINEL_BEGIN,
+    LINTING_SENTINEL_END,
     LINTING_SETTINGS_TEMPLATE,
     buildLintingSettingsContent,
     createScaffoldFile,
     detectExistingLintingKeys,
+    detectUserManagedLintingKeys,
 } from '../scaffold';
 import { activate } from './helper';
 
@@ -31,6 +34,10 @@ function loadCommandContributions(): CommandContribution[] {
         contributes?: { commands?: CommandContribution[] };
     };
     return pkg.contributes?.commands ?? [];
+}
+
+function escapeRegex(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function loadLintingSettingKeys(): string[] {
@@ -109,6 +116,22 @@ suite('scaffold templates', () => {
             present,
             declared,
             'every raven.linting.* configuration key must appear in the scaffold template',
+        );
+    });
+
+    test('linting-settings template wraps the block in sentinel comments', () => {
+        assert.ok(
+            LINTING_SETTINGS_TEMPLATE.includes(LINTING_SENTINEL_BEGIN),
+            'template must include the begin sentinel for safe re-run stripping',
+        );
+        assert.ok(
+            LINTING_SETTINGS_TEMPLATE.includes(LINTING_SENTINEL_END),
+            'template must include the end sentinel for safe re-run stripping',
+        );
+        assert.ok(
+            LINTING_SETTINGS_TEMPLATE.indexOf(LINTING_SENTINEL_BEGIN) <
+                LINTING_SETTINGS_TEMPLATE.indexOf(LINTING_SENTINEL_END),
+            'begin sentinel must come before the end sentinel',
         );
     });
 
@@ -219,6 +242,62 @@ suite('scaffold linting-settings merge', () => {
         );
     });
 
+    test('re-running on a sentineled file does not duplicate the block or its lintr comments', () => {
+        const merged = buildLintingSettingsContent(LINTING_SETTINGS_TEMPLATE);
+
+        const beginCount = (merged.match(new RegExp(escapeRegex(LINTING_SENTINEL_BEGIN), 'g')) ?? [])
+            .length;
+        const endCount = (merged.match(new RegExp(escapeRegex(LINTING_SENTINEL_END), 'g')) ?? [])
+            .length;
+        assert.strictEqual(beginCount, 1, 'begin sentinel must appear exactly once after re-run');
+        assert.strictEqual(endCount, 1, 'end sentinel must appear exactly once after re-run');
+
+        const lintrHeaderCount = (merged.match(/\/\/ lintr: line_length_linter/g) ?? []).length;
+        assert.strictEqual(
+            lintrHeaderCount,
+            1,
+            'lintr header comments must not accumulate across re-runs',
+        );
+
+        const enabledCount = (merged.match(/"raven\.linting\.enabled"/g) ?? []).length;
+        assert.strictEqual(enabledCount, 1, 'each raven.linting.* key must appear exactly once');
+    });
+
+    test('re-run strips a previous sentinel block while keeping unrelated keys', () => {
+        const previous = `{
+  // a comment the user wrote
+  "editor.tabSize": 4,
+  ${LINTING_SENTINEL_BEGIN}
+  // Raven native style/lint diagnostics.
+  // lintr: line_length_linter(length = N)
+  "raven.linting.enabled": false,
+  "raven.linting.lineLength": 200,
+  ${LINTING_SENTINEL_END}
+  "files.autoSave": "onFocusChange"
+}
+`;
+        const merged = buildLintingSettingsContent(previous);
+        assert.ok(merged.includes('"editor.tabSize": 4'), 'unrelated keys must survive');
+        assert.ok(
+            merged.includes('"files.autoSave": "onFocusChange"'),
+            'unrelated keys after the old block must survive',
+        );
+        assert.ok(
+            merged.includes('// a comment the user wrote'),
+            'unrelated comments must survive',
+        );
+        const enabledCount = (merged.match(/"raven\.linting\.enabled"/g) ?? []).length;
+        assert.strictEqual(enabledCount, 1, 'no duplicate raven.linting.enabled');
+        assert.ok(
+            merged.includes('"raven.linting.enabled": true'),
+            'value must reflect the scaffold default (true), not the prior false',
+        );
+        assert.ok(
+            merged.includes('"raven.linting.lineLength": 120'),
+            'value must reflect the scaffold default (120), not the prior 200',
+        );
+    });
+
     test('output parses as valid JSON after comment + trailing-comma stripping', () => {
         const existing = `{
   "editor.tabSize": 4,
@@ -233,6 +312,41 @@ suite('scaffold linting-settings merge', () => {
         const parsed = JSON.parse(stripped) as Record<string, unknown>;
         assert.strictEqual(parsed['editor.tabSize'], 4);
         assert.strictEqual(parsed['raven.linting.enabled'], true);
+    });
+});
+
+suite('detectUserManagedLintingKeys', () => {
+    test('returns an empty array when all keys are inside the sentinel block', () => {
+        const text = `{
+  ${LINTING_SENTINEL_BEGIN}
+  "raven.linting.enabled": true,
+  "raven.linting.lineLength": 120,
+  ${LINTING_SENTINEL_END}
+}`;
+        assert.deepStrictEqual(detectUserManagedLintingKeys(text), []);
+    });
+
+    test('returns only user-managed keys (outside the sentinel block)', () => {
+        const text = `{
+  "raven.linting.objectLength": 50,
+  ${LINTING_SENTINEL_BEGIN}
+  "raven.linting.enabled": true,
+  ${LINTING_SENTINEL_END}
+}`;
+        assert.deepStrictEqual(detectUserManagedLintingKeys(text), [
+            'raven.linting.objectLength',
+        ]);
+    });
+
+    test('falls back to the full key list when no sentinels are present', () => {
+        const text = `{
+  "raven.linting.enabled": true,
+  "raven.linting.lineLength": 120
+}`;
+        assert.deepStrictEqual((detectUserManagedLintingKeys(text) ?? []).sort(), [
+            'raven.linting.enabled',
+            'raven.linting.lineLength',
+        ]);
     });
 });
 

--- a/editors/vscode/src/test/scaffold.test.ts
+++ b/editors/vscode/src/test/scaffold.test.ts
@@ -299,6 +299,13 @@ suite('scaffold linting-settings merge', () => {
         assert.strictEqual(buildLintingSettingsContent('{ this is not json'), null);
     });
 
+    test('returns null for an unterminated block comment', () => {
+        // An unterminated `/*` used to slip through the comment stripper
+        // silently, producing apparently-valid JSON and an invalid output.
+        assert.strictEqual(buildLintingSettingsContent('{} /*'), null);
+        assert.strictEqual(buildLintingSettingsContent('{ "a": 1 } /* unfinished'), null);
+    });
+
     test('re-running on a sentineled file does not duplicate the block or its lintr comments', () => {
         const merged = mergeOrThrow(LINTING_SETTINGS_TEMPLATE);
 


### PR DESCRIPTION
Closes #245.

## Summary

- Drop the `Raven: Create .lintr` command and its `LINTR_TEMPLATE` — the file Raven scaffolded was lintr's own DSL and Raven never read it.
- Add `Raven: Create linting settings` (`raven.scaffold.lintingSettings`), which scaffolds every `raven.linting.*` key Raven understands into `.vscode/settings.json`. Each key is prefaced with a `//` comment naming its lintr equivalent, so the file doubles as a reference.
- Merge logic preserves unrelated keys and comments in an existing `settings.json` and prompts before overwriting any pre-existing `raven.linting.*` values.
- Docs (`docs/configuration.md`, `docs/linting.md`) repointed at the new command; the one-line `.lintr` snippet for the lintr-via-REditorSupport workflow is now inline in `docs/linting.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (187 mocha tests pass, including new scaffold unit + merge tests and the registration test asserting `raven.scaffold.lintr` is gone)
- [x] Full `bun test` workspace suite (cargo + vscode-mocha) green
- [ ] Manual smoke: run "Raven: Create linting settings" in a fresh workspace; the file should open with all `raven.linting.*` keys and per-group `// lintr: …` comments.
- [ ] Manual smoke: re-run in a workspace that already has `raven.linting.enabled` — the modal prompt should fire and, on confirm, the prior key is replaced exactly once (no duplicates, unrelated keys preserved).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Create linting settings" scaffold command that generates Raven linting configuration directly in `.vscode/settings.json`.

* **Documentation**
  * Updated guidance to document the new scaffold command and clarify that Raven does not generate `.lintr` files automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->