### PR TITLE
issue183

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -132,6 +132,25 @@ same `View(mtcars)` opened tomorrow remembers the layout.
 - A 5,000,000-cell hard cap protects against accidental huge clipboard
   writes; over the cap the panel shows a toast and refuses the copy.
 
+### Keyboard shortcuts
+
+| Key                | Action                                  |
+| ------------------ | --------------------------------------- |
+| `Home`             | Jump to the first row.                  |
+| `End`              | Jump to the last row.                   |
+| `PageUp`           | Scroll one viewport up.                 |
+| `PageDown`         | Scroll one viewport down.               |
+| `Cmd/Ctrl+A`       | Select all rows across visible columns. |
+| `Cmd/Ctrl+C`       | Copy the current selection as TSV.      |
+
+`Home` and `End` are the recommended way to reach the very first or very
+last row in a large data frame. The native scrollbar's minimum thumb
+size prevents dragging the pill all the way to the bottom of a multi-
+million-row grid (see [issue #183](https://github.com/jbearak/raven/issues/183)),
+but `End` jumps there in one keystroke. Modifier combinations (`Shift`,
+`Cmd`/`Ctrl`, `Alt` on these navigation keys) fall through to the
+browser/OS unchanged so platform shortcuts are not hijacked.
+
 ## Settings
 
 | Setting | Default | Description |

--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -151,6 +151,11 @@ but `End` jumps there in one keystroke. Modifier combinations (`Shift`,
 `Cmd`/`Ctrl`, `Alt` on these navigation keys) fall through to the
 browser/OS unchanged so platform shortcuts are not hijacked.
 
+On data frames with more than ~625 K rows, Raven also replaces the
+native vertical scrollbar with an overlay so dragging the scrollbar
+thumb to the bottom reaches the last row. The native scrollbar is
+preserved on smaller frames.
+
 ## Settings
 
 | Setting | Default | Description |

--- a/docs/superpowers/plans/2026-05-16-data-viewer-custom-scrollbar.md
+++ b/docs/superpowers/plans/2026-05-16-data-viewer-custom-scrollbar.md
@@ -1,0 +1,1044 @@
+# Custom Scrollbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken native vertical scrollbar with a custom overlay
+on data frames where `totalGridHeight > MAX_SCROLL_PX`, so dragging the
+thumb reaches the very last row. Native scrollbar preserved for smaller
+frames. Closes the "Known limitation" from the prior issue #183 PR.
+
+**Architecture:** Custom scrollbar widget rendered as a sibling of the
+viewport inside a relatively-positioned wrapper (so the overlay stays
+fixed in viewport coordinates while the scroll content scrolls). Math
+functions in `grid-model.ts` are pure and bun-testable. Pointer event
+handling is in a new `CustomScrollbar.svelte` component. Test API drives
+synthetic pointer events on the thumb to exercise the real handler
+pipeline.
+
+**Tech Stack:** TypeScript + Svelte 5 in the data-viewer webview;
+TypeScript + VS Code APIs in the extension host; Bun for unit tests;
+Mocha + `@vscode/test-electron` for the integration test.
+
+See `docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md`
+for the full design rationale.
+
+---
+
+## File Structure
+
+```text
+editors/vscode/src/data-viewer/
+├── webview/
+│   ├── grid-model.ts                          # MODIFY — 3 new pure
+│   │                                          #   functions + 2 constants
+│   ├── App.svelte                             # MODIFY — wrapper layout,
+│   │                                          #   gate, conditional render,
+│   │                                          #   CSS classes
+│   ├── CustomScrollbar.svelte                 # NEW — overlay widget with
+│   │                                          #   pointer handlers
+│   └── styles.css                             # MODIFY — new selectors
+├── messages.ts                                # MODIFY — testScrollbarDrag
+├── panel.ts                                   # MODIFY — pressKey-style
+│                                              #   passthrough for drag
+├── manager.ts                                 # MODIFY — passthrough
+
+editors/vscode/src/extension.ts                # MODIFY — RavenExtensionApi
+                                               #   adds dragDataViewerScrollbar
+
+editors/vscode/src/test/data-viewer.test.ts    # MODIFY — integration test
+
+tests/bun/data-viewer-grid-model.test.ts       # MODIFY — math unit tests
+
+docs/data-viewer.md                            # MODIFY — note the custom
+                                               #   scrollbar on huge frames
+
+docs/superpowers/plans/
+└── 2026-05-16-data-viewer-custom-scrollbar.md # THIS PLAN
+```
+
+Each file has one responsibility:
+- `grid-model.ts` — pure scroll/thumb math.
+- `CustomScrollbar.svelte` — overlay widget (rendering + pointer events).
+- `App.svelte` — viewport, wrapper, gate, conditional rendering.
+- `styles.css` — declarative styling.
+- `messages.ts` — wire types only.
+- `panel.ts` / `manager.ts` / `extension.ts` — extension-host plumbing.
+- Tests + docs.
+
+---
+
+## Task 1: Bun unit tests for the new scrollbar math (RED)
+
+**Files:**
+- Modify: `tests/bun/data-viewer-grid-model.test.ts`
+
+This task and Task 2 are a TDD pair.
+
+- [ ] **Step 1: Add the imports the new tests need**
+
+At the top of `tests/bun/data-viewer-grid-model.test.ts`, extend the
+existing import:
+
+```typescript
+import {
+    visibleRange,
+    coalesceScroll,
+    MAX_SCROLL_PX,
+    cappedScrollHeight,
+    logicalScrollTop,
+    visualOffsetPx,
+    MIN_THUMB_PX,
+    HORIZONTAL_GUTTER_PX,
+    customThumbHeight,
+    customThumbTop,
+    customScrollTopFromThumbTop,
+} from '../../editors/vscode/src/data-viewer/webview/grid-model';
+```
+
+The tests will fail to load until Task 2 adds these exports — that's
+expected RED for an import-level failure.
+
+- [ ] **Step 2: Append a new describe block at the end of the file**
+
+After the existing top-level describe blocks, add:
+
+```typescript
+describe('custom scrollbar math', () => {
+    const VH = 600;
+    const RH = 24;
+    const TRACK = VH - HORIZONTAL_GUTTER_PX;  // 588
+
+    test('customThumbHeight: tiny dataset → full track', () => {
+        // 5 rows fit in the track many times over → thumb fills track.
+        expect(customThumbHeight(TRACK, RH, 5)).toBe(TRACK);
+    });
+    test('customThumbHeight: large dataset → MIN_THUMB_PX floor', () => {
+        // 10M rows on 600 px viewport: proportional thumb = TRACK *
+        // visibleCount/nrow ≈ TRACK * 25/10_000_000 ≈ 0.0015 px.
+        // Clamped up to MIN_THUMB_PX.
+        expect(customThumbHeight(TRACK, RH, 10_000_000)).toBe(MIN_THUMB_PX);
+    });
+    test('customThumbHeight: mid-size proportional', () => {
+        // 100 rows: visibleCount = ceil(588/24) = 25.
+        // proportional = 588 * (25/100) = 147. Above MIN_THUMB.
+        expect(customThumbHeight(TRACK, RH, 100)).toBeCloseTo(147);
+    });
+    test('customThumbHeight: nrow === 0 → full track', () => {
+        expect(customThumbHeight(TRACK, RH, 0)).toBe(TRACK);
+    });
+    test('customThumbHeight: rowHeight === 0 → full track', () => {
+        expect(customThumbHeight(TRACK, 0, 1000)).toBe(TRACK);
+    });
+    test('customThumbHeight: trackHeight === 0 → 0', () => {
+        expect(customThumbHeight(0, RH, 1000)).toBe(0);
+    });
+    test('customThumbHeight: trackHeight < MIN_THUMB_PX → trackHeight', () => {
+        // 20-px track gets a 20-px thumb, not a 30-px overflowing one.
+        expect(customThumbHeight(20, RH, 10_000_000)).toBe(20);
+    });
+
+    test('customThumbTop: scrollTop=0 → 0', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        expect(customThumbTop(0, TRACK, th, 14_999_424)).toBe(0);
+    });
+    test('customThumbTop: scrollTop=maxPhysical → trackHeight - thumbHeight', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        expect(customThumbTop(maxPhysical, TRACK, th, maxPhysical))
+            .toBeCloseTo(TRACK - th);
+    });
+    test('customThumbTop: midpoint → midpoint', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        expect(customThumbTop(maxPhysical / 2, TRACK, th, maxPhysical))
+            .toBeCloseTo((TRACK - th) / 2);
+    });
+    test('customThumbTop: maxPhysical <= 0 → 0', () => {
+        expect(customThumbTop(100, TRACK, MIN_THUMB_PX, 0)).toBe(0);
+        expect(customThumbTop(100, TRACK, MIN_THUMB_PX, -10)).toBe(0);
+    });
+    test('customThumbTop: thumbHeight >= trackHeight → 0', () => {
+        // Whole track is thumb; nothing to scroll.
+        expect(customThumbTop(100, TRACK, TRACK, 14_999_424)).toBe(0);
+    });
+
+    test('customScrollTopFromThumbTop: thumbTop=0 → 0', () => {
+        expect(customScrollTopFromThumbTop(0, TRACK, MIN_THUMB_PX, 14_999_424))
+            .toBe(0);
+    });
+    test('customScrollTopFromThumbTop: thumbTop=trackUsable → maxPhysical', () => {
+        const th = MIN_THUMB_PX;
+        const maxPhysical = 14_999_424;
+        expect(customScrollTopFromThumbTop(TRACK - th, TRACK, th, maxPhysical))
+            .toBeCloseTo(maxPhysical);
+    });
+    test('customScrollTopFromThumbTop: round-trip with customThumbTop', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        for (const scrollTop of [0, 1234, maxPhysical / 3, maxPhysical / 2,
+                                 maxPhysical * 0.99, maxPhysical]) {
+            const top = customThumbTop(scrollTop, TRACK, th, maxPhysical);
+            const back = customScrollTopFromThumbTop(top, TRACK, th, maxPhysical);
+            expect(back).toBeCloseTo(scrollTop);
+        }
+    });
+    test('customScrollTopFromThumbTop: maxPhysical <= 0 → 0', () => {
+        expect(customScrollTopFromThumbTop(100, TRACK, MIN_THUMB_PX, 0)).toBe(0);
+    });
+    test('customScrollTopFromThumbTop: trackUsable <= 0 → 0', () => {
+        expect(customScrollTopFromThumbTop(100, TRACK, TRACK, 14_999_424)).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 3: Run the bun tests to verify the new ones fail**
+
+```bash
+bun test tests/bun/data-viewer-grid-model.test.ts
+```
+
+Expected: bun fails to LOAD the test file (the new symbols don't exist
+yet). The error message should be like `MIN_THUMB_PX is not exported`
+or similar. That's the RED state — Task 2 will add the exports and run
+the tests for real.
+
+---
+
+## Task 2: Implement scrollbar math in `grid-model.ts` (GREEN)
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/webview/grid-model.ts`
+
+- [ ] **Step 1: Add the constants and three functions**
+
+At the bottom of `editors/vscode/src/data-viewer/webview/grid-model.ts`,
+**after** the existing `coalesceScroll` function, append:
+
+```typescript
+
+// ----- Custom scrollbar math (issue #183 follow-up) ---------------------
+
+/** Minimum pixel height for the custom scrollbar thumb. Below this the
+ *  thumb is hard to click/drag. Chosen so even a 10 M-row dataset gets a
+ *  visible, draggable thumb. */
+export const MIN_THUMB_PX = 30;
+
+/** Pixel reservation at the bottom of the custom scrollbar track for the
+ *  native horizontal scrollbar, when present. The CSS rule sets the
+ *  track's `bottom: HORIZONTAL_GUTTER_PX`, and the math takes
+ *  `trackHeight = viewportHeight - HORIZONTAL_GUTTER_PX`. Sharing the
+ *  constant guarantees the math + layout agree.
+ *
+ *  Always reserved, regardless of whether the horizontal scrollbar is
+ *  actually present. The visual cost when absent is the thumb stopping
+ *  ~12 px shy of the viewport bottom (negligible). The alternative —
+ *  measuring dynamically — adds layout-thrash on every render with
+ *  little benefit. */
+export const HORIZONTAL_GUTTER_PX = 12;
+
+/** Pixel height of the custom scrollbar thumb. The thumb represents the
+ *  fraction of the dataset currently visible (visibleCount / nrow), with
+ *  a hard minimum so even a single visible row in a 10 M-row dataset
+ *  produces a draggable thumb. The minimum is itself capped at the
+ *  track height — for tiny tracks (< MIN_THUMB_PX), the thumb fills the
+ *  track rather than overflowing it.
+ *
+ *  Note `trackHeight`, not `viewportHeight`: the track is shorter than
+ *  the viewport by HORIZONTAL_GUTTER_PX (see above). */
+export function customThumbHeight(
+    trackHeight: number,
+    rowHeight: number,
+    nrow: number,
+): number {
+    if (trackHeight <= 0) return 0;
+    if (nrow <= 0 || rowHeight <= 0) return trackHeight;
+    const visibleCount = Math.max(1, Math.ceil(trackHeight / rowHeight));
+    if (visibleCount >= nrow) return trackHeight;
+    const proportional = trackHeight * (visibleCount / nrow);
+    return Math.min(trackHeight, Math.max(MIN_THUMB_PX, proportional));
+}
+
+/** Pixel offset of the thumb's top from the top of the track. Track
+ *  height is `viewportHeight - HORIZONTAL_GUTTER_PX`; the thumb's top
+ *  can range from 0 to (trackHeight - thumbHeight). The mapping is
+ *  linear in the *physical* scrollTop so the thumb tracks user
+ *  scrolling exactly. */
+export function customThumbTop(
+    scrollTop: number,
+    trackHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
+    if (maxPhysical <= 0 || trackUsable <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, scrollTop / maxPhysical));
+    return fraction * trackUsable;
+}
+
+/** Convert a thumb-top pixel offset (during a drag) back to the physical
+ *  scrollTop the viewport needs. Inverse of customThumbTop. The caller
+ *  sets viewportEl.scrollTop = result; the existing onScroll →
+ *  scheduleFetchVisible pipeline does the rest. */
+export function customScrollTopFromThumbTop(
+    thumbTop: number,
+    trackHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
+    if (trackUsable <= 0 || maxPhysical <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, thumbTop / trackUsable));
+    return fraction * maxPhysical;
+}
+```
+
+- [ ] **Step 2: Run bun tests, expect 100% pass**
+
+```bash
+bun test tests/bun/data-viewer-grid-model.test.ts
+```
+
+Expected: all tests PASS, including the 17 new ones from Task 1 plus
+the existing 44.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add editors/vscode/src/data-viewer/webview/grid-model.ts \
+        tests/bun/data-viewer-grid-model.test.ts
+git commit -m "feat(data-viewer): add custom-scrollbar math (#183)
+
+Adds MIN_THUMB_PX, HORIZONTAL_GUTTER_PX, customThumbHeight,
+customThumbTop, customScrollTopFromThumbTop. All pure functions, all
+unit-tested under Bun. Math layer for the upcoming custom scrollbar
+overlay; no behavior change yet."
+```
+
+---
+
+## Task 3: Create the `CustomScrollbar.svelte` component
+
+**Files:**
+- Create: `editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte`
+
+- [ ] **Step 1: Create the file with the full component**
+
+```svelte
+<script lang="ts">
+    import {
+        customThumbHeight,
+        customThumbTop,
+        customScrollTopFromThumbTop,
+    } from './grid-model';
+
+    interface Props {
+        /** Pixel height of the scrollbar track (viewportHeight minus the
+         *  HORIZONTAL_GUTTER_PX bottom reservation). */
+        trackHeight: number;
+        /** Current physical scrollTop of the viewport. */
+        scrollTop: number;
+        /** Total row count in the dataset. */
+        nrow: number;
+        /** Pixel height of one row. */
+        rowHeight: number;
+        /** Maximum physical scrollTop = MAX_SCROLL_PX + rowHeight - viewportHeight. */
+        maxPhysical: number;
+        /** Callback invoked when the user's drag or click changes the
+         *  desired scrollTop. The parent should set viewportEl.scrollTop
+         *  to this value; the browser's onScroll handler does the rest. */
+        onScrollTo: (newScrollTop: number) => void;
+    }
+
+    let { trackHeight, scrollTop, nrow, rowHeight, maxPhysical, onScrollTo }: Props = $props();
+
+    let trackEl: HTMLDivElement | null = $state(null);
+    let thumbEl: HTMLDivElement | null = $state(null);
+
+    /** Pointer Y offset relative to thumb top at drag start. null when
+     *  not dragging. */
+    let dragOffset: number | null = $state(null);
+    /** Captured pointer id, for safe release on cleanup paths. */
+    let dragPointerId: number | null = null;
+    /** getBoundingClientRect().top of the track at drag start. Cached so
+     *  pointermove doesn't re-measure on every frame. */
+    let dragTrackTop = 0;
+
+    const thumbHeight = $derived(customThumbHeight(trackHeight, rowHeight, nrow));
+    const thumbTop = $derived(customThumbTop(scrollTop, trackHeight, thumbHeight, maxPhysical));
+
+    function onThumbPointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
+        if (!trackEl) return;
+        e.preventDefault();
+        e.stopPropagation();   // don't also trigger track-paging
+        dragPointerId = e.pointerId;
+        dragOffset = e.clientY - (trackEl.getBoundingClientRect().top + thumbTop);
+        dragTrackTop = trackEl.getBoundingClientRect().top;
+        // Synthetic events from the test seam may not be eligible for
+        // capture in all browsers; real user events always succeed.
+        try {
+            (e.target as Element).setPointerCapture(e.pointerId);
+        } catch {
+            // ignore — capture is a quality-of-life win, not required
+        }
+    }
+
+    function onThumbPointerMove(e: PointerEvent): void {
+        if (dragOffset === null) return;
+        const rawThumbTop = e.clientY - dragTrackTop - dragOffset;
+        const clampedThumbTop = Math.max(0, Math.min(trackHeight - thumbHeight, rawThumbTop));
+        onScrollTo(customScrollTopFromThumbTop(clampedThumbTop, trackHeight, thumbHeight, maxPhysical));
+    }
+
+    function endDrag(e: PointerEvent): void {
+        if (dragPointerId !== null) {
+            const target = e.target as Element;
+            // hasPointerCapture guard: lostpointercapture fires *after*
+            // the browser has released, so a naive releasePointerCapture
+            // would throw.
+            try {
+                if (target.hasPointerCapture(dragPointerId)) {
+                    target.releasePointerCapture(dragPointerId);
+                }
+            } catch {
+                // ignore
+            }
+        }
+        dragOffset = null;
+        dragPointerId = null;
+    }
+
+    function onTrackPointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
+        if (!trackEl) return;
+        // Page up if click is above the thumb, down if below.
+        const trackTop = trackEl.getBoundingClientRect().top;
+        const clickY = e.clientY - trackTop;
+        const direction = clickY < thumbTop ? -1 : 1;
+        onScrollTo(scrollTop + direction * trackHeight);
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="custom-scrollbar-track"
+    bind:this={trackEl}
+    onpointerdown={onTrackPointerDown}
+>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="custom-scrollbar-thumb"
+        class:dragging={dragOffset !== null}
+        bind:this={thumbEl}
+        data-test-id="custom-scrollbar-thumb"
+        style="top: {thumbTop}px; height: {thumbHeight}px;"
+        onpointerdown={onThumbPointerDown}
+        onpointermove={onThumbPointerMove}
+        onpointerup={endDrag}
+        onpointercancel={endDrag}
+        onlostpointercapture={endDrag}
+    ></div>
+</div>
+```
+
+- [ ] **Step 2: Verify the component file is syntactically valid**
+
+```bash
+cd editors/vscode && bun run typecheck
+```
+
+Expected: typecheck PASSES (the component file compiles in isolation;
+it's not yet imported by App.svelte so its type errors won't show up
+yet, but the underlying TS in the script block does type-check).
+
+- [ ] **Step 3: Verify the bundle builds**
+
+```bash
+cd editors/vscode && bun run bundle
+```
+
+Expected: PASS. esbuild-svelte processes the new file even though
+nothing imports it yet.
+
+---
+
+## Task 4: Update `styles.css` with scrollbar selectors
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/webview/styles.css`
+
+- [ ] **Step 1: Append the new selectors at the end of the file**
+
+```css
+
+/* ---------- Custom scrollbar (issue #183) ----------
+ * Engaged only when totalGridHeight > MAX_SCROLL_PX, via the
+ * `using-custom-scrollbar` class on `.viewport`. Below the cap we leave
+ * the native scrollbar alone. */
+
+.viewport-wrapper {
+    /* Wraps the viewport so the custom scrollbar overlay (sibling, not
+     * descendant) is laid out in the wrapper's coordinate space rather
+     * than the viewport's scroll-content coordinate space. min-height:
+     * 0 + min-width: 0 are required so flex shrink-to-fit allows the
+     * inner viewport to scroll its own content rather than growing the
+     * wrapper to the inner grid's intrinsic height. */
+    position: relative;
+    flex: 1 1 auto;
+    display: flex;
+    min-height: 0;
+    min-width: 0;
+}
+.viewport-wrapper > .viewport {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+}
+
+.viewport.using-custom-scrollbar {
+    /* Reserve a 12 px lane for the overlay so grid content doesn't
+     * extend under it. Without this, hiding the native scrollbar via
+     * ::-webkit-scrollbar:vertical { display: none } collapses the
+     * gutter and the rightmost cells/resize handles are obscured. */
+    padding-right: 12px;
+}
+
+.viewport.using-custom-scrollbar::-webkit-scrollbar:vertical {
+    display: none;
+}
+
+.custom-scrollbar-track {
+    position: absolute;
+    right: 0;
+    top: 0;
+    /* HORIZONTAL_GUTTER_PX = 12 px reserved at the bottom for the native
+     * horizontal scrollbar when present. The math layer takes
+     * trackHeight = viewportHeight - 12 to match (see grid-model.ts). */
+    bottom: 12px;
+    width: 12px;
+    background: transparent;
+    z-index: 3;  /* above sticky header (z-index: 2) */
+    user-select: none;
+}
+
+.custom-scrollbar-thumb {
+    position: absolute;
+    left: 2px;
+    right: 2px;
+    background: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+    border-radius: 4px;
+    cursor: default;
+}
+
+.custom-scrollbar-thumb:hover {
+    background: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
+}
+
+.custom-scrollbar-thumb.dragging {
+    background: var(--vscode-scrollbarSlider-activeBackground, rgba(191, 191, 191, 0.4));
+}
+```
+
+---
+
+## Task 5: Update `App.svelte` — wrapper layout, gate, conditional render
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/webview/App.svelte`
+
+- [ ] **Step 1: Extend the imports**
+
+Locate the existing import (around line 11):
+
+```typescript
+import {
+    visibleRange, coalesceScroll,
+    cappedScrollHeight, logicalScrollTop, visualOffsetPx,
+} from './grid-model';
+```
+
+Replace with:
+
+```typescript
+import {
+    visibleRange, coalesceScroll,
+    cappedScrollHeight, logicalScrollTop, visualOffsetPx,
+    MAX_SCROLL_PX, HORIZONTAL_GUTTER_PX,
+} from './grid-model';
+import CustomScrollbar from './CustomScrollbar.svelte';
+```
+
+- [ ] **Step 2: Add the `useCustomScrollbar` derived flag**
+
+Locate the existing `const totalGridHeight = $derived(...)` line (around
+line 100). Add **immediately below** it:
+
+```typescript
+const totalGridHeight = $derived(nrow * ROW_HEIGHT);
+const useCustomScrollbar = $derived(totalGridHeight > MAX_SCROLL_PX);
+```
+
+- [ ] **Step 3: Wrap the viewport with `.viewport-wrapper` and conditionally render the scrollbar**
+
+Locate the `<div class="viewport"` (around line 857). Wrap it with a
+new `<div class="viewport-wrapper">` and conditionally render
+`<CustomScrollbar />` as a sibling. The existing viewport's class list
+also gains `class:using-custom-scrollbar={useCustomScrollbar}`.
+
+Find:
+
+```svelte
+    <div class="viewport"
+         role="grid"
+         aria-rowcount={nrow}
+         bind:this={viewportEl}
+         onscroll={onScroll}
+         tabindex="0">
+        <div class="grid" style="height: {cappedScrollHeight(totalGridHeight) + ROW_HEIGHT}px;">
+```
+
+Replace with:
+
+```svelte
+    <div class="viewport-wrapper">
+        <div class="viewport"
+             class:using-custom-scrollbar={useCustomScrollbar}
+             role="grid"
+             aria-rowcount={nrow}
+             bind:this={viewportEl}
+             onscroll={onScroll}
+             tabindex="0">
+            <div class="grid" style="height: {cappedScrollHeight(totalGridHeight) + ROW_HEIGHT}px;">
+```
+
+Then locate the matching closing `</div>` for the existing viewport
+(it's the one that closes after the grid's contents — search for
+`</div>\n    </div>` near the bottom of the template). Add the
+conditional scrollbar render and a closing wrapper `</div>`. The full
+closing pattern becomes:
+
+```svelte
+        </div>  <!-- /.grid -->
+    </div>  <!-- /.viewport -->
+    {#if useCustomScrollbar}
+        <CustomScrollbar
+            trackHeight={Math.max(0, viewportHeight - HORIZONTAL_GUTTER_PX)}
+            scrollTop={scrollTop}
+            nrow={nrow}
+            rowHeight={ROW_HEIGHT}
+            maxPhysical={MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight}
+            onScrollTo={(newScrollTop) => {
+                if (viewportEl) viewportEl.scrollTop = newScrollTop;
+            }}
+        />
+    {/if}
+</div>  <!-- /.viewport-wrapper -->
+```
+
+Visually verify the resulting tree: `.data-viewer > .viewport-wrapper >
+.viewport > .grid` plus the optional `<CustomScrollbar />` sibling of
+`.viewport`. The `{#if contextMenu}` block (which was already a sibling
+of `.viewport`) stays a sibling of `.viewport-wrapper` — i.e. don't
+move it inside the wrapper.
+
+- [ ] **Step 4: Verify typecheck and bundle**
+
+```bash
+cd editors/vscode && bun run typecheck && bun run bundle
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit Tasks 3-5**
+
+```bash
+git add editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte \
+        editors/vscode/src/data-viewer/webview/App.svelte \
+        editors/vscode/src/data-viewer/webview/styles.css
+git commit -m "feat(data-viewer): custom scrollbar overlay for huge frames (#183)
+
+Renders an overlay scrollbar on the right edge of the viewport when
+totalGridHeight > MAX_SCROLL_PX. Native vertical scrollbar is hidden
+in that regime; below the cap, native scrollbar is unchanged.
+
+The overlay is a sibling of the viewport (not a descendant) so it
+stays fixed in viewport coordinates while the scroll content scrolls.
+Pointer-down/move/up handlers manage the drag with setPointerCapture
+wrapped in try/catch (synthetic test events may not be eligible for
+capture). Track-click pages by trackHeight in the click direction.
+
+Math is in grid-model.ts. CustomScrollbar.svelte handles the pointer
+events. App.svelte wires the gate."
+```
+
+---
+
+## Task 6: Extend `messages.ts` protocol
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/messages.ts`
+
+- [ ] **Step 1: Add the `testScrollbarDrag` ExtensionToWebview variant**
+
+Locate the existing `testKey` variant (added in the prior PR, near the
+end of the `ExtensionToWebview` union). Append a new variant
+**immediately after** `testKey`:
+
+```typescript
+    | {
+        /** Test-only: drive a custom-scrollbar drag-to-fraction (0..1)
+         *  by dispatching synthetic pointerdown/move/up events on the
+         *  thumb element. fraction=0 jumps to top, fraction=1 jumps to
+         *  bottom. The webview computes the target thumbTop, then fires
+         *  the events to exercise the real pointer handlers (drag
+         *  offset capture, drag math, cleanup).
+         *
+         *  Production code paths never post this message; the webview
+         *  can only receive messages from its own extension host, so
+         *  exposing it does not introduce an external attack surface. */
+        type: 'testScrollbarDrag';
+        panelGeneration: number;
+        fraction: number;
+    };
+```
+
+The trailing semicolon ends the union. Make sure the prior variant's
+trailing `;` becomes a `|` (the same diff pattern the prior PR used for
+adding `testKey`).
+
+- [ ] **Step 2: Verify typecheck**
+
+```bash
+cd editors/vscode && bun run typecheck
+```
+
+Expected: PASS. (No consumers of the new variant yet; that's Task 7+.)
+
+---
+
+## Task 7: panel.ts + manager.ts + extension.ts: drag passthrough
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/panel.ts`
+- Modify: `editors/vscode/src/data-viewer/manager.ts`
+- Modify: `editors/vscode/src/extension.ts`
+
+- [ ] **Step 1: Add `dragScrollbar` method to `DataViewerPanel`**
+
+Open `panel.ts`. Locate the existing `pressKey` method (added in the
+prior PR). Add a new method **immediately after** it:
+
+```typescript
+    /** Test-only: post a `testScrollbarDrag` message to the webview so
+     *  it dispatches synthetic pointer events on the thumb element.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Awaiting
+     *  waits for the message to be queued, not for any reply; tests
+     *  should poll `getVisibleRange()` to observe the result. */
+    async dragScrollbar(fraction: number): Promise<void> {
+        if (this.disposed) return;
+        const msg: ExtensionToWebview = {
+            type: 'testScrollbarDrag',
+            panelGeneration: this.generation,
+            fraction,
+        };
+        await this.webviewPanel.webview.postMessage(msg);
+    }
+```
+
+- [ ] **Step 2: Add `dragScrollbarOnPanel` passthrough to `DataViewerManager`**
+
+Open `manager.ts`. Locate the existing `pressKeyOnPanel` method. Add
+**immediately after** it:
+
+```typescript
+    /** Test-only: drive a custom-scrollbar drag in the named panel.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Awaiting
+     *  waits for message queuing; tests should poll
+     *  `getPanelVisibleRange()` to observe results. */
+    async dragScrollbarOnPanel(panelName: string, fraction: number): Promise<void> {
+        await this.panels.get(panelName)?.dragScrollbar(fraction);
+    }
+```
+
+- [ ] **Step 3: Add `dragDataViewerScrollbar` to `RavenExtensionApi`**
+
+Open `extension.ts`. Locate the existing `pressDataViewerKey` declaration
+in the `RavenExtensionApi` interface. Add **immediately after** it:
+
+```typescript
+    /** Test-only: drive a custom-scrollbar drag in a data viewer panel.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Used by
+     *  integration tests to exercise the drag math + scroll pipeline.
+     *  Awaiting waits for the message to be queued; poll
+     *  getDataViewerPanelVisibleRange to observe the result. */
+    dragDataViewerScrollbar(panelName: string, fraction: number): Promise<void>;
+```
+
+Then locate the `return { ... }` block at the bottom of `activate()` (you
+added entries here in the prior PR). Add the implementation
+**immediately after** `pressDataViewerKey`:
+
+```typescript
+        pressDataViewerKey: async (panelName: string, key: string) => {
+            await data_viewer_manager?.pressKeyOnPanel(panelName, key);
+        },
+        dragDataViewerScrollbar: async (panelName: string, fraction: number) => {
+            await data_viewer_manager?.dragScrollbarOnPanel(panelName, fraction);
+        },
+```
+
+- [ ] **Step 4: Add the `testScrollbarDrag` handler in `App.svelte`**
+
+Open `App.svelte`. Locate the existing `case 'testKey':` branch (added
+in the prior PR). Add a new case **immediately after** the `return;` for
+`testKey`:
+
+```typescript
+                case 'testScrollbarDrag': {
+                    // Test-only: dispatch synthetic pointerdown/move/up
+                    // events on the thumb element so the same drag
+                    // handlers a real user pointer would invoke run
+                    // end-to-end. pointerId 999 avoids colliding with
+                    // any real mouse pointer (Chromium primary mouse is
+                    // pointerId 1).
+                    const thumb = document.querySelector('[data-test-id="custom-scrollbar-thumb"]');
+                    if (!(thumb instanceof HTMLElement)) return;
+                    const trackHeight = Math.max(0, viewportHeight - HORIZONTAL_GUTTER_PX);
+                    const thumbHeightPx = thumb.getBoundingClientRect().height;
+                    const trackRect = (thumb.parentElement as HTMLElement).getBoundingClientRect();
+                    const thumbRect = thumb.getBoundingClientRect();
+                    // Current thumb center.
+                    const startX = thumbRect.left + thumbRect.width / 2;
+                    const startY = thumbRect.top + thumbRect.height / 2;
+                    // Target thumb-top, then target Y for the pointer.
+                    const targetThumbTop = m.fraction * Math.max(0, trackHeight - thumbHeightPx);
+                    const targetY = trackRect.top + targetThumbTop + thumbHeightPx / 2;
+                    const opts = {
+                        pointerId: 999,
+                        pointerType: 'mouse',
+                        bubbles: true,
+                        cancelable: true,
+                    } as const;
+                    thumb.dispatchEvent(new PointerEvent('pointerdown', {
+                        ...opts, clientX: startX, clientY: startY, button: 0,
+                    }));
+                    thumb.dispatchEvent(new PointerEvent('pointermove', {
+                        ...opts, clientX: startX, clientY: targetY, button: 0,
+                    }));
+                    thumb.dispatchEvent(new PointerEvent('pointerup', {
+                        ...opts, clientX: startX, clientY: targetY, button: 0,
+                    }));
+                    return;
+                }
+```
+
+`HORIZONTAL_GUTTER_PX` is already imported by Task 5; if not, add it
+to the existing `from './grid-model'` import.
+
+- [ ] **Step 5: Verify typecheck and bundle**
+
+```bash
+cd editors/vscode && bun run typecheck && bun run bundle
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add editors/vscode/src/data-viewer/messages.ts \
+        editors/vscode/src/data-viewer/panel.ts \
+        editors/vscode/src/data-viewer/manager.ts \
+        editors/vscode/src/extension.ts \
+        editors/vscode/src/data-viewer/webview/App.svelte
+git commit -m "feat(data-viewer): test-only scrollbar drag protocol (#183)
+
+Adds testScrollbarDrag ExtensionToWebview variant + DataViewerPanel
+dragScrollbar + DataViewerManager dragScrollbarOnPanel +
+RavenExtensionApi dragDataViewerScrollbar. The webview's handler
+dispatches synthetic pointerdown/move/up events on the thumb so the
+real CustomScrollbar pointer handlers run end-to-end.
+
+No user-visible behavior change."
+```
+
+---
+
+## Task 8: Mocha integration test
+
+**Files:**
+- Modify: `editors/vscode/src/test/data-viewer.test.ts`
+
+- [ ] **Step 1: Add the new test at the end of the suite**
+
+Locate the existing `End key reaches the last row...` test (added in the
+prior PR). Add **immediately after** it:
+
+```typescript
+    test('Drag scrollbar to bottom reaches last row in 700K-row data frame',
+        async function () {
+            this.timeout(240000);
+            const N = 700_000;
+
+            // Reuse the panel from the End-key test if still open;
+            // otherwise the prior test created and left it in place.
+            // pollForPanel returns immediately if it already exists.
+            if (!api.getDataViewerPanelNames().includes('big')) {
+                await api.sendToRTerminal(
+                    `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+                    + `nrow = ${N}, ncol = 5)); View(big)`,
+                );
+                const appeared = await pollForPanel(api, 'big', 90000);
+                assert.ok(appeared, 'panel "big" did not appear within 90 s');
+            }
+
+            // Reset to top, wait for steady state.
+            await api.pressDataViewerKey('big', 'Home');
+            const topRange = await pollFor(() => {
+                const r = api.getDataViewerPanelVisibleRange('big');
+                return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+            }, 60000);
+            assert.ok(topRange,
+                `pre-drag Home reset did not land at the top within 60 s; `
+                + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+
+            // Drag the scrollbar thumb to the bottom.
+            await api.dragDataViewerScrollbar('big', 1.0);
+
+            const bottomRange = await pollFor(() => {
+                const r = api.getDataViewerPanelVisibleRange('big');
+                return r && r.end === N ? r : undefined;
+            }, 60000);
+            assert.ok(bottomRange,
+                `Drag-to-bottom did not reach the last row within 60 s; `
+                + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+        });
+
+    test('Drag scrollbar to 50% lands near row N/2 in 700K-row data frame',
+        async function () {
+            this.timeout(240000);
+            const N = 700_000;
+
+            if (!api.getDataViewerPanelNames().includes('big')) {
+                await api.sendToRTerminal(
+                    `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+                    + `nrow = ${N}, ncol = 5)); View(big)`,
+                );
+                const appeared = await pollForPanel(api, 'big', 90000);
+                assert.ok(appeared, 'panel "big" did not appear within 90 s');
+            }
+
+            await api.pressDataViewerKey('big', 'Home');
+            const topRange = await pollFor(() => {
+                const r = api.getDataViewerPanelVisibleRange('big');
+                return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+            }, 60000);
+            assert.ok(topRange);
+
+            await api.dragDataViewerScrollbar('big', 0.5);
+
+            const midRange = await pollFor(() => {
+                const r = api.getDataViewerPanelVisibleRange('big');
+                if (!r) return undefined;
+                // Allow a generous 10% band around N/2 — the exact value
+                // depends on thumb-height / track-usable arithmetic.
+                return r.start >= 0.40 * N && r.start <= 0.60 * N ? r : undefined;
+            }, 60000);
+            assert.ok(midRange,
+                `Drag-to-50% did not land near N/2 within 60 s; `
+                + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+        });
+```
+
+- [ ] **Step 2: Run the data-viewer mocha suite**
+
+```bash
+cd editors/vscode && bun run pretest && bun run test --grep "data-viewer smoke"
+```
+
+Expected: all 6 data-viewer tests pass (4 prior + 2 new). The drag tests
+typically complete in 1-2 s once R + Arrow are warm.
+
+If R isn't installed locally, the suite skips entirely. Verify by
+inspection that the test file compiles via `bun run typecheck`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add editors/vscode/src/test/data-viewer.test.ts
+git commit -m "test(data-viewer): drag-scrollbar integration tests (#183)
+
+Two new tests on a 700K-row frame: drag-to-bottom reaches the last
+row, and drag-to-50% lands near row N/2. Both reuse the 'big' panel
+from the End-key test if still open, or create it. Each test gets
+its own 240s timeout (per-test) to handle R startup + matrix rnorm
++ Arrow write under suite load."
+```
+
+---
+
+## Task 9: Update `docs/data-viewer.md`
+
+**Files:**
+- Modify: `docs/data-viewer.md`
+
+- [ ] **Step 1: Append a sentence to the existing keyboard-shortcuts section**
+
+Open `docs/data-viewer.md`. Locate the existing "Keyboard shortcuts"
+subsection (added in the prior PR). The paragraph after the shortcuts
+table currently mentions `End` jumps to the last row. **Append** at the
+end of that paragraph:
+
+```markdown
+On data frames with more than ~625 K rows, Raven also replaces the
+native vertical scrollbar with an overlay so dragging the scrollbar
+thumb to the bottom reaches the last row. The native scrollbar is
+preserved on smaller frames.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/data-viewer.md
+git commit -m "docs(data-viewer): note custom scrollbar on huge frames (#183)"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Run the full bun test suite**
+
+```bash
+bun test
+```
+
+Expected: all bun tests PASS.
+
+- [ ] **Step 2: Run the full VS Code mocha suite**
+
+```bash
+cd editors/vscode && bun run pretest && bun run test
+```
+
+Expected: all data-viewer tests PASS. Other suites should be unchanged.
+
+- [ ] **Step 3: Typecheck + bundle + cargo**
+
+```bash
+cd editors/vscode && bun run typecheck && bun run bundle
+cd ../.. && cargo build -p raven
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Inspect git log**
+
+```bash
+git log --oneline -15
+```
+
+Expected: a clean sequence of (~7) commits, each scoped to one logical
+change, all referencing #183.

--- a/docs/superpowers/plans/2026-05-16-data-viewer-scroll-to-bottom.md
+++ b/docs/superpowers/plans/2026-05-16-data-viewer-scroll-to-bottom.md
@@ -1,0 +1,994 @@
+# Data Viewer Scroll-to-Last-Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue #183 (data viewer can't scroll to the last row of a large
+data frame) by adding Home/End/PageUp/PageDown keyboard shortcuts, clamping
+`logicalScrollTop` so macOS rubber-band overshoot doesn't blank the grid, and
+covering both fixes with automated tests — including a mocha integration
+test that drives `End` against a real R-loaded 700K-row data frame.
+
+**Architecture:** Two production-code changes (Svelte webview keyboard
+handler + `grid-model.ts` clamp), plus a small extension to the existing
+postMessage protocol so the mocha test can dispatch a synthetic
+`KeyboardEvent` from the extension host and read back the resulting visible
+row range. No new processes, caches, or threads. See
+`docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md`.
+
+**Tech Stack:** TypeScript + Svelte 5 in the data-viewer webview;
+TypeScript + VS Code APIs in the extension host; Bun (`bun:test`) for
+pure-function unit tests; Mocha + `@vscode/test-electron` for integration
+tests; R + the `arrow` R package for the integration fixture.
+
+---
+
+## File Structure
+
+Files created or modified by this plan:
+
+```text
+editors/vscode/src/data-viewer/
+├── webview/
+│   ├── grid-model.ts                          # MODIFY — clamp logicalScrollTop
+│   └── App.svelte                             # MODIFY — testKey handler,
+│                                              #   keyboard shortcuts,
+│                                              #   postLifecycle visibleRange,
+│                                              #   cache-hit lifecycle post
+├── messages.ts                                # MODIFY — extend lifecycle +
+│                                              #   add testKey ExtensionToWebview
+├── panel.ts                                   # MODIFY — lastVisibleRange,
+│                                              #   getVisibleRange, pressKey
+├── manager.ts                                 # MODIFY — passthroughs
+
+editors/vscode/src/extension.ts                # MODIFY — RavenExtensionApi
+                                               #   adds two methods
+
+editors/vscode/src/test/data-viewer.test.ts    # MODIFY — new End-key test
+
+tests/bun/data-viewer-grid-model.test.ts       # MODIFY — 4 new clamp tests
+
+docs/data-viewer.md                            # MODIFY — Keyboard shortcuts
+                                               #   subsection
+
+docs/superpowers/plans/
+└── 2026-05-16-data-viewer-scroll-to-bottom.md # THIS PLAN
+```
+
+Each file has one responsibility:
+
+- `grid-model.ts` — pure scroll math; the clamp lives here so it's
+  unit-testable under Bun without DOM.
+- `App.svelte` — UI behavior (key bindings, scroll → fetch pipeline).
+- `messages.ts` — wire types only, no behavior.
+- `panel.ts` — extension-side panel state + protocol handling.
+- `manager.ts` — multiplexing across panels by name.
+- `extension.ts` — the public test API surface.
+- `data-viewer.test.ts` — integration coverage of the runtime pipeline.
+- `data-viewer-grid-model.test.ts` — coverage of the math layer.
+- `docs/data-viewer.md` — user-facing keyboard shortcut docs.
+
+---
+
+## Task 1: Bun unit tests for the new clamp behavior (RED)
+
+**Files:**
+- Modify: `tests/bun/data-viewer-grid-model.test.ts`
+
+This task runs in parallel with Task 2 as a TDD pair (RED → GREEN). We
+write the tests first and watch them fail before implementing the clamp.
+
+- [ ] **Step 1: Add four new tests inside the existing `'scroll height capping'` describe block**
+
+Open `tests/bun/data-viewer-grid-model.test.ts`. Locate the
+`describe('scroll height capping', ...)` block. Right after the existing
+test `'bottom: max scrollTop reaches the last row'` (around line 110), add
+four new tests. The full new block to insert is:
+
+```typescript
+    test('logicalScrollTop: clamps overshoot above maxPhysical to maxLogical (large)', () => {
+        // macOS rubber-band can briefly push scrollTop above maxPhysical.
+        // Without the clamp, the scaled value exceeds maxLogical and
+        // visibleRange would return an empty window.
+        expect(logicalScrollTop(maxPhysical * 1.1, LARGE, VH, RH))
+            .toBe(maxLogicalLarge);
+    });
+
+    test('logicalScrollTop: clamps negative scrollTop to 0 (large)', () => {
+        // Defensive: Chromium shouldn't report negative scrollTop, but the
+        // clamp removes the assumption.
+        expect(logicalScrollTop(-50, LARGE, VH, RH)).toBe(0);
+    });
+
+    test('logicalScrollTop: clamps negative scrollTop to 0 (small)', () => {
+        // The small-data fast path also clamps now, so a stray negative
+        // scrollTop never propagates to visibleRange's floor() math.
+        expect(logicalScrollTop(-50, SMALL, VH, RH)).toBe(0);
+    });
+
+    test('visibleRange after clamped overshoot still includes the last row', () => {
+        const nrow = 10_000_000;
+        const totalGridHeight = nrow * RH;
+        // Simulate rubber-band overshoot: scrollTop 10% past maxPhysical.
+        const logical = logicalScrollTop(maxPhysical * 1.1, totalGridHeight, VH, RH);
+        const range = visibleRange({
+            scrollTop: logical, viewportHeight: VH,
+            rowHeight: RH, nrow, overscan: 8,
+        });
+        expect(range.end).toBe(nrow);
+    });
+```
+
+- [ ] **Step 2: Run the bun tests to verify the new ones fail**
+
+From the repo root, run:
+
+```bash
+bun test tests/bun/data-viewer-grid-model.test.ts
+```
+
+Expected: the 4 new tests FAIL with messages like
+- `expected maxLogicalLarge, received <some number > maxLogicalLarge>`
+- `expected 0, received -50` (the small-path test)
+- `expected nrow, received <smaller number>` (the round-trip test)
+
+The pre-existing tests in the suite should still PASS. Do not commit yet —
+the implementation in Task 2 will make these green and the commit happens
+there.
+
+---
+
+## Task 2: Implement the clamp in `grid-model.ts` (GREEN)
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/webview/grid-model.ts`
+
+- [ ] **Step 1: Replace `logicalScrollTop`'s body with the clamping version**
+
+Open `editors/vscode/src/data-viewer/webview/grid-model.ts`. Locate the
+existing `logicalScrollTop` function (lines 22–34). Replace its body
+**and** extend its doc comment so the clamp invariant is recorded next to
+the code. The full new function:
+
+```typescript
+/** Map a physical scrollTop (in the capped container) to the logical
+ *  scrollTop that visibleRange() expects. Identity-shaped when content fits.
+ *
+ *  The physical scroll range is [0, MAX_SCROLL_PX + rowHeight - viewportHeight]
+ *  and the logical scroll range is [0, totalGridHeight + rowHeight - viewportHeight],
+ *  so we scale between those two maxima (not between MAX_SCROLL_PX and
+ *  totalGridHeight) to reach the very last row when scrolled to the bottom.
+ *
+ *  Both branches clamp to [0, maxLogical]. macOS rubber-band can briefly
+ *  push scrollTop above maxPhysical; without the clamp the scaled value
+ *  exceeds maxLogical, visibleRange's floor() math gives start > nrow,
+ *  and the resulting empty range blanks the grid until the bounce
+ *  resolves. The negative clamp is defensive against hypothetical
+ *  Chromium oddities; in practice scrollTop should never be negative. */
+export function logicalScrollTop(
+    scrollTop: number,
+    totalGridHeight: number,
+    viewportHeight: number,
+    rowHeight: number,
+): number {
+    if (totalGridHeight <= MAX_SCROLL_PX) {
+        const maxLogicalSmall = Math.max(0, totalGridHeight + rowHeight - viewportHeight);
+        return Math.max(0, Math.min(maxLogicalSmall, scrollTop));
+    }
+    const maxPhysical = MAX_SCROLL_PX + rowHeight - viewportHeight;
+    if (maxPhysical <= 0) return 0;
+    const maxLogical = totalGridHeight + rowHeight - viewportHeight;
+    const scaled = (scrollTop / maxPhysical) * maxLogical;
+    return Math.max(0, Math.min(maxLogical, scaled));
+}
+```
+
+- [ ] **Step 2: Run the bun tests and verify they all pass**
+
+```bash
+bun test tests/bun/data-viewer-grid-model.test.ts
+```
+
+Expected: all tests PASS, including the 4 new ones from Task 1 and the
+original `'bottom: max scrollTop reaches the last row'` (unchanged behavior
+since clamping at `maxLogical` is a no-op when `scrollTop ≤ maxPhysical`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add editors/vscode/src/data-viewer/webview/grid-model.ts \
+        tests/bun/data-viewer-grid-model.test.ts
+git commit -m "fix(data-viewer): clamp logicalScrollTop to [0, maxLogical] (#183)
+
+macOS rubber-band overshoot briefly pushes scrollTop above maxPhysical.
+Without a clamp the scaled value exceeds maxLogical, visibleRange returns
+end < start, and the grid blanks until the bounce resolves. Clamp both
+branches of logicalScrollTop. Add bun tests covering both branches and a
+visibleRange round-trip from an overshooting scrollTop."
+```
+
+---
+
+## Task 3: Extend `messages.ts` protocol
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/messages.ts`
+
+This task is types-only; no runtime behavior changes yet. Subsequent
+tasks (4-6) make the new fields/types live.
+
+- [ ] **Step 1: Add `visibleRangeStart` / `visibleRangeEnd` to the lifecycle variant**
+
+Open `editors/vscode/src/data-viewer/messages.ts`. Locate the `lifecycle`
+variant of `WebviewToExtension` (around lines 92–100). Add the two new
+fields **before** `timestamp`:
+
+```typescript
+    | {
+        type: 'lifecycle';
+        event: string;
+        panelGeneration: number;
+        nrow: number;
+        columns: number;
+        visibleRows: number;
+        /** Start row index of the currently rendered window (inclusive).
+         *  Used by the test API to verify scroll position. Always reflects
+         *  visibleRangeStart at the moment postLifecycle was called. */
+        visibleRangeStart: number;
+        /** End row index of the currently rendered window (exclusive).
+         *  Equal to visibleRangeStart + visibleRows.length. */
+        visibleRangeEnd: number;
+        timestamp: number;
+    }
+```
+
+- [ ] **Step 2: Add the `testKey` `ExtensionToWebview` variant**
+
+Locate the `ExtensionToWebview` union (starts at line 30). At the end of
+the union — after the `error` variant (around line 86) — add:
+
+```typescript
+    | {
+        /** Test-only: dispatch a synthetic KeyboardEvent on `window` from
+         *  inside the webview, so the integration test harness can drive
+         *  the same onKeyDown handler a real keypress would invoke.
+         *  Production code paths never post this message; the webview can
+         *  only receive messages from its own extension host, so exposing
+         *  it does not introduce an external attack surface. */
+        type: 'testKey';
+        panelGeneration: number;
+        key: string;
+    }
+```
+
+The doc comment is required — it's the discoverability signal that warns
+future contributors not to call this from production code (per the spec's
+Risks section).
+
+- [ ] **Step 3: Verify the file still type-checks**
+
+From `editors/vscode/`:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS. (TypeScript will flag any consumer that destructures the
+old lifecycle shape, but no current consumer does — `panel.ts` only reads
+the legacy fields, and App.svelte's `postLifecycle` constructs the message
+inline. New required fields will surface as compile errors in Tasks 4-5,
+which is the point.)
+
+Actually, this WILL fail because App.svelte's `postLifecycle` does not yet
+populate the new required fields. That's expected at this stage. Continue
+to Task 4 (which fixes panel.ts to consume the new fields) and Task 5
+(which fixes App.svelte to populate them) before re-running typecheck. Do
+not commit until those tasks complete.
+
+---
+
+## Task 4: Add `panel.ts` test infrastructure (lastVisibleRange + getVisibleRange + pressKey)
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/panel.ts`
+
+- [ ] **Step 1: Add the `lastVisibleRange` private field**
+
+Open `editors/vscode/src/data-viewer/panel.ts`. Locate the
+`DataViewerPanel` class fields (around line 30). Add a new private field
+after `private readonly traceId`:
+
+```typescript
+    /** Latest visible-row range observed via lifecycle events. Used by
+     *  the integration test API. `undefined` until the first lifecycle
+     *  message arrives; cleared on `replace()` so a stale range from the
+     *  previous dataset is never returned for the new one. */
+    private lastVisibleRange: { start: number; end: number } | undefined;
+```
+
+- [ ] **Step 2: Update the lifecycle handler to cache the range and add new public methods**
+
+Locate the `if (m.type === 'lifecycle')` branch in `handleInner` (around
+line 232). Replace it with the version that also caches the range, with
+defensive narrowing:
+
+```typescript
+        if (m.type === 'lifecycle') {
+            this.trace(`webview-${m.event}`, {
+                generation: m.panelGeneration,
+                nrow: m.nrow,
+                columns: m.columns,
+                visibleRows: m.visibleRows,
+                visibleRangeStart: m.visibleRangeStart,
+                visibleRangeEnd: m.visibleRangeEnd,
+                timestamp: m.timestamp,
+            });
+            // Cache the range only when both fields are finite numbers.
+            // panel.ts is the trust boundary for messages from the webview;
+            // narrow defensively so a malformed message can never store
+            // {start: NaN, end: undefined as number} into lastVisibleRange.
+            if (m.panelGeneration === this.generation
+                && Number.isFinite(m.visibleRangeStart)
+                && Number.isFinite(m.visibleRangeEnd)) {
+                this.lastVisibleRange = {
+                    start: m.visibleRangeStart,
+                    end: m.visibleRangeEnd,
+                };
+            }
+            return;
+        }
+```
+
+Then locate the existing `getColumnNames()` method (search for
+`/** Column names in schema order — used by the test harness. */`) and add
+two new methods immediately above it:
+
+```typescript
+    /** Latest visible-row range from the most recent lifecycle message,
+     *  or undefined if none has arrived yet. Used by the test harness to
+     *  verify scroll position. */
+    getVisibleRange(): { start: number; end: number } | undefined {
+        return this.lastVisibleRange;
+    }
+
+    /** Test-only: post a `testKey` message to the webview so it dispatches
+     *  a synthetic KeyboardEvent on `window`. Awaiting the returned promise
+     *  waits for the message to be queued, not for any reply; tests should
+     *  poll `getVisibleRange()` to observe the result. */
+    async pressKey(key: string): Promise<void> {
+        if (this.disposed) return;
+        const msg: ExtensionToWebview = {
+            type: 'testKey',
+            panelGeneration: this.generation,
+            key,
+        };
+        await this.webviewPanel.webview.postMessage(msg);
+    }
+```
+
+- [ ] **Step 3: Clear `lastVisibleRange` on `replace()`**
+
+Locate the `async replace(...)` method (around line 95). Inside the method,
+right after the `this.generation += 1;` line, add:
+
+```typescript
+        this.generation += 1;
+        // Clear cached visible range so a stale range from the previous
+        // dataset is never returned for the new one. The next lifecycle
+        // event from the webview will repopulate it.
+        this.lastVisibleRange = undefined;
+```
+
+- [ ] **Step 4: Verify the file type-checks against the new messages**
+
+From `editors/vscode/`:
+
+```bash
+bun run typecheck
+```
+
+Expected: still failing because App.svelte doesn't populate the new
+required lifecycle fields yet. That's expected; Task 5 fixes it.
+
+---
+
+## Task 5: Update `App.svelte` — testKey handler, postLifecycle range, cache-hit lifecycle
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/webview/App.svelte`
+
+This task adds all the webview-side infrastructure the test needs, but
+**not** the keyboard shortcuts themselves (those come in Task 7). After
+this task, the testKey message dispatches a synthetic KeyboardEvent that
+flows through `onKeyDown` — but `onKeyDown` only handles Cmd-A/Cmd-C, so
+nothing scrolls. That's the RED state Task 7 will turn GREEN.
+
+- [ ] **Step 1: Extend `postLifecycle` to include the visible range**
+
+Open `editors/vscode/src/data-viewer/webview/App.svelte`. Locate
+`function postLifecycle` (around line 117). Replace its body:
+
+```typescript
+    function postLifecycle(event: string): void {
+        vscode.postMessage({
+            type: 'lifecycle',
+            event,
+            panelGeneration,
+            nrow,
+            columns: columns.length,
+            visibleRows: visibleRows.length,
+            visibleRangeStart,
+            visibleRangeEnd: visibleRangeStart + visibleRows.length,
+            timestamp: Date.now(),
+        });
+    }
+```
+
+- [ ] **Step 2: Add the `testKey` message-handler branch**
+
+Locate the message handler in `onMount` (the `switch (m.type)` block around
+lines 142–155). Add a new case **after** `case 'copyDone'`:
+
+```typescript
+                case 'copyDone':
+                    applyCopyDone(m);
+                    return;
+                case 'testKey':
+                    // Test-only: dispatch a synthetic KeyboardEvent on
+                    // `window` so the same onKeyDown handler a real
+                    // keypress would invoke runs end-to-end. The
+                    // <svelte:window onkeydown={onKeyDown}> binding
+                    // listens at the window level, so window.dispatchEvent
+                    // is the canonical delivery path for synthetic events.
+                    window.dispatchEvent(new KeyboardEvent('keydown', {
+                        key: m.key,
+                        code: m.key,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+                    return;
+```
+
+- [ ] **Step 3: Add `postLifecycle('cache-hit')` and `postLifecycle('empty-range')` to `scheduleFetchVisible`'s fast paths**
+
+Locate the `scheduleFetchVisible = coalesceScroll(...)` call (around line
+300). Replace the empty-range and cache-hit branches so each posts a
+lifecycle event before returning:
+
+```typescript
+    const scheduleFetchVisible = coalesceScroll(() => {
+        const range = visibleRange({
+            scrollTop: logicalScrollTop(scrollTop, totalGridHeight, viewportHeight, ROW_HEIGHT),
+            viewportHeight, rowHeight: ROW_HEIGHT, nrow, overscan: 8,
+        });
+        if (range.end <= range.start) {
+            visibleRows = [];
+            visibleRangeStart = range.start;
+            persistWebviewState();
+            // Tell the host every change to visibleRangeStart, including
+            // the empty-range case — otherwise the test API can stall on
+            // a stale range when nrow shrinks to 0 or the viewport
+            // collapses.
+            postLifecycle('empty-range');
+            return;
+        }
+        const cached = rowCache.get(range.start, range.end);
+        if (cached) {
+            visibleRows = cached;
+            visibleRangeStart = range.start;
+            persistWebviewState();
+            // Without this, an End keypress that lands on a pre-cached
+            // window (e.g., re-pressing End after a scroll-up) would
+            // never tell the host its range changed, leaving the polling
+            // test stuck on a stale lastVisibleRange.
+            postLifecycle('cache-hit');
+            return;
+        }
+        viewportGeneration += 1;
+```
+
+(The rest of the function is unchanged.)
+
+- [ ] **Step 4: Verify everything type-checks**
+
+From `editors/vscode/`:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify the bundle builds**
+
+From `editors/vscode/`:
+
+```bash
+bun run bundle
+```
+
+Expected: PASS. The data-viewer webview is built from `App.svelte` via
+`esbuild-svelte`; if any Svelte syntax or TypeScript type is wrong, this
+step will fail.
+
+- [ ] **Step 6: Commit (test infrastructure complete; mocha test will follow)**
+
+```bash
+git add editors/vscode/src/data-viewer/messages.ts \
+        editors/vscode/src/data-viewer/panel.ts \
+        editors/vscode/src/data-viewer/webview/App.svelte
+git commit -m "feat(data-viewer): add test-only protocol for driving keys + reading visible range
+
+Extends the postMessage protocol with:
+- visibleRangeStart / visibleRangeEnd on lifecycle events (always sent)
+- testKey ExtensionToWebview variant (test-only, gated by doc comment)
+
+DataViewerPanel caches lastVisibleRange from lifecycle messages and
+exposes getVisibleRange() / pressKey() for the test harness. The webview
+posts lifecycle events from scheduleFetchVisible's cache-hit and empty-
+range fast paths so every change to visibleRangeStart is observable from
+the host (without this, an End keypress into a pre-cached window would
+silently update only the webview).
+
+No user-visible behavior change."
+```
+
+---
+
+## Task 6: Wire up `manager.ts` and `extension.ts` test API
+
+**Files:**
+- Modify: `editors/vscode/src/data-viewer/manager.ts`
+- Modify: `editors/vscode/src/extension.ts`
+
+- [ ] **Step 1: Add passthrough methods to `DataViewerManager`**
+
+Open `editors/vscode/src/data-viewer/manager.ts`. Locate `getPanelColumnNames`
+(around line 71). Add two new methods immediately after:
+
+```typescript
+    /** Latest visible-row range for a named panel — used by the test
+     *  harness to verify scroll position. */
+    getPanelVisibleRange(panelName: string): { start: number; end: number } | undefined {
+        return this.panels.get(panelName)?.getVisibleRange();
+    }
+
+    /** Test-only: dispatch a synthetic key event in a named panel's
+     *  webview. Awaiting waits for the message to be queued, not for any
+     *  reply; tests should poll `getPanelVisibleRange()` to observe
+     *  results. */
+    async pressKeyOnPanel(panelName: string, key: string): Promise<void> {
+        await this.panels.get(panelName)?.pressKey(key);
+    }
+```
+
+- [ ] **Step 2: Extend `RavenExtensionApi` with two new methods**
+
+Open `editors/vscode/src/extension.ts`. Locate the `RavenExtensionApi`
+interface (around line 125). Add two new methods at the end of the
+interface, immediately after `_disposeCachedRTerminalForTest`:
+
+```typescript
+    /** Latest visible-row range for a data viewer panel, or undefined if
+     *  none has arrived yet. Used by integration tests to verify scroll
+     *  position. */
+    getDataViewerPanelVisibleRange(panelName: string):
+        { start: number; end: number } | undefined;
+    /** Test-only: dispatch a synthetic key event in a data viewer panel.
+     *  Used by integration tests to drive End / Home / PageDown / PageUp.
+     *  Awaiting waits for the message to be queued; poll
+     *  getDataViewerPanelVisibleRange to observe the result. */
+    pressDataViewerKey(panelName: string, key: string): Promise<void>;
+```
+
+Then locate the `return { ... }` block at the bottom of `activate()`
+(around line 387). Add the two new methods to the returned object,
+immediately after `getDataViewerPanelColumnNames`:
+
+```typescript
+    return {
+        getLanguageClient: () => client,
+        sendToRTerminal: async (code: string) => {
+            const terminal = await get_or_create_r_terminal();
+            terminal.sendText(code, true);
+        },
+        getDataViewerPanelNames: () => data_viewer_manager?.getPanelNames() ?? [],
+        getDataViewerPanelColumnNames: (panelName: string) =>
+            data_viewer_manager?.getPanelColumnNames(panelName),
+        getDataViewerPanelVisibleRange: (panelName: string) =>
+            data_viewer_manager?.getPanelVisibleRange(panelName),
+        pressDataViewerKey: async (panelName: string, key: string) => {
+            await data_viewer_manager?.pressKeyOnPanel(panelName, key);
+        },
+        _disposeCachedRTerminalForTest: () => _dispose_cached_r_terminal_for_test(),
+    };
+```
+
+- [ ] **Step 3: Verify everything type-checks**
+
+```bash
+cd editors/vscode && bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Verify the bundle builds**
+
+```bash
+cd editors/vscode && bun run bundle
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit (extension API surface complete)**
+
+```bash
+git add editors/vscode/src/data-viewer/manager.ts \
+        editors/vscode/src/extension.ts
+git commit -m "feat(data-viewer): expose visible range + key dispatch on test API
+
+Adds getDataViewerPanelVisibleRange / pressDataViewerKey to
+RavenExtensionApi so integration tests can drive scroll keys against a
+real panel and observe the resulting visible row range.
+
+No user-visible behavior change."
+```
+
+---
+
+## Task 7: Write the mocha integration test (RED) and add keyboard shortcuts (GREEN)
+
+**Files:**
+- Modify: `editors/vscode/src/test/data-viewer.test.ts`
+- Modify: `editors/vscode/src/data-viewer/webview/App.svelte`
+
+This task is the TDD pair for the runtime path. We add the failing test
+first (it can't reach the last row because no key handlers exist), then
+implement Home / End / PageDown / PageUp and watch it pass.
+
+- [ ] **Step 1: Add a `pollFor<T>` helper if one isn't already in scope**
+
+Open `editors/vscode/src/test/data-viewer.test.ts`. The existing
+`pollForPanel` is hard-coded to wait for a panel name. We need a more
+general polling helper. Add it at the top of the file, immediately after
+the existing `pollForPanel` function:
+
+```typescript
+/** Poll a predicate at 100 ms intervals until it returns a truthy value or
+ *  the deadline elapses. Returns the truthy value on success or `undefined`
+ *  on timeout (caller asserts). */
+async function pollFor<T>(
+    predicate: () => T | undefined,
+    timeoutMs: number,
+    intervalMs = 100,
+): Promise<T | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const value = predicate();
+        if (value !== undefined && value !== null && value !== false) {
+            return value as T;
+        }
+        await sleep(intervalMs);
+    }
+    return undefined;
+}
+```
+
+- [ ] **Step 2: Add the new test at the end of the suite**
+
+Inside the same `suite('data-viewer smoke tests', ...)` block, after the
+last existing `test(...)` (the "View(mtcars) a second time replaces"
+test), add:
+
+```typescript
+    test('End key reaches the last row in a 700K-row data frame', async function () {
+        // Smallest size that engages the cap (700_000 × 24 = 16.8 M >
+        // MAX_SCROLL_PX of 15 M) — exactly the failure mode from #183.
+        const N = 700_000;
+
+        await api.sendToRTerminal(
+            `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+            + `nrow = ${N}, ncol = 5)); View(big)`,
+        );
+
+        // Wait for the panel to exist. R startup + matrix rnorm + Arrow
+        // write can take several seconds on a cold runner.
+        const panelAppeared = await pollForPanel(api, 'big', 60000);
+        assert.ok(panelAppeared, 'panel "big" did not appear within 60 s');
+
+        // Reset scroll to the top. A previous --watch run could have left
+        // the same-shape panel scrolled to the bottom; applyInitOrReplace's
+        // sameDataset branch intentionally preserves visibleRangeStart, so
+        // an unconditional 'end < N/2' gate would deadlock on that.
+        // Press Home as a deterministic reset (this also exercises Home
+        // as a bonus side check).
+        await api.pressDataViewerKey('big', 'Home');
+
+        // Wait for the Home reset to land AND rows for the top of the
+        // grid to be fetched. A mount/init lifecycle reports
+        // {start: 0, end: 0}, which would satisfy 'end < N/2' alone — so
+        // require end > 0 too.
+        const topRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+        }, 30000);
+        assert.ok(topRange, `Home reset did not land at the top within 30 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+
+        // Drive End and wait for the bottom-row fetch to land.
+        await api.pressDataViewerKey('big', 'End');
+
+        const bottomRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end === N ? r : undefined;
+        }, 30000);
+        assert.ok(bottomRange,
+            `End key did not reach the last row within 30 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+    });
+```
+
+- [ ] **Step 3: Run the data-viewer test suite to confirm the new test fails**
+
+The full suite is gated on R + `arrow` being installed; if either is
+missing, the suite skips and there's nothing to verify. From
+`editors/vscode/`:
+
+```bash
+bun run pretest && bun run test --grep 'data-viewer smoke tests'
+```
+
+Expected: the new test FAILS (or times out at 30 s on the bottom-range
+poll), with an error that the `End` key did not reach the last row. The
+existing three tests should still PASS. This is the RED state of TDD.
+
+If R is not installed locally, the suite will skip entirely; in that case
+this step is "no-op verified by inspection" — just make sure the test
+file compiles via `bun run typecheck`. Note this in the commit message.
+
+- [ ] **Step 4: Add the keyboard shortcut branches to `onKeyDown` in `App.svelte`**
+
+Open `editors/vscode/src/data-viewer/webview/App.svelte`. Locate
+`function onKeyDown` (around line 468). Replace its body with:
+
+```typescript
+    function onKeyDown(e: KeyboardEvent): void {
+        const meta = e.metaKey || e.ctrlKey;
+        if (e.key === 'Escape' && contextMenu) {
+            closeContextMenu();
+            return;
+        }
+        // Plain (no-modifier) navigation keys — added for issue #183.
+        // We deliberately ignore any modifier so platform shortcuts
+        // (Shift+End to extend selection, Cmd+End in some apps to jump-
+        // and-extend) fall through to the browser/OS unchanged. The
+        // viewportEl null guard handles the brief window between mount
+        // and the bind:this assignment.
+        if (!meta && !e.shiftKey && !e.altKey && viewportEl) {
+            switch (e.key) {
+                case 'End':
+                    e.preventDefault();
+                    // scrollHeight - clientHeight is the canonical
+                    // browser-clamped maximum. The inner .grid div is
+                    // height-capped at MAX_SCROLL_PX + ROW_HEIGHT, so
+                    // this lands at or near the model's maxPhysical;
+                    // logicalScrollTop's clamp absorbs any DOM-vs-model
+                    // rounding mismatch.
+                    viewportEl.scrollTop = viewportEl.scrollHeight - viewportEl.clientHeight;
+                    return;
+                case 'Home':
+                    e.preventDefault();
+                    viewportEl.scrollTop = 0;
+                    return;
+                case 'PageDown':
+                    e.preventDefault();
+                    viewportEl.scrollTop += viewportEl.clientHeight;
+                    return;
+                case 'PageUp':
+                    e.preventDefault();
+                    viewportEl.scrollTop -= viewportEl.clientHeight;
+                    return;
+            }
+        }
+        if (meta && (e.key === 'a' || e.key === 'A')) {
+            e.preventDefault();
+            selection.selectAll(nrow, visibleCols);
+            bumpSelection();
+            return;
+        }
+        if (meta && (e.key === 'c' || e.key === 'C')) {
+            if (!selection.rect()) return;
+            e.preventDefault();
+            copySelection();
+        }
+    }
+```
+
+- [ ] **Step 5: Rebuild the bundle and re-run the test to confirm GREEN**
+
+```bash
+cd editors/vscode && bun run pretest && bun run test --grep 'data-viewer smoke tests'
+```
+
+Expected: all four data-viewer tests PASS, including the new End-key
+test. The bottom range poll should land within seconds (the End-key
+scrollTop set fires onScroll → scheduleFetchVisible → getRows → applyRows
+→ postLifecycle('rows')).
+
+If R is not installed locally, the suite skips. In that case verify by
+inspection that:
+- Plain `End` / `Home` / `PageDown` / `PageUp` no longer fall through to
+  the browser default (they're handled and `preventDefault` is called).
+- `Shift+End`, `Cmd+End`, `Alt+End` etc. still fall through to the Cmd-A /
+  Cmd-C branches or the browser default (they don't enter the switch
+  because of the `!meta && !e.shiftKey && !e.altKey` guard).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add editors/vscode/src/test/data-viewer.test.ts \
+        editors/vscode/src/data-viewer/webview/App.svelte
+git commit -m "feat(data-viewer): add Home/End/PageDown/PageUp keyboard shortcuts (#183)
+
+Issue #183: dragging the scrollbar pill, holding ArrowDown, and macOS
+inertia-scroll all fail to reach the last row of a large data frame
+because the browser's minimum scrollbar-thumb size compresses the bottom
+of the drag track. Add Home / End / PageUp / PageDown as a deterministic
+keyboard path to any row regardless of widget quirks.
+
+End sets viewportEl.scrollTop to scrollHeight - clientHeight, which after
+logicalScrollTop's clamp resolves to the last row. Modifier-shift / cmd /
+alt combinations fall through unchanged so platform shortcuts aren't
+hijacked.
+
+Adds a 700K-row mocha integration test that drives Home then End via the
+testKey protocol and asserts the visible-row range reaches nrow.
+Skips automatically when R or the arrow package is unavailable."
+```
+
+---
+
+## Task 8: Update `docs/data-viewer.md` with keyboard shortcuts
+
+**Files:**
+- Modify: `docs/data-viewer.md`
+
+- [ ] **Step 1: Locate the right insertion point**
+
+Open `docs/data-viewer.md`. Find the existing copy/selection section (search
+for `Cmd-A` or `Cmd+A` or `Cmd/Ctrl-A`). The keyboard shortcuts subsection
+goes immediately after the section that documents copy/selection.
+
+If no such section exists yet (the file's current structure may differ),
+insert the new subsection before any "Limitations" or "Known issues"
+section near the bottom.
+
+- [ ] **Step 2: Insert the keyboard shortcuts subsection**
+
+Add this Markdown block:
+
+```markdown
+## Keyboard shortcuts
+
+| Key                | Action                                  |
+| ------------------ | --------------------------------------- |
+| `Home`             | Jump to the first row.                  |
+| `End`              | Jump to the last row.                   |
+| `PageUp`           | Scroll one viewport up.                 |
+| `PageDown`         | Scroll one viewport down.               |
+| `Cmd/Ctrl-A`       | Select all visible cells.               |
+| `Cmd/Ctrl-C`       | Copy the current selection as TSV.      |
+
+`Home` and `End` are the recommended way to reach the very first or very
+last row in a large data frame: the native scrollbar's minimum thumb size
+prevents dragging the pill all the way to the bottom of a multi-million-
+row grid (see [issue #183](https://github.com/jbearak/raven/issues/183)),
+but `End` jumps there in one keystroke.
+```
+
+- [ ] **Step 3: Verify the markdown lints clean (if a markdown linter is
+   configured for the repo)**
+
+If the repo has markdownlint, run it. If not, skip this step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/data-viewer.md
+git commit -m "docs(data-viewer): document Home/End/PageUp/PageDown shortcuts (#183)"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full bun test suite**
+
+From the repo root:
+
+```bash
+bun test
+```
+
+Expected: all bun tests PASS, including the 4 new data-viewer-grid-model
+tests. No regressions.
+
+- [ ] **Step 2: Run the full VS Code extension test suite**
+
+```bash
+cd editors/vscode && bun run pretest && bun run test
+```
+
+Expected: all suites PASS or skip cleanly (data-viewer suite skips if R or
+arrow are missing). No new failures.
+
+- [ ] **Step 3: Run the typecheck**
+
+```bash
+cd editors/vscode && bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the bundle build**
+
+```bash
+cd editors/vscode && bun run bundle
+```
+
+Expected: PASS. The data-viewer webview compiles cleanly from
+`App.svelte`.
+
+- [ ] **Step 5: Run the Rust build (sanity check that no Rust changes
+   slipped in)**
+
+From the repo root:
+
+```bash
+cargo build -p raven
+```
+
+Expected: PASS (this PR doesn't touch Rust, but the umbrella build should
+still be clean).
+
+- [ ] **Step 6: Confirm git log is clean**
+
+```bash
+git log --oneline -10
+```
+
+Expected output (commit hashes will differ):
+
+```text
+<hash> docs(data-viewer): document Home/End/PageUp/PageDown shortcuts (#183)
+<hash> feat(data-viewer): add Home/End/PageDown/PageUp keyboard shortcuts (#183)
+<hash> feat(data-viewer): expose visible range + key dispatch on test API
+<hash> feat(data-viewer): add test-only protocol for driving keys + reading visible range
+<hash> fix(data-viewer): clamp logicalScrollTop to [0, maxLogical] (#183)
+<hash> docs(spec): address codex pass 3 — Home readiness needs end > 0 too
+<hash> docs(spec): address codex pass 2 — readiness gate, diagram, shift-key example
+<hash> docs(spec): address codex adversarial review pass on scroll-to-bottom design
+<hash> docs(spec): data viewer scroll-to-last-row design (#183)
+…
+```
+
+Five implementation commits + four spec commits, all referencing #183 or
+the spec. No accidental WIP commits.
+
+---
+
+## Out of scope (for issue #183 follow-up)
+
+These items are explicitly **not** in this plan, per the design's
+"Non-goals" and "Known limitations" sections:
+
+- A custom overlay scrollbar that maps thumb position directly to
+  `[0, nrow]`. Required to fix the "drag the pill to the bottom" symptom
+  from #183 (which `End` works around but does not eliminate).
+- Spreadsheet-style `Cmd-Down` / `Cmd-End` chord shortcuts.
+- Sort, filter, or search semantics.
+- Adjusting `MAX_SCROLL_PX`.
+
+Each of these is a meaningful follow-up but has its own design surface
+that would balloon this change.

--- a/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
@@ -123,7 +123,11 @@ The horizontal native scrollbar is unchanged on every code path.
 
 ## Math additions to `grid-model.ts`
 
-Three new pure functions, all unit-testable under Bun:
+Three new pure functions plus a shared constant for the bottom reservation,
+all unit-testable under Bun. The CSS layout and the math share `HORIZONTAL_GUTTER_PX`
+as a single source of truth — earlier drafts had them disagree (CSS used
+`bottom: 12 px` while math used full `viewportHeight`, so a drag to
+fraction 1 would overshoot the visible track by 12 px).
 
 ```typescript
 /** Minimum pixel height for the custom scrollbar thumb. Below this the
@@ -131,39 +135,53 @@ Three new pure functions, all unit-testable under Bun:
  *  visible, draggable thumb. */
 export const MIN_THUMB_PX = 30;
 
+/** Pixel reservation at the bottom of the custom scrollbar track for the
+ *  native horizontal scrollbar, when present. The CSS rule sets the
+ *  track's `bottom: HORIZONTAL_GUTTER_PX`, and the math takes
+ *  `trackHeight = viewportHeight - HORIZONTAL_GUTTER_PX`. Sharing the
+ *  constant guarantees the math + layout agree.
+ *
+ *  Always reserved, regardless of whether the horizontal scrollbar is
+ *  actually present. The visual cost when absent is the thumb stopping
+ *  ~12 px shy of the viewport bottom (negligible). The alternative —
+ *  measuring dynamically — adds layout-thrash on every render with
+ *  little benefit. */
+export const HORIZONTAL_GUTTER_PX = 12;
+
 /** Pixel height of the custom scrollbar thumb. The thumb represents the
  *  fraction of the dataset currently visible (visibleCount / nrow), with
  *  a hard minimum so even a single visible row in a 10 M-row dataset
  *  produces a draggable thumb. The minimum is itself capped at the
- *  viewport height — for tiny viewports (< MIN_THUMB_PX), the thumb
- *  fills the track rather than overflowing it. */
+ *  track height — for tiny tracks (< MIN_THUMB_PX), the thumb fills the
+ *  track rather than overflowing it.
+ *
+ *  Note `trackHeight`, not `viewportHeight`: the track is shorter than
+ *  the viewport by HORIZONTAL_GUTTER_PX (see above). */
 export function customThumbHeight(
-    viewportHeight: number,
+    trackHeight: number,
     rowHeight: number,
     nrow: number,
 ): number {
-    if (viewportHeight <= 0) return 0;
-    if (nrow <= 0 || rowHeight <= 0) return viewportHeight;
-    const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
-    if (visibleCount >= nrow) return viewportHeight;
-    const proportional = viewportHeight * (visibleCount / nrow);
-    // Apply MIN_THUMB_PX floor first, then clamp to viewportHeight ceiling
-    // — this ordering means a tiny viewport (< MIN_THUMB_PX) gets a
-    // full-track thumb rather than an over-tall one.
-    return Math.min(viewportHeight, Math.max(MIN_THUMB_PX, proportional));
+    if (trackHeight <= 0) return 0;
+    if (nrow <= 0 || rowHeight <= 0) return trackHeight;
+    const visibleCount = Math.max(1, Math.ceil(trackHeight / rowHeight));
+    if (visibleCount >= nrow) return trackHeight;
+    const proportional = trackHeight * (visibleCount / nrow);
+    return Math.min(trackHeight, Math.max(MIN_THUMB_PX, proportional));
 }
 
-/** Pixel offset of the thumb's top from the top of the track. The track
- *  height equals the viewport height; the thumb's top can range from 0
- *  to (viewportHeight - thumbHeight). The mapping is linear in the
- *  *physical* scrollTop so the thumb tracks user scrolling exactly. */
+/** Pixel offset of the thumb's top from the top of the track. Track
+ *  height is `viewportHeight - HORIZONTAL_GUTTER_PX`; the thumb's top
+ *  can range from 0 to (trackHeight - thumbHeight). The mapping is
+ *  linear in the *physical* scrollTop so the thumb tracks user
+ *  scrolling exactly. */
 export function customThumbTop(
     scrollTop: number,
-    viewportHeight: number,
+    trackHeight: number,
     thumbHeight: number,
     maxPhysical: number,
 ): number {
-    const trackUsable = Math.max(0, viewportHeight - thumbHeight);
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
     if (maxPhysical <= 0 || trackUsable <= 0) return 0;
     const fraction = Math.max(0, Math.min(1, scrollTop / maxPhysical));
     return fraction * trackUsable;
@@ -175,11 +193,11 @@ export function customThumbTop(
  *  scheduleFetchVisible pipeline does the rest. */
 export function customScrollTopFromThumbTop(
     thumbTop: number,
-    viewportHeight: number,
+    trackHeight: number,
     thumbHeight: number,
     maxPhysical: number,
 ): number {
-    const trackUsable = Math.max(0, viewportHeight - thumbHeight);
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
     if (trackUsable <= 0 || maxPhysical <= 0) return 0;
     const fraction = Math.max(0, Math.min(1, thumbTop / trackUsable));
     return fraction * maxPhysical;
@@ -196,14 +214,15 @@ unit-testable.
 ### Imports
 
 `MAX_SCROLL_PX` is currently used only inside `grid-model.ts`. App.svelte
-needs to import it for the gate and for the `maxPhysical` prop on
-`<CustomScrollbar />`. Add to the existing import:
+needs to import it (and the new `HORIZONTAL_GUTTER_PX`) for the gate and
+for the `trackHeight` / `maxPhysical` props on `<CustomScrollbar />`.
+Add to the existing import:
 
 ```typescript
 import {
     visibleRange, coalesceScroll,
     cappedScrollHeight, logicalScrollTop, visualOffsetPx,
-    MAX_SCROLL_PX,
+    MAX_SCROLL_PX, HORIZONTAL_GUTTER_PX,
 } from './grid-model';
 ```
 
@@ -236,9 +255,9 @@ Two new classes, prefixed and named for their role:
     position: absolute;
     right: 0;
     top: 0;
-    /* 12 px reserved at the bottom for the native horizontal scrollbar
-     * when present. If absent, the overlay just stops 12 px shy of the
-     * viewport bottom. */
+    /* HORIZONTAL_GUTTER_PX = 12 px reserved at the bottom for the native
+     * horizontal scrollbar when present. The math layer takes
+     * trackHeight = viewportHeight - 12 to match. */
     bottom: 12px;
     width: 12px;
     background: transparent;
@@ -286,7 +305,7 @@ content:
     </div>
     {#if useCustomScrollbar}
         <CustomScrollbar
-            viewportHeight={viewportHeight}
+            trackHeight={Math.max(0, viewportHeight - HORIZONTAL_GUTTER_PX)}
             scrollTop={scrollTop}
             nrow={nrow}
             rowHeight={ROW_HEIGHT}
@@ -304,12 +323,19 @@ content:
     position: relative;
     flex: 1 1 auto;
     display: flex;
-    /* The viewport inside us takes the full wrapper area; the overlay,
-     * if present, sits on the right edge in absolute coordinates. */
+    /* Required so the inner viewport can shrink-to-fit and scroll its
+     * own content. Default `min-height/width: auto` on flex items would
+     * make the wrapper grow to the inner grid's intrinsic height
+     * (potentially MAX_SCROLL_PX!), defeating the overlay-as-fixed-to-
+     * scrollport premise. */
+    min-height: 0;
+    min-width: 0;
 }
 
 .viewport-wrapper > .viewport {
     flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
 }
 ```
 
@@ -324,7 +350,7 @@ the widget reaches back via a callback to set `viewportEl.scrollTop`.
 
 ```text
 Props:
-- viewportHeight: number
+- trackHeight: number   (= viewportHeight - HORIZONTAL_GUTTER_PX)
 - scrollTop: number
 - nrow: number
 - rowHeight: number
@@ -337,6 +363,9 @@ Internal state:
   thumb's top. `null` when not dragging.
 - `pointerId: number | null` — captured pointer id, used to release
   capture safely on cleanup paths.
+- `dragTrackTop: number` — `getBoundingClientRect().top` of the track,
+  cached at drag start so `pointermove` doesn't have to re-measure each
+  frame.
 
 Visual structure (the widget is the track; thumb is its child):
 
@@ -351,23 +380,30 @@ Pointer event flow:
 
 - `pointerdown` on `.custom-scrollbar-thumb`:
   - Record `pointerId = e.pointerId`, `dragOffset = e.clientY -
-    thumbTopAbsolute`.
-  - `(e.target as Element).setPointerCapture(e.pointerId)`.
+    thumbTopAbsolute`, `dragTrackTop = trackEl.getBoundingClientRect().top`.
+  - `try { (e.target as Element).setPointerCapture(e.pointerId); }
+    catch { /* ignore — synthetic events from the test seam may not be
+    eligible for capture */ }`. Real user events always succeed.
   - `e.preventDefault()` and `e.stopPropagation()` — the latter so the
     track-paging handler below doesn't also fire.
-- `pointermove` on `.custom-scrollbar-thumb` (only while dragging):
-  - Compute `thumbTop = e.clientY - trackTopAbsolute - dragOffset`,
-    clamp to `[0, viewportHeight - thumbHeight]`.
-  - `onScrollTo(customScrollTopFromThumbTop(thumbTop, viewportHeight,
+- `pointermove` on `.custom-scrollbar-thumb` (only while
+  `dragOffset !== null`):
+  - Compute `thumbTop = e.clientY - dragTrackTop - dragOffset`,
+    clamp to `[0, trackHeight - thumbHeight]`.
+  - `onScrollTo(customScrollTopFromThumbTop(thumbTop, trackHeight,
     thumbHeight, maxPhysical))`.
-- `pointerup` / `pointercancel` / `lostpointercapture`: cleanup. Clear
-  `dragOffset` and `pointerId`. Release capture *only* when
-  `hasPointerCapture(pointerId)` returns true — calling
-  `releasePointerCapture` on a pointer that's already been released
-  (e.g. by `lostpointercapture`) throws in some browsers.
+- `pointerup` / `pointercancel` / `lostpointercapture`: cleanup.
+  - `if (pointerId !== null && (e.target as Element).hasPointerCapture(pointerId)) {
+       (e.target as Element).releasePointerCapture(pointerId);
+     }`
+  - Clear `dragOffset` and `pointerId`.
+  - The `hasPointerCapture` guard is required because
+    `lostpointercapture` fires *after* the browser has already released
+    the capture; calling `releasePointerCapture` on an already-released
+    pointer throws in some browsers.
 - `pointerdown` on the track (not on the thumb): page up or down
   depending on whether the click is above or below the current thumb
-  position. `onScrollTo(scrollTop ± viewportHeight)`. The browser
+  position. `onScrollTo(scrollTop ± trackHeight)`. The browser
   clamps the assignment to `viewportEl.scrollTop` at `[0, maxPhysical]`.
 
 The widget does **not** capture wheel or keyboard events; those continue
@@ -375,11 +411,6 @@ to flow through the native scroll mechanism (the vertical scrollbar is
 hidden but the viewport is still `overflow: auto` and accepts wheel /
 keyboard scroll natively, which fires `onScroll` and updates the thumb
 position via the derived state).
-
-`trackTopAbsolute` is computed via `track.getBoundingClientRect().top`
-at the start of each drag and cached in `dragOffset`'s sibling state —
-recomputing it on every `pointermove` is fine but unnecessary, and we
-avoid getBoundingClientRect's small layout-thrash cost in the hot path.
 
 ## Test surface
 
@@ -407,19 +438,25 @@ The webview's `testScrollbarDrag` handler:
 1. Grabs the thumb element via the same internal `bind:this` ref the
    widget uses for itself (or via a `data-test-id="custom-scrollbar-thumb"`
    attribute looked up with `document.querySelector`).
-2. Computes `thumbHeight`, current `thumbTop`, and target
-   `thumbTop = fraction * (viewportHeight - thumbHeight)`.
+2. Computes `trackHeight = viewportHeight - HORIZONTAL_GUTTER_PX`,
+   `thumbHeight = customThumbHeight(trackHeight, ROW_HEIGHT, nrow)`, current
+   `thumbTop`, and target `thumbTop = fraction * (trackHeight - thumbHeight)`.
 3. Dispatches a `pointerdown` on the thumb at its current position with
-   `pointerId: 1, clientX: thumbCenterX, clientY: thumbCenterY,
-   bubbles: true, cancelable: true`.
+   `pointerId: 999, pointerType: 'mouse', clientX: thumbCenterX,
+   clientY: thumbCenterY, bubbles: true, cancelable: true`. The
+   `pointerId: 999` is chosen high enough to avoid colliding with any
+   real mouse pointer (Chromium uses `1` for the primary mouse), and
+   the handler's `setPointerCapture` is wrapped in try/catch so a
+   synthetic-event capture failure doesn't break the test.
 4. Dispatches a `pointermove` at the target position with the same
    pointerId so the drag handler computes the move delta.
 5. Dispatches a `pointerup` to terminate the drag.
 
 Because the same thumb-element listener handles all three events, the
-real pointer-event glue (capture/move/up cleanup, `lostpointercapture`
-guard) is exercised — not just the underlying math. This addresses the
-codex review's concern that math-only tests miss the pointer wiring.
+real pointer-event glue (move/up cleanup, `lostpointercapture` guard,
+`hasPointerCapture` defensive release) is exercised — not just the
+underlying math. The `setPointerCapture` call may be a no-op in the
+synthetic case, but the rest of the drag pipeline runs end-to-end.
 
 A new method on `RavenExtensionApi`:
 

--- a/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
@@ -1,0 +1,448 @@
+# Data Viewer: Custom Scrollbar for Large Datasets (issue #183 follow-up)
+
+Date: 2026-05-16
+Status: Draft for review
+Issue: [#183](https://github.com/jbearak/raven/issues/183) — "Data viewer:
+can't scroll to the very last row in large datasets"
+
+## Problem
+
+The earlier PR for #183 added `End` / `Home` / `PageUp` / `PageDown`
+keyboard shortcuts and clamped `logicalScrollTop` to fix the elastic-scroll
+flicker, but explicitly left the native scrollbar drag broken in a
+"Known limitations" section. That gap is now in scope.
+
+For datasets with `totalGridHeight > MAX_SCROLL_PX` (≈ 625 K rows × 24 px),
+two facts collide:
+
+1. The browser's minimum scrollbar-thumb height (~17 px in Chromium) is
+   reached when `clientHeight² / scrollHeight < ~17`. Past that point the
+   thumb is rendered larger than its natural size, but Chromium's drag
+   math uses the natural size, so the bottom of the drag track maps to a
+   `scrollTop < scrollHeight - clientHeight`. Dragging the pill all the
+   way down stops short of the last row.
+2. Reducing `MAX_SCROLL_PX` to a value that keeps the natural thumb ≥ 17 px
+   (≈ 21 K px for a 600-px viewport) destroys per-pixel scroll resolution:
+   one wheel notch or one `ArrowDown` press would jump thousands of rows on
+   a multi-million-row dataset. Wheel and arrow scrolling become unusable.
+
+There is no value of `MAX_SCROLL_PX` that simultaneously gives a
+draggable thumb *and* responsive wheel/arrow scrolling on huge datasets.
+The only fix is to take ownership of the scrollbar widget.
+
+## Goals / Non-Goals
+
+Goals:
+
+1. Dragging the scrollbar thumb to the bottom reaches the very last row
+   on any dataset, including multi-million-row frames.
+2. The fix engages **only** when the existing remap engages — i.e. only
+   when `totalGridHeight > MAX_SCROLL_PX`. Below that threshold, the
+   native scrollbar is preserved unchanged; users see the same VS Code
+   styling they're used to for the common case (most R data frames are
+   under 100 K rows).
+3. The custom scrollbar is theme-aware via VS Code's
+   `--vscode-scrollbarSlider-*` CSS variables, so the visual treatment
+   matches the rest of VS Code as closely as a hand-rolled widget can.
+4. Wheel, keyboard, and `ArrowDown` continue to behave exactly as they do
+   today (they aren't part of the bug). No new event interception.
+5. Cover both code paths with automated tests:
+   - Bun unit tests for the new scrollbar math.
+   - A mocha integration test that drives a drag-to-bottom and asserts
+     the last row is reached.
+
+Non-goals for this change:
+
+- Replacing the **horizontal** native scrollbar. It isn't part of the
+  bug; column counts stay small, no min-thumb compression problem.
+  Keeping native horizontal preserves the platform-native feel where
+  it works.
+- Animation / smooth-scroll on track click. Native scrollbar paging is
+  immediate; we match that.
+- Touch / pointer-pen scrolling on touchscreens. The webview rarely
+  runs on a touchscreen, and pointer events cover the common case.
+  Touch-momentum scrolling continues to work via the native (visible
+  but no-thumb) scroll mechanism.
+- A draggable thumb on the **horizontal** scrollbar. See above.
+- Changing `MAX_SCROLL_PX` or the existing remap. The remap is correct;
+  the scrollbar widget was the broken piece.
+- Custom track-click animations or velocity-aware scroll behavior.
+
+## Architecture
+
+A new Svelte-rendered scrollbar overlay that **conditionally** appears on
+the right edge of the viewport. The native vertical scrollbar is hidden
+on the same condition via CSS. A single derived flag controls both:
+
+```typescript
+const useCustomScrollbar = $derived(totalGridHeight > MAX_SCROLL_PX);
+```
+
+When `useCustomScrollbar` is `true`:
+- A `class="custom-scrollbar"` is applied to the viewport, which hides
+  the native vertical scrollbar via `::-webkit-scrollbar:vertical`.
+- A new `<CustomScrollbar />` widget is rendered (positioned absolutely
+  inside the viewport, top: 0, right: 0, height: 100%, width: 12 px).
+- The widget owns pointer-down / move / up handling on the thumb, plus
+  pointer-down on the track for paging.
+
+When `useCustomScrollbar` is `false` (the small/moderate-data case),
+nothing changes from today: native scrollbar, no overlay, no hidden
+class.
+
+Architecture diagram:
+
+```text
+viewport (overflow: auto, native scrollbar hidden when above cap)
+├── grid (height: cappedScrollHeight + ROW_HEIGHT)
+│   ├── header-row (sticky)
+│   └── rows (translateY = visualOffsetPx(...))
+└── custom-scrollbar (only when totalGridHeight > MAX_SCROLL_PX)
+    └── thumb (size + position derived from scroll state)
+```
+
+The horizontal native scrollbar is unchanged on every code path.
+
+## Math additions to `grid-model.ts`
+
+Three new pure functions, all unit-testable under Bun:
+
+```typescript
+/** Minimum pixel height for the custom scrollbar thumb. Below this the
+ *  thumb is hard to click/drag. Chosen so even a 10 M-row dataset gets a
+ *  visible, draggable thumb. */
+export const MIN_THUMB_PX = 30;
+
+/** Pixel height of the custom scrollbar thumb. The thumb represents the
+ *  fraction of the dataset currently visible (visibleCount / nrow), with
+ *  a hard minimum so even a single visible row in a 10 M-row dataset
+ *  produces a draggable thumb. */
+export function customThumbHeight(
+    viewportHeight: number,
+    rowHeight: number,
+    nrow: number,
+): number {
+    if (nrow <= 0) return viewportHeight;
+    const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
+    if (visibleCount >= nrow) return viewportHeight;
+    const proportional = viewportHeight * (visibleCount / nrow);
+    return Math.max(MIN_THUMB_PX, Math.min(viewportHeight, proportional));
+}
+
+/** Pixel offset of the thumb's top from the top of the track. The track
+ *  height equals the viewport height; the thumb's top can range from 0
+ *  to (viewportHeight - thumbHeight). The mapping is linear in the
+ *  *physical* scrollTop so the thumb tracks user scrolling exactly. */
+export function customThumbTop(
+    scrollTop: number,
+    viewportHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, viewportHeight - thumbHeight);
+    if (maxPhysical <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, scrollTop / maxPhysical));
+    return fraction * trackUsable;
+}
+
+/** Convert a thumb-top pixel offset (during a drag) back to the physical
+ *  scrollTop the viewport needs. Inverse of customThumbTop. The caller
+ *  sets viewportEl.scrollTop = result; the existing onScroll →
+ *  scheduleFetchVisible pipeline does the rest. */
+export function customScrollTopFromThumbTop(
+    thumbTop: number,
+    viewportHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, viewportHeight - thumbHeight);
+    if (trackUsable <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, thumbTop / trackUsable));
+    return fraction * maxPhysical;
+}
+```
+
+`maxPhysical` here is the same `MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight`
+the existing code already computes in `logicalScrollTop`. Exposing the
+math layer in `grid-model.ts` keeps the thumb computations DOM-free and
+unit-testable.
+
+## App.svelte changes
+
+### CSS hide rule (conditional)
+
+Add a class `custom-scrollbar` that, when applied to the viewport, hides
+the native vertical scrollbar via Chromium's pseudo-element. The
+horizontal scrollbar is **not** hidden. Firefox can't selectively hide
+one direction (`scrollbar-width: none` hides both), but VS Code's webview
+runs on Chromium so this is moot in practice.
+
+```css
+.viewport.custom-scrollbar::-webkit-scrollbar:vertical {
+    display: none;
+}
+```
+
+The class is applied via `class:custom-scrollbar={useCustomScrollbar}`
+on the viewport element.
+
+### `<CustomScrollbar />` widget
+
+A new Svelte component file `editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte`.
+Rationale for a separate file: the pointer-event logic is self-contained
+(track + thumb), and isolating it keeps `App.svelte` focused on grid
+rendering. Inputs are read-only props derived from `App.svelte`'s state;
+the widget reaches back via a callback to set `viewportEl.scrollTop`.
+
+```text
+Props:
+- viewportHeight: number
+- scrollTop: number
+- nrow: number
+- rowHeight: number
+- maxPhysical: number
+- onScrollTo: (newScrollTop: number) => void
+```
+
+Internal state:
+- `dragOffset: number | null` — pointer Y at drag start, relative to the
+  thumb's top. `null` when not dragging.
+
+Visual structure (positioned absolutely inside the viewport, right edge):
+
+```text
+<div class="custom-scrollbar">       ← the track; pointer-down → paging
+    <div class="custom-thumb">       ← pointer-down → drag
+    </div>
+</div>
+```
+
+Pointer event flow:
+
+- `pointerdown` on `.custom-thumb`: `setPointerCapture`, record
+  `dragOffset = clientY - thumbTopAbsolute`.
+- `pointermove` (during drag): compute new `thumbTop` = `clientY -
+  trackTopAbsolute - dragOffset`, clamp to `[0, viewportHeight -
+  thumbHeight]`, call `onScrollTo(customScrollTopFromThumbTop(...))`.
+- `pointerup` / `pointercancel`: clear `dragOffset`,
+  `releasePointerCapture`.
+- `pointerdown` on the track (not on the thumb): page up or down
+  depending on whether the click is above or below the current thumb
+  position. `onScrollTo(scrollTop ± viewportHeight)`. The browser handles
+  the clamp at `[0, maxPhysical]` automatically when the value is set on
+  `viewportEl.scrollTop`.
+
+The widget does **not** capture wheel or keyboard events; those continue
+to flow through the native scroll mechanism (the vertical scrollbar is
+hidden but the viewport is still `overflow: auto` and accepts wheel /
+keyboard scroll natively, which fires `onScroll` and updates the thumb
+position).
+
+### App.svelte mounting
+
+```svelte
+<div class="viewport"
+     class:custom-scrollbar={useCustomScrollbar}
+     ...>
+    <div class="grid">...</div>
+    {#if useCustomScrollbar}
+        <CustomScrollbar
+            viewportHeight={viewportHeight}
+            scrollTop={scrollTop}
+            nrow={nrow}
+            rowHeight={ROW_HEIGHT}
+            maxPhysical={MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight}
+            onScrollTo={(newScrollTop) => {
+                if (viewportEl) viewportEl.scrollTop = newScrollTop;
+            }}
+        />
+    {/if}
+</div>
+```
+
+`maxPhysical` is computed inline rather than in `grid-model.ts` because
+it's only used here; the math functions accept it as a parameter so they
+stay DOM-free.
+
+## Test surface
+
+A new test-only message lets the integration test drive the drag math
+without simulating raw pointer events (which is fragile inside a webview
+iframe):
+
+```typescript
+| {
+    /** Test-only: drive a custom-scrollbar drag-to-fraction (0..1).
+     *  The webview computes the resulting physical scrollTop via
+     *  customScrollTopFromThumbTop and applies it to viewportEl. This
+     *  tests the math + scroll pipeline; the pointer-handler wiring
+     *  itself is exercised by the bun unit tests on the math functions
+     *  and verified by inspection. */
+    type: 'testScrollbarDrag';
+    panelGeneration: number;
+    fraction: number;   // 0 = top, 1 = bottom
+  }
+```
+
+The webview's message handler:
+- Computes `thumbHeight = customThumbHeight(viewportHeight, ROW_HEIGHT, nrow)`.
+- Computes `thumbTop = fraction * (viewportHeight - thumbHeight)`.
+- Computes `physical = customScrollTopFromThumbTop(thumbTop, viewportHeight, thumbHeight, maxPhysical)`.
+- Sets `viewportEl.scrollTop = physical`.
+
+This routes through the same `onScrollTo` callback the real pointer
+handlers use — the math layer is shared.
+
+A new method on `RavenExtensionApi`:
+
+```typescript
+/** Test-only: drive a custom-scrollbar drag in the named panel.
+ *  fraction=0 jumps to top, fraction=1 jumps to bottom. */
+dragDataViewerScrollbar(panelName: string, fraction: number): Promise<void>;
+```
+
+Plus `manager.ts` and `panel.ts` passthroughs analogous to `pressKey`.
+
+## Tests
+
+### Bun unit tests
+
+Add a new `'custom scrollbar math'` describe block to
+`tests/bun/data-viewer-grid-model.test.ts`:
+
+```text
+test('customThumbHeight: tiny dataset → full track')
+test('customThumbHeight: large dataset → MIN_THUMB_PX floor')
+test('customThumbHeight: mid-size proportional')
+test('customThumbHeight: nrow === 0 → full track')
+
+test('customThumbTop: scrollTop=0 → 0')
+test('customThumbTop: scrollTop=maxPhysical → viewportHeight - thumbHeight')
+test('customThumbTop: midpoint → midpoint')
+
+test('customScrollTopFromThumbTop: thumbTop=0 → 0')
+test('customScrollTopFromThumbTop: thumbTop=trackUsable → maxPhysical')
+test('customScrollTopFromThumbTop: round-trip with customThumbTop')
+```
+
+The round-trip test: for any `scrollTop ∈ [0, maxPhysical]`, the result of
+applying `customThumbTop` then `customScrollTopFromThumbTop` should match
+the original (within floating-point tolerance). This catches any
+asymmetry between the forward and reverse mappings.
+
+### Mocha integration test
+
+Add one test to `editors/vscode/src/test/data-viewer.test.ts`:
+
+```text
+test('Drag scrollbar to bottom reaches last row in 700K-row data frame', async () => {
+    const N = 700_000;
+    // Reuse the 'big' panel from the End-key test if it's still open;
+    // otherwise create it.
+    if (!api.getDataViewerPanelNames().includes('big')) {
+        await api.sendToRTerminal(`big <- as.data.frame(matrix(rnorm(${N} * 5), nrow = ${N}, ncol = 5)); View(big)`);
+        const appeared = await pollForPanel(api, 'big', 90000);
+        assert.ok(appeared);
+        // wait for steady state
+    }
+    await api.pressDataViewerKey('big', 'Home');
+    // wait for end > 0 && end < N/2
+    await api.dragDataViewerScrollbar('big', 1.0);
+    // poll for end === N
+});
+```
+
+The test deliberately covers the same outcome as the End-key test (last
+row reachable) but via a different code path (drag math + scroll
+pipeline). If the End-key test passes but this one fails, the bug is
+specifically in the drag math; if both fail together, the bug is in the
+shared scroll pipeline.
+
+A second integration assertion adds **drag-to-midpoint**:
+
+```text
+test('Drag scrollbar to 50% lands near row N/2', async () => {
+    // ... open panel, Home reset ...
+    await api.dragDataViewerScrollbar('big', 0.5);
+    // poll until visibleRangeStart in [0.4 * N, 0.6 * N]
+});
+```
+
+This catches asymmetric mappings (e.g. accidentally using `nrow * fraction`
+on one side and `(nrow - visibleCount) * fraction` on the other).
+
+## Documentation
+
+`docs/data-viewer.md` — append to the existing **Keyboard shortcuts**
+subsection (which already mentions issue #183) with a one-paragraph note
+that, on multi-million-row data frames, the scrollbar widget is replaced
+with a Raven-rendered overlay so dragging the thumb to the bottom
+reaches the last row. The native scrollbar is preserved on smaller
+frames.
+
+The "Known limitations / partially-resolved part of #183" section in the
+**previous design spec**
+(`docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md`)
+will be left intact — that document is a historical record of the prior
+PR's scope. This new spec supersedes its known-limitation by closing the
+gap.
+
+## Open questions
+
+None — the design follows directly from the architecture analysis in the
+in-conversation discussion (mathematical impossibility of small
+`MAX_SCROLL_PX` keeping wheel responsive on huge data, plus standard
+data-grid practice of custom-scrolling above a threshold).
+
+## Risks
+
+- **Pointer events in VS Code's webview iframe.** Synthetic pointer
+  events from outside the iframe wouldn't reach our handlers, but the
+  widget runs *inside* the iframe and listens to real user pointer
+  events on its own DOM, so this risk is the same as any other
+  webview-internal interaction (which already works for cell selection,
+  column-resize, and toolbar buttons).
+- **`pointercapture` browser support.** All Chromium-based webviews
+  support it; we already use it for column resize
+  (`onResizeHandlePointerDown` calls `setPointerCapture`). No new
+  dependency.
+- **Theming drift.** VS Code's `--vscode-scrollbarSlider-*` variables
+  may not exactly match every theme's native scrollbar. Mitigation: use
+  the canonical names and accept minor visual differences. The
+  alternative (perfectly matching every theme) is impossible without
+  rendering through the OS scrollbar API, which we're explicitly moving
+  away from.
+- **Hidden vertical scrollbar gutter.** When `::-webkit-scrollbar:vertical`
+  is hidden, the scroll gutter still consumes width if the layout doesn't
+  account for it. Mitigation: the custom scrollbar overlays the right
+  edge with the same width Chromium reserves (~12 px), so the visual
+  layout is unchanged. We test this by inspection.
+- **Visual jump at the cap threshold.** Users opening a 624 K-row dataset
+  see the native scrollbar; opening a 626 K-row dataset sees the custom
+  one. The visual difference is minor (themed via VS Code variables) but
+  exists. Mitigation: the threshold is unchanged (it's the existing
+  `MAX_SCROLL_PX`), so users only encounter the switch when they're also
+  on the boundary of the existing remap behavior — they'd see *some*
+  change at this threshold either way.
+- **Drag during fast scroll.** If the user wheels rapidly while
+  `dragOffset !== null`, both inputs would compete for `scrollTop`. The
+  pointer-capture should keep the drag dominant. We don't need to
+  explicitly suppress wheel during drag.
+
+## What the mocha test does and does not prove
+
+Same caveat as the prior PR: the `testScrollbarDrag` mechanism shares the
+math + scroll-pipeline path with the real pointer handlers but does not
+exercise the pointer event wiring itself (pointer-down → drag offset
+capture → pointer-move → drag math → pointer-up). Those are simple
+event-glue functions; if the math is right (verified by bun) and the
+glue is straightforward (verified by inspection), the integration is
+right. A regression purely in the pointer-event wiring would slip
+through.
+
+## Summary
+
+The bug for huge datasets is in the browser's scrollbar widget, not in
+our scroll math. We replace the widget on exactly the cases where the
+remap engages, leave everything else untouched, and verify the math via
+bun + the integration via a thin test API.

--- a/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
@@ -72,34 +72,52 @@ Non-goals for this change:
 
 A new Svelte-rendered scrollbar overlay that **conditionally** appears on
 the right edge of the viewport. The native vertical scrollbar is hidden
-on the same condition via CSS. A single derived flag controls both:
+on the same condition via CSS, with the gutter explicitly reserved so
+the overlay has a 12-px lane to live in. A single derived flag controls
+both:
 
 ```typescript
 const useCustomScrollbar = $derived(totalGridHeight > MAX_SCROLL_PX);
 ```
 
 When `useCustomScrollbar` is `true`:
-- A `class="custom-scrollbar"` is applied to the viewport, which hides
-  the native vertical scrollbar via `::-webkit-scrollbar:vertical`.
-- A new `<CustomScrollbar />` widget is rendered (positioned absolutely
-  inside the viewport, top: 0, right: 0, height: 100%, width: 12 px).
+- A class `using-custom-scrollbar` is applied to the viewport, which
+  hides the native vertical scrollbar via `::-webkit-scrollbar:vertical`
+  *and* reserves 12 px of right padding so the layout doesn't reclaim
+  the scrollbar gutter.
+- A new `<CustomScrollbar />` widget is rendered as a **sibling of the
+  viewport**, inside a `viewport-wrapper` element that has
+  `position: relative` so the overlay's `position: absolute` is
+  relative to the viewport's bounding box (not its scroll content).
 - The widget owns pointer-down / move / up handling on the thumb, plus
   pointer-down on the track for paging.
 
 When `useCustomScrollbar` is `false` (the small/moderate-data case),
-nothing changes from today: native scrollbar, no overlay, no hidden
-class.
+nothing changes from today: native scrollbar, no overlay, no extra
+padding, no extra wrapper class.
 
 Architecture diagram:
 
 ```text
-viewport (overflow: auto, native scrollbar hidden when above cap)
-├── grid (height: cappedScrollHeight + ROW_HEIGHT)
-│   ├── header-row (sticky)
-│   └── rows (translateY = visualOffsetPx(...))
-└── custom-scrollbar (only when totalGridHeight > MAX_SCROLL_PX)
+viewport-wrapper (position: relative; flex: 1 1 auto)
+├── viewport (overflow: auto; padding-right: 12px when using-custom-scrollbar)
+│   └── grid (height: cappedScrollHeight + ROW_HEIGHT)
+│       ├── header-row (sticky)
+│       └── rows (translateY = visualOffsetPx(...))
+└── CustomScrollbar (only when totalGridHeight > MAX_SCROLL_PX)
+    │   position: absolute; right: 0; top: 0; bottom: 12px; width: 12px
+    │   (bottom: 12px reserves room for the native horizontal scrollbar
+    │    when present; if absent the overlay just stops 12 px shy of the
+    │    bottom — visually negligible)
     └── thumb (size + position derived from scroll state)
 ```
+
+The overlay being a **sibling** of the viewport rather than a child is
+the key fix: an absolutely-positioned descendant of an `overflow: auto`
+element is laid out in the element's *scroll content* coordinate space
+(it scrolls with the content). Sibling-with-relative-wrapper places it
+in the wrapper's coordinate space, which is fixed relative to the
+scrollport.
 
 The horizontal native scrollbar is unchanged on every code path.
 
@@ -116,17 +134,23 @@ export const MIN_THUMB_PX = 30;
 /** Pixel height of the custom scrollbar thumb. The thumb represents the
  *  fraction of the dataset currently visible (visibleCount / nrow), with
  *  a hard minimum so even a single visible row in a 10 M-row dataset
- *  produces a draggable thumb. */
+ *  produces a draggable thumb. The minimum is itself capped at the
+ *  viewport height — for tiny viewports (< MIN_THUMB_PX), the thumb
+ *  fills the track rather than overflowing it. */
 export function customThumbHeight(
     viewportHeight: number,
     rowHeight: number,
     nrow: number,
 ): number {
-    if (nrow <= 0) return viewportHeight;
+    if (viewportHeight <= 0) return 0;
+    if (nrow <= 0 || rowHeight <= 0) return viewportHeight;
     const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
     if (visibleCount >= nrow) return viewportHeight;
     const proportional = viewportHeight * (visibleCount / nrow);
-    return Math.max(MIN_THUMB_PX, Math.min(viewportHeight, proportional));
+    // Apply MIN_THUMB_PX floor first, then clamp to viewportHeight ceiling
+    // — this ordering means a tiny viewport (< MIN_THUMB_PX) gets a
+    // full-track thumb rather than an over-tall one.
+    return Math.min(viewportHeight, Math.max(MIN_THUMB_PX, proportional));
 }
 
 /** Pixel offset of the thumb's top from the top of the track. The track
@@ -140,7 +164,7 @@ export function customThumbTop(
     maxPhysical: number,
 ): number {
     const trackUsable = Math.max(0, viewportHeight - thumbHeight);
-    if (maxPhysical <= 0) return 0;
+    if (maxPhysical <= 0 || trackUsable <= 0) return 0;
     const fraction = Math.max(0, Math.min(1, scrollTop / maxPhysical));
     return fraction * trackUsable;
 }
@@ -156,7 +180,7 @@ export function customScrollTopFromThumbTop(
     maxPhysical: number,
 ): number {
     const trackUsable = Math.max(0, viewportHeight - thumbHeight);
-    if (trackUsable <= 0) return 0;
+    if (trackUsable <= 0 || maxPhysical <= 0) return 0;
     const fraction = Math.max(0, Math.min(1, thumbTop / trackUsable));
     return fraction * maxPhysical;
 }
@@ -169,26 +193,130 @@ unit-testable.
 
 ## App.svelte changes
 
-### CSS hide rule (conditional)
+### Imports
 
-Add a class `custom-scrollbar` that, when applied to the viewport, hides
-the native vertical scrollbar via Chromium's pseudo-element. The
-horizontal scrollbar is **not** hidden. Firefox can't selectively hide
-one direction (`scrollbar-width: none` hides both), but VS Code's webview
-runs on Chromium so this is moot in practice.
+`MAX_SCROLL_PX` is currently used only inside `grid-model.ts`. App.svelte
+needs to import it for the gate and for the `maxPhysical` prop on
+`<CustomScrollbar />`. Add to the existing import:
+
+```typescript
+import {
+    visibleRange, coalesceScroll,
+    cappedScrollHeight, logicalScrollTop, visualOffsetPx,
+    MAX_SCROLL_PX,
+} from './grid-model';
+```
+
+### CSS classes (distinct names, no collision risk)
+
+Two new classes, prefixed and named for their role:
+
+- `.viewport.using-custom-scrollbar` — applied to the viewport when the
+  gate is on. Hides the native vertical scrollbar pseudo-element and
+  reserves 12 px of right padding so the layout doesn't reclaim the
+  scrollbar gutter (Chromium removes the gutter entirely when the
+  pseudo is `display: none`).
+- `.custom-scrollbar-track` — the overlay's outer element.
+- `.custom-scrollbar-thumb` — the draggable thumb inside the track.
 
 ```css
-.viewport.custom-scrollbar::-webkit-scrollbar:vertical {
+.viewport.using-custom-scrollbar {
+    /* Reserve a 12 px lane for the overlay so grid content doesn't
+     * extend under it. Without this, hiding the native scrollbar via
+     * ::-webkit-scrollbar:vertical { display: none } collapses the
+     * gutter and the rightmost cells/resize handles are obscured. */
+    padding-right: 12px;
+}
+
+.viewport.using-custom-scrollbar::-webkit-scrollbar:vertical {
     display: none;
+}
+
+.custom-scrollbar-track {
+    position: absolute;
+    right: 0;
+    top: 0;
+    /* 12 px reserved at the bottom for the native horizontal scrollbar
+     * when present. If absent, the overlay just stops 12 px shy of the
+     * viewport bottom. */
+    bottom: 12px;
+    width: 12px;
+    background: transparent;
+    z-index: 3;  /* above sticky header (z-index: 2) */
+    user-select: none;
+}
+
+.custom-scrollbar-thumb {
+    position: absolute;
+    left: 2px;
+    right: 2px;
+    background: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+    border-radius: 4px;
+    cursor: default;
+}
+
+.custom-scrollbar-thumb:hover {
+    background: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
+}
+
+.custom-scrollbar-thumb.dragging {
+    background: var(--vscode-scrollbarSlider-activeBackground, rgba(191, 191, 191, 0.4));
 }
 ```
 
-The class is applied via `class:custom-scrollbar={useCustomScrollbar}`
-on the viewport element.
+### Layout
+
+The viewport is wrapped in a relatively-positioned wrapper so the
+`<CustomScrollbar />` overlay (sibling of the viewport) is laid out in
+the wrapper's coordinate space rather than the viewport's scroll
+content:
+
+```svelte
+<div class="viewport-wrapper">
+    <div class="viewport"
+         class:using-custom-scrollbar={useCustomScrollbar}
+         bind:this={viewportEl}
+         onscroll={onScroll}
+         tabindex="0"
+         role="grid"
+         aria-rowcount={nrow}>
+        <div class="grid">
+            <!-- header-row, rows ... -->
+        </div>
+    </div>
+    {#if useCustomScrollbar}
+        <CustomScrollbar
+            viewportHeight={viewportHeight}
+            scrollTop={scrollTop}
+            nrow={nrow}
+            rowHeight={ROW_HEIGHT}
+            maxPhysical={MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight}
+            onScrollTo={(newScrollTop) => {
+                if (viewportEl) viewportEl.scrollTop = newScrollTop;
+            }}
+        />
+    {/if}
+</div>
+```
+
+```css
+.viewport-wrapper {
+    position: relative;
+    flex: 1 1 auto;
+    display: flex;
+    /* The viewport inside us takes the full wrapper area; the overlay,
+     * if present, sits on the right edge in absolute coordinates. */
+}
+
+.viewport-wrapper > .viewport {
+    flex: 1 1 auto;
+}
+```
 
 ### `<CustomScrollbar />` widget
 
-A new Svelte component file `editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte`.
+A new Svelte component file
+`editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte`.
 Rationale for a separate file: the pointer-event logic is self-contained
 (track + thumb), and isolating it keeps `App.svelte` focused on grid
 rendering. Inputs are read-only props derived from `App.svelte`'s state;
@@ -207,91 +335,91 @@ Props:
 Internal state:
 - `dragOffset: number | null` — pointer Y at drag start, relative to the
   thumb's top. `null` when not dragging.
+- `pointerId: number | null` — captured pointer id, used to release
+  capture safely on cleanup paths.
 
-Visual structure (positioned absolutely inside the viewport, right edge):
+Visual structure (the widget is the track; thumb is its child):
 
 ```text
-<div class="custom-scrollbar">       ← the track; pointer-down → paging
-    <div class="custom-thumb">       ← pointer-down → drag
+<div class="custom-scrollbar-track">
+    <div class="custom-scrollbar-thumb">
     </div>
 </div>
 ```
 
 Pointer event flow:
 
-- `pointerdown` on `.custom-thumb`: `setPointerCapture`, record
-  `dragOffset = clientY - thumbTopAbsolute`.
-- `pointermove` (during drag): compute new `thumbTop` = `clientY -
-  trackTopAbsolute - dragOffset`, clamp to `[0, viewportHeight -
-  thumbHeight]`, call `onScrollTo(customScrollTopFromThumbTop(...))`.
-- `pointerup` / `pointercancel`: clear `dragOffset`,
-  `releasePointerCapture`.
+- `pointerdown` on `.custom-scrollbar-thumb`:
+  - Record `pointerId = e.pointerId`, `dragOffset = e.clientY -
+    thumbTopAbsolute`.
+  - `(e.target as Element).setPointerCapture(e.pointerId)`.
+  - `e.preventDefault()` and `e.stopPropagation()` — the latter so the
+    track-paging handler below doesn't also fire.
+- `pointermove` on `.custom-scrollbar-thumb` (only while dragging):
+  - Compute `thumbTop = e.clientY - trackTopAbsolute - dragOffset`,
+    clamp to `[0, viewportHeight - thumbHeight]`.
+  - `onScrollTo(customScrollTopFromThumbTop(thumbTop, viewportHeight,
+    thumbHeight, maxPhysical))`.
+- `pointerup` / `pointercancel` / `lostpointercapture`: cleanup. Clear
+  `dragOffset` and `pointerId`. Release capture *only* when
+  `hasPointerCapture(pointerId)` returns true — calling
+  `releasePointerCapture` on a pointer that's already been released
+  (e.g. by `lostpointercapture`) throws in some browsers.
 - `pointerdown` on the track (not on the thumb): page up or down
   depending on whether the click is above or below the current thumb
-  position. `onScrollTo(scrollTop ± viewportHeight)`. The browser handles
-  the clamp at `[0, maxPhysical]` automatically when the value is set on
-  `viewportEl.scrollTop`.
+  position. `onScrollTo(scrollTop ± viewportHeight)`. The browser
+  clamps the assignment to `viewportEl.scrollTop` at `[0, maxPhysical]`.
 
 The widget does **not** capture wheel or keyboard events; those continue
 to flow through the native scroll mechanism (the vertical scrollbar is
 hidden but the viewport is still `overflow: auto` and accepts wheel /
 keyboard scroll natively, which fires `onScroll` and updates the thumb
-position).
+position via the derived state).
 
-### App.svelte mounting
-
-```svelte
-<div class="viewport"
-     class:custom-scrollbar={useCustomScrollbar}
-     ...>
-    <div class="grid">...</div>
-    {#if useCustomScrollbar}
-        <CustomScrollbar
-            viewportHeight={viewportHeight}
-            scrollTop={scrollTop}
-            nrow={nrow}
-            rowHeight={ROW_HEIGHT}
-            maxPhysical={MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight}
-            onScrollTo={(newScrollTop) => {
-                if (viewportEl) viewportEl.scrollTop = newScrollTop;
-            }}
-        />
-    {/if}
-</div>
-```
-
-`maxPhysical` is computed inline rather than in `grid-model.ts` because
-it's only used here; the math functions accept it as a parameter so they
-stay DOM-free.
+`trackTopAbsolute` is computed via `track.getBoundingClientRect().top`
+at the start of each drag and cached in `dragOffset`'s sibling state —
+recomputing it on every `pointermove` is fine but unnecessary, and we
+avoid getBoundingClientRect's small layout-thrash cost in the hot path.
 
 ## Test surface
 
-A new test-only message lets the integration test drive the drag math
-without simulating raw pointer events (which is fragile inside a webview
-iframe):
+A new test-only message lets the integration test drive the **real
+pointer-event pipeline** rather than just the math layer. The webview
+synthesizes pointerdown / pointermove / pointerup events on the thumb
+element so the same handlers a user's drag would invoke run end-to-end:
 
 ```typescript
 | {
-    /** Test-only: drive a custom-scrollbar drag-to-fraction (0..1).
-     *  The webview computes the resulting physical scrollTop via
-     *  customScrollTopFromThumbTop and applies it to viewportEl. This
-     *  tests the math + scroll pipeline; the pointer-handler wiring
-     *  itself is exercised by the bun unit tests on the math functions
-     *  and verified by inspection. */
+    /** Test-only: drive a custom-scrollbar drag-to-fraction (0..1) by
+     *  dispatching synthetic pointerdown / pointermove / pointerup
+     *  events on the thumb element. fraction=0 jumps to top, fraction=1
+     *  jumps to bottom. The webview computes the target thumbTop, then
+     *  fires the events to exercise the real pointer handlers (drag
+     *  offset capture, pointer capture, drag math, cleanup). */
     type: 'testScrollbarDrag';
     panelGeneration: number;
     fraction: number;   // 0 = top, 1 = bottom
   }
 ```
 
-The webview's message handler:
-- Computes `thumbHeight = customThumbHeight(viewportHeight, ROW_HEIGHT, nrow)`.
-- Computes `thumbTop = fraction * (viewportHeight - thumbHeight)`.
-- Computes `physical = customScrollTopFromThumbTop(thumbTop, viewportHeight, thumbHeight, maxPhysical)`.
-- Sets `viewportEl.scrollTop = physical`.
+The webview's `testScrollbarDrag` handler:
 
-This routes through the same `onScrollTo` callback the real pointer
-handlers use — the math layer is shared.
+1. Grabs the thumb element via the same internal `bind:this` ref the
+   widget uses for itself (or via a `data-test-id="custom-scrollbar-thumb"`
+   attribute looked up with `document.querySelector`).
+2. Computes `thumbHeight`, current `thumbTop`, and target
+   `thumbTop = fraction * (viewportHeight - thumbHeight)`.
+3. Dispatches a `pointerdown` on the thumb at its current position with
+   `pointerId: 1, clientX: thumbCenterX, clientY: thumbCenterY,
+   bubbles: true, cancelable: true`.
+4. Dispatches a `pointermove` at the target position with the same
+   pointerId so the drag handler computes the move delta.
+5. Dispatches a `pointerup` to terminate the drag.
+
+Because the same thumb-element listener handles all three events, the
+real pointer-event glue (capture/move/up cleanup, `lostpointercapture`
+guard) is exercised — not just the underlying math. This addresses the
+codex review's concern that math-only tests miss the pointer wiring.
 
 A new method on `RavenExtensionApi`:
 
@@ -315,20 +443,33 @@ test('customThumbHeight: tiny dataset → full track')
 test('customThumbHeight: large dataset → MIN_THUMB_PX floor')
 test('customThumbHeight: mid-size proportional')
 test('customThumbHeight: nrow === 0 → full track')
+test('customThumbHeight: rowHeight === 0 → full track')   // edge
+test('customThumbHeight: viewportHeight === 0 → 0')        // edge
+test('customThumbHeight: viewportHeight < MIN_THUMB_PX → viewportHeight (no overflow)')
 
 test('customThumbTop: scrollTop=0 → 0')
 test('customThumbTop: scrollTop=maxPhysical → viewportHeight - thumbHeight')
 test('customThumbTop: midpoint → midpoint')
+test('customThumbTop: maxPhysical <= 0 → 0')               // edge
+test('customThumbTop: thumbHeight >= viewportHeight → 0')  // edge
 
 test('customScrollTopFromThumbTop: thumbTop=0 → 0')
 test('customScrollTopFromThumbTop: thumbTop=trackUsable → maxPhysical')
 test('customScrollTopFromThumbTop: round-trip with customThumbTop')
+test('customScrollTopFromThumbTop: maxPhysical <= 0 → 0')  // edge
+test('customScrollTopFromThumbTop: trackUsable <= 0 → 0')  // edge
 ```
 
 The round-trip test: for any `scrollTop ∈ [0, maxPhysical]`, the result of
 applying `customThumbTop` then `customScrollTopFromThumbTop` should match
 the original (within floating-point tolerance). This catches any
 asymmetry between the forward and reverse mappings.
+
+The tiny-viewport edge tests guard against the
+`Math.max(MIN_THUMB_PX, ...)` regression from the codex review: with the
+clamp in the corrected order (`min(viewportHeight, max(MIN_THUMB_PX,
+proportional))`), a 20-px viewport gets a 20-px thumb (full track), not
+a 30-px thumb that overflows.
 
 ### Mocha integration test
 
@@ -431,14 +572,32 @@ data-grid practice of custom-scrolling above a threshold).
 
 ## What the mocha test does and does not prove
 
-Same caveat as the prior PR: the `testScrollbarDrag` mechanism shares the
-math + scroll-pipeline path with the real pointer handlers but does not
-exercise the pointer event wiring itself (pointer-down → drag offset
-capture → pointer-move → drag math → pointer-up). Those are simple
-event-glue functions; if the math is right (verified by bun) and the
-glue is straightforward (verified by inspection), the integration is
-right. A regression purely in the pointer-event wiring would slip
-through.
+Unlike the prior PR's keyboard test (which dispatched a synthetic
+`KeyboardEvent` on `window` and only proved the handler logic), the
+custom-scrollbar test dispatches synthetic **pointer** events on the
+**thumb element itself**. That exercises the full pipeline:
+
+- pointerdown → drag-offset capture + `setPointerCapture`
+- pointermove → drag math (`customScrollTopFromThumbTop`) →
+  `onScrollTo` → `viewportEl.scrollTop` → `onScroll` →
+  `scheduleFetchVisible` → `getRows` → `applyRows` →
+  `postLifecycle('rows')`
+- pointerup → cleanup via `lostpointercapture` / `releasePointerCapture`
+  guarded by `hasPointerCapture`
+
+What the test still does **not** exercise:
+
+- VS Code's parent-window → iframe pointer event forwarding (a real user
+  click outside the iframe wouldn't reach our handlers; a real user
+  click inside the iframe would).
+- Trackpad / touchscreen pointer types (the synthetic events use the
+  default `pointerType: 'mouse'`).
+- Hover-state styling transitions (`:hover`, `.dragging` class).
+
+Those are the legitimate pieces of the pointer pipeline that an
+extension-host integration test fundamentally can't reach. The test
+covers the failure mode that matters for issue #183: **does dragging the
+thumb to the bottom land on the last row?**
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-custom-scrollbar-design.md
@@ -481,14 +481,14 @@ test('customThumbHeight: large dataset → MIN_THUMB_PX floor')
 test('customThumbHeight: mid-size proportional')
 test('customThumbHeight: nrow === 0 → full track')
 test('customThumbHeight: rowHeight === 0 → full track')   // edge
-test('customThumbHeight: viewportHeight === 0 → 0')        // edge
-test('customThumbHeight: viewportHeight < MIN_THUMB_PX → viewportHeight (no overflow)')
+test('customThumbHeight: trackHeight === 0 → 0')           // edge
+test('customThumbHeight: trackHeight < MIN_THUMB_PX → trackHeight (no overflow)')
 
 test('customThumbTop: scrollTop=0 → 0')
-test('customThumbTop: scrollTop=maxPhysical → viewportHeight - thumbHeight')
+test('customThumbTop: scrollTop=maxPhysical → trackHeight - thumbHeight')
 test('customThumbTop: midpoint → midpoint')
 test('customThumbTop: maxPhysical <= 0 → 0')               // edge
-test('customThumbTop: thumbHeight >= viewportHeight → 0')  // edge
+test('customThumbTop: thumbHeight >= trackHeight → 0')     // edge
 
 test('customScrollTopFromThumbTop: thumbTop=0 → 0')
 test('customScrollTopFromThumbTop: thumbTop=trackUsable → maxPhysical')
@@ -502,11 +502,10 @@ applying `customThumbTop` then `customScrollTopFromThumbTop` should match
 the original (within floating-point tolerance). This catches any
 asymmetry between the forward and reverse mappings.
 
-The tiny-viewport edge tests guard against the
-`Math.max(MIN_THUMB_PX, ...)` regression from the codex review: with the
-clamp in the corrected order (`min(viewportHeight, max(MIN_THUMB_PX,
-proportional))`), a 20-px viewport gets a 20-px thumb (full track), not
-a 30-px thumb that overflows.
+The tiny-track edge tests guard against the `Math.max(MIN_THUMB_PX, ...)`
+regression from the codex review: with the clamp in the corrected order
+(`min(trackHeight, max(MIN_THUMB_PX, proportional))`), a 20-px track gets
+a 20-px thumb (full track), not a 30-px thumb that overflows.
 
 ### Mocha integration test
 

--- a/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
@@ -49,10 +49,11 @@ Goals:
 
 Non-goals for this change:
 
-- A custom overlay scrollbar that bypasses the native widget. (The issue lists
-  it as an option; out of scope here. Once End/Home/PageUp/PageDown work, the
-  remaining "drag the pill to the bottom" gap is a UX nice-to-have, not a
-  blocker.)
+- A custom overlay scrollbar that bypasses the native widget. (See "Known
+  limitations" — the native-drag-to-bottom symptom from the issue is
+  *partially* unresolved by this change. End-key support fully addresses
+  the keyboard / programmatic case; dragging the scrollbar pill is a
+  separate fix that lives outside this PR.)
 - Sort/filter/search semantics. Unrelated.
 - Adjusting `MAX_SCROLL_PX`. The issue notes this trades resolution for thumb
   size with non-trivial side effects — out of scope until a custom scrollbar
@@ -94,8 +95,11 @@ api.getDataViewerPanelVisibleRange  →     poll until end === nrow
 ### 1. Keyboard shortcuts in `App.svelte`
 
 Add Home / End / PageUp / PageDown branches to `onKeyDown`, **before** the
-existing Cmd-A / Cmd-C branches so the new keys win when no modifier is
-pressed:
+existing Cmd-A / Cmd-C branches. Each branch fires only when no modifier is
+pressed (`!e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey`) so platform
+shortcuts like `Cmd-End` (extend selection in some apps) don't get hijacked
+into "scroll to last row" — that combination falls through unchanged for the
+browser/OS to handle:
 
 - `End` → `viewportEl.scrollTop = viewportEl.scrollHeight - viewportEl.clientHeight`
 - `Home` → `viewportEl.scrollTop = 0`
@@ -109,43 +113,58 @@ render).
 
 The existing `onScroll` handler does the rest — we don't bypass
 `scheduleFetchVisible` or call `visibleRange` directly. The inner `.grid` div
-is already height-capped at `MAX_SCROLL_PX`, so `scrollHeight - clientHeight`
-yields exactly `maxPhysical`, which after the existing `logicalScrollTop`
-remap drives `visibleRange.end === nrow` — the bottom-row math already
-verified by `tests/bun/data-viewer-grid-model.test.ts` ("bottom: max
-scrollTop reaches the last row").
+is height-capped at `MAX_SCROLL_PX + ROW_HEIGHT`, so
+`scrollHeight - clientHeight` lands at or near the model's `maxPhysical`. The
+two values can differ slightly under sub-pixel layout rounding or when a
+horizontal scrollbar reduces `clientHeight`; the new `logicalScrollTop` clamp
+(below) absorbs the difference so `visibleRange.end` still resolves to
+`nrow`.
 
 A doc comment on the new branches notes that `scrollHeight - clientHeight`
 is the canonical browser-clamped maximum and works regardless of the
-container's content height.
+container's content height; the clamp in `logicalScrollTop` makes the math
+robust to any DOM-vs-model rounding mismatch.
 
 ### 2. Clamp `logicalScrollTop` in `grid-model.ts`
 
-The current implementation:
+Both branches of `logicalScrollTop` get a clamp. The current implementation:
 
 ```typescript
+if (totalGridHeight <= MAX_SCROLL_PX) return scrollTop;
+const maxPhysical = MAX_SCROLL_PX + rowHeight - viewportHeight;
+if (maxPhysical <= 0) return 0;
+const maxLogical = totalGridHeight + rowHeight - viewportHeight;
 return (scrollTop / maxPhysical) * maxLogical;
 ```
 
 becomes:
 
 ```typescript
+const maxLogicalSmall = Math.max(0, totalGridHeight + rowHeight - viewportHeight);
+if (totalGridHeight <= MAX_SCROLL_PX) {
+    return Math.max(0, Math.min(maxLogicalSmall, scrollTop));
+}
+const maxPhysical = MAX_SCROLL_PX + rowHeight - viewportHeight;
+if (maxPhysical <= 0) return 0;
+const maxLogical = totalGridHeight + rowHeight - viewportHeight;
 const scaled = (scrollTop / maxPhysical) * maxLogical;
 return Math.max(0, Math.min(maxLogical, scaled));
 ```
 
-Without the clamp, a macOS rubber-band overshoot (`scrollTop > maxPhysical`)
-maps to `logical > maxLogical`. `visibleRange` then computes
-`start = floor(logical / rowHeight) - overscan`, which may exceed `nrow`,
-and the resulting range is empty. With the clamp, `logical` saturates at
-`maxLogical`, `visibleRange.end` stays at `nrow`, and the bottom row keeps
-rendering through the bounce.
+Without a clamp on the large path, a macOS rubber-band overshoot
+(`scrollTop > maxPhysical`) maps to `logical > maxLogical`. `visibleRange`
+then computes `start = floor(logical / rowHeight) - overscan`, which may
+exceed `nrow`, and the resulting range is empty. With the clamp, `logical`
+saturates at `maxLogical`, `visibleRange.end` stays at `nrow`, and the
+bottom row keeps rendering through the bounce.
 
-The clamp is also defensive against negative `scrollTop` values — Chromium
-shouldn't report them, but the clamp removes the assumption.
+Clamping the small-data fast path is defensive: Chromium shouldn't report
+`scrollTop < 0` or `scrollTop > totalGridHeight - viewportHeight` in normal
+flow, but rubber-band overshoot has been observed to do so under macOS
+elastic scroll, and the cost of the clamp is two `Math.min/max` calls.
 
-The function's existing doc comment is extended with a one-line note
-explaining the clamp's purpose.
+The function's existing doc comment is extended with a note explaining the
+clamp's purpose.
 
 ## Test surface
 
@@ -215,6 +234,17 @@ exercising the same code path a user keypress would.
 `postLifecycle(event)` is updated to include `visibleRangeStart` and
 `visibleRangeEnd: visibleRangeStart + visibleRows.length`.
 
+`scheduleFetchVisible` currently posts a lifecycle event from `applyRows`
+but **not** from its own cache-hit fast path (where rows come from
+`rowCache.get`). Without a fix, an `End` keypress that lands on a
+pre-cached window — e.g., re-pressing `End` after a brief scroll-up — would
+update `visibleRangeStart` in the webview but never tell the host, leaving
+the polling test stuck on a stale range. Add `postLifecycle('cache-hit')`
+to the cache-hit branch so every change to `visibleRangeStart` is
+observable from the host. The same call goes in the empty-range branch so
+the host sees a `{start, end}` even when the visible window is empty (e.g.,
+`nrow === 0`).
+
 ### `panel.ts`
 
 `DataViewerPanel` gains:
@@ -228,8 +258,11 @@ exercising the same code path a user keypress would.
   queued, not for a reply; the test polls `getVisibleRange` after.
 
 The lifecycle handler in `handleInner` (which today only traces the event)
-extends to also update `lastVisibleRange` from the now-required
-`visibleRangeStart` / `visibleRangeEnd` fields. `lastVisibleRange` is
+extends to also update `lastVisibleRange`. Because `panel.ts` is the
+extension-side trust boundary for messages from the webview, the handler
+narrows defensively: it only writes `lastVisibleRange` when both
+`m.visibleRangeStart` and `m.visibleRangeEnd` are finite numbers, leaving
+the previous value (or `undefined`) otherwise. `lastVisibleRange` is
 cleared on `replace()` so a stale range from the previous dataset is never
 returned for the new one.
 
@@ -267,35 +300,48 @@ Each delegates to the manager.
 Add one test to `editors/vscode/src/test/data-viewer.test.ts`:
 
 ```text
-test('End key reaches the last row in a 1M-row data frame', async () => {
+test('End key reaches the last row in a 700K-row data frame', async () => {
+    const N = 700_000;
     await api.sendToRTerminal(
-        'big <- as.data.frame(matrix(rnorm(1e6 * 5), nrow = 1e6, ncol = 5)); View(big)'
+        `big <- as.data.frame(matrix(rnorm(${N} * 5), nrow = ${N}, ncol = 5)); View(big)`
     );
     // poll until panel "big" exists
-    // poll until visibleRange is reported (initial fetch landed)
+    // poll until lastVisibleRange has end > start AND end < N (the
+    //   initial fetch landed for rows near the top, and the panel has
+    //   reached steady state — not just a mount/init lifecycle with
+    //   visibleRows === 0)
     await api.pressDataViewerKey('big', 'End');
-    // poll until visibleRange.end === 1_000_000
+    // poll until lastVisibleRange.end === N (the bottom-row fetch arrived)
 });
 ```
 
-`1_000_000 rows × 5 cols` is `~38 MB` of doubles; well below the cap and
-small enough that R can compute and write it in a few seconds. The suite
-already runs at a 120 s timeout. The test inherits the same R-availability
-and `arrow`-package-availability skips the existing tests use.
+`700_000 rows × 5 cols` is `~28 MB` of doubles, the smallest size that
+engages the cap (`700_000 × 24 = 16.8 M > MAX_SCROLL_PX`) — exactly the
+failure mode from the issue. R can compute and write it in a few seconds.
+The suite already runs at a 120 s timeout. The test inherits the same
+R-availability and `arrow`-package-availability skips the existing tests
+use.
 
-`1 M rows × 24 px = 24 M px > MAX_SCROLL_PX (15 M)`, so the cap is engaged
-and the remap is exercised — exactly the failure mode from the issue.
+The readiness gate ("end > start AND end < N") deliberately distinguishes
+the post-init steady state (rows fetched near the top) from the
+post-`End` state (rows fetched near the bottom). Without this gate the
+test could observe `lastVisibleRange` from the very first lifecycle event
+posted by the `init` handler, where `visibleRows.length === 0` — and the
+subsequent `End` key would race the initial row fetch.
 
 ### Bun unit tests
 
-Three additions to the existing `'scroll height capping'` group in
+Four additions to the existing `'scroll height capping'` group in
 `tests/bun/data-viewer-grid-model.test.ts`:
 
-- `logicalScrollTop: clamps overshoot above maxPhysical to maxLogical` —
+- `logicalScrollTop: clamps overshoot above maxPhysical to maxLogical (large)` —
   `logicalScrollTop(maxPhysical * 1.1, LARGE, VH, RH)` should equal
   `maxLogicalLarge` exactly.
-- `logicalScrollTop: clamps negative scrollTop to 0` — `logicalScrollTop(-50,
-  LARGE, VH, RH)` should equal `0`.
+- `logicalScrollTop: clamps negative scrollTop to 0 (large)` —
+  `logicalScrollTop(-50, LARGE, VH, RH)` should equal `0`.
+- `logicalScrollTop: clamps negative scrollTop to 0 (small)` —
+  `logicalScrollTop(-50, SMALL, VH, RH)` should equal `0` (the small-data
+  fast path now clamps too).
 - `visibleRange after clamped overshoot still includes the last row` —
   round-trip test asserting `end === nrow` even with an overshooting
   `scrollTop`.
@@ -313,29 +359,78 @@ pass unchanged (clamping at `maxLogical` is a no-op for the in-range case).
 > - `Cmd/Ctrl-C` — copy the current selection as TSV.
 
 Per AGENTS.md ("prefer code comments over Learnings entries"), the invariants
-that pin behavior — that `End` uses `scrollHeight - clientHeight` to reach
-exactly `maxPhysical`, and that `logicalScrollTop` clamps overshoot — go in
-doc comments on the relevant code, not in `AGENTS.md`.
+that pin behavior — that `End` sets `scrollTop = scrollHeight - clientHeight`
+(the canonical browser-clamped bottom), and that `logicalScrollTop` clamps
+overshoot/undershoot to `[0, maxLogical]` so any DOM-vs-model rounding still
+lands on the last row — go in doc comments on the relevant code, not in
+`AGENTS.md`.
 
 ## Open questions
 
 None — the fix is small enough and the protocol extension narrow enough that
 the design is fully determined by the existing code.
 
+## What the mocha test does and does not prove
+
+The `testKey` mechanism dispatches a synthetic `KeyboardEvent` against
+`window` from inside the webview's iframe. That reaches the
+`<svelte:window onkeydown={onKeyDown}>` listener and exercises the full
+`onKeyDown` → `viewportEl.scrollTop = …` → `onScroll` → `scheduleFetchVisible`
+→ `getRows` → `applyRows` → `postLifecycle('rows')` pipeline.
+
+It does **not** exercise:
+
+- VS Code's parent-window → iframe key forwarding.
+- Iframe focus acquisition (we already pull focus on mount via
+  `focusViewport()`, but this isn't tested here).
+- Chromium's default behavior for End / Home / PageUp / PageDown on a
+  focused scrollable element — the synthetic event fires our handler
+  *after* the browser would have its turn at a real key event.
+
+Those are the legitimate pieces of the keyboard pipeline that an
+extension-host integration test fundamentally can't reach. The synthetic
+mechanism is the closest a mocha test can get without spawning a UI
+automation driver. A regression in any of the un-covered layers (focus
+loss, key forwarding) would be caught by manual testing or higher-level
+end-to-end harnesses, not this test.
+
+## Known limitations / partially-resolved part of #183
+
+Issue #183's first listed failure mode — "dragging the scrollbar pill to
+the very bottom" — is **not** addressed by this PR. The browser's minimum
+thumb size compresses the bottom of the drag track, so even with the
+clamp in place the pill cannot map a drag to `scrollTop = maxPhysical`.
+Closing this gap requires a custom overlay scrollbar (issue option 1) and
+is tracked as a follow-up rather than rolled into this change.
+
+The new `End` key gives users a deterministic way to reach the last row
+in the meantime, and the clamp ensures the grid no longer blanks during
+elastic-scroll overshoot. Pointer wheel and `ArrowDown` continue to work
+within the native scrollbar's range (which is the same as before this PR).
+
 ## Risks
 
-- **Mocha test runtime.** R startup + 1 M-row matrix construction +
-  Arrow write can take 5–10 s on slow machines. The 120 s suite timeout has
+- **Mocha test runtime.** R startup + 700 K-row matrix construction +
+  Arrow write can take 5–8 s on slow machines. The 120 s suite timeout has
   ample headroom, but the new test extends total suite runtime by roughly
   that amount. Acceptable; the existing `View(mtcars)` tests already pay R
-  startup cost once.
+  startup cost once. If timing becomes flaky on slower CI runners, the
+  test can be split into its own describe block with a tighter
+  per-test timeout, or moved behind a `RAVEN_RUN_LARGE_TESTS` env-gate.
 - **Synthetic `KeyboardEvent` reaching `<svelte:window onkeydown>`.** In
   Svelte 5, `<svelte:window>` attaches a window-level listener;
   `window.dispatchEvent` is the documented way to deliver synthetic events
   to such listeners and is verified by Chromium. If the binding ever moves
-  off `window`, the test handler must move with it.
+  off `window`, the test handler must move with it. See "What the mocha
+  test does and does not prove" for what this synthetic path covers.
 - **`testKey` discoverability.** A future contributor could call this from
   production code. Mitigation: the doc comment marks it test-only and the
   branch is the only `testKey` consumer; a lint/grep check at PR time would
   catch new callers, but no automated guard is added (the surface is
   small).
+- **Lifecycle event volume.** Adding a `postLifecycle('cache-hit')` to
+  `scheduleFetchVisible` increases the rate of lifecycle messages by one
+  per cached scroll. Lifecycle handling is trace-only on the host side
+  (no I/O, no state writes besides `lastVisibleRange`), and
+  `scheduleFetchVisible` is already coalesced at 16 ms, so the worst
+  case is one extra message per coalesce window — negligible.

--- a/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
@@ -74,7 +74,11 @@ mocha test (extension host)               webview (App.svelte)
 api.pressDataViewerKey('big','End')  →    msg handler dispatches synthetic
                                           KeyboardEvent on window
                                           → onKeyDown('End')
-                                          → viewportEl.scrollTop = maxPhysical
+                                          → viewportEl.scrollTop =
+                                              scrollHeight - clientHeight
+                                              (≈ maxPhysical; clamp in
+                                              logicalScrollTop absorbs
+                                              any rounding mismatch)
                                           → onScroll → scheduleFetchVisible
                                           → getRows
                                           ← rows
@@ -97,9 +101,12 @@ api.getDataViewerPanelVisibleRange  →     poll until end === nrow
 Add Home / End / PageUp / PageDown branches to `onKeyDown`, **before** the
 existing Cmd-A / Cmd-C branches. Each branch fires only when no modifier is
 pressed (`!e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey`) so platform
-shortcuts like `Cmd-End` (extend selection in some apps) don't get hijacked
-into "scroll to last row" — that combination falls through unchanged for the
-browser/OS to handle:
+shortcuts like `Shift-End` (extend selection in spreadsheets) and
+`Cmd-Shift-End` (jump-and-extend) don't get hijacked into a plain "scroll to
+last row" — those combinations fall through unchanged for the browser/OS to
+handle. Selection-extension while scrolling is intentionally **not** wired
+in this PR (see non-goals); a future PR can add it by widening the
+key-handler branches and integrating with the existing `Selection` model:
 
 - `End` → `viewportEl.scrollTop = viewportEl.scrollHeight - viewportEl.clientHeight`
 - `Home` → `viewportEl.scrollTop = 0`
@@ -306,10 +313,14 @@ test('End key reaches the last row in a 700K-row data frame', async () => {
         `big <- as.data.frame(matrix(rnorm(${N} * 5), nrow = ${N}, ncol = 5)); View(big)`
     );
     // poll until panel "big" exists
-    // poll until lastVisibleRange has end > start AND end < N (the
-    //   initial fetch landed for rows near the top, and the panel has
-    //   reached steady state — not just a mount/init lifecycle with
-    //   visibleRows === 0)
+    // explicitly reset scroll to the top so the test is independent of any
+    //   retained scroll state from a prior --watch run that re-View()s the
+    //   same dataset (a same-shape replace doesn't reset visibleRangeStart
+    //   inside applyInitOrReplace)
+    await api.pressDataViewerKey('big', 'Home');
+    // poll until lastVisibleRange.end < N / 2 (the Home reset has landed
+    //   AND the rows for the top of the grid have been fetched —
+    //   distinguishes 'panel exists' from 'panel reached steady state')
     await api.pressDataViewerKey('big', 'End');
     // poll until lastVisibleRange.end === N (the bottom-row fetch arrived)
 });
@@ -322,12 +333,13 @@ The suite already runs at a 120 s timeout. The test inherits the same
 R-availability and `arrow`-package-availability skips the existing tests
 use.
 
-The readiness gate ("end > start AND end < N") deliberately distinguishes
-the post-init steady state (rows fetched near the top) from the
-post-`End` state (rows fetched near the bottom). Without this gate the
-test could observe `lastVisibleRange` from the very first lifecycle event
-posted by the `init` handler, where `visibleRows.length === 0` — and the
-subsequent `End` key would race the initial row fetch.
+The Home-then-poll pre-step makes the test robust to retained scroll state.
+A `View(big)` after a previous `View(big)` with the same shape goes through
+`applyInitOrReplace`'s `sameDataset` branch, which intentionally preserves
+`visibleRangeStart` so the user's scroll position survives a refresh — but
+that means an unconditional "wait for end < N" gate could observe a stale
+near-bottom range. Pressing `Home` first is cheap, deterministic, and tests
+that the new `Home` key works as a side benefit.
 
 ### Bun unit tests
 

--- a/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
@@ -1,0 +1,341 @@
+# Data Viewer: Scroll to Last Row (issue #183)
+
+Date: 2026-05-16
+Status: Draft for review
+Issue: [#183](https://github.com/jbearak/raven/issues/183) — "Data viewer:
+can't scroll to the very last row in large datasets"
+
+## Problem
+
+In a large data frame (issue example: 10 M rows × 50 cols), the user cannot
+reach the very last row by any of the available means:
+
+- Dragging the scrollbar pill to the bottom stops short of the last row.
+- Holding `ArrowDown` stops short.
+- On macOS, an inertia-scroll overshoot briefly reveals the last row but the
+  grid blanks during the rubber-band bounce ("row 10,000,000 flickers and
+  disappears").
+
+Two distinct root causes from the issue:
+
+1. **Scrollbar thumb compression.** The scroll container is capped at
+   `MAX_SCROLL_PX = 15_000_000` to stay below Chrome/Electron's `2^24` pixel
+   limit. For a 600 px viewport, the calculated thumb height is
+   `600² / 15_000_024 ≈ 0.024 px`. The browser enforces a ~17 px minimum, so
+   the bottom of the drag track maps to a `scrollTop` below `maxPhysical` and
+   the last rows are never reached by dragging.
+2. **Elastic-scroll overshoot.** macOS rubber-band can briefly push
+   `scrollTop > maxPhysical`. Because `logicalScrollTop` is unclamped, the
+   scaled value exceeds `maxLogical`; `visibleRange` then returns
+   `end < start` and the grid blanks until the scroll bounces back.
+
+PRs ea84482 and 69bdd3c fixed the math at the bottom of the remap so that
+*if* a `scrollTop` of `maxPhysical` is reached, `visibleRange.end === nrow`.
+What's left is making it possible to *reach* `maxPhysical` deterministically,
+and stopping the overshoot from blanking the grid.
+
+## Goals / Non-Goals
+
+Goals:
+
+1. Provide a deterministic way for the user to reach the very last row of any
+   data frame, regardless of dataset size or scrollbar widget quirks.
+2. Stop the elastic-scroll bounce from blanking the grid on macOS.
+3. Cover both fixes with automated tests:
+   - A mocha integration test that opens a large data frame in a real R
+     session, drives `End`, and asserts the last row enters the visible
+     range.
+   - Bun unit tests for the new clamp behavior.
+
+Non-goals for this change:
+
+- A custom overlay scrollbar that bypasses the native widget. (The issue lists
+  it as an option; out of scope here. Once End/Home/PageUp/PageDown work, the
+  remaining "drag the pill to the bottom" gap is a UX nice-to-have, not a
+  blocker.)
+- Sort/filter/search semantics. Unrelated.
+- Adjusting `MAX_SCROLL_PX`. The issue notes this trades resolution for thumb
+  size with non-trivial side effects — out of scope until a custom scrollbar
+  is on the table.
+- Cmd-arrow / Cmd-End spreadsheet conventions. Plain `End` already covers the
+  "reach the last row" use case; spreadsheet shortcuts are a follow-up.
+
+## Architecture
+
+Two production-code changes plus an extension to the existing webview ↔
+extension postMessage protocol so the mocha test can drive a key event and
+read back the visible row range. No new processes, no new caches, no new
+threads.
+
+```text
+mocha test (extension host)               webview (App.svelte)
+─────────────────────────────             ───────────────────────────────
+api.pressDataViewerKey('big','End')  →    msg handler dispatches synthetic
+                                          KeyboardEvent on window
+                                          → onKeyDown('End')
+                                          → viewportEl.scrollTop = maxPhysical
+                                          → onScroll → scheduleFetchVisible
+                                          → getRows
+                                          ← rows
+                                          → applyRows updates
+                                            visibleRangeStart
+                                          → postLifecycle('rows', {
+                                              visibleRangeStart,
+                                              visibleRangeEnd,
+                                            })
+
+DataViewerPanel caches latest      ←      lifecycle event
+{start, end}
+api.getDataViewerPanelVisibleRange  →     poll until end === nrow
+```
+
+## Production fixes
+
+### 1. Keyboard shortcuts in `App.svelte`
+
+Add Home / End / PageUp / PageDown branches to `onKeyDown`, **before** the
+existing Cmd-A / Cmd-C branches so the new keys win when no modifier is
+pressed:
+
+- `End` → `viewportEl.scrollTop = viewportEl.scrollHeight - viewportEl.clientHeight`
+- `Home` → `viewportEl.scrollTop = 0`
+- `PageDown` → `viewportEl.scrollTop += viewportEl.clientHeight`
+- `PageUp` → `viewportEl.scrollTop -= viewportEl.clientHeight`
+
+Each branch calls `e.preventDefault()` so the browser's default page-scroll
+behavior doesn't double-fire on a focused scrollable element. Each branch
+guards on `viewportEl !== null` (it's bound asynchronously after the first
+render).
+
+The existing `onScroll` handler does the rest — we don't bypass
+`scheduleFetchVisible` or call `visibleRange` directly. The inner `.grid` div
+is already height-capped at `MAX_SCROLL_PX`, so `scrollHeight - clientHeight`
+yields exactly `maxPhysical`, which after the existing `logicalScrollTop`
+remap drives `visibleRange.end === nrow` — the bottom-row math already
+verified by `tests/bun/data-viewer-grid-model.test.ts` ("bottom: max
+scrollTop reaches the last row").
+
+A doc comment on the new branches notes that `scrollHeight - clientHeight`
+is the canonical browser-clamped maximum and works regardless of the
+container's content height.
+
+### 2. Clamp `logicalScrollTop` in `grid-model.ts`
+
+The current implementation:
+
+```typescript
+return (scrollTop / maxPhysical) * maxLogical;
+```
+
+becomes:
+
+```typescript
+const scaled = (scrollTop / maxPhysical) * maxLogical;
+return Math.max(0, Math.min(maxLogical, scaled));
+```
+
+Without the clamp, a macOS rubber-band overshoot (`scrollTop > maxPhysical`)
+maps to `logical > maxLogical`. `visibleRange` then computes
+`start = floor(logical / rowHeight) - overscan`, which may exceed `nrow`,
+and the resulting range is empty. With the clamp, `logical` saturates at
+`maxLogical`, `visibleRange.end` stays at `nrow`, and the bottom row keeps
+rendering through the bounce.
+
+The clamp is also defensive against negative `scrollTop` values — Chromium
+shouldn't report them, but the clamp removes the assumption.
+
+The function's existing doc comment is extended with a one-line note
+explaining the clamp's purpose.
+
+## Test surface
+
+A small extension to the postMessage protocol so the mocha test can:
+
+1. Drive a key event that flows through the real `onKeyDown` handler.
+2. Observe the resulting visible-row range.
+
+Both are gated to the test API; production code paths never post `testKey`,
+and `getDataViewerPanelVisibleRange` is only called from the test harness.
+Because the webview can only receive messages from its own extension host,
+exposing `testKey` does not introduce an external attack surface.
+
+### `messages.ts`
+
+Extend the `lifecycle` `WebviewToExtension` variant:
+
+```typescript
+| {
+    type: 'lifecycle';
+    event: string;
+    panelGeneration: number;
+    nrow: number;
+    columns: number;
+    visibleRows: number;
+    visibleRangeStart: number;   // NEW
+    visibleRangeEnd: number;     // NEW
+    timestamp: number;
+  }
+```
+
+`App.svelte`'s `postLifecycle` already has both numbers in scope
+(`visibleRangeStart` is `$state`; `visibleRangeEnd` is
+`visibleRangeStart + visibleRows.length`). The change is wire-format
+compatible with rolling reloads because consumers ignore unknown fields.
+
+Add a new `ExtensionToWebview` variant for test-driven key events (the
+extension posts it to the webview, which then dispatches a synthetic
+keyboard event on `window`):
+
+```typescript
+| {
+    type: 'testKey';
+    panelGeneration: number;
+    key: string;
+  }
+```
+
+A doc comment marks it test-only.
+
+### `App.svelte`
+
+Add a message-handler branch for `testKey` that dispatches a synthetic
+`KeyboardEvent` on `window`:
+
+```typescript
+case 'testKey':
+    window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: m.key, code: m.key, bubbles: true, cancelable: true,
+    }));
+    return;
+```
+
+This routes through the real `<svelte:window onkeydown={onKeyDown}>` binding,
+exercising the same code path a user keypress would.
+
+`postLifecycle(event)` is updated to include `visibleRangeStart` and
+`visibleRangeEnd: visibleRangeStart + visibleRows.length`.
+
+### `panel.ts`
+
+`DataViewerPanel` gains:
+
+- A private `lastVisibleRange: { start: number; end: number } | undefined`,
+  updated from each lifecycle event whose `panelGeneration` matches the
+  current generation.
+- `getVisibleRange(): { start: number; end: number } | undefined`.
+- `async pressKey(key: string): Promise<void>` — posts a `testKey` message
+  carrying the current generation. Awaiting it waits for the message to be
+  queued, not for a reply; the test polls `getVisibleRange` after.
+
+The lifecycle handler in `handleInner` (which today only traces the event)
+extends to also update `lastVisibleRange` from the now-required
+`visibleRangeStart` / `visibleRangeEnd` fields. `lastVisibleRange` is
+cleared on `replace()` so a stale range from the previous dataset is never
+returned for the new one.
+
+### `manager.ts`
+
+Add passthroughs:
+
+```typescript
+getPanelVisibleRange(panelName: string): { start: number; end: number } | undefined {
+    return this.panels.get(panelName)?.getVisibleRange();
+}
+async pressKeyOnPanel(panelName: string, key: string): Promise<void> {
+    await this.panels.get(panelName)?.pressKey(key);
+}
+```
+
+### `extension.ts`
+
+Two new methods on `RavenExtensionApi`, doc-commented `Used by integration
+tests` like the existing `getDataViewerPanelNames` /
+`getDataViewerPanelColumnNames`:
+
+```typescript
+getDataViewerPanelVisibleRange(panelName: string):
+    { start: number; end: number } | undefined;
+pressDataViewerKey(panelName: string, key: string): Promise<void>;
+```
+
+Each delegates to the manager.
+
+## Tests
+
+### Mocha integration test
+
+Add one test to `editors/vscode/src/test/data-viewer.test.ts`:
+
+```text
+test('End key reaches the last row in a 1M-row data frame', async () => {
+    await api.sendToRTerminal(
+        'big <- as.data.frame(matrix(rnorm(1e6 * 5), nrow = 1e6, ncol = 5)); View(big)'
+    );
+    // poll until panel "big" exists
+    // poll until visibleRange is reported (initial fetch landed)
+    await api.pressDataViewerKey('big', 'End');
+    // poll until visibleRange.end === 1_000_000
+});
+```
+
+`1_000_000 rows × 5 cols` is `~38 MB` of doubles; well below the cap and
+small enough that R can compute and write it in a few seconds. The suite
+already runs at a 120 s timeout. The test inherits the same R-availability
+and `arrow`-package-availability skips the existing tests use.
+
+`1 M rows × 24 px = 24 M px > MAX_SCROLL_PX (15 M)`, so the cap is engaged
+and the remap is exercised — exactly the failure mode from the issue.
+
+### Bun unit tests
+
+Three additions to the existing `'scroll height capping'` group in
+`tests/bun/data-viewer-grid-model.test.ts`:
+
+- `logicalScrollTop: clamps overshoot above maxPhysical to maxLogical` —
+  `logicalScrollTop(maxPhysical * 1.1, LARGE, VH, RH)` should equal
+  `maxLogicalLarge` exactly.
+- `logicalScrollTop: clamps negative scrollTop to 0` — `logicalScrollTop(-50,
+  LARGE, VH, RH)` should equal `0`.
+- `visibleRange after clamped overshoot still includes the last row` —
+  round-trip test asserting `end === nrow` even with an overshooting
+  `scrollTop`.
+
+The existing "bottom: max scrollTop reaches the last row" test continues to
+pass unchanged (clamping at `maxLogical` is a no-op for the in-range case).
+
+## Documentation
+
+`docs/data-viewer.md` — add a short "Keyboard shortcuts" subsection:
+
+> - `Home` / `End` — jump to the first / last row.
+> - `PageUp` / `PageDown` — scroll one viewport up / down.
+> - `Cmd/Ctrl-A` — select all visible cells.
+> - `Cmd/Ctrl-C` — copy the current selection as TSV.
+
+Per AGENTS.md ("prefer code comments over Learnings entries"), the invariants
+that pin behavior — that `End` uses `scrollHeight - clientHeight` to reach
+exactly `maxPhysical`, and that `logicalScrollTop` clamps overshoot — go in
+doc comments on the relevant code, not in `AGENTS.md`.
+
+## Open questions
+
+None — the fix is small enough and the protocol extension narrow enough that
+the design is fully determined by the existing code.
+
+## Risks
+
+- **Mocha test runtime.** R startup + 1 M-row matrix construction +
+  Arrow write can take 5–10 s on slow machines. The 120 s suite timeout has
+  ample headroom, but the new test extends total suite runtime by roughly
+  that amount. Acceptable; the existing `View(mtcars)` tests already pay R
+  startup cost once.
+- **Synthetic `KeyboardEvent` reaching `<svelte:window onkeydown>`.** In
+  Svelte 5, `<svelte:window>` attaches a window-level listener;
+  `window.dispatchEvent` is the documented way to deliver synthetic events
+  to such listeners and is verified by Chromium. If the binding ever moves
+  off `window`, the test handler must move with it.
+- **`testKey` discoverability.** A future contributor could call this from
+  production code. Mitigation: the doc comment marks it test-only and the
+  branch is the only `testKey` consumer; a lint/grep check at PR time would
+  catch new callers, but no automated guard is added (the surface is
+  small).

--- a/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
+++ b/docs/superpowers/specs/2026-05-16-data-viewer-scroll-to-bottom-design.md
@@ -318,9 +318,10 @@ test('End key reaches the last row in a 700K-row data frame', async () => {
     //   same dataset (a same-shape replace doesn't reset visibleRangeStart
     //   inside applyInitOrReplace)
     await api.pressDataViewerKey('big', 'Home');
-    // poll until lastVisibleRange.end < N / 2 (the Home reset has landed
-    //   AND the rows for the top of the grid have been fetched —
-    //   distinguishes 'panel exists' from 'panel reached steady state')
+    // poll until lastVisibleRange has 0 < end < N / 2 (the Home reset
+    //   has landed AND rows for the top of the grid have actually been
+    //   fetched — a mount/init lifecycle reports {start: 0, end: 0},
+    //   which satisfies end < N / 2 alone but means no rows yet)
     await api.pressDataViewerKey('big', 'End');
     // poll until lastVisibleRange.end === N (the bottom-row fetch arrived)
 });

--- a/editors/vscode/src/data-viewer/manager.ts
+++ b/editors/vscode/src/data-viewer/manager.ts
@@ -70,6 +70,20 @@ export class DataViewerManager {
         return this.panels.get(panelName)?.getColumnNames();
     }
 
+    /** Latest visible-row range for a named panel — used by the test
+     *  harness to verify scroll position. */
+    getPanelVisibleRange(panelName: string): { start: number; end: number } | undefined {
+        return this.panels.get(panelName)?.getVisibleRange();
+    }
+
+    /** Test-only: dispatch a synthetic key event in a named panel's
+     *  webview. Awaiting waits for the message to be queued, not for any
+     *  reply; tests should poll `getPanelVisibleRange()` to observe
+     *  results. */
+    async pressKeyOnPanel(panelName: string, key: string): Promise<void> {
+        await this.panels.get(panelName)?.pressKey(key);
+    }
+
     /** For tests + activation; delegates to {@link sweep_stale}. */
     static sweepStale = sweep_stale;
 }

--- a/editors/vscode/src/data-viewer/manager.ts
+++ b/editors/vscode/src/data-viewer/manager.ts
@@ -84,6 +84,14 @@ export class DataViewerManager {
         await this.panels.get(panelName)?.pressKey(key);
     }
 
+    /** Test-only: drive a custom-scrollbar drag in the named panel.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Awaiting
+     *  waits for message queuing; tests should poll
+     *  `getPanelVisibleRange()` to observe results. */
+    async dragScrollbarOnPanel(panelName: string, fraction: number): Promise<void> {
+        await this.panels.get(panelName)?.dragScrollbar(fraction);
+    }
+
     /** For tests + activation; delegates to {@link sweep_stale}. */
     static sweepStale = sweep_stale;
 }

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -83,6 +83,17 @@ export type ExtensionToWebview =
         type: 'error';
         panelGeneration: number;
         message: string;
+    }
+    | {
+        /** Test-only: dispatch a synthetic KeyboardEvent on `window` from
+         *  inside the webview, so the integration test harness can drive
+         *  the same onKeyDown handler a real keypress would invoke.
+         *  Production code paths never post this message; the webview can
+         *  only receive messages from its own extension host, so exposing
+         *  it does not introduce an external attack surface. */
+        type: 'testKey';
+        panelGeneration: number;
+        key: string;
     };
 
 export type WebviewToExtension =
@@ -96,6 +107,13 @@ export type WebviewToExtension =
         nrow: number;
         columns: number;
         visibleRows: number;
+        /** Start row index of the currently rendered window (inclusive).
+         *  Used by the test API to verify scroll position. Always reflects
+         *  visibleRangeStart at the moment postLifecycle was called. */
+        visibleRangeStart: number;
+        /** End row index of the currently rendered window (exclusive).
+         *  Equal to visibleRangeStart + visibleRows.length. */
+        visibleRangeEnd: number;
         timestamp: number;
     }
     | {

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -94,6 +94,21 @@ export type ExtensionToWebview =
         type: 'testKey';
         panelGeneration: number;
         key: string;
+    }
+    | {
+        /** Test-only: drive a custom-scrollbar drag-to-fraction (0..1)
+         *  by dispatching synthetic pointerdown/move/up events on the
+         *  thumb element. fraction=0 jumps to top, fraction=1 jumps to
+         *  bottom. The webview computes the target thumbTop, then fires
+         *  the events to exercise the real pointer handlers (drag
+         *  offset capture, drag math, cleanup).
+         *
+         *  Production code paths never post this message; the webview
+         *  can only receive messages from its own extension host, so
+         *  exposing it does not introduce an external attack surface. */
+        type: 'testScrollbarDrag';
+        panelGeneration: number;
+        fraction: number;
     };
 
 export type WebviewToExtension =

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -127,7 +127,7 @@ export type WebviewToExtension =
          *  visibleRangeStart at the moment postLifecycle was called. */
         visibleRangeStart: number;
         /** End row index of the currently rendered window (exclusive).
-         *  Equal to visibleRangeStart + visibleRows.length. */
+         *  Equal to visibleRangeStart + visibleRows. */
         visibleRangeEnd: number;
         timestamp: number;
     }

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -433,6 +433,21 @@ export class DataViewerPanel {
         await this.webviewPanel.webview.postMessage(msg);
     }
 
+    /** Test-only: post a `testScrollbarDrag` message to the webview so
+     *  it dispatches synthetic pointer events on the thumb element.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Awaiting
+     *  waits for the message to be queued, not for any reply; tests
+     *  should poll `getVisibleRange()` to observe the result. */
+    async dragScrollbar(fraction: number): Promise<void> {
+        if (this.disposed) return;
+        const msg: ExtensionToWebview = {
+            type: 'testScrollbarDrag',
+            panelGeneration: this.generation,
+            fraction,
+        };
+        await this.webviewPanel.webview.postMessage(msg);
+    }
+
     /** Column names in schema order — used by the test harness. */
     getColumnNames(): string[] {
         return this.columns.map(c => c.name);

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -39,6 +39,11 @@ export class DataViewerPanel {
     private columns: ColumnSchema[] = [];
     private layout: Layout = { columnWidths: {}, hiddenColumns: [] };
     private readonly traceId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    /** Latest visible-row range observed via lifecycle events. Used by
+     *  the integration test API. `undefined` until the first lifecycle
+     *  message arrives; cleared on `replace()` so a stale range from the
+     *  previous dataset is never returned for the new one. */
+    private lastVisibleRange: { start: number; end: number } | undefined;
 
     private constructor(
         panelName: string,
@@ -105,6 +110,10 @@ export class DataViewerPanel {
             return;
         }
         this.generation += 1;
+        // Clear cached visible range so a stale range from the previous
+        // dataset is never returned for the new one. The next lifecycle
+        // event from the webview will repopulate it.
+        this.lastVisibleRange = undefined;
         const prevReader = this.reader;
         const prevPath = this.filePath;
         this.reader = reader;
@@ -235,8 +244,22 @@ export class DataViewerPanel {
                 nrow: m.nrow,
                 columns: m.columns,
                 visibleRows: m.visibleRows,
+                visibleRangeStart: m.visibleRangeStart,
+                visibleRangeEnd: m.visibleRangeEnd,
                 timestamp: m.timestamp,
             });
+            // Cache the range only when both fields are finite numbers.
+            // panel.ts is the trust boundary for messages from the webview;
+            // narrow defensively so a malformed message can never store
+            // {start: NaN, end: undefined as number} into lastVisibleRange.
+            if (m.panelGeneration === this.generation
+                && Number.isFinite(m.visibleRangeStart)
+                && Number.isFinite(m.visibleRangeEnd)) {
+                this.lastVisibleRange = {
+                    start: m.visibleRangeStart,
+                    end: m.visibleRangeEnd,
+                };
+            }
             return;
         }
         // Save messages are keyed by their carried schemaHash, not by the
@@ -387,6 +410,27 @@ export class DataViewerPanel {
             await this.webviewPanel.webview.postMessage(
                 replyDone(false, err instanceof Error ? err.message : String(err)));
         }
+    }
+
+    /** Latest visible-row range from the most recent lifecycle message,
+     *  or undefined if none has arrived yet. Used by the test harness to
+     *  verify scroll position. */
+    getVisibleRange(): { start: number; end: number } | undefined {
+        return this.lastVisibleRange;
+    }
+
+    /** Test-only: post a `testKey` message to the webview so it dispatches
+     *  a synthetic KeyboardEvent on `window`. Awaiting the returned promise
+     *  waits for the message to be queued, not for any reply; tests should
+     *  poll `getVisibleRange()` to observe the result. */
+    async pressKey(key: string): Promise<void> {
+        if (this.disposed) return;
+        const msg: ExtensionToWebview = {
+            type: 'testKey',
+            panelGeneration: this.generation,
+            key,
+        };
+        await this.webviewPanel.webview.postMessage(msg);
     }
 
     /** Column names in schema order — used by the test harness. */

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -414,9 +414,12 @@ export class DataViewerPanel {
 
     /** Latest visible-row range from the most recent lifecycle message,
      *  or undefined if none has arrived yet. Used by the test harness to
-     *  verify scroll position. */
+     *  verify scroll position. Returns a defensive copy so callers cannot
+     *  mutate the internal state. */
     getVisibleRange(): { start: number; end: number } | undefined {
-        return this.lastVisibleRange;
+        return this.lastVisibleRange
+            ? { ...this.lastVisibleRange }
+            : undefined;
     }
 
     /** Test-only: post a `testKey` message to the webview so it dispatches
@@ -435,15 +438,21 @@ export class DataViewerPanel {
 
     /** Test-only: post a `testScrollbarDrag` message to the webview so
      *  it dispatches synthetic pointer events on the thumb element.
-     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Awaiting
-     *  waits for the message to be queued, not for any reply; tests
-     *  should poll `getVisibleRange()` to observe the result. */
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Non-finite
+     *  inputs are rejected, and finite values are clamped to [0, 1] to
+     *  keep test behavior deterministic. Awaiting waits for the message
+     *  to be queued, not for any reply; tests should poll
+     *  `getVisibleRange()` to observe the result. */
     async dragScrollbar(fraction: number): Promise<void> {
         if (this.disposed) return;
+        if (!Number.isFinite(fraction)) {
+            throw new RangeError('fraction must be a finite number');
+        }
+        const clampedFraction = Math.min(1, Math.max(0, fraction));
         const msg: ExtensionToWebview = {
             type: 'testScrollbarDrag',
             panelGeneration: this.generation,
-            fraction,
+            fraction: clampedFraction,
         };
         await this.webviewPanel.webview.postMessage(msg);
     }

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -503,7 +503,21 @@
         // and-extend) fall through to the browser/OS unchanged. The
         // viewportEl null guard handles the brief window between mount
         // and the bind:this assignment.
-        if (!meta && !e.shiftKey && !e.altKey && viewportEl) {
+        //
+        // Skip when focus is on a form control: <select>, <input>,
+        // <textarea>, or a contenteditable element have their own native
+        // Home/End/PageUp/PageDown semantics (e.g. <select> jumps to the
+        // first/last option) that we'd otherwise hijack. The toolbar's
+        // digits <select> and the column-popover checkboxes are concrete
+        // examples.
+        const target = e.target;
+        const onFormControl = target instanceof HTMLElement && (
+            target.tagName === 'INPUT'
+            || target.tagName === 'SELECT'
+            || target.tagName === 'TEXTAREA'
+            || target.isContentEditable
+        );
+        if (!meta && !e.shiftKey && !e.altKey && !onFormControl && viewportEl) {
             switch (e.key) {
                 case 'End':
                     e.preventDefault();

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -122,6 +122,8 @@
             nrow,
             columns: columns.length,
             visibleRows: visibleRows.length,
+            visibleRangeStart,
+            visibleRangeEnd: visibleRangeStart + visibleRows.length,
             timestamp: Date.now(),
         });
     }
@@ -151,6 +153,20 @@
                     return;
                 case 'copyDone':
                     applyCopyDone(m);
+                    return;
+                case 'testKey':
+                    // Test-only: dispatch a synthetic KeyboardEvent on
+                    // `window` so the same onKeyDown handler a real
+                    // keypress would invoke runs end-to-end. The
+                    // <svelte:window onkeydown={onKeyDown}> binding
+                    // listens at the window level, so window.dispatchEvent
+                    // is the canonical delivery path for synthetic events.
+                    window.dispatchEvent(new KeyboardEvent('keydown', {
+                        key: m.key,
+                        code: m.key,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
                     return;
             }
         };
@@ -306,6 +322,11 @@
             visibleRows = [];
             visibleRangeStart = range.start;
             persistWebviewState();
+            // Tell the host every change to visibleRangeStart, including
+            // the empty-range case — otherwise the test API can stall on
+            // a stale range when nrow shrinks to 0 or the viewport
+            // collapses.
+            postLifecycle('empty-range');
             return;
         }
         const cached = rowCache.get(range.start, range.end);
@@ -313,6 +334,11 @@
             visibleRows = cached;
             visibleRangeStart = range.start;
             persistWebviewState();
+            // Without this, an End keypress that lands on a pre-cached
+            // window (e.g., re-pressing End after a scroll-up) would
+            // never tell the host its range changed, leaving the polling
+            // test stuck on a stale lastVisibleRange.
+            postLifecycle('cache-hit');
             return;
         }
         viewportGeneration += 1;

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -497,6 +497,38 @@
             closeContextMenu();
             return;
         }
+        // Plain (no-modifier) navigation keys — added for issue #183.
+        // We deliberately ignore any modifier so platform shortcuts
+        // (Shift+End to extend selection, Cmd+End in some apps to jump-
+        // and-extend) fall through to the browser/OS unchanged. The
+        // viewportEl null guard handles the brief window between mount
+        // and the bind:this assignment.
+        if (!meta && !e.shiftKey && !e.altKey && viewportEl) {
+            switch (e.key) {
+                case 'End':
+                    e.preventDefault();
+                    // scrollHeight - clientHeight is the canonical
+                    // browser-clamped maximum. The inner .grid div is
+                    // height-capped at MAX_SCROLL_PX + ROW_HEIGHT, so
+                    // this lands at or near the model's maxPhysical;
+                    // logicalScrollTop's clamp absorbs any DOM-vs-model
+                    // rounding mismatch.
+                    viewportEl.scrollTop = viewportEl.scrollHeight - viewportEl.clientHeight;
+                    return;
+                case 'Home':
+                    e.preventDefault();
+                    viewportEl.scrollTop = 0;
+                    return;
+                case 'PageDown':
+                    e.preventDefault();
+                    viewportEl.scrollTop += viewportEl.clientHeight;
+                    return;
+                case 'PageUp':
+                    e.preventDefault();
+                    viewportEl.scrollTop -= viewportEl.clientHeight;
+                    return;
+            }
+        }
         if (meta && (e.key === 'a' || e.key === 'A')) {
             e.preventDefault();
             selection.selectAll(nrow, visibleCols);

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -171,6 +171,47 @@
                         cancelable: true,
                     }));
                     return;
