### PR TITLE
fix(package-mode): treat testthat exports + helpers as in-scope under tests/testthat/ (#275)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ When making significant changes:
   - `config_file::recompute_parsed_configs(state)` is the only function that should write to `state.lint_config` / `cross_file_config` / etc. after a settings change.
   - Callers (`initialize`, `did_change_configuration`, `did_change_watched_files`) must mutate the raw layers and then call `recompute_parsed_configs`, never the parsers directly.
 
+- **Package-mode scope contribution**
+  - `PackageScopeContribution`'s `r_internal_symbols`, `imported_symbols`, `test_helper_symbols`, and `test_attached_packages` are injected into the queried file's scope by `append_package_contribution` (recursive path, depth 0) and `ScopeStream::snapshot()` (streaming path). Both gate on `is_r_source_path(uri, root)`: files under `R/` see `r_internal_symbols` + `imported_symbols`; files under `tests/testthat/` see those PLUS `test_helper_symbols` (per-helper-path keyed so a helper does not self-inject) PLUS `test_attached_packages` (added to `scope.inherited_packages`, modelling `testthat::test_check`'s implicit `library(testthat)`). Files outside `R/` / `tests/testthat/` get NO contribution.
+  - `ScopeStream::is_visible` and `symbol_for` must consult the pre-computed `contribution_symbol_names` after frame/prefix checks, otherwise out-of-scope diagnostics misattribute contribution-provided names to forward `source()` calls.
+  - Test-only contributions (`test_helper_symbols`, `test_attached_packages`) MUST stay invisible to `R/` files. Mirror the gate by branching on `RFileKind::Test` inside the injection helpers, not by re-deriving the test-dir check from the path.
+
 ## Quick commands
 
 - Debug build: `cargo build -p raven`

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -4077,11 +4077,73 @@ where
     // always take precedence (additive-only).
     if current_depth == 0 {
         if let Some(contrib) = package_contribution {
-            append_package_contribution(&mut scope.symbols, uri, contrib);
+            append_package_contribution(&mut scope, uri, contrib);
         }
     }
 
     scope
+}
+
+/// Compute the set of symbol names the package contribution would inject
+/// for `queried_uri`, mirroring [`append_package_contribution`]'s path /
+/// `RFileKind` gating. Returns an empty set when there's no contribution
+/// or when the queried URI isn't under `<root>/R/` or
+/// `<root>/tests/testthat/`.
+///
+/// Used by [`ScopeStream`] so `is_visible` / `symbol_for` agree with
+/// `snapshot()` on which contribution-derived names are in scope — out-of-
+/// scope diagnostics call only `is_visible`, so without this set they
+/// would emit "used before available" misattributions for helper symbols.
+///
+/// `test_helper_symbols` keyed by helper path are filtered to exclude the
+/// queried file's own entry, preserving forward-reference diagnostics
+/// inside a helper file.
+fn compute_contribution_symbol_names(
+    queried_uri: &Url,
+    contribution: Option<&crate::package_state::PackageScopeContribution>,
+) -> HashSet<Arc<str>> {
+    let mut out: HashSet<Arc<str>> = HashSet::new();
+    let Some(contrib) = contribution else {
+        return out;
+    };
+    let Some(root) = contrib.workspace_root.as_ref() else {
+        return out;
+    };
+    let Ok(path) = queried_uri.to_file_path() else {
+        return out;
+    };
+    let Some(kind) = crate::package_state::is_r_source_path(&path, root) else {
+        return out;
+    };
+    for sym in contrib.r_internal_symbols.iter() {
+        out.insert(Arc::from(sym.as_str()));
+    }
+    for sym in contrib.imported_symbols.keys() {
+        out.insert(Arc::from(sym.as_str()));
+    }
+    if kind == crate::package_state::RFileKind::Test {
+        // Mirror `append_package_contribution`'s sourcing-order gate so
+        // `is_visible` / `symbol_for` agree with `snapshot()`: a helper
+        // file only sees alphabetically-earlier helpers, while
+        // `test-*.R` and other non-helper test files see them all.
+        let queried_is_helper = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(crate::package_state::is_test_helper_filename)
+            .unwrap_or(false);
+        for (helper_path, syms) in contrib.test_helper_symbols.iter() {
+            if helper_path == &path {
+                continue;
+            }
+            if queried_is_helper && helper_path >= &path {
+                continue;
+            }
+            for sym in syms.iter() {
+                out.insert(Arc::from(sym.as_str()));
+            }
+        }
+    }
+    out
 }
 
 /// Synthetic `source_uri` used for symbols injected by
@@ -4102,19 +4164,29 @@ pub fn is_package_internal_uri(uri: &Url) -> bool {
     uri.as_str() == PACKAGE_INTERNAL_URI
 }
 
-/// Inject package-mode symbols into a visible-symbol map for Phase 5a.
+/// Inject package-mode symbols into the queried file's scope for Phase 5a.
 ///
-/// Called only at depth 0 from `scope_at_position_with_graph_recursive`.
-/// Inserts synthetic `ScopedSymbol` entries for:
+/// Called only at depth 0 from `scope_at_position_with_graph_recursive`
+/// (and from the streaming `ScopeStream::snapshot()` path).
+///
+/// For files under `<root>/R/` or `<root>/tests/testthat/`, inserts synthetic
+/// `ScopedSymbol` entries for:
 /// - Every name in `contrib.r_internal_symbols` (package-internal definitions)
 /// - Every key in `contrib.imported_symbols` (NAMESPACE `importFrom` targets)
+///
+/// For files under `<root>/tests/testthat/` additionally:
+/// - Every name in `contrib.test_helper_symbols` (top-level defs from
+///   `tests/testthat/helper-*.R`) is inserted into the symbol map
+/// - Every package in `contrib.test_attached_packages` is added to
+///   `scope.inherited_packages`, modelling the implicit `library(testthat)`
+///   that `tests/testthat.R` performs before sourcing each test file.
 ///
 /// Names already present in `symbols` are NOT overwritten — local and cross-file
 /// definitions always take precedence. `full_imports` entries are intentionally
 /// skipped: enumerating their symbols requires the package library, which is
 /// handled by the existing `pkg_resolver` / combined-exports path.
 pub(crate) fn append_package_contribution(
-    symbols: &mut HashMap<Arc<str>, ScopedSymbol>,
+    scope: &mut ScopeAtPosition,
     uri: &Url,
     contrib: &crate::package_state::PackageScopeContribution,
 ) {
@@ -4125,9 +4197,9 @@ pub(crate) fn append_package_contribution(
         return;
     };
     // Only inject for files under <root>/R/ or <root>/tests/testthat/.
-    if crate::package_state::is_r_source_path(&path, root).is_none() {
+    let Some(kind) = crate::package_state::is_r_source_path(&path, root) else {
         return;
-    }
+    };
 
     // Use a synthetic URI scheme for package-internal symbols so consumers
     // can distinguish them from real file-backed definitions.
@@ -4141,7 +4213,7 @@ pub(crate) fn append_package_contribution(
     // `PackageScopeContribution` propagates kind metadata, use it here.
     for sym in contrib.r_internal_symbols.iter() {
         let name: Arc<str> = Arc::from(sym.as_str());
-        symbols.entry(name.clone()).or_insert_with(|| ScopedSymbol {
+        scope.symbols.entry(name.clone()).or_insert_with(|| ScopedSymbol {
             name,
             kind: SymbolKind::Variable,
             source_uri: pkg_uri.clone(),
@@ -4154,7 +4226,7 @@ pub(crate) fn append_package_contribution(
 
     for sym in contrib.imported_symbols.keys() {
         let name: Arc<str> = Arc::from(sym.as_str());
-        symbols.entry(name.clone()).or_insert_with(|| ScopedSymbol {
+        scope.symbols.entry(name.clone()).or_insert_with(|| ScopedSymbol {
             name,
             kind: SymbolKind::Variable,
             source_uri: pkg_uri.clone(),
@@ -4163,6 +4235,64 @@ pub(crate) fn append_package_contribution(
             signature: None,
             is_declared: false,
         });
+    }
+
+    // Test-only contributions: only inject when the queried file is under
+    // `tests/testthat/`. Helper symbols are visible to peer test files;
+    // attached packages model `testthat::test_check`'s implicit
+    // `library(testthat)` before sourcing tests. Neither propagates into R/
+    // — that asymmetry is preserved by gating on `RFileKind::Test` here,
+    // mirroring how `r_internal_symbols` is partitioned in
+    // `build_scope_contribution`.
+    if kind == crate::package_state::RFileKind::Test {
+        // Per-helper-file iteration so a helper's own top-level defs are
+        // NOT injected back into the helper itself — preserves
+        // forward-reference diagnostics inside a helper file. Without
+        // this skip, a `use_x()` usage above an `x <- ...` definition
+        // would see `x` via the package contribution and silently mute
+        // the legitimate "undefined variable" / forward-reference
+        // diagnostic.
+        //
+        // For a helper file querying ITS scope, only earlier-sorted
+        // helpers are visible — `testthat::source_test_helpers` sources
+        // files matching `^helper.*\.[rR]$` with `sort()` applied first,
+        // so `helper-b.R`'s top-level code never sees `helper-c.R`'s
+        // defs. For non-helper test files (`test-*.R`, etc.), all
+        // helpers have already been sourced by the time the test runs,
+        // so all helpers are visible.
+        let queried_is_helper = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(crate::package_state::is_test_helper_filename)
+            .unwrap_or(false);
+        for (helper_path, syms) in contrib.test_helper_symbols.iter() {
+            if helper_path == &path {
+                continue;
+            }
+            // When the queried file is itself a helper, restrict
+            // visibility to helpers that sort strictly before it
+            // (testthat's source order). `PathBuf` comparison is
+            // byte-lexicographic, which matches what `sort()` produces
+            // for the typical flat `tests/testthat/` layout.
+            if queried_is_helper && helper_path >= &path {
+                continue;
+            }
+            for sym in syms.iter() {
+                let name: Arc<str> = Arc::from(sym.as_str());
+                scope.symbols.entry(name.clone()).or_insert_with(|| ScopedSymbol {
+                    name,
+                    kind: SymbolKind::Variable,
+                    source_uri: pkg_uri.clone(),
+                    defined_line: 0,
+                    defined_column: 0,
+                    signature: None,
+                    is_declared: false,
+                });
+            }
+        }
+        for pkg in contrib.test_attached_packages.iter() {
+            scope.inherited_packages.insert(pkg.clone());
+        }
     }
 }
 
@@ -4311,6 +4441,27 @@ where
     /// Shared prefix cache so child-source recursion benefits from the
     /// same Stage-1 caching as the queried URI.
     prefix_cache: &'a std::cell::RefCell<ParentPrefixCache>,
+    /// Package-mode contribution. When `Some`, `snapshot()` applies it to
+    /// the materialized `ScopeAtPosition` at the queried URI, mirroring the
+    /// recursive resolver's depth-0 `append_package_contribution` call.
+    /// This ensures the streaming and recursive paths agree on which
+    /// package-internal symbols, imported names, helper top-level defs, and
+    /// test-attached packages (e.g. `testthat` under `tests/testthat/`) are
+    /// visible at the cursor.
+    package_contribution: Option<&'a crate::package_state::PackageScopeContribution>,
+
+    /// Pre-computed set of symbol names that the package contribution would
+    /// inject for `queried_uri` (R/ internals + NAMESPACE-imported names +
+    /// helper top-level defs from peer `helper-*.R` files when querying a
+    /// file under `tests/testthat/`). Consulted by `is_visible` and
+    /// `symbol_for` as a fallthrough so out-of-scope diagnostics — which
+    /// only call `is_visible` — don't misattribute a contribution-provided
+    /// name to a forward `source()` call.
+    ///
+    /// Helper symbols from the queried file itself are intentionally
+    /// excluded (per-helper-file keying in `test_helper_symbols`) so
+    /// forward-reference diagnostics inside the helper still fire.
+    contribution_symbol_names: HashSet<Arc<str>>,
 }
 
 impl<'a, F, G> ScopeStream<'a, F, G>
@@ -4338,6 +4489,7 @@ where
         backward_dep_mode: super::config::BackwardDependencyMode,
         is_cancelled: &'a dyn Fn() -> bool,
         prefix_cache: &'a std::cell::RefCell<ParentPrefixCache>,
+        package_contribution: Option<&'a crate::package_state::PackageScopeContribution>,
     ) -> Option<Self> {
         let artifacts = get_artifacts(queried_uri)?;
 
@@ -4395,6 +4547,13 @@ where
             })
             .or_else(|| super::path_resolve::PathContext::new(queried_uri, workspace_root));
 
+        // Pre-compute the names the package contribution would inject for
+        // `queried_uri`. Doing it once at construction keeps
+        // `is_visible`/`symbol_for` O(1) hash lookups instead of repeatedly
+        // walking the BTreeMap of helper files.
+        let contribution_symbol_names =
+            compute_contribution_symbol_names(queried_uri, package_contribution);
+
         Some(Self {
             queried_uri,
             artifacts,
@@ -4417,6 +4576,8 @@ where
             is_cancelled,
             path_ctx,
             prefix_cache,
+            package_contribution,
+            contribution_symbol_names,
         })
     }
 
@@ -4672,7 +4833,11 @@ where
                 return true;
             }
             if frame.removed_names.contains(name) {
-                return false;
+                // Contribution re-injects after rm() in the recursive
+                // resolver's depth-0 ordering, so we must match that:
+                // a removed name remains visible if the package
+                // contribution would re-add it.
+                return self.contribution_symbol_names.contains(name);
             }
         }
         // Global frame: strict or late, depending on hoisting.
@@ -4681,11 +4846,21 @@ where
             return true;
         }
         if global.removed_names.contains(name) {
-            return false;
+            return self.contribution_symbol_names.contains(name);
         }
         // Prefix (parent walk).
         let prefix = self.choose_prefix();
-        prefix.symbols.contains_key(name)
+        if prefix.symbols.contains_key(name) {
+            return true;
+        }
+        // Package contribution last — keeps the streaming visibility view
+        // aligned with the recursive resolver's depth-0
+        // `append_package_contribution`. The out-of-scope diagnostic
+        // collector and any other `is_visible`-only consumers need this
+        // fallthrough; otherwise a contribution-provided name would be
+        // misreported as "used before available" relative to a forward
+        // `source()` that happens to export the same name.
+        self.contribution_symbol_names.contains(name)
     }
 
     /// Materialize a full `ScopeAtPosition` at the cursor. The resulting
@@ -4832,6 +5007,16 @@ where
             }
         }
 
+        // Apply package-mode contribution at the queried URI, mirroring the
+        // recursive resolver's depth-0 injection. Keeping the call here (not
+        // inside `is_visible` / `symbol_for`) keeps the streaming fast path
+        // cheap; diagnostic callers that need the contribution in the
+        // visibility check route through `parent_symbol_names` (computed via
+        // the recursive path at position (0, 0)).
+        if let Some(contrib) = self.package_contribution {
+            append_package_contribution(&mut scope, self.queried_uri, contrib);
+        }
+
         scope
     }
 
