### PR TITLE
chore: remove unused re-exports from config_file::mod

### DIFF
--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -7,13 +7,13 @@ pub mod overrides;
 pub mod toml_loader;
 
 pub use discovery::{find_config, DiscoveredConfig};
-pub use lintr_loader::{load as load_lintr, load_str as load_lintr_str, LoadedLintr};
+pub use lintr_loader::{load as load_lintr, load_str as load_lintr_str};
 pub use merge::merge as merge_settings;
 pub use overrides::{
     compile_lint_overrides, is_skipped_by_overrides, resolve_lint_for_document,
     CompiledLintOverride,
 };
-pub use toml_loader::{load as load_toml, load_str as load_toml_str, LoadedToml};
+pub use toml_loader::load as load_toml;
 
 /// Re-run every `parse_*_config` over the merged `(client, project)` JSON
 /// and overwrite the parsed configs on `state`. Idempotent.


### PR DESCRIPTION
## Summary

- `LoadedLintr`, `LoadedToml`, and `load_toml_str as load_str` were re-exported from `config_file/mod.rs` but never imported anywhere in the crate
- Removing them eliminates two compiler warnings that appeared on every build

## Test plan

- [x] `cargo build -p raven` — clean, no warnings
- [x] `cargo test -p raven` — all 58 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->