### PR TITLE
feat(coexistence): gate chunk surfaces & rmd/quarto r.json snippets (closes #252)

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -5,7 +5,7 @@ Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delim
 This is the daily-driver workflow for `.Rmd` / `.qmd` users coming from RStudio or vscode-R.
 
 > [!NOTE]
-> Navigation commands (Go to Next/Previous Chunk, Select Current Chunk) and chunk background highlighting work regardless of `raven.rConsole.activation`. The **run** commands (for example, Run Current Chunk, Run Above Chunks, Run All Chunks — see [Commands](#commands) for the full set) and every chunk CodeLens button (defaults `▷ Run Chunk` / `↥ Run Above`, plus any others added via `raven.chunks.codeLens.commands`) require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), the run commands and CodeLens are not registered. See [Coexistence](./coexistence.md).
+> All chunk-related features — navigation commands (Go to Next/Previous Chunk, Select Current Chunk), chunk background highlighting and the active-cell indicator, `.R` cell mode (`# %%` markers and RStudio-style `# Section ----` dividers), the **run** commands (for example, Run Current Chunk, Run Above Chunks, Run All Chunks — see [Commands](#commands) for the full set), and every chunk CodeLens button (defaults `▷ Run Chunk` / `↥ Run Above`, plus any others added via `raven.chunks.codeLens.commands`) — are gated behind `raven.rConsole.activation`. The run commands and CodeLens additionally require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), none of these surfaces register, so REditorSupport / Positron handle chunks instead. See [Coexistence](./coexistence.md).
 
 ## Chunk forms
 

--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -8,6 +8,13 @@ Raven's **language server** and **help viewer** always activate — they don't o
 
 Raven's **R console**, **plot viewer**, and **data viewer** are the features that can overlap with another extension's R-session integration. The plot and data viewers are reached *through* Raven's R console: the R console boots a profile that overrides `View()` (data viewer) and starts httpgd (plot viewer). When Raven's R console isn't activated, neither of those viewers is wired up — `View(df)` and `plot(...)` go to whatever R session your other extension manages.
 
+Several editor surfaces that overlap with REditorSupport's R Markdown / Quarto tooling are gated behind the same R-console-activation switch:
+
+- **Chunk navigation** commands and keybindings (`raven.goToNextChunk`, `raven.goToPreviousChunk`, `raven.selectCurrentChunk`).
+- **Chunk background highlighting** and the **active-cell indicator** in `.Rmd` / `.qmd` documents.
+- **`.R` cell mode** support: `# %%` cell markers and RStudio-style `# Section ----` dividers used for chunk navigation / highlighting in plain `.R` files.
+- **R-language snippets in `.Rmd` / `.qmd` fenced chunks** — Raven's `r.json` snippets (`if`, `fun`, `for`, etc.) are registered for `rmd` / `quarto` only when Raven's R console is active. R-Markdown- and Quarto-specific snippets that scaffold new chunks (`rchunk`, `setupchunk`, ...) always register, since REditorSupport doesn't ship equivalents.
+
 ## Who benefits from Raven's R console?
 
 Raven's R console, plot viewer, and data viewer overlap with [REditorSupport (R)](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r)'s equivalents. Whether Raven's versions help you depends on your workflow:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ These Command Palette entries write starter R config files to the first workspac
 
 | Setting | Default | Description |
 |---|---|---|
-| `raven.rConsole.activation` | `"auto"` | When Raven's R console (and the plot and data viewers it powers) activates. `"enabled"`: always activate. `"disabled"`: never activate. `"auto"`: activate unless the REditorSupport (R) extension is enabled or VS Code is running as Positron. See [R Console](r-console.md) and [Coexistence](coexistence.md). |
+| `raven.rConsole.activation` | `"auto"` | When Raven's R console — and the surfaces gated alongside it (plot viewer, data viewer, chunk navigation / highlighting / active-cell indicator, `.R` cell mode, and the `r.json` snippets contributed to `.Rmd` / `.qmd`) — activates. `"enabled"`: always activate. `"disabled"`: never activate. `"auto"`: activate unless the REditorSupport (R) extension is enabled or VS Code is running as Positron. See [R Console](r-console.md) and [Coexistence](coexistence.md). |
 
 ## Plot Settings
 

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -14,7 +14,7 @@ For the exact trigger list and expansion bodies, see `editors/vscode/snippets/r.
 
 ## R Markdown and Quarto
 
-Raven contributes dedicated `rmd` and `quarto` language IDs for `.Rmd` and `.qmd` files. Both also register the plain-R snippets from `r.json`, so `for` / `fun` / `if` etc. still expand inside `.Rmd` / `.qmd` buffers — typically what you want when the cursor sits inside an R chunk.
+Raven contributes dedicated `rmd` and `quarto` language IDs for `.Rmd` and `.qmd` files. Plain-R snippets from `r.json` (`for` / `fun` / `if` etc.) also expand inside `.Rmd` / `.qmd` buffers when Raven's R console is active — typically what you want when the cursor sits inside an R chunk. These overlap with REditorSupport's snippet contributions, so they are gated behind `raven.rConsole.activation`; see [Coexistence](./coexistence.md). The R Markdown and Quarto chunk / helper snippets below register unconditionally, since REditorSupport doesn't ship equivalents.
 
 The R Markdown set (`rmd`) adds:
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -259,13 +259,13 @@
         "command": "raven.goToNextChunk",
         "key": "ctrl+alt+n",
         "mac": "cmd+alt+n",
-        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto)"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
       },
       {
         "command": "raven.goToPreviousChunk",
         "key": "ctrl+alt+shift+n",
         "mac": "cmd+alt+shift+n",
-        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto)"
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
       }
     ],
     "submenus": [
@@ -286,6 +286,18 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "raven.goToNextChunk",
+          "when": "raven.rConsoleEnabled"
+        },
+        {
+          "command": "raven.goToPreviousChunk",
+          "when": "raven.rConsoleEnabled"
+        },
+        {
+          "command": "raven.selectCurrentChunk",
+          "when": "raven.rConsoleEnabled"
+        },
         {
           "command": "raven.build.loadAll",
           "when": "raven.rConsoleEnabled && raven.isRPackage"
@@ -569,15 +581,7 @@
       },
       {
         "language": "rmd",
-        "path": "./snippets/r.json"
-      },
-      {
-        "language": "rmd",
         "path": "./snippets/rmarkdown.json"
-      },
-      {
-        "language": "quarto",
-        "path": "./snippets/r.json"
       },
       {
         "language": "quarto",

--- a/editors/vscode/src/chunks/index.ts
+++ b/editors/vscode/src/chunks/index.ts
@@ -9,11 +9,12 @@ import { register_chunk_decorations } from './chunk-highlighting';
  *
  *   - Navigation commands (`raven.goToNextChunk`, `raven.goToPreviousChunk`,
  *     `raven.selectCurrentChunk`).
- *   - Background-tint decorations.
+ *   - Background-tint decorations and the active-cell indicator.
  *
- * These are safe to enable regardless of `raven.rConsole.activation` so users
- * who coexist with REditorSupport or Positron still get the visual aids and
- * cursor-motion commands when reading `.Rmd` / `.qmd` notebooks.
+ * Although these surfaces don't strictly require an R terminal, they overlap
+ * with REditorSupport's chunk navigation and visuals. Callers gate them
+ * behind `raven.rConsole.activation` (only register when resolved to
+ * `enabled`) so coexistence users don't get duplicate behaviour.
  */
 export function register_chunks_navigation_and_highlight(
     context: vscode.ExtensionContext,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -33,6 +33,7 @@ import {
     register_chunks_navigation_and_highlight,
     register_chunks_with_terminal,
 } from './chunks';
+import { registerRSnippetCompletionsForRmdAndQuarto } from './rSnippetProvider';
 import { register_r_package_detection } from './r-package-detection';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';
@@ -236,12 +237,19 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         register_inspection_commands(context);
         register_build_commands(context);
         register_chunks_with_terminal(context);
-    }
 
-    // Chunk navigation and highlighting work without an R terminal, so register
-    // them regardless of `raven.rConsole.activation` — REditorSupport / Positron
-    // users still get the visual aids and cursor-motion commands.
-    register_chunks_navigation_and_highlight(context);
+        // Chunk navigation and highlighting overlap with REditorSupport's
+        // chunk surfaces, so they're gated behind R-console activation. With
+        // REditorSupport / Positron handling chunks, Raven steps aside.
+        register_chunks_navigation_and_highlight(context);
+
+        // R snippets for `rmd` / `quarto` are registered programmatically here
+        // (rather than statically in package.json) so they only appear when
+        // Raven's R-console is active. The static `language: "r"` registration
+        // in package.json continues to provide them in `.R` files. See
+        // docs/coexistence.md.
+        registerRSnippetCompletionsForRmdAndQuarto(context);
+    }
 
     // Package-mode context key. The `raven.isRPackage` key gates the
     // Build commands' palette entries and editor-title submenu — every

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -33,7 +33,7 @@ import {
     register_chunks_navigation_and_highlight,
     register_chunks_with_terminal,
 } from './chunks';
-import { registerRSnippetCompletionsForRmdAndQuarto } from './rSnippetProvider';
+import { registerRSnippetCompletionsForRmdAndQuarto } from './r-snippet-provider';
 import { register_r_package_detection } from './r-package-detection';
 import { PlotServices } from './plot';
 import { registerDataViewer, dataViewerDirOf } from './data-viewer';

--- a/editors/vscode/src/r-snippet-provider.ts
+++ b/editors/vscode/src/r-snippet-provider.ts
@@ -19,13 +19,11 @@ import * as vscode from 'vscode';
 export function registerRSnippetCompletionsForRmdAndQuarto(
     context: vscode.ExtensionContext,
 ): void {
-    const snippets = loadRSnippetsFromDisk(context.extensionPath);
-    if (snippets.length === 0) return;
+    const items = loadRSnippetCompletionItems(context.extensionPath);
+    if (items.length === 0) return;
 
     const provider: vscode.CompletionItemProvider = {
-        provideCompletionItems(): vscode.CompletionItem[] {
-            return snippets.map(buildCompletionItem);
-        },
+        provideCompletionItems: () => items,
     };
 
     for (const language of ['rmd', 'quarto']) {
@@ -38,37 +36,32 @@ export function registerRSnippetCompletionsForRmdAndQuarto(
     }
 }
 
-interface SnippetDefinition {
-    name: string;
-    prefix: string;
-    body: string;
-    description: string;
-}
-
 interface RawSnippet {
     prefix: string | string[];
     body: string | string[];
     description?: string;
 }
 
-function loadRSnippetsFromDisk(extensionPath: string): SnippetDefinition[] {
+function loadRSnippetCompletionItems(extensionPath: string): vscode.CompletionItem[] {
     const file = path.join(extensionPath, 'snippets', 'r.json');
     let raw: string;
     try {
         raw = fs.readFileSync(file, 'utf8');
-    } catch {
+    } catch (err) {
+        console.error(`raven: failed to read ${file}:`, err);
         return [];
     }
 
     let parsed: Record<string, RawSnippet>;
     try {
         parsed = JSON.parse(raw) as Record<string, RawSnippet>;
-    } catch {
+    } catch (err) {
+        console.error(`raven: failed to parse ${file}:`, err);
         return [];
     }
 
-    const out: SnippetDefinition[] = [];
-    for (const [name, snippet] of Object.entries(parsed)) {
+    const items: vscode.CompletionItem[] = [];
+    for (const snippet of Object.values(parsed)) {
         const prefixes = Array.isArray(snippet.prefix)
             ? snippet.prefix
             : [snippet.prefix];
@@ -77,16 +70,20 @@ function loadRSnippetsFromDisk(extensionPath: string): SnippetDefinition[] {
             : snippet.body;
         const description = snippet.description ?? '';
         for (const prefix of prefixes) {
-            out.push({ name, prefix, body, description });
+            items.push(buildCompletionItem(prefix, body, description));
         }
     }
-    return out;
+    return items;
 }
 
-function buildCompletionItem(s: SnippetDefinition): vscode.CompletionItem {
-    const item = new vscode.CompletionItem(s.prefix, vscode.CompletionItemKind.Snippet);
-    item.insertText = new vscode.SnippetString(s.body);
-    item.detail = s.description;
-    item.documentation = new vscode.MarkdownString().appendCodeblock(s.body, 'r');
+function buildCompletionItem(
+    prefix: string,
+    body: string,
+    description: string,
+): vscode.CompletionItem {
+    const item = new vscode.CompletionItem(prefix, vscode.CompletionItemKind.Snippet);
+    item.insertText = new vscode.SnippetString(body);
+    item.detail = description;
+    item.documentation = new vscode.MarkdownString().appendCodeblock(body, 'r');
     return item;
 }

--- a/editors/vscode/src/rSnippetProvider.ts
+++ b/editors/vscode/src/rSnippetProvider.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Programmatic registration of R-language snippets (loaded from
+ * `snippets/r.json`) for `rmd` and `quarto` language IDs.
+ *
+ * `package.json` can't conditionally register snippet contributions, so to
+ * keep these snippets out of the way when R-console is disabled (i.e. when
+ * REditorSupport or Positron is handling R), the caller invokes this only
+ * inside the gated branch in `activate()`. See `docs/coexistence.md`.
+ *
+ * The `.R` language ID itself is registered statically in `package.json`;
+ * R-only files always get these snippets regardless of activation, because
+ * `r.json` doesn't overlap with REditorSupport's `.R` snippet contributions
+ * the same way it does inside fenced R chunks.
+ */
+export function registerRSnippetCompletionsForRmdAndQuarto(
+    context: vscode.ExtensionContext,
+): void {
+    const snippets = loadRSnippetsFromDisk(context.extensionPath);
+    if (snippets.length === 0) return;
+
+    const provider: vscode.CompletionItemProvider = {
+        provideCompletionItems(): vscode.CompletionItem[] {
+            return snippets.map(buildCompletionItem);
+        },
+    };
+
+    for (const language of ['rmd', 'quarto']) {
+        context.subscriptions.push(
+            vscode.languages.registerCompletionItemProvider(
+                { language },
+                provider,
+            ),
+        );
+    }
+}
+
+interface SnippetDefinition {
+    name: string;
+    prefix: string;
+    body: string;
+    description: string;
+}
+
+interface RawSnippet {
+    prefix: string | string[];
+    body: string | string[];
+    description?: string;
+}
+
+function loadRSnippetsFromDisk(extensionPath: string): SnippetDefinition[] {
+    const file = path.join(extensionPath, 'snippets', 'r.json');
+    let raw: string;
+    try {
+        raw = fs.readFileSync(file, 'utf8');
+    } catch {
+        return [];
+    }
+
+    let parsed: Record<string, RawSnippet>;
+    try {
+        parsed = JSON.parse(raw) as Record<string, RawSnippet>;
+    } catch {
+        return [];
+    }
+
+    const out: SnippetDefinition[] = [];
+    for (const [name, snippet] of Object.entries(parsed)) {
+        const prefixes = Array.isArray(snippet.prefix)
+            ? snippet.prefix
+            : [snippet.prefix];
+        const body = Array.isArray(snippet.body)
+            ? snippet.body.join('\n')
+            : snippet.body;
+        const description = snippet.description ?? '';
+        for (const prefix of prefixes) {
+            out.push({ name, prefix, body, description });
+        }
+    }
+    return out;
+}
+
+function buildCompletionItem(s: SnippetDefinition): vscode.CompletionItem {
+    const item = new vscode.CompletionItem(s.prefix, vscode.CompletionItemKind.Snippet);
+    item.insertText = new vscode.SnippetString(s.body);
+    item.detail = s.description;
+    item.documentation = new vscode.MarkdownString().appendCodeblock(s.body, 'r');
+    return item;
+}

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -231,14 +231,22 @@ suite('chunk commands: registration and behavior', () => {
 
     test('every chunk command is registered in VS Code', async () => {
         // Skip when R-console activation is disabled (REditorSupport / Positron):
-        // the run / CodeLens-positional commands aren't registered then. The
-        // three navigation commands always are.
+        // chunk navigation, decorations, and run / CodeLens-positional commands
+        // are all gated together so coexistence users don't get duplicate
+        // surfaces. The assertion still validates the package.json declarations
+        // in the next test, which run unconditionally.
         const all = new Set(await vscode.commands.getCommands(true));
         const r_console_disabled = !all.has('raven.runLineOrSelection');
-        const expected = r_console_disabled
-            ? ['raven.goToNextChunk', 'raven.goToPreviousChunk', 'raven.selectCurrentChunk']
-            : CHUNK_COMMANDS;
-        for (const cmd of expected) {
+        if (r_console_disabled) {
+            for (const cmd of CHUNK_COMMANDS) {
+                assert.ok(
+                    !all.has(cmd),
+                    `expected chunk command "${cmd}" to be absent when R-console is disabled`,
+                );
+            }
+            return;
+        }
+        for (const cmd of CHUNK_COMMANDS) {
             assert.ok(
                 all.has(cmd),
                 `expected chunk command "${cmd}" to be registered`,
@@ -267,7 +275,47 @@ suite('chunk commands: registration and behavior', () => {
         }
     });
 
+    test('chunk navigation surfaces are gated behind raven.rConsoleEnabled', () => {
+        // The navigation commands, their keybindings, and their command-palette
+        // entries must all require `raven.rConsoleEnabled` — REditorSupport /
+        // Positron ship equivalent chunk navigation, so coexistence users
+        // should not see duplicates. See `docs/coexistence.md`.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../package.json') as {
+            contributes: {
+                keybindings: Array<{ command: string; when?: string }>;
+                menus: { commandPalette: Array<{ command: string; when?: string }> };
+            };
+        };
+        const NAV = ['raven.goToNextChunk', 'raven.goToPreviousChunk', 'raven.selectCurrentChunk'];
+
+        for (const cmd of NAV) {
+            const palette = pkg.contributes.menus.commandPalette.find(
+                (entry) => entry.command === cmd,
+            );
+            assert.ok(palette, `command palette must gate ${cmd}`);
+            assert.ok(
+                palette.when?.includes('raven.rConsoleEnabled'),
+                `${cmd} command palette entry must require raven.rConsoleEnabled`,
+            );
+        }
+
+        for (const cmd of ['raven.goToNextChunk', 'raven.goToPreviousChunk']) {
+            const binding = pkg.contributes.keybindings.find(
+                (entry) => entry.command === cmd,
+            );
+            assert.ok(binding, `${cmd} should have a keybinding`);
+            assert.ok(
+                binding.when?.includes('raven.rConsoleEnabled'),
+                `${cmd} keybinding must require raven.rConsoleEnabled`,
+            );
+        }
+    });
+
     test('goToNextChunk places cursor inside the next R chunk body', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.goToNextChunk');
+        if (r_console_disabled) return; // command not registered in this env
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 0); // before any chunk
         await vscode.commands.executeCommand('raven.goToNextChunk');
@@ -283,6 +331,9 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('goToPreviousChunk walks chunks in reverse', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.goToPreviousChunk');
+        if (r_console_disabled) return;
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the second R chunk body
         await vscode.commands.executeCommand('raven.goToPreviousChunk');
@@ -291,6 +342,9 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('selectCurrentChunk selects only the body of the chunk under the cursor', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.selectCurrentChunk');
+        if (r_console_disabled) return;
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the "second" R chunk
         await vscode.commands.executeCommand('raven.selectCurrentChunk');
@@ -387,6 +441,9 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('# %% cell mode in .R: selectCurrentChunk grabs the cell body', async () => {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.selectCurrentChunk');
+        if (r_console_disabled) return;
         const editor = await open_doc(R_CELL_FIXTURE, 'r');
         place_cursor(editor, 1); // inside cell "one"
         await vscode.commands.executeCommand('raven.selectCurrentChunk');

--- a/editors/vscode/src/test/snippets.test.ts
+++ b/editors/vscode/src/test/snippets.test.ts
@@ -80,6 +80,27 @@ suite('Snippet contributions', () => {
         );
     });
 
+    test('r.json is NOT statically registered for rmd / quarto', () => {
+        // r.json overlaps with REditorSupport's snippet contributions inside
+        // fenced R chunks. The static package.json entries were removed in
+        // favor of programmatic registration inside the R-console-activation
+        // gate (see registerRSnippetCompletionsForRmdAndQuarto). This test
+        // protects against regressions that would re-introduce duplicate
+        // completions for coexistence users.
+        const contributions = loadSnippetContributions();
+        const offending = contributions.filter(
+            (e) =>
+                (e.language === 'rmd' || e.language === 'quarto') &&
+                e.path.endsWith('r.json'),
+        );
+        assert.deepStrictEqual(
+            offending,
+            [],
+            'r.json must not be statically registered for rmd / quarto — '
+            + 'it is registered programmatically inside the R-console gate.',
+        );
+    });
+
     test('every registered snippets path resolves to an existing file', () => {
         for (const entry of loadSnippetContributions()) {
             const resolvedPath = path.resolve(vscodeRoot, entry.path);


### PR DESCRIPTION
## Summary

Closes #252. Moves the following editor surfaces behind the existing `raven.rConsole.activation` gate so coexistence users (REditorSupport / Positron) don't see duplicate behaviour:

- Chunk navigation commands (`raven.goToNextChunk`, `raven.goToPreviousChunk`, `raven.selectCurrentChunk`) and their keybindings / command-palette entries.
- Chunk background highlighting and the active-cell indicator.
- `.R` cell mode via `# %%` markers and RStudio-style `# Section ----` dividers (covered transitively via the chunk detector).
- `r.json` snippets registered for `rmd` / `quarto` language IDs.

Static `package.json` snippet contributions can't be conditional, so the `rmd` / `quarto` entries that pointed to `r.json` are dropped and re-registered programmatically inside the `r_console_resolved === 'enabled'` branch via `vscode.languages.registerCompletionItemProvider`. The `r` language entry remains static (it doesn't overlap with REditorSupport).

`docs/coexistence.md` is updated to list the newly gated surfaces alongside the R console, plot viewer, and data viewer.

## Test plan

- [x] `cargo test -p raven` — 3 711 + 103 + 58 tests pass.
- [x] `bun test` (root) — 467 bun + 208 VS Code Mocha tests pass.
- [x] `bun run typecheck` (editors/vscode) passes.
- [x] Chunks test asserts navigation commands are *absent* when R-console is disabled and *present* when enabled.
- [x] New snippets test asserts `r.json` is not statically registered for `rmd` / `quarto`.
- [x] New chunks test asserts navigation keybindings / palette entries require `raven.rConsoleEnabled`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->