@@ -4845,23 +5030,52 @@ where
         if self.query_inside_function() {
             self.ensure_global_late_frame();
         }
+        let mut removed = false;
         for (_iv, frame) in self.function_stack.iter().rev() {
             if let Some(sym) = frame.symbols.get(name) {
                 return Some(sym.clone());
             }
             if frame.removed_names.contains(name) {
-                return None;
+                removed = true;
+                break;
             }
         }
-        let global = self.choose_global_frame();
-        if let Some(sym) = global.symbols.get(name) {
-            return Some(sym.clone());
+        if !removed {
+            let global = self.choose_global_frame();
+            if let Some(sym) = global.symbols.get(name) {
+                return Some(sym.clone());
+            }
+            if global.removed_names.contains(name) {
+                removed = true;
+            }
         }
-        if global.removed_names.contains(name) {
-            return None;
+        if !removed {
+            let prefix = self.choose_prefix();
+            if let Some(sym) = prefix.symbols.get(name).cloned() {
+                return Some(sym);
+            }
         }
-        let prefix = self.choose_prefix();
-        prefix.symbols.get(name).cloned()
+        // Package contribution fallthrough — matches the recursive
+        // resolver's depth-0 `or_insert_with`, where contribution
+        // symbols are added AFTER local timeline events (including rm).
+        // We return a synthetic `ScopedSymbol` whose `source_uri` is the
+        // shared package-internal URI; downstream consumers already
+        // recognize it via [`is_package_internal_uri`].
+        if self.contribution_symbol_names.contains(name) {
+            let pkg_uri = Url::parse(PACKAGE_INTERNAL_URI)
+                .unwrap_or_else(|_| Url::parse("package:internal").unwrap());
+            let name_arc: Arc<str> = Arc::from(name);
+            return Some(ScopedSymbol {
+                name: name_arc,
+                kind: SymbolKind::Variable,
+                source_uri: pkg_uri,
+                defined_line: 0,
+                defined_column: 0,
+                signature: None,
+                is_declared: false,
+            });
+        }
+        None
     }
 
     /// Pick the prefix slot matching the cursor's current state. With
@@ -13561,6 +13775,7 @@ y <- filter(df)"#;
                     crate::cross_file::config::BackwardDependencyMode::Auto,
                     &is_cancelled,
                     &prefix_cache,
+                    None,
                 ).expect("stream construction must succeed");
 
                 for &(line, col) in &positions {
@@ -13823,6 +14038,7 @@ y <- filter(df)"#;
                 crate::cross_file::config::BackwardDependencyMode::Auto,
                 &is_cancelled,
                 &prefix_cache,
+                None,
             )
             .expect("stream construction must succeed");
 
@@ -13977,6 +14193,7 @@ y <- filter(df)"#;
                 crate::cross_file::config::BackwardDependencyMode::Auto,
                 &is_cancelled,
                 &prefix_cache,
+                None,
             )
             .expect("stream construction must succeed");
             stream.advance_to(3, 0);
@@ -14098,6 +14315,7 @@ y <- filter(df)"#;
                 crate::cross_file::config::BackwardDependencyMode::Auto,
                 &is_cancelled,
                 &prefix_cache,
+                None,
             )
             .expect("stream construction must succeed");
             stream.advance_to(1, 0);
@@ -16865,6 +17083,7 @@ y <- filter(df)"#;
             crate::cross_file::config::BackwardDependencyMode::Auto,
             &is_cancelled,
             &prefix_cache,
+            None,
         )
         .expect("stream construction must succeed");
 
@@ -16999,6 +17218,7 @@ y <- filter(df)"#;
             crate::cross_file::config::BackwardDependencyMode::Auto,
             &is_cancelled,
             &prefix_cache,
+            None,
         )
         .expect("stream construction must succeed");
 
@@ -17059,6 +17279,7 @@ y <- filter(df)"#;
             crate::cross_file::config::BackwardDependencyMode::Auto,
             &is_cancelled,
             &prefix_cache,
+            None,
         )
         .expect("stream construction must succeed");
 
@@ -17131,6 +17352,7 @@ y <- filter(df)"#;
             crate::cross_file::config::BackwardDependencyMode::Auto,
             &is_cancelled,
             &prefix_cache,
+            None,
         )
         .expect("stream construction must succeed");
 
@@ -17221,6 +17443,7 @@ y <- filter(df)"#;
             crate::cross_file::config::BackwardDependencyMode::Auto,
             &is_cancelled,
             &prefix_cache,
+            None,
         )
         .expect("stream construction must succeed");
 
@@ -17317,6 +17540,8 @@ mod package_contribution_tests {
             r_internal_symbols: Arc::new(r_internal_symbols),
             imported_symbols: Arc::new(imported_symbols),
             full_imports: Arc::new(BTreeSet::new()),
+            test_attached_packages: Arc::new(BTreeSet::new()),
+            test_helper_symbols: Arc::new(std::collections::BTreeMap::new()),
         }
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5067,6 +5067,21 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         snapshot.cross_file_config.backward_dependencies,
         &is_cancelled_fn,
         &snapshot.parent_prefix_cache,
+        Some(&snapshot.scope_contribution),
+    );
+
+    // Pre-compute the names of test-attached packages (testthat under
+    // `tests/testthat/`) for this URI so the per-usage loop below can
+    // suppress "used before available" misattributions for testthat
+    // exports. Without this, a `test_that(...)` use earlier than a later
+    // `source()` whose target also exports `test_that` would falsely
+    // report the source() as the binding origin. The undefined-variable
+    // collector handles this via `is_package_export` reading
+    // `scope.inherited_packages`, but `is_visible` here only checks the
+    // symbol set, so we need the explicit guard.
+    let test_attached_packages_for_uri: Vec<String> = test_attached_packages_for_uri(
+        snapshot,
+        uri,
     );
 
     // Pre-resolve scope at each forward-source's call site so the
