### PR TITLE
fix(knit): output webview + progress lifecycle

### DIFF
--- a/docs/knit.md
+++ b/docs/knit.md
@@ -66,11 +66,26 @@ explorer-context-menu hook is opt-in via your own keybindings).
    (`raven.knit.timeoutMs = 600000`). Windows uses `taskkill /T /F`
    instead of POSIX signals.
 10. **Reveal.** On a clean exit Raven parses `Output created: <path>`
-    out of stdout and offers an `Open` button. `.html` / `.htm` open
-    via `vscode.open` (which routes through Simple Browser in remote
-    workspaces); everything else opens via `revealFileInOS`. When the
-    parse fails Raven still surfaces "Knit succeeded (output path
-    unknown)" — the subprocess exit code is the ground truth.
+    out of stdout. When the primary output is HTML (or there's any HTML
+    in a multi-output knit), Raven opens it in the **Knit Output**
+    webview panel beside the editor. The panel toolbar has two buttons:
+
+    - **Refresh** — re-knits the source `.Rmd` (the same code path as
+      invoking `Raven: Knit` from the palette).
+    - **Open in Browser** — opens the rendered file in your OS default
+      browser. In remote workspaces (SSH, Codespaces, dev containers)
+      this may not work because `file://` URIs target the remote
+      machine; Raven warns and writes the path to the `Raven: Knit`
+      output channel as a fallback.
+
+    The rendered HTML loads inside an `<iframe sandbox="">` — scripts,
+    forms, and external navigation are blocked. Intra-document anchor
+    links (`#section`) work; clicking an external `<a>` does nothing
+    (use **Open in Browser** for full interactivity, including
+    htmlwidgets). For PDF / Word / etc., Raven still reveals the file
+    in your OS file browser. When the output-path parse fails Raven
+    surfaces "Knit succeeded (output path unknown)" — the subprocess
+    exit code is the ground truth.
 
 ## Settings
 
@@ -86,6 +101,7 @@ explorer-context-menu hook is opt-in via your own keybindings).
 | Capability | Where it lives |
 |---|---|
 | Live preview of `.Rmd` or `.qmd` | `quarto.quarto`'s `Quarto: Preview` |
+| Auto-refresh / live preview on save | `quarto.quarto`'s `Quarto: Preview`. The Knit Output panel is a static viewer with a manual Refresh button — not a live recompile. |
 | `.qmd` rendering | `quarto.quarto`'s `Quarto: Render` |
 | `.qmd` grammar / LSP | `quarto.quarto` |
 | `.Rmd` grammar | `REditorSupport.r-syntax` or `REditorSupport.r` |