+                case 'testScrollbarDrag': {
+                    // Test-only: dispatch synthetic pointerdown/move/up
+                    // events on the thumb element so the same drag
+                    // handlers a real user pointer would invoke run
+                    // end-to-end. pointerId 999 avoids colliding with
+                    // any real mouse pointer (Chromium primary mouse is
+                    // pointerId 1).
+                    const thumb = document.querySelector('[data-test-id="custom-scrollbar-thumb"]');
+                    if (!(thumb instanceof HTMLElement)) return;
+                    const trackEl = thumb.parentElement;
+                    if (!(trackEl instanceof HTMLElement)) return;
+                    const trackHeight = Math.max(0, viewportHeight - HORIZONTAL_GUTTER_PX);
+                    const thumbRect = thumb.getBoundingClientRect();
+                    const trackRect = trackEl.getBoundingClientRect();
+                    const thumbHeightPx = thumbRect.height;
+                    // Current thumb center.
+                    const centerX = thumbRect.left + thumbRect.width / 2;
+                    const startY = thumbRect.top + thumbRect.height / 2;
+                    // Target thumb-top, then target Y for the pointer
+                    // (we want the pointer to end up such that thumb's
+                    // top lands at fraction*(trackHeight - thumbHeight)).
+                    const targetThumbTop = m.fraction * Math.max(0, trackHeight - thumbHeightPx);
+                    const targetY = trackRect.top + targetThumbTop + thumbHeightPx / 2;
+                    const opts = {
+                        pointerId: 999,
+                        pointerType: 'mouse',
+                        bubbles: true,
+                        cancelable: true,
+                        button: 0,
+                    } as const;
+                    thumb.dispatchEvent(new PointerEvent('pointerdown', {
+                        ...opts, clientX: centerX, clientY: startY,
+                    }));
+                    thumb.dispatchEvent(new PointerEvent('pointermove', {
+                        ...opts, clientX: centerX, clientY: targetY,
+                    }));
+                    thumb.dispatchEvent(new PointerEvent('pointerup', {
+                        ...opts, clientX: centerX, clientY: targetY,
+                    }));
+                    return;
+                }
             }
         };
         window.addEventListener('message', handler);

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -178,6 +178,7 @@
                     // end-to-end. pointerId 999 avoids colliding with
                     // any real mouse pointer (Chromium primary mouse is
                     // pointerId 1).
