### PR TITLE
feat(diagnostics): semantic warnings + improved syntax error messages

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -303,6 +303,20 @@ pub(crate) fn parse_cross_file_config(
         {
             config.undefined_variable_severity = parse_severity(sev);
         }
+        // Parse diagnostics.mixedLogicalSeverity
+        if let Some(sev) = diag
+            .get("mixedLogicalSeverity")
+            .and_then(|v| v.as_str())
+        {
+            config.mixed_logical_severity = parse_severity(sev);
+        }
+        // Parse diagnostics.conditionAssignmentSeverity
+        if let Some(sev) = diag
+            .get("conditionAssignmentSeverity")
+            .and_then(|v| v.as_str())
+        {
+            config.condition_assignment_severity = parse_severity(sev);
+        }
     }
 
     // Parse package settings (Requirement 12, Task 14.2)

--- a/crates/raven/src/config_file/toml_loader.rs
+++ b/crates/raven/src/config_file/toml_loader.rs
@@ -93,7 +93,8 @@ const KNOWN_LINTING_KEYS: &[&str] = &[
     "trailingBlankLinesSeverity", "assignmentOperatorSeverity", "objectNameSeverity",
     "infixSpacesSeverity", "commentedCodeSeverity", "quotesSeverity", "commasSeverity",
     "tAndFSymbolSeverity", "semicolonSeverity", "equalsNaSeverity", "objectLengthSeverity",
-    "vectorLogicSeverity", "functionLeftParenthesesSeverity", "spacesInsideSeverity",
+    "vectorLogicSeverity",
+    "functionLeftParenthesesSeverity", "spacesInsideSeverity",
     "indentationSeverity", "overrides",
 ];
 

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -91,6 +91,18 @@ pub struct CrossFileConfig {
     /// same file as earlier source() call)
     /// _Requirements: 6.2_
     pub redundant_directive_severity: Option<DiagnosticSeverity>,
+    /// Severity for the mixed-logical rule. `None` disables the rule.
+    ///
+    /// Flags `|` / `||` binary operators whose immediate operand is a bare
+    /// `&` / `&&` (no parentheses), e.g. `a & b | c`. Stops at call/subset
+    /// boundaries so vectorized data-mask patterns are not flagged.
+    pub mixed_logical_severity: Option<DiagnosticSeverity>,
+    /// Severity for the condition-assignment rule. `None` disables the rule.
+    ///
+    /// Flags `=` used as a binary operator directly inside an `if` or `while`
+    /// condition. R rejects `if (x = 1)` as a syntax error at runtime;
+    /// tree-sitter-r accepts it silently.
+    pub condition_assignment_severity: Option<DiagnosticSeverity>,
     /// Maximum entries in the metadata cache (LRU eviction)
     pub cache_metadata_max_entries: usize,
     /// Maximum entries in the file content cache (LRU eviction)
@@ -173,6 +185,8 @@ impl Default for CrossFileConfig {
             packages_watch_library_paths: true,
             packages_watch_debounce_ms: 500,
             redundant_directive_severity: Some(DiagnosticSeverity::HINT),
+            mixed_logical_severity: Some(DiagnosticSeverity::WARNING),
+            condition_assignment_severity: Some(DiagnosticSeverity::WARNING),
             cache_metadata_max_entries: 1000,
             cache_file_content_max_entries: 500,
             cache_existence_max_entries: 2000,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -369,6 +369,15 @@ pub(crate) fn diagnostics_from_snapshot(
         &mut diagnostics,
     );
 
+    // Semantic checks: always-on rules that flag likely-wrong code regardless
+    // of the style-lint master switch.
+    diagnostics.extend(crate::linting::run_semantic_checks(
+        &snapshot.text,
+        snapshot.tree.root_node(),
+        snapshot.cross_file_config.mixed_logical_severity,
+        snapshot.cross_file_config.condition_assignment_severity,
+    ));
+
     // Style/lint diagnostics. Native Rust rules driven by `lint_config`; no R
     // subprocess. `run_lints` short-circuits when the master switch is off.
     diagnostics.extend(crate::linting::run_lints(
@@ -6113,11 +6122,7 @@ fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnosti
     use crate::cross_file::types::byte_offset_to_utf16_column;
 
     if node.is_error() {
-        let message = if has_unclosed_quote_child(node) {
-            "Unclosed string literal".to_string()
-        } else {
-            "Syntax error".to_string()
-        };
+        let message = classify_error(node, text);
         diagnostics.push(Diagnostic {
             range: minimize_error_range(node, text),
             severity: Some(DiagnosticSeverity::ERROR),
@@ -6175,6 +6180,95 @@ fn has_unclosed_quote_child(node: Node) -> bool {
         }
     }
     false
+}
+
+/// Classify an ERROR node into a specific, actionable message where possible,
+/// falling back to the generic "Syntax error" for unrecognised patterns.
+///
+/// Checks (in priority order):
+/// 1. Unclosed string literal — lone `"` / `'` as a direct child.
+/// 2. Consecutive pipe — only meaningful child is `|>` / `%>%`.
+/// 3. Mismatched bracket — opens with `(`, `[`, or `[[` but closes with a
+///    non-matching bracket (detected through a nested ERROR child).
+fn classify_error(node: Node, text: &str) -> String {
+    if has_unclosed_quote_child(node) {
+        return "Unclosed string literal".to_string();
+    }
+    if let Some(msg) = detect_consecutive_pipe(node, text) {
+        return msg;
+    }
+    if let Some(msg) = detect_mismatched_bracket(node, text) {
+        return msg;
+    }
+    "Syntax error".to_string()
+}
+
+/// Returns a diagnostic message if `node` is an ERROR whose only non-trivial
+/// direct child is a pipe operator (`|>`, `%>%`, or `%|>%`). This pattern
+/// arises from code like `x |> |> y` where a second pipe appears where an
+/// expression is expected.
+fn detect_consecutive_pipe(node: Node, text: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    // Collect direct children, skipping anonymous whitespace/comment tokens
+    // that tree-sitter may inject.
+    let named_children: Vec<_> = node
+        .children(&mut cursor)
+        .filter(|n| !n.is_extra())
+        .collect();
+    if named_children.len() == 1 {
+        let child = &named_children[0];
+        let child_text = text.get(child.start_byte()..child.end_byte()).unwrap_or("");
+        if matches!(child_text, "|>" | "%>%" | "%|>%") {
+            return Some(format!(
+                "Consecutive pipe `{child_text}`: expected an expression before this operator."
+            ));
+        }
+    }
+    None
+}
+
+/// Returns a diagnostic message if `node` is an ERROR that opens with a
+/// bracket (`(`, `[`, `[[`) and contains a nested ERROR child that is a
+/// non-matching closing bracket. Catches patterns like `c(1, 2]` where the
+/// programmer used the wrong closing delimiter.
+fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    let children: Vec<_> = node.children(&mut cursor).collect();
+
+    // Find the first bracket-opener among direct children.
+    let opener = children.iter().find_map(|n| {
+        let t = text.get(n.start_byte()..n.end_byte()).unwrap_or("");
+        if matches!(t, "(" | "[" | "[[") {
+            Some(t)
+        } else {
+            None
+        }
+    })?;
+
+    let expected_closer = match opener {
+        "(" => ")",
+        "[" => "]",
+        "[[" => "]]",
+        _ => return None,
+    };
+
+    // Look for a wrong closer token inside a nested ERROR child.
+    for child in &children {
+        if !child.is_error() {
+            continue;
+        }
+        let child_text = text
+            .get(child.start_byte()..child.end_byte())
+            .unwrap_or("")
+            .trim();
+        if matches!(child_text, ")" | "]" | "]]") && child_text != expected_closer {
+            return Some(format!(
+                "Mismatched brackets: `{opener}` opened here; \
+                 close with `{expected_closer}` not `{child_text}`."
+            ));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -6913,6 +7007,50 @@ mod syntax_error_range_tests {
                 .iter()
                 .any(|d| d.message == "Syntax error" || d.message.starts_with("Missing")),
             "should produce a syntax/missing diagnostic, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    // ========================================================================
+    // Specific-message tests for classify_error patterns
+    // ========================================================================
+
+    #[test]
+    fn consecutive_pipe_emits_descriptive_message() {
+        // `x |> |> y` — a second pipe where an expression is expected.
+        let code = "x |> |> y";
+        let diags = collect(code);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("Consecutive pipe")),
+            "should emit 'Consecutive pipe' message, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn mismatched_bracket_emits_descriptive_message() {
+        // `c(1, 2]` — opened with `(` but closed with `]`.
+        let code = "c(1, 2]";
+        let diags = collect(code);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("Mismatched brackets")),
+            "should emit 'Mismatched brackets' message, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn well_matched_brackets_no_mismatch_message() {
+        // `c(1, 2)` — correctly matched, no diagnostic expected.
+        let code = "c(1, 2)";
+        let diags = collect(code);
+        assert!(
+            diags.is_empty(),
+            "well-matched brackets should produce no diagnostics, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
@@ -43367,3 +43505,4 @@ mod issue_149_utf16_handlers {
         assert_eq!(parsed, vec!["`weird name`".to_string(), "pkg".to_string()]);
     }
 }
+

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8368,6 +8368,58 @@ mod invalid_assignment_target_tests {
     }
 }
 
+/// Regression guard: semantic-warning rules must fire through `diagnostics_from_snapshot`
+/// even when the style-lint master switch (`LintConfig::enabled`) is off.
+///
+/// These rules live in the always-on diagnostic pipeline (`CrossFileConfig`), not in the
+/// opt-in lint pipeline (`LintConfig`). A future refactor that accidentally moved them
+/// behind `run_lints` would silently suppress them for any user with linting disabled.
+#[cfg(test)]
+mod semantic_warning_pipeline_tests {
+    use super::{diagnostics_from_snapshot, DiagCancelToken, DiagnosticsSnapshot};
+    use crate::linting::LintConfig;
+    use crate::state::{Document, WorldState};
+    use tower_lsp::lsp_types::Url;
+
+    fn build_snapshot_with_lint_disabled(code: &str) -> (DiagnosticsSnapshot, Url) {
+        let uri = Url::parse("file:///test.R").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+        // Disable the opt-in lint master switch — semantic rules must still fire.
+        state.lint_config = LintConfig {
+            enabled: false,
+            ..LintConfig::default()
+        };
+        state.documents.insert(uri.clone(), Document::new(code, None));
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        (snapshot, uri)
+    }
+
+    #[test]
+    fn mixed_logical_fires_when_linting_disabled() {
+        let (snapshot, uri) = build_snapshot_with_lint_disabled("x <- a & b | c\n");
+        let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned");
+        assert!(
+            diags.iter().any(|d| d.message.contains("parentheses")),
+            "mixed_logical must fire regardless of LintConfig::enabled; got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn condition_assignment_fires_when_linting_disabled() {
+        let (snapshot, uri) = build_snapshot_with_lint_disabled("if (x = 1) x\n");
+        let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned");
+        assert!(
+            diags.iter().any(|d| d.message.contains("==")),
+            "condition_assignment must fire regardless of LintConfig::enabled; got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+}
+
 /// Detect and report diagnostics for `else` keywords that appear on a new line
 /// after the closing brace of an `if` block.
 ///

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -38,6 +38,14 @@
 //!   maximum length.
 //! * `vector_logic` — flag `&` / `|` in `if` / `while` conditions; call
 //!   boundaries stop the scan so `if (any(x & y))` is left alone.
+//! * `mixed_logical` — flag `|` / `||` whose immediate operand is a bare
+//!   `&` / `&&` (without parentheses), e.g. `a & b | c`. `&` binds tighter
+//!   than `|` in R, making the grouping easy to mis-read; adding parentheses
+//!   makes the intent explicit.
+//! * `condition_assignment` — flag `=` used as a binary operator directly
+//!   inside an `if` or `while` condition. R rejects `if (x = 1)` as a
+//!   syntax error at runtime but tree-sitter-r accepts it silently; use `==`
+//!   for equality tests and `<-` for assignment.
 //! * `function_left_parentheses` — flag whitespace between `function`
 //!   (or `\`) and `(`.
 //! * `spaces_inside` — flag whitespace immediately inside `(`, `[`, `[[`
@@ -193,6 +201,32 @@ pub fn run_lints(text: &str, tree_root: Node<'_>, config: &LintConfig) -> Vec<Di
     out
 }
 
+/// Runs the always-on semantic checks that flag likely-wrong code regardless of
+/// whether the style-lint master switch (`LintConfig::enabled`) is on.
+///
+/// These rules detect precedence bugs and runtime errors, not style preferences,
+/// and belong in the main diagnostic pipeline. Callers should pass severity
+/// values from `CrossFileConfig`.
+pub fn run_semantic_checks(
+    text: &str,
+    root: Node<'_>,
+    mixed_logical_severity: Option<tower_lsp::lsp_types::DiagnosticSeverity>,
+    condition_assignment_severity: Option<tower_lsp::lsp_types::DiagnosticSeverity>,
+) -> Vec<Diagnostic> {
+    if mixed_logical_severity.is_none() && condition_assignment_severity.is_none() {
+        return Vec::new();
+    }
+    let suppressions = nolint::Suppressions::from_text(text);
+    let mut out = Vec::new();
+    if let Some(sev) = mixed_logical_severity {
+        rules::mixed_logical::collect(text, root, sev, &suppressions, &mut out);
+    }
+    if let Some(sev) = condition_assignment_severity {
+        rules::condition_assignment::collect(text, root, sev, &suppressions, &mut out);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,6 +243,15 @@ mod tests {
     fn lint(text: &str, config: &LintConfig) -> Vec<Diagnostic> {
         let tree = with_parser(|p| p.parse(text, None)).expect("parse must succeed");
         run_lints(text, tree.root_node(), config)
+    }
+
+    fn lint_semantic(
+        text: &str,
+        mixed_sev: Option<DiagnosticSeverity>,
+        cond_sev: Option<DiagnosticSeverity>,
+    ) -> Vec<Diagnostic> {
+        let tree = with_parser(|p| p.parse(text, None)).expect("parse must succeed");
+        run_semantic_checks(text, tree.root_node(), mixed_sev, cond_sev)
     }
 
     #[test]
@@ -1649,6 +1692,193 @@ print.data.frame <- function(x, ...) NULL
     }
 
     // ------------------------------------------------------------------
+    // mixed_logical  (semantic check — uses lint_semantic, not lint)
+    // ------------------------------------------------------------------
+
+    const ML_WARN: Option<DiagnosticSeverity> = Some(DiagnosticSeverity::WARNING);
+
+    #[test]
+    fn mixed_logical_flags_and_inside_or() {
+        let diags = lint_semantic("x <- a & b | c\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "expected diagnostic, got none");
+        assert!(diags[0].message.contains("parentheses"), "got: {:?}", diags[0].message);
+    }
+
+    #[test]
+    fn mixed_logical_flags_or_inside_and() {
+        // tree-sitter parses `a | b & c` as `a | (b & c)`; `|` is outer.
+        let diags = lint_semantic("x <- a | b & c\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "expected diagnostic, got none");
+    }
+
+    #[test]
+    fn mixed_logical_flags_double_operators() {
+        let diags = lint_semantic("x <- a && b || c\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "expected diagnostic, got none");
+        assert!(diags[0].message.contains("&&"), "got: {:?}", diags[0].message);
+    }
+
+    #[test]
+    fn mixed_logical_accepts_explicit_parens_left() {
+        let diags = lint_semantic("x <- (a & b) | c\n", ML_WARN, None);
+        assert!(diags.is_empty(), "expected no diagnostic, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_accepts_explicit_parens_right() {
+        let diags = lint_semantic("x <- a & (b | c)\n", ML_WARN, None);
+        assert!(diags.is_empty(), "expected no diagnostic, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_accepts_pure_and() {
+        let diags = lint_semantic("x <- a & b & c\n", ML_WARN, None);
+        assert!(diags.is_empty(), "pure `&` should not be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_accepts_pure_or() {
+        let diags = lint_semantic("x <- a | b | c\n", ML_WARN, None);
+        assert!(diags.is_empty(), "pure `|` should not be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_flags_in_if_condition() {
+        let diags = lint_semantic("if (a & b | c) x\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "should flag mixed operators in condition");
+    }
+
+    #[test]
+    fn mixed_logical_flags_cross_family_or_then_double_and() {
+        let diags = lint_semantic("x <- a | b && c\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "a | b && c should be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_flags_cross_family_double_or_then_and() {
+        let diags = lint_semantic("x <- a || b & c\n", ML_WARN, None);
+        assert!(!diags.is_empty(), "a || b & c should be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn mixed_logical_skips_inside_call() {
+        let diags = lint_semantic("filter(df, a | b & c)\n", ML_WARN, None);
+        assert!(
+            diags.is_empty(),
+            "mixed operators inside a call should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn mixed_logical_skips_inside_subset() {
+        let diags = lint_semantic("df[a | b & c, ]\n", ML_WARN, None);
+        assert!(
+            diags.is_empty(),
+            "mixed operators inside subset should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // condition_assignment  (semantic check — uses lint_semantic, not lint)
+    // ------------------------------------------------------------------
+
+    const CA_WARN: Option<DiagnosticSeverity> = Some(DiagnosticSeverity::WARNING);
+
+    #[test]
+    fn condition_assignment_flags_equals_in_if() {
+        let diags = lint_semantic("if (x = 1) x\n", None, CA_WARN);
+        assert!(!diags.is_empty(), "expected diagnostic, got none");
+        assert!(diags[0].message.contains("=="), "got: {:?}", diags[0].message);
+    }
+
+    #[test]
+    fn condition_assignment_flags_equals_in_while() {
+        let diags = lint_semantic("while (done = FALSE) x\n", None, CA_WARN);
+        assert!(!diags.is_empty(), "expected diagnostic for = in while condition");
+    }
+
+    #[test]
+    fn condition_assignment_accepts_double_equals() {
+        let diags = lint_semantic("if (x == 1) x\n", None, CA_WARN);
+        assert!(diags.is_empty(), "`==` should not be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn condition_assignment_accepts_left_arrow() {
+        let diags = lint_semantic("if (x <- 1) x\n", None, CA_WARN);
+        assert!(
+            diags.is_empty(),
+            "`<-` in condition should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn condition_assignment_skips_named_arg_inside_call() {
+        let diags = lint_semantic("if (identical(x = 1, 1)) x\n", None, CA_WARN);
+        assert!(
+            diags.is_empty(),
+            "named-arg `=` inside a call should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn condition_assignment_accepts_top_level_equals() {
+        let diags = lint_semantic("x = 1\n", None, CA_WARN);
+        assert!(diags.is_empty(), "top-level `=` should not be flagged, got {:?}", diags);
+    }
+
+    #[test]
+    fn condition_assignment_skips_parenthesized_condition() {
+        let diags = lint_semantic("if ((x = 1)) x\n", None, CA_WARN);
+        assert!(
+            diags.is_empty(),
+            "`=` inside parenthesized_expression should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn condition_assignment_skips_braced_condition() {
+        let diags = lint_semantic("if ({ x = 1; x > 0 }) x\n", None, CA_WARN);
+        assert!(
+            diags.is_empty(),
+            "`=` inside braced_expression should not be flagged, got {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn condition_assignment_no_duplicate_with_assignment_operator() {
+        // `if (x = 1)` — condition_assignment fires; assignment_operator must
+        // NOT also fire (contradictory advice).
+        let semantic = lint_semantic("if (x = 1) x\n", None, CA_WARN);
+        let style = lint(
+            "if (x = 1) x\n",
+            &LintConfig {
+                assignment_operator_severity: Some(DiagnosticSeverity::HINT),
+                ..solo_config()
+            },
+        );
+        let mut all = semantic;
+        all.extend(style);
+        assert_eq!(
+            all.len(),
+            1,
+            "expected exactly one diagnostic for `if (x = 1)`, got {:?}",
+            all
+        );
+        assert!(
+            all[0].message.contains("=="),
+            "expected condition_assignment message, got {:?}",
+            all[0].message
+        );
+    }
+
+    // ------------------------------------------------------------------
     // function_left_parentheses
     // ------------------------------------------------------------------
 
@@ -1801,6 +2031,15 @@ mod code_field_tests {
         }
     }
 
+    fn lint_semantic(
+        text: &str,
+        mixed_sev: Option<DiagnosticSeverity>,
+        cond_sev: Option<DiagnosticSeverity>,
+    ) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+        let tree = with_parser(|p| p.parse(text, None)).expect("parse must succeed");
+        run_semantic_checks(text, tree.root_node(), mixed_sev, cond_sev)
+    }
+
     fn run_one(
         text: &str,
         configure: impl FnOnce(&mut LintConfig),
@@ -1933,6 +2172,24 @@ mod code_field_tests {
                 diags
             );
         }
+    }
+
+    #[test]
+    fn semantic_rules_emit_their_ids() {
+        use super::rule_ids::*;
+        let sev = Some(DiagnosticSeverity::WARNING);
+        let ml = lint_semantic("x <- a & b | c\n", sev, None);
+        assert!(
+            ml.iter().any(|d| rule_id_of(d) == Some(MIXED_LOGICAL)),
+            "mixed_logical rule emitted unexpected ids: {:?}",
+            ml
+        );
+        let ca = lint_semantic("if (x = 1) x\n", None, sev);
+        assert!(
+            ca.iter().any(|d| rule_id_of(d) == Some(CONDITION_ASSIGNMENT)),
+            "condition_assignment rule emitted unexpected ids: {:?}",
+            ca
+        );
     }
 }
 

--- a/crates/raven/src/linting/rule_ids.rs
+++ b/crates/raven/src/linting/rule_ids.rs
@@ -22,6 +22,8 @@ pub const VECTOR_LOGIC: &str = "vector_logic";
 pub const FUNCTION_LEFT_PARENTHESES: &str = "function_left_parentheses";
 pub const SPACES_INSIDE: &str = "spaces_inside";
 pub const INDENTATION: &str = "indentation";
+pub const MIXED_LOGICAL: &str = "mixed_logical";
+pub const CONDITION_ASSIGNMENT: &str = "condition_assignment";
 
 #[cfg(test)]
 mod tests {
@@ -34,7 +36,7 @@ mod tests {
             ASSIGNMENT_OPERATOR, OBJECT_NAME, INFIX_SPACES, COMMENTED_CODE,
             QUOTES, COMMAS, T_AND_F_SYMBOL, SEMICOLON, EQUALS_NA,
             OBJECT_LENGTH, VECTOR_LOGIC, FUNCTION_LEFT_PARENTHESES,
-            SPACES_INSIDE, INDENTATION,
+            SPACES_INSIDE, INDENTATION, MIXED_LOGICAL, CONDITION_ASSIGNMENT,
         ];
         for id in ids {
             assert!(!id.is_empty(), "rule id must be non-empty");

--- a/crates/raven/src/linting/rules/assignment_operator.rs
+++ b/crates/raven/src/linting/rules/assignment_operator.rs
@@ -39,7 +39,10 @@ fn visit(
     if node.kind() == "binary_operator" {
         if let Some(op_node) = node.child_by_field_name("operator") {
             let op_text = node_text(op_node, text);
-            if !is_named_argument(node, op_text) {
+            // Skip `=` that is directly in an if/while condition —
+            // condition_assignment handles it with a more specific message.
+            let skip_for_condition = op_text == "=" && is_if_while_condition_directly(node);
+            if !skip_for_condition && !is_named_argument(node, op_text) {
                 let bad = match style {
                     AssignmentOperatorStyle::LeftArrow => op_text == "=",
                     AssignmentOperatorStyle::Equals => op_text == "<-",
@@ -101,6 +104,20 @@ fn is_named_argument(binop: Node<'_>, op_text: &str) -> bool {
     binop
         .parent()
         .is_some_and(|p| p.kind() == "argument")
+}
+
+/// Returns `true` if `binop` is the direct `condition` field of an
+/// `if_statement` or `while_statement`. Used to avoid double-diagnosing
+/// `if (x = 1)` — `condition_assignment` handles that case specifically.
+fn is_if_while_condition_directly(binop: Node<'_>) -> bool {
+    if let Some(parent) = binop.parent() {
+        if matches!(parent.kind(), "if_statement" | "while_statement") {
+            if let Some(cond) = parent.child_by_field_name("condition") {
+                return cond.id() == binop.id();
+            }
+        }
+    }
+    false
 }
 
 fn node_text<'a>(node: Node<'_>, text: &'a str) -> &'a str {

--- a/crates/raven/src/linting/rules/condition_assignment.rs
+++ b/crates/raven/src/linting/rules/condition_assignment.rs
@@ -1,0 +1,119 @@
+//! Flag `=` used as a binary operator inside `if` / `while` conditions.
+//!
+//! In R, `=` inside an `if` or `while` condition is a syntax error at runtime:
+//!
+//! ```text
+//! > if (x = 1) print(x)
+//! Error: unexpected '=' in "if (x ="
+//! ```
+//!
+//! tree-sitter-r's grammar accepts it silently (it treats `=` as an assignment
+//! binary operator), so Raven would otherwise emit no diagnostic. This rule
+//! fills the gap: when `=` appears as the operator of a `binary_operator` node
+//! directly inside the condition of an `if_statement` or `while_statement`, it
+//! reports the `=` with a suggestion to use `==` (equality) or `<-`
+//! (assignment).
+//!
+//! **Scope:** the condition field of `if_statement` and `while_statement`
+//! nodes only. Recursion stops at function-call / subset boundaries so that
+//! named-argument `=` inside a call within the condition (`if (f(x = 1) > 0)`)
+//! is never flagged.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::rule_ids;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if matches!(node.kind(), "if_statement" | "while_statement") {
+        if let Some(cond) = node.child_by_field_name("condition") {
+            scan_condition(cond, text, severity, suppressions, out);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn scan_condition(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    // Stop at call/subset boundaries — named-argument `=` is intentional.
+    // Stop at parenthesized_expression — `(x = 1)` is a valid R assignment
+    // expression that evaluates to its value; `if ((x = 1))` is legal.
+    // Stop at braced_expression — `{ x = 1; x > 0 }` is a block, not a
+    // simple condition; assignments inside it are not the if/while condition.
+    if matches!(
+        node.kind(),
+        "call" | "subset" | "subset2" | "parenthesized_expression" | "braced_expression"
+    ) {
+        return;
+    }
+    if node.kind() == "binary_operator" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+            if op_text == "=" {
+                emit(op, text, severity, suppressions, out);
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_condition(child, text, severity, suppressions, out);
+    }
+}
+
+fn emit(
+    op: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = op.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, op.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, op.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(op.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        code: Some(NumberOrString::String(
+            rule_ids::CONDITION_ASSIGNMENT.to_string(),
+        )),
+        message: "Use `==` to test equality; `=` is not valid in R conditions. \
+                  For assignment use `<-`."
+            .to_string(),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/mixed_logical.rs
+++ b/crates/raven/src/linting/rules/mixed_logical.rs
@@ -1,0 +1,119 @@
+//! Flag `&` / `&&` mixed with `|` / `||` in the same expression without
+//! explicit parentheses.
+//!
+//! In R `&` binds more tightly than `|` (and `&&` more tightly than `||`), so
+//! `a & b | c` is always `(a & b) | c`. Writers who intend the alternative
+//! grouping — `a & (b | c)` — need explicit parentheses; without them the
+//! expression silently does the wrong thing. Flagging the mix encourages the
+//! author to make the intended precedence explicit.
+//!
+//! **Detection rule:** a `|` / `||` binary_operator node whose immediate
+//! left-hand or right-hand operand is itself a bare `&` / `&&`
+//! binary_operator (i.e. not wrapped in a `parenthesized_expression`) is
+//! flagged. The diagnostic is placed on the `|` / `||` operator token.
+//!
+//! **Scope:** the entire AST — the check is not limited to `if`/`while`
+//! conditions because the precedence surprise applies everywhere. Mirroring
+//! lintr's `outer_negation_linter` / Sight's MIXED_LOGICAL_OPERATORS (6004).
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use tree_sitter::Node;
+
+use crate::linting::nolint::Suppressions;
+use crate::linting::rule_ids;
+use crate::linting::LINT_SOURCE;
+use crate::utf16::byte_offset_to_utf16_column;
+
+pub(crate) fn collect(
+    text: &str,
+    root: Node<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    visit(root, text, severity, suppressions, out);
+}
+
+fn visit(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    // Stop at call/subset boundaries — vectorized data-mask patterns like
+    // `dplyr::filter(df, a | b & c)` are intentional.
+    if matches!(node.kind(), "call" | "subset" | "subset2") {
+        return;
+    }
+    if node.kind() == "binary_operator" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+            if matches!(op_text, "|" | "||") {
+                let lhs = node.child_by_field_name("lhs");
+                let rhs = node.child_by_field_name("rhs");
+                let lhs_bare = lhs.is_some_and(|n| is_bare_and(n, text));
+                let rhs_bare = rhs.is_some_and(|n| is_bare_and(n, text));
+                if lhs_bare || rhs_bare {
+                    let and_node = if lhs_bare { lhs.unwrap() } else { rhs.unwrap() };
+                    let and_op_text = and_node
+                        .child_by_field_name("operator")
+                        .and_then(|n| text.get(n.start_byte()..n.end_byte()))
+                        .unwrap_or("&");
+                    emit(op, op_text, and_op_text, text, severity, suppressions, out);
+                }
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit(child, text, severity, suppressions, out);
+    }
+}
+
+/// Returns `true` if `node` is a `binary_operator` whose operator is `&` or
+/// `&&` and is not wrapped in a `parenthesized_expression`.
+fn is_bare_and(node: Node<'_>, text: &str) -> bool {
+    if node.kind() != "binary_operator" {
+        return false;
+    }
+    node.child_by_field_name("operator").is_some_and(|op| {
+        matches!(
+            text.get(op.start_byte()..op.end_byte()).unwrap_or(""),
+            "&" | "&&"
+        )
+    })
+}
+
+fn emit(
+    op: Node<'_>,
+    op_text: &str,
+    and_op: &str,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let line_no = op.start_position().row as u32;
+    if suppressions.is_suppressed(line_no) {
+        return;
+    }
+    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line_text, op.start_position().column);
+    let end_col = byte_offset_to_utf16_column(line_text, op.end_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(op.end_position().row as u32, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        code: Some(NumberOrString::String(rule_ids::MIXED_LOGICAL.to_string())),
+        message: format!(
+            "Mixed `{and_op}` and `{op_text}` without parentheses; `{and_op}` binds \
+             tighter than `{op_text}`. Add parentheses to clarify intent: \
+             `(a {and_op} b) {op_text} c` or `a {and_op} (b {op_text} c)`."
+        ),
+        ..Default::default()
+    });
+}

--- a/crates/raven/src/linting/rules/mod.rs
+++ b/crates/raven/src/linting/rules/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod object_name;
 pub(crate) mod quotes;
 pub(crate) mod semicolon;
 pub(crate) mod spaces_inside;
+pub(crate) mod condition_assignment;
+pub(crate) mod mixed_logical;
 pub(crate) mod t_and_f_symbol;
 pub(crate) mod trailing_blank_lines;
 pub(crate) mod trailing_whitespace;

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -57,7 +57,7 @@ Raven checks whether each symbol reference has a visible definition — either i
 | Missing file | warning | `source()` or directive references a file that doesn't exist |
 | Circular dependency | error | Two files source each other (directly or transitively) |
 | Max chain depth exceeded | warning | Source chain exceeds configured maximum depth |
-| Out-of-scope symbol | warning | Symbol from a sourced file used before the source() call |
+| `'x' is used before it's available (sourced on line N)` | warning | Symbol from a sourced file used before the `source()` call |
 | Ambiguous parent | warning | Multiple parents source this file and auto-inference can't determine which to use |
 | Redundant directive | hint | `@lsp-source` directive for a file already sourced via `source()` on the same line |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -24,6 +24,7 @@ Raven surfaces parse errors from the tree-sitter R grammar whenever the document
 | `Consecutive pipe \|>`: expected an expression before this operator | Two pipe operators appear back-to-back without an intervening expression (`x \|> \|> y`) |
 | `Mismatched brackets: \`(\` opened here; close with \`)\` not \`]`` | A bracket opened with `(`, `[`, or `[[` is closed with a non-matching bracket (`c(1, 2]`) |
 | `Missing \`)`` / `Missing \`]`` / etc. | A delimiter was opened but never closed (`library(`) |
+| In R, `else` must appear on the same line as the closing `}` of the if block | `else` placed on its own line after `if (cond) { body }` — R treats the `if` as complete and the `else` becomes an unexpected token |
 | `Syntax error` | Tree-sitter detected a parse error that doesn't match any of the specific patterns above |
 
 ### Undefined Variables

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -57,7 +57,7 @@ Raven checks whether each symbol reference has a visible definition — either i
 | Missing file | warning | `source()` or directive references a file that doesn't exist |
 | Circular dependency | error | Two files source each other (directly or transitively) |
 | Max chain depth exceeded | warning | Source chain exceeds configured maximum depth |
-| `'x' is used before it's available (sourced on line N)` | warning | Symbol from a sourced file used before the `source()` call |
+| Out-of-scope symbol | warning | Symbol from a sourced file used before the `source()` call |
 | Ambiguous parent | warning | Multiple parents source this file and auto-inference can't determine which to use |
 | Redundant directive | hint | `@lsp-source` directive for a file already sourced via `source()` on the same line |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -14,6 +14,18 @@ Diagnostics are deferred until the workspace scan completes (in `auto` backward 
 
 ## Diagnostic Categories
 
+### Parse Errors
+
+Raven surfaces parse errors from the tree-sitter R grammar whenever the document cannot be parsed as valid R. These diagnostics are always on and not configurable. Where possible Raven provides a specific, actionable message rather than a generic "Syntax error":
+
+| Message | Trigger |
+|---|---|
+| `Unclosed string literal` | An opening `"` or `'` has no matching closing delimiter |
+| `Consecutive pipe \|>`: expected an expression before this operator | Two pipe operators appear back-to-back without an intervening expression (`x \|> \|> y`) |
+| `Mismatched brackets: \`(\` opened here; close with \`)\` not \`]`` | A bracket opened with `(`, `[`, or `[[` is closed with a non-matching bracket (`c(1, 2]`) |
+| `Missing \`)`` / `Missing \`]`` / etc. | A delimiter was opened but never closed (`library(`) |
+| `Syntax error` | Tree-sitter detected a parse error that doesn't match any of the specific patterns above |
+
 ### Undefined Variables
 
 | Diagnostic | Default Severity | Trigger |
@@ -63,9 +75,22 @@ Always on whenever diagnostics are enabled; not configurable per rule. Applies t
 - `function(x = TRUE)` — default values in formal parameters, not assignment.
 - `if <- 1`, `for <- 1`, `while <- 1`, `function <- 1`, `repeat <- 1` — tree-sitter reports these as syntax errors directly, so the same code surfaces only one diagnostic.
 
+### Semantic Warnings
+
+Always-on diagnostics that flag likely-wrong code — not style preferences. Active as long as `raven.diagnostics.enabled` is true. Configurable severity via `raven.diagnostics.*`; honor `# @lsp-ignore` / `# @lsp-ignore-next` and `# nolint`.
+
+| Diagnostic | Default Severity | Trigger |
+|---|---|---|
+| Mixed logical operators | warning | `\|` / `\|\|` whose immediate operand is a bare `&` / `&&` (no parentheses), e.g. `a & b \| c`. `&` binds more tightly than `\|` in R, making the grouping easy to mis-read. Stops at call/subset boundaries |
+| Condition assignment | warning | `=` used as a binary operator directly inside an `if` / `while` condition (`if (x = 1)`). R rejects this as a syntax error at runtime; tree-sitter-r accepts it silently. Stops at call, parenthesized-expression, and braced-expression boundaries |
+
+**Suppression:** `# @lsp-ignore` on the line, `# @lsp-ignore-next` on the line above, or `# nolint` (with optional rule names `mixed_logical`, `condition_assignment`).
+
+**Settings:** `raven.diagnostics.mixedLogicalSeverity` (default `"warning"`), `raven.diagnostics.conditionAssignmentSeverity` (default `"warning"`).
+
 ### Style Lints
 
-Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-lib.org/)). Implemented in Rust against the tree-sitter AST — no R or `lintr` install required. Off by default; enable with `raven.linting.enabled` and tune per rule via the `raven.linting.*` severities. All rules default to severity `hint` so they don't crowd the Problems pane. For a user-facing guide — quick-start config, `.lintr` migration, gaps vs `lintr`, and how to run `lintr` alongside Raven — see [Linting](linting.md).
+Native, opt-in style diagnostics (a small subset of [`lintr`](https://lintr.r-lib.org/)). Implemented in Rust against the tree-sitter AST — no R or `lintr` install required. Off by default; enable with `raven.linting.enabled` and tune per rule via the `raven.linting.*` severities. All style lint rules default to severity `hint` so they don't crowd the Problems pane. For a user-facing guide — quick-start config, `.lintr` migration, gaps vs `lintr`, and how to run `lintr` alongside Raven — see [Linting](linting.md).
 
 | Diagnostic | Default Severity | Trigger |
 |---|---|---|

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -14,7 +14,7 @@ The linter is off by default. The minimum `settings.json` to turn it on with def
 }
 ```
 
-All rules default to severity `hint` so they don't crowd the Problems pane. To raise a rule (e.g. line length) to `warning`, or to disable an individual rule, set its severity:
+All style lint rules default to severity `hint` so they don't crowd the Problems pane. To raise a rule (e.g. line length) to `warning`, or to disable an individual rule, set its severity:
 
 ```json
 {
@@ -176,6 +176,8 @@ The recommended path is to configure Raven via `raven.toml` at the project root 
 | `equals_na_linter()` | `raven.linting.equalsNaSeverity` |
 | `object_length_linter(length = N)` | `raven.linting.objectLength = N`, `raven.linting.objectLengthSeverity` |
 | `vector_logic_linter()` | `raven.linting.vectorLogicSeverity` |
+| *(no equivalent)* | `raven.linting.mixedLogicalSeverity` |
+| *(no equivalent)* | `raven.linting.conditionAssignmentSeverity` |
 | `function_left_parentheses_linter()` | `raven.linting.functionLeftParenthesesSeverity` |
 | `spaces_inside_linter()` | `raven.linting.spacesInsideSeverity` |
 | `indentation_linter(indent = N)` | `raven.linting.indentationUnit = N`, `raven.linting.indentationSeverity` |

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -176,13 +176,13 @@ The recommended path is to configure Raven via `raven.toml` at the project root 
 | `equals_na_linter()` | `raven.linting.equalsNaSeverity` |
 | `object_length_linter(length = N)` | `raven.linting.objectLength = N`, `raven.linting.objectLengthSeverity` |
 | `vector_logic_linter()` | `raven.linting.vectorLogicSeverity` |
-| *(no equivalent)* | `raven.linting.mixedLogicalSeverity` |
-| *(no equivalent)* | `raven.linting.conditionAssignmentSeverity` |
 | `function_left_parentheses_linter()` | `raven.linting.functionLeftParenthesesSeverity` |
 | `spaces_inside_linter()` | `raven.linting.spacesInsideSeverity` |
 | `indentation_linter(indent = N)` | `raven.linting.indentationUnit = N`, `raven.linting.indentationSeverity` |
 
 To disable a rule from a `.lintr` `linters_with_defaults(..., default = list())` setup, set its severity to `"off"`. To raise a rule that `lintr` would flag as a `warning`, raise its severity from `"hint"` to `"warning"`.
+
+> **Note:** `mixed_logical` and `condition_assignment` are not in this table because they have no `lintr` equivalent and are not style lints — they are always-on semantic warnings configured under `raven.diagnostics.mixedLogicalSeverity` and `raven.diagnostics.conditionAssignmentSeverity`. See [Diagnostics § Semantic Warnings](diagnostics.md#semantic-warnings).
 
 If you'd like a starter `raven.linting.*` block scaffolded into `.vscode/settings.json` — every key Raven understands, each prefaced with a `//` comment naming its `lintr` equivalent — run the **Raven: Create linting settings** command from the Command Palette ([Configuration § Scaffold Commands](configuration.md#scaffold-commands)). It merges into an existing `settings.json` without disturbing unrelated keys or comments, and prompts before overwriting any pre-existing `raven.linting.*` values.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1028,6 +1028,44 @@
           "default": "warning",
           "description": "Severity level for diagnostics when a variable is used but not defined in the current scope, sourced files, or loaded packages. Set to \"off\" to suppress undefined variable diagnostics if they produce too many false positives in your workflow."
         },
+        "raven.diagnostics.mixedLogicalSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report mixed `&`/`|` without parentheses as errors",
+            "Report mixed `&`/`|` without parentheses as warnings",
+            "Report mixed `&`/`|` without parentheses as information",
+            "Report mixed `&`/`|` without parentheses as hints",
+            "Disable the mixed-logical diagnostic"
+          ],
+          "default": "warning",
+          "description": "Severity for the mixed-logical diagnostic. Flags `|`/`||` whose immediate operand is a bare `&`/`&&` (without explicit parentheses), e.g. `a & b | c`. Because `&` binds more tightly than `|` in R, the grouping is easy to mis-read. Stops at call/subset boundaries so vectorized data-mask patterns are not flagged."
+        },
+        "raven.diagnostics.conditionAssignmentSeverity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Report `=` in conditions as errors",
+            "Report `=` in conditions as warnings",
+            "Report `=` in conditions as information",
+            "Report `=` in conditions as hints",
+            "Disable the condition-assignment diagnostic"
+          ],
+          "default": "warning",
+          "description": "Severity for the condition-assignment diagnostic. Flags `=` used as a binary operator directly inside an `if` or `while` condition. R rejects `if (x = 1)` as a syntax error at runtime but tree-sitter-r accepts it silently. Named-argument `=` inside function calls within the condition is not flagged."
+        },
         "raven.packages.enabled": {
           "type": "boolean",
           "default": true,

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -75,6 +75,8 @@ export interface RavenInitializationOptions {
     diagnostics?: {
         enabled?: boolean;
         undefinedVariableSeverity?: SeverityLevel;
+        mixedLogicalSeverity?: SeverityLevel;
+        conditionAssignmentSeverity?: SeverityLevel;
     };
     packages?: {
         enabled?: boolean;
@@ -295,12 +297,20 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
 
     const diagnosticsEnabled = config.get<boolean>('diagnostics.enabled', true);
     const undefinedVariableSeverity = getExplicitSetting<SeverityLevel>(config, 'diagnostics.undefinedVariableSeverity');
+    const mixedLogicalSeverity = getExplicitSetting<SeverityLevel>(config, 'diagnostics.mixedLogicalSeverity');
+    const conditionAssignmentSeverity = getExplicitSetting<SeverityLevel>(config, 'diagnostics.conditionAssignmentSeverity');
 
     options.diagnostics = {
         enabled: diagnosticsEnabled,
     };
     if (undefinedVariableSeverity !== undefined) {
         options.diagnostics.undefinedVariableSeverity = undefinedVariableSeverity;
+    }
+    if (mixedLogicalSeverity !== undefined) {
+        options.diagnostics.mixedLogicalSeverity = mixedLogicalSeverity;
+    }
+    if (conditionAssignmentSeverity !== undefined) {
+        options.diagnostics.conditionAssignmentSeverity = conditionAssignmentSeverity;
     }
 
     const packagesEnabled = getExplicitSetting<boolean>(config, 'packages.enabled');

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -147,6 +147,8 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'linting.equalsNaSeverity', jsonPath: ['linting', 'equalsNaSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.objectLengthSeverity', jsonPath: ['linting', 'objectLengthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.vectorLogicSeverity', jsonPath: ['linting', 'vectorLogicSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
+    { vsCodeKey: 'diagnostics.mixedLogicalSeverity', jsonPath: ['diagnostics', 'mixedLogicalSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
+    { vsCodeKey: 'diagnostics.conditionAssignmentSeverity', jsonPath: ['diagnostics', 'conditionAssignmentSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     { vsCodeKey: 'linting.functionLeftParenthesesSeverity', jsonPath: ['linting', 'functionLeftParenthesesSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.spacesInsideSeverity', jsonPath: ['linting', 'spacesInsideSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },
     { vsCodeKey: 'linting.indentationSeverity', jsonPath: ['linting', 'indentationSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const, defaultWhenUnconfigured: 'hint' },


### PR DESCRIPTION
## Summary

- **Two new always-on semantic warning rules** — placed in the main diagnostic pipeline (not the opt-in style lint system) because they catch likely-wrong code, not style preferences:
  - **`mixed_logical`** (`raven.diagnostics.mixedLogicalSeverity`, default `warning`): flags `|`/`||` whose direct operand is a bare `&`/`&&` with no parentheses — a silent precedence bug in R
  - **`condition_assignment`** (`raven.diagnostics.conditionAssignmentSeverity`, default `warning`): flags `=` used as a binary operator directly inside an `if`/`while` condition — R rejects this at runtime but tree-sitter-r accepts it silently

- **Improved syntax error messages**: `collect_syntax_errors` now classifies specific ERROR node shapes before falling back to "Syntax error":
  - "Consecutive pipe `|>`: expected an expression before this operator" 
  - "Mismatched brackets: `(` opened here; close with `)` not `]`"

- **No duplicate diagnostics**: the `assignment_operator` lint skips `=` operators already flagged by `condition_assignment`

- **Docs updated**: `docs/diagnostics.md` has a new "Semantic Warnings" section; the two rules are removed from the Style Lints table in `docs/linting.md`

## Settings

Both new rules live under `raven.diagnostics.*` (not `raven.linting.*`) to reflect that they are always-on and configurable via the same severity mechanism as undefined-variable and cross-file diagnostics:

```json
"raven.diagnostics.mixedLogicalSeverity": "warning",
"raven.diagnostics.conditionAssignmentSeverity": "warning"
```

Set either to `"off"` to disable, or `"error"`/`"information"`/`"hint"` to adjust severity. Both honor `# @lsp-ignore`, `# @lsp-ignore-next`, and `# nolint`.

## Test plan

- [x] `cargo test -p raven` — 58 tests pass
- [x] `bun test` — 575 tests pass
- [ ] Manual smoke test: open an R file with `a & b | c` — mixed_logical warning should appear without enabling `raven.linting.enabled`
- [ ] Manual smoke test: open an R file with `if (x = 1)` — condition_assignment warning should appear
- [ ] Verify both can be silenced with `# @lsp-ignore` and tuned to `"off"` via settings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->