--- a/docs/superpowers/plans/2026-05-17-knit-output-webview.md
+++ b/docs/superpowers/plans/2026-05-17-knit-output-webview.md
@@ -1,0 +1,1798 @@
+# Knit Output Webview + Progress-Lifecycle Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the stuck "Knitting …" progress notification (which also causes the spurious "already being knitted" gate), and add an iframe-sandbox webview that renders HTML knit output with **Refresh** and **Open in Browser** toolbar buttons.
+
+**Architecture:** Two pieces. (A) Refactor `runKnitCommand` so `withProgress` returns a discriminated `KnitOutcome` and all user-facing toasts run *after* the progress callback resolves; add a `deps` injection seam for tests. (B) New `KnitOutputPanel` module: a singleton webview whose outer document is a Raven-controlled shell (CSP in `<head>`, toolbar, nonce'd script) hosting an `<iframe sandbox="">` whose `src` is `webview.asWebviewUri(outputPath)`. No HTML parsing or rewriting; security enforced by three independent layers (sandbox attribute, outer-shell CSP, `localResourceRoots`).
+
+**Tech Stack:** TypeScript, VS Code Extension API (`vscode.window.createWebviewPanel`, `webview.asWebviewUri`, `vscode.env.openExternal`), Bun for unit tests, Mocha + `@vscode/test-electron` for integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` (v2, commit `34e8a47`).
+
+---
+
+## File map
+
+| Path | Action | Responsibility |
+| -- | -- | -- |
+| `editors/vscode/src/knit/knit-commands.ts` | Modify | Refactor `runKnitCommand`: classify → withProgress → renderOutcome. Add `deps` seam. Wire HTML success to `KnitOutputPanel.showOrUpdate`. |
+| `editors/vscode/src/knit/knit-output.ts` | Create | Pure helpers: `KnitOutcome`, `classify`, `pickPrimaryOutput`, `isKnitOutputMessage`, `buildShellHtml`. |
+| `editors/vscode/src/knit/knit-output-panel.ts` | Create | `KnitOutputPanel` singleton class; `openInBrowser` helper. |
+| `tests/bun/knit-output-pick-primary.test.ts` | Create | Bun unit tests for `pickPrimaryOutput`. |
+| `tests/bun/knit-output-message.test.ts` | Create | Bun unit tests for `isKnitOutputMessage`. |
+| `tests/bun/knit-output-classify.test.ts` | Create | Bun unit tests for `classify`. |
+| `tests/bun/knit-output-shell.test.ts` | Create | Bun unit tests for `buildShellHtml` (CSP-in-head, sandbox, escaping, asWebviewUri). |
+| `editors/vscode/src/test/knit-progress-lifecycle.test.ts` | Create | Mocha integration test for Piece A (inFlight cleared before toast). |
+| `editors/vscode/src/test/knit-output-panel.test.ts` | Create | Mocha integration test: refresh roundtrip, openInBrowser roundtrip, singleton reuse, rootDir-change recreation. |
+| `editors/vscode/src/test/fixtures/sample.Rmd` | Create | Minimal `.Rmd` fixture used by integration tests (no R subprocess actually invoked). |
+| `docs/knit.md` | Modify | Update step 10 (Reveal); document iframe-sandbox limitations (external links). |
+
+`editors/vscode/src/knit/index.ts` stays unchanged.
+
+`editors/vscode/src/knit/knit-engine.ts` stays unchanged.
+
+`editors/vscode/package.json` stays unchanged (no new commands or settings).
+
+---
+
+## Phase 1 — Pure helpers (TDD via Bun)
+
+Each task: write the failing test, run it to confirm failure, write the minimal implementation, run to confirm pass, commit.
+
+### Task 1.1: `pickPrimaryOutput`
+
+**Files:**
+- Create: `editors/vscode/src/knit/knit-output.ts`
+- Create: `tests/bun/knit-output-pick-primary.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/bun/knit-output-pick-primary.test.ts`:
+
+```ts
+import { describe, test, expect } from 'bun:test';
+import { pickPrimaryOutput } from '../../editors/vscode/src/knit/knit-output';
+
+describe('pickPrimaryOutput', () => {
+    test('returns the only entry when there is one', () => {
+        expect(pickPrimaryOutput(['/a/foo.html'])).toBe('/a/foo.html');
+    });
+
+    test('prefers .html when present mid-list', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.html', '/a/foo.docx']))
+            .toBe('/a/foo.html');
+    });
+
+    test('prefers .htm when no .html', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.htm'])).toBe('/a/foo.htm');
+    });
+
+    test('returns the first when no HTML is present', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.docx'])).toBe('/a/foo.pdf');
+    });
+
+    test('case-insensitive extension match', () => {
+        expect(pickPrimaryOutput(['/a/foo.PDF', '/a/foo.HTML'])).toBe('/a/foo.HTML');
+    });
+
+    test('returns undefined for an empty list', () => {
+        expect(pickPrimaryOutput([])).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+bun test tests/bun/knit-output-pick-primary.test.ts
+```
+
+Expected: FAIL with `Cannot find module '../../editors/vscode/src/knit/knit-output'` (the module doesn't exist yet).
+
+- [ ] **Step 3: Create the module with the minimal implementation**
+
+Create `editors/vscode/src/knit/knit-output.ts`:
+
+```ts
+import * as path from 'path';
+
+/**
+ * Pick the output path to surface in the Knit Output panel.
+ *
+ * When `output_format = "all"` (or a custom multi-format render) produces
+ * a mix of formats, the user almost always wants the HTML viewer rather
+ * than e.g. revealing a PDF in the file browser. Prefer the first HTML
+ * output; fall back to the first entry overall.
+ *
+ * Codex adversarial review #4 on the v1 spec called out that v1 always
+ * used `parsed.paths[0]`, which would hide an HTML output behind a
+ * PDF/DOCX-first reveal.
+ */
+export function pickPrimaryOutput(paths: readonly string[]): string | undefined {
+    if (paths.length === 0) return undefined;
+    const html = paths.find((p) => {
+        const ext = path.extname(p).toLowerCase();
+        return ext === '.html' || ext === '.htm';
+    });
+    return html ?? paths[0];
+}
+```
+
+- [ ] **Step 4: Run the test to confirm pass**
+
+```bash
+bun test tests/bun/knit-output-pick-primary.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-output.ts tests/bun/knit-output-pick-primary.test.ts
+git commit -m "feat(knit): pickPrimaryOutput prefers HTML in multi-output renders"
+```
+
+---
+
+### Task 1.2: `isKnitOutputMessage`
+
+**Files:**
+- Modify: `editors/vscode/src/knit/knit-output.ts` (append)
+- Create: `tests/bun/knit-output-message.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/bun/knit-output-message.test.ts`:
+
+```ts
+import { describe, test, expect } from 'bun:test';
+import { isKnitOutputMessage } from '../../editors/vscode/src/knit/knit-output';
+
+describe('isKnitOutputMessage', () => {
+    test('accepts {type: "refresh"}', () => {
+        expect(isKnitOutputMessage({ type: 'refresh' })).toBe(true);
+    });
+
+    test('accepts {type: "openInBrowser"}', () => {
+        expect(isKnitOutputMessage({ type: 'openInBrowser' })).toBe(true);
+    });
+
+    test('rejects unknown type', () => {
+        expect(isKnitOutputMessage({ type: 'evil' })).toBe(false);
+    });
+
+    test('rejects null', () => {
+        expect(isKnitOutputMessage(null)).toBe(false);
+    });
+
+    test('rejects undefined', () => {
+        expect(isKnitOutputMessage(undefined)).toBe(false);
+    });
+
+    test('rejects primitives', () => {
+        expect(isKnitOutputMessage('refresh')).toBe(false);
+        expect(isKnitOutputMessage(42)).toBe(false);
+    });
+
+    test('rejects empty object', () => {
+        expect(isKnitOutputMessage({})).toBe(false);
+    });
+
+    test('rejects object missing the type key', () => {
+        expect(isKnitOutputMessage({ kind: 'refresh' })).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+bun test tests/bun/knit-output-message.test.ts
+```
+
+Expected: FAIL — `isKnitOutputMessage` is not exported.
+
+- [ ] **Step 3: Append the implementation to `knit-output.ts`**
+
+Add to `editors/vscode/src/knit/knit-output.ts`:
+
+```ts
+export type KnitOutputMessage =
+    | { type: 'refresh' }
+    | { type: 'openInBrowser' };
+
+/**
+ * Strict type-narrowing for messages posted from the Knit Output webview.
+ * The webview is a trust boundary; reject anything we did not explicitly
+ * shape. Additional unknown properties on a recognized type are allowed
+ * (the handler ignores them).
+ */
+export function isKnitOutputMessage(msg: unknown): msg is KnitOutputMessage {
+    if (msg === null || typeof msg !== 'object') return false;
+    const t = (msg as { type?: unknown }).type;
+    return t === 'refresh' || t === 'openInBrowser';
+}
+```
+
+- [ ] **Step 4: Run the test to confirm pass**
+
+```bash
+bun test tests/bun/knit-output-message.test.ts
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-output.ts tests/bun/knit-output-message.test.ts
+git commit -m "feat(knit): isKnitOutputMessage type guard for webview→extension messages"
+```
+
+---
+
+### Task 1.3: `KnitOutcome` + `classify`
+
+**Files:**
+- Modify: `editors/vscode/src/knit/knit-output.ts` (append)
+- Create: `tests/bun/knit-output-classify.test.ts`
+
+- [ ] **Step 1: Inspect the current `runKnit` return shape**
+
+Run:
+
+```bash
+grep -nE "interface|^export|spawnError|cancelled|timedOut|exitCode" editors/vscode/src/knit/knit-engine.ts
+```
+
+Confirm the `runKnit` result type has fields `{ spawnError, cancelled, timedOut, exitCode, stdout, stderr }`. (The plan below assumes these; if the field names differ, mirror the actual names.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/bun/knit-output-classify.test.ts`:
+
+```ts
+import { describe, test, expect } from 'bun:test';
+import { classify } from '../../editors/vscode/src/knit/knit-output';
+
+describe('classify', () => {
+    test('spawn error wins over everything', () => {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        const outcome = classify({
+            spawnError: err,
+            cancelled: false,
+            timedOut: false,
+            exitCode: null,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('spawnError');
+    });
+
+    test('cancelled beats timedOut and failure', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: true,
+            timedOut: false,
+            exitCode: 130,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('cancelled');
+    });
+
+    test('timedOut beats failure', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: false,
+            timedOut: true,
+            exitCode: null,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('timedOut');
+    });
+
+    test('non-zero exit is "failed"', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 1,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('failed');
+        if (outcome.kind === 'failed') expect(outcome.exitCode).toBe(1);
+    });
+
+    test('clean exit with no output path is "noOutput"', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: '\n',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('noOutput');
+    });
+
+    test('clean exit with output path is "ok"', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: 'Output created: out.html\n',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('ok');
+        if (outcome.kind === 'ok') {
+            expect(outcome.parsedOutputs).toEqual(['out.html']);
+            expect(outcome.cwd).toBe('/wd');
+        }
+    });
+
+    test('cwd undefined propagates through ok outcome', () => {
+        const outcome = classify({
+            spawnError: undefined,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: 'Output created: out.html\n',
+            stderr: '',
+        }, { cwd: undefined });
+        expect(outcome.kind).toBe('ok');
+        if (outcome.kind === 'ok') expect(outcome.cwd).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+```bash
+bun test tests/bun/knit-output-classify.test.ts
+```
+
+Expected: FAIL — `classify` not exported.
+
+- [ ] **Step 4: Append the implementation to `knit-output.ts`**
+
+Add to `editors/vscode/src/knit/knit-output.ts`:
+
+```ts
+import { parseRenderedOutputPath } from './output-path';
+
+/**
+ * Possible outcomes of a single `runKnit` invocation, after we have
+ * classified the raw engine result. Discriminated by `kind`. No user-
+ * facing toasts or webview operations have been performed yet — that
+ * happens in `renderOutcome`, OUTSIDE the `withProgress` callback. This
+ * is the core of the Piece A bug fix: keeping the `withProgress`
+ * lifecycle short and predictable.
+ */
+export type KnitOutcome =
+    | { kind: 'spawnError'; error: NodeJS.ErrnoException }
+    | { kind: 'cancelled' }
+    | { kind: 'timedOut'; timeoutMs?: number }
+    | { kind: 'failed'; exitCode: number | null }
+    | { kind: 'noOutput' }
+    | { kind: 'ok'; parsedOutputs: string[]; cwd: string | undefined };
+
+/** Minimal subset of `runKnit`'s return value classify needs. */
+export interface ClassifyInput {
+    spawnError?: NodeJS.ErrnoException;
+    cancelled: boolean;
+    timedOut: boolean;
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Pure classifier mapping the engine's raw result onto a KnitOutcome.
+ * Branch priority mirrors the original runKnitCommand:
+ *   spawnError > cancelled > timedOut > failed > noOutput / ok
+ */
+export function classify(
+    result: ClassifyInput,
+    ctx: { cwd: string | undefined },
+): KnitOutcome {
+    if (result.spawnError) return { kind: 'spawnError', error: result.spawnError };
+    if (result.cancelled) return { kind: 'cancelled' };
+    if (result.timedOut) return { kind: 'timedOut' };
+    if (result.exitCode !== 0) return { kind: 'failed', exitCode: result.exitCode };
+    const parsed = parseRenderedOutputPath(result.stdout + '\n' + result.stderr).paths;
+    if (parsed.length === 0) return { kind: 'noOutput' };
+    return { kind: 'ok', parsedOutputs: parsed, cwd: ctx.cwd };
+}
+```
+
+- [ ] **Step 5: Run the test to confirm pass**
+
+```bash
+bun test tests/bun/knit-output-classify.test.ts
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-output.ts tests/bun/knit-output-classify.test.ts
+git commit -m "feat(knit): classify pure helper produces KnitOutcome discriminated union"
+```
+
+---
+
+## Phase 2 — Outer-shell HTML builder
+
+### Task 2.1: `buildShellHtml`
+
+**Files:**
+- Modify: `editors/vscode/src/knit/knit-output.ts` (append)
+- Create: `tests/bun/knit-output-shell.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/bun/knit-output-shell.test.ts`:
+
+```ts
+import { describe, test, expect } from 'bun:test';
+import { buildShellHtml } from '../../editors/vscode/src/knit/knit-output';
+
+const fakeWebview = {
+    asWebviewUri: (uri: { fsPath: string }) =>
+        `https://webview.test${uri.fsPath}`,
+    cspSource: 'https://webview.test',
+};
+
+describe('buildShellHtml', () => {
+    test('CSP <meta> appears in <head>, before <body>', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        const cspIdx = html.indexOf('Content-Security-Policy');
+        const bodyIdx = html.indexOf('<body');
+        expect(cspIdx).toBeGreaterThan(0);
+        expect(bodyIdx).toBeGreaterThan(0);
+        expect(cspIdx).toBeLessThan(bodyIdx);
+    });
+
+    test('CSP contains nonce, frame-src, no default-src loophole', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain("default-src 'none'");
+        expect(html).toContain('frame-src https://webview.test');
+        expect(html).toContain("script-src 'nonce-NONCE123'");
+        expect(html).toContain("connect-src 'none'");
+    });
+
+    test('iframe src is asWebviewUri of the output path', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain('src="https://webview.test/work/report.html"');
+    });
+
+    test('iframe sandbox attribute is empty (most restrictive)', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        // Note: sandbox="" (empty string) is the strictest mode. Be exact.
+        expect(html).toMatch(/<iframe\b[^>]*\bsandbox=""/);
+    });
+
+    test('toolbar contains refresh and open-in-browser buttons', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain('id="raven-knit-refresh"');
+        expect(html).toContain('id="raven-knit-open-browser"');
+    });
+
+    test('filename is HTML-escaped', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/<script>alert(1)</script>.html',
+            nonce: 'NONCE123',
+        });
+        // The basename appears in the title attribute and the toolbar span.
+        // Verify the raw "<script>" substring does NOT appear in the HTML.
+        expect(html).not.toContain('<script>alert(1)</script>.html');
+        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;.html');
+    });
+
+    test('toolbar script is nonce-tagged', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toMatch(/<script\s+nonce="NONCE123">/);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+bun test tests/bun/knit-output-shell.test.ts
+```
+
+Expected: FAIL — `buildShellHtml` not exported.
+
+- [ ] **Step 3: Append the implementation to `knit-output.ts`**
+
+Add to `editors/vscode/src/knit/knit-output.ts`:
+
+```ts
+/**
+ * Minimal vscode.Webview shape buildShellHtml needs. Defined inline so
+ * the pure helper has no dependency on the actual vscode module — tests
+ * pass a fake.
+ */
+export interface MinimalWebview {
+    asWebviewUri(uri: { fsPath: string }): { toString(): string };
+    cspSource: string;
+}
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+/**
+ * Build the outer-shell HTML for the Knit Output webview.
+ *
+ * The shell is Raven-controlled and owns the CSP in `<head>`; the
+ * rendered HTML loads inside `<iframe sandbox="">` from
+ * `webview.asWebviewUri(outputPath)`. Three independent containment
+ * layers (sandbox attribute, outer-shell CSP, localResourceRoots) make
+ * the security model robust to either layer failing.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`
+ * for the threat model.
+ */
+export function buildShellHtml(args: {
+    webview: MinimalWebview;
+    outputPath: string;
+    nonce: string;
+}): string {
+    const { webview, outputPath, nonce } = args;
+    const iframeSrc = webview.asWebviewUri({ fsPath: outputPath }).toString();
+    // path.basename handles both POSIX and Windows separators.
+    const lastSep = Math.max(outputPath.lastIndexOf('/'), outputPath.lastIndexOf('\\'));
+    const basename = lastSep >= 0 ? outputPath.slice(lastSep + 1) : outputPath;
+    const safeName = escapeHtml(basename);
+
+    const csp = [
+        `default-src 'none'`,
+        `frame-src ${webview.cspSource}`,
+        `img-src ${webview.cspSource} https: data:`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `font-src ${webview.cspSource} https: data:`,
+        `script-src 'nonce-${nonce}'`,
+        `connect-src 'none'`,
+    ].join('; ');
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<title>Knit Output</title>
+<style nonce="${nonce}">
+  body { margin: 0; padding: 0; height: 100vh; display: flex; flex-direction: column;
+         font-family: var(--vscode-font-family); color: var(--vscode-foreground); }
+  #raven-knit-toolbar { display: flex; gap: 0.5rem; align-items: center;
+                        padding: 0.4rem 0.75rem;
+                        background: var(--vscode-editorWidget-background);
+                        border-bottom: 1px solid var(--vscode-editorWidget-border);
+                        flex: 0 0 auto; }
+  #raven-knit-toolbar button { font: inherit; padding: 0.2rem 0.6rem;
+                               background: var(--vscode-button-background);
+                               color: var(--vscode-button-foreground);
+                               border: 1px solid var(--vscode-button-border, transparent);
+                               cursor: pointer; }
+  #raven-knit-toolbar button:hover { background: var(--vscode-button-hoverBackground); }
+  #raven-knit-filename { margin-left: 0.5rem; opacity: 0.8; font-size: 0.9em; }
+  #raven-knit-frame { flex: 1 1 auto; width: 100%; border: 0; background: white; }
+</style>
+</head>
+<body>
+  <div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
+    <button id="raven-knit-refresh" type="button" title="Re-knit the source document">Refresh</button>
+    <button id="raven-knit-open-browser" type="button" title="Open the rendered file in your default browser">Open in Browser</button>
+    <span id="raven-knit-filename" aria-live="polite">${safeName}</span>
+  </div>
+  <iframe id="raven-knit-frame"
+          src="${escapeHtml(iframeSrc)}"
+          sandbox=""
+          referrerpolicy="no-referrer"
+          title="Rendered output: ${safeName}"></iframe>
+  <script nonce="${nonce}">
+    (function () {
+      const vscode = acquireVsCodeApi();
+      document.getElementById('raven-knit-refresh').addEventListener('click', function () {
+        vscode.postMessage({ type: 'refresh' });
+      });
+      document.getElementById('raven-knit-open-browser').addEventListener('click', function () {
+        vscode.postMessage({ type: 'openInBrowser' });
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm pass**
+
+```bash
+bun test tests/bun/knit-output-shell.test.ts
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Run all knit Bun tests to verify nothing else broke**
+
+```bash
+bun test tests/bun/knit-output-*.test.ts
+```
+
+Expected: all tests pass across the four files added so far.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-output.ts tests/bun/knit-output-shell.test.ts
+git commit -m "feat(knit): buildShellHtml outer-shell with CSP in head and sandboxed iframe"
+```
+
+---
+
+## Phase 3 — `KnitOutputPanel` singleton
+
+### Task 3.1: Create the panel module
+
+This module has direct vscode dependencies and is integration-tested in Mocha, not Bun. We write it after the pure helpers so the surface is small.
+
+**Files:**
+- Create: `editors/vscode/src/knit/knit-output-panel.ts`
+
+- [ ] **Step 1: Create the file**
+
+Create `editors/vscode/src/knit/knit-output-panel.ts`:
+
+```ts
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { buildShellHtml, isKnitOutputMessage } from './knit-output';
+
+/**
+ * Singleton webview panel that renders the most recent HTML knit output
+ * inside an `<iframe sandbox="">` with Refresh and Open-in-Browser
+ * toolbar buttons.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`.
+ *
+ * Architecture:
+ *  - Outer Raven-controlled shell document owns the CSP (in `<head>`),
+ *    the toolbar, and a nonce'd `<script>` that posts messages.
+ *  - Inner `<iframe>` loads the rendered HTML via
+ *    `webview.asWebviewUri(outputPath)`. `sandbox=""` (empty, most
+ *    restrictive) blocks scripts, forms, popups, and top-navigation.
+ *    `frame-src ${cspSource}` on the outer CSP prevents iframe
+ *    navigation to external hosts.
+ *  - `localResourceRoots` is confined to `path.dirname(outputPath)`,
+ *    which is also where rmarkdown's `_files/` figure directories sit.
+ *
+ * Singleton: one panel per VS Code window. Subsequent knits replace the
+ * iframe `src`. If the new output's `rootDir` differs, the panel is
+ * disposed and recreated (VS Code does not allow updating
+ * `localResourceRoots` post-creation — see `help-panel.ts:284`).
+ */
+export class KnitOutputPanel {
+    private static instance: KnitOutputPanel | undefined;
+
+    private panel: vscode.WebviewPanel;
+    private rootDir: string;
+    private sourceUri: vscode.Uri;
+    private outputPath: string;
+    private readonly output: vscode.OutputChannel;
+
+    /**
+     * Open or update the singleton panel. Returns `{ ok: true }` on
+     * success, `{ ok: false, error }` if the rendered file cannot be
+     * accessed (caller should fall back to `revealFileInOS`).
+     */
+    static async showOrUpdate(
+        context: vscode.ExtensionContext,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+    ): Promise<{ ok: true } | { ok: false; error: string }> {
+        try {
+            await fs.promises.access(args.outputPath, fs.constants.R_OK);
+        } catch (err) {
+            return { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+
+        const rootDir = path.dirname(args.outputPath);
+        const existing = KnitOutputPanel.instance;
+
+        if (existing && existing.rootDir === rootDir) {
+            existing.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+            existing.panel.reveal(existing.panel.viewColumn ?? vscode.ViewColumn.Beside, true);
+            return { ok: true };
+        }
+
+        if (existing) {
+            // localResourceRoots is immutable after panel creation — dispose
+            // and recreate in the same column. Same workaround as help-panel.
+            const column = existing.panel.viewColumn ?? vscode.ViewColumn.Beside;
+            existing.panel.dispose();
+            // panel.dispose() fires onDidDispose, which clears `instance`.
+            const created = KnitOutputPanel.create(context, args, rootDir, column);
+            return { ok: true };
+        }
+
+        KnitOutputPanel.create(context, args, rootDir, vscode.ViewColumn.Beside);
+        return { ok: true };
+    }
+
+    /** Visible only for tests. */
+    static getInstanceForTesting(): KnitOutputPanel | undefined {
+        return KnitOutputPanel.instance;
+    }
+
+    /** Visible only for tests — destroys the singleton. */
+    static disposeForTesting(): void {
+        KnitOutputPanel.instance?.panel.dispose();
+    }
+
+    private static create(
+        context: vscode.ExtensionContext,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+        rootDir: string,
+        column: vscode.ViewColumn,
+    ): KnitOutputPanel {
+        const panel = vscode.window.createWebviewPanel(
+            'raven.knitOutput',
+            'Knit Output',
+            { viewColumn: column, preserveFocus: true },
+            {
+                enableScripts: true,
+                enableFindWidget: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.file(rootDir)],
+            },
+        );
+        const instance = new KnitOutputPanel(context, panel, rootDir, args);
+        KnitOutputPanel.instance = instance;
+        instance.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+        return instance;
+    }
+
+    private constructor(
+        private readonly context: vscode.ExtensionContext,
+        panel: vscode.WebviewPanel,
+        rootDir: string,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+    ) {
+        this.panel = panel;
+        this.rootDir = rootDir;
+        this.sourceUri = args.sourceUri;
+        this.outputPath = args.outputPath;
+        this.output = args.output;
+
+        this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg));
+        this.panel.onDidDispose(() => {
+            if (KnitOutputPanel.instance === this) {
+                KnitOutputPanel.instance = undefined;
+            }
+        });
+    }
+
+    private updateContent(args: { sourceUri: vscode.Uri; outputPath: string }): void {
+        this.sourceUri = args.sourceUri;
+        this.outputPath = args.outputPath;
+        const nonce = crypto.randomBytes(16).toString('base64');
+        this.panel.webview.html = buildShellHtml({
+            webview: this.panel.webview,
+            outputPath: args.outputPath,
+            nonce,
+        });
+        this.panel.title = `Knit Output: ${path.basename(args.outputPath)}`;
+    }
+
+    private handleMessage(msg: unknown): void {
+        if (!isKnitOutputMessage(msg)) return;
+        if (msg.type === 'refresh') {
+            void vscode.commands.executeCommand('raven.knit', this.sourceUri);
+            return;
+        }
+        if (msg.type === 'openInBrowser') {
+            void openInBrowser(this.outputPath, this.output);
+        }
+    }
+}
+
+/**
+ * Open the rendered file via the user's OS default browser.
+ *
+ * In local workspaces this opens the configured handler for `file:` (a
+ * browser, typically). In remote workspaces, `openExternal(file:)` may
+ * route the request to the extension-host machine — i.e. the remote
+ * server, not where the user is sitting. When `openExternal` returns
+ * false we write the path to the Knit output channel and warn the user.
+ */
+export async function openInBrowser(
+    outputPath: string,
+    output: vscode.OutputChannel,
+): Promise<void> {
+    const uri = vscode.Uri.file(outputPath);
+    let opened = false;
+    try {
+        opened = await vscode.env.openExternal(uri);
+    } catch (err) {
+        output.appendLine(`[Open in Browser] openExternal threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (opened) return;
+    output.appendLine(`[Open in Browser] file:// did not open. Rendered output is at: ${outputPath}`);
+    void vscode.window.showWarningMessage(
+        'Open in Browser is not available for this workspace. The rendered file path has been written to the Raven: Knit output channel.',
+    );
+}
+```
+
+- [ ] **Step 2: Compile-check**
+
+```bash
+cd editors/vscode && bun run compile:test
+```
+
+Expected: clean TypeScript compile with no errors.
+
+- [ ] **Step 3: Run the existing Bun suite to confirm no regressions**
+
+```bash
+bun test tests/bun/knit-output-*.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-output-panel.ts
+git commit -m "feat(knit): KnitOutputPanel singleton with iframe-sandbox shell"
+```
+
+---
+
+## Phase 4 — Progress-lifecycle fix in `knit-commands.ts`
+
+This is Piece A. The refactor splits the monolithic `runKnitCommand` into three phases: `withProgress` callback returns a `KnitOutcome`; then `inFlight.delete(fsPath)` runs in the `finally`; then `renderOutcome` does all UI work.
+
+### Task 4.1: Add the `deps` injection seam and `renderOutcome` helper
+
+**Files:**
+- Modify: `editors/vscode/src/knit/knit-commands.ts`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+wc -l editors/vscode/src/knit/knit-commands.ts
+```
+
+Expected: ~429 lines.
+
+- [ ] **Step 2: Refactor**
+
+Apply these targeted edits to `editors/vscode/src/knit/knit-commands.ts`:
+
+1. **Imports** — add at the top, after the existing `runKnit` import:
+
+```ts
+import { KnitOutputPanel } from './knit-output-panel';
+import {
+    classify,
+    pickPrimaryOutput,
+    type KnitOutcome,
+} from './knit-output';
+```
+
+2. **DI seam type and signature** — replace the top of `registerKnitCommands`:
+
+Find:
+
+```ts
+export function registerKnitCommands(context: vscode.ExtensionContext): void {
+```
+
+Replace with:
+
+```ts
+/**
+ * Resolved dependency surface used throughout the knit command. The
+ * fields are required at the point of use; the public optional shape
+ * (`Partial<KnitDeps>` parameter on `registerKnitCommands`) lets tests
+ * override individual functions while production omits the parameter
+ * entirely.
+ */
+export interface KnitDeps {
+    runKnit: typeof runKnit;
+    showOrUpdatePanel: typeof KnitOutputPanel.showOrUpdate;
+}
+
+export function registerKnitCommands(
+    context: vscode.ExtensionContext,
+    deps?: Partial<KnitDeps>,
+): void {
+    const resolved: KnitDeps = {
+        runKnit: deps?.runKnit ?? runKnit,
+        showOrUpdatePanel: deps?.showOrUpdatePanel ?? KnitOutputPanel.showOrUpdate,
+    };
+```
+
+3. **Pass deps through** — find:
+
+```ts
+        vscode.commands.registerCommand(
+            'raven.knit',
+            async (uri?: vscode.Uri) => {
+                await runKnitCommand(uri, getOutput(), inFlight);
+            },
+        ),
+```
+
+Replace with:
+
+```ts
+        vscode.commands.registerCommand(
+            'raven.knit',
+            async (uri?: vscode.Uri) => {
+                await runKnitCommand(uri, getOutput(), inFlight, context, resolved);
+            },
+        ),
+```
+
+4. **Update `runKnitCommand` signature**:
+
+Find:
+
+```ts
+async function runKnitCommand(
+    explicitUri: vscode.Uri | undefined,
+    output: vscode.OutputChannel,
+    inFlight: Set<string>,
+): Promise<void> {
+```
+
+Replace with:
+
+```ts
+async function runKnitCommand(
+    explicitUri: vscode.Uri | undefined,
+    output: vscode.OutputChannel,
+    inFlight: Set<string>,
+    context: vscode.ExtensionContext,
+    deps: KnitDeps,
+): Promise<void> {
+```
+
+5. **Replace the `withProgress` block** — this is the critical lifecycle fix.
+
+Find the existing block starting at `output.appendLine(`---`);` through the end of the `try` ... `finally` ... `inFlight.delete(fsPath);` (currently approximately lines 210–311). Replace with:
+
+```ts
+    output.appendLine(`---`);
+    output.appendLine(`Knitting ${fsPath}`);
+    output.appendLine(`R: ${rBinary}`);
+    output.appendLine(`Expression: ${expression}`);
+    output.appendLine(`cwd: ${cwd}`);
+    output.appendLine(``);
+
+    let outcome: KnitOutcome;
+    try {
+        outcome = await vscode.window.withProgress<KnitOutcome>(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Knitting ${baseName}…`,
+                cancellable: true,
+            },
+            async (_progress, token) => {
+                const result = await deps.runKnit({
+                    rBinary,
+                    expression,
+                    cwd,
+                    timeoutMs,
+                    output,
+                    cancellation: token,
+                });
+                return classify(result, { cwd });
+            },
+        );
+    } finally {
+        // Critical: inFlight.delete runs the moment withProgress resolves,
+        // BEFORE any user-facing toast is awaited. This is the Piece A
+        // fix — under the previous code, awaiting showInformationMessage
+        // inside the withProgress callback held both the progress
+        // notification AND the inFlight gate open until the user
+        // dismissed the toast, causing a spurious "already being knitted"
+        // on rapid re-invocation.
+        inFlight.delete(fsPath);
+    }
+
+    await renderOutcome(outcome, {
+        fsPath,
+        baseName,
+        sourceUri: docUri,
+        cwd,
+        output,
+        rBinary,
+        timeoutMs,
+        context,
+        showOrUpdatePanel: deps.showOrUpdatePanel,
+    });
+}
+
+interface RenderOutcomeCtx {
+    fsPath: string;
+    baseName: string;
+    sourceUri: vscode.Uri;
+    cwd: string | undefined;
+    output: vscode.OutputChannel;
+    rBinary: string;
+    timeoutMs: number;
+    context: vscode.ExtensionContext;
+    showOrUpdatePanel: KnitDeps['showOrUpdatePanel'];
+}
+
+/**
+ * Surface the result of a knit to the user. Runs OUTSIDE the
+ * `vscode.window.withProgress` callback so that the progress
+ * notification closes the moment the R subprocess exits, regardless of
+ * how long the user takes to dismiss the success/failure toast.
+ */
+async function renderOutcome(outcome: KnitOutcome, ctx: RenderOutcomeCtx): Promise<void> {
+    if (outcome.kind === 'spawnError') {
+        const code = outcome.error.code;
+        if (code === 'ENOENT') {
+            ctx.output.appendLine(`[error] R not found at "${ctx.rBinary}".`);
+            void vscode.window.showErrorMessage(
+                'Raven: Knit — R not found on PATH. Set `raven.packages.rPath`.',
+            );
+        } else {
+            ctx.output.appendLine(`[error] ${outcome.error.message}`);
+            void vscode.window.showErrorMessage(
+                `Raven: Knit — failed to launch R: ${outcome.error.message}`,
+            );
+        }
+        return;
+    }
+
+    if (outcome.kind === 'cancelled') {
+        ctx.output.appendLine('Knit cancelled.');
+        void vscode.window.showInformationMessage('Raven: Knit cancelled.');
+        return;
+    }
+
+    if (outcome.kind === 'timedOut') {
+        ctx.output.appendLine(`Knit timed out after ${ctx.timeoutMs} ms.`);
+        ctx.output.show(true);
+        void vscode.window.showErrorMessage('Raven: Knit timed out.');
+        return;
+    }
+
+    if (outcome.kind === 'failed') {
+        ctx.output.show(true);
+        void vscode.window.showErrorMessage(
+            `Raven: Knit failed (exit ${outcome.exitCode}). See Raven: Knit output.`,
+        );
+        return;
+    }
+
+    if (outcome.kind === 'noOutput') {
+        const SHOW = 'Show Output';
+        const choice = await vscode.window.showInformationMessage(
+            'Raven: Knit succeeded (output path unknown).',
+            SHOW,
+        );
+        if (choice === SHOW) ctx.output.show(true);
+        return;
+    }
+
+    // ok branch
+    const base = outcome.cwd ?? path.dirname(ctx.fsPath);
+    const absolutized = outcome.parsedOutputs.map((p) => absolutizeFromCwd(p, base));
+    const primary = pickPrimaryOutput(absolutized);
+    if (!primary) {
+        // Defensive — classify guarantees parsedOutputs.length >= 1 for 'ok'.
+        void vscode.window.showInformationMessage('Raven: Knit succeeded.');
+        return;
+    }
+
+    const ext = path.extname(primary).toLowerCase();
+    const baseLabel = path.basename(primary);
+    const isHtml = ext === '.html' || ext === '.htm';
+    const SHOW_ALL = 'Show All';
+    const SHOW_PANEL = 'Show Output Panel';
+    const OPEN = 'Open';
+
+    if (isHtml) {
+        const panelResult = await ctx.showOrUpdatePanel(ctx.context, {
+            sourceUri: ctx.sourceUri,
+            outputPath: primary,
+            output: ctx.output,
+        });
+        if (!panelResult.ok) {
+            ctx.output.appendLine(`[panel] ${panelResult.error}`);
+            // Fall through to the non-HTML reveal path.
+            void revealKnitOutput(primary);
+            return;
+        }
+        const buttons = absolutized.length > 1 ? [SHOW_PANEL, SHOW_ALL] : [SHOW_PANEL];
+        const label = absolutized.length > 1
+            ? `Raven: Knit succeeded: ${baseLabel} (and ${absolutized.length - 1} more).`
+            : `Raven: Knit succeeded: ${baseLabel}.`;
+        const choice = await vscode.window.showInformationMessage(label, ...buttons);
+        if (choice === SHOW_PANEL) {
+            const instance = KnitOutputPanel.getInstanceForTesting();
+            // No public reveal method on the panel; calling showOrUpdate
+            // again with the same args reveals it. (Idempotent — no
+            // recompile of the iframe since the rootDir is unchanged.)
+            if (instance) {
+                await ctx.showOrUpdatePanel(ctx.context, {
+                    sourceUri: ctx.sourceUri,
+                    outputPath: primary,
+                    output: ctx.output,
+                });
+            }
+        } else if (choice === SHOW_ALL) {
+            ctx.output.show(true);
+        }
+        return;
+    }
+
+    // Non-HTML: PDF, Word, plain text, etc.
+    const buttons = absolutized.length > 1 ? [OPEN, SHOW_ALL] : [OPEN];
+    const label = absolutized.length > 1
+        ? `Raven: Knit succeeded: ${baseLabel} (and ${absolutized.length - 1} more).`
+        : `Raven: Knit succeeded: ${baseLabel}.`;
+    const choice = await vscode.window.showInformationMessage(label, ...buttons);
+    if (choice === OPEN) await revealKnitOutput(primary);
+    else if (choice === SHOW_ALL) ctx.output.show(true);
+}
+```
+
+6. **Remove the obsolete inline `revealKnitOutput` for HTML** — find:
+
+```ts
+async function revealKnitOutput(outputPath: string): Promise<void> {
+    const uri = vscode.Uri.file(outputPath);
+    const ext = path.extname(outputPath).toLowerCase();
+    if (ext === '.html' || ext === '.htm') {
+        await vscode.commands.executeCommand('vscode.open', uri);
+        return;
+    }
+    await vscode.commands.executeCommand('revealFileInOS', uri);
+}
+```
+
+Replace with:
+
+```ts
+/**
+ * Reveal non-HTML knit output. HTML outputs route through the Knit
+ * Output webview panel instead (see renderOutcome). PDFs / Word docs /
+ * etc. open via the OS file browser — the user double-clicks to launch
+ * their preferred reader.
+ */
+async function revealKnitOutput(outputPath: string): Promise<void> {
+    const uri = vscode.Uri.file(outputPath);
+    await vscode.commands.executeCommand('revealFileInOS', uri);
+}
+```
+
+- [ ] **Step 3: Compile-check**
+
+```bash
+cd editors/vscode && bun run compile:test
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Re-run Bun tests to confirm no Bun-level regression**
+
+```bash
+bun test tests/bun/knit-output-*.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-commands.ts
+git commit -m "refactor(knit): renderOutcome runs outside withProgress; fix stuck progress + inFlight gate"
+```
+
+---
+
+## Phase 5 — Mocha integration tests
+
+### Task 5.1: Progress-lifecycle integration test
+
+**Files:**
+- Create: `editors/vscode/src/test/knit-progress-lifecycle.test.ts`
+
+- [ ] **Step 1: Verify the existing helpers we'll reuse**
+
+```bash
+grep -nE "export (function|const) (activate|openDocument|sleep)" editors/vscode/src/test/helper.ts
+```
+
+Expected: `activate`, `openDocument`, `sleep` exported. (If not, adjust the imports in the test below to match the actual helper exports.)
+
+- [ ] **Step 2: Expose a test-only entry point**
+
+The production `raven.knit` is registered at activation time against the real `runKnit`; we cannot override the registered command from a test. Expose the internal `runKnitCommand` via a thin wrapper.
+
+Append to `editors/vscode/src/knit/knit-commands.ts`:
+
+```ts
+/**
+ * Test-only entry point that bypasses the registered `raven.knit`
+ * command. Exposes the same code path with caller-controlled deps.
+ * Used by `knit-progress-lifecycle.test.ts` to verify the Piece A
+ * invariant: `inFlight.delete` runs the moment `withProgress` resolves,
+ * NOT when the user dismisses the success toast.
+ *
+ * The `__` prefix signals "test-only"; do not call from production
+ * code.
+ */
+export async function __runKnitCommandForTest(args: {
+    uri: vscode.Uri | undefined;
+    output: vscode.OutputChannel;
+    inFlight: Set<string>;
+    context: vscode.ExtensionContext;
+    deps: KnitDeps;
+}): Promise<void> {
+    await runKnitCommand(args.uri, args.output, args.inFlight, args.context, args.deps);
+}
+```
+
+- [ ] **Step 3: Create the test**
+
+Create `editors/vscode/src/test/knit-progress-lifecycle.test.ts`:
+
+```ts
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, openDocument } from './helper';
+import { __runKnitCommandForTest } from '../knit/knit-commands';
+
+suite('knit progress lifecycle', () => {
+    test('inFlight clears the moment runKnit resolves, not when toast is dismissed', async () => {
+        const api = await activate();
+        assert.ok(api, 'extension activated');
+
+        const fixture = path.join(__dirname, 'fixtures', 'sample.Rmd');
+        const doc = await openDocument(vscode.Uri.file(fixture));
+        await vscode.window.showTextDocument(doc);
+
+        const inFlight = new Set<string>();
+        const output = vscode.window.createOutputChannel('Knit Test');
+
+        // Stub showInformationMessage so the test does not hang on the
+        // success toast. The bug under test was that inFlight stayed
+        // populated until this resolved.
+        const origShow = vscode.window.showInformationMessage;
+        let showResolve: ((v: string | undefined) => void) | null = null;
+        (vscode.window as any).showInformationMessage = (
+            ...args: unknown[]
+        ): Thenable<string | undefined> => {
+            return new Promise<string | undefined>((res) => {
+                showResolve = res;
+            });
+        };
+
+        try {
+            const runPromise = __runKnitCommandForTest({
+                uri: doc.uri,
+                output,
+                inFlight,
+                context: { subscriptions: [], extensionUri: api.extensionUri } as unknown as vscode.ExtensionContext,
+                deps: {
+                    runKnit: (async () => ({
+                        spawnError: undefined,
+                        cancelled: false,
+                        timedOut: false,
+                        exitCode: 0,
+                        stdout: `Output created: ${path.join(path.dirname(fixture), 'sample.html')}\n`,
+                        stderr: '',
+                    })) as any,
+                    showOrUpdatePanel: async () => ({ ok: true }),
+                },
+            });
+
+            // Yield to let withProgress + runKnit resolve. After this
+            // microtask drain, withProgress should be done AND
+            // inFlight.delete should have happened — even though the
+            // info-message stub is still suspended.
+            await new Promise((res) => setTimeout(res, 50));
+
+            assert.strictEqual(
+                inFlight.has(doc.uri.fsPath),
+                false,
+                'inFlight should be cleared before the success toast is dismissed',
+            );
+
+            // Now dismiss the info-message so runPromise can resolve.
+            showResolve?.(undefined);
+            await runPromise;
+        } finally {
+            (vscode.window as any).showInformationMessage = origShow;
+            output.dispose();
+        }
+    });
+});
+```
+
+- [ ] **Step 4: Create the fixture**
+
+Create `editors/vscode/src/test/fixtures/sample.Rmd`:
+
+```markdown
+---
+title: "Knit test sample"
+output: html_document
+---
+
+Hello.
+```
+
+- [ ] **Step 5: Compile-check**
+
+```bash
+cd editors/vscode && bun run compile:test
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Run the Mocha suite**
+
+```bash
+cd editors/vscode && bun run test 2>&1 | tail -40
+```
+
+Expected: the new `knit progress lifecycle` test passes alongside the existing suite.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add editors/vscode/src/knit/knit-commands.ts editors/vscode/src/test/knit-progress-lifecycle.test.ts editors/vscode/src/test/fixtures/sample.Rmd
+git commit -m "test(knit): inFlight clears before success toast (Piece A)"
+```
+
+---
+
+### Task 5.2: Panel integration test — refresh + open-in-browser + singleton
+
+**Files:**
+- Create: `editors/vscode/src/test/knit-output-panel.test.ts`
+
+- [ ] **Step 1: Create the test**
+
+Create `editors/vscode/src/test/knit-output-panel.test.ts`:
+
+```ts
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+function writeFixture(dir: string, name: string, body = '<html><body>hi</body></html>'): string {
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, body, 'utf-8');
+    return p;
+}
+
+suite('KnitOutputPanel integration', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-panel-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('showOrUpdate reuses the singleton when rootDir is unchanged', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const a = writeFixture(tmp, 'a.html');
+            const b = writeFixture(tmp, 'b.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            const r1 = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: a, output },
+            );
+            assert.deepStrictEqual(r1, { ok: true });
+            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst1);
+
+            const r2 = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: b, output },
+            );
+            assert.deepStrictEqual(r2, { ok: true });
+            const inst2 = KnitOutputPanel.getInstanceForTesting();
+            assert.strictEqual(inst1, inst2, 'singleton instance should be reused');
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('showOrUpdate creates a fresh panel when rootDir changes', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const sub = path.join(tmp, 'sub');
+            const a = writeFixture(tmp, 'a.html');
+            const b = writeFixture(sub, 'b.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: a, output },
+            );
+            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst1);
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: b, output },
+            );
+            const inst2 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst2);
+            assert.notStrictEqual(inst1, inst2, 'a new singleton should be created when rootDir changes');
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('showOrUpdate returns {ok: false} when the output file does not exist', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+            const result = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: path.join(tmp, 'does-not-exist.html'), output },
+            );
+            assert.strictEqual(result.ok, false);
+            if (!result.ok) assert.ok(result.error.length > 0);
+        } finally {
+            output.dispose();
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Compile and run**
+
+```bash
+cd editors/vscode && bun run compile:test && bun run test
+```
+
+Expected: all knit tests pass; the rest of the suite is unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add editors/vscode/src/test/knit-output-panel.test.ts
+git commit -m "test(knit): KnitOutputPanel singleton lifecycle integration tests"
+```
+
+---
+
+## Phase 6 — Docs
+
+### Task 6.1: Update `docs/knit.md`
+
+**Files:**
+- Modify: `docs/knit.md`
+
+- [ ] **Step 1: Update step 10 (Reveal) and the "what raven does not do" table**
+
+Find:
+
+```markdown
+10. **Reveal.** On a clean exit Raven parses `Output created: <path>`
+    out of stdout and offers an `Open` button. `.html` / `.htm` open
+    via `vscode.open` (which routes through Simple Browser in remote
+    workspaces); everything else opens via `revealFileInOS`. When the
+    parse fails Raven still surfaces "Knit succeeded (output path
+    unknown)" — the subprocess exit code is the ground truth.
+```
+
+Replace with:
+
+```markdown
+10. **Reveal.** On a clean exit Raven parses `Output created: <path>`
+    out of stdout. When the primary output is HTML (or there's any HTML
+    in a multi-output knit), Raven opens it in the **Knit Output**
+    webview panel beside the editor. The panel toolbar has two buttons:
+    - **Refresh** — re-knits the source `.Rmd` (the same code path as
+      invoking `Raven: Knit` from the palette).
+    - **Open in Browser** — opens the rendered file in your OS default
+      browser. In remote workspaces (SSH, Codespaces, dev containers)
+      this may not work because `file://` URIs target the remote
+      machine; Raven warns and writes the path to the `Raven: Knit`
+      output channel as a fallback.
+
+    The rendered HTML loads inside an `<iframe sandbox="">` — scripts,
+    forms, and external navigation are blocked. Intra-document anchor
+    links (`#section`) work; clicking an external `<a>` does nothing
+    (use **Open in Browser** for full interactivity, including
+    htmlwidgets). For PDF / Word / etc., Raven still reveals the file
+    in your OS file browser. When the output-path parse fails Raven
+    surfaces "Knit succeeded (output path unknown)" — the subprocess
+    exit code is the ground truth.
+```
+
+- [ ] **Step 2: Add a clarifying row to the "What Raven does **not** do" table**
+
+Find:
+
+```markdown
+| Live preview of `.Rmd` or `.qmd` | `quarto.quarto`'s `Quarto: Preview` |
+```
+
+Add a row below it (no change to the existing one):
+
+```markdown
+| Auto-refresh / live preview on save | `quarto.quarto`'s `Quarto: Preview`. The Knit Output panel is a static viewer with a manual Refresh button — not a live recompile. |
+```
+
+- [ ] **Step 3: Compile-check that markdown still lints**
+
+(The project uses `markdownlint`; the only constraint relevant here is MD040 — fenced code blocks need a language. The new content does not add fences.)
+
+Skip — no command needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/knit.md
+git commit -m "docs(knit): document Knit Output webview panel, refresh, open in browser, iframe limitations"
+```
+
+---
+
+## Phase 7 — Local verification
+
+### Task 7.1: Run the full local suite
+
+- [ ] **Step 1: Bun tests**
+
+```bash
+bun test tests/bun/
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Cargo tests (sanity — no Rust code changed, but the workspace test suite catches accidental cross-cutting breakage)**
+
+```bash
+cargo test -p raven 2>&1 | tail -20
+```
+
+Expected: no new failures introduced. (Existing pass/fail unchanged.)
+
+- [ ] **Step 3: VS Code Mocha**
+
+```bash
+cd editors/vscode && bun run compile:test && bun run test 2>&1 | tail -60
+```
+
+Expected: all knit tests pass; rest unchanged.
+
+If anything fails, fix it and re-commit with a `fix:` message before proceeding.
+
+- [ ] **Step 4: Settings reference regen (precautionary — if any package.json change crept in)**
+
+```bash
+bun editors/vscode/scripts/generate-settings-reference.mjs
+git diff --stat
+```
+
+Expected: no diff. If there is one, commit it with `chore(vscode): regenerate settings reference`.
+
+---
+
+### Task 7.2: Manual smoke
+
+Manual steps the implementer runs locally. Each must pass before opening the PR.
+
+- [ ] Open a `.Rmd` fixture (the `editors/vscode/src/test/fixtures/sample.Rmd` works, or any local one). Run **Raven: Knit**.
+  - "Knitting …" notification closes the moment R exits.
+  - Knit Output panel opens beside the editor.
+  - **Refresh** and **Open in Browser** are visible.
+- [ ] Click **Refresh**. New "Knitting …" notification appears; panel content updates on success; no "already being knitted" toast.
+- [ ] Click **Refresh** quickly twice while a knit is running. Second click produces "is already being knitted" (existing inFlight gate).
+- [ ] Knit a `.Rmd` with `output: pdf_document`. Verify the success toast has **Open** and **Open** triggers `revealFileInOS` (file browser). No panel opens.
+- [ ] (Optional, if remote workspace available) Knit in Codespaces / SSH. **Open in Browser** either opens locally OR shows the "not available for this workspace" warning + path in output channel.
+
+---
+
+## Phase 8 — Codex review, PR, merge
+
+### Task 8.1: Codex adversarial review of the implementation
+
+- [ ] **Step 1: Run Codex review on the diff**
+
+Invoke the codex rescue subagent with a focused prompt:
+
+```text
+Adversarial review of branch fix-knit-bug vs main. Focus on:
+- correctness of the Piece A lifecycle fix
+- security of the iframe-sandbox shell (CSP, sandbox attribute, localResourceRoots)
+- multi-output handling
+- test coverage gaps
+Find problems, not validate.
+```
+
+Use the `/codex:rescue` slash command (or `Agent` with `subagent_type: "codex:codex-rescue"`).
+
+- [ ] **Step 2: Triage findings**
+
+For each finding, decide:
+- **Fix now** — incorrect or insecure code. Make the change, add a regression test, commit.
+- **Document** — intentional trade-off. Note in the spec's "v2 → v3 changes" table if non-trivial.
+- **Reject** — disagree, with reasoning. Surface to the user before dismissing.
+
+Commit any fixes with `fix(knit): <Codex finding>` messages.
+
+- [ ] **Step 3: Re-run the full local suite after fixes**
+
+```bash
+bun test tests/bun/ && cargo test -p raven 2>&1 | tail -10 && cd editors/vscode && bun run test 2>&1 | tail -30
+```
+
+Expected: all green.
+
+---
+
+### Task 8.2: Open the PR
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push -u origin fix-knit-bug
+gh pr create --title "fix(knit): output webview + progress lifecycle" --body "$(cat <<'EOF'
+## Summary
+
+- Fixes the stuck "Knitting …" progress notification (and the spurious "already being knitted" gate on re-invocation) by moving all user-facing toasts out of the `withProgress` callback. `inFlight.delete(fsPath)` now runs the moment the R subprocess exits.
+- Adds a Knit Output webview panel: an iframe-sandbox shell that renders HTML output with **Refresh** and **Open in Browser** toolbar buttons. Three-layer security model (sandbox attribute, outer-shell CSP in `<head>`, `localResourceRoots`) — no HTML parsing or rewriting on Raven's side.
+- Multi-output knits (`output_format = "all"`) prefer the HTML output for the viewer; PDF / DOCX / etc. remain on the existing `revealFileInOS` path.
+
+## Spec
+- `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` (v2, addresses Codex adversarial review of v1)
+- Plan: `docs/superpowers/plans/2026-05-17-knit-output-webview.md`
+
+## Test plan
+- [ ] Bun unit tests for `pickPrimaryOutput`, `isKnitOutputMessage`, `classify`, `buildShellHtml`
+- [ ] Mocha integration test asserting `inFlight` clears before the success toast (Piece A)
+- [ ] Mocha integration tests for `KnitOutputPanel` singleton reuse and rootDir-change recreation
+- [ ] Manual smoke: knit `.Rmd` locally, verify panel opens, Refresh re-knits, Open in Browser launches default browser
+- [ ] Manual smoke: knit `output: pdf_document`, verify existing `revealFileInOS` path unchanged
+EOF
+)"
+```
+
+- [ ] **Step 2: Capture the PR URL**
+
+The PR URL is printed by `gh pr create`. Use it for the merge step.
+
+---
+
+### Task 8.3: Monitor CI
+
+- [ ] **Step 1: Check CI status**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all checks green.
+
+- [ ] **Step 2: Address any CI failures**
+
+For each failure: read the log (`gh pr view <number> --log`), reproduce locally, fix, push.
+
+---
+
+### Task 8.4: Final Codex sign-off and merge
+
+- [ ] **Step 1: Codex final review**
+
+Run Codex on the final diff:
+
+```text
+Final review of branch fix-knit-bug. Is this safe to merge?
+Address only blocking issues (security, correctness, test gaps).
+```
+
+- [ ] **Step 2: Address any blocking findings**
+
+Same triage as Task 8.2. Push fixes; CI runs again.
+
+- [ ] **Step 3: Merge once Codex agrees and CI is green**
+
+```bash
+gh pr merge --squash --auto
+```
+
+(The `--auto` flag merges as soon as CI passes if it isn't already green.)
+
+- [ ] **Step 4: Confirm merge**
+
+```bash
+gh pr view <number> --json state,mergedAt
+```
+
+Expected: `state: MERGED`.
+
+---
+
+## Self-review checklist (run before handing off)
+
+- [ ] Spec coverage: every section in `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` has at least one task implementing it (Goals 1–5 ✓ Piece A, Piece B, multi-output, docs, tests).
+- [ ] No placeholders: every code block in this plan contains executable text; every command has expected output stated.
+- [ ] Type consistency: `KnitOutcome`, `KnitOutputMessage`, `KnitDeps`, `RenderOutcomeCtx` are all defined in exactly one task and referenced consistently.
+- [ ] Commit cadence: 7 implementation commits + Codex-fix commits + docs commit = ~10 commits total. Each is independently revertible.
+

--- a/docs/superpowers/specs/2026-05-17-knit-output-webview-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-output-webview-design.md
@@ -1,9 +1,10 @@
 # R Markdown Knit — Output Webview + Progress-Lifecycle Fix
 
-**Status**: Design.
+**Status**: Design (v2 — addresses Codex adversarial review of v1).
 **Date**: 2026-05-17.
 **Branch**: `fix-knit-bug`.
 **Amends**: [`2026-05-16-rmd-knit-preview-design.md`](2026-05-16-rmd-knit-preview-design.md) — supersedes step 10 ("Reveal") of that spec's data flow and adds one new module. All other sections of the 2026-05-16 spec are unchanged.
+**Review**: Codex adversarial review pass on v1 surfaced two critical issues (CSP-in-`<body>` is not honored; rewrite-pass failure could bypass the security model). v2 replaces the in-place CSP+rewrite architecture with an iframe-sandbox shell, eliminating both by construction.
 
 ## Why this spec exists
 
@@ -40,7 +41,8 @@ The earlier design deliberately kept *live preview* (iframe + recompile-on-save,
 
 - Live / auto-refresh preview. Refresh is exclusively manual.
 - Rendering `.qmd`. `quarto.quarto` continues to own that.
-- htmlwidgets / interactive JS inside the rendered document running in the panel. The panel's CSP allows our refresh-button script (nonce-gated) and inline styles; arbitrary scripts from the rendered HTML do not run. Users who need htmlwidgets can open the `.html` file in a browser via the panel's existing OS file path (current behavior preserved on the success toast for non-HTML outputs, and an `Open in Browser` button on the toast — see "Open Externally" below).
+- htmlwidgets / interactive JS inside the rendered document running in the panel. The rendered HTML loads inside an `<iframe sandbox>` with no flags — scripts, forms, and same-origin access are all blocked. Users who need widgets click the panel toolbar's **Open in Browser** button.
+- External hyperlinks inside the rendered HTML opening in a new tab from inside the panel. The iframe sandbox prevents script-driven navigation and the outer CSP's `frame-src` directive prevents the iframe from navigating to external URLs. Anchors with `href="#…"` (intra-document) work; relative anchors to other rendered files work; external `http(s)://…` anchors fail silently inside the iframe. Documented in `docs/knit.md`.
 - PDF / DOCX inline rendering. Non-HTML outputs continue to use `revealFileInOS`.
 - A multi-tab "history" of past knits. The panel is a singleton and always shows the most recent successful output.
 - Persisting panel state across window reloads (`retainContextWhenHidden: true` is enabled for switching editor groups; full session restoration is not).
@@ -55,7 +57,7 @@ editors/vscode/src/knit/
   yaml-frontmatter.ts     # unchanged
   r-expression.ts         # unchanged
   output-path.ts          # unchanged
-  knit-output-panel.ts    # NEW: singleton WebviewPanel + HTML rewrite + refresh wiring
+  knit-output-panel.ts    # NEW: singleton WebviewPanel with iframe-sandbox shell + refresh / open-in-browser wiring
 ```
 
 No changes to `package.json` contributions, settings schema, or context keys.
@@ -83,7 +85,11 @@ type KnitOutcome =
   | { kind: 'timedOut'; timeoutMs: number }
   | { kind: 'failed'; exitCode: number | null }
   | { kind: 'noOutput' }
-  | { kind: 'ok'; parsedOutputs: string[]; cwd: string };
+  | { kind: 'ok'; parsedOutputs: string[]; cwd: string | undefined };
+//                                                ^^^^^^^^^^^^^^^^^^^
+// `cwd` is `string | undefined`, matching the existing `resolveKnitDir`
+// return (undefined when mode === 'current' with no workspace open).
+// `renderOutcome` falls back to `path.dirname(fsPath)` when needed.
 
 // inside runKnitCommand:
 let outcome: KnitOutcome;
@@ -91,7 +97,7 @@ try {
   outcome = await vscode.window.withProgress(
     { location: ProgressLocation.Notification, title: `Knitting ${baseName}…`, cancellable: true },
     async (_progress, token) => {
-      const result = await runKnit({ /* ... */ cancellation: token });
+      const result = await runKnitImpl({ /* ... */ cancellation: token });
       return classify(result);              // returns KnitOutcome — no awaits on user input
     },
   );
@@ -99,8 +105,10 @@ try {
   inFlight.delete(fsPath);
 }
 
-await renderOutcome(outcome, { /* fsPath, baseName, sourceUri, output channel, cwd, panelMgr */ });
+await renderOutcome(outcome, { fsPath, baseName, sourceUri, output, panelMgr });
 ```
+
+**Injection seam for testing.** `registerKnitCommands` accepts an optional `deps: { runKnit?: typeof runKnit; openPanel?: typeof KnitOutputPanel.showOrUpdate }` parameter, defaulting to the real implementations imported from `./knit-engine` and `./knit-output-panel`. Tests pass fakes via this parameter. The lifecycle test (see "Testing" below) substitutes `runKnit` and asserts the `withProgress` promise resolves before `renderOutcome` runs. No top-level module mocking required.
 
 `inFlight.delete(fsPath)` runs the instant `withProgress` resolves, so a second knit invoked between the subprocess exit and the user dismissing the success toast is no longer blocked.
 
@@ -112,7 +120,19 @@ A focused test under `editors/vscode/src/test/` (see "Testing" below) substitute
 - `inFlight.has(fsPath) === false` at the moment `withProgress` resolves.
 - A second concurrent `raven.knit` invocation issued at that moment is *not* rejected with "already being knitted".
 
-## Piece B — Knit Output webview panel
+## Piece B — Knit Output webview panel (iframe-sandbox shell)
+
+### Architectural choice
+
+The panel is an **outer Raven-controlled shell document** that hosts an `<iframe sandbox>` pointing at the rendered HTML. Security is enforced by:
+
+- The outer shell's CSP (in `<head>`, fully under our control).
+- The iframe's `sandbox` attribute (no flags — blocks scripts, forms, same-origin access, popups, and top-navigation).
+- `webview.localResourceRoots` confined to the rendered output's parent directory.
+
+We do not parse or rewrite the rendered HTML. The iframe loads it directly from `webview.asWebviewUri(...)`; relative asset paths (figures, CSS) resolve against the webview origin naturally because `localResourceRoots` includes the output's parent directory.
+
+This addresses Codex critical findings #1 (CSP must live in `<head>`) and #2 (security model must not depend on a rewrite that may throw) by construction — there is no rewrite, and the CSP lives in our shell's head.
 
 ### Module
 
@@ -124,6 +144,7 @@ export class KnitOutputPanel {
   private panel: vscode.WebviewPanel;
   private rootDir: string;       // current localResourceRoots[0].fsPath
   private sourceUri: vscode.Uri; // for refresh
+  private outputPath: string;    // for Open in Browser
 
   static showOrUpdate(
     context: vscode.ExtensionContext,
@@ -131,17 +152,18 @@ export class KnitOutputPanel {
   ): Promise<void>;
 
   private constructor(/* ... */);
-  private updateHtml(outputPath: string): Promise<void>;
+  private updateContent(args: { sourceUri: vscode.Uri; outputPath: string }): void;
   private dispose(): void;
 }
 ```
 
 `showOrUpdate` is the only public entry point. It:
 
-1. Computes `rootDir = path.dirname(outputPath)`.
-2. If `instance` exists and `instance.rootDir === rootDir`: replaces content via `updateHtml`, reveals (`panel.reveal(panel.viewColumn ?? ViewColumn.Beside, false)`).
-3. If `instance` exists but `instance.rootDir !== rootDir`: disposes the old panel (column is preserved via the `viewColumn` we read before disposing) and creates a new one in the same column. This is the same `localResourceRoots`-immutability workaround used in `help-panel.ts`.
-4. If no instance: creates a fresh panel in `ViewColumn.Beside`.
+1. Verifies `outputPath` exists with `fs.promises.access(outputPath, fs.constants.R_OK)`. On failure, returns a "could not read rendered file" error; the caller falls back to `revealFileInOS`.
+2. Computes `rootDir = path.dirname(outputPath)`.
+3. If `instance` exists and `instance.rootDir === rootDir`: replaces content via `updateContent`, reveals (`panel.reveal(panel.viewColumn ?? ViewColumn.Beside, /* preserveFocus */ true)`).
+4. If `instance` exists but `instance.rootDir !== rootDir`: disposes the old panel (column read first) and creates a new one in the same column. (`localResourceRoots` is immutable post-creation — same workaround `help-panel.ts` uses.)
+5. If no instance: creates a fresh panel in `ViewColumn.Beside`.
 
 ### Webview options
 
@@ -152,87 +174,119 @@ vscode.window.createWebviewPanel(
   { viewColumn: ViewColumn.Beside, preserveFocus: true },
   {
     enableScripts: true,
+    enableFindWidget: true,           // Cmd/Ctrl-F over the rendered text
     retainContextWhenHidden: true,
     localResourceRoots: [vscode.Uri.file(rootDir)],
   },
 );
 ```
 
-`preserveFocus: true` keeps the cursor in the editor — the user's primary surface for editing.
+`preserveFocus: true` keeps the cursor in the editor.
 
-### HTML loading and rewrite
+### Outer shell HTML
 
-`updateHtml(outputPath)`:
-
-1. `const raw = await fs.promises.readFile(outputPath, 'utf-8')`. On error, dispose the panel and surface a toast "Knit Output: could not read rendered file: {message}"; the caller falls back to `revealFileInOS`.
-2. Rewrite `src`/`href` attributes with a hand-rolled tag-attribute pass scoped to `<img>`, `<link rel="stylesheet">`, `<script src>`, and `<a href>` — ~60 lines, sufficient for rmarkdown's stock templates. (See Open Question #1 for the `parse5` alternative.) For each relative path:
-   - Resolve relative to `path.dirname(outputPath)` to an absolute path.
-   - `path.relative(rootDir, absolute)` — reject (skip rewrite, log warning) if the result starts with `..` or is absolute on Windows. This is the path-containment guard.
-   - `vscode.Uri.file(absolute)` → `panel.webview.asWebviewUri(...)`.
-   - Absolute URLs (`http:`, `https:`, `data:`, `mailto:`, `#fragment`) are passed through unchanged.
-3. Inject a CSP `<meta>` and a fixed toolbar at the top of `<body>`:
+`updateContent` regenerates the shell HTML each time and assigns to `panel.webview.html`. The shell is a small fixed template:
 
 ```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy"
       content="default-src 'none';
+               frame-src ${cspSource};
                img-src ${cspSource} https: data:;
                style-src ${cspSource} 'unsafe-inline';
                font-src ${cspSource} https: data:;
                script-src 'nonce-${nonce}';
                connect-src 'none';">
-
-<div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
-  <button id="raven-knit-refresh" type="button">Refresh</button>
-  <span id="raven-knit-filename" aria-live="polite">${escapeHtml(path.basename(outputPath))}</span>
-</div>
-<script nonce="${nonce}">
-  (function () {
-    const vscode = acquireVsCodeApi();
-    document.getElementById('raven-knit-refresh').addEventListener('click', function () {
-      vscode.postMessage({ type: 'refresh' });
-    });
-  })();
-</script>
+<title>Knit Output</title>
+<style nonce="${nonce}">
+  /* toolbar styles — fixed at top, ~36px tall, VS Code theme variables */
+</style>
+</head>
+<body>
+  <div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
+    <button id="raven-knit-refresh" type="button" title="Re-knit the source document">Refresh</button>
+    <button id="raven-knit-open-browser" type="button" title="Open the rendered file in your default browser">Open in Browser</button>
+    <span id="raven-knit-filename" aria-live="polite">${escapeHtml(path.basename(outputPath))}</span>
+  </div>
+  <iframe id="raven-knit-frame"
+          src="${asWebviewUri(outputPath)}"
+          sandbox=""
+          referrerpolicy="no-referrer"
+          title="Rendered output: ${escapeHtml(path.basename(outputPath))}"></iframe>
+  <script nonce="${nonce}">
+    (function () {
+      const vscode = acquireVsCodeApi();
+      document.getElementById('raven-knit-refresh').addEventListener('click', function () {
+        vscode.postMessage({ type: 'refresh' });
+      });
+      document.getElementById('raven-knit-open-browser').addEventListener('click', function () {
+        vscode.postMessage({ type: 'openInBrowser' });
+      });
+    })();
+  </script>
+</body>
+</html>
 ```
 
-`'unsafe-inline'` for styles is the same compromise `help-panel.ts` makes — rmarkdown's default templates emit inline `<style>` blocks for highlight themes. Scripts inside the rendered HTML cannot run because they lack the nonce; this is intentional and called out in the non-goals.
+Notes:
 
-The toolbar is appended via DOM-string concatenation rather than DOM injection (the panel never executes the rendered scripts, so a post-load `appendChild` couldn't work). The toolbar markup precedes `<body>`'s existing content, and lightly-styled to float at the top of the viewport.
+- `sandbox=""` (empty value) is the most restrictive sandbox: no scripts, no forms, no same-origin, no popups, no top-navigation. The rendered HTML is purely static rendering.
+- `frame-src ${cspSource}` confines the iframe to the webview origin. External anchors in the rendered HTML cannot navigate the iframe to an external host (the navigation is blocked silently).
+- `'unsafe-inline'` for styles is needed by rmarkdown's stock templates (inline `<style>` for highlight themes); the iframe sandbox makes this safe because the inline styles cannot reach the outer toolbar.
+- The toolbar uses VS Code theme variables (`--vscode-button-background`, etc.) for visual consistency. Standard pattern across `help-panel.ts` and `plot-viewer-panel.ts`.
 
 ### Message protocol
 
-The webview never receives the source URI or output path. The extension side captures both when `showOrUpdate` is called and uses them on receipt of:
-
 ```ts
-type KnitOutputMessage = { type: 'refresh' };
+type KnitOutputMessage =
+  | { type: 'refresh' }
+  | { type: 'openInBrowser' };
 ```
 
-Handler:
+The webview never receives the source URI or output path. The extension side captures both at `showOrUpdate` time and uses them on receipt:
 
 ```ts
 panel.webview.onDidReceiveMessage((msg: unknown) => {
-  if (isRefreshMessage(msg)) {
+  if (!isKnitOutputMessage(msg)) return;     // strict type-narrowing
+  if (msg.type === 'refresh') {
     void vscode.commands.executeCommand('raven.knit', this.sourceUri);
+  } else if (msg.type === 'openInBrowser') {
+    void openInBrowser(this.outputPath, this.output);
   }
 });
 ```
 
-`isRefreshMessage` is a narrow `msg !== null && typeof msg === 'object' && (msg as any).type === 'refresh'` check.
-
 ### What refresh does
 
-`raven.knit` re-runs against `this.sourceUri`. Every gate, blocker detection, validation, subprocess invocation, output-channel write, progress notification, cancellation, and reveal step that the original knit went through runs again. The same code path that called `KnitOutputPanel.showOrUpdate` for the original knit calls it again. The panel content is replaced; the panel reference does not change unless the output's `rootDir` did.
+`raven.knit` re-runs against `this.sourceUri`. Every gate, blocker detection, validation, subprocess invocation, output-channel write, progress notification, cancellation, and reveal step that the original knit went through runs again. The same code path that called `KnitOutputPanel.showOrUpdate` for the original knit calls it again. The iframe's `src` is replaced; the panel reference does not change unless the output's `rootDir` did.
 
-The existing `inFlight` Set in `registerKnitCommands` already prevents two concurrent knits of the same file with a clear info toast. Refresh inherits that gate. No webview-side in-flight state is needed.
+The existing `inFlight` Set in `registerKnitCommands` already prevents two concurrent knits of the same file with a clear info toast. Refresh inherits that gate.
 
-### Open Externally
+### Open in Browser
 
-The success toast for HTML outputs is replaced with two buttons:
+`openInBrowser(outputPath, output)`:
 
-- **Show Output Panel** — focuses the Knit Output webview (`panel.reveal`).
-- **Open in Browser** — `vscode.env.openExternal(vscode.Uri.file(outputPath))`. Gives users with htmlwidget / JS-heavy documents an escape hatch to a full browser. In remote workspaces, `openExternal` correctly routes through the remote-tunnel.
+```ts
+async function openInBrowser(outputPath: string, output: vscode.OutputChannel): Promise<void> {
+  const uri = vscode.Uri.file(outputPath);
+  const opened = await vscode.env.openExternal(uri);
+  if (opened) return;
+  // Remote workspaces: openExternal(file:) opens on the extension-host
+  // machine, which is the remote server — not where the user is sitting.
+  // Surface a clear fallback message and keep the rendered path in the
+  // output channel so the user can act on it.
+  output.appendLine(`[Open in Browser] file:// did not open on the local machine.`);
+  output.appendLine(`Rendered output is at: ${outputPath}`);
+  await vscode.window.showWarningMessage(
+    'Open in Browser is not available for this workspace. The rendered file path has been written to the Raven: Knit output channel.',
+  );
+}
+```
 
-Non-HTML output toasts are unchanged.
+The previous spec's claim that `openExternal(file:)` "correctly routes through the remote-tunnel" was unverified (Codex finding #6); it is retracted here. Local workspaces continue to use the OS default browser via `openExternal`; remote workspaces surface a clear fallback rather than silently failing.
 
 ## Updated data flow (delta from the 2026-05-16 spec)
 
@@ -242,44 +296,68 @@ Steps [1]–[9] are unchanged. Step [10] ("Reveal") is replaced:
  [10] Reveal — supersedes step 10 of the 2026-05-16 spec.
 
    Exit 0, parsed.paths.length >= 1:
-     primary = absolutizeFromCwd(parsed.paths[0], cwd ?? path.dirname(fsPath))
+     base = cwd ?? path.dirname(fsPath)
+     absolutized = parsed.paths.map(p => absolutizeFromCwd(p, base))
+
+     // Codex finding #4: when output_format = "all" produces a mix of formats,
+     // prefer the HTML output for the webview. The user explicitly asked for
+     // an HTML viewer; PDF/DOCX outputs of the same knit still surface via
+     // the toast.
+     html = absolutized.find(p =>
+       ['.html', '.htm'].includes(path.extname(p).toLowerCase())
+     )
+     primary = html ?? absolutized[0]
      ext = path.extname(primary).toLowerCase()
 
      if ext is '.html' or '.htm':
-       KnitOutputPanel.showOrUpdate(context, { sourceUri: docUri, outputPath: primary })
-       Toast (NON-MODAL, no awaited button): "Knit succeeded: <basename>." with buttons
-         [Show Output Panel] [Open in Browser] [Show All if parsed.paths > 1]
-       The toast is fire-and-forget; the panel has already opened. The withProgress
-       promise has already resolved (Piece A).
+       panelResult = KnitOutputPanel.showOrUpdate(context, {
+         sourceUri: docUri, outputPath: primary,
+       })
+       if panelResult is { ok: false }:
+         output.appendLine(`[panel] ${panelResult.error}`)
+         fall through to revealFileInOS(primary) — see "else" branch
+       else:
+         Toast (NON-MODAL, fire-and-forget): "Knit succeeded: <basename>." with buttons
+           [Show Output Panel] [Show All if absolutized.length > 1]
+         The panel has already opened; the toast is for feedback.
+         Open in Browser lives in the panel toolbar, not on the toast.
 
      else (PDF, Word, plain text, …):
-       Toast (NON-MODAL, no awaited button): "Knit succeeded: <basename>." with buttons
-         [Open] [Show All if parsed.paths > 1]
+       Toast (NON-MODAL, fire-and-forget): "Knit succeeded: <basename>." with buttons
+         [Open] [Show All if absolutized.length > 1]
        [Open] → revealFileInOS(primary).
-       Behavior is identical to the pre-spec implementation, minus the await-inside-progress bug.
+       Behavior is identical to the pre-spec implementation, minus the
+       await-inside-progress bug.
 ```
 
 The "output path unknown" branch (Exit 0, parsed.paths.length === 0) and the failure branches (non-zero exit, cancellation, timeout, spawn error) are unchanged in semantics but no longer execute inside `withProgress`.
 
 ## Security model
 
-1. **`localResourceRoots` is the only escape**: the panel can load images / CSS / fonts only from the rendered file's directory and below. The HTML rewrite pass enforces this by skipping any relative path that resolves outside `rootDir`.
-2. **CSP** allows our refresh-button script via nonce and rmarkdown's inline styles via `'unsafe-inline'`. Scripts inside the rendered HTML do not match the nonce and do not run. `connect-src 'none'` prevents any `fetch`/`XHR` even if a script did slip past.
-3. **No source URI in the webview.** The refresh-button script posts only `{type: 'refresh'}`. The extension side captures the `sourceUri` once at `showOrUpdate` time. A compromised rendered HTML cannot retarget the refresh to a different file.
-4. **Message-type narrowing.** The `onDidReceiveMessage` handler accepts only the exact shape `{type: 'refresh'}`. Anything else is silently dropped.
-5. **Path containment** on rewrite uses `path.relative` plus a Windows absolute-path check. We never widen `localResourceRoots` to satisfy a rewrite.
+The model has three independent layers; each enforces containment by itself, and any one of them failing does not breach the others.
+
+1. **`iframe sandbox` (no flags).** The rendered HTML loads inside `<iframe sandbox="" …>`. This blocks scripts, forms, popups, top-level navigation, and same-origin access. The iframe cannot read or modify the outer toolbar; the outer toolbar's scripts cannot inspect the iframe content. Even if the rendered HTML contains `<script>` tags, they do not execute.
+2. **Outer-shell CSP** (in `<head>` of the Raven-controlled shell). `default-src 'none'`, `frame-src ${cspSource}` (blocks the iframe navigating to external hosts), `script-src 'nonce-${nonce}'` (only our toolbar script runs), `connect-src 'none'` (no `fetch`/`XHR`). The CSP is in `<head>` and is guaranteed honored, addressing Codex critical finding #1.
+3. **`localResourceRoots`.** Confined to `path.dirname(outputPath)`. The webview can resolve files only from that directory and below. Defense in depth — even if the iframe sandbox were misconfigured, the renderer cannot fetch arbitrary files.
+
+Additional invariants:
+
+- **No source URI in the webview.** The toolbar script posts only `{type: 'refresh'}` or `{type: 'openInBrowser'}`. The extension captures the `sourceUri` and `outputPath` once at `showOrUpdate` time. Compromised rendered HTML cannot retarget the refresh to a different file.
+- **Message-type narrowing.** `onDidReceiveMessage` accepts only the two exact message shapes; anything else is silently dropped.
+- **No HTML parsing on Raven's side.** Codex finding #7 (hand-rolled parser misses single-quoted attrs, `srcset`, CSS `url(...)`, etc.) is moot — we don't parse. The iframe's browser parses the rendered HTML, and the sandbox+CSP+roots stack governs what the browser can do with it.
+- **No rewrite-failure fallback path.** Codex finding #2 (rewrite throws → renders unrewritten in script-enabled webview) is moot — there is no rewrite. The shell is a small fixed template; if it can't be assembled, we fall back to `revealFileInOS`.
 
 ## Error handling
 
-| Condition                                            | Surface                                                                                                                                              |
-| --                                                   | --                                                                                                                                                   |
-| Rendered HTML file read fails                        | Toast: "Knit Output: could not read rendered file: {message}"; dispose panel; `revealFileInOS` on the path.                                          |
-| HTML rewrite throws                                  | Log to `Raven: Knit` output channel with details; render the unrewritten HTML in the panel (broken figures are acceptable; text is still readable).  |
-| Refresh-while-knit-in-flight                         | Existing inFlight gate fires: info toast "<file> is already being knitted." No change.                                                               |
-| Refresh produces output under a different `rootDir`  | Dispose & recreate panel in the same column. User-visible: brief flash; no error.                                                                    |
-| Panel disposed by user, then knit re-run             | A fresh panel opens. The previous singleton was garbage collected on `onDidDispose`.                                                                 |
-| Knit re-run produces non-HTML output                 | Existing toast with `[Open]` fires; the previous HTML panel is left visible (it shows the last successful HTML — accurate, not stale-for-the-format). |
-| `vscode.env.openExternal` rejected                   | Surface a toast with the message and fall back to `revealFileInOS`.                                                                                  |
+| Condition                                            | Surface                                                                                                                                                                                                            |
+| --                                                   | --                                                                                                                                                                                                                 |
+| Rendered HTML file not readable (`fs.access` fails)  | Toast: "Knit Output: could not access rendered file: {message}"; log to output channel; do not open the panel; fall back to `revealFileInOS` on the path.                                                          |
+| Refresh-while-knit-in-flight                         | Existing inFlight gate fires: info toast "<file> is already being knitted." No change.                                                                                                                             |
+| Refresh produces output under a different `rootDir`  | Dispose & recreate panel in the same column. User-visible: brief flash; no error.                                                                                                                                  |
+| Panel disposed by user, then knit re-run             | A fresh panel opens. The previous singleton was garbage collected on `onDidDispose`.                                                                                                                               |
+| Knit re-run produces non-HTML output                 | The new toast with `[Open]` fires; the previous HTML panel is left visible (it shows the last successful HTML — accurate, not stale-for-the-format).                                                               |
+| `vscode.env.openExternal` returns false              | Surface "Open in Browser is not available for this workspace" toast and write the rendered file path to the Raven: Knit output channel. Common in remote workspaces where `file:` URIs target the remote machine. |
+| User clicks external `<a>` inside the rendered HTML  | Navigation blocked silently by `frame-src` CSP and `sandbox`. Document this in `docs/knit.md` as a known limitation; users use **Open in Browser** for interactive content.                                        |
 
 ## Configuration
 
@@ -293,28 +371,32 @@ No new commands. The `Refresh` button invokes `raven.knit`; no separate `raven.k
 
 ### Unit tests (Bun, `tests/bun/`)
 
-- **`knit-output-html-rewrite.test.ts`** — given a synthetic rendered HTML string with a mix of relative (`figure-1.png`, `assets/style.css`), absolute (`/etc/passwd`), parent-escaping (`../../secret.txt`), and external (`https://…`, `data:…`) references:
-  - relative paths inside `rootDir` are rewritten to `asWebviewUri(...)` results
-  - parent-escaping paths are left unrewritten and the rewrite logs a warning
-  - absolute and external references are left unchanged
-  - the CSP `<meta>`, toolbar markup, and nonce-bearing script are present in the output
-- **`knit-output-panel-singleton.test.ts`** — `showOrUpdate` called twice with the same `rootDir` reuses the panel (same panel reference, content swapped). Called with a different `rootDir`, the first is disposed and a new one created.
+- **`knit-output-shell.test.ts`** — given fixed inputs (sourceUri, outputPath, fake webview with `asWebviewUri` and `cspSource`), the shell HTML emitted by `buildShellHtml(...)`:
+  - includes a CSP `<meta>` inside `<head>` (asserted by checking the offset of `Content-Security-Policy` is before the offset of `<body>`)
+  - sets the iframe `src` to the `asWebviewUri` of the output path and `sandbox=""` (empty)
+  - includes the nonce-bearing `<script>` and the two toolbar buttons with the expected IDs
+  - HTML-escapes the filename in the toolbar (test with a filename containing `<script>` to verify escaping)
+- **`knit-multi-output.test.ts`** — `pickPrimaryOutput([pdf, html, docx])` returns the html; `pickPrimaryOutput([pdf, docx])` returns the pdf; `pickPrimaryOutput([html])` returns the html. Asserts the Codex-finding-#4 fix.
+- **`knit-output-message.test.ts`** — `isKnitOutputMessage` accepts `{type: 'refresh'}` and `{type: 'openInBrowser'}` only; rejects `{type: 'evil'}`, `null`, `undefined`, `'refresh'`, `{}`, and additional-property variants.
 
 ### VS Code extension tests (Mocha, `editors/vscode/src/test/`)
 
-- **`knit-progress-lifecycle.test.ts`** (Piece A) — substitutes a fake `runKnit` that resolves with a successful result. Asserts:
-  - the `withProgress` promise resolves before any `showInformationMessage` is awaited
+- **`knit-progress-lifecycle.test.ts`** (Piece A) — calls `registerKnitCommands` with a fake `runKnit` via the injection seam. Fires `raven.knit`; the fake resolves with a successful result. Asserts:
+  - the `withProgress` promise resolves before any `showInformationMessage` is observed
   - `inFlight.has(fsPath) === false` at the moment `withProgress` resolves
   - a second `raven.knit` invocation issued at that moment is not blocked with "already being knitted"
-- **`knit-refresh-roundtrip.test.ts`** — opens the panel by calling `KnitOutputPanel.showOrUpdate` with a fixture HTML, posts `{type: 'refresh'}` from a stubbed webview, asserts `vscode.commands.executeCommand` is called exactly once with `('raven.knit', sourceUri)`.
+- **`knit-panel-singleton.test.ts`** — calling `KnitOutputPanel.showOrUpdate` twice with the same `rootDir` reuses the panel (same `panel` reference, iframe src swapped). With a different `rootDir`, the first is disposed and a new one created in the same column.
+- **`knit-refresh-roundtrip.test.ts`** — opens a panel with a fixture HTML on disk, posts `{type: 'refresh'}` from `panel.webview.onDidReceiveMessage` test-only fake, asserts `vscode.commands.executeCommand` is called exactly once with `('raven.knit', sourceUri)`. Same test plus `{type: 'openInBrowser'}` asserts `vscode.env.openExternal` is called with the file URI.
 
 ### Manual smoke (post-merge)
 
-- Knit a simple `.Rmd` on macOS. Verify "Knitting …" closes when R exits; Knit Output panel opens beside the editor; refresh button is visible; clicking it re-knits; second click while still in-flight produces the existing toast.
-- Knit on Linux and Windows. Verify CSS / figure loading in all three OSes.
-- Knit in a remote workspace (Codespaces). Verify the panel opens with figures intact and `Open in Browser` routes through the remote tunnel.
+- Knit a simple `.Rmd` on macOS. Verify "Knitting …" closes when R exits; Knit Output panel opens beside the editor; **Refresh** and **Open in Browser** are visible in the toolbar; Refresh re-knits; second Refresh while still in-flight produces the existing toast.
+- Knit on Linux and Windows. Verify CSS / figure loading in the iframe in all three OSes.
+- Knit in a remote workspace (Codespaces / SSH). Verify the panel renders and Refresh works. Verify **Open in Browser** either opens locally (best case) OR surfaces the "not available for this workspace" warning + path-in-output-channel fallback (acceptable case). Codex finding #6: we make no guarantees about remote `openExternal(file:)`; the fallback is the contract.
 - Knit a PDF output (`output: pdf_document`). Verify the existing reveal-in-OS path is unchanged.
-- Knit a document whose `.html` includes htmlwidgets. Verify the widget JS does not execute in the panel (silent — no errors visible to the user), and that `Open in Browser` from the success toast yields a working widget in the default browser.
+- Knit a document whose `.html` includes htmlwidgets. Verify the widget JS does not execute in the panel (silent — sandbox blocks it). Click **Open in Browser** and verify a working widget loads in the default browser (local workspaces only).
+- Knit a document with `output_format = "all"` producing both HTML and PDF. Verify the HTML opens in the panel, the success toast names the HTML's basename, and the PDF is accessible via **Show All** in the output channel.
+- Knit a document with external anchor links (e.g. `[Google](https://google.com)`). Verify clicking the link inside the iframe does not navigate anywhere (silently blocked). Verify **Open in Browser** opens the rendered file in the default browser, where the link works.
 
 ## Documentation updates
 
@@ -324,6 +406,23 @@ No new commands. The `Refresh` button invokes `raven.knit`; no separate `raven.k
 
 ## Open questions
 
-1. **`parse5` vs hand-rolled rewriter.** Pulling `parse5` in adds ~500 KB to the extension bundle. A hand-rolled rewrite is ~60 lines and covers `<img>`, `<link rel="stylesheet">`, `<script src>`, and `<a href>` — enough for rmarkdown's stock templates. **Recommendation**: hand-rolled, with a clear comment that we cover the rmarkdown-template subset. Revisit only if a user reports a broken document.
-2. **`Open in Browser` placement.** Toast button vs. a second button in the panel toolbar. **Recommendation**: toast button only, to keep the toolbar minimal. Users who need it frequently can re-knit and click again.
-3. **`retainContextWhenHidden`** vs. lazy re-render on visibility. `retainContextWhenHidden: true` costs memory proportional to the rendered HTML; lazy re-render adds latency to tab-switching. **Recommendation**: `retainContextWhenHidden: true` for v1; revisit if memory pressure is reported.
+1. **`retainContextWhenHidden`** vs. lazy re-render on visibility. `retainContextWhenHidden: true` costs memory proportional to the rendered HTML; lazy re-render adds latency to tab-switching. **Recommendation**: `retainContextWhenHidden: true` for v1; revisit if memory pressure is reported.
+2. **`Refresh` button availability during in-flight knit.** The button currently doesn't know about the inFlight gate; clicking it during a knit produces the existing "already being knitted" toast. We could disable the button while a knit is running by sending a status message from the extension. **Recommendation**: don't add it in v1; the toast is already clear and the cross-component state is real complexity. File a follow-up if a user reports the friction.
+3. **Internal anchor support inside the iframe.** Intra-document anchors (`#section`) work natively; relative anchors to sibling rendered files (e.g. another section of a bookdown chapter) also work because the webview origin governs both. External anchors are blocked (documented as a limitation). **Recommendation**: ship the current behavior; revisit if bookdown / multi-file rendering becomes a use case (currently out of scope per the 2026-05-16 spec).
+
+## v1 → v2 changes (response to Codex review)
+
+Summary of changes between this revision and the version reviewed by Codex (`109d932`):
+
+| Codex finding | v2 disposition |
+| --            | --             |
+| #1 CSP-in-`<body>` not honored | Iframe-sandbox shell: CSP lives in the outer shell's `<head>`; rendered HTML is in a sandboxed iframe. |
+| #2 Rewrite-failure renders unrewritten HTML | No rewrite; no fallback path. Shell is a fixed template. |
+| #3 No anchor-click classifier | Iframe `sandbox=""` + `frame-src ${cspSource}` blocks external navigation; documented as a limitation. |
+| #4 Multi-output prefers `parsed.paths[0]` | `pickPrimaryOutput` prefers any HTML; documented and unit-tested. |
+| #5 `runKnit` injection seam unspecified | `registerKnitCommands(context, deps?)` accepts a `deps` parameter for tests. |
+| #6 `openExternal(file:)` remote-tunnel claim | Retracted; remote-workspace fallback explicit (warning toast + path written to output channel). |
+| #7 Hand-rolled HTML rewriter too narrow | No rewriter; the rendered browser parses the HTML and the sandbox+CSP stack governs it. |
+| #8 `KnitOutcome.cwd` type mismatch | `cwd: string | undefined`; `renderOutcome` resolves with `cwd ?? path.dirname(fsPath)` as fallback. |
+| #9 Open-in-Browser only on toast | Moved to the panel toolbar; persistent and always reachable. |
+| #10 Missing `enableFindWidget` | Added. |

--- a/docs/superpowers/specs/2026-05-17-knit-output-webview-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-output-webview-design.md
@@ -1,0 +1,329 @@
+# R Markdown Knit — Output Webview + Progress-Lifecycle Fix
+
+**Status**: Design.
+**Date**: 2026-05-17.
+**Branch**: `fix-knit-bug`.
+**Amends**: [`2026-05-16-rmd-knit-preview-design.md`](2026-05-16-rmd-knit-preview-design.md) — supersedes step 10 ("Reveal") of that spec's data flow and adds one new module. All other sections of the 2026-05-16 spec are unchanged.
+
+## Why this spec exists
+
+Two user-visible regressions in the shipped `Raven: Knit` flow:
+
+1. **The "Knitting …" progress notification never closes after a successful knit**, and a second invocation reports `"<file> is already being knitted"` until the user dismisses the success toast.
+2. **HTML output opens as raw markup** in a text editor on local workspaces (`vscode.commands.executeCommand('vscode.open', <html-uri>)` only routes to Simple Browser in remote workspaces; locally it opens the file in the default text editor).
+
+The user also asks for a **refresh button** so they can re-knit from the viewer without round-tripping to the command palette.
+
+## Relationship to the 2026-05-16 spec
+
+The earlier design deliberately kept *live preview* (iframe + recompile-on-save, the `quarto preview` model) out of scope to avoid duplicating `quarto.quarto`. That decision stands. This design adds a **post-render output viewer**, which is a different surface:
+
+| Feature                         | `quarto.quarto`'s live preview | This spec's Knit Output viewer |
+| --                              | --                             | --                             |
+| Trigger                         | Save / edit in the source      | Explicit `Raven: Knit` command |
+| Recompile cadence               | Automatic, debounced           | Manual, only when user clicks  |
+| Transport                       | Quarto's internal token/iframe | Static HTML loaded into webview |
+| `.qmd` support                  | Yes                            | Out of scope                   |
+| Requires Quarto CLI             | Yes                            | No                             |
+
+`Raven: Knit` only runs when `raven.rConsole.activation` resolves to `enabled` — i.e. `REditorSupport.r` is not active and we're not in Positron. In that population, no sibling extension is providing post-render output viewing for `.Rmd` files. There is no overlap to defer.
+
+## Goals
+
+1. The "Knitting …" progress notification closes the moment the R subprocess exits, regardless of subsequent UI prompts.
+2. Repeated knits of the same file are not blocked by an unresolved success/failure toast from the previous knit.
+3. Successful HTML knits render the output in a VS Code webview panel, not as raw HTML in a text editor.
+4. The webview panel exposes a **Refresh** button that re-invokes `Raven: Knit` for the originating `.Rmd`.
+5. No new commands, no new settings, no change to gating, working-directory resolution, or subprocess lifecycle.
+
+## Non-goals
+
+- Live / auto-refresh preview. Refresh is exclusively manual.
+- Rendering `.qmd`. `quarto.quarto` continues to own that.
+- htmlwidgets / interactive JS inside the rendered document running in the panel. The panel's CSP allows our refresh-button script (nonce-gated) and inline styles; arbitrary scripts from the rendered HTML do not run. Users who need htmlwidgets can open the `.html` file in a browser via the panel's existing OS file path (current behavior preserved on the success toast for non-HTML outputs, and an `Open in Browser` button on the toast — see "Open Externally" below).
+- PDF / DOCX inline rendering. Non-HTML outputs continue to use `revealFileInOS`.
+- A multi-tab "history" of past knits. The panel is a singleton and always shows the most recent successful output.
+- Persisting panel state across window reloads (`retainContextWhenHidden: true` is enabled for switching editor groups; full session restoration is not).
+
+## Architecture
+
+```text
+editors/vscode/src/knit/
+  index.ts                # unchanged
+  knit-commands.ts        # CHANGED: progress lifecycle + reveal dispatch
+  knit-engine.ts          # unchanged
+  yaml-frontmatter.ts     # unchanged
+  r-expression.ts         # unchanged
+  output-path.ts          # unchanged
+  knit-output-panel.ts    # NEW: singleton WebviewPanel + HTML rewrite + refresh wiring
+```
+
+No changes to `package.json` contributions, settings schema, or context keys.
+
+## Piece A — progress-lifecycle fix
+
+### Root cause
+
+In `editors/vscode/src/knit/knit-commands.ts`, the `vscode.window.withProgress(...)` callback (line ~218) `await`s `vscode.window.showInformationMessage(...)` for the success-path "Open" / "Show All" toast (line ~299). `showInformationMessage` resolves only when the user clicks a button or dismisses the toast. Until then:
+
+- The "Knitting …" progress notification stays visible.
+- The `finally` block at line ~309 cannot run.
+- `inFlight.delete(fsPath)` is deferred, so re-invoking the command hits the gate at line ~202 and reports `"<file> is already being knitted"`.
+
+The "spawn error", "cancelled", "timed out", and non-zero exit branches all have the same shape and the same defect.
+
+### Fix
+
+The `withProgress` callback returns a plain result discriminated union; no user-facing toasts are awaited inside it. The post-knit branching (toast, panel open, output-channel focus, OS reveal) runs after `withProgress` resolves.
+
+```ts
+type KnitOutcome =
+  | { kind: 'spawnError'; error: NodeJS.ErrnoException; rBinary: string }
+  | { kind: 'cancelled' }
+  | { kind: 'timedOut'; timeoutMs: number }
+  | { kind: 'failed'; exitCode: number | null }
+  | { kind: 'noOutput' }
+  | { kind: 'ok'; parsedOutputs: string[]; cwd: string };
+
+// inside runKnitCommand:
+let outcome: KnitOutcome;
+try {
+  outcome = await vscode.window.withProgress(
+    { location: ProgressLocation.Notification, title: `Knitting ${baseName}…`, cancellable: true },
+    async (_progress, token) => {
+      const result = await runKnit({ /* ... */ cancellation: token });
+      return classify(result);              // returns KnitOutcome — no awaits on user input
+    },
+  );
+} finally {
+  inFlight.delete(fsPath);
+}
+
+await renderOutcome(outcome, { /* fsPath, baseName, sourceUri, output channel, cwd, panelMgr */ });
+```
+
+`inFlight.delete(fsPath)` runs the instant `withProgress` resolves, so a second knit invoked between the subprocess exit and the user dismissing the success toast is no longer blocked.
+
+### Verifying the fix
+
+A focused test under `editors/vscode/src/test/` (see "Testing" below) substitutes a fake `runKnit` that resolves immediately with a successful result, and asserts:
+
+- The `withProgress` promise resolves before the success toast is shown.
+- `inFlight.has(fsPath) === false` at the moment `withProgress` resolves.
+- A second concurrent `raven.knit` invocation issued at that moment is *not* rejected with "already being knitted".
+
+## Piece B — Knit Output webview panel
+
+### Module
+
+`editors/vscode/src/knit/knit-output-panel.ts` exposes a singleton manager modelled on `editors/vscode/src/help/help-panel.ts`:
+
+```ts
+export class KnitOutputPanel {
+  private static instance: KnitOutputPanel | undefined;
+  private panel: vscode.WebviewPanel;
+  private rootDir: string;       // current localResourceRoots[0].fsPath
+  private sourceUri: vscode.Uri; // for refresh
+
+  static showOrUpdate(
+    context: vscode.ExtensionContext,
+    args: { sourceUri: vscode.Uri; outputPath: string },
+  ): Promise<void>;
+
+  private constructor(/* ... */);
+  private updateHtml(outputPath: string): Promise<void>;
+  private dispose(): void;
+}
+```
+
+`showOrUpdate` is the only public entry point. It:
+
+1. Computes `rootDir = path.dirname(outputPath)`.
+2. If `instance` exists and `instance.rootDir === rootDir`: replaces content via `updateHtml`, reveals (`panel.reveal(panel.viewColumn ?? ViewColumn.Beside, false)`).
+3. If `instance` exists but `instance.rootDir !== rootDir`: disposes the old panel (column is preserved via the `viewColumn` we read before disposing) and creates a new one in the same column. This is the same `localResourceRoots`-immutability workaround used in `help-panel.ts`.
+4. If no instance: creates a fresh panel in `ViewColumn.Beside`.
+
+### Webview options
+
+```ts
+vscode.window.createWebviewPanel(
+  'raven.knitOutput',
+  'Knit Output',
+  { viewColumn: ViewColumn.Beside, preserveFocus: true },
+  {
+    enableScripts: true,
+    retainContextWhenHidden: true,
+    localResourceRoots: [vscode.Uri.file(rootDir)],
+  },
+);
+```
+
+`preserveFocus: true` keeps the cursor in the editor — the user's primary surface for editing.
+
+### HTML loading and rewrite
+
+`updateHtml(outputPath)`:
+
+1. `const raw = await fs.promises.readFile(outputPath, 'utf-8')`. On error, dispose the panel and surface a toast "Knit Output: could not read rendered file: {message}"; the caller falls back to `revealFileInOS`.
+2. Rewrite `src`/`href` attributes with a hand-rolled tag-attribute pass scoped to `<img>`, `<link rel="stylesheet">`, `<script src>`, and `<a href>` — ~60 lines, sufficient for rmarkdown's stock templates. (See Open Question #1 for the `parse5` alternative.) For each relative path:
+   - Resolve relative to `path.dirname(outputPath)` to an absolute path.
+   - `path.relative(rootDir, absolute)` — reject (skip rewrite, log warning) if the result starts with `..` or is absolute on Windows. This is the path-containment guard.
+   - `vscode.Uri.file(absolute)` → `panel.webview.asWebviewUri(...)`.
+   - Absolute URLs (`http:`, `https:`, `data:`, `mailto:`, `#fragment`) are passed through unchanged.
+3. Inject a CSP `<meta>` and a fixed toolbar at the top of `<body>`:
+
+```html
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none';
+               img-src ${cspSource} https: data:;
+               style-src ${cspSource} 'unsafe-inline';
+               font-src ${cspSource} https: data:;
+               script-src 'nonce-${nonce}';
+               connect-src 'none';">
+
+<div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
+  <button id="raven-knit-refresh" type="button">Refresh</button>
+  <span id="raven-knit-filename" aria-live="polite">${escapeHtml(path.basename(outputPath))}</span>
+</div>
+<script nonce="${nonce}">
+  (function () {
+    const vscode = acquireVsCodeApi();
+    document.getElementById('raven-knit-refresh').addEventListener('click', function () {
+      vscode.postMessage({ type: 'refresh' });
+    });
+  })();
+</script>
+```
+
+`'unsafe-inline'` for styles is the same compromise `help-panel.ts` makes — rmarkdown's default templates emit inline `<style>` blocks for highlight themes. Scripts inside the rendered HTML cannot run because they lack the nonce; this is intentional and called out in the non-goals.
+
+The toolbar is appended via DOM-string concatenation rather than DOM injection (the panel never executes the rendered scripts, so a post-load `appendChild` couldn't work). The toolbar markup precedes `<body>`'s existing content, and lightly-styled to float at the top of the viewport.
+
+### Message protocol
+
+The webview never receives the source URI or output path. The extension side captures both when `showOrUpdate` is called and uses them on receipt of:
+
+```ts
+type KnitOutputMessage = { type: 'refresh' };
+```
+
+Handler:
+
+```ts
+panel.webview.onDidReceiveMessage((msg: unknown) => {
+  if (isRefreshMessage(msg)) {
+    void vscode.commands.executeCommand('raven.knit', this.sourceUri);
+  }
+});
+```
+
+`isRefreshMessage` is a narrow `msg !== null && typeof msg === 'object' && (msg as any).type === 'refresh'` check.
+
+### What refresh does
+
+`raven.knit` re-runs against `this.sourceUri`. Every gate, blocker detection, validation, subprocess invocation, output-channel write, progress notification, cancellation, and reveal step that the original knit went through runs again. The same code path that called `KnitOutputPanel.showOrUpdate` for the original knit calls it again. The panel content is replaced; the panel reference does not change unless the output's `rootDir` did.
+
+The existing `inFlight` Set in `registerKnitCommands` already prevents two concurrent knits of the same file with a clear info toast. Refresh inherits that gate. No webview-side in-flight state is needed.
+
+### Open Externally
+
+The success toast for HTML outputs is replaced with two buttons:
+
+- **Show Output Panel** — focuses the Knit Output webview (`panel.reveal`).
+- **Open in Browser** — `vscode.env.openExternal(vscode.Uri.file(outputPath))`. Gives users with htmlwidget / JS-heavy documents an escape hatch to a full browser. In remote workspaces, `openExternal` correctly routes through the remote-tunnel.
+
+Non-HTML output toasts are unchanged.
+
+## Updated data flow (delta from the 2026-05-16 spec)
+
+Steps [1]–[9] are unchanged. Step [10] ("Reveal") is replaced:
+
+```text
+ [10] Reveal — supersedes step 10 of the 2026-05-16 spec.
+
+   Exit 0, parsed.paths.length >= 1:
+     primary = absolutizeFromCwd(parsed.paths[0], cwd ?? path.dirname(fsPath))
+     ext = path.extname(primary).toLowerCase()
+
+     if ext is '.html' or '.htm':
+       KnitOutputPanel.showOrUpdate(context, { sourceUri: docUri, outputPath: primary })
+       Toast (NON-MODAL, no awaited button): "Knit succeeded: <basename>." with buttons
+         [Show Output Panel] [Open in Browser] [Show All if parsed.paths > 1]
+       The toast is fire-and-forget; the panel has already opened. The withProgress
+       promise has already resolved (Piece A).
+
+     else (PDF, Word, plain text, …):
+       Toast (NON-MODAL, no awaited button): "Knit succeeded: <basename>." with buttons
+         [Open] [Show All if parsed.paths > 1]
+       [Open] → revealFileInOS(primary).
+       Behavior is identical to the pre-spec implementation, minus the await-inside-progress bug.
+```
+
+The "output path unknown" branch (Exit 0, parsed.paths.length === 0) and the failure branches (non-zero exit, cancellation, timeout, spawn error) are unchanged in semantics but no longer execute inside `withProgress`.
+
+## Security model
+
+1. **`localResourceRoots` is the only escape**: the panel can load images / CSS / fonts only from the rendered file's directory and below. The HTML rewrite pass enforces this by skipping any relative path that resolves outside `rootDir`.
+2. **CSP** allows our refresh-button script via nonce and rmarkdown's inline styles via `'unsafe-inline'`. Scripts inside the rendered HTML do not match the nonce and do not run. `connect-src 'none'` prevents any `fetch`/`XHR` even if a script did slip past.
+3. **No source URI in the webview.** The refresh-button script posts only `{type: 'refresh'}`. The extension side captures the `sourceUri` once at `showOrUpdate` time. A compromised rendered HTML cannot retarget the refresh to a different file.
+4. **Message-type narrowing.** The `onDidReceiveMessage` handler accepts only the exact shape `{type: 'refresh'}`. Anything else is silently dropped.
+5. **Path containment** on rewrite uses `path.relative` plus a Windows absolute-path check. We never widen `localResourceRoots` to satisfy a rewrite.
+
+## Error handling
+
+| Condition                                            | Surface                                                                                                                                              |
+| --                                                   | --                                                                                                                                                   |
+| Rendered HTML file read fails                        | Toast: "Knit Output: could not read rendered file: {message}"; dispose panel; `revealFileInOS` on the path.                                          |
+| HTML rewrite throws                                  | Log to `Raven: Knit` output channel with details; render the unrewritten HTML in the panel (broken figures are acceptable; text is still readable).  |
+| Refresh-while-knit-in-flight                         | Existing inFlight gate fires: info toast "<file> is already being knitted." No change.                                                               |
+| Refresh produces output under a different `rootDir`  | Dispose & recreate panel in the same column. User-visible: brief flash; no error.                                                                    |
+| Panel disposed by user, then knit re-run             | A fresh panel opens. The previous singleton was garbage collected on `onDidDispose`.                                                                 |
+| Knit re-run produces non-HTML output                 | Existing toast with `[Open]` fires; the previous HTML panel is left visible (it shows the last successful HTML — accurate, not stale-for-the-format). |
+| `vscode.env.openExternal` rejected                   | Surface a toast with the message and fall back to `revealFileInOS`.                                                                                  |
+
+## Configuration
+
+No new settings.
+
+## Commands
+
+No new commands. The `Refresh` button invokes `raven.knit`; no separate `raven.knit.refresh` is registered (avoids a UI surface duplicating the gate logic).
+
+## Testing
+
+### Unit tests (Bun, `tests/bun/`)
+
+- **`knit-output-html-rewrite.test.ts`** — given a synthetic rendered HTML string with a mix of relative (`figure-1.png`, `assets/style.css`), absolute (`/etc/passwd`), parent-escaping (`../../secret.txt`), and external (`https://…`, `data:…`) references:
+  - relative paths inside `rootDir` are rewritten to `asWebviewUri(...)` results
+  - parent-escaping paths are left unrewritten and the rewrite logs a warning
+  - absolute and external references are left unchanged
+  - the CSP `<meta>`, toolbar markup, and nonce-bearing script are present in the output
+- **`knit-output-panel-singleton.test.ts`** — `showOrUpdate` called twice with the same `rootDir` reuses the panel (same panel reference, content swapped). Called with a different `rootDir`, the first is disposed and a new one created.
+
+### VS Code extension tests (Mocha, `editors/vscode/src/test/`)
+
+- **`knit-progress-lifecycle.test.ts`** (Piece A) — substitutes a fake `runKnit` that resolves with a successful result. Asserts:
+  - the `withProgress` promise resolves before any `showInformationMessage` is awaited
+  - `inFlight.has(fsPath) === false` at the moment `withProgress` resolves
+  - a second `raven.knit` invocation issued at that moment is not blocked with "already being knitted"
+- **`knit-refresh-roundtrip.test.ts`** — opens the panel by calling `KnitOutputPanel.showOrUpdate` with a fixture HTML, posts `{type: 'refresh'}` from a stubbed webview, asserts `vscode.commands.executeCommand` is called exactly once with `('raven.knit', sourceUri)`.
+
+### Manual smoke (post-merge)
+
+- Knit a simple `.Rmd` on macOS. Verify "Knitting …" closes when R exits; Knit Output panel opens beside the editor; refresh button is visible; clicking it re-knits; second click while still in-flight produces the existing toast.
+- Knit on Linux and Windows. Verify CSS / figure loading in all three OSes.
+- Knit in a remote workspace (Codespaces). Verify the panel opens with figures intact and `Open in Browser` routes through the remote tunnel.
+- Knit a PDF output (`output: pdf_document`). Verify the existing reveal-in-OS path is unchanged.
+- Knit a document whose `.html` includes htmlwidgets. Verify the widget JS does not execute in the panel (silent — no errors visible to the user), and that `Open in Browser` from the success toast yields a working widget in the default browser.
+
+## Documentation updates
+
+- **`docs/knit.md`** — rewrite step 10 ("Reveal") to describe the Knit Output panel for HTML, the refresh button, and the `Open in Browser` button. Add one sentence to the "What it does, step by step" preamble noting that HTML output opens in a webview rather than the OS browser by default.
+- **`docs/knit.md`** — the "What raven does **not** do" table keeps "Live preview of `.Rmd` or `.qmd`" pointing to `quarto.quarto`. Add a one-line clarification: the post-render viewer is *not* live preview; it is a static viewer with manual refresh.
+- **`docs/development.md`** — short note describing the singleton-panel pattern (cross-link to `help-panel.ts`).
+
+## Open questions
+
+1. **`parse5` vs hand-rolled rewriter.** Pulling `parse5` in adds ~500 KB to the extension bundle. A hand-rolled rewrite is ~60 lines and covers `<img>`, `<link rel="stylesheet">`, `<script src>`, and `<a href>` — enough for rmarkdown's stock templates. **Recommendation**: hand-rolled, with a clear comment that we cover the rmarkdown-template subset. Revisit only if a user reports a broken document.
+2. **`Open in Browser` placement.** Toast button vs. a second button in the panel toolbar. **Recommendation**: toast button only, to keep the toolbar minimal. Users who need it frequently can re-knit and click again.
+3. **`retainContextWhenHidden`** vs. lazy re-render on visibility. `retainContextWhenHidden: true` costs memory proportional to the rendered HTML; lazy re-render adds latency to tab-switching. **Recommendation**: `retainContextWhenHidden: true` for v1; revisit if memory pressure is reported.

--- a/editors/vscode/src/knit/knit-commands.ts
+++ b/editors/vscode/src/knit/knit-commands.ts
@@ -14,8 +14,13 @@ import {
     ValidatePathError,
 } from './r-expression';
 import { runKnit } from './knit-engine';
-import { parseRenderedOutputPath } from './output-path';
 import { resolveRConsoleActivation } from '../r-console-activation';
+import { KnitOutputPanel } from './knit-output-panel';
+import {
+    classify,
+    pickPrimaryOutput,
+    type KnitOutcome,
+} from './knit-output';
 
 const OUTPUT_CHANNEL_NAME = 'Raven: Knit';
 const DEFAULT_TIMEOUT_MS = 600_000;
@@ -23,10 +28,30 @@ const DEFAULT_TIMEOUT_MS = 600_000;
 type WorkingDirectoryMode = 'document' | 'project' | 'current';
 
 /**
+ * Resolved dependency surface used throughout the knit command. The
+ * fields are required at the point of use; the public optional shape
+ * (`Partial<KnitDeps>` parameter on `registerKnitCommands`) lets tests
+ * override individual functions while production omits the parameter
+ * entirely.
+ */
+export interface KnitDeps {
+    runKnit: typeof runKnit;
+    showOrUpdatePanel: typeof KnitOutputPanel.showOrUpdate;
+}
+
+/**
  * Top-level registration. Creates the lazy OutputChannel and registers
  * the two commands listed in `package.json`.
  */
-export function registerKnitCommands(context: vscode.ExtensionContext): void {
+export function registerKnitCommands(
+    context: vscode.ExtensionContext,
+    deps?: Partial<KnitDeps>,
+): void {
+    const resolved: KnitDeps = {
+        runKnit: deps?.runKnit ?? runKnit,
+        showOrUpdatePanel: deps?.showOrUpdatePanel ?? KnitOutputPanel.showOrUpdate,
+    };
+
     let outputChannel: vscode.OutputChannel | undefined;
     const getOutput = (): vscode.OutputChannel => {
         if (!outputChannel) {
@@ -46,7 +71,7 @@ export function registerKnitCommands(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand(
             'raven.knit',
             async (uri?: vscode.Uri) => {
-                await runKnitCommand(uri, getOutput(), inFlight);
+                await runKnitCommand(uri, getOutput(), inFlight, context, resolved);
             },
         ),
         vscode.commands.registerCommand(
@@ -60,6 +85,8 @@ async function runKnitCommand(
     explicitUri: vscode.Uri | undefined,
     output: vscode.OutputChannel,
     inFlight: Set<string>,
+    context: vscode.ExtensionContext,
+    deps: KnitDeps,
 ): Promise<void> {
     const docUri = explicitUri ?? vscode.window.activeTextEditor?.document.uri;
     if (!docUri) {
@@ -214,101 +241,191 @@ async function runKnitCommand(
     output.appendLine(`cwd: ${cwd}`);
     output.appendLine(``);
 
+    let outcome: KnitOutcome;
     try {
-    await vscode.window.withProgress(
-        {
-            location: vscode.ProgressLocation.Notification,
-            title: `Knitting ${baseName}…`,
-            cancellable: true,
-        },
-        async (_progress, token) => {
-            const result = await runKnit({
-                rBinary,
-                expression,
-                cwd,
-                timeoutMs,
-                output,
-                cancellation: token,
-            });
-
-            if (result.spawnError) {
-                const code = result.spawnError.code;
-                if (code === 'ENOENT') {
-                    output.appendLine(`[error] R not found at "${rBinary}".`);
-                    await vscode.window.showErrorMessage(
-                        'Raven: Knit — R not found on PATH. Set `raven.packages.rPath`.',
-                    );
-                } else {
-                    output.appendLine(`[error] ${result.spawnError.message}`);
-                    await vscode.window.showErrorMessage(
-                        `Raven: Knit — failed to launch R: ${result.spawnError.message}`,
-                    );
-                }
-                return;
-            }
-
-            if (result.cancelled) {
-                output.appendLine('Knit cancelled.');
-                await vscode.window.showInformationMessage('Raven: Knit cancelled.');
-                return;
-            }
-
-            if (result.timedOut) {
-                output.appendLine(`Knit timed out after ${timeoutMs} ms.`);
-                output.show(true);
-                await vscode.window.showErrorMessage('Raven: Knit timed out.');
-                return;
-            }
-
-            if (result.exitCode !== 0) {
-                output.show(true);
-                await vscode.window.showErrorMessage(
-                    `Raven: Knit failed (exit ${result.exitCode}). See Raven: Knit output.`,
-                );
-                return;
-            }
-
-            // rmarkdown::render's "Output created:" line is emitted
-            // via R's `message()`, which writes to stderr. Older
-            // configurations / future versions could route it to stdout,
-            // so we parse both streams to stay robust.
-            const parsedOutputs = parseRenderedOutputPath(
-                result.stdout + '\n' + result.stderr,
-            ).paths;
-            if (parsedOutputs.length === 0) {
-                const SHOW = 'Show Output';
-                const choice = await vscode.window.showInformationMessage(
-                    'Raven: Knit succeeded (output path unknown).',
-                    SHOW,
-                );
-                if (choice === SHOW) output.show(true);
-                return;
-            }
-            // Resolve any relative `Output created:` path against the
-            // subprocess cwd we passed (or the document directory when
-            // `current` mode is in effect with no workspace open). The
-            // input file is always absolute, so rmarkdown normally
-            // prints absolute paths and `absolutizeFromCwd` short-
-            // circuits via `path.isAbsolute`.
-            const base = cwd ?? path.dirname(fsPath);
-            const primary = absolutizeFromCwd(parsedOutputs[0], base);
-            const OPEN = 'Open';
-            const SHOW_ALL = 'Show All';
-            const buttons = parsedOutputs.length > 1 ? [OPEN, SHOW_ALL] : [OPEN];
-            const baseLabel = path.basename(primary);
-            const choice = await vscode.window.showInformationMessage(
-                parsedOutputs.length > 1
-                    ? `Raven: Knit succeeded: ${baseLabel} (and ${parsedOutputs.length - 1} more).`
-                    : `Raven: Knit succeeded: ${baseLabel}.`,
-                ...buttons,
-            );
-            if (choice === OPEN) await revealKnitOutput(primary);
-            else if (choice === SHOW_ALL) output.show(true);
-        },
-    );
+        outcome = await vscode.window.withProgress<KnitOutcome>(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Knitting ${baseName}…`,
+                cancellable: true,
+            },
+            async (_progress, token) => {
+                const result = await deps.runKnit({
+                    rBinary,
+                    expression,
+                    cwd,
+                    timeoutMs,
+                    output,
+                    cancellation: token,
+                });
+                return classify(result, { cwd });
+            },
+        );
     } finally {
+        // Critical: inFlight.delete runs the moment withProgress resolves,
+        // BEFORE any user-facing toast is awaited. This is the Piece A
+        // fix — under the previous code, awaiting showInformationMessage
+        // inside the withProgress callback held both the progress
+        // notification AND the inFlight gate open until the user
+        // dismissed the toast, causing a spurious "already being knitted"
+        // on rapid re-invocation.
         inFlight.delete(fsPath);
     }
+
+    await renderOutcome(outcome, {
+        fsPath,
+        baseName,
+        sourceUri: docUri,
+        cwd,
+        output,
+        rBinary,
+        timeoutMs,
+        context,
+        showOrUpdatePanel: deps.showOrUpdatePanel,
+    });
+}
+
+interface RenderOutcomeCtx {
+    fsPath: string;
+    baseName: string;
+    sourceUri: vscode.Uri;
+    cwd: string | undefined;
+    output: vscode.OutputChannel;
+    rBinary: string;
+    timeoutMs: number;
+    context: vscode.ExtensionContext;
+    showOrUpdatePanel: KnitDeps['showOrUpdatePanel'];
+}
+
+/**
+ * Surface the result of a knit to the user. Runs OUTSIDE the
+ * `vscode.window.withProgress` callback so that the progress
+ * notification closes the moment the R subprocess exits, regardless of
+ * how long the user takes to dismiss the success/failure toast.
+ */
+async function renderOutcome(outcome: KnitOutcome, ctx: RenderOutcomeCtx): Promise<void> {
+    if (outcome.kind === 'spawnError') {
+        const code = outcome.error.code;
+        if (code === 'ENOENT') {
+            ctx.output.appendLine(`[error] R not found at "${ctx.rBinary}".`);
+            void vscode.window.showErrorMessage(
+                'Raven: Knit — R not found on PATH. Set `raven.packages.rPath`.',
+            );
+        } else {
+            ctx.output.appendLine(`[error] ${outcome.error.message}`);
+            void vscode.window.showErrorMessage(
+                `Raven: Knit — failed to launch R: ${outcome.error.message}`,
+            );
+        }
+        return;
+    }
+
+    if (outcome.kind === 'cancelled') {
+        ctx.output.appendLine('Knit cancelled.');
+        void vscode.window.showInformationMessage('Raven: Knit cancelled.');
+        return;
+    }
+
+    if (outcome.kind === 'timedOut') {
+        ctx.output.appendLine(`Knit timed out after ${ctx.timeoutMs} ms.`);
+        ctx.output.show(true);
+        void vscode.window.showErrorMessage('Raven: Knit timed out.');
+        return;
+    }
+
+    if (outcome.kind === 'failed') {
+        ctx.output.show(true);
+        void vscode.window.showErrorMessage(
+            `Raven: Knit failed (exit ${outcome.exitCode}). See Raven: Knit output.`,
+        );
+        return;
+    }
+
+    if (outcome.kind === 'noOutput') {
+        const SHOW = 'Show Output';
+        const choice = await vscode.window.showInformationMessage(
+            'Raven: Knit succeeded (output path unknown).',
+            SHOW,
+        );
+        if (choice === SHOW) ctx.output.show(true);
+        return;
+    }
+
+    // ok branch — multi-output handling prefers HTML.
+    const base = outcome.cwd ?? path.dirname(ctx.fsPath);
+    const absolutized = outcome.parsedOutputs.map((p) => absolutizeFromCwd(p, base));
+    const primary = pickPrimaryOutput(absolutized);
+    if (!primary) {
+        // Defensive — classify guarantees parsedOutputs.length >= 1 for 'ok'.
+        void vscode.window.showInformationMessage('Raven: Knit succeeded.');
+        return;
+    }
+
+    const ext = path.extname(primary).toLowerCase();
+    const baseLabel = path.basename(primary);
+    const isHtml = ext === '.html' || ext === '.htm';
+    const SHOW_ALL = 'Show All';
+    const SHOW_PANEL = 'Show Output Panel';
+    const OPEN = 'Open';
+
+    if (isHtml) {
+        const panelResult = await ctx.showOrUpdatePanel(ctx.context, {
+            sourceUri: ctx.sourceUri,
+            outputPath: primary,
+            output: ctx.output,
+        });
+        if (!panelResult.ok) {
+            ctx.output.appendLine(`[panel] ${panelResult.error}`);
+            // Fall through to the non-HTML reveal path.
+            void revealKnitOutput(primary);
+            return;
+        }
+        const buttons = absolutized.length > 1 ? [SHOW_PANEL, SHOW_ALL] : [SHOW_PANEL];
+        const label = absolutized.length > 1
+            ? `Raven: Knit succeeded: ${baseLabel} (and ${absolutized.length - 1} more).`
+            : `Raven: Knit succeeded: ${baseLabel}.`;
+        const choice = await vscode.window.showInformationMessage(label, ...buttons);
+        if (choice === SHOW_PANEL) {
+            // Idempotent re-reveal; same rootDir → reuses the panel.
+            await ctx.showOrUpdatePanel(ctx.context, {
+                sourceUri: ctx.sourceUri,
+                outputPath: primary,
+                output: ctx.output,
+            });
+        } else if (choice === SHOW_ALL) {
+            ctx.output.show(true);
+        }
+        return;
+    }
+
+    // Non-HTML: PDF, Word, plain text, etc.
+    const buttons = absolutized.length > 1 ? [OPEN, SHOW_ALL] : [OPEN];
+    const label = absolutized.length > 1
+        ? `Raven: Knit succeeded: ${baseLabel} (and ${absolutized.length - 1} more).`
+        : `Raven: Knit succeeded: ${baseLabel}.`;
+    const choice = await vscode.window.showInformationMessage(label, ...buttons);
+    if (choice === OPEN) await revealKnitOutput(primary);
+    else if (choice === SHOW_ALL) ctx.output.show(true);
+}
+
+/**
+ * Test-only entry point that bypasses the registered `raven.knit`
+ * command. Exposes the same code path with caller-controlled deps.
+ * Used by `knit-progress-lifecycle.test.ts` to verify the Piece A
+ * invariant: `inFlight.delete` runs the moment `withProgress` resolves,
+ * NOT when the user dismisses the success toast.
+ *
+ * The `__` prefix signals "test-only"; do not call from production
+ * code.
+ */
+export async function __runKnitCommandForTest(args: {
+    uri: vscode.Uri | undefined;
+    output: vscode.OutputChannel;
+    inFlight: Set<string>;
+    context: vscode.ExtensionContext;
+    deps: KnitDeps;
+}): Promise<void> {
+    await runKnitCommand(args.uri, args.output, args.inFlight, args.context, args.deps);
 }
 
 interface KnitDirOk {
@@ -417,12 +534,13 @@ async function showBlocker(blocker: Blocker, fsPath: string): Promise<void> {
     }
 }
 
+/**
+ * Reveal non-HTML knit output. HTML outputs route through the Knit
+ * Output webview panel instead (see `renderOutcome`). PDFs / Word docs
+ * / etc. open via the OS file browser — the user double-clicks to
+ * launch their preferred reader.
+ */
 async function revealKnitOutput(outputPath: string): Promise<void> {
     const uri = vscode.Uri.file(outputPath);
-    const ext = path.extname(outputPath).toLowerCase();
-    if (ext === '.html' || ext === '.htm') {
-        await vscode.commands.executeCommand('vscode.open', uri);
-        return;
-    }
     await vscode.commands.executeCommand('revealFileInOS', uri);
 }

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -143,8 +143,12 @@ export class KnitOutputPanel {
         this.sourceUri = args.sourceUri;
         this.outputPath = args.outputPath;
         const nonce = crypto.randomBytes(16).toString('base64');
+        const iframeSrc = this.panel.webview
+            .asWebviewUri(vscode.Uri.file(args.outputPath))
+            .toString();
         this.panel.webview.html = buildShellHtml({
-            webview: this.panel.webview,
+            iframeSrc,
+            cspSource: this.panel.webview.cspSource,
             outputPath: args.outputPath,
             nonce,
         });

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -1,0 +1,193 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { buildShellHtml, isKnitOutputMessage } from './knit-output';
+
+/**
+ * Singleton webview panel that renders the most recent HTML knit output
+ * inside an `<iframe sandbox="">` with Refresh and Open-in-Browser
+ * toolbar buttons.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`.
+ *
+ * Architecture:
+ *  - Outer Raven-controlled shell document owns the CSP (in `<head>`),
+ *    the toolbar, and a nonce'd `<script>` that posts messages.
+ *  - Inner `<iframe>` loads the rendered HTML via
+ *    `webview.asWebviewUri(outputPath)`. `sandbox=""` (empty, most
+ *    restrictive) blocks scripts, forms, popups, and top-navigation.
+ *    `frame-src ${cspSource}` on the outer CSP prevents iframe
+ *    navigation to external hosts.
+ *  - `localResourceRoots` is confined to `path.dirname(outputPath)`,
+ *    which is also where rmarkdown's `_files/` figure directories sit.
+ *
+ * Singleton: one panel per VS Code window. Subsequent knits replace the
+ * iframe `src`. If the new output's `rootDir` differs, the panel is
+ * disposed and recreated (VS Code does not allow updating
+ * `localResourceRoots` post-creation — see `help-panel.ts`).
+ */
+export class KnitOutputPanel {
+    private static instance: KnitOutputPanel | undefined;
+
+    private panel: vscode.WebviewPanel;
+    private rootDir: string;
+    private sourceUri: vscode.Uri;
+    private outputPath: string;
+    private readonly output: vscode.OutputChannel;
+
+    /**
+     * Open or update the singleton panel. Returns `{ ok: true }` on
+     * success, `{ ok: false, error }` if the rendered file cannot be
+     * accessed (caller should fall back to `revealFileInOS`).
+     */
+    static async showOrUpdate(
+        context: vscode.ExtensionContext,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+    ): Promise<{ ok: true } | { ok: false; error: string }> {
+        try {
+            await fs.promises.access(args.outputPath, fs.constants.R_OK);
+        } catch (err) {
+            return { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+
+        const rootDir = path.dirname(args.outputPath);
+        const existing = KnitOutputPanel.instance;
+
+        if (existing && existing.rootDir === rootDir) {
+            existing.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+            existing.panel.reveal(existing.panel.viewColumn ?? vscode.ViewColumn.Beside, true);
+            return { ok: true };
+        }
+
+        if (existing) {
+            // localResourceRoots is immutable after panel creation — dispose
+            // and recreate in the same column. Same workaround as help-panel.
+            const column = existing.panel.viewColumn ?? vscode.ViewColumn.Beside;
+            existing.panel.dispose();
+            // panel.dispose() fires onDidDispose, which clears `instance`.
+            KnitOutputPanel.create(context, args, rootDir, column);
+            return { ok: true };
+        }
+
+        KnitOutputPanel.create(context, args, rootDir, vscode.ViewColumn.Beside);
+        return { ok: true };
+    }
+
+    /** Visible only for tests. */
+    static getInstanceForTesting(): KnitOutputPanel | undefined {
+        return KnitOutputPanel.instance;
+    }
+
+    /** Visible only for tests — destroys the singleton. */
+    static disposeForTesting(): void {
+        KnitOutputPanel.instance?.panel.dispose();
+    }
+
+    private static create(
+        context: vscode.ExtensionContext,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+        rootDir: string,
+        column: vscode.ViewColumn,
+    ): KnitOutputPanel {
+        const panel = vscode.window.createWebviewPanel(
+            'raven.knitOutput',
+            'Knit Output',
+            { viewColumn: column, preserveFocus: true },
+            {
+                enableScripts: true,
+                enableFindWidget: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.file(rootDir)],
+            },
+        );
+        const instance = new KnitOutputPanel(context, panel, rootDir, args);
+        KnitOutputPanel.instance = instance;
+        instance.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+        return instance;
+    }
+
+    private constructor(
+        _context: vscode.ExtensionContext,
+        panel: vscode.WebviewPanel,
+        rootDir: string,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+    ) {
+        this.panel = panel;
+        this.rootDir = rootDir;
+        this.sourceUri = args.sourceUri;
+        this.outputPath = args.outputPath;
+        this.output = args.output;
+
+        this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg));
+        this.panel.onDidDispose(() => {
+            if (KnitOutputPanel.instance === this) {
+                KnitOutputPanel.instance = undefined;
+            }
+        });
+    }
+
+    private updateContent(args: { sourceUri: vscode.Uri; outputPath: string }): void {
+        this.sourceUri = args.sourceUri;
+        this.outputPath = args.outputPath;
+        const nonce = crypto.randomBytes(16).toString('base64');
+        this.panel.webview.html = buildShellHtml({
+            webview: this.panel.webview,
+            outputPath: args.outputPath,
+            nonce,
+        });
+        this.panel.title = `Knit Output: ${path.basename(args.outputPath)}`;
+    }
+
+    private handleMessage(msg: unknown): void {
+        if (!isKnitOutputMessage(msg)) return;
+        if (msg.type === 'refresh') {
+            void vscode.commands.executeCommand('raven.knit', this.sourceUri);
+            return;
+        }
+        if (msg.type === 'openInBrowser') {
+            void openInBrowser(this.outputPath, this.output);
+        }
+    }
+}
+
+/**
+ * Open the rendered file via the user's OS default browser.
+ *
+ * In local workspaces this opens the configured handler for `file:` (a
+ * browser, typically). In remote workspaces, `openExternal(file:)` may
+ * route the request to the extension-host machine — i.e. the remote
+ * server, not where the user is sitting. When `openExternal` returns
+ * false we write the path to the Knit output channel and warn the user.
+ */
+export async function openInBrowser(
+    outputPath: string,
+    output: vscode.OutputChannel,
+): Promise<void> {
+    const uri = vscode.Uri.file(outputPath);
+    let opened = false;
+    try {
+        opened = await vscode.env.openExternal(uri);
+    } catch (err) {
+        output.appendLine(
+            `[Open in Browser] openExternal threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+    if (opened) return;
+    output.appendLine(`[Open in Browser] file:// did not open. Rendered output is at: ${outputPath}`);
+    void vscode.window.showWarningMessage(
+        'Open in Browser is not available for this workspace. The rendered file path has been written to the Raven: Knit output channel.',
+    );
+}

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -66,11 +66,6 @@ export function classify(
  * the pure helper has no dependency on the actual vscode module — tests
  * pass a fake.
  */
-export interface MinimalWebview {
-    asWebviewUri(uri: { fsPath: string }): { toString(): string };
-    cspSource: string;
-}
-
 function escapeHtml(s: string): string {
     return s
         .replace(/&/g, '&amp;')
@@ -84,21 +79,26 @@ function escapeHtml(s: string): string {
  * Build the outer-shell HTML for the Knit Output webview.
  *
  * The shell is Raven-controlled and owns the CSP in `<head>`; the
- * rendered HTML loads inside `<iframe sandbox="">` from
- * `webview.asWebviewUri(outputPath)`. Three independent containment
- * layers (sandbox attribute, outer-shell CSP, localResourceRoots) make
- * the security model robust to either layer failing.
+ * rendered HTML loads inside `<iframe sandbox="">`. Three independent
+ * containment layers (sandbox attribute, outer-shell CSP,
+ * `localResourceRoots`) make the security model robust to either layer
+ * failing.
+ *
+ * Pure helper — no dependency on the vscode module. The caller
+ * (`KnitOutputPanel`) is responsible for converting the output path via
+ * `webview.asWebviewUri(vscode.Uri.file(...))` and passing the result
+ * here as `iframeSrc`, and for forwarding `webview.cspSource`.
  *
  * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`
  * for the threat model.
  */
 export function buildShellHtml(args: {
-    webview: MinimalWebview;
+    iframeSrc: string;
+    cspSource: string;
     outputPath: string;
     nonce: string;
 }): string {
-    const { webview, outputPath, nonce } = args;
-    const iframeSrc = webview.asWebviewUri({ fsPath: outputPath }).toString();
+    const { iframeSrc, cspSource, outputPath, nonce } = args;
     // path.basename handles both POSIX and Windows separators.
     const lastSep = Math.max(outputPath.lastIndexOf('/'), outputPath.lastIndexOf('\\'));
     const basename = lastSep >= 0 ? outputPath.slice(lastSep + 1) : outputPath;
@@ -106,10 +106,10 @@ export function buildShellHtml(args: {
 
     const csp = [
         `default-src 'none'`,
-        `frame-src ${webview.cspSource}`,
-        `img-src ${webview.cspSource} https: data:`,
-        `style-src ${webview.cspSource} 'unsafe-inline'`,
-        `font-src ${webview.cspSource} https: data:`,
+        `frame-src ${cspSource}`,
+        `img-src ${cspSource} https: data:`,
+        `style-src ${cspSource} 'unsafe-inline'`,
+        `font-src ${cspSource} https: data:`,
         `script-src 'nonce-${nonce}'`,
         `connect-src 'none'`,
     ].join('; ');

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -62,6 +62,109 @@ export function classify(
 }
 
 /**
+ * Minimal vscode.Webview shape buildShellHtml needs. Defined inline so
+ * the pure helper has no dependency on the actual vscode module — tests
+ * pass a fake.
+ */
+export interface MinimalWebview {
+    asWebviewUri(uri: { fsPath: string }): { toString(): string };
+    cspSource: string;
+}
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+/**
+ * Build the outer-shell HTML for the Knit Output webview.
+ *
+ * The shell is Raven-controlled and owns the CSP in `<head>`; the
+ * rendered HTML loads inside `<iframe sandbox="">` from
+ * `webview.asWebviewUri(outputPath)`. Three independent containment
+ * layers (sandbox attribute, outer-shell CSP, localResourceRoots) make
+ * the security model robust to either layer failing.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`
+ * for the threat model.
+ */
+export function buildShellHtml(args: {
+    webview: MinimalWebview;
+    outputPath: string;
+    nonce: string;
+}): string {
+    const { webview, outputPath, nonce } = args;
+    const iframeSrc = webview.asWebviewUri({ fsPath: outputPath }).toString();
+    // path.basename handles both POSIX and Windows separators.
+    const lastSep = Math.max(outputPath.lastIndexOf('/'), outputPath.lastIndexOf('\\'));
+    const basename = lastSep >= 0 ? outputPath.slice(lastSep + 1) : outputPath;
+    const safeName = escapeHtml(basename);
+
+    const csp = [
+        `default-src 'none'`,
+        `frame-src ${webview.cspSource}`,
+        `img-src ${webview.cspSource} https: data:`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `font-src ${webview.cspSource} https: data:`,
+        `script-src 'nonce-${nonce}'`,
+        `connect-src 'none'`,
+    ].join('; ');
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<title>Knit Output</title>
+<style nonce="${nonce}">
+  body { margin: 0; padding: 0; height: 100vh; display: flex; flex-direction: column;
+         font-family: var(--vscode-font-family); color: var(--vscode-foreground); }
+  #raven-knit-toolbar { display: flex; gap: 0.5rem; align-items: center;
+                        padding: 0.4rem 0.75rem;
+                        background: var(--vscode-editorWidget-background);
+                        border-bottom: 1px solid var(--vscode-editorWidget-border);
+                        flex: 0 0 auto; }
+  #raven-knit-toolbar button { font: inherit; padding: 0.2rem 0.6rem;
+                               background: var(--vscode-button-background);
+                               color: var(--vscode-button-foreground);
+                               border: 1px solid var(--vscode-button-border, transparent);
+                               cursor: pointer; }
+  #raven-knit-toolbar button:hover { background: var(--vscode-button-hoverBackground); }
+  #raven-knit-filename { margin-left: 0.5rem; opacity: 0.8; font-size: 0.9em; }
+  #raven-knit-frame { flex: 1 1 auto; width: 100%; border: 0; background: white; }
+</style>
+</head>
+<body>
+  <div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
+    <button id="raven-knit-refresh" type="button" title="Re-knit the source document">Refresh</button>
+    <button id="raven-knit-open-browser" type="button" title="Open the rendered file in your default browser">Open in Browser</button>
+    <span id="raven-knit-filename" aria-live="polite">${safeName}</span>
+  </div>
+  <iframe id="raven-knit-frame"
+          src="${escapeHtml(iframeSrc)}"
+          sandbox=""
+          referrerpolicy="no-referrer"
+          title="Rendered output: ${safeName}"></iframe>
+  <script nonce="${nonce}">
+    (function () {
+      const vscode = acquireVsCodeApi();
+      document.getElementById('raven-knit-refresh').addEventListener('click', function () {
+        vscode.postMessage({ type: 'refresh' });
+      });
+      document.getElementById('raven-knit-open-browser').addEventListener('click', function () {
+        vscode.postMessage({ type: 'openInBrowser' });
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+/**
  * Pick the output path to surface in the Knit Output panel.
  *
  * When `output_format = "all"` (or a custom multi-format render) produces

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -1,0 +1,83 @@
+import * as path from 'path';
+import { parseRenderedOutputPath } from './output-path';
+
+export type KnitOutputMessage =
+    | { type: 'refresh' }
+    | { type: 'openInBrowser' };
+
+/**
+ * Strict type-narrowing for messages posted from the Knit Output webview.
+ * The webview is a trust boundary; reject anything we did not explicitly
+ * shape. Additional unknown properties on a recognized type are allowed
+ * (the handler ignores them).
+ */
+export function isKnitOutputMessage(msg: unknown): msg is KnitOutputMessage {
+    if (msg === null || typeof msg !== 'object') return false;
+    const t = (msg as { type?: unknown }).type;
+    return t === 'refresh' || t === 'openInBrowser';
+}
+
+/**
+ * Possible outcomes of a single `runKnit` invocation, after we have
+ * classified the raw engine result. Discriminated by `kind`. No user-
+ * facing toasts or webview operations have been performed yet — that
+ * happens in `renderOutcome`, OUTSIDE the `withProgress` callback. This
+ * is the core of the Piece A bug fix: keeping the `withProgress`
+ * lifecycle short and predictable.
+ */
+export type KnitOutcome =
+    | { kind: 'spawnError'; error: NodeJS.ErrnoException }
+    | { kind: 'cancelled' }
+    | { kind: 'timedOut'; timeoutMs?: number }
+    | { kind: 'failed'; exitCode: number | null }
+    | { kind: 'noOutput' }
+    | { kind: 'ok'; parsedOutputs: string[]; cwd: string | undefined };
+
+/** Minimal subset of `runKnit`'s return value classify needs. */
+export interface ClassifyInput {
+    spawnError: NodeJS.ErrnoException | null;
+    cancelled: boolean;
+    timedOut: boolean;
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Pure classifier mapping the engine's raw result onto a KnitOutcome.
+ * Branch priority mirrors the original runKnitCommand:
+ *   spawnError > cancelled > timedOut > failed > noOutput / ok
+ */
+export function classify(
+    result: ClassifyInput,
+    ctx: { cwd: string | undefined },
+): KnitOutcome {
+    if (result.spawnError) return { kind: 'spawnError', error: result.spawnError };
+    if (result.cancelled) return { kind: 'cancelled' };
+    if (result.timedOut) return { kind: 'timedOut' };
+    if (result.exitCode !== 0) return { kind: 'failed', exitCode: result.exitCode };
+    const parsed = parseRenderedOutputPath(result.stdout + '\n' + result.stderr).paths;
+    if (parsed.length === 0) return { kind: 'noOutput' };
+    return { kind: 'ok', parsedOutputs: parsed, cwd: ctx.cwd };
+}
+
+/**
+ * Pick the output path to surface in the Knit Output panel.
+ *
+ * When `output_format = "all"` (or a custom multi-format render) produces
+ * a mix of formats, the user almost always wants the HTML viewer rather
+ * than e.g. revealing a PDF in the file browser. Prefer the first HTML
+ * output; fall back to the first entry overall.
+ *
+ * Codex adversarial review #4 on the v1 spec called out that v1 always
+ * used `parsed.paths[0]`, which would hide an HTML output behind a
+ * PDF/DOCX-first reveal.
+ */
+export function pickPrimaryOutput(paths: readonly string[]): string | undefined {
+    if (paths.length === 0) return undefined;
+    const html = paths.find((p) => {
+        const ext = path.extname(p).toLowerCase();
+        return ext === '.html' || ext === '.htm';
+    });
+    return html ?? paths[0];
+}

--- a/editors/vscode/src/test/fixtures/sample.Rmd
+++ b/editors/vscode/src/test/fixtures/sample.Rmd
@@ -1,0 +1,6 @@
+---
+title: "Knit test sample"
+output: html_document
+---
+
+Hello.

--- a/editors/vscode/src/test/knit-output-panel.test.ts
+++ b/editors/vscode/src/test/knit-output-panel.test.ts
@@ -81,6 +81,35 @@ suite('KnitOutputPanel integration', () => {
         }
     });
 
+    test('panel is created with the security-relevant webview options', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const a = writeFixture(tmp, 'a.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            const r = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: a, output },
+            );
+            assert.deepStrictEqual(r, { ok: true });
+            const inst = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst);
+
+            // Access the panel via the singleton — the panel field is
+            // private but the only public surface, `panel.webview`, is
+            // reachable via `WebviewPanel.webview`. We assert the
+            // *options* set at creation time.
+            const opts = (inst as unknown as { panel: vscode.WebviewPanel }).panel.webview.options;
+            assert.strictEqual(opts.enableScripts, true);
+            assert.ok(opts.localResourceRoots, 'localResourceRoots is set');
+            assert.strictEqual(opts.localResourceRoots!.length, 1);
+            assert.strictEqual(opts.localResourceRoots![0].fsPath, tmp);
+        } finally {
+            output.dispose();
+        }
+    });
+
     test('showOrUpdate returns {ok: false} when the output file does not exist', async () => {
         await activate();
         const output = vscode.window.createOutputChannel('Knit Test');

--- a/editors/vscode/src/test/knit-output-panel.test.ts
+++ b/editors/vscode/src/test/knit-output-panel.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+function writeFixture(dir: string, name: string, body = '<html><body>hi</body></html>'): string {
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, body, 'utf-8');
+    return p;
+}
+
+suite('KnitOutputPanel integration', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-panel-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('showOrUpdate reuses the singleton when rootDir is unchanged', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const a = writeFixture(tmp, 'a.html');
+            const b = writeFixture(tmp, 'b.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            const r1 = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: a, output },
+            );
+            assert.deepStrictEqual(r1, { ok: true });
+            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst1);
+
+            const r2 = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: b, output },
+            );
+            assert.deepStrictEqual(r2, { ok: true });
+            const inst2 = KnitOutputPanel.getInstanceForTesting();
+            assert.strictEqual(inst1, inst2, 'singleton instance should be reused');
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('showOrUpdate creates a fresh panel when rootDir changes', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const sub = path.join(tmp, 'sub');
+            const a = writeFixture(tmp, 'a.html');
+            const b = writeFixture(sub, 'b.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: a, output },
+            );
+            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst1);
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: b, output },
+            );
+            const inst2 = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst2);
+            assert.notStrictEqual(inst1, inst2, 'a new singleton should be created when rootDir changes');
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('showOrUpdate returns {ok: false} when the output file does not exist', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+            const result = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: path.join(tmp, 'does-not-exist.html'), output },
+            );
+            assert.strictEqual(result.ok, false);
+            if (!result.ok) assert.ok(result.error.length > 0);
+        } finally {
+            output.dispose();
+        }
+    });
+});

--- a/editors/vscode/src/test/knit-progress-lifecycle.test.ts
+++ b/editors/vscode/src/test/knit-progress-lifecycle.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, getFixtureUri, sleep } from './helper';
+import { __runKnitCommandForTest, type KnitDeps } from '../knit/knit-commands';
+
+/**
+ * Verifies the Piece A fix: `inFlight.delete(fsPath)` must happen the
+ * moment `withProgress` resolves, NOT after the user dismisses the
+ * success toast. Under the old code, a fake `runKnit` that resolved
+ * immediately would still leave the file marked in-flight until the
+ * test dismissed the message — which is what caused the user-reported
+ * "is already being knitted" bug.
+ */
+suite('knit progress lifecycle', () => {
+    test('inFlight clears the moment runKnit resolves, not when toast is dismissed', async () => {
+        await activate();
+
+        const docUri = getFixtureUri('sample.Rmd');
+        const doc = await vscode.workspace.openTextDocument(docUri);
+        await vscode.window.showTextDocument(doc);
+
+        const inFlight = new Set<string>();
+        const output = vscode.window.createOutputChannel('Knit Test');
+
+        // Stub showInformationMessage so the test does not hang on the
+        // success toast. The bug under test was that inFlight stayed
+        // populated until this resolved.
+        const origShow = vscode.window.showInformationMessage;
+        type Resolver = (v: string | undefined) => void;
+        const resolvers: Resolver[] = [];
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            ..._args: unknown[]
+        ): Thenable<string | undefined> => {
+            return new Promise<string | undefined>((res) => {
+                resolvers.push(res);
+            });
+        };
+
+        const fakeContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+        let runKnitCalled = false;
+        const deps: KnitDeps = {
+            runKnit: (async () => {
+                runKnitCalled = true;
+                return {
+                    spawnError: null,
+                    cancelled: false,
+                    timedOut: false,
+                    exitCode: 0,
+                    stdout: `Output created: ${path.join(path.dirname(docUri.fsPath), 'sample.html')}\n`,
+                    stderr: '',
+                };
+            }) as KnitDeps['runKnit'],
+            showOrUpdatePanel: (async () => ({ ok: true })) as KnitDeps['showOrUpdatePanel'],
+        };
+
+        try {
+            const runPromise = __runKnitCommandForTest({
+                uri: docUri,
+                output,
+                inFlight,
+                context: fakeContext,
+                deps,
+            });
+
+            // Yield to let withProgress + runKnit resolve. After this
+            // microtask drain, withProgress should be done AND
+            // inFlight.delete should have happened — even though the
+            // info-message stub is still suspended.
+            await sleep(100);
+
+            assert.ok(
+                runKnitCalled,
+                'fake runKnit was never invoked — runKnitCommand short-circuited on a precondition check',
+            );
+            assert.strictEqual(
+                inFlight.has(docUri.fsPath),
+                false,
+                'inFlight should be cleared before the success toast is dismissed',
+            );
+
+            // Now dismiss every pending info-message so runPromise can resolve.
+            for (const res of resolvers) res(undefined);
+            await runPromise;
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = origShow;
+            output.dispose();
+        }
+    });
+});

--- a/editors/vscode/src/test/knit-progress-lifecycle.test.ts
+++ b/editors/vscode/src/test/knit-progress-lifecycle.test.ts
@@ -79,9 +79,42 @@ suite('knit progress lifecycle', () => {
                 'inFlight should be cleared before the success toast is dismissed',
             );
 
-            // Now dismiss every pending info-message so runPromise can resolve.
+            // Direct regression check: a second invocation while the first
+            // success toast is still pending must NOT report "already being
+            // knitted". This reproduces the user-reported bug ("____ is
+            // already being knitted" on rapid re-invoke).
+            let secondRunKnitCalled = false;
+            const secondDeps: KnitDeps = {
+                runKnit: (async () => {
+                    secondRunKnitCalled = true;
+                    return {
+                        spawnError: null,
+                        cancelled: false,
+                        timedOut: false,
+                        exitCode: 0,
+                        stdout: `Output created: ${path.join(path.dirname(docUri.fsPath), 'sample.html')}\n`,
+                        stderr: '',
+                    };
+                }) as KnitDeps['runKnit'],
+                showOrUpdatePanel: (async () => ({ ok: true })) as KnitDeps['showOrUpdatePanel'],
+            };
+            const secondPromise = __runKnitCommandForTest({
+                uri: docUri,
+                output,
+                inFlight,
+                context: fakeContext,
+                deps: secondDeps,
+            });
+            await sleep(100);
+            assert.ok(
+                secondRunKnitCalled,
+                'second invocation was blocked by the inFlight gate — the original bug regressed',
+            );
+
+            // Now dismiss every pending info-message so both promises resolve.
             for (const res of resolvers) res(undefined);
             await runPromise;
+            await secondPromise;
         } finally {
             (vscode.window as { showInformationMessage: unknown }).showInformationMessage = origShow;
             output.dispose();

--- a/tests/bun/knit-output-classify.test.ts
+++ b/tests/bun/knit-output-classify.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test';
+import { classify } from '../../editors/vscode/src/knit/knit-output';
+
+describe('classify', () => {
+    test('spawn error wins over everything', () => {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        const outcome = classify({
+            spawnError: err,
+            cancelled: false,
+            timedOut: false,
+            exitCode: null,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('spawnError');
+    });
+
+    test('cancelled beats timedOut and failure', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: true,
+            timedOut: false,
+            exitCode: 130,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('cancelled');
+    });
+
+    test('timedOut beats failure', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: false,
+            timedOut: true,
+            exitCode: null,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('timedOut');
+    });
+
+    test('non-zero exit is "failed"', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 1,
+            stdout: '',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('failed');
+        if (outcome.kind === 'failed') expect(outcome.exitCode).toBe(1);
+    });
+
+    test('clean exit with no output path is "noOutput"', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: '\n',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('noOutput');
+    });
+
+    test('clean exit with output path is "ok"', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: 'Output created: out.html\n',
+            stderr: '',
+        }, { cwd: '/wd' });
+        expect(outcome.kind).toBe('ok');
+        if (outcome.kind === 'ok') {
+            expect(outcome.parsedOutputs).toEqual(['out.html']);
+            expect(outcome.cwd).toBe('/wd');
+        }
+    });
+
+    test('cwd undefined propagates through ok outcome', () => {
+        const outcome = classify({
+            spawnError: null,
+            cancelled: false,
+            timedOut: false,
+            exitCode: 0,
+            stdout: 'Output created: out.html\n',
+            stderr: '',
+        }, { cwd: undefined });
+        expect(outcome.kind).toBe('ok');
+        if (outcome.kind === 'ok') expect(outcome.cwd).toBeUndefined();
+    });
+});

--- a/tests/bun/knit-output-message.test.ts
+++ b/tests/bun/knit-output-message.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { isKnitOutputMessage } from '../../editors/vscode/src/knit/knit-output';
+
+describe('isKnitOutputMessage', () => {
+    test('accepts {type: "refresh"}', () => {
+        expect(isKnitOutputMessage({ type: 'refresh' })).toBe(true);
+    });
+
+    test('accepts {type: "openInBrowser"}', () => {
+        expect(isKnitOutputMessage({ type: 'openInBrowser' })).toBe(true);
+    });
+
+    test('rejects unknown type', () => {
+        expect(isKnitOutputMessage({ type: 'evil' })).toBe(false);
+    });
+
+    test('rejects null', () => {
+        expect(isKnitOutputMessage(null)).toBe(false);
+    });
+
+    test('rejects undefined', () => {
+        expect(isKnitOutputMessage(undefined)).toBe(false);
+    });
+
+    test('rejects primitives', () => {
+        expect(isKnitOutputMessage('refresh')).toBe(false);
+        expect(isKnitOutputMessage(42)).toBe(false);
+    });
+
+    test('rejects empty object', () => {
+        expect(isKnitOutputMessage({})).toBe(false);
+    });
+
+    test('rejects object missing the type key', () => {
+        expect(isKnitOutputMessage({ kind: 'refresh' })).toBe(false);
+    });
+});

--- a/tests/bun/knit-output-pick-primary.test.ts
+++ b/tests/bun/knit-output-pick-primary.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test';
+import { pickPrimaryOutput } from '../../editors/vscode/src/knit/knit-output';
+
+describe('pickPrimaryOutput', () => {
+    test('returns the only entry when there is one', () => {
+        expect(pickPrimaryOutput(['/a/foo.html'])).toBe('/a/foo.html');
+    });
+
+    test('prefers .html when present mid-list', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.html', '/a/foo.docx']))
+            .toBe('/a/foo.html');
+    });
+
+    test('prefers .htm when no .html', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.htm'])).toBe('/a/foo.htm');
+    });
+
+    test('returns the first when no HTML is present', () => {
+        expect(pickPrimaryOutput(['/a/foo.pdf', '/a/foo.docx'])).toBe('/a/foo.pdf');
+    });
+
+    test('case-insensitive extension match', () => {
+        expect(pickPrimaryOutput(['/a/foo.PDF', '/a/foo.HTML'])).toBe('/a/foo.HTML');
+    });
+
+    test('returns undefined for an empty list', () => {
+        expect(pickPrimaryOutput([])).toBeUndefined();
+    });
+});

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -1,19 +1,16 @@
 import { describe, test, expect } from 'bun:test';
 import { buildShellHtml } from '../../editors/vscode/src/knit/knit-output';
 
-const fakeWebview = {
-    asWebviewUri: (uri: { fsPath: string }) =>
-        `https://webview.test${uri.fsPath}`,
+const args = (outputPath: string, nonce = 'NONCE123') => ({
+    iframeSrc: `https://webview.test${outputPath}`,
     cspSource: 'https://webview.test',
-};
+    outputPath,
+    nonce,
+});
 
 describe('buildShellHtml', () => {
     test('CSP <meta> appears in <head>, before <body>', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
+        const html = buildShellHtml(args('/work/report.html'));
         const cspIdx = html.indexOf('Content-Security-Policy');
         const bodyIdx = html.indexOf('<body');
         expect(cspIdx).toBeGreaterThan(0);
@@ -22,64 +19,37 @@ describe('buildShellHtml', () => {
     });
 
     test('CSP contains nonce, frame-src, no default-src loophole', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
+        const html = buildShellHtml(args('/work/report.html'));
         expect(html).toContain("default-src 'none'");
         expect(html).toContain('frame-src https://webview.test');
         expect(html).toContain("script-src 'nonce-NONCE123'");
         expect(html).toContain("connect-src 'none'");
     });
 
-    test('iframe src is asWebviewUri of the output path', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
+    test('iframe src is the supplied iframeSrc', () => {
+        const html = buildShellHtml(args('/work/report.html'));
         expect(html).toContain('src="https://webview.test/work/report.html"');
     });
 
     test('iframe sandbox attribute is empty (most restrictive)', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
-        // Note: sandbox="" (empty string) is the strictest mode. Be exact.
+        const html = buildShellHtml(args('/work/report.html'));
         expect(html).toMatch(/<iframe\b[^>]*\bsandbox=""/);
     });
 
     test('toolbar contains refresh and open-in-browser buttons', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
+        const html = buildShellHtml(args('/work/report.html'));
         expect(html).toContain('id="raven-knit-refresh"');
         expect(html).toContain('id="raven-knit-open-browser"');
     });
 
     test('filename is HTML-escaped', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/<script>alert(1)</script>.html',
-            nonce: 'NONCE123',
-        });
-        // The basename appears in the title attribute and the toolbar span.
-        // Verify the raw "<script>" substring does NOT appear in the HTML.
+        const html = buildShellHtml(args('/work/<script>alert(1)</script>.html'));
         expect(html).not.toContain('<script>alert(1)</script>.html');
         expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;.html');
     });
 
     test('toolbar script is nonce-tagged', () => {
-        const html = buildShellHtml({
-            webview: fakeWebview as any,
-            outputPath: '/work/report.html',
-            nonce: 'NONCE123',
-        });
+        const html = buildShellHtml(args('/work/report.html'));
         expect(html).toMatch(/<script\s+nonce="NONCE123">/);
     });
 });

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { buildShellHtml } from '../../editors/vscode/src/knit/knit-output';
+
+const fakeWebview = {
+    asWebviewUri: (uri: { fsPath: string }) =>
+        `https://webview.test${uri.fsPath}`,
+    cspSource: 'https://webview.test',
+};
+
+describe('buildShellHtml', () => {
+    test('CSP <meta> appears in <head>, before <body>', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        const cspIdx = html.indexOf('Content-Security-Policy');
+        const bodyIdx = html.indexOf('<body');
+        expect(cspIdx).toBeGreaterThan(0);
+        expect(bodyIdx).toBeGreaterThan(0);
+        expect(cspIdx).toBeLessThan(bodyIdx);
+    });
+
+    test('CSP contains nonce, frame-src, no default-src loophole', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain("default-src 'none'");
+        expect(html).toContain('frame-src https://webview.test');
+        expect(html).toContain("script-src 'nonce-NONCE123'");
+        expect(html).toContain("connect-src 'none'");
+    });
+
+    test('iframe src is asWebviewUri of the output path', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain('src="https://webview.test/work/report.html"');
+    });
+
+    test('iframe sandbox attribute is empty (most restrictive)', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        // Note: sandbox="" (empty string) is the strictest mode. Be exact.
+        expect(html).toMatch(/<iframe\b[^>]*\bsandbox=""/);
+    });
+
+    test('toolbar contains refresh and open-in-browser buttons', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toContain('id="raven-knit-refresh"');
+        expect(html).toContain('id="raven-knit-open-browser"');
+    });
+
+    test('filename is HTML-escaped', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/<script>alert(1)</script>.html',
+            nonce: 'NONCE123',
+        });
+        // The basename appears in the title attribute and the toolbar span.
+        // Verify the raw "<script>" substring does NOT appear in the HTML.
+        expect(html).not.toContain('<script>alert(1)</script>.html');
+        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;.html');
+    });
+
+    test('toolbar script is nonce-tagged', () => {
+        const html = buildShellHtml({
+            webview: fakeWebview as any,
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+        });
+        expect(html).toMatch(/<script\s+nonce="NONCE123">/);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes the stuck "Knitting …" progress notification (and the spurious "already being knitted" gate on re-invocation) by moving all user-facing toasts out of the `withProgress` callback. `inFlight.delete(fsPath)` now runs the moment the R subprocess exits.
- Adds a Knit Output webview panel: an iframe-sandbox shell that renders HTML output with **Refresh** and **Open in Browser** toolbar buttons. Three-layer security model (sandbox attribute, outer-shell CSP in `<head>`, `localResourceRoots`) — no HTML parsing or rewriting on Raven's side.
- Multi-output knits (`output_format = "all"`) prefer the HTML output for the viewer; PDF / DOCX / etc. remain on the existing `revealFileInOS` path.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` (v2, addresses two rounds of Codex adversarial review)
- Plan: `docs/superpowers/plans/2026-05-17-knit-output-webview.md`

## Test plan

- [x] Bun unit tests for `pickPrimaryOutput`, `isKnitOutputMessage`, `classify`, `buildShellHtml` (29 assertions, all pass)
- [x] Mocha integration: `inFlight` clears before the success toast, and a second invocation issued while the first toast is pending is NOT blocked (Piece A regression guard)
- [x] Mocha integration: `KnitOutputPanel` singleton reuse, rootDir-change recreation, missing-file fallback, security-relevant webview options
- [ ] Manual smoke: knit `.Rmd` locally, verify panel opens, Refresh re-knits, Open in Browser launches default browser
- [ ] Manual smoke: knit `output: pdf_document`, verify existing `revealFileInOS` path is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knit Output panel to display rendered R Markdown output directly in VS Code with Refresh and Open in Browser controls.
  * Fixed stuck "Knitting..." notifications that blocked subsequent knit operations.

* **Documentation**
  * Updated documentation describing Knit Output panel behavior and security features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->