### PR TITLE
chore(config): remove dead raven.crossFile.ambiguousParentSeverity setting

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -208,12 +208,6 @@ pub(crate) fn parse_cross_file_config(
             config.out_of_scope_severity = parse_severity(sev);
         }
         if let Some(sev) = cross_file
-            .get("ambiguousParentSeverity")
-            .and_then(|v| v.as_str())
-        {
-            config.ambiguous_parent_severity = parse_severity(sev);
-        }
-        if let Some(sev) = cross_file
             .get("maxChainDepthSeverity")
             .and_then(|v| v.as_str())
         {
@@ -405,10 +399,6 @@ pub(crate) fn parse_cross_file_config(
         config.circular_dependency_severity
     );
     log::info!("    out_of_scope: {:?}", config.out_of_scope_severity);
-    log::info!(
-        "    ambiguous_parent: {:?}",
-        config.ambiguous_parent_severity
-    );
     log::info!("    max_chain_depth: {:?}", config.max_chain_depth_severity);
     log::info!(
         "    redundant_directive: {:?}",

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -62,8 +62,6 @@ pub struct CrossFileConfig {
     pub circular_dependency_severity: Option<DiagnosticSeverity>,
     /// Severity for out-of-scope symbol diagnostics (None = disabled)
     pub out_of_scope_severity: Option<DiagnosticSeverity>,
-    /// Severity for ambiguous parent diagnostics (None = disabled)
-    pub ambiguous_parent_severity: Option<DiagnosticSeverity>,
     /// Severity for max chain depth exceeded diagnostics (None = disabled)
     pub max_chain_depth_severity: Option<DiagnosticSeverity>,
     /// Whether on-demand indexing is enabled
@@ -173,7 +171,6 @@ impl Default for CrossFileConfig {
             missing_file_severity: Some(DiagnosticSeverity::WARNING),
             circular_dependency_severity: Some(DiagnosticSeverity::ERROR),
             out_of_scope_severity: Some(DiagnosticSeverity::WARNING),
-            ambiguous_parent_severity: Some(DiagnosticSeverity::WARNING),
             max_chain_depth_severity: Some(DiagnosticSeverity::WARNING),
             on_demand_indexing_enabled: true,
             on_demand_indexing_max_transitive_depth: 2,

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -666,10 +666,6 @@ impl WorldState {
             config.circular_dependency_severity
         );
         log::info!("    out_of_scope: {:?}", config.out_of_scope_severity);
-        log::info!(
-            "    ambiguous_parent: {:?}",
-            config.ambiguous_parent_severity
-        );
         log::info!("    max_chain_depth: {:?}", config.max_chain_depth_severity);
 
         Self {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,6 @@ Each accepts: `"error"`, `"warning"`, `"information"`, `"hint"`, or `"off"`.
 | `raven.crossFile.circularDependencySeverity` | `"error"` | Circular dependency detected |
 | `raven.crossFile.maxChainDepthSeverity` | `"warning"` | Source chain exceeds max depth |
 | `raven.crossFile.outOfScopeSeverity` | `"warning"` | Symbol used before it's in scope |
-| `raven.crossFile.ambiguousParentSeverity` | `"warning"` | **Reserved.** Parsed for backwards compatibility but no diagnostic is currently emitted under this key. |
 | `raven.crossFile.redundantDirectiveSeverity` | `"hint"` | Redundant `@lsp-source` directive |
 | `raven.diagnostics.mixedLogicalSeverity` | `"warning"` | `\|` / `\|\|` whose immediate operand is a bare `&` / `&&` (not wrapped in parentheses). Since `&` binds tighter than `\|` in R, the grouping is silent — the rule asks for explicit parentheses. Applies everywhere, not just inside `if` / `while` conditions. |
 | `raven.diagnostics.conditionAssignmentSeverity` | `"warning"` | Binary `=` used directly inside an `if` / `while` condition (likely `==` intended). |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -906,25 +906,6 @@
           "default": "warning",
           "description": "Severity level for diagnostics when symbols are used before they are available in scope. This can occur when referencing symbols from a sourced file before the source() call."
         },
-        "raven.crossFile.ambiguousParentSeverity": {
-          "type": "string",
-          "enum": [
-            "error",
-            "warning",
-            "information",
-            "hint",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Report ambiguous parent resolution as errors",
-            "Report ambiguous parent resolution as warnings",
-            "Report ambiguous parent resolution as information",
-            "Report ambiguous parent resolution as hints",
-            "Disable ambiguous parent diagnostics"
-          ],
-          "default": "warning",
-          "description": "Severity level for diagnostics when a file's parent cannot be unambiguously determined. This occurs when multiple files source the same child file and the call site cannot be resolved."
-        },
         "raven.crossFile.maxChainDepthSeverity": {
           "type": "string",
           "enum": [

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -57,7 +57,6 @@ export interface RavenInitializationOptions {
         missingFileSeverity?: SeverityLevel;
         circularDependencySeverity?: SeverityLevel;
         outOfScopeSeverity?: SeverityLevel;
-        ambiguousParentSeverity?: SeverityLevel;
         maxChainDepthSeverity?: SeverityLevel;
         redundantDirectiveSeverity?: SeverityLevel;
         onDemandIndexing?: {
@@ -168,7 +167,6 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
     const missingFileSeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.missingFileSeverity');
     const circularDependencySeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.circularDependencySeverity');
     const outOfScopeSeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.outOfScopeSeverity');
-    const ambiguousParentSeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.ambiguousParentSeverity');
     const maxChainDepthSeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.maxChainDepthSeverity');
     const redundantDirectiveSeverity = getExplicitSetting<SeverityLevel>(config, 'crossFile.redundantDirectiveSeverity');
 
@@ -238,7 +236,6 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         missingFileSeverity !== undefined ||
         circularDependencySeverity !== undefined ||
         outOfScopeSeverity !== undefined ||
-        ambiguousParentSeverity !== undefined ||
         maxChainDepthSeverity !== undefined ||
         redundantDirectiveSeverity !== undefined ||
         onDemandIndexing !== undefined ||
@@ -277,9 +274,6 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         }
         if (outOfScopeSeverity !== undefined) {
             options.crossFile.outOfScopeSeverity = outOfScopeSeverity;
-        }
-        if (ambiguousParentSeverity !== undefined) {
-            options.crossFile.ambiguousParentSeverity = ambiguousParentSeverity;
         }
         if (maxChainDepthSeverity !== undefined) {
             options.crossFile.maxChainDepthSeverity = maxChainDepthSeverity;

--- a/editors/vscode/src/test/settings.test.ts
+++ b/editors/vscode/src/test/settings.test.ts
@@ -91,7 +91,6 @@ const SETTINGS_MAPPING: Array<{
     { vsCodeKey: 'crossFile.missingFileSeverity', jsonPath: ['crossFile', 'missingFileSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     { vsCodeKey: 'crossFile.circularDependencySeverity', jsonPath: ['crossFile', 'circularDependencySeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     { vsCodeKey: 'crossFile.outOfScopeSeverity', jsonPath: ['crossFile', 'outOfScopeSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
-    { vsCodeKey: 'crossFile.ambiguousParentSeverity', jsonPath: ['crossFile', 'ambiguousParentSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     { vsCodeKey: 'crossFile.maxChainDepthSeverity', jsonPath: ['crossFile', 'maxChainDepthSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     { vsCodeKey: 'crossFile.redundantDirectiveSeverity', jsonPath: ['crossFile', 'redundantDirectiveSeverity'], type: 'enum', enumValues: ['error', 'warning', 'information', 'hint', 'off'] as const },
     // On-demand indexing settings
@@ -770,7 +769,6 @@ suite('Settings Transmission Unit Tests', () => {
             ['crossFile.missingFileSeverity', 'error'],
             ['crossFile.circularDependencySeverity', 'warning'],
             ['crossFile.outOfScopeSeverity', 'information'],
-            ['crossFile.ambiguousParentSeverity', 'hint'],
             ['crossFile.maxChainDepthSeverity', 'error'],
             ['packages.missingPackageSeverity', 'warning'],
             ['diagnostics.undefinedVariableSeverity', 'off'],
@@ -782,7 +780,6 @@ suite('Settings Transmission Unit Tests', () => {
         assert.strictEqual(options.crossFile?.missingFileSeverity, 'error');
         assert.strictEqual(options.crossFile?.circularDependencySeverity, 'warning');
         assert.strictEqual(options.crossFile?.outOfScopeSeverity, 'information');
-        assert.strictEqual(options.crossFile?.ambiguousParentSeverity, 'hint');
         assert.strictEqual(options.crossFile?.maxChainDepthSeverity, 'error');
         assert.strictEqual(options.packages?.missingPackageSeverity, 'warning');
         assert.strictEqual(options.diagnostics?.undefinedVariableSeverity, 'off');


### PR DESCRIPTION
## Summary

- Removes the orphaned `raven.crossFile.ambiguousParentSeverity` setting (schema, parser, config field, init-options forwarder, settings test fixture, and docs row). The setting was parsed but never emitted any diagnostic — the original emitter was removed in commit `2bebd7e` when multiple parents became a supported use case.
- Users who still have the key in their config will continue to load without errors: the TOML loader only warns on unknown top-level sections, and the VS Code settings schema tolerates unknown keys.

Closes #264

## Test plan

- [x] `cargo build -p raven` — clean
- [x] `cargo test -p raven --lib` — 3824 passed, 0 failed
- [x] `cargo test -p raven::cross_file::config` — 4 passed
- [x] `bun run typecheck` (in `editors/vscode`) — passes
- [x] `grep` for `ambiguous_parent_severity` / `ambiguousParentSeverity` in active code returns no hits
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->