@@ -5131,6 +5146,34 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         };
 
         if in_scope {
+            continue;
+        }
+
+        // Suppress out-of-scope misattribution when `name` is exported by a
+        // test-attached package (testthat under `tests/testthat/`). Matches
+        // the undefined-variable collector's `is_package_export` path —
+        // without it, a later `source()` that happens to export the same
+        // name would be reported as the binding origin even though the
+        // testthat attachment already provides it.
+        //
+        // Intentional limitation: we do not apply a pending-cache fallback
+        // here (as the undefined-variable collector does). The
+        // out-of-scope diagnostic is much narrower — it only fires when a
+        // later `source()` exports the same name — so a transient false
+        // positive during `PackageLibrary` startup is preferable to the
+        // over-suppression a pending fallback would introduce: such a
+        // fallback would skip *every* function-call usage in
+        // `tests/testthat/` whenever testthat is uncached, silencing real
+        // "used before source()" bugs for unrelated names.
+        if snapshot.cross_file_config.packages_enabled
+            && snapshot.package_library_ready
+            && !test_attached_packages_for_uri.is_empty()
+            && is_package_export(
+                name,
+                &test_attached_packages_for_uri,
+                &snapshot.package_library,
+            )
+        {
             continue;
         }
 
@@ -5374,6 +5417,7 @@ fn collect_undefined_variables_from_snapshot(
         snapshot.cross_file_config.backward_dependencies,
         &is_cancelled_fn,
         &snapshot.parent_prefix_cache,
+        Some(&snapshot.scope_contribution),
     );
 
     // Reusable buffer for position-aware packages; avoids per-iteration allocation.
@@ -9391,6 +9435,38 @@ fn is_package_export(
     // This checks base exports first, then cached package exports
     // Requirements 8.1, 8.2: Check position-aware loaded packages
     package_library.is_symbol_from_loaded_packages(name, loaded_packages)
+}
+
+/// Return the list of test-attached package names that apply to `uri` —
+/// i.e. the packages the snapshot's `scope_contribution.test_attached_packages`
+/// declares, but only when `uri` is under `<root>/tests/testthat/`. Empty
+/// otherwise (R/ files and non-package workspaces).
+///
+/// Used by the out-of-scope diagnostic collector to suppress
+/// misattribution of testthat exports to a later `source()` call.
+/// The undefined-variable collector achieves the same effect via
+/// `scope.inherited_packages` (which `append_package_contribution`
+/// populates), but `ScopeStream::is_visible` only consults the symbol
+/// set, so the out-of-scope path needs this explicit guard.
+fn test_attached_packages_for_uri(snapshot: &DiagnosticsSnapshot, uri: &Url) -> Vec<String> {
+    if snapshot.scope_contribution.test_attached_packages.is_empty() {
+        return Vec::new();
+    }
+    let Some(root) = snapshot.scope_contribution.workspace_root.as_ref() else {
+        return Vec::new();
+    };
+    let Ok(path) = uri.to_file_path() else {
+        return Vec::new();
+    };
+    match crate::package_state::is_r_source_path(&path, root) {
+        Some(crate::package_state::RFileKind::Test) => snapshot
+            .scope_contribution
+            .test_attached_packages
+            .iter()
+            .cloned()
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 #[allow(dead_code)]
@@ -15631,6 +15707,8 @@ clean_data <- function(x) {
                         r_internal_symbols: std::sync::Arc::new(internal),
                         imported_symbols: Default::default(),
                         full_imports: Default::default(),
+                        test_attached_packages: Default::default(),
+                        test_helper_symbols: Default::default(),
                     },
                     ..Default::default()
                 });
@@ -15708,6 +15786,8 @@ clean_data <- function(x) {
                         r_internal_symbols: Default::default(),
                         imported_symbols: Default::default(),
                         full_imports: std::sync::Arc::new(full),
+                        test_attached_packages: Default::default(),
+                        test_helper_symbols: Default::default(),
                     },
                     ..Default::default()
                 });
@@ -15772,6 +15852,8 @@ clean_data <- function(x) {
                     r_internal_symbols: Default::default(),
                     imported_symbols: std::sync::Arc::new(imported),
                     full_imports: Default::default(),
+                    test_attached_packages: Default::default(),
+                    test_helper_symbols: Default::default(),
                 },
                 ..Default::default()
             });
@@ -15851,6 +15933,8 @@ clean_data <- function(x) {
                     r_internal_symbols: std::sync::Arc::new(internal),
                     imported_symbols: Default::default(),
                     full_imports: Default::default(),
+                    test_attached_packages: Default::default(),
+                    test_helper_symbols: Default::default(),
                 },
                 ..Default::default()
             });
