### PR TITLE
feat(diag): detect `=>` typo and emit actionable message

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6277,19 +6277,28 @@ fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
 }
 
 /// Returns a diagnostic message if `node` is an ERROR consisting of a lone
-/// `>` token whose immediately-preceding sibling is an `=` operator. This is
-/// the parse shape tree-sitter-r produces for the JavaScript-style fat-arrow
-/// typo `x => 1`: a `binary_operator` with `=` as its operator child, an
-/// ERROR child containing `>`, and the right-hand expression as the next
-/// sibling.
+/// `>` token *immediately* following an `=` operator (no intervening
+/// whitespace or comments). This is the parse shape tree-sitter-r produces
+/// for the JavaScript-style fat-arrow typo `x => 1`: inside a
+/// `binary_operator` (or named `argument`) we get `=` as one child, an
+/// ERROR child whose only token is `>`, and the right-hand expression as
+/// the next sibling. Adjacency matters — `x = > 1` (with a space) and
+/// `x =\n> 1` produce the same node shape but are *not* a literal `=>`
+/// token, so they should fall back to the generic "Syntax error".
 fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
-    let node_text = text.get(node.start_byte()..node.end_byte())?.trim();
+    let node_text = text.get(node.start_byte()..node.end_byte())?;
     if node_text != ">" {
         return None;
     }
     let prev = node.prev_sibling()?;
     let prev_text = text.get(prev.start_byte()..prev.end_byte())?;
     if prev_text != "=" {
+        return None;
+    }
+    // Adjacency check: the `=` must be flush against the `>` (no
+    // whitespace/comments between), otherwise the user did not type the
+    // `=>` token even though the parse shape happens to match.
+    if prev.end_byte() != node.start_byte() {
         return None;
     }
     Some(
@@ -7117,6 +7126,44 @@ mod syntax_error_range_tests {
         assert!(
             diags.iter().all(|d| !d.message.contains("no `=>` operator")),
             "non-`=>` errors must not be misclassified as fat-arrow, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fat_arrow_typo_inside_call_argument() {
+        // `f(x => 1)` — the same parse shape appears inside an `argument`
+        // node when the typo is written at a named-argument position.
+        let code = "f(x => 1)";
+        let diags = collect(code);
+        assert!(
+            diags.iter().any(|d| d.message.contains("no `=>` operator")),
+            "should emit fat-arrow diagnostic inside a call, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn space_between_eq_and_gt_is_not_fat_arrow() {
+        // `x = > 1` — `=` and `>` are not adjacent, so this is not a literal
+        // `=>` token even though the parse shape happens to match.
+        let code = "x = > 1";
+        let diags = collect(code);
+        assert!(
+            diags.iter().all(|d| !d.message.contains("no `=>` operator")),
+            "spaced `= >` must not be misclassified as fat-arrow, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn newline_between_eq_and_gt_is_not_fat_arrow() {
+        // `x =\n> 1` — newline between `=` and `>` rules out a literal `=>`.
+        let code = "x =\n> 1";
+        let diags = collect(code);
+        assert!(
+            diags.iter().all(|d| !d.message.contains("no `=>` operator")),
+            "newline-separated `= ... >` must not be misclassified as fat-arrow, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6190,6 +6190,8 @@ fn has_unclosed_quote_child(node: Node) -> bool {
 /// 2. Consecutive pipe — only meaningful child is `|>` / `%>%`.
 /// 3. Mismatched bracket — opens with `(`, `[`, or `[[` but closes with a
 ///    non-matching bracket (detected through a nested ERROR child).
+/// 4. Fat-arrow typo — a lone `>` immediately following an `=` token, which
+///    arises from writing `=>` (no such operator in R).
 fn classify_error(node: Node, text: &str) -> String {
     if has_unclosed_quote_child(node) {
         return "Unclosed string literal".to_string();
@@ -6198,6 +6200,9 @@ fn classify_error(node: Node, text: &str) -> String {
         return msg;
     }
     if let Some(msg) = detect_mismatched_bracket(node, text) {
+        return msg;
+    }
+    if let Some(msg) = detect_fat_arrow(node, text) {
         return msg;
     }
     "Syntax error".to_string()
@@ -6269,6 +6274,29 @@ fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Returns a diagnostic message if `node` is an ERROR consisting of a lone
+/// `>` token whose immediately-preceding sibling is an `=` operator. This is
+/// the parse shape tree-sitter-r produces for the JavaScript-style fat-arrow
+/// typo `x => 1`: a `binary_operator` with `=` as its operator child, an
+/// ERROR child containing `>`, and the right-hand expression as the next
+/// sibling.
+fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
+    let node_text = text.get(node.start_byte()..node.end_byte())?.trim();
+    if node_text != ">" {
+        return None;
+    }
+    let prev = node.prev_sibling()?;
+    let prev_text = text.get(prev.start_byte()..prev.end_byte())?;
+    if prev_text != "=" {
+        return None;
+    }
+    Some(
+        "Unexpected `>`: R has no `=>` operator. \
+         For assignment use `<-`; for a pipeline use `|>` (R 4.1+) or `%>%`."
+            .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -7051,6 +7079,44 @@ mod syntax_error_range_tests {
         assert!(
             diags.is_empty(),
             "well-matched brackets should produce no diagnostics, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fat_arrow_typo_emits_descriptive_message() {
+        // `x => 1` — R has no `=>` operator. tree-sitter-r parses this as
+        // `binary_operator(=)` with an ERROR child containing `>`.
+        let code = "x => 1";
+        let diags = collect(code);
+        assert!(
+            diags.iter().any(|d| d.message.contains("no `=>` operator")),
+            "should emit fat-arrow diagnostic, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fat_arrow_typo_with_call_rhs() {
+        // `foo => bar(x)` — same pattern with a more complex right-hand side.
+        let code = "foo => bar(x)";
+        let diags = collect(code);
+        assert!(
+            diags.iter().any(|d| d.message.contains("no `=>` operator")),
+            "should emit fat-arrow diagnostic for call rhs, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn lone_gt_after_non_eq_is_generic_syntax_error() {
+        // `1 > > 2` — the second `>` is an ERROR but its preceding token is
+        // not `=`, so it should NOT be reported as the fat-arrow typo.
+        let code = "1 > > 2";
+        let diags = collect(code);
+        assert!(
+            diags.iter().all(|d| !d.message.contains("no `=>` operator")),
+            "non-`=>` errors must not be misclassified as fat-arrow, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -25,6 +25,7 @@ Raven surfaces parse errors from the tree-sitter R grammar whenever the document
 | `Unclosed string literal` | An opening `"` or `'` has no matching closing delimiter |
 | ``Consecutive pipe `\|>`: expected an expression before this operator.`` | Two pipe operators appear back-to-back without an intervening expression (`x \|> \|> y`) |
 | ``Mismatched brackets: `(` opened here; close with `)` not `]`.`` | A bracket opened with `(`, `[`, or `[[` is closed with a non-matching bracket (`c(1, 2]`) |
+| ``Unexpected `>`: R has no `=>` operator. For assignment use `<-`; for a pipeline use `\|>` (R 4.1+) or `%>%`.`` | A fat-arrow-style token `=>` appears where R expected an expression — common when porting code from JavaScript or other languages (`x => 1`) |
 | `Missing )` / `Missing ]` / etc. | A delimiter was opened but never closed (`library(`) |
 | `In R, 'else' must appear on the same line as the closing '}' of the if block` | `else` placed on its own line after `if (cond) { body }` — R treats the `if` as complete and the `else` becomes an unexpected token |
 | `Syntax error` | Tree-sitter detected a parse error that doesn't match any of the specific patterns above |


### PR DESCRIPTION
## Summary

- Add a `detect_fat_arrow` classifier in `collect_syntax_errors` that recognises the parse shape tree-sitter-r produces for the JavaScript-style fat-arrow typo `x => 1`: a `binary_operator` with `=` as its operator child and an ERROR child consisting solely of `>`. Emits a specific, actionable message in place of the generic `Syntax error`.
- Issue #259 suggested either threading a `parent` parameter (Option A) or running a separate pass (Option B). Implementation uses neither — `tree_sitter::Node::prev_sibling()` already exposes the `=` token directly, so no refactor of `collect_syntax_errors` was needed.
- Document the new message in `docs/diagnostics.md` alongside the other specific parse-error patterns.

Closes #259

## Test plan

- [x] `cargo test -p raven` — all 3827 unit + 103 integration tests pass.
- [x] `cargo test --release -p raven --features test-support` (the CI configuration) — green.
- [x] New unit tests cover the happy path (`x => 1`), a complex RHS (`foo => bar(x)`), and the negative case (`1 > > 2` — a lone `>` whose preceding token is not `=` must remain `Syntax error`, not be misclassified).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/raven/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->