### PR TITLE
docs: clarify linting is opt-in style; correctness diagnostics always on

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -4,6 +4,8 @@ Raven reports problems in your R code as you type — undefined variables, missi
 
 Diagnostics are deferred until the workspace scan completes (in `auto` backward dependency mode), so cross-file warnings reflect the full project.
 
+Diagnostics fall into two groups. **Correctness diagnostics** — parse errors, undefined variables, package and cross-file issues, assignment-target errors, and semantic warnings — are always on whenever `raven.diagnostics.enabled` is true; per-category severities only tune them. **Style lints** are subjective formatting rules and are off until you set `raven.linting.enabled` to `true`. If you're looking for a specific check, scan the categories below before reaching for [Linting](linting.md), which only covers the opt-in style group.
+
 ## Quick Reference
 
 - **Silence one site** — add `# @lsp-ignore` on the line, or `# @lsp-ignore-next` on the line above

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -4,7 +4,7 @@ Raven reports problems in your R code as you type — undefined variables, missi
 
 Diagnostics are deferred until the workspace scan completes (in `auto` backward dependency mode), so cross-file warnings reflect the full project.
 
-Diagnostics fall into two groups. **Correctness diagnostics** — parse errors, undefined variables, package and cross-file issues, assignment-target errors, and semantic warnings — are always on whenever `raven.diagnostics.enabled` is true; per-category severities only tune them. **Style lints** are subjective formatting rules and are off until you set `raven.linting.enabled` to `true`. If you're looking for a specific check, scan the categories below before reaching for [Linting](linting.md), which only covers the opt-in style group.
+Diagnostics fall into two groups. **Correctness diagnostics** — parse errors, undefined variables, package and cross-file issues, assignment-target errors, and semantic warnings — are on by default whenever `raven.diagnostics.enabled` is true. Most categories expose a severity setting that can raise, lower, or silence them (set to `"off"`); a few (parse errors, assignment-target errors) have no per-category knob and respond only to the master switch. **Style lints** are subjective formatting rules and the whole group is off until you set `raven.linting.enabled` to `true`. If you're looking for a specific check, scan the categories below before reaching for [Linting](linting.md), which only covers the opt-in style group.
 
 ## Quick Reference
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -4,6 +4,9 @@ Raven ships an opt-in, native style linter that re-implements a small subset of 
 
 This page is the landing point for users coming from `lintr` or `REditorSupport`. For these rules alongside Raven's other diagnostic categories, see [Diagnostics § Style Lints](diagnostics.md#style-lints); the per-key configuration reference lives in [Configuration § Linting Settings](configuration.md#linting-settings).
 
+> [!NOTE]
+> In Raven, "linting" means subjective style rules — line length, naming, infix spacing, and similar — and is opt-in. Correctness diagnostics (parse errors, semantic warnings, cross-file issues, assignment-target errors) are always on under `raven.diagnostics.enabled` and are not controlled by `raven.linting.*`. If you're looking for things like the orphan-`else` parse error, see [Diagnostics](diagnostics.md), not this page.
+
 ## Quick start
 
 The linter is off by default. The minimum `settings.json` to turn it on with default rules:

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -5,7 +5,7 @@ Raven ships an opt-in, native style linter that re-implements a small subset of 
 This page is the landing point for users coming from `lintr` or `REditorSupport`. For these rules alongside Raven's other diagnostic categories, see [Diagnostics § Style Lints](diagnostics.md#style-lints); the per-key configuration reference lives in [Configuration § Linting Settings](configuration.md#linting-settings).
 
 > [!NOTE]
-> In Raven, "linting" means subjective style rules — line length, naming, infix spacing, and similar — and is opt-in. Correctness diagnostics (parse errors, semantic warnings, cross-file issues, assignment-target errors) are always on under `raven.diagnostics.enabled` and are not controlled by `raven.linting.*`. If you're looking for things like the orphan-`else` parse error, see [Diagnostics](diagnostics.md), not this page.
+> In Raven, "linting" means subjective style rules — line length, naming, infix spacing, and similar — and the whole group is opt-in via `raven.linting.enabled`. Correctness diagnostics (parse errors, semantic warnings, cross-file issues, assignment-target errors) are on by default under `raven.diagnostics.enabled`; most categories have a per-category severity that can silence them (`"off"`), while a few (parse errors, assignment-target errors) respond only to the master switch. None of these are controlled by `raven.linting.*`. If you're looking for things like the orphan-`else` parse error, see [Diagnostics](diagnostics.md), not this page.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- Adds a NOTE callout at the top of `docs/linting.md` explaining that "linting" in Raven means subjective style rules (opt-in via `raven.linting.enabled`), and that correctness diagnostics (parse errors, semantic warnings, cross-file issues, assignment-target errors) live under `raven.diagnostics.enabled` and are always on.
- Adds a framing paragraph near the top of `docs/diagnostics.md` splitting diagnostics into the always-on correctness group vs. the opt-in style group, so readers scan the categories there before reaching for `linting.md`.

Motivation: a user searching for "the orphan-`else` lint setting" can come away thinking they need to enable something under `raven.linting.*`, when in reality `collect_else_newline_errors` (`crates/raven/src/handlers.rs:8458`) already emits that as an always-on parse error. This is a docs-only clarification.

## Test plan
- [ ] Skim rendered `docs/linting.md` and `docs/diagnostics.md` on GitHub to confirm the NOTE callout and framing paragraph read well and the cross-links resolve.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->