@@ -15887,6 +15971,556 @@ clean_data <- function(x) {
                 .any(|d| d.message == "Undefined variable: helper_fn"),
             "r_internal_symbols must suppress undefined-variable for R/ files. \
              messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Issue #275: `test_helper_symbols` (top-level defs from
+    /// `tests/testthat/helper-*.R`) must suppress undefined-variable
+    /// diagnostics in peer files under `tests/testthat/`.
+    ///
+    /// The synthetic `helper-*.R` symbol contribution flows through the
+    /// recursive resolver's depth-0 `append_package_contribution`; the
+    /// streaming diagnostic loop catches it via `parent_symbol_names`
+    /// (computed by `snapshot.get_scope(uri, 0, 0)` — the recursive path
+    /// with the package contribution applied).
+    #[tokio::test]
+    async fn test_diagnostic_suppresses_test_helper_symbol_in_testthat_file() {
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::BTreeSet;
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+
+        let mut helper_syms = BTreeSet::new();
+        helper_syms.insert("fixture".to_string());
+        let mut helpers = std::collections::BTreeMap::new();
+        helpers.insert(
+            std::path::PathBuf::from("/work/pkg/tests/testthat/helper-fixtures.R"),
+            std::sync::Arc::new(helper_syms),
+        );
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(std::path::PathBuf::from("/work/pkg")),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: Default::default(),
+                    test_helper_symbols: std::sync::Arc::new(helpers),
+                },
+                ..Default::default()
+            });
+
+        let code = "x <- fixture()\n";
+        let uri = Url::parse("file:///work/pkg/tests/testthat/test-foo.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message == "Undefined variable: fixture"),
+            "test_helper_symbols must suppress undefined-variable for peer test files. \
+             messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Issue #275 asymmetry: `test_helper_symbols` must NOT suppress the
+    /// undefined-variable diagnostic for files under `R/` — the same one-way
+    /// visibility that excludes `tests/testthat/` defs from
+    /// `r_internal_symbols` applies here.
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn test_diagnostic_does_not_suppress_test_helper_in_R_file() {
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::BTreeSet;
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+
+        let mut helper_syms = BTreeSet::new();
+        helper_syms.insert("fixture".to_string());
+        let mut helpers = std::collections::BTreeMap::new();
+        helpers.insert(
+            std::path::PathBuf::from("/work/pkg/tests/testthat/helper-fixtures.R"),
+            std::sync::Arc::new(helper_syms),
+        );
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(std::path::PathBuf::from("/work/pkg")),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: Default::default(),
+                    test_helper_symbols: std::sync::Arc::new(helpers),
+                },
+                ..Default::default()
+            });
+
+        let code = "x <- fixture()\n";
+        let uri = Url::parse("file:///work/pkg/R/main.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message == "Undefined variable: fixture"),
+            "R/ files must not see test_helper_symbols — expected an \
+             undefined-variable diagnostic. messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Issue #275: when testthat is in `test_attached_packages` and the
+    /// queried file is under `tests/testthat/`, an undefined-variable
+    /// diagnostic for a testthat export (e.g. `test_that`) must be
+    /// suppressed via the standard package-export path. This exercises the
+    /// `ScopeStream::snapshot()` injection — `is_package_export` reads
+    /// `scope.inherited_packages`, which the contribution populates with
+    /// "testthat" for files under `tests/testthat/`.
+    #[tokio::test]
+    async fn test_diagnostic_suppresses_testthat_export_in_testthat_file() {
+        use crate::package_library::PackageInfo;
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::{BTreeSet, HashSet};
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+
+        // Seed `testthat` with `test_that` as an export so `is_package_export`
+        // recognizes it through the package_library lookup.
+        let mut testthat_exports = HashSet::new();
+        testthat_exports.insert("test_that".to_string());
+        testthat_exports.insert("expect_equal".to_string());
+        state
+            .package_library
+            .insert_package(PackageInfo::new("testthat".to_string(), testthat_exports))
+            .await;
+
+        let mut attached = BTreeSet::new();
+        attached.insert("testthat".to_string());
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(std::path::PathBuf::from("/work/pkg")),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: std::sync::Arc::new(attached),
+                    test_helper_symbols: Default::default(),
+                },
+                ..Default::default()
+            });
+
+        let code = "test_that(\"x works\", { expect_equal(1, 1) })\n";
+        let uri = Url::parse("file:///work/pkg/tests/testthat/test-foo.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message.contains("test_that") || d.message.contains("expect_equal")),
+            "testthat exports must not trigger undefined-variable in tests/testthat/. \
+             messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Codex follow-up: the out-of-scope diagnostic collector must not
+    /// misattribute a testthat export to a later `source()` call when the
+    /// queried file is under `tests/testthat/`. The
+    /// `test_attached_packages_for_uri` guard inside
+    /// `collect_out_of_scope_diagnostics_from_snapshot` covers this case;
+    /// `ScopeStream::is_visible` alone does not, because the implicit
+    /// `library(testthat)` adds to `inherited_packages`, not `symbols`.
+    ///
+    /// Test layout: a `tests/testthat/` directory with one file calling
+    /// `test_that(...)` at line 0 then `source('test-other.R')` at line 1,
+    /// where `test-other.R` redefines `test_that`. Without the guard the
+    /// collector would report `test_that` as "used before source()".
+    /// Both files are registered in `state.cross_file_graph` so the AST-
+    /// detected source() edge is present — without this the collector's
+    /// inner loop has no source target to misattribute against, and the
+    /// guard would never be exercised.
+    #[tokio::test]
+    async fn test_out_of_scope_suppresses_test_attached_export_in_testthat_file() {
+        use crate::package_library::PackageInfo;
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::{BTreeSet, HashSet};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+        let testthat_dir = workspace_path.join("tests").join("testthat");
+        std::fs::create_dir_all(&testthat_dir).unwrap();
+        let main_path = testthat_dir.join("test-foo.R");
+        let other_path = testthat_dir.join("test-other.R");
+
+        let main_code = "test_that(\"x\", { 1 })\nsource('test-other.R')\n";
+        let other_code = "test_that <- function(...) NULL\n";
+        std::fs::write(&other_path, other_code).unwrap();
+        std::fs::write(&main_path, main_code).unwrap();
+
+        let workspace_url = Url::from_file_path(workspace_path).unwrap();
+        let main_url = Url::from_file_path(&main_path).unwrap();
+        let other_url = Url::from_file_path(&other_path).unwrap();
+
+        let mut state = WorldState::new(Vec::new());
+        state.workspace_folders = vec![workspace_url];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.out_of_scope_severity = Some(DiagnosticSeverity::WARNING);
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+
+        // Register testthat's exports so `is_package_export` recognizes `test_that`.
+        let mut testthat_exports = HashSet::new();
+        testthat_exports.insert("test_that".to_string());
+        state
+            .package_library
+            .insert_package(PackageInfo::new("testthat".to_string(), testthat_exports))
+            .await;
+
+        let mut attached = BTreeSet::new();
+        attached.insert("testthat".to_string());
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(workspace_path.to_path_buf()),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: std::sync::Arc::new(attached),
+                    test_helper_symbols: Default::default(),
+                },
+                ..Default::default()
+            });
+
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(main_code, None));
+        state
+            .documents
+            .insert(other_url.clone(), Document::new(other_code, None));
+
+        // Wire up the dependency graph so the source() edge is visible
+        // to the out-of-scope collector. Without these calls
+        // `snapshot.cross_file_graph.get_dependencies(main_url)` returns
+        // nothing and the inner loop's `source_target_live_exports` lookup
+        // returns None — meaning the guard under test would never fire
+        // even if it were broken.
+        state.cross_file_graph.update_file(
+            &main_url,
+            &crate::cross_file::extract_metadata(main_code),
+            None,
+            |_| None,
+        );
+        state.cross_file_graph.update_file(
+            &other_url,
+            &crate::cross_file::extract_metadata(other_code),
+            None,
+            |_| None,
+        );
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for test-foo.R");
+        let mut diagnostics = Vec::new();
+        collect_out_of_scope_diagnostics_from_snapshot(
+            &snapshot,
+            &main_url,
+            snapshot.tree.root_node(),
+            &snapshot.text,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message.contains("test_that") && d.message.contains("used before")),
+            "testthat exports under tests/testthat/ must not be reported as used-before-sourced. \
+             messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Codex follow-up #2: the pending-cache fallback in the out-of-scope
+    /// guard must only treat uncached packages as pending when they
+    /// actually exist on disk. A declared-but-uninstalled testthat would
+    /// otherwise leave `is_cached_sync` returning false forever, silently
+    /// suppressing every function-call usage in `tests/testthat/`.
+    ///
+    /// Construction notes: `package_library.package_exists("testthat")`
+    /// reports false because we never insert testthat into the library
+    /// nor write a fake libpath. The source() target `test-other.R`
+    /// defines `test_that`, so the diagnostic SHOULD fire once the
+    /// pending-cache shortcut is correctly gated on installation status.
+    #[tokio::test]
+    async fn test_out_of_scope_does_not_suppress_when_test_pkg_uninstalled() {
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::BTreeSet;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+        let testthat_dir = workspace_path.join("tests").join("testthat");
+        std::fs::create_dir_all(&testthat_dir).unwrap();
+        let main_path = testthat_dir.join("test-foo.R");
+        let other_path = testthat_dir.join("test-other.R");
+
+        let main_code = "test_that(\"x\", { 1 })\nsource('test-other.R')\n";
+        let other_code = "test_that <- function(...) NULL\n";
+        std::fs::write(&other_path, other_code).unwrap();
+        std::fs::write(&main_path, main_code).unwrap();
+
+        let workspace_url = Url::from_file_path(workspace_path).unwrap();
+        let main_url = Url::from_file_path(&main_path).unwrap();
+        let other_url = Url::from_file_path(&other_path).unwrap();
+
+        let mut state = WorldState::new(Vec::new());
+        state.workspace_folders = vec![workspace_url];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.out_of_scope_severity = Some(DiagnosticSeverity::WARNING);
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+        // NOTE: we intentionally do NOT seed testthat into package_library.
+        // package_exists("testthat") returns false (no libpath, no entry),
+        // so the pending-cache shortcut must NOT silence the diagnostic.
+
+        let mut attached = BTreeSet::new();
+        attached.insert("testthat".to_string());
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(workspace_path.to_path_buf()),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: std::sync::Arc::new(attached),
+                    test_helper_symbols: Default::default(),
+                },
+                ..Default::default()
+            });
+
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(main_code, None));
+        state
+            .documents
+            .insert(other_url.clone(), Document::new(other_code, None));
+        state.cross_file_graph.update_file(
+            &main_url,
+            &crate::cross_file::extract_metadata(main_code),
+            None,
+            |_| None,
+        );
+        state.cross_file_graph.update_file(
+            &other_url,
+            &crate::cross_file::extract_metadata(other_code),
+            None,
+            |_| None,
+        );
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for test-foo.R");
+        let mut diagnostics = Vec::new();
+        collect_out_of_scope_diagnostics_from_snapshot(
+            &snapshot,
+            &main_url,
+            snapshot.tree.root_node(),
+            &snapshot.text,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("test_that") && d.message.contains("used before")),
+            "uninstalled test-attached package must NOT silence the out-of-scope diagnostic. \
+             messages: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Issue #275 asymmetry: testthat exports must STILL be flagged as
+    /// undefined when used outside `tests/testthat/` — even if the package
+    /// declares `Suggests: testthat`. Implicit attachment is scoped to
+    /// `tests/testthat/`; an R/ file calling `test_that(...)` is a real bug.
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn test_diagnostic_flags_testthat_export_in_R_file() {
+        use crate::package_library::PackageInfo;
+        use crate::package_state::PackageScopeContribution;
+        use crate::state::{Document, WorldState};
+        use std::collections::{BTreeSet, HashSet};
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+
+        let mut testthat_exports = HashSet::new();
+        testthat_exports.insert("test_that".to_string());
+        state
+            .package_library
+            .insert_package(PackageInfo::new("testthat".to_string(), testthat_exports))
+            .await;
+
+        let mut attached = BTreeSet::new();
+        attached.insert("testthat".to_string());
+        state
+            .package_state
+            .set_from(crate::package_state::PackageState {
+                scope_contribution: PackageScopeContribution {
+                    workspace_root: Some(std::path::PathBuf::from("/work/pkg")),
+                    r_internal_symbols: Default::default(),
+                    imported_symbols: Default::default(),
+                    full_imports: Default::default(),
+                    test_attached_packages: std::sync::Arc::new(attached),
+                    test_helper_symbols: Default::default(),
+                },
+                ..Default::default()
+            });
+
+        let code = "test_that(\"x works\", { 1 })\n";
+        let uri = Url::parse("file:///work/pkg/R/main.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message == "Undefined variable: test_that"),
+            "R/ files must flag testthat exports as undefined. messages: {:?}",
             diagnostics
                 .iter()
                 .map(|d| d.message.clone())

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -300,6 +300,14 @@ pub fn parse_description_depends(description_path: &Path) -> Result<Vec<String>>
     Ok(parse_description_field(&content, "Depends"))
 }
 
+/// Public wrapper around `parse_description_field` for use from other modules
+/// that need to inspect dependency lists (e.g., the package-mode derivation
+/// querying `Suggests:` / `Imports:` / `Depends:` for implicit attachment in
+/// `tests/testthat/`). Strips version constraints and the special `R` entry.
+pub fn parse_description_field_pub(content: &str, field_name: &str) -> Vec<String> {
+    parse_description_field(content, field_name)
+}
+
 /// Extracts the value of a named field from DESCRIPTION (DCF) content and parses it into package names.
 ///
 /// The function locates `field_name:` at the start of a line, accumulates its value including continuation

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -36,7 +36,12 @@ pub fn derive_package_state(
     } else {
         None
     };
-    let scope_contribution = build_scope_contribution(&workspace, &namespace_model, &r_file_facts);
+    let scope_contribution = build_scope_contribution(
+        &workspace,
+        &namespace_model,
+        &r_file_facts,
+        inputs.description.as_ref(),
+    );
     PackageState {
         workspace,
         namespace_model,
@@ -50,6 +55,7 @@ fn build_scope_contribution(
     workspace: &Option<PackageWorkspace>,
     namespace_model: &Option<PackageNamespaceModel>,
     r_file_facts: &BTreeMap<PathBuf, RFileFacts>,
+    description: Option<&DescriptionInput>,
 ) -> PackageScopeContribution {
     let Some(ws) = workspace else {
         return PackageScopeContribution::default();
@@ -58,13 +64,56 @@ fn build_scope_contribution(
     // (exclude tests/testthat/* — those are kind == Test). Partition is
     // driven by the canonical `RFileKind` classification carried in
     // `RFileFacts`, not by a path-prefix check.
+    //
+    // test_helper_symbols: union of top_level_defs from `tests/testthat/helper-*.R`
+    // (kind == Test AND filename starts with "helper"), keyed by file path so
+    // the scope-injection layer can skip a helper's own self-injection.
+    // Visible to peer test files; never injected into R/.
+    //
+    // Known limitation (matches `r_internal_symbols`): both sets are built
+    // from `top_level_defs`, which captures every top-level assignment
+    // without applying timeline-level `rm()` / `remove()`. A helper that
+    // does `x <- 1; rm(x)` still contributes `x` to peer-visible names. The
+    // rm-aware extractor (`live_top_level_exports`) operates on parsed
+    // `ScopeArtifacts`, not on the cheap `top_level_defs` slice; aligning
+    // here would require either re-parsing helper files at derive time or
+    // re-keying `RFileFacts` around `ScopeArtifacts`. This edge case is
+    // uncommon in real testthat helpers, so it is left untreated for
+    // symmetry with `r_internal_symbols` (which has the same limitation
+    // for R/ files).
     let mut r_internal_symbols: BTreeSet<String> = BTreeSet::new();
-    for (_path, facts) in r_file_facts {
-        if facts.kind != RFileKind::Source {
-            continue;
-        }
-        for def in facts.top_level_defs.iter() {
-            r_internal_symbols.insert(def.clone());
+    let mut test_helper_symbols: BTreeMap<PathBuf, Arc<BTreeSet<String>>> = BTreeMap::new();
+    for (path, facts) in r_file_facts {
+        match facts.kind {
+            RFileKind::Source => {
+                for def in facts.top_level_defs.iter() {
+                    r_internal_symbols.insert(def.clone());
+                }
+            }
+            RFileKind::Test => {
+                // Helpers must be direct children of `tests/testthat/` —
+                // `testthat::source_test_helpers` uses non-recursive
+                // `dir(path, pattern = "^helper.*\\.[Rr]$")`, so files in
+                // subdirectories (e.g. `tests/testthat/sub/helper-x.R`)
+                // are never auto-sourced. Treating them as helpers here
+                // would silently mute legitimate undefined-variable
+                // diagnostics for any symbol they define.
+                let direct_child = ws.root.join("tests").join("testthat");
+                let is_direct_child_of_testthat = path.parent() == Some(direct_child.as_path());
+                let is_helper = is_direct_child_of_testthat
+                    && path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(super::is_test_helper_filename)
+                        .unwrap_or(false);
+                if is_helper {
+                    // Reuse the helper's `top_level_defs` `Arc` rather than
+                    // cloning into a fresh set — keeps `derive_package_state`
+                    // O(helper-file count) on the cached path instead of
+                    // O(total helper defs).
+                    test_helper_symbols.insert(path.clone(), facts.top_level_defs.clone());
+                }
+            }
         }
     }
     let (imported_symbols, full_imports) = match namespace_model {
@@ -78,12 +127,51 @@ fn build_scope_contribution(
         }
         None => (BTreeMap::new(), BTreeSet::new()),
     };
+    let test_attached_packages = compute_test_attached_packages(description);
     PackageScopeContribution {
         workspace_root: Some(ws.root.clone()),
         r_internal_symbols: Arc::new(r_internal_symbols),
         imported_symbols: Arc::new(imported_symbols),
         full_imports: Arc::new(full_imports),
+        test_attached_packages: Arc::new(test_attached_packages),
+        test_helper_symbols: Arc::new(test_helper_symbols),
     }
+}
+
+/// Packages that should be implicitly attached when resolving scope under
+/// `tests/testthat/`. Currently this is the singleton `{"testthat"}` whenever
+/// the package's `DESCRIPTION` declares testthat in `Suggests:`, `Imports:`,
+/// or `Depends:` — matching `R CMD check`'s "declared dependency" gate.
+/// Returns an empty set otherwise.
+///
+/// The set is intentionally narrow: implicitly attaching every `Suggests:`
+/// dependency in tests would over-approximate and mute legitimate undefined-
+/// variable diagnostics. Other test-only packages should be brought in with
+/// an explicit `library()` call in a `helper-*.R` file or the test file
+/// itself.
+fn compute_test_attached_packages(description: Option<&DescriptionInput>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(desc) = description else {
+        return out;
+    };
+    if description_declares_dependency(&desc.text, "testthat") {
+        out.insert("testthat".to_string());
+    }
+    out
+}
+
+/// Returns `true` if `pkg` appears in DESCRIPTION's `Suggests:`, `Imports:`,
+/// or `Depends:` field. Stripping of version constraints and the special
+/// `R` entry is handled by `parse_description_field_pub`.
+fn description_declares_dependency(description_text: &str, pkg: &str) -> bool {
+    for field in ["Suggests", "Imports", "Depends"] {
+        let listed =
+            crate::namespace_parser::parse_description_field_pub(description_text, field);
+        if listed.iter().any(|p| p == pkg) {
+            return true;
+        }
+    }
+    false
 }
 
 fn merge_namespace_model(
@@ -716,5 +804,298 @@ foo <- function() 1
             n_files,
             imports_per_file,
         );
+    }
+
+    // ------------------------------------------------------------------
+    // testthat implicit-attachment and helper file visibility (#275)
+    // ------------------------------------------------------------------
+
+    /// Suggests-declared testthat should populate `test_attached_packages`,
+    /// which the scope-injection layer uses to model `testthat::test_check`'s
+    /// implicit `library(testthat)` in `tests/testthat/` files.
+    #[test]
+    fn scope_contribution_attaches_testthat_when_in_suggests() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: foo\nSuggests: testthat\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(
+            s.scope_contribution
+                .test_attached_packages
+                .contains("testthat"),
+            "testthat in Suggests must populate test_attached_packages, got: {:?}",
+            s.scope_contribution.test_attached_packages,
+        );
+    }
+
+    /// Imports- and Depends-declared testthat also count: matches `R CMD
+    /// check`'s declared-dependency semantics.
+    #[test]
+    fn scope_contribution_attaches_testthat_when_in_imports_or_depends() {
+        let s_imp = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: foo\nImports: testthat\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(s_imp
+            .scope_contribution
+            .test_attached_packages
+            .contains("testthat"));
+
+        let s_dep = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: foo\nDepends: testthat\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(s_dep
+            .scope_contribution
+            .test_attached_packages
+            .contains("testthat"));
+    }
+
+    /// Without testthat declared anywhere, do not implicitly attach it.
+    /// Hard gate: an undeclared testthat would silently mute legitimate
+    /// undefined-variable diagnostics for any name that happens to be a
+    /// testthat export.
+    #[test]
+    fn scope_contribution_skips_testthat_when_undeclared() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: foo\nSuggests: knitr\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(
+            !s.scope_contribution
+                .test_attached_packages
+                .contains("testthat"),
+            "testthat must NOT be attached when only `knitr` is suggested: {:?}",
+            s.scope_contribution.test_attached_packages,
+        );
+    }
+
+    /// Without package mode active (no DESCRIPTION → no workspace), the
+    /// scope contribution is empty regardless of declared dependencies.
+    #[test]
+    fn scope_contribution_is_empty_outside_package_mode() {
+        let mut inputs = empty_inputs(PackageMode::Auto);
+        inputs.description = Some(DescriptionInput {
+            text: "Suggests: testthat\n".into(), // No Package: field.
+        });
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        assert!(s.workspace.is_none());
+        assert!(s.scope_contribution.test_attached_packages.is_empty());
+        assert!(s.scope_contribution.test_helper_symbols.is_empty());
+    }
+
+    /// `tests/testthat/helper-*.R` top-level defs go into `test_helper_symbols`
+    /// (visible to peer tests) but NOT into `r_internal_symbols` (the one-way
+    /// visibility into R/ stays asymmetric).
+    #[test]
+    fn scope_contribution_collects_helper_top_level_defs() {
+        let helper_path: PathBuf = "/work/pkg/tests/testthat/helper-fixtures.R".into();
+        let test_path: PathBuf = "/work/pkg/tests/testthat/test-foo.R".into();
+
+        let helper_text: Arc<str> = "fixture <- function() 1\n".into();
+        let test_text: Arc<str> = "test_local <- function() 2\n".into();
+
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            helper_path,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: helper_text.clone(),
+                content_digest: ContentDigest::of(&helper_text),
+            },
+        );
+        inputs.r_files.insert(
+            test_path,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: test_text.clone(),
+                content_digest: ContentDigest::of(&test_text),
+            },
+        );
+
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+
+        // Helper defs go into test_helper_symbols.
+        assert!(
+            s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("fixture")),
+            "helper top-level defs must populate test_helper_symbols: {:?}",
+            s.scope_contribution.test_helper_symbols,
+        );
+        // Non-helper test files do NOT pollute test_helper_symbols.
+        assert!(
+            !s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("test_local")),
+            "test-*.R defs must NOT appear in test_helper_symbols: {:?}",
+            s.scope_contribution.test_helper_symbols,
+        );
+        // Neither leaks into r_internal_symbols (R/ files remain isolated
+        // from tests/testthat/ contributions).
+        assert!(!s
+            .scope_contribution
+            .r_internal_symbols
+            .contains("fixture"));
+        assert!(!s
+            .scope_contribution
+            .r_internal_symbols
+            .contains("test_local"));
+    }
+
+    /// Multiple helper files contribute their union — peer helpers see each
+    /// other since `testthat::test_check` sources them in order before each
+    /// test.
+    #[test]
+    fn scope_contribution_unions_helpers_across_files() {
+        let helper_a: PathBuf = "/work/pkg/tests/testthat/helper-a.R".into();
+        let helper_b: PathBuf = "/work/pkg/tests/testthat/helper-b.R".into();
+        let text_a: Arc<str> = "helper_a_fn <- function() 1\n".into();
+        let text_b: Arc<str> = "helper_b_fn <- function() 2\n".into();
+
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            helper_a,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: text_a.clone(),
+                content_digest: ContentDigest::of(&text_a),
+            },
+        );
+        inputs.r_files.insert(
+            helper_b,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: text_b.clone(),
+                content_digest: ContentDigest::of(&text_b),
+            },
+        );
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        assert!(s
+            .scope_contribution
+            .test_helper_symbols
+            .values()
+            .any(|syms| syms.contains("helper_a_fn")));
+        assert!(s
+            .scope_contribution
+            .test_helper_symbols
+            .values()
+            .any(|syms| syms.contains("helper_b_fn")));
+    }
+
+    /// Codex follow-up: `tests/testthat/sub/helper-x.R` must NOT be
+    /// treated as a testthat helper — `testthat::source_test_helpers`
+    /// uses non-recursive `dir(path, pattern = "^helper.*\\.[Rr]$")`, so
+    /// subdirectory helpers are never auto-sourced. Including them in
+    /// `test_helper_symbols` would silently mute legitimate
+    /// undefined-variable diagnostics for any symbol they define.
+    #[test]
+    fn helpers_in_subdirectories_are_not_collected() {
+        let nested: PathBuf = "/work/pkg/tests/testthat/sub/helper-deep.R".into();
+        let direct: PathBuf = "/work/pkg/tests/testthat/helper-top.R".into();
+        let nested_text: Arc<str> = "deep_fixture <- function() 1\n".into();
+        let direct_text: Arc<str> = "top_fixture <- function() 2\n".into();
+
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            nested,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: nested_text.clone(),
+                content_digest: ContentDigest::of(&nested_text),
+            },
+        );
+        inputs.r_files.insert(
+            direct,
+            RFileInput {
+                kind: RFileKind::Test,
+                text: direct_text.clone(),
+                content_digest: ContentDigest::of(&direct_text),
+            },
+        );
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        assert!(
+            s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("top_fixture")),
+            "direct child helper-top.R must contribute its def",
+        );
+        assert!(
+            !s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("deep_fixture")),
+            "subdir helper-deep.R must NOT contribute (testthat does not recurse): {:?}",
+            s.scope_contribution.test_helper_symbols,
+        );
+    }
+
+    /// Issue #275 / Codex review: a helper file's own top-level defs must
+    /// NOT be visible to the helper itself via the contribution. They're
+    /// keyed by file path so the scope-injection layer can skip
+    /// `helper_path == queried_path` entries — that preserves
+    /// forward-reference diagnostics inside a helper.
+    #[test]
+    fn test_helper_symbols_keyed_by_helper_path() {
+        let helper_a: PathBuf = "/work/pkg/tests/testthat/helper-a.R".into();
+        let helper_b: PathBuf = "/work/pkg/tests/testthat/helper-b.R".into();
+        let text_a: Arc<str> = "fixture_a <- function() 1\n".into();
+        let text_b: Arc<str> = "fixture_b <- function() 2\n".into();
+
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            helper_a.clone(),
+            RFileInput {
+                kind: RFileKind::Test,
+                text: text_a.clone(),
+                content_digest: ContentDigest::of(&text_a),
+            },
+        );
+        inputs.r_files.insert(
+            helper_b.clone(),
+            RFileInput {
+                kind: RFileKind::Test,
+                text: text_b.clone(),
+                content_digest: ContentDigest::of(&text_b),
+            },
+        );
+
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+
+        let map = &s.scope_contribution.test_helper_symbols;
+        // Each helper keeps its own defs under its own path.
+        let a_syms = map.get(&helper_a).expect("helper-a entry");
+        assert!(a_syms.contains("fixture_a"));
+        assert!(!a_syms.contains("fixture_b"));
+        let b_syms = map.get(&helper_b).expect("helper-b entry");
+        assert!(b_syms.contains("fixture_b"));
+        assert!(!b_syms.contains("fixture_a"));
     }
 }