+                    const fraction = Math.max(0, Math.min(1, m.fraction));
                     const thumb = document.querySelector('[data-test-id="custom-scrollbar-thumb"]');
                     if (!(thumb instanceof HTMLElement)) return;
                     const trackEl = thumb.parentElement;
@@ -192,7 +193,7 @@
                     // Target thumb-top, then target Y for the pointer
                     // (we want the pointer to end up such that thumb's
                     // top lands at fraction*(trackHeight - thumbHeight)).
-                    const targetThumbTop = m.fraction * Math.max(0, trackHeight - thumbHeightPx);
+                    const targetThumbTop = fraction * Math.max(0, trackHeight - thumbHeightPx);
                     const targetY = trackRect.top + targetThumbTop + thumbHeightPx / 2;
                     const opts = {
                         pointerId: 999,

--- a/editors/vscode/src/data-viewer/webview/App.svelte
+++ b/editors/vscode/src/data-viewer/webview/App.svelte
@@ -11,11 +11,13 @@
     import {
         visibleRange, coalesceScroll,
         cappedScrollHeight, logicalScrollTop, visualOffsetPx,
+        MAX_SCROLL_PX, HORIZONTAL_GUTTER_PX,
     } from './grid-model';
     import { RowCache } from './row-cache';
     import { Selection } from './selection-model';
     import { formatCell } from './cell-render';
     import Toolbar from './Toolbar.svelte';
+    import CustomScrollbar from './CustomScrollbar.svelte';
     type PersistedState = {
         panelGeneration: number;
         nrow: number;
@@ -103,6 +105,7 @@
             .filter(i => !hiddenSet.has(i)),
     );
     const totalGridHeight = $derived(nrow * ROW_HEIGHT);
+    const useCustomScrollbar = $derived(totalGridHeight > MAX_SCROLL_PX);
     /** Width of the sticky row-number column, sized to fit the widest row number. */
     const rowColWidth = $derived(`calc(${String(Math.max(1, nrow)).length}ch + 16px)`);
 
@@ -854,20 +857,22 @@
     {#if copyStatus !== ''}
         <div class="toast toast-{copyStatus}">{copyStatusMsg}</div>
     {/if}
-    <div class="viewport"
-         role="grid"
-         aria-rowcount={nrow}
-         bind:this={viewportEl}
-         onscroll={onScroll}
-         tabindex="0">
-        <div class="grid" style="height: {cappedScrollHeight(totalGridHeight) + ROW_HEIGHT}px;">
-            <!-- Header row (sticky top) -->
-            <div class="header-row">
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div class="cell header rowname-col corner-cell"
-                     style="width: {rowColWidth};"
-                     title="Select all"
-                     onpointerdown={onCornerPointerDown}>#</div>
+    <div class="viewport-wrapper">
+        <div class="viewport"
+             class:using-custom-scrollbar={useCustomScrollbar}
+             role="grid"
+             aria-rowcount={nrow}
+             bind:this={viewportEl}
+             onscroll={onScroll}
+             tabindex="0">
+            <div class="grid" style="height: {cappedScrollHeight(totalGridHeight) + ROW_HEIGHT}px;">
+                <!-- Header row (sticky top) -->
+                <div class="header-row">
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div class="cell header rowname-col corner-cell"
+                         style="width: {rowColWidth};"
+                         title="Select all"
+                         onpointerdown={onCornerPointerDown}>#</div>
                 {#each visibleCols as colIdx (colIdx)}
                     {@const col = columns[colIdx]}
                     <div class="cell header col-header
@@ -937,6 +942,19 @@
                 {/each}
             </div>
         </div>
+    </div>
+    {#if useCustomScrollbar}
+        <CustomScrollbar
+            trackHeight={Math.max(0, viewportHeight - HORIZONTAL_GUTTER_PX)}
+            scrollTop={scrollTop}
+            nrow={nrow}
+            rowHeight={ROW_HEIGHT}
+            maxPhysical={MAX_SCROLL_PX + ROW_HEIGHT - viewportHeight}
+            onScrollTo={(newScrollTop) => {
+                if (viewportEl) viewportEl.scrollTop = newScrollTop;
+            }}
+        />
+    {/if}
     </div>
     {#if contextMenu}
         <div class="context-menu"

--- a/editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte
+++ b/editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte
@@ -32,9 +32,6 @@
     let dragOffset: number | null = $state(null);
     /** Captured pointer id, for safe release on cleanup paths. */
     let dragPointerId: number | null = null;
-    /** getBoundingClientRect().top of the track at drag start. Cached so
-     *  pointermove doesn't re-measure on every frame. */
-    let dragTrackTop = 0;
 
     const thumbHeight = $derived(customThumbHeight(trackHeight, rowHeight, nrow));
     const thumbTop = $derived(customThumbTop(scrollTop, trackHeight, thumbHeight, maxPhysical));
@@ -45,8 +42,8 @@
         e.preventDefault();
         e.stopPropagation();   // don't also trigger track-paging
         dragPointerId = e.pointerId;
-        dragTrackTop = trackEl.getBoundingClientRect().top;
-        dragOffset = e.clientY - (dragTrackTop + thumbTop);
+        const trackTopAbsolute = trackEl.getBoundingClientRect().top;
+        dragOffset = e.clientY - (trackTopAbsolute + thumbTop);
         // Synthetic events from the test seam may not be eligible for
         // capture in all browsers; real user events always succeed.
         try {
@@ -58,7 +55,11 @@
 
     function onThumbPointerMove(e: PointerEvent): void {
         if (dragOffset === null) return;
-        const rawThumbTop = e.clientY - dragTrackTop - dragOffset;
+        if (!trackEl) return;
+        // Re-measure trackTop on every move so a viewport resize during
+        // a drag doesn't desynchronize pointer Y from track Y.
+        const trackTopAbsolute = trackEl.getBoundingClientRect().top;
+        const rawThumbTop = e.clientY - trackTopAbsolute - dragOffset;
         const clampedThumbTop = Math.max(0, Math.min(trackHeight - thumbHeight, rawThumbTop));
         onScrollTo(customScrollTopFromThumbTop(clampedThumbTop, trackHeight, thumbHeight, maxPhysical));
     }
@@ -84,9 +85,16 @@
     function onTrackPointerDown(e: PointerEvent): void {
         if (e.button !== 0) return;
         if (!trackEl) return;
-        // Page up if click is above the thumb, down if below.
         const trackTop = trackEl.getBoundingClientRect().top;
         const clickY = e.clientY - trackTop;
+        // Skip if the click landed on the thumb area. The thumb's hit
+        // target is narrower than the visual track due to its 2 px side
+        // insets, so a click 1-2 px to the side of the visual thumb at
+        // the same Y reaches *this* (track) handler — without the
+        // skip-check, that click would page instead of being a no-op as
+        // the user expects.
+        if (clickY >= thumbTop && clickY <= thumbTop + thumbHeight) return;
+        // Page up if click is above the thumb, down if below.
         const direction = clickY < thumbTop ? -1 : 1;
         onScrollTo(scrollTop + direction * trackHeight);
     }

--- a/editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte
+++ b/editors/vscode/src/data-viewer/webview/CustomScrollbar.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+    import {
+        customThumbHeight,
+        customThumbTop,
+        customScrollTopFromThumbTop,
+    } from './grid-model';
+
+    interface Props {
+        /** Pixel height of the scrollbar track (viewportHeight minus the
+         *  HORIZONTAL_GUTTER_PX bottom reservation). */
+        trackHeight: number;
+        /** Current physical scrollTop of the viewport. */
+        scrollTop: number;
+        /** Total row count in the dataset. */
+        nrow: number;
+        /** Pixel height of one row. */
+        rowHeight: number;
+        /** Maximum physical scrollTop = MAX_SCROLL_PX + rowHeight - viewportHeight. */
+        maxPhysical: number;
+        /** Callback invoked when the user's drag or click changes the
+         *  desired scrollTop. The parent should set viewportEl.scrollTop
+         *  to this value; the browser's onScroll handler does the rest. */
+        onScrollTo: (newScrollTop: number) => void;
+    }
+
+    let { trackHeight, scrollTop, nrow, rowHeight, maxPhysical, onScrollTo }: Props = $props();
+
+    let trackEl: HTMLDivElement | null = $state(null);
+
+    /** Pointer Y offset relative to thumb top at drag start. null when
+     *  not dragging. */
+    let dragOffset: number | null = $state(null);
+    /** Captured pointer id, for safe release on cleanup paths. */
+    let dragPointerId: number | null = null;
+    /** getBoundingClientRect().top of the track at drag start. Cached so
+     *  pointermove doesn't re-measure on every frame. */
+    let dragTrackTop = 0;
+
+    const thumbHeight = $derived(customThumbHeight(trackHeight, rowHeight, nrow));
+    const thumbTop = $derived(customThumbTop(scrollTop, trackHeight, thumbHeight, maxPhysical));
+
+    function onThumbPointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
+        if (!trackEl) return;
+        e.preventDefault();
+        e.stopPropagation();   // don't also trigger track-paging
+        dragPointerId = e.pointerId;
+        dragTrackTop = trackEl.getBoundingClientRect().top;
+        dragOffset = e.clientY - (dragTrackTop + thumbTop);
+        // Synthetic events from the test seam may not be eligible for
+        // capture in all browsers; real user events always succeed.
+        try {
+            (e.target as Element).setPointerCapture(e.pointerId);
+        } catch {
+            // ignore — capture is a quality-of-life win, not required
+        }
+    }
+
+    function onThumbPointerMove(e: PointerEvent): void {
+        if (dragOffset === null) return;
+        const rawThumbTop = e.clientY - dragTrackTop - dragOffset;
+        const clampedThumbTop = Math.max(0, Math.min(trackHeight - thumbHeight, rawThumbTop));
+        onScrollTo(customScrollTopFromThumbTop(clampedThumbTop, trackHeight, thumbHeight, maxPhysical));
+    }
+
+    function endDrag(e: PointerEvent): void {
+        if (dragPointerId !== null) {
+            const target = e.target as Element;
+            // hasPointerCapture guard: lostpointercapture fires *after*
+            // the browser has released, so a naive releasePointerCapture
+            // would throw.
+            try {
+                if (target.hasPointerCapture(dragPointerId)) {
+                    target.releasePointerCapture(dragPointerId);
+                }
+            } catch {
+                // ignore
+            }
+        }
+        dragOffset = null;
+        dragPointerId = null;
+    }
+
+    function onTrackPointerDown(e: PointerEvent): void {
+        if (e.button !== 0) return;
+        if (!trackEl) return;
+        // Page up if click is above the thumb, down if below.
+        const trackTop = trackEl.getBoundingClientRect().top;
+        const clickY = e.clientY - trackTop;
+        const direction = clickY < thumbTop ? -1 : 1;
+        onScrollTo(scrollTop + direction * trackHeight);
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="custom-scrollbar-track"
+    bind:this={trackEl}
+    onpointerdown={onTrackPointerDown}
+>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="custom-scrollbar-thumb"
+        class:dragging={dragOffset !== null}
+        data-test-id="custom-scrollbar-thumb"
+        style="top: {thumbTop}px; height: {thumbHeight}px;"
+        onpointerdown={onThumbPointerDown}
+        onpointermove={onThumbPointerMove}
+        onpointerup={endDrag}
+        onpointercancel={endDrag}
+        onlostpointercapture={endDrag}
+    ></div>
+</div>

--- a/editors/vscode/src/data-viewer/webview/grid-model.ts
+++ b/editors/vscode/src/data-viewer/webview/grid-model.ts
@@ -98,3 +98,79 @@ export function coalesceScroll<F extends (...args: any[]) => void>(
         }, intervalMs);
     };
 }
+
+
+// ----- Custom scrollbar math (issue #183 follow-up) ---------------------
+
+/** Minimum pixel height for the custom scrollbar thumb. Below this the
+ *  thumb is hard to click/drag. Chosen so even a 10 M-row dataset gets a
+ *  visible, draggable thumb. */
+export const MIN_THUMB_PX = 30;
+
+/** Pixel reservation at the bottom of the custom scrollbar track for the
+ *  native horizontal scrollbar, when present. The CSS rule sets the
+ *  track's `bottom: HORIZONTAL_GUTTER_PX`, and the math takes
+ *  `trackHeight = viewportHeight - HORIZONTAL_GUTTER_PX`. Sharing the
+ *  constant guarantees the math + layout agree.
+ *
+ *  Always reserved, regardless of whether the horizontal scrollbar is
+ *  actually present. The visual cost when absent is the thumb stopping
+ *  ~12 px shy of the viewport bottom (negligible). The alternative —
+ *  measuring dynamically — adds layout-thrash on every render with
+ *  little benefit. */
+export const HORIZONTAL_GUTTER_PX = 12;
+
+/** Pixel height of the custom scrollbar thumb. The thumb represents the
+ *  fraction of the dataset currently visible (visibleCount / nrow), with
+ *  a hard minimum so even a single visible row in a 10 M-row dataset
+ *  produces a draggable thumb. The minimum is itself capped at the
+ *  track height — for tiny tracks (< MIN_THUMB_PX), the thumb fills the
+ *  track rather than overflowing it.
+ *
+ *  Note `trackHeight`, not `viewportHeight`: the track is shorter than
+ *  the viewport by HORIZONTAL_GUTTER_PX (see above). */
+export function customThumbHeight(
+    trackHeight: number,
+    rowHeight: number,
+    nrow: number,
+): number {
+    if (trackHeight <= 0) return 0;
+    if (nrow <= 0 || rowHeight <= 0) return trackHeight;
+    const visibleCount = Math.max(1, Math.ceil(trackHeight / rowHeight));
+    if (visibleCount >= nrow) return trackHeight;
+    const proportional = trackHeight * (visibleCount / nrow);
+    return Math.min(trackHeight, Math.max(MIN_THUMB_PX, proportional));
+}
+
+/** Pixel offset of the thumb's top from the top of the track. Track
+ *  height is `viewportHeight - HORIZONTAL_GUTTER_PX`; the thumb's top
+ *  can range from 0 to (trackHeight - thumbHeight). The mapping is
+ *  linear in the *physical* scrollTop so the thumb tracks user
+ *  scrolling exactly. */
+export function customThumbTop(
+    scrollTop: number,
+    trackHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
+    if (maxPhysical <= 0 || trackUsable <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, scrollTop / maxPhysical));
+    return fraction * trackUsable;
+}
+
+/** Convert a thumb-top pixel offset (during a drag) back to the physical
+ *  scrollTop the viewport needs. Inverse of customThumbTop. The caller
+ *  sets viewportEl.scrollTop = result; the existing onScroll →
+ *  scheduleFetchVisible pipeline does the rest. */
+export function customScrollTopFromThumbTop(
+    thumbTop: number,
+    trackHeight: number,
+    thumbHeight: number,
+    maxPhysical: number,
+): number {
+    const trackUsable = Math.max(0, trackHeight - thumbHeight);
+    if (trackUsable <= 0 || maxPhysical <= 0) return 0;
+    const fraction = Math.max(0, Math.min(1, thumbTop / trackUsable));
+    return fraction * maxPhysical;
+}

--- a/editors/vscode/src/data-viewer/webview/grid-model.ts
+++ b/editors/vscode/src/data-viewer/webview/grid-model.ts
@@ -14,23 +14,34 @@ export function cappedScrollHeight(totalGridHeight: number): number {
 }
 
 /** Map a physical scrollTop (in the capped container) to the logical
- *  scrollTop that visibleRange() expects. Identity when content fits.
+ *  scrollTop that visibleRange() expects. Identity-shaped when content fits.
  *
  *  The physical scroll range is [0, MAX_SCROLL_PX + rowHeight - viewportHeight]
  *  and the logical scroll range is [0, totalGridHeight + rowHeight - viewportHeight],
  *  so we scale between those two maxima (not between MAX_SCROLL_PX and
- *  totalGridHeight) to reach the very last row when scrolled to the bottom. */
+ *  totalGridHeight) to reach the very last row when scrolled to the bottom.
+ *
+ *  Both branches clamp to [0, maxLogical]. macOS rubber-band can briefly
+ *  push scrollTop above maxPhysical; without the clamp the scaled value
+ *  exceeds maxLogical, visibleRange's floor() math gives start > nrow,
+ *  and the resulting empty range blanks the grid until the bounce
+ *  resolves. The negative clamp is defensive against hypothetical
+ *  Chromium oddities; in practice scrollTop should never be negative. */
 export function logicalScrollTop(
     scrollTop: number,
     totalGridHeight: number,
     viewportHeight: number,
     rowHeight: number,
 ): number {
-    if (totalGridHeight <= MAX_SCROLL_PX) return scrollTop;
+    if (totalGridHeight <= MAX_SCROLL_PX) {
+        const maxLogicalSmall = Math.max(0, totalGridHeight + rowHeight - viewportHeight);
+        return Math.max(0, Math.min(maxLogicalSmall, scrollTop));
+    }
     const maxPhysical = MAX_SCROLL_PX + rowHeight - viewportHeight;
     if (maxPhysical <= 0) return 0;
     const maxLogical = totalGridHeight + rowHeight - viewportHeight;
-    return (scrollTop / maxPhysical) * maxLogical;
+    const scaled = (scrollTop / maxPhysical) * maxLogical;
+    return Math.max(0, Math.min(maxLogical, scaled));
 }
 
 /** Map a logical pixel offset (visibleRangeStart × rowHeight) back to a

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -376,3 +376,71 @@ html, body, #root {
     color: var(--vscode-menu-selectionForeground, var(--vscode-list-activeSelectionForeground, #fff));
     outline: none;
 }
+
+
+/* ---------- Custom scrollbar (issue #183) ----------
+ * Engaged only when totalGridHeight > MAX_SCROLL_PX, via the
+ * `using-custom-scrollbar` class on `.viewport`. Below the cap we leave
+ * the native scrollbar alone. */
+
+.viewport-wrapper {
+    /* Wraps the viewport so the custom scrollbar overlay (sibling, not
+     * descendant) is laid out in the wrapper's coordinate space rather
+     * than the viewport's scroll-content coordinate space. min-height:
+     * 0 + min-width: 0 are required so flex shrink-to-fit allows the
+     * inner viewport to scroll its own content rather than growing the
+     * wrapper to the inner grid's intrinsic height. */
+    position: relative;
+    flex: 1 1 auto;
+    display: flex;
+    min-height: 0;
+    min-width: 0;
+}
+.viewport-wrapper > .viewport {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+}
+
+.viewport.using-custom-scrollbar {
+    /* Reserve a 12 px lane for the overlay so grid content doesn't
+     * extend under it. Without this, hiding the native scrollbar via
+     * ::-webkit-scrollbar:vertical { display: none } collapses the
+     * gutter and the rightmost cells/resize handles are obscured. */
+    padding-right: 12px;
+}
+
+.viewport.using-custom-scrollbar::-webkit-scrollbar:vertical {
+    display: none;
+}
+
+.custom-scrollbar-track {
+    position: absolute;
+    right: 0;
+    top: 0;
+    /* HORIZONTAL_GUTTER_PX = 12 px reserved at the bottom for the native
+     * horizontal scrollbar when present. The math layer takes
+     * trackHeight = viewportHeight - 12 to match (see grid-model.ts). */
+    bottom: 12px;
+    width: 12px;
+    background: transparent;
+    z-index: 3;  /* above sticky header (z-index: 2) */
+    user-select: none;
+}
+
+.custom-scrollbar-thumb {
+    position: absolute;
+    left: 2px;
+    right: 2px;
+    background: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+    border-radius: 4px;
+    cursor: default;
+}
+
+.custom-scrollbar-thumb:hover {
+    background: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
+}
+
+.custom-scrollbar-thumb.dragging {
+    background: var(--vscode-scrollbarSlider-activeBackground, rgba(191, 191, 191, 0.4));
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -134,6 +134,16 @@ export interface RavenExtensionApi {
     getDataViewerPanelNames(): string[];
     /** Column names for a named data viewer panel. Used by integration tests. */
     getDataViewerPanelColumnNames(panelName: string): string[] | undefined;
+    /** Latest visible-row range for a data viewer panel, or undefined if
+     *  none has arrived yet. Used by integration tests to verify scroll
+     *  position. */
+    getDataViewerPanelVisibleRange(panelName: string):
+        { start: number; end: number } | undefined;
+    /** Test-only: dispatch a synthetic key event in a data viewer panel.
+     *  Used by integration tests to drive End / Home / PageDown / PageUp.
+     *  Awaiting waits for the message to be queued; poll
+     *  getDataViewerPanelVisibleRange to observe the result. */
+    pressDataViewerKey(panelName: string, key: string): Promise<void>;
     /**
      * Test-only: forget the bundled extension's cached R terminal so the next
      * `sendToRTerminal` recreates it through the real `createTerminal` path.
@@ -394,6 +404,11 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         getDataViewerPanelNames: () => data_viewer_manager?.getPanelNames() ?? [],
         getDataViewerPanelColumnNames: (panelName: string) =>
             data_viewer_manager?.getPanelColumnNames(panelName),
+        getDataViewerPanelVisibleRange: (panelName: string) =>
+            data_viewer_manager?.getPanelVisibleRange(panelName),
+        pressDataViewerKey: async (panelName: string, key: string) => {
+            await data_viewer_manager?.pressKeyOnPanel(panelName, key);
+        },
         _disposeCachedRTerminalForTest: () => _dispose_cached_r_terminal_for_test(),
     };
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -144,6 +144,12 @@ export interface RavenExtensionApi {
      *  Awaiting waits for the message to be queued; poll
      *  getDataViewerPanelVisibleRange to observe the result. */
     pressDataViewerKey(panelName: string, key: string): Promise<void>;
+    /** Test-only: drive a custom-scrollbar drag in a data viewer panel.
+     *  fraction=0 jumps to top, fraction=1 jumps to bottom. Used by
+     *  integration tests to exercise the drag math + scroll pipeline.
+     *  Awaiting waits for the message to be queued; poll
+     *  getDataViewerPanelVisibleRange to observe the result. */
+    dragDataViewerScrollbar(panelName: string, fraction: number): Promise<void>;
     /**
      * Test-only: forget the bundled extension's cached R terminal so the next
      * `sendToRTerminal` recreates it through the real `createTerminal` path.
@@ -408,6 +414,9 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
             data_viewer_manager?.getPanelVisibleRange(panelName),
         pressDataViewerKey: async (panelName: string, key: string) => {
             await data_viewer_manager?.pressKeyOnPanel(panelName, key);
+        },
+        dragDataViewerScrollbar: async (panelName: string, fraction: number) => {
+            await data_viewer_manager?.dragScrollbarOnPanel(panelName, fraction);
         },
         _disposeCachedRTerminalForTest: () => _dispose_cached_r_terminal_for_test(),
     };

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -229,4 +229,78 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
             `End key did not reach the last row within 60 s; `
             + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
     });
+
+    test('Drag scrollbar to bottom reaches last row in 700K-row data frame', async function () {
+        // R startup + 700K rnorm + arrow write + scroll round-trip can
+        // run up against the suite's 120 s default when earlier suites
+        // have put the runner under load.
+        this.timeout(240000);
+        const N = 700_000;
+
+        // Reuse the panel from the End-key test if still open;
+        // otherwise the prior test created and left it in place.
+        if (!api.getDataViewerPanelNames().includes('big')) {
+            await api.sendToRTerminal(
+                `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+                + `nrow = ${N}, ncol = 5)); View(big)`,
+            );
+            const appeared = await pollForPanel(api, 'big', 90000);
+            assert.ok(appeared, 'panel "big" did not appear within 90 s');
+        }
+
+        // Reset to top, wait for steady state.
+        await api.pressDataViewerKey('big', 'Home');
+        const topRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+        }, 60000);
+        assert.ok(topRange,
+            `pre-drag Home reset did not land at the top within 60 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+
+        // Drag the scrollbar thumb to the bottom.
+        await api.dragDataViewerScrollbar('big', 1.0);
+
+        const bottomRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end === N ? r : undefined;
+        }, 60000);
+        assert.ok(bottomRange,
+            `Drag-to-bottom did not reach the last row within 60 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+    });
+
+    test('Drag scrollbar to 50% lands near row N/2 in 700K-row data frame', async function () {
+        this.timeout(240000);
+        const N = 700_000;
+
+        if (!api.getDataViewerPanelNames().includes('big')) {
+            await api.sendToRTerminal(
+                `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+                + `nrow = ${N}, ncol = 5)); View(big)`,
+            );
+            const appeared = await pollForPanel(api, 'big', 90000);
+            assert.ok(appeared, 'panel "big" did not appear within 90 s');
+        }
+
+        await api.pressDataViewerKey('big', 'Home');
+        const topRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+        }, 60000);
+        assert.ok(topRange);
+
+        await api.dragDataViewerScrollbar('big', 0.5);
+
+        const midRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            if (!r) return undefined;
+            // Allow a generous 10 % band around N/2 — the exact value
+            // depends on thumb-height / track-usable arithmetic.
+            return r.start >= 0.40 * N && r.start <= 0.60 * N ? r : undefined;
+        }, 60000);
+        assert.ok(midRange,
+            `Drag-to-50% did not land near N/2 within 60 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+    });
 });

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -193,12 +193,17 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         const panelAppeared = await pollForPanel(api, 'big', 90000);
         assert.ok(panelAppeared, 'panel "big" did not appear within 90 s');
 
-        // Reset scroll to the top. A previous --watch run could have left
-        // the same-shape panel scrolled to the bottom; applyInitOrReplace's
-        // sameDataset branch intentionally preserves visibleRangeStart, so
-        // an unconditional 'end < N/2' gate would deadlock on that.
-        // Press Home as a deterministic reset (this also exercises Home
-        // as a bonus side check).
+        // Reset scroll to the top before the End test. A previous --watch
+        // run could have left the same-shape panel scrolled to the bottom;
+        // applyInitOrReplace's sameDataset branch intentionally preserves
+        // visibleRangeStart, so an unconditional 'end < N/2' gate would
+        // deadlock on that. Pressing Home first makes the readiness gate
+        // robust regardless of prior state.
+        //
+        // Note: this is NOT a positive test for Home — a fresh panel's
+        // initial fetch lands at the top regardless of whether Home does
+        // anything, so the gate below is satisfied either way. It's
+        // strictly a deterministic-reset step for the End test.
         await api.pressDataViewerKey('big', 'Home');
 
         // Wait for the Home reset to land AND rows for the top of the

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -31,6 +31,25 @@ async function pollForPanel(
     return false;
 }
 
+/** Poll a predicate at 100 ms intervals until it returns a truthy value or
+ *  the deadline elapses. Returns the truthy value on success or `undefined`
+ *  on timeout (caller asserts). */
+async function pollFor<T>(
+    predicate: () => T | undefined,
+    timeoutMs: number,
+    intervalMs = 100,
+): Promise<T | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const value = predicate();
+        if (value !== undefined && value !== null && value !== false) {
+            return value as T;
+        }
+        await sleep(intervalMs);
+    }
+    return undefined;
+}
+
 suite('data-viewer smoke tests', function (this: Mocha.Suite) {
     // Each test may need to wait for R startup + arrow write + HTTP round-trip.
     this.timeout(120000);
@@ -150,5 +169,52 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
             after.includes('mtcars'),
             `"mtcars" panel must still be open after replace; panels: ${JSON.stringify(after)}`,
         );
+    });
+
+    test('End key reaches the last row in a 700K-row data frame', async function () {
+        // Smallest size that engages the cap (700_000 × 24 = 16.8 M >
+        // MAX_SCROLL_PX of 15 M) — exactly the failure mode from #183.
+        const N = 700_000;
+
+        await api.sendToRTerminal(
+            `big <- as.data.frame(matrix(rnorm(${N} * 5), `
+            + `nrow = ${N}, ncol = 5)); View(big)`,
+        );
+
+        // Wait for the panel to exist. R startup + matrix rnorm + Arrow
+        // write can take several seconds on a cold runner.
+        const panelAppeared = await pollForPanel(api, 'big', 60000);
+        assert.ok(panelAppeared, 'panel "big" did not appear within 60 s');
+
+        // Reset scroll to the top. A previous --watch run could have left
+        // the same-shape panel scrolled to the bottom; applyInitOrReplace's
+        // sameDataset branch intentionally preserves visibleRangeStart, so
+        // an unconditional 'end < N/2' gate would deadlock on that.
+        // Press Home as a deterministic reset (this also exercises Home
+        // as a bonus side check).
+        await api.pressDataViewerKey('big', 'Home');
+
+        // Wait for the Home reset to land AND rows for the top of the
+        // grid to be fetched. A mount/init lifecycle reports
+        // {start: 0, end: 0}, which would satisfy 'end < N/2' alone — so
+        // require end > 0 too.
+        const topRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end > 0 && r.end < N / 2 ? r : undefined;
+        }, 30000);
+        assert.ok(topRange,
+            `Home reset did not land at the top within 30 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
+
+        // Drive End and wait for the bottom-row fetch to land.
+        await api.pressDataViewerKey('big', 'End');
+
+        const bottomRange = await pollFor(() => {
+            const r = api.getDataViewerPanelVisibleRange('big');
+            return r && r.end === N ? r : undefined;
+        }, 30000);
+        assert.ok(bottomRange,
+            `End key did not reach the last row within 30 s; `
+            + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
     });
 });

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -172,6 +172,12 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
     });
 
     test('End key reaches the last row in a 700K-row data frame', async function () {
+        // R startup + 700K rnorm + arrow write + scroll round-trip can run
+        // up against the suite's 120 s default when earlier suites have put
+        // the runner under load. Give this test its own larger budget so
+        // it isn't flaky on slow CI runners.
+        this.timeout(240000);
+
         // Smallest size that engages the cap (700_000 × 24 = 16.8 M >
         // MAX_SCROLL_PX of 15 M) — exactly the failure mode from #183.
         const N = 700_000;
@@ -182,9 +188,10 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         );
 
         // Wait for the panel to exist. R startup + matrix rnorm + Arrow
-        // write can take several seconds on a cold runner.
-        const panelAppeared = await pollForPanel(api, 'big', 60000);
-        assert.ok(panelAppeared, 'panel "big" did not appear within 60 s');
+        // write can take several seconds on a cold runner; allow extra
+        // headroom for slow CI.
+        const panelAppeared = await pollForPanel(api, 'big', 90000);
+        assert.ok(panelAppeared, 'panel "big" did not appear within 90 s');
 
         // Reset scroll to the top. A previous --watch run could have left
         // the same-shape panel scrolled to the bottom; applyInitOrReplace's
@@ -201,9 +208,9 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         const topRange = await pollFor(() => {
             const r = api.getDataViewerPanelVisibleRange('big');
             return r && r.end > 0 && r.end < N / 2 ? r : undefined;
-        }, 30000);
+        }, 60000);
         assert.ok(topRange,
-            `Home reset did not land at the top within 30 s; `
+            `Home reset did not land at the top within 60 s; `
             + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
 
         // Drive End and wait for the bottom-row fetch to land.
@@ -212,9 +219,9 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
         const bottomRange = await pollFor(() => {
             const r = api.getDataViewerPanelVisibleRange('big');
             return r && r.end === N ? r : undefined;
-        }, 30000);
+        }, 60000);
         assert.ok(bottomRange,
-            `End key did not reach the last row within 30 s; `
+            `End key did not reach the last row within 60 s; `
             + `last range: ${JSON.stringify(api.getDataViewerPanelVisibleRange('big'))}`);
     });
 });

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -42,7 +42,7 @@ async function pollFor<T>(
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         const value = predicate();
-        if (value !== undefined && value !== null && value !== false) {
+        if (value) {
             return value as T;
         }
         await sleep(intervalMs);

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -133,6 +133,15 @@ describe('scroll height capping', () => {
         expect(logicalScrollTop(-50, SMALL, VH, RH)).toBe(0);
     });
 
+    test('logicalScrollTop: clamps positive overshoot in small data to maxLogicalSmall', () => {
+        // The small-data branch also clamps overshoot. macOS rubber-band
+        // can briefly push scrollTop above maxLogicalSmall; without the
+        // clamp, visibleRange would read past the end of the dataset.
+        const maxLogicalSmall = SMALL + RH - VH;
+        expect(logicalScrollTop(maxLogicalSmall * 1.1, SMALL, VH, RH))
+            .toBe(maxLogicalSmall);
+    });
+
     test('visibleRange after clamped overshoot still includes the last row', () => {
         const nrow = 10_000_000;
         const totalGridHeight = nrow * RH;

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -6,6 +6,11 @@ import {
     cappedScrollHeight,
     logicalScrollTop,
     visualOffsetPx,
+    MIN_THUMB_PX,
+    HORIZONTAL_GUTTER_PX,
+    customThumbHeight,
+    customThumbTop,
+    customScrollTopFromThumbTop,
 } from '../../editors/vscode/src/data-viewer/webview/grid-model';
 import { RowCache } from '../../editors/vscode/src/data-viewer/webview/row-cache';
 import { Selection } from '../../editors/vscode/src/data-viewer/webview/selection-model';
@@ -315,5 +320,91 @@ describe('formatCell', () => {
     test('truncated cell shows truncation indicator', () => {
         expect(formatCell({ _: 'trunc', v: 'long…' }, undefined, undefined, false, false, 3))
             .toEqual({ text: 'long…', missing: false });
+    });
+});
+
+describe('custom scrollbar math', () => {
+    const VH = 600;
+    const RH = 24;
+    const TRACK = VH - HORIZONTAL_GUTTER_PX;  // 588
+
+    test('customThumbHeight: tiny dataset → full track', () => {
+        // 5 rows fit in the track many times over → thumb fills track.
+        expect(customThumbHeight(TRACK, RH, 5)).toBe(TRACK);
+    });
+    test('customThumbHeight: large dataset → MIN_THUMB_PX floor', () => {
+        // 10M rows on 600 px viewport: proportional thumb ≈ 0.0015 px.
+        // Clamped up to MIN_THUMB_PX.
+        expect(customThumbHeight(TRACK, RH, 10_000_000)).toBe(MIN_THUMB_PX);
+    });
+    test('customThumbHeight: mid-size proportional', () => {
+        // 100 rows: visibleCount = ceil(588/24) = 25.
+        // proportional = 588 * (25/100) = 147. Above MIN_THUMB.
+        expect(customThumbHeight(TRACK, RH, 100)).toBeCloseTo(147);
+    });
+    test('customThumbHeight: nrow === 0 → full track', () => {
+        expect(customThumbHeight(TRACK, RH, 0)).toBe(TRACK);
+    });
+    test('customThumbHeight: rowHeight === 0 → full track', () => {
+        expect(customThumbHeight(TRACK, 0, 1000)).toBe(TRACK);
+    });
+    test('customThumbHeight: trackHeight === 0 → 0', () => {
+        expect(customThumbHeight(0, RH, 1000)).toBe(0);
+    });
+    test('customThumbHeight: trackHeight < MIN_THUMB_PX → trackHeight', () => {
+        // 20-px track gets a 20-px thumb, not a 30-px overflowing one.
+        expect(customThumbHeight(20, RH, 10_000_000)).toBe(20);
+    });
+
+    test('customThumbTop: scrollTop=0 → 0', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        expect(customThumbTop(0, TRACK, th, 14_999_424)).toBe(0);
+    });
+    test('customThumbTop: scrollTop=maxPhysical → trackHeight - thumbHeight', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        expect(customThumbTop(maxPhysical, TRACK, th, maxPhysical))
+            .toBeCloseTo(TRACK - th);
+    });
+    test('customThumbTop: midpoint → midpoint', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        expect(customThumbTop(maxPhysical / 2, TRACK, th, maxPhysical))
+            .toBeCloseTo((TRACK - th) / 2);
+    });
+    test('customThumbTop: maxPhysical <= 0 → 0', () => {
+        expect(customThumbTop(100, TRACK, MIN_THUMB_PX, 0)).toBe(0);
+        expect(customThumbTop(100, TRACK, MIN_THUMB_PX, -10)).toBe(0);
+    });
+    test('customThumbTop: thumbHeight >= trackHeight → 0', () => {
+        // Whole track is thumb; nothing to scroll.
+        expect(customThumbTop(100, TRACK, TRACK, 14_999_424)).toBe(0);
+    });
+
+    test('customScrollTopFromThumbTop: thumbTop=0 → 0', () => {
+        expect(customScrollTopFromThumbTop(0, TRACK, MIN_THUMB_PX, 14_999_424))
+            .toBe(0);
+    });
+    test('customScrollTopFromThumbTop: thumbTop=trackUsable → maxPhysical', () => {
+        const th = MIN_THUMB_PX;
+        const maxPhysical = 14_999_424;
+        expect(customScrollTopFromThumbTop(TRACK - th, TRACK, th, maxPhysical))
+            .toBeCloseTo(maxPhysical);
+    });
+    test('customScrollTopFromThumbTop: round-trip with customThumbTop', () => {
+        const th = customThumbHeight(TRACK, RH, 10_000_000);
+        const maxPhysical = 14_999_424;
+        for (const scrollTop of [0, 1234, maxPhysical / 3, maxPhysical / 2,
+                                 maxPhysical * 0.99, maxPhysical]) {
+            const top = customThumbTop(scrollTop, TRACK, th, maxPhysical);
+            const back = customScrollTopFromThumbTop(top, TRACK, th, maxPhysical);
+            expect(back).toBeCloseTo(scrollTop);
+        }
+    });
+    test('customScrollTopFromThumbTop: maxPhysical <= 0 → 0', () => {
+        expect(customScrollTopFromThumbTop(100, TRACK, MIN_THUMB_PX, 0)).toBe(0);
+    });
+    test('customScrollTopFromThumbTop: trackUsable <= 0 → 0', () => {
+        expect(customScrollTopFromThumbTop(100, TRACK, TRACK, 14_999_424)).toBe(0);
     });
 });

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -112,6 +112,42 @@ describe('scroll height capping', () => {
         });
         expect(range.end).toBe(nrow);
     });
+
+    test('logicalScrollTop: clamps overshoot above maxPhysical to maxLogical (large)', () => {
+        // macOS rubber-band can briefly push scrollTop above maxPhysical.
+        // Without the clamp, the scaled value exceeds maxLogical and
+        // visibleRange would return an empty window.
+        expect(logicalScrollTop(maxPhysical * 1.1, LARGE, VH, RH))
+            .toBe(maxLogicalLarge);
+    });
+
+    test('logicalScrollTop: clamps negative scrollTop to 0 (large)', () => {
+        // Defensive: Chromium shouldn't report negative scrollTop, but the
+        // clamp removes the assumption.
+        expect(logicalScrollTop(-50, LARGE, VH, RH)).toBe(0);
+    });
+
+    test('logicalScrollTop: clamps negative scrollTop to 0 (small)', () => {
+        // The small-data fast path also clamps now, so a stray negative
+        // scrollTop never propagates to visibleRange's floor() math.
+        expect(logicalScrollTop(-50, SMALL, VH, RH)).toBe(0);
+    });
+
+    test('visibleRange after clamped overshoot still includes the last row', () => {
+        const nrow = 10_000_000;
+        const totalGridHeight = nrow * RH;
+        // Simulate rubber-band overshoot: scrollTop 10% past maxPhysical.
+        const logical = logicalScrollTop(maxPhysical * 1.1, totalGridHeight, VH, RH);
+        const range = visibleRange({
+            scrollTop: logical, viewportHeight: VH,
+            rowHeight: RH, nrow, overscan: 8,
+        });
+        // Without the clamp, logical exceeds maxLogical, range.start exceeds
+        // nrow, and range.end (clamped at nrow) ends up < range.start — an
+        // empty window that blanks the grid. The clamp keeps start < end.
+        expect(range.start).toBeLessThan(range.end);
+        expect(range.end).toBe(nrow);
+    });
 });
 
 describe('coalesceScroll', () => {


### PR DESCRIPTION
- **docs(spec): data viewer scroll-to-last-row design (#183)**
- **docs(spec): address codex adversarial review pass on scroll-to-bottom design**
- **docs(spec): address codex pass 2 — readiness gate, diagram, shift-key example**
- **docs(spec): address codex pass 3 — Home readiness needs end > 0 too**
- **docs(plan): data viewer scroll-to-last-row implementation plan (#183)**
- **fix(data-viewer): clamp logicalScrollTop to [0, maxLogical] (#183)**
- **feat(data-viewer): add test-only protocol for driving keys + reading visible range**
- **feat(data-viewer): expose visible range + key dispatch on test API**
- **feat(data-viewer): add Home/End/PageDown/PageUp keyboard shortcuts (#183)**
- **docs(data-viewer): document Home/End/PageUp/PageDown shortcuts (#183)**
- **test(data-viewer): increase timeouts for End-key test (#183)**
- **fix(data-viewer): address codex review pass 5 (#183)**
- **docs(spec): custom scrollbar for large data frames (#183 follow-up)**
- **docs(spec): address codex pass 1 on custom-scrollbar design**
- **docs(spec): address codex pass 2 on custom-scrollbar design**
- **docs(spec): bun test labels use trackHeight (codex pass 3 polish)**
- **docs(plan): custom scrollbar implementation plan (#183)**
- **feat(data-viewer): add custom-scrollbar math (#183)**
- **feat(data-viewer): custom scrollbar overlay for huge frames (#183)**
- **feat(data-viewer): test-only scrollbar drag protocol (#183)**
- **test(data-viewer): drag-scrollbar integration tests (#183)**
- **docs(data-viewer): note custom scrollbar overlay on huge frames (#183)**
- **fix(data-viewer): address codex review on custom-scrollbar (#183)**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom vertical scrollbar overlay for navigating large datasets with millions of rows.
  * Keyboard shortcuts (Home/End/PageUp/PageDown) for scrolling within the data viewer.
  * Improved scrollbar dragging behavior for reaching any position in large datasets.

* **Documentation**
  * Added keyboard shortcuts reference guide.
  * Updated data viewer documentation for handling large datasets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #183 