--- a/crates/raven/src/package_state/mod.rs
+++ b/crates/raven/src/package_state/mod.rs
@@ -169,6 +169,41 @@ pub fn is_r_source_path(path: &Path, workspace_root: &Path) -> Option<RFileKind>
     }
 }
 
+/// Returns `true` for testthat-recognized helper files: files under
+/// `tests/testthat/` whose basename starts with `"helper"` (case-insensitive
+/// match against testthat's own loader, which sources `^helper.*\\.[rR]$`
+/// before each test file). Helper top-level definitions are visible to peer
+/// files under `tests/testthat/`, but never propagate to `R/`. Setup files
+/// (`setup-*.R`) are not currently treated as helpers; if that scope expands,
+/// adjust here.
+///
+/// The caller is responsible for first confirming the file is under
+/// `tests/testthat/` (e.g. via `is_r_source_path` returning `RFileKind::Test`);
+/// this function only inspects the basename.
+pub fn is_test_helper_filename(file_name: &str) -> bool {
+    // Case-insensitive ASCII "helper" prefix. Slicing by raw byte index
+    // would panic when byte 6 lands inside a multi-byte UTF-8 sequence
+    // (e.g. `tes\u{00E9}.R`), so iterate `bytes()` and compare against
+    // the ASCII prefix instead. Filenames are not normalized by Raven —
+    // a leading non-ASCII glyph that happens to lowercase to "helper" is
+    // intentionally not matched; testthat's loader matches the ASCII
+    // pattern `^helper.*\.[rR]$`.
+    const PREFIX: &[u8] = b"helper";
+    let bytes = file_name.as_bytes();
+    if bytes.len() < PREFIX.len() {
+        return false;
+    }
+    for (i, p) in PREFIX.iter().enumerate() {
+        if !bytes[i].eq_ignore_ascii_case(p) {
+            return false;
+        }
+    }
+    matches!(
+        Path::new(file_name).extension().and_then(|e| e.to_str()),
+        Some("R" | "r")
+    )
+}
+
 #[cfg(test)]
 mod path_tests {
     use super::*;
@@ -230,6 +265,50 @@ mod path_tests {
             Some(RFileKind::Source),
         );
     }
+
+    #[test]
+    fn test_helper_filename_recognizes_helper_prefix() {
+        assert!(is_test_helper_filename("helper.R"));
+        assert!(is_test_helper_filename("helper-utils.R"));
+        assert!(is_test_helper_filename("helper_utils.R"));
+        assert!(is_test_helper_filename("helper.r"));
+        assert!(is_test_helper_filename("Helper-mixedCase.R"));
+        assert!(is_test_helper_filename("HELPER-shouty.R"));
+    }
+
+    #[test]
+    fn test_helper_filename_rejects_non_helpers() {
+        assert!(!is_test_helper_filename("test-utils.R"));
+        assert!(!is_test_helper_filename("setup.R"));
+        assert!(!is_test_helper_filename("teardown.R"));
+        // Prefix matches but extension is not R.
+        assert!(!is_test_helper_filename("helper-data.csv"));
+        assert!(!is_test_helper_filename("helper.txt"));
+        // Too short to start with "helper".
+        assert!(!is_test_helper_filename("help.R"));
+        // Doesn't start with the helper prefix.
+        assert!(!is_test_helper_filename("my-helper.R"));
+    }
+
+    /// Regression: byte-indexed slicing of a multi-byte UTF-8 filename
+    /// must not panic. The original implementation evaluated
+    /// `file_name[..6].eq_ignore_ascii_case("helper")`, which panics when
+    /// byte index 6 falls inside a non-ASCII character.
+    #[test]
+    fn test_helper_filename_multibyte_safe() {
+        // "hel😀.R" — 3 ASCII bytes followed by the 4-byte UTF-8 sequence
+        // for U+1F600. Byte index 6 sits in the MIDDLE of the 4-byte
+        // emoji (bytes 3..7), so the old `file_name[..6]` slice would
+        // panic with "byte index 6 is not a char boundary". The byte-iter
+        // implementation must not panic and must not match (prefix bytes
+        // 0..6 are "hel" + 3 bytes of emoji, which do not equal "helper").
+        let name = "hel\u{1F600}.R";
+        assert!(!is_test_helper_filename(name));
+        // A purely non-ASCII prefix must not match (and must not panic).
+        assert!(!is_test_helper_filename("βλέπω-utils.R"));
+        // A non-ASCII-leading name that happens to share a tail must not match either.
+        assert!(!is_test_helper_filename("éhelper.R"));
+    }
 }
 
 // ============== OUTPUTS (continued) ==============
@@ -258,4 +337,32 @@ pub struct PackageScopeContribution {
     pub r_internal_symbols: Arc<BTreeSet<String>>,
     pub imported_symbols: Arc<BTreeMap<String, BTreeSet<String>>>,
     pub full_imports: Arc<BTreeSet<String>>,
+
+    /// Packages that should be treated as if attached (via `library(...)`)
+    /// when resolving scope for any file under `<root>/tests/testthat/`.
+    ///
+    /// Populated for testthat when the package's `DESCRIPTION` declares
+    /// `testthat` in `Suggests:`, `Imports:`, or `Depends:`. The standard
+    /// `tests/testthat.R` runner attaches testthat before sourcing each test
+    /// file (matching `testthat::test_check`'s semantics), so test files
+    /// transitively see testthat exports without an explicit `library(testthat)`.
+    /// These packages are NOT visible to files under `R/` — they are scoped
+    /// to `tests/testthat/` only.
+    pub test_attached_packages: Arc<BTreeSet<String>>,
+
+    /// Top-level definitions contributed by `tests/testthat/helper-*.R`
+    /// files, keyed by the helper file's path so the scope-injection layer
+    /// can skip a helper's own definitions when querying that helper file
+    /// (otherwise a `use_x()` line earlier in the helper would falsely see
+    /// `x <- ...` defined later in the same file).
+    ///
+    /// Visible from any file under `<root>/tests/testthat/` — peer helpers
+    /// see each other and `test-*.R` files see them all. Never injected
+    /// into files under `R/`. Mirrors `r_internal_symbols` but with the
+    /// opposite visibility direction.
+    ///
+    /// `BTreeMap` ordering is intentional — derive iteration is
+    /// deterministic so cached `PackageState` equality (used by the
+    /// proptest machine) is stable across runs.
+    pub test_helper_symbols: Arc<BTreeMap<PathBuf, Arc<BTreeSet<String>>>>,
 }

--- a/crates/raven/src/state_tests.rs
+++ b/crates/raven/src/state_tests.rs
@@ -691,5 +691,442 @@ mod package_testthat_visibility_tests {
             symbols.keys().collect::<Vec<_>>()
         );
     }
+
+    // ------------------------------------------------------------------
+    // Test C: helper-*.R defs visible to peer test files (issue #275)
+    // ------------------------------------------------------------------
+
+    /// End-to-end: a top-level def in `tests/testthat/helper-fixtures.R`
+    /// is visible when resolving scope inside `tests/testthat/test-foo.R`.
+    #[test]
+    fn helper_top_level_def_visible_in_peer_test_file_end_to_end() {
+        let root = "/work/pkg";
+        let state = build_state_with_files(
+            root,
+            vec![
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-fixtures.R", root)),
+                    RFileKind::Test,
+                    "fixture <- function() 1\n",
+                ),
+                (
+                    PathBuf::from(format!("{}/tests/testthat/test-foo.R", root)),
+                    RFileKind::Test,
+                    "result <- fixture()\n",
+                ),
+            ],
+        );
+
+        // Helper symbol must be carried in `test_helper_symbols`.
+        assert!(
+            state
+                .package_state
+                .scope_contribution()
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("fixture")),
+            "fixture must appear in test_helper_symbols, got: {:?}",
+            state.package_state.scope_contribution().test_helper_symbols,
+        );
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let test_uri = Url::parse("file:///work/pkg/tests/testthat/test-foo.R").unwrap();
+        let test_arts = make_artifacts(&test_uri, "result <- fixture()\n");
+
+        let symbols = resolve_symbols(
+            &test_uri,
+            test_arts,
+            &workspace_root,
+            state.package_state.scope_contribution(),
+        );
+
+        assert!(
+            symbols.contains_key("fixture"),
+            "helper top-level def must be visible in peer tests/testthat/ test file. \
+             visible: {:?}",
+            symbols.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test D: helper-*.R defs NOT visible in R/ files (asymmetry holds)
+    // ------------------------------------------------------------------
+
+    /// End-to-end: a top-level def in `tests/testthat/helper-fixtures.R` is
+    /// NOT visible when resolving scope inside `R/main.R` — preserves the
+    /// existing one-way visibility (tests/testthat/ → R/, never the reverse).
+    #[test]
+    fn helper_top_level_def_not_visible_in_r_dir_end_to_end() {
+        let root = "/work/pkg";
+        let state = build_state_with_files(
+            root,
+            vec![
+                (
+                    PathBuf::from(format!("{}/R/main.R", root)),
+                    RFileKind::Source,
+                    "result <- fixture()\n",
+                ),
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-fixtures.R", root)),
+                    RFileKind::Test,
+                    "fixture <- function() 1\n",
+                ),
+            ],
+        );
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let main_uri = Url::parse("file:///work/pkg/R/main.R").unwrap();
+        let main_arts = make_artifacts(&main_uri, "result <- fixture()\n");
+
+        let symbols = resolve_symbols(
+            &main_uri,
+            main_arts,
+            &workspace_root,
+            state.package_state.scope_contribution(),
+        );
+
+        assert!(
+            !symbols.contains_key("fixture"),
+            "helper top-level def must NOT be visible in R/main.R. \
+             visible: {:?}",
+            symbols.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test E: testthat implicit attachment under tests/testthat/ (issue #275)
+    // ------------------------------------------------------------------
+
+    /// End-to-end: when `testthat` is declared in `DESCRIPTION` (Suggests:),
+    /// scope resolution for a file under `tests/testthat/` lists `testthat`
+    /// in `inherited_packages` — modelling the implicit `library(testthat)`
+    /// that `tests/testthat.R` does before sourcing test files.
+    #[test]
+    fn testthat_attached_to_test_file_scope_when_in_suggests() {
+        use crate::package_state::{DescriptionInput, PackageInputDelta};
+
+        let root = "/work/pkg";
+        let mut state = WorldState::new(vec![]);
+        state.package_inputs.workspace_root = Some(PathBuf::from(root));
+        state.package_inputs.package_mode = crate::cross_file::config::PackageMode::Auto;
+        state.package_inputs.description = Some(DescriptionInput {
+            text: "Package: foo\nSuggests: testthat\n".into(),
+        });
+        let test_path = PathBuf::from(format!("{}/tests/testthat/test-foo.R", root));
+        let test_text: Arc<str> = "expect_equal(1, 1)\n".into();
+        state.package_inputs.r_files.insert(
+            test_path,
+            crate::package_state::RFileInput {
+                kind: RFileKind::Test,
+                text: test_text.clone(),
+                content_digest: crate::package_state::ContentDigest::of(&test_text),
+            },
+        );
+        state.apply_package_event(&PackageInputDelta::Initial);
+
+        // The derived contribution must list testthat as an attached package.
+        assert!(
+            state
+                .package_state
+                .scope_contribution()
+                .test_attached_packages
+                .contains("testthat"),
+            "testthat must appear in test_attached_packages, got: {:?}",
+            state.package_state.scope_contribution().test_attached_packages,
+        );
+
+        // Resolved scope under tests/testthat/ must carry testthat in inherited_packages.
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let test_uri = Url::parse("file:///work/pkg/tests/testthat/test-foo.R").unwrap();
+        let test_arts = make_artifacts(&test_uri, &test_text);
+
+        let get_artifacts = |u: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if u == &test_uri { Some(test_arts.clone()) } else { None }
+        };
+        let get_metadata =
+            |_u: &Url| -> Option<Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+        let graph = DependencyGraph::new();
+
+        let scope = scope_at_position_with_graph(
+            &test_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&workspace_root),
+            TEST_MAX_CHAIN_DEPTH,
+            &HashSet::new(),
+            false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            Some(state.package_state.scope_contribution()),
+        );
+
+        assert!(
+            scope.inherited_packages.contains("testthat"),
+            "testthat must be in inherited_packages for a file under tests/testthat/. \
+             got: {:?}",
+            scope.inherited_packages,
+        );
+    }
+
+    /// End-to-end: testthat must NOT be attached to scope for a file under R/
+    /// even if declared in DESCRIPTION — package mode keeps R/ free of
+    /// test-only attachments so legitimate undefined-variable diagnostics fire.
+    #[test]
+    #[allow(non_snake_case)]
+    fn testthat_not_attached_to_R_file_scope() {
+        use crate::package_state::{DescriptionInput, PackageInputDelta};
+
+        let root = "/work/pkg";
+        let mut state = WorldState::new(vec![]);
+        state.package_inputs.workspace_root = Some(PathBuf::from(root));
+        state.package_inputs.package_mode = crate::cross_file::config::PackageMode::Auto;
+        state.package_inputs.description = Some(DescriptionInput {
+            text: "Package: foo\nSuggests: testthat\n".into(),
+        });
+        let r_path = PathBuf::from(format!("{}/R/main.R", root));
+        let r_text: Arc<str> = "f <- function() 1\n".into();
+        state.package_inputs.r_files.insert(
+            r_path,
+            crate::package_state::RFileInput {
+                kind: RFileKind::Source,
+                text: r_text.clone(),
+                content_digest: crate::package_state::ContentDigest::of(&r_text),
+            },
+        );
+        state.apply_package_event(&PackageInputDelta::Initial);
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let main_uri = Url::parse("file:///work/pkg/R/main.R").unwrap();
+        let main_arts = make_artifacts(&main_uri, &r_text);
+
+        let get_artifacts = |u: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if u == &main_uri { Some(main_arts.clone()) } else { None }
+        };
+        let get_metadata =
+            |_u: &Url| -> Option<Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+        let graph = DependencyGraph::new();
+
+        let scope = scope_at_position_with_graph(
+            &main_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&workspace_root),
+            TEST_MAX_CHAIN_DEPTH,
+            &HashSet::new(),
+            false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            Some(state.package_state.scope_contribution()),
+        );
+
+        assert!(
+            !scope.inherited_packages.contains("testthat"),
+            "testthat must NOT leak into inherited_packages for files under R/. \
+             got: {:?}",
+            scope.inherited_packages,
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test F: a helper file does NOT see its own top-level defs via the
+    //         contribution (Codex review, issue 1)
+    // ------------------------------------------------------------------
+
+    /// End-to-end regression: a helper file must NOT see its OWN later
+    /// top-level def via the package contribution. With per-helper-path
+    /// keying in `test_helper_symbols`, the scope-injection layer skips
+    /// the queried helper's own entry — so a `use_x()` call earlier than
+    /// the `x <- ...` definition in the same helper still triggers the
+    /// forward-reference / undefined-variable diagnostic. Peer helpers
+    /// and `test-*.R` siblings continue to see all helper defs because
+    /// they have a different path.
+    ///
+    /// Layout:
+    ///   helper-a.R line 0: (empty: query position)
+    ///   helper-a.R line 1: `fixture_a <- function() 1`
+    ///   helper-b.R line 0: `fixture_b <- function() 2`
+    ///
+    /// Querying helper-a at line 0 col 0 should see `fixture_b` (peer helper),
+    /// NOT `fixture_a` (self-contribution skipped).
+    #[test]
+    fn helper_file_does_not_see_own_top_level_defs_via_contribution() {
+        let root = "/work/pkg";
+        let helper_a_text = "\nfixture_a <- function() 1\n";
+        let state = build_state_with_files(
+            root,
+            vec![
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-a.R", root)),
+                    RFileKind::Test,
+                    helper_a_text,
+                ),
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-b.R", root)),
+                    RFileKind::Test,
+                    "fixture_b <- function() 2\n",
+                ),
+            ],
+        );
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let helper_a_uri =
+            Url::parse("file:///work/pkg/tests/testthat/helper-a.R").unwrap();
+        let helper_a_arts = make_artifacts(&helper_a_uri, helper_a_text);
+        let get_artifacts = |u: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if u == &helper_a_uri {
+                Some(helper_a_arts.clone())
+            } else {
+                None
+            }
+        };
+        let get_metadata =
+            |_u: &Url| -> Option<Arc<crate::cross_file::types::CrossFileMetadata>> {
+                None
+            };
+        let graph = DependencyGraph::new();
+
+        // Query at line 0 col 0 — strictly before the local Def at line 1.
+        let scope = scope_at_position_with_graph(
+            &helper_a_uri,
+            0,
+            0,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&workspace_root),
+            TEST_MAX_CHAIN_DEPTH,
+            &HashSet::new(),
+            false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            Some(state.package_state.scope_contribution()),
+        );
+
+        assert!(
+            !scope.symbols.contains_key("fixture_a"),
+            "helper-a.R must NOT see its own `fixture_a` via the package contribution \
+             at line 0 (before the local Def at line 1). symbols: {:?}",
+            scope.symbols.keys().collect::<Vec<_>>(),
+        );
+        // helper-a.R is alphabetically before helper-b.R, so helper-a does
+        // NOT see helper-b's defs (testthat sources helpers via
+        // `sort()`-then-source, so helper-b runs strictly later).
+        assert!(
+            !scope.symbols.contains_key("fixture_b"),
+            "helper-a.R must NOT see alphabetically-later helper-b.R's `fixture_b`. \
+             symbols: {:?}",
+            scope.symbols.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test G: helper sourcing order — helper-b sees helper-a (earlier),
+    //         test-foo sees both (all helpers sourced first).
+    //         Codex follow-up review, issue 1.
+    // ------------------------------------------------------------------
+
+    /// `testthat::source_test_helpers` sources `^helper.*\\.[rR]$` files in
+    /// `sort()` order, so a later helper sees earlier ones but not vice
+    /// versa. Non-helper test files run after all helpers have been
+    /// sourced, so they see all helpers.
+    #[test]
+    fn helper_sourcing_order_matches_testthat_sort_semantics() {
+        let root = "/work/pkg";
+        let helper_a_text = "fixture_a <- function() 1\n";
+        let helper_b_text = "\nfixture_b <- function() 2\n";
+        let state = build_state_with_files(
+            root,
+            vec![
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-a.R", root)),
+                    RFileKind::Test,
+                    helper_a_text,
+                ),
+                (
+                    PathBuf::from(format!("{}/tests/testthat/helper-b.R", root)),
+                    RFileKind::Test,
+                    helper_b_text,
+                ),
+                (
+                    PathBuf::from(format!("{}/tests/testthat/test-foo.R", root)),
+                    RFileKind::Test,
+                    "result <- fixture_a() + fixture_b()\n",
+                ),
+            ],
+        );
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+
+        // helper-b.R MUST see fixture_a (helper-a sorts before helper-b).
+        // Query at line 0 col 0 so the local Def for fixture_b (line 1) is
+        // NOT yet applied — that isolates the contribution path.
+        let helper_b_uri = Url::parse("file:///work/pkg/tests/testthat/helper-b.R").unwrap();
+        let helper_b_arts = make_artifacts(&helper_b_uri, helper_b_text);
+        let get_artifacts = |u: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if u == &helper_b_uri {
+                Some(helper_b_arts.clone())
+            } else {
+                None
+            }
+        };
+        let get_metadata =
+            |_u: &Url| -> Option<Arc<crate::cross_file::types::CrossFileMetadata>> { None };
+        let graph = DependencyGraph::new();
+        let scope_b = scope_at_position_with_graph(
+            &helper_b_uri,
+            0,
+            0,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&workspace_root),
+            TEST_MAX_CHAIN_DEPTH,
+            &HashSet::new(),
+            false,
+            crate::cross_file::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            Some(state.package_state.scope_contribution()),
+        );
+        let symbols_b = scope_b.symbols;
+        assert!(
+            symbols_b.contains_key("fixture_a"),
+            "helper-b.R must see fixture_a from alphabetically-earlier helper-a.R. \
+             symbols: {:?}",
+            symbols_b.keys().collect::<Vec<_>>(),
+        );
+        assert!(
+            !symbols_b.contains_key("fixture_b"),
+            "helper-b.R must NOT see its own fixture_b at (0,0), before the local def \
+             at line 1. symbols: {:?}",
+            symbols_b.keys().collect::<Vec<_>>(),
+        );
+
+        // test-foo.R MUST see both fixture_a and fixture_b (all helpers
+        // sourced before any test file runs).
+        let test_uri = Url::parse("file:///work/pkg/tests/testthat/test-foo.R").unwrap();
+        let test_arts = make_artifacts(&test_uri, "result <- fixture_a() + fixture_b()\n");
+        let symbols_test = resolve_symbols(
+            &test_uri,
+            test_arts,
+            &workspace_root,
+            state.package_state.scope_contribution(),
+        );
+        assert!(
+            symbols_test.contains_key("fixture_a"),
+            "test-foo.R must see fixture_a from helper-a.R. symbols: {:?}",
+            symbols_test.keys().collect::<Vec<_>>(),
+        );
+        assert!(
+            symbols_test.contains_key("fixture_b"),
+            "test-foo.R must see fixture_b from helper-b.R. symbols: {:?}",
+            symbols_test.keys().collect::<Vec<_>>(),
+        );
+    }
 }
 

--- a/demo/package-mode/DESCRIPTION
+++ b/demo/package-mode/DESCRIPTION
@@ -3,3 +3,4 @@ Title: Demo Package for Raven Smoke Tests
 Version: 0.1.0
 Description: Demonstrates Raven's package mode mutual visibility.
 License: MIT
+Suggests: testthat

--- a/demo/package-mode/tests/testthat.R
+++ b/demo/package-mode/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(demopackage)
+
+test_check("demopackage")

--- a/demo/package-mode/tests/testthat/helper-fixtures.R
+++ b/demo/package-mode/tests/testthat/helper-fixtures.R
@@ -1,0 +1,3 @@
+# Auto-sourced by testthat::test_check before each test. Defines fixtures
+# visible across peer tests under tests/testthat/, but not to R/ files.
+demo_fixture_input <- c(1, 2, 3)

--- a/demo/package-mode/tests/testthat/test-analysis.R
+++ b/demo/package-mode/tests/testthat/test-analysis.R
@@ -1,6 +1,8 @@
-# Tests can see R/ symbols (one-way visibility)
+# Tests can see R/ symbols (one-way visibility), testthat exports (because
+# `Suggests: testthat` plus the tests/testthat.R runner), and helper-*.R
+# top-level defs (here, demo_fixture_input from helper-fixtures.R).
 test_that("run_analysis works", {
-  result <- run_analysis(c(1, 2, 3))
+  result <- run_analysis(demo_fixture_input)
   expect_equal(result, 2)
 })
 

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -52,6 +52,58 @@ In contrast, a function defined in `tests/testthat/test-helpers.R` is **not**
 visible to `R/helpers.R` — symbols in `R/` are visible from `tests/testthat/`,
 but not the other way around.
 
+#### Implicit `library(testthat)` under `tests/testthat/`
+
+Raven treats `testthat` as if it were attached (via `library(testthat)`) when
+all of the following hold:
+
+- the workspace is in package mode (DESCRIPTION with a valid `Package:` field), and
+- the DESCRIPTION declares `testthat` in `Suggests:`, `Imports:`, or `Depends:`, and
+- the queried file is under `tests/testthat/`.
+
+This matches `testthat::test_check`'s loader, which attaches testthat before
+sourcing each test file. Test files therefore do not need (and conventionally
+do not include) an explicit `library(testthat)` — calling `test_that(...)`,
+`expect_equal(...)`, etc. produces no "undefined variable" diagnostic. Outside
+`tests/testthat/`, the same calls remain flagged: implicit attachment is scoped
+to the testthat directory.
+
+If the DESCRIPTION does not declare testthat, no implicit attachment happens —
+the diagnostic stays as "undefined variable" until the user either adds
+`Suggests: testthat` (the conventional fix) or adds an explicit `library(testthat)`.
+
+#### Helper files (`tests/testthat/helper-*.R`)
+
+`testthat::source_test_helpers` sources files matching `^helper.*\.[Rr]$`
+in `sort()` order before each test runs. Raven mirrors this:
+
+- Top-level definitions in any `tests/testthat/helper-*.R` file are visible
+  from `test-*.R` (and other non-helper test files), because by the time a
+  test runs all helpers have been sourced.
+- Between helpers, visibility follows sourcing order: a helper sees
+  earlier-sorted peers but not later ones. For example, `helper-b.R`
+  sees `helper-a.R`'s top-level defs, but `helper-a.R` does NOT see
+  `helper-b.R`'s — `helper-b.R` is sourced strictly later.
+- Helpers are matched by filename only at the top level of
+  `tests/testthat/`; files in subdirectories (e.g.
+  `tests/testthat/sub/helper-x.R`) are not auto-sourced by testthat and
+  are NOT treated as helpers here either.
+- Helper defs never propagate into `R/` (the one-way visibility into `R/`
+  stays asymmetric).
+
+```r
+# tests/testthat/helper-fixtures.R
+demo_input <- c(1, 2, 3)
+
+# tests/testthat/test-foo.R
+test_that("works on demo_input", {
+  expect_equal(length(demo_input), 3)  # No diagnostic — visible from helper
+})
+```
+
+Setup files (`setup-*.R`, `teardown-*.R`) are not currently treated as helpers
+for visibility purposes; declare any cross-file fixtures in `helper-*.R`.
+
 ### Build commands
 
 When the workspace is detected as an R package (DESCRIPTION with a non-empty


### PR DESCRIPTION
## Summary

- Closes #275.
- In package mode, `tests/testthat/*.R` files no longer falsely flag testthat exports (`test_that`, `expect_equal`, …) or top-level defs from `helper-*.R` siblings as "undefined variable".
- Two new gated contributions on `PackageScopeContribution`:
  - `test_attached_packages` — populated with `testthat` when DESCRIPTION declares it in `Suggests:`/`Imports:`/`Depends:`; injected into `scope.inherited_packages` for files under `tests/testthat/`, modelling `testthat::test_check`'s implicit `library(testthat)` before sourcing each test file.
  - `test_helper_symbols` — keyed by helper path so a helper does NOT self-inject (forward-reference diagnostics stay live), helpers see alphabetically-earlier peers (`testthat::source_test_helpers` sorts before sourcing), and non-helper test files see all helpers. Subdirectory helpers are excluded (testthat's `dir()` is non-recursive).
- Both contributions are strictly invisible to `R/` — the one-way visibility into `R/` stays asymmetric, gated on `RFileKind::Test`.
- `ScopeStream` gains a pre-computed `contribution_symbol_names` set so `is_visible` / `symbol_for` agree with `snapshot()` — critical for the out-of-scope diagnostic collector which only calls `is_visible`. That collector additionally checks `is_package_export` against `test_attached_packages` so testthat exports aren't misattributed to a later `source()`.
- Demo (`demo/package-mode/`) wired up properly: `Suggests: testthat`, a `tests/testthat.R` runner, and a `helper-fixtures.R` exercising the helper-visibility path.

## Test plan

- [x] `cargo test -p raven` — 3923 passed, 0 failed
- [x] `cargo test --release -p raven --features test-support` — 3923 passed, 0 failed
- [x] Codex adversarial review — multiple rounds, all findings addressed
- [x] New regression tests:
  - `scope_contribution_attaches_testthat_when_in_suggests` / `_imports_or_depends`
  - `scope_contribution_skips_testthat_when_undeclared`
  - `scope_contribution_collects_helper_top_level_defs`
  - `scope_contribution_unions_helpers_across_files`
  - `test_helper_symbols_keyed_by_helper_path`
  - `helpers_in_subdirectories_are_not_collected`
  - `test_helper_filename_multibyte_safe` (Unicode safety)
  - `helper_top_level_def_visible_in_peer_test_file_end_to_end`
  - `helper_top_level_def_not_visible_in_r_dir_end_to_end`
  - `testthat_attached_to_test_file_scope_when_in_suggests`
  - `testthat_not_attached_to_R_file_scope`
  - `helper_file_does_not_see_own_top_level_defs_via_contribution`
  - `helper_sourcing_order_matches_testthat_sort_semantics`
  - `test_diagnostic_suppresses_test_helper_symbol_in_testthat_file`
  - `test_diagnostic_does_not_suppress_test_helper_in_R_file`
  - `test_diagnostic_suppresses_testthat_export_in_testthat_file`
  - `test_diagnostic_flags_testthat_export_in_R_file`
  - `test_out_of_scope_suppresses_test_attached_export_in_testthat_file`
  - `test_out_of_scope_does_not_suppress_when_test_pkg_uninstalled`
- [x] Manually verified `demo/package-mode/tests/testthat/test-analysis.R` no longer flags `test_that` / `expect_equal`
- [x] Docs updated: `docs/r-package-dev.md` describes the testthat attachment, the helper sourcing-order semantics, and the direct-child requirement
- [x] AGENTS.md learning added covering the new injection invariants