### PR TITLE
Bracket diagnostics: opener-anchored unclosed + named stray closers (#286)

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6456,6 +6456,36 @@ fn collect_syntax_errors_inner(
     }
 
     if node.is_missing() {
+        // Bracket-kind MISSING routes through the opener-anchoring helper
+        // unless the opener is already covered by a mismatched-bracket
+        // diagnostic emitted earlier in this traversal.
+        if matches!(node.kind(), ")" | "}" | "]" | "]]") {
+            if let Some((opener, range)) = find_opener_for_missing(node, text) {
+                if !state.covered_openers.contains(&opener.id()) {
+                    let opener_text = text
+                        .get(opener.start_byte()..opener.end_byte())
+                        .unwrap_or("");
+                    if let Some(k) = DelimiterKind::from_opener(opener_text) {
+                        diagnostics.push(Diagnostic {
+                            range,
+                            severity: Some(DiagnosticSeverity::ERROR),
+                            message: format!(
+                                "Unclosed `{}`: missing matching `{}`",
+                                k.opener_str(),
+                                k.closer_str(),
+                            ),
+                            ..Default::default()
+                        });
+                    }
+                }
+                return;
+            }
+            // Bracket-kind MISSING with no structural parent: fall through
+            // to the existing default branch.
+        }
+
+        // Existing default branch for non-bracket MISSING (e.g. identifier
+        // missing after `x <-`). PRESERVE BYTE-FOR-BYTE from Task 3.
         let (row, col) = anchor_missing_position(
             node.start_position().row,
             node.start_position().column,
@@ -7233,21 +7263,24 @@ mod syntax_error_range_tests {
         //
         // The diagnostic should anchor on line 0 (the line with the unmatched
         // `(`), so the user's eye lands on the broken expression.
+        //
+        // Message updated (Task 7): bracket-kind MISSING now emits
+        // "Unclosed `(`: missing matching `)`" via the opener-anchoring path.
         let code = "x <- mean(c(1, 2, 3)\n\n# Here is a comment\n";
         let diags = collect(code);
         assert!(!diags.is_empty(), "should produce a diagnostic");
         let missing_close = diags
             .iter()
-            .find(|d| d.message.contains("Missing") && d.message.contains(')'))
+            .find(|d| d.message.contains("Unclosed `(`"))
             .unwrap_or_else(|| {
                 panic!(
-                    "expected a 'Missing )' diagnostic, got: {:?}",
+                    "expected an 'Unclosed `(`: ...' diagnostic, got: {:?}",
                     diags.iter().map(|d| &d.message).collect::<Vec<_>>()
                 )
             });
         assert_eq!(
             missing_close.range.start.line, 0,
-            "Missing ) diagnostic should anchor on line 0 (the line with the \
+            "Unclosed `(` diagnostic should anchor on line 0 (the line with the \
              unclosed `(`), got line {}. Full range: ({},{})..({},{})",
             missing_close.range.start.line,
             missing_close.range.start.line,
@@ -7852,6 +7885,8 @@ mod syntax_error_range_tests {
     #[test]
     fn unclosed_library_call() {
         // `library(` — unclosed function call.
+        // Message updated (Task 7): bracket-kind MISSING now emits
+        // "Unclosed `(`: missing matching `)`" via the opener-anchoring path.
         let code = "library(";
         let diags = collect(code);
         assert!(
@@ -7859,10 +7894,12 @@ mod syntax_error_range_tests {
             "should produce at least one diagnostic for unclosed library call"
         );
         assert!(
-            diags
-                .iter()
-                .any(|d| d.message == "Syntax error" || d.message.starts_with("Missing")),
-            "should produce a syntax/missing diagnostic, got: {:?}",
+            diags.iter().any(|d| {
+                d.message == "Syntax error"
+                    || d.message.starts_with("Missing")
+                    || d.message.starts_with("Unclosed")
+            }),
+            "should produce a syntax/missing/unclosed diagnostic, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
@@ -8108,6 +8145,23 @@ mod syntax_error_range_tests {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if let Some(found) = find_error_at(child, row, col) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    /// Find a MISSING node at the given (row, col) position via depth-first search.
+    fn find_missing_node_at<'a>(node: Node<'a>, row: u32, col: u32) -> Option<Node<'a>> {
+        if node.is_missing()
+            && node.start_position().row as u32 == row
+            && node.start_position().column as u32 == col
+        {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_missing_node_at(child, row, col) {
                 return Some(found);
             }
         }
@@ -8417,9 +8471,40 @@ mod syntax_error_range_tests {
             // 1. minimize_error_range Phase 1 (MISSING inside ERROR → "Syntax error")
             // 2. collect_syntax_errors direct MISSING handling (→ "Missing <kind>")
             //
-            // In either case, the diagnostic start position must match the MISSING
-            // node's position.
+            // Exception (Task 7): bracket-kind MISSING nodes (`)`, `}`, `]`, `]]`)
+            // are re-anchored to the opener position and emit "Unclosed `X`...".
+            // For those, we verify that at least one "Unclosed" diagnostic exists
+            // for the code, rather than checking the raw MISSING position.
+            let has_any_unclosed = diagnostics.iter().any(|d| d.message.starts_with("Unclosed `"));
+            let mut all_missing_are_bracket_kind = true;
+
             for &(m_row, m_col) in &missing_positions {
+                // Find the MISSING node at this position to check its kind.
+                // We use the tree to walk and identify it.
+                let missing_node = find_missing_node_at(root, m_row, m_col);
+                let is_bracket_missing = missing_node
+                    .map(|n| matches!(n.kind(), ")" | "}" | "]" | "]]"))
+                    .unwrap_or(false);
+
+                if is_bracket_missing {
+                    // Bracket-kind MISSING: diagnostic is at the opener, not the MISSING
+                    // position. Verify at least one "Unclosed" diagnostic was emitted.
+                    prop_assert!(
+                        has_any_unclosed,
+                        "Expected an 'Unclosed' diagnostic for bracket-kind MISSING at ({}, {}). \
+                         Code: {}, Diagnostics: {:?}",
+                        m_row,
+                        m_col,
+                        code,
+                        diagnostics
+                            .iter()
+                            .map(|d| &d.message)
+                            .collect::<Vec<_>>()
+                    );
+                    continue;
+                }
+                all_missing_are_bracket_kind = false;
+
                 let has_matching_diag = diagnostics.iter().any(|d| {
                     d.range.start.line == m_row && d.range.start.character == m_col
                 });
@@ -8444,6 +8529,7 @@ mod syntax_error_range_tests {
                         .collect::<Vec<_>>()
                 );
             }
+            let _ = all_missing_are_bracket_kind; // suppress unused warning
         }
 
         // ============================================================================
@@ -8715,8 +8801,23 @@ mod syntax_error_range_tests {
             // 1. "Missing <kind>" — from collect_syntax_errors direct MISSING handling
             // 2. "Syntax error" — from minimize_error_range Phase 1 (MISSING inside ERROR)
             //
-            // Both paths create a 1-column-wide range at the MISSING node's position.
+            // Exception (Task 7): bracket-kind MISSING nodes (`)`, `}`, `]`, `]]`)
+            // are re-anchored to the opener position and emit "Unclosed `X`...".
+            // The opener-anchored diagnostic range spans opener..EOL (not 1 column),
+            // so we skip the width check for bracket-kind MISSING.
             for &(m_row, m_col) in &missing_positions {
+                let missing_node = find_missing_node_at(root, m_row, m_col);
+                let is_bracket_missing = missing_node
+                    .map(|n| matches!(n.kind(), ")" | "}" | "]" | "]]"))
+                    .unwrap_or(false);
+
+                if is_bracket_missing {
+                    // Bracket-kind MISSING diagnostic is at the opener, not the MISSING
+                    // position. Width check does not apply; the "Unclosed" diagnostic
+                    // spans opener..EOL (see find_opener_for_missing). Skip.
+                    continue;
+                }
+
                 let matching_diag = diagnostics.iter().find(|d| {
                     d.range.start.line == m_row && d.range.start.character == m_col
                 });
@@ -9234,6 +9335,94 @@ mod syntax_error_range_tests {
             "got: {}",
             diags[0].0,
         );
+    }
+
+    // ========================================================================
+    // Bracket-kind MISSING anchor tests (Task 7)
+    // ========================================================================
+
+    #[test]
+    fn unclosed_paren_anchors_on_opener() {
+        // mean(c(1,2,3) — opener `(` of mean( at col 9, EOL of opener line at col 20
+        let diags = collect("x <- mean(c(1, 2, 3)\n\n# comment\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 9);
+        assert_eq!(target.range.end.line, 0);
+        assert_eq!(target.range.end.character, 20);
+    }
+
+    #[test]
+    fn unclosed_brace_anchors_on_opener() {
+        // f <- function() { ... — opener `{` at col 16, EOL at col 17
+        let diags = collect("f <- function() {\n  x <- 1\n  y <- 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `{`"))
+            .expect("expected Unclosed { diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 16);
+        assert_eq!(target.range.end.character, 17);
+    }
+
+    #[test]
+    fn unclosed_bracket_anchors_on_opener() {
+        let diags = collect("vec[1, 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `[`"))
+            .expect("expected Unclosed [ diagnostic");
+        assert_eq!(target.range.start.character, 3);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_double_bracket_anchors_on_opener() {
+        let diags = collect("vec[[1, 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `[[`"))
+            .expect("expected Unclosed [[ diagnostic");
+        assert_eq!(target.range.start.character, 3);
+        assert_eq!(target.range.end.character, 9);
+    }
+
+    #[test]
+    fn unclosed_paren_at_end_of_file() {
+        let diags = collect("library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_with_trailing_comment() {
+        // `f( # comment\n` — opener `(` at col 1, range collapses to just `(`
+        let diags = collect("f( # comment\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 1);
+        assert_eq!(target.range.end.character, 2);
+    }
+
+    #[test]
+    fn unclosed_opener_with_trailing_whitespace() {
+        let diags = collect("f(   \n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 1);
+        assert_eq!(target.range.end.character, 2);
     }
 
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6418,6 +6418,42 @@ fn has_unclosed_quote_child(node: Node) -> bool {
     false
 }
 
+/// One classified syntax-error diagnostic produced by `classify_error`.
+/// Kept separate from `tower_lsp::lsp_types::Diagnostic` so that the
+/// classifier doesn't need to fill in `source` / `severity` / etc. — the
+/// caller (`collect_syntax_errors_inner`) does that.
+#[derive(Debug, Clone)]
+struct ClassifiedSyntaxDiagnostic {
+    message: String,
+    range: Range,
+}
+
+/// Result of classifying an ERROR node. A single ERROR can now produce
+/// either one whole-error diagnostic (the existing classifiers) or
+/// multiple per-fault diagnostics (the new delimiter scan).
+#[derive(Debug, Clone)]
+enum ErrorClassification {
+    /// Single diagnostic describing the whole ERROR. Used by unclosed
+    /// string, consecutive pipe, mismatched bracket, fat-arrow.
+    Whole(ClassifiedSyntaxDiagnostic),
+    /// Zero or more diagnostics, each describing a distinct delimiter
+    /// fault inside the ERROR. An empty Vec means "no classifier matched
+    /// — caller falls back to a single generic 'Syntax error' at the
+    /// minimized range".
+    Multi(Vec<ClassifiedSyntaxDiagnostic>),
+}
+
+/// Per-traversal mutable state threaded through `collect_syntax_errors_inner`
+/// so that the mismatched-bracket coalescing rule can suppress a duplicate
+/// `Unclosed X` diagnostic for the same opener.
+#[derive(Default)]
+struct CollectState {
+    /// `Node::id()` values of opener tokens already covered by a
+    /// `Mismatched brackets` diagnostic. The MISSING-anchoring branch
+    /// skips emitting `Unclosed X` for any opener whose id appears here.
+    covered_openers: std::collections::HashSet<usize>,
+}
+
 /// Classify an ERROR node into a specific, actionable message where possible,
 /// falling back to the generic "Syntax error" for unrecognised patterns.
 ///

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6740,36 +6740,61 @@ fn extract_from_leaf(raw: &str, base_byte: usize, row: u32, out: &mut Vec<DelimE
         return;
     }
 
-    // Otherwise: tokenize per-character left-to-right, recognizing `]]`
-    // greedily.
+    // Per spec ("leaf whose text consists only of closer characters"):
+    // only byte-scan when every byte is a closer (`}`, `)`, `]`) or ASCII
+    // whitespace. Tree-sitter occasionally wraps multi-line closer runs in
+    // a single leaf ERROR (e.g. `}\n}`), so we allow whitespace between
+    // closer characters. Any other byte (identifier chars, `%`, etc.)
+    // means this leaf is a non-delimiter token (e.g. an unparseable
+    // special operator like `%]%`); emitting bracket events from such a
+    // leaf would produce misleading `Missing opening …` / `Unclosed …`
+    // diagnostics where the user's real problem is a different syntax
+    // error.
+    let allowed = !raw.is_empty()
+        && raw
+            .bytes()
+            .all(|b| matches!(b, b'}' | b')' | b']' | b' ' | b'\t' | b'\n' | b'\r'));
+    if !allowed {
+        return;
+    }
+
+    // Tokenize per-character left-to-right, recognizing `]]` greedily.
+    // Only closer events are emitted from this path; openers only enter
+    // the stream as exact-match leaf tokens (handled by the fast path
+    // above), never from byte-scanning a mixed leaf.
+    //
+    // Track `current_row` through the loop so that a leaf containing an
+    // embedded newline (e.g. tree-sitter wrapping `}\n}` in a single
+    // ERROR leaf) emits each closer event on its actual row. Reusing the
+    // leaf's starting row for every emitted event would mis-anchor the
+    // downstream diagnostic.
+    let mut current_row = row;
     let bytes = raw.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
+        if b == b'\n' {
+            current_row += 1;
+            i += 1;
+            continue;
+        }
         if b == b']' && i + 1 < bytes.len() && bytes[i + 1] == b']' {
             out.push(DelimEvent {
                 is_open: false,
                 kind: DelimiterKind::DoubleBracket,
                 range_bytes: base_byte + i..base_byte + i + 2,
-                row,
+                row: current_row,
             });
             i += 2;
             continue;
         }
         let one = std::str::from_utf8(&bytes[i..i + 1]).unwrap_or("");
-        if let Some(k) = DelimiterKind::from_opener(one) {
-            out.push(DelimEvent {
-                is_open: true,
-                kind: k,
-                range_bytes: base_byte + i..base_byte + i + 1,
-                row,
-            });
-        } else if let Some(k) = DelimiterKind::from_closer(one) {
+        if let Some(k) = DelimiterKind::from_closer(one) {
             out.push(DelimEvent {
                 is_open: false,
                 kind: k,
                 range_bytes: base_byte + i..base_byte + i + 1,
-                row,
+                row: current_row,
             });
         }
         i += 1;
@@ -6804,8 +6829,8 @@ fn classify_error(node: Node, text: &str, state: &mut CollectState) -> ErrorClas
     if let Some(msg) = detect_consecutive_pipe(node, text) {
         return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
-    if let Some(msg) = detect_mismatched_bracket(node, text) {
-        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    if let Some(diag) = detect_mismatched_bracket(node, text) {
+        return ErrorClassification::Whole(diag);
     }
     if let Some(diag) = detect_mismatched_via_structural_parent(node, text, state) {
         return ErrorClassification::Whole(diag);
@@ -7036,11 +7061,18 @@ fn detect_consecutive_pipe(node: Node, text: &str) -> Option<String> {
     None
 }
 
-/// Returns a diagnostic message if `node` is an ERROR that opens with a
-/// bracket (`(`, `[`, `[[`) and contains a nested ERROR child that is a
-/// non-matching closing bracket. Catches patterns like `c(1, 2]` where the
-/// programmer used the wrong closing delimiter.
-fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
+/// Detects ERROR nodes shaped like `c(1, 2]` — a single bracket opener
+/// (`(`, `[`, `[[`) as a direct child paired with a wrong-closer leaf in
+/// a nested ERROR child.
+///
+/// Returns the `Mismatched brackets` message together with a range
+/// anchored on the offending closer (per the design goal of pointing at
+/// the bad delimiter, not the whole expression). The range is
+/// single-line; the closer leaves tree-sitter produces here are always
+/// single tokens.
+fn detect_mismatched_bracket(node: Node, text: &str) -> Option<ClassifiedSyntaxDiagnostic> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
     let mut cursor = node.walk();
     let children: Vec<_> = node.children(&mut cursor).collect();
 
@@ -7066,16 +7098,32 @@ fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
         if !child.is_error() {
             continue;
         }
-        let child_text = text
-            .get(child.start_byte()..child.end_byte())
-            .unwrap_or("")
-            .trim();
-        if matches!(child_text, ")" | "]" | "]]") && child_text != expected_closer {
-            return Some(format!(
+        let child_raw = text.get(child.start_byte()..child.end_byte()).unwrap_or("");
+        let child_text = child_raw.trim();
+        if !matches!(child_text, ")" | "]" | "]]") || child_text == expected_closer {
+            continue;
+        }
+        // Locate the closer token's byte span within the (possibly
+        // whitespace-padded) child range, so the diagnostic range falls on
+        // the closer character itself.
+        let leading_ws = child_raw.len() - child_raw.trim_start().len();
+        let closer_start_byte = child.start_byte() + leading_ws;
+        let closer_end_byte = closer_start_byte + child_text.len();
+        let row = text[..closer_start_byte].bytes().filter(|&b| b == b'\n').count() as u32;
+        let line = text.lines().nth(row as usize).unwrap_or("");
+        let line_start = line_start_byte(text, row as usize);
+        let start_col = byte_offset_to_utf16_column(line, closer_start_byte - line_start);
+        let end_col = byte_offset_to_utf16_column(line, closer_end_byte - line_start);
+        return Some(ClassifiedSyntaxDiagnostic {
+            message: format!(
                 "Mismatched brackets: `{opener}` opened here; \
                  close with `{expected_closer}` not `{child_text}`."
-            ));
-        }
+            ),
+            range: Range {
+                start: Position::new(row, start_col),
+                end: Position::new(row, end_col),
+            },
+        });
     }
     None
 }
@@ -9549,6 +9597,67 @@ mod syntax_error_range_tests {
             .expect("expected Unclosed ( diagnostic");
         assert_eq!(target.range.start.character, 1);
         assert_eq!(target.range.end.character, 2);
+    }
+
+    // Regression: a leaf ERROR whose text spans multiple lines (e.g.
+    // tree-sitter wrapping `}\n}` into a single leaf) must emit each
+    // closer event on its actual row, not the leaf's starting row. With
+    // the wrong row, `classify_via_delimiter_scan` mis-anchors the
+    // downstream diagnostic (wrong line, zero-width column).
+    #[test]
+    fn multiline_closer_run_anchors_on_each_row() {
+        // `x <- 1\n}\n}` — two stray `}` on lines 1 and 2.
+        let diags = collect("x <- 1\n}\n}");
+        let close_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("Missing opening `{`"))
+            .collect();
+        assert_eq!(close_diags.len(), 2, "got: {diags:?}");
+        assert_eq!(close_diags[0].range.start.line, 1);
+        assert_eq!(close_diags[0].range.start.character, 0);
+        assert_eq!(close_diags[0].range.end.character, 1);
+        assert_eq!(close_diags[1].range.start.line, 2);
+        assert_eq!(close_diags[1].range.start.character, 0);
+        assert_eq!(close_diags[1].range.end.character, 1);
+    }
+
+    // Regression: leaves that aren't pure-closer runs must not produce
+    // bracket diagnostics. Unparseable special operators (`%]%`, `%(%`,
+    // etc.) parse as a single ERROR leaf whose text contains `%`;
+    // byte-scanning such a leaf used to emit spurious `Missing opening …`
+    // / `Unclosed …` events. The fix in `extract_from_leaf` guards the
+    // byte-scan with an "every byte is `}`/`)`/`]` or ASCII whitespace"
+    // precondition, so these leaves now fall back to the generic
+    // "Syntax error".
+    #[test]
+    fn special_operator_with_bracket_chars_no_spurious_bracket_diag() {
+        for code in &["x <- %]%", "x <- %}%", "x <- %(%", "x <- %[[%"] {
+            let diags = collect(code);
+            for d in &diags {
+                let m = &d.message;
+                assert!(
+                    !m.contains("Missing opening") && !m.contains("Unclosed"),
+                    "code {code:?} should not produce a bracket diagnostic; got: {m:?}"
+                );
+            }
+        }
+    }
+
+    // Regression: the `c(1, 2]` mismatched-bracket path used to return
+    // the whole minimized ERROR range. Per the design (anchor on the
+    // offending delimiter), the range must be the wrong closer's span.
+    #[test]
+    fn mismatched_bracket_range_anchors_on_wrong_closer() {
+        let code = "c(1, 2]";
+        let diags = collect(code);
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Mismatched brackets"))
+            .expect("expected Mismatched diagnostic");
+        // `]` is at byte 6, column 6 in UTF-16.
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 6);
+        assert_eq!(target.range.end.character, 7);
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6418,10 +6418,10 @@ fn has_unclosed_quote_child(node: Node) -> bool {
     false
 }
 
-/// One classified syntax-error diagnostic produced by `classify_error`.
-/// Kept separate from `tower_lsp::lsp_types::Diagnostic` so that the
-/// classifier doesn't need to fill in `source` / `severity` / etc. — the
-/// caller (`collect_syntax_errors_inner`) does that.
+/// One classified syntax-error diagnostic. After the bracket-diagnostics
+/// refactor (see `docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md`),
+/// `classify_error` will return this type instead of a bare `String` so the
+/// caller can attach `source`, `severity`, etc. without re-parsing the message.
 #[derive(Debug, Clone)]
 struct ClassifiedSyntaxDiagnostic {
     message: String,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6028,7 +6028,7 @@ fn anchor_missing_position(
 /// Returns None when:
 /// - `missing.kind()` is not `)`, `}`, `]`, or `]]`
 /// - the parent's kind is not one of the three structural kinds above
-fn find_opener_for_missing<'a>(missing: Node<'a>, text: &'a str) -> Option<(Node<'a>, Range)> {
+fn find_opener_for_missing<'a>(missing: Node<'a>, text: &str) -> Option<(Node<'a>, Range)> {
     use crate::cross_file::types::byte_offset_to_utf16_column;
 
     if !matches!(missing.kind(), ")" | "}" | "]" | "]]") {
@@ -8587,7 +8587,7 @@ mod syntax_error_range_tests {
     // find_opener_for_missing
     // ------------------------------------------------------------------
 
-    fn first_missing(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node> {
+    fn first_missing(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node<'_>> {
         fn walk<'a>(n: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
             if n.is_missing() { return Some(n); }
             let mut c = n.walk();

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -817,7 +817,7 @@ fn encode_semantic_tokens(mut absolute_tokens: Vec<AbsoluteSemanticToken>) -> Ve
 
 /// Delimiter character types used in banner-style section detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DelimiterKind {
+enum BannerDelimKind {
     Hash,
     Dash,
     Equals,
@@ -839,7 +839,7 @@ enum ModelCommentStyle {
 /// - `# ================` (leading `#` + space + 4+ of one delimiter)
 ///
 /// Returns `Some(kind)` if the line is a delimiter line, `None` otherwise.
-fn classify_delimiter_line(line: &str) -> Option<DelimiterKind> {
+fn classify_delimiter_line(line: &str) -> Option<BannerDelimKind> {
     let trimmed = line.trim();
     let after_first_hash = trimmed.strip_prefix('#')?;
 
@@ -848,7 +848,7 @@ fn classify_delimiter_line(line: &str) -> Option<DelimiterKind> {
         && after_first_hash.chars().all(|c| c == '#')
         && trimmed.len() >= 4
     {
-        return Some(DelimiterKind::Hash);
+        return Some(BannerDelimKind::Hash);
     }
 
     // Case 2: "# <delimiters>" — leading # then space then 4+ of one delimiter
@@ -864,11 +864,11 @@ fn classify_delimiter_line(line: &str) -> Option<DelimiterKind> {
 
     let first_char = content.chars().next()?;
     let kind = match first_char {
-        '-' => DelimiterKind::Dash,
-        '=' => DelimiterKind::Equals,
-        '*' => DelimiterKind::Asterisk,
-        '+' => DelimiterKind::Plus,
-        '#' => DelimiterKind::Hash,
+        '-' => BannerDelimKind::Dash,
+        '=' => BannerDelimKind::Equals,
+        '*' => BannerDelimKind::Asterisk,
+        '+' => BannerDelimKind::Plus,
+        '#' => BannerDelimKind::Hash,
         _ => return None,
     };
 
@@ -920,7 +920,7 @@ fn strip_model_comment_prefix(line: &str, style: ModelCommentStyle) -> Option<&s
     }
 }
 
-fn classify_model_delimiter_line(line: &str, style: ModelCommentStyle) -> Option<DelimiterKind> {
+fn classify_model_delimiter_line(line: &str, style: ModelCommentStyle) -> Option<BannerDelimKind> {
     let content = strip_model_comment_prefix(line, style)?.trim();
     if content.len() < 4 {
         return None;
@@ -928,11 +928,11 @@ fn classify_model_delimiter_line(line: &str, style: ModelCommentStyle) -> Option
 
     let first_char = content.chars().next()?;
     let kind = match first_char {
-        '#' => DelimiterKind::Hash,
-        '-' => DelimiterKind::Dash,
-        '=' => DelimiterKind::Equals,
-        '*' => DelimiterKind::Asterisk,
-        '+' => DelimiterKind::Plus,
+        '#' => BannerDelimKind::Hash,
+        '-' => BannerDelimKind::Dash,
+        '=' => BannerDelimKind::Equals,
+        '*' => BannerDelimKind::Asterisk,
+        '+' => BannerDelimKind::Plus,
         _ => return None,
     };
 
@@ -6506,6 +6506,59 @@ fn has_unclosed_quote_child(node: Node) -> bool {
     false
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DelimiterKind {
+    Paren,         // ( )
+    Brace,         // { }
+    Bracket,       // [ ]
+    DoubleBracket, // [[ ]]
+}
+
+impl DelimiterKind {
+    fn opener_str(self) -> &'static str {
+        match self {
+            DelimiterKind::Paren => "(",
+            DelimiterKind::Brace => "{",
+            DelimiterKind::Bracket => "[",
+            DelimiterKind::DoubleBracket => "[[",
+        }
+    }
+    fn closer_str(self) -> &'static str {
+        match self {
+            DelimiterKind::Paren => ")",
+            DelimiterKind::Brace => "}",
+            DelimiterKind::Bracket => "]",
+            DelimiterKind::DoubleBracket => "]]",
+        }
+    }
+    fn from_opener(s: &str) -> Option<Self> {
+        match s {
+            "(" => Some(Self::Paren),
+            "{" => Some(Self::Brace),
+            "[" => Some(Self::Bracket),
+            "[[" => Some(Self::DoubleBracket),
+            _ => None,
+        }
+    }
+    fn from_closer(s: &str) -> Option<Self> {
+        match s {
+            ")" => Some(Self::Paren),
+            "}" => Some(Self::Brace),
+            "]" => Some(Self::Bracket),
+            "]]" => Some(Self::DoubleBracket),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DelimEvent {
+    is_open: bool,
+    kind: DelimiterKind,
+    range_bytes: std::ops::Range<usize>,
+    row: u32,
+}
+
 /// One classified syntax-error diagnostic produced by [`classify_error`].
 /// The caller in [`collect_syntax_errors_inner`] attaches `severity` and
 /// `source` when constructing the final [`Diagnostic`].
@@ -6539,6 +6592,150 @@ struct CollectState {
     /// `Mismatched brackets` diagnostic. The MISSING-anchoring branch
     /// skips emitting `Unclosed X` for any opener whose id appears here.
     covered_openers: std::collections::HashSet<usize>,
+}
+
+/// Walk an ERROR node's direct children and produce a flat stream of
+/// delimiter events. See bracket-diagnostics design spec.
+fn delimiter_events(error: Node, text: &str) -> Vec<DelimEvent> {
+    let mut out = Vec::new();
+    walk_for_delimiters(error, text, &mut out, /*allow_recurse_into_error=*/ true);
+    out
+}
+
+fn walk_for_delimiters(
+    node: Node,
+    text: &str,
+    out: &mut Vec<DelimEvent>,
+    allow_recurse_into_error: bool,
+) {
+    // Only the ROOT ERROR is walked with `allow_recurse_into_error=true`;
+    // we recurse one level into nested ERRORs but not into balanced
+    // semantic children.
+    //
+    // Tree-sitter sometimes represents a bare token run (e.g. `}}}`) as a
+    // leaf ERROR node (child_count=0) nested inside the outer ERROR.  When
+    // we arrive here with `allow_recurse_into_error=false` and the node
+    // itself has no children, treat the node as a leaf directly.
+    if node.child_count() == 0 {
+        let raw = text.get(node.start_byte()..node.end_byte()).unwrap_or("");
+        extract_from_leaf(raw, node.start_byte(), node.start_position().row as u32, out);
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.is_error() && allow_recurse_into_error {
+            walk_for_delimiters(child, text, out, false);
+            continue;
+        }
+        if child.is_error() {
+            // Leaf-like ERROR child at the non-recurse level: treat as leaf.
+            if child.child_count() == 0 {
+                let raw = text.get(child.start_byte()..child.end_byte()).unwrap_or("");
+                extract_from_leaf(
+                    raw,
+                    child.start_byte(),
+                    child.start_position().row as u32,
+                    out,
+                );
+            }
+            // Non-leaf inner ERROR at this depth: skip (balanced subtree).
+            continue;
+        }
+        if child.child_count() == 0 {
+            let raw = text.get(child.start_byte()..child.end_byte()).unwrap_or("");
+            extract_from_leaf(
+                raw,
+                child.start_byte(),
+                child.start_position().row as u32,
+                out,
+            );
+            continue;
+        }
+        // Non-leaf, non-error child: skip.
+    }
+}
+
+/// Extract delimiter events from a raw leaf text slice. Implements the
+/// homogeneous-run rule (`}}}` → one event) and the mixed-run rule
+/// (`])` → per-character events with `]]` recognized greedily).
+fn extract_from_leaf(raw: &str, base_byte: usize, row: u32, out: &mut Vec<DelimEvent>) {
+    // Fast path: the leaf is exactly one opener or closer token.
+    if let Some(k) = DelimiterKind::from_opener(raw) {
+        out.push(DelimEvent {
+            is_open: true,
+            kind: k,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+    if let Some(k) = DelimiterKind::from_closer(raw) {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: k,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+
+    // Homogeneous closer runs of `}` or `)` → one event.
+    let all_brace = !raw.is_empty() && raw.chars().all(|c| c == '}');
+    let all_paren = !raw.is_empty() && raw.chars().all(|c| c == ')');
+    if all_brace {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: DelimiterKind::Brace,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+    if all_paren {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: DelimiterKind::Paren,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+
+    // Otherwise: tokenize per-character left-to-right, recognizing `]]`
+    // greedily.
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b']' && i + 1 < bytes.len() && bytes[i + 1] == b']' {
+            out.push(DelimEvent {
+                is_open: false,
+                kind: DelimiterKind::DoubleBracket,
+                range_bytes: base_byte + i..base_byte + i + 2,
+                row,
+            });
+            i += 2;
+            continue;
+        }
+        let one = std::str::from_utf8(&bytes[i..i + 1]).unwrap_or("");
+        if let Some(k) = DelimiterKind::from_opener(one) {
+            out.push(DelimEvent {
+                is_open: true,
+                kind: k,
+                range_bytes: base_byte + i..base_byte + i + 1,
+                row,
+            });
+        } else if let Some(k) = DelimiterKind::from_closer(one) {
+            out.push(DelimEvent {
+                is_open: false,
+                kind: k,
+                range_bytes: base_byte + i..base_byte + i + 1,
+                row,
+            });
+        }
+        i += 1;
+    }
 }
 
 /// Classify an ERROR node into a specific, actionable diagnostic where possible,
@@ -6686,8 +6883,8 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 #[cfg(test)]
 mod syntax_error_range_tests {
     use super::{
-        anchor_missing_position, collect_syntax_errors, end_of_meaningful_content,
-        find_first_content_line, find_innermost_error, find_opener_for_missing,
+        anchor_missing_position, collect_syntax_errors, delimiter_events, end_of_meaningful_content,
+        find_first_content_line, find_innermost_error, find_opener_for_missing, DelimiterKind,
     };
     use tower_lsp::lsp_types::Diagnostic;
 
@@ -8656,6 +8853,106 @@ mod syntax_error_range_tests {
         let missing = first_missing(&tree).unwrap();
         assert!(find_opener_for_missing(missing, code).is_none());
     }
+
+    // ------------------------------------------------------------------
+    // delimiter_events
+    // ------------------------------------------------------------------
+
+    fn find_first_error(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node<'_>> {
+        fn walk<'a>(n: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+            if n.is_error() {
+                return Some(n);
+            }
+            let mut c = n.walk();
+            for child in n.children(&mut c) {
+                if let Some(e) = walk(child) {
+                    return Some(e);
+                }
+            }
+            None
+        }
+        walk(tree.root_node())
+    }
+
+    #[test]
+    fn devents_flat_nested_openers() {
+        // f(g(h(  -> ERROR("(" "g" "(" "h" "(")
+        let code = "f(g(h(\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        assert_eq!(evs.len(), 3, "got: {evs:?}");
+        for ev in &evs {
+            assert!(ev.is_open);
+            assert_eq!(ev.kind, DelimiterKind::Paren);
+        }
+    }
+
+    #[test]
+    fn devents_stray_close_brace() {
+        let code = "x <- 1\n}\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        assert_eq!(evs.len(), 1);
+        assert!(!evs[0].is_open);
+        assert_eq!(evs[0].kind, DelimiterKind::Brace);
+    }
+
+    #[test]
+    fn devents_homogeneous_run() {
+        let code = "}}}\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        assert_eq!(evs.len(), 1);
+        assert!(!evs[0].is_open);
+        assert_eq!(evs[0].kind, DelimiterKind::Brace);
+        assert_eq!(evs[0].range_bytes, 0..3);
+    }
+
+    #[test]
+    fn devents_mixed_closer_run() {
+        let code = "f(])";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        let open_count = evs.iter().filter(|e| e.is_open).count();
+        let close_count = evs.iter().filter(|e| !e.is_open).count();
+        assert!(open_count >= 1, "expected ≥1 open event, got: {evs:?}");
+        assert!(close_count >= 2, "expected ≥2 close events, got: {evs:?}");
+        let mut closes = evs.iter().filter(|e| !e.is_open);
+        let first = closes.next().unwrap();
+        let second = closes.next().unwrap();
+        assert_eq!(first.kind, DelimiterKind::Bracket);
+        assert_eq!(second.kind, DelimiterKind::Paren);
+    }
+
+    #[test]
+    fn devents_double_bracket_run() {
+        let code = "]]]]\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        let closes: Vec<_> = evs.iter().filter(|e| !e.is_open).collect();
+        assert_eq!(closes.len(), 2, "got: {evs:?}");
+        for c in closes {
+            assert_eq!(c.kind, DelimiterKind::DoubleBracket);
+        }
+    }
+
+    #[test]
+    fn devents_triple_bracket_pairs_then_single() {
+        // `]]]` greedy left-to-right -> one `]]` event + one `]` event
+        let code = "]]]\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        let closes: Vec<_> = evs.iter().filter(|e| !e.is_open).collect();
+        assert_eq!(closes.len(), 2, "got: {evs:?}");
+        assert_eq!(closes[0].kind, DelimiterKind::DoubleBracket);
+        assert_eq!(closes[1].kind, DelimiterKind::Bracket);
+    }
 }
 
 #[cfg(test)]
@@ -9086,6 +9383,7 @@ mod invalid_assignment_target_tests {
         assert_eq!(diags[0].range.start.character, 7);
         assert_eq!(diags[0].range.end.character, 11);
     }
+
 }
 
 /// Regression guard: semantic-warning rules must fire through `diagnostics_from_snapshot`
@@ -20612,13 +20910,13 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_all_hashes() {
         assert_eq!(
             classify_delimiter_line("################"),
-            Some(DelimiterKind::Hash)
+            Some(BannerDelimKind::Hash)
         );
     }
 
     #[test]
     fn test_classify_delimiter_line_min_hashes() {
-        assert_eq!(classify_delimiter_line("####"), Some(DelimiterKind::Hash));
+        assert_eq!(classify_delimiter_line("####"), Some(BannerDelimKind::Hash));
     }
 
     #[test]
@@ -20630,7 +20928,7 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_equals() {
         assert_eq!(
             classify_delimiter_line("# ================"),
-            Some(DelimiterKind::Equals)
+            Some(BannerDelimKind::Equals)
         );
     }
 
@@ -20638,7 +20936,7 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_dashes() {
         assert_eq!(
             classify_delimiter_line("# ----------------"),
-            Some(DelimiterKind::Dash)
+            Some(BannerDelimKind::Dash)
         );
     }
 
@@ -20646,7 +20944,7 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_asterisks() {
         assert_eq!(
             classify_delimiter_line("# ****************"),
-            Some(DelimiterKind::Asterisk)
+            Some(BannerDelimKind::Asterisk)
         );
     }
 
@@ -20654,7 +20952,7 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_plus() {
         assert_eq!(
             classify_delimiter_line("# ++++++++++++++++"),
-            Some(DelimiterKind::Plus)
+            Some(BannerDelimKind::Plus)
         );
     }
 
@@ -20662,7 +20960,7 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_hash_after_hash_space() {
         assert_eq!(
             classify_delimiter_line("# ################"),
-            Some(DelimiterKind::Hash)
+            Some(BannerDelimKind::Hash)
         );
     }
 
@@ -20695,11 +20993,11 @@ result <- data %>% filter(x > 0)
     fn test_classify_delimiter_line_leading_whitespace() {
         assert_eq!(
             classify_delimiter_line("  ################"),
-            Some(DelimiterKind::Hash)
+            Some(BannerDelimKind::Hash)
         );
         assert_eq!(
             classify_delimiter_line("  # ================"),
-            Some(DelimiterKind::Equals)
+            Some(BannerDelimKind::Equals)
         );
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6007,8 +6007,10 @@ fn anchor_missing_position(
         let prev_line = &text[prev_line_start..prev_line_end];
         r -= 1;
         if is_code_line(prev_line) {
-            let trimmed_len = prev_line.trim_end().len();
-            return (r as u32, byte_offset_to_utf16_column(prev_line, trimmed_len));
+            // Use the same comment-aware trim as opener-line ranges so a
+            // trailing inline comment (e.g. `f( # tail`) doesn't push the
+            // anchor column past the last meaningful byte.
+            return (r as u32, end_of_meaningful_content(prev_line));
         }
         cur_start = prev_line_start;
     }
@@ -7423,6 +7425,17 @@ mod syntax_error_range_tests {
         // MISSING positioned at the end of "# eof" on row 2.
         let (row, col) = anchor_missing_position(2, 5, 0, 12, text);
         assert_eq!((row, col), (0, 3));
+    }
+
+    #[test]
+    fn anchor_missing_strips_inline_comment_on_prev_line() {
+        // The walk-back lands on `f( # tail`; the anchor must skip past the
+        // inline comment (and its leading whitespace) to the last meaningful
+        // byte — col 2, just after the `(` — not the end of "# tail".
+        let text = "f( # tail\n\n# more\n";
+        // MISSING positioned at end of "# more" on row 2 (raw_byte = 17).
+        let (row, col) = anchor_missing_position(2, 6, 0, 17, text);
+        assert_eq!((row, col), (0, 2));
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -9642,6 +9642,44 @@ mod syntax_error_range_tests {
         assert_eq!(target.range.end.character, 8);
     }
 
+    #[test]
+    fn nested_flat_unclosed_emits_per_opener_via_collect() {
+        // f(g(h(  -> three Unclosed `(` diagnostics with non-overlapping
+        // ranges via the public collect() path (not run_scan). Verifies
+        // the ErrorClassification::Multi dispatch in collect_syntax_errors_inner.
+        let diags = collect("f(g(h(\n");
+        let unclosed: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("Unclosed `(`"))
+            .collect();
+        assert_eq!(unclosed.len(), 3, "expected 3 Unclosed ( diagnostics, got: {diags:?}");
+        let mut sorted = unclosed.clone();
+        sorted.sort_by_key(|d| d.range.start.character);
+        // Non-overlapping per spec: cols 1..3, 3..5, 5..6
+        assert_eq!(sorted[0].range.start.character, 1);
+        assert_eq!(sorted[0].range.end.character, 3);
+        assert_eq!(sorted[1].range.start.character, 3);
+        assert_eq!(sorted[1].range.end.character, 5);
+        assert_eq!(sorted[2].range.start.character, 5);
+        assert_eq!(sorted[2].range.end.character, 6);
+    }
+
+    #[test]
+    fn stray_closer_after_valid_expr_via_collect() {
+        // f() }  -> exactly one Missing opening `{` diagnostic on the `}`,
+        // none on the complete `f()` call.
+        let diags = collect("f() }\n");
+        let stray: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("Missing opening `{`"))
+            .collect();
+        assert_eq!(stray.len(), 1, "expected exactly one Missing opening `{{` diagnostic, got: {diags:?}");
+        // The `}` is on line 0 at col 4
+        assert_eq!(stray[0].range.start.line, 0);
+        assert_eq!(stray[0].range.start.character, 4);
+        assert_eq!(stray[0].range.end.character, 5);
+    }
+
 }
 
 #[cfg(test)]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6809,8 +6809,9 @@ fn classify_via_delimiter_scan(
 
     // For mismatched-bracket coalescing we need the opener's tree-sitter
     // Node id. Map an opener event's start byte back to a Node by scanning
-    // the error subtree (one level into nested ERRORs, matching how
-    // delimiter_events extracted the leaf).
+    // the error subtree, recursing up to two levels deep into nested
+    // ERROR children (matches the two-level wrapping pattern tree-sitter
+    // uses for closer-runs like `}}}` — see Task 5 probe finding).
     fn find_node_by_byte<'a>(
         root: Node<'a>,
         target: usize,
@@ -6894,6 +6895,9 @@ fn classify_via_delimiter_scan(
                         ),
                     },
                 });
+                // Task 7 reads `covered_openers` from the MISSING-handling branch of
+                // `collect_syntax_errors_inner` to suppress the duplicate `Unclosed X`
+                // diagnostic that would otherwise fire for the same opener.
                 if opener_node_id != 0 {
                     state.covered_openers.insert(opener_node_id);
                 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6353,14 +6353,46 @@ fn minimize_error_range(node: Node, text: &str) -> Range {
 }
 
 fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnostic>) {
+    let mut state = CollectState::default();
+    collect_syntax_errors_inner(node, text, diagnostics, &mut state);
+}
+
+fn collect_syntax_errors_inner(
+    node: Node,
+    text: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+    state: &mut CollectState,
+) {
     if node.is_error() {
-        let message = classify_error(node, text);
-        diagnostics.push(Diagnostic {
-            range: minimize_error_range(node, text),
-            severity: Some(DiagnosticSeverity::ERROR),
-            message,
-            ..Default::default()
-        });
+        match classify_error(node, text, state) {
+            ErrorClassification::Whole(diag) => {
+                diagnostics.push(Diagnostic {
+                    range: diag.range,
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    message: diag.message,
+                    ..Default::default()
+                });
+            }
+            ErrorClassification::Multi(diags) if diags.is_empty() => {
+                // Fallback: generic "Syntax error" at the minimized range.
+                diagnostics.push(Diagnostic {
+                    range: minimize_error_range(node, text),
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    message: "Syntax error".to_string(),
+                    ..Default::default()
+                });
+            }
+            ErrorClassification::Multi(diags) => {
+                for diag in diags {
+                    diagnostics.push(Diagnostic {
+                        range: diag.range,
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        message: diag.message,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
         // Don't recurse into ERROR children — the minimized range already
         // accounts for nested MISSING nodes, and recursing would produce
         // duplicate diagnostics for nested ERROR children.
@@ -6393,7 +6425,7 @@ fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnosti
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_syntax_errors(child, text, diagnostics);
+        collect_syntax_errors_inner(child, text, diagnostics, state);
     }
 }
 
@@ -6454,8 +6486,9 @@ struct CollectState {
     covered_openers: std::collections::HashSet<usize>,
 }
 
-/// Classify an ERROR node into a specific, actionable message where possible,
-/// falling back to the generic "Syntax error" for unrecognised patterns.
+/// Classify an ERROR node into a specific, actionable diagnostic where possible,
+/// falling back to `ErrorClassification::Multi(vec![])` (the sentinel for
+/// "no classifier matched — caller emits a single generic 'Syntax error'").
 ///
 /// Checks (in priority order):
 /// 1. Unclosed string literal — lone `"` / `'` as a direct child.
@@ -6464,20 +6497,32 @@ struct CollectState {
 ///    non-matching bracket (detected through a nested ERROR child).
 /// 4. Fat-arrow typo — a lone `>` immediately following an `=` token, which
 ///    arises from writing `=>` (no such operator in R).
-fn classify_error(node: Node, text: &str) -> String {
+///
+/// Returns `ErrorClassification::Whole` when a single classifier matched, or
+/// `ErrorClassification::Multi(vec![])` when none matched. Future work (Task 5)
+/// will return non-empty `Multi` for delimiter-scan results.
+fn classify_error(node: Node, text: &str, _state: &mut CollectState) -> ErrorClassification {
+    let range = minimize_error_range(node, text);
+
     if has_unclosed_quote_child(node) {
-        return "Unclosed string literal".to_string();
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic {
+            message: "Unclosed string literal".to_string(),
+            range,
+        });
     }
     if let Some(msg) = detect_consecutive_pipe(node, text) {
-        return msg;
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
     if let Some(msg) = detect_mismatched_bracket(node, text) {
-        return msg;
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
     if let Some(msg) = detect_fat_arrow(node, text) {
-        return msg;
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
-    "Syntax error".to_string()
+    // No classifier matched. Caller falls back to a single generic
+    // "Syntax error" at the minimized range. Returning Multi(vec![]) is
+    // the sentinel for "delimiter scan / fallback".
+    ErrorClassification::Multi(Vec::new())
 }
 
 /// Returns a diagnostic message if `node` is an ERROR whose only non-trivial

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6450,10 +6450,9 @@ fn has_unclosed_quote_child(node: Node) -> bool {
     false
 }
 
-/// One classified syntax-error diagnostic. After the bracket-diagnostics
-/// refactor (see `docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md`),
-/// `classify_error` will return this type instead of a bare `String` so the
-/// caller can attach `source`, `severity`, etc. without re-parsing the message.
+/// One classified syntax-error diagnostic produced by [`classify_error`].
+/// The caller in [`collect_syntax_errors_inner`] attaches `severity` and
+/// `source` when constructing the final [`Diagnostic`].
 #[derive(Debug, Clone)]
 struct ClassifiedSyntaxDiagnostic {
     message: String,
@@ -6501,6 +6500,9 @@ struct CollectState {
 /// Returns `ErrorClassification::Whole` when a single classifier matched, or
 /// `ErrorClassification::Multi(vec![])` when none matched. Future work (Task 5)
 /// will return non-empty `Multi` for delimiter-scan results.
+///
+/// `_state` is reserved for the delimiter-scan and mismatched-bracket coalescing
+/// tasks; rename to `state` and pass it through when those tasks land.
 fn classify_error(node: Node, text: &str, _state: &mut CollectState) -> ErrorClassification {
     let range = minimize_error_range(node, text);
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5895,46 +5895,65 @@ fn collect_identifier_usages_utf16<'a>(
 /// comment-only), walk back within `lower_bound..=raw_row` to the last line
 /// with non-comment, non-whitespace content and anchor at end-of-line there so
 /// the diagnostic squiggle lands on the offending expression. See issue #286.
+///
+/// `raw_byte` is the global byte offset of `(raw_row, raw_col)` — i.e.
+/// `node.start_byte()` from the caller. Tree-sitter reports `column` as bytes
+/// within the line, so `raw_byte - raw_col` is the byte offset where line
+/// `raw_row` begins. That lets us locate the starting line in O(1) and walk
+/// backward via `rfind('\n')`, touching only the bytes of lines we actually
+/// visit — far better than re-scanning the prefix of `text` for every call,
+/// which would be linear in file size even when the offending code line is
+/// just a few rows above the MISSING.
 fn anchor_missing_position(
     raw_row: usize,
     raw_col: usize,
     lower_bound: usize,
+    raw_byte: usize,
     text: &str,
 ) -> (u32, u32) {
     use crate::cross_file::types::byte_offset_to_utf16_column;
 
-    // Materialize lines `0..=raw_row` up front. Calling `text.lines().nth(row)`
-    // per iteration of the backwards walk is O(row) each, making the scan
-    // O(N²) on large files with long runs of blank/comment-only lines before
-    // a top-level MISSING token (see lower_bound=0 caller).
-    let lines: Vec<&str> = text.lines().take(raw_row.saturating_add(1)).collect();
-    let line_at = |row: usize| -> &str { lines.get(row).copied().unwrap_or("") };
     let is_code_line = |s: &str| {
         let t = s.trim_start();
         !t.is_empty() && !t.starts_with('#')
     };
 
-    if is_code_line(line_at(raw_row)) {
+    let raw_line_start = raw_byte.saturating_sub(raw_col).min(text.len());
+    let raw_line_end = text[raw_line_start..]
+        .find('\n')
+        .map(|i| raw_line_start + i)
+        .unwrap_or(text.len());
+    let raw_line = &text[raw_line_start..raw_line_end];
+
+    if is_code_line(raw_line) {
         return (
             raw_row as u32,
-            byte_offset_to_utf16_column(line_at(raw_row), raw_col),
+            byte_offset_to_utf16_column(raw_line, raw_col),
         );
     }
 
     let lower = lower_bound.min(raw_row);
     let mut r = raw_row;
-    while r > lower {
+    let mut cur_start = raw_line_start;
+    while r > lower && cur_start > 0 {
+        // Byte `cur_start - 1` is the `\n` terminating the previous line.
+        let prev_line_end = cur_start - 1;
+        let prev_line_start = text[..prev_line_end]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let prev_line = &text[prev_line_start..prev_line_end];
         r -= 1;
-        if is_code_line(line_at(r)) {
-            let line = line_at(r);
-            let trimmed_len = line.trim_end().len();
-            return (r as u32, byte_offset_to_utf16_column(line, trimmed_len));
+        if is_code_line(prev_line) {
+            let trimmed_len = prev_line.trim_end().len();
+            return (r as u32, byte_offset_to_utf16_column(prev_line, trimmed_len));
         }
+        cur_start = prev_line_start;
     }
 
     (
         raw_row as u32,
-        byte_offset_to_utf16_column(line_at(raw_row), raw_col),
+        byte_offset_to_utf16_column(raw_line, raw_col),
     )
 }
 
@@ -6158,6 +6177,7 @@ fn minimize_error_range(node: Node, text: &str) -> Range {
             missing.start_position().row,
             missing.start_position().column,
             node.start_position().row,
+            missing.start_byte(),
             text,
         );
         return Range {
@@ -6290,6 +6310,7 @@ fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnosti
             node.start_position().row,
             node.start_position().column,
             0,
+            node.start_byte(),
             text,
         );
         let message = if is_string_quote_kind(node.kind()) {

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5918,7 +5918,7 @@ fn anchor_missing_position(
         !t.is_empty() && !t.starts_with('#')
     };
 
-    let raw_line_start = raw_byte.saturating_sub(raw_col).min(text.len());
+    let raw_line_start = raw_byte.saturating_sub(raw_col);
     let raw_line_end = text[raw_line_start..]
         .find('\n')
         .map(|i| raw_line_start + i)
@@ -6484,7 +6484,10 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 
 #[cfg(test)]
 mod syntax_error_range_tests {
-    use super::{collect_syntax_errors, find_first_content_line, find_innermost_error};
+    use super::{
+        anchor_missing_position, collect_syntax_errors, find_first_content_line,
+        find_innermost_error,
+    };
     use tower_lsp::lsp_types::Diagnostic;
 
     fn parse_r(code: &str) -> tree_sitter::Tree {
@@ -6662,6 +6665,58 @@ mod syntax_error_range_tests {
             missing_close.range.end.line,
             missing_close.range.end.character,
         );
+    }
+
+    #[test]
+    fn anchor_missing_walks_back_past_blank_lines() {
+        // The MISSING node is reported on a trailing comment line; the walk
+        // should skip the comment and the two blank lines above it to land on
+        // the code line containing the unclosed expression.
+        let text = "x <-\n\n\n# more";
+        let (row, col) = anchor_missing_position(3, 6, 0, text.len(), text);
+        assert_eq!((row, col), (0, 4));
+    }
+
+    #[test]
+    fn anchor_missing_no_walk_when_raw_row_is_code() {
+        // When the MISSING's own row already has code, the fast path returns
+        // immediately without inspecting prior lines.
+        let text = "x <- mean(c(1, 2, 3";
+        let (row, col) = anchor_missing_position(0, 19, 0, 19, text);
+        assert_eq!((row, col), (0, 19));
+    }
+
+    #[test]
+    fn anchor_missing_lower_bound_clamps_walk() {
+        // With lower_bound = 2, the walk may not reach the code on row 0.
+        // The function falls back to the raw position rather than crossing the
+        // bound — this protects nested ERROR contexts from anchoring on code
+        // that's outside the enclosing node's span.
+        let text = "code()\n\n\n# bad";
+        let (row, col) = anchor_missing_position(3, 5, 2, text.len(), text);
+        assert_eq!((row, col), (3, 5));
+    }
+
+    #[test]
+    fn anchor_missing_handles_multibyte_utf8() {
+        // The `é` on row 0 is two bytes but one UTF-16 code unit. The byte
+        // arithmetic (`raw_byte - raw_col`) must land on a valid char boundary,
+        // and the returned column must be a UTF-16 offset, not a byte offset.
+        let text = "café <- 1\n\n\n# trailing";
+        let (row, col) = anchor_missing_position(3, 10, 0, text.len(), text);
+        // "café <- 1" has 10 bytes but 9 UTF-16 code units.
+        assert_eq!((row, col), (0, 9));
+    }
+
+    #[test]
+    fn anchor_missing_handles_crlf_line_endings() {
+        // Slicing on `\n` keeps a trailing `\r` in each line, but `trim_end`
+        // strips it before we measure the column, so the returned offset
+        // matches what `text.lines()` would have produced.
+        let text = "x()\r\n\r\n# eof\r\n";
+        // MISSING positioned at the end of "# eof" on row 2.
+        let (row, col) = anchor_missing_position(2, 5, 0, 12, text);
+        assert_eq!((row, col), (0, 3));
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8168,12 +8168,13 @@ mod syntax_error_range_tests {
         None
     }
 
-    /// Collect all MISSING node positions (row, col) in the tree.
-    fn collect_missing_positions(node: Node, out: &mut Vec<(u32, u32)>) {
+    /// Collect all MISSING node positions (row, col, kind) in the tree.
+    fn collect_missing_positions(node: Node, out: &mut Vec<(u32, u32, String)>) {
         if node.is_missing() {
             out.push((
                 node.start_position().row as u32,
                 node.start_position().column as u32,
+                node.kind().to_string(),
             ));
         }
         let mut cursor = node.walk();
@@ -8228,23 +8229,6 @@ mod syntax_error_range_tests {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if let Some(found) = find_error_at(child, row, col) {
-                return Some(found);
-            }
-        }
-        None
-    }
-
-    /// Find a MISSING node at the given (row, col) position via depth-first search.
-    fn find_missing_node_at<'a>(node: Node<'a>, row: u32, col: u32) -> Option<Node<'a>> {
-        if node.is_missing()
-            && node.start_position().row as u32 == row
-            && node.start_position().column as u32 == col
-        {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_missing_node_at(child, row, col) {
                 return Some(found);
             }
         }
@@ -8530,7 +8514,7 @@ mod syntax_error_range_tests {
             let tree = parse_r(&code);
             let root = tree.root_node();
 
-            let mut missing_positions: Vec<(u32, u32)> = Vec::new();
+            let mut missing_positions: Vec<(u32, u32, String)> = Vec::new();
             collect_missing_positions(root, &mut missing_positions);
 
             // Our generator should always produce at least one MISSING node
@@ -8564,13 +8548,10 @@ mod syntax_error_range_tests {
             // this to verify one "Unclosed" per distinct bracket-kind MISSING.
             let has_any_unclosed = diagnostics.iter().any(|d| d.message.starts_with("Unclosed `"));
 
-            for &(m_row, m_col) in &missing_positions {
-                // Find the MISSING node at this position to check its kind.
-                // We use the tree to walk and identify it.
-                let missing_node = find_missing_node_at(root, m_row, m_col);
-                let is_bracket_missing = missing_node
-                    .map(|n| matches!(n.kind(), ")" | "}" | "]" | "]]"))
-                    .unwrap_or(false);
+            for (m_row, m_col, m_kind) in &missing_positions {
+                let m_row = *m_row;
+                let m_col = *m_col;
+                let is_bracket_missing = matches!(m_kind.as_str(), ")" | "}" | "]" | "]]");
 
                 if is_bracket_missing {
                     // Bracket-kind MISSING: diagnostic is at the opener, not the MISSING
@@ -8859,7 +8840,7 @@ mod syntax_error_range_tests {
             let tree = parse_r(&code);
             let root = tree.root_node();
 
-            let mut missing_positions: Vec<(u32, u32)> = Vec::new();
+            let mut missing_positions: Vec<(u32, u32, String)> = Vec::new();
             collect_missing_positions(root, &mut missing_positions);
 
             // Our generator should always produce at least one MISSING node
@@ -8889,11 +8870,10 @@ mod syntax_error_range_tests {
             // are re-anchored to the opener position and emit "Unclosed `X`...".
             // The opener-anchored diagnostic range spans opener..EOL (not 1 column),
             // so we skip the width check for bracket-kind MISSING.
-            for &(m_row, m_col) in &missing_positions {
-                let missing_node = find_missing_node_at(root, m_row, m_col);
-                let is_bracket_missing = missing_node
-                    .map(|n| matches!(n.kind(), ")" | "}" | "]" | "]]"))
-                    .unwrap_or(false);
+            for (m_row, m_col, m_kind) in &missing_positions {
+                let m_row = *m_row;
+                let m_col = *m_col;
+                let is_bracket_missing = matches!(m_kind.as_str(), ")" | "}" | "]" | "]]");
 
                 if is_bracket_missing {
                     // Bracket-kind MISSING diagnostic is at the opener, not the MISSING
@@ -8957,6 +8937,55 @@ mod syntax_error_range_tests {
                     diag.range.end.line,
                     diag.range.end.character,
                     code
+                );
+            }
+        }
+
+        // ============================================================================
+        // Feature: bracket-diagnostics, Property: bracket-kind MISSING anchors on opener
+        //
+        // For each bracket-kind MISSING node, the corresponding diagnostic
+        // is NOT at the MISSING's position; it's anchored on the opener
+        // (an ancestor's first delimiter child) with a range whose start
+        // <= the MISSING's column.
+        //
+        // **Validates: bracket-diagnostics design spec.**
+        // ============================================================================
+
+        #[test]
+        fn prop_bracket_missing_anchors_on_opener(code in missing_node_code()) {
+            let tree = parse_r(&code);
+            let root = tree.root_node();
+
+            let mut missing_positions: Vec<(u32, u32, String)> = Vec::new();
+            collect_missing_positions(root, &mut missing_positions);
+
+            prop_assume!(
+                missing_positions.iter().any(|(_, _, k)| matches!(k.as_str(), ")" | "}" | "]" | "]]")),
+                "Generated code must produce at least one bracket-kind MISSING"
+            );
+
+            let mut diagnostics = Vec::new();
+            collect_syntax_errors(root, &code, &mut diagnostics);
+
+            for (m_row, m_col, m_kind) in &missing_positions {
+                let m_row = *m_row;
+                let m_col = *m_col;
+                if !matches!(m_kind.as_str(), ")" | "}" | "]" | "]]") {
+                    continue;
+                }
+                // Find a diagnostic of the right kind anchored at or before
+                // the MISSING position (on the same or earlier line).
+                let matching = diagnostics.iter().find(|d| {
+                    (d.message.contains("Unclosed")
+                        || d.message.contains("Mismatched brackets"))
+                        && d.range.start.line <= m_row
+                });
+                prop_assert!(
+                    matching.is_some(),
+                    "Expected an 'Unclosed' or 'Mismatched' diagnostic anchored at or before \
+                     the MISSING position ({m_row}, {m_col}) kind {m_kind}, but none found. \
+                     Code: {code:?}, Diagnostics: {diagnostics:?}",
                 );
             }
         }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6019,6 +6019,62 @@ fn anchor_missing_position(
     )
 }
 
+/// Walk up one level from a bracket-kind MISSING node to its structural
+/// parent (`arguments`, `braced_expression`, `parenthesized_expression`)
+/// and return that parent's first delimiter child plus a UTF-16 Range
+/// from the opener's column through `end_of_meaningful_content` of the
+/// opener's line.
+///
+/// Returns None when:
+/// - `missing.kind()` is not `)`, `}`, `]`, or `]]`
+/// - the parent's kind is not one of the three structural kinds above
+fn find_opener_for_missing<'a>(missing: Node<'a>, text: &'a str) -> Option<(Node<'a>, Range)> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    if !matches!(missing.kind(), ")" | "}" | "]" | "]]") {
+        return None;
+    }
+
+    let parent = missing.parent()?;
+    if !matches!(
+        parent.kind(),
+        "arguments" | "braced_expression" | "parenthesized_expression"
+    ) {
+        return None;
+    }
+
+    let mut cursor = parent.walk();
+    let opener = parent
+        .children(&mut cursor)
+        .find(|n| {
+            let t = text.get(n.start_byte()..n.end_byte()).unwrap_or("");
+            matches!(t, "(" | "{" | "[" | "[[")
+        })?;
+
+    let opener_row = opener.start_position().row as u32;
+    let opener_start_byte_col = opener.start_position().column;
+
+    let line = text.lines().nth(opener_row as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line, opener_start_byte_col);
+    let end_col = end_of_meaningful_content(line);
+
+    let end_col = if end_col > start_col {
+        end_col
+    } else {
+        // For multi-char openers like `[[`, span the opener token's width.
+        let opener_end_byte_col = opener.end_position().column;
+        byte_offset_to_utf16_column(line, opener_end_byte_col).max(start_col + 1)
+    };
+
+    Some((
+        opener,
+        Range {
+            start: Position::new(opener_row, start_col),
+            end: Position::new(opener_row, end_col),
+        },
+    ))
+}
+
 /// Find the first MISSING descendant inside a node (depth-first).
 fn find_first_missing_descendant(node: Node) -> Option<Node> {
     // Avoid recursion to prevent stack exhaustion on pathological/malicious trees.
@@ -6631,7 +6687,7 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 mod syntax_error_range_tests {
     use super::{
         anchor_missing_position, collect_syntax_errors, end_of_meaningful_content,
-        find_first_content_line, find_innermost_error,
+        find_first_content_line, find_innermost_error, find_opener_for_missing,
     };
     use tower_lsp::lsp_types::Diagnostic;
 
@@ -8525,6 +8581,80 @@ mod syntax_error_range_tests {
     fn eomc_astral_emoji() {
         // 😀 = 2 UTF-16 code units; "😀 <- 1" — `1` at UTF-16 col 6; just past = 7
         assert_eq!(end_of_meaningful_content("😀 <- 1"), 7);
+    }
+
+    // ------------------------------------------------------------------
+    // find_opener_for_missing
+    // ------------------------------------------------------------------
+
+    fn first_missing(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node> {
+        fn walk<'a>(n: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+            if n.is_missing() { return Some(n); }
+            let mut c = n.walk();
+            for child in n.children(&mut c) {
+                if let Some(m) = walk(child) {
+                    return Some(m);
+                }
+            }
+            None
+        }
+        walk(tree.root_node())
+    }
+
+    #[test]
+    fn fofm_call_arguments_paren() {
+        let code = "library(";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).expect("expected MISSING");
+        let (opener, range) = find_opener_for_missing(missing, code)
+            .expect("should find opener for ( inside arguments");
+        assert_eq!(opener.kind(), "(");
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 7);
+        assert_eq!(range.end.line, 0);
+        assert_eq!(range.end.character, 8);
+    }
+
+    #[test]
+    fn fofm_subset_arguments_bracket() {
+        let code = "vec[1, 2\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "[");
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.character, 8);
+    }
+
+    #[test]
+    fn fofm_subset2_arguments_double_bracket() {
+        let code = "vec[[1, 2\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "[[");
+        assert_eq!(range.start.character, 3);
+        assert_eq!(range.end.character, 9);
+    }
+
+    #[test]
+    fn fofm_braced_expression() {
+        let code = "f <- function() {\n  x <- 1\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "{");
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 16);
+        assert_eq!(range.end.character, 17);
+    }
+
+    #[test]
+    fn fofm_non_bracket_missing_returns_none() {
+        let code = "x <-";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        assert!(find_opener_for_missing(missing, code).is_none());
     }
 }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5885,6 +5885,68 @@ fn collect_identifier_usages_utf16<'a>(
     }
 }
 
+/// Compute the UTF-16 column just past the last non-comment, non-whitespace
+/// character on `line`. Comment detection is string-aware: a `#` inside
+/// `"..."`, `'...'`, or `` `...` `` is not a comment. `\r` is treated as
+/// trailing whitespace.
+///
+/// Used to trim trailing comments and whitespace from the opener-line range
+/// of an `Unclosed X` diagnostic. See bracket-diagnostics design spec.
+fn end_of_meaningful_content(line: &str) -> u32 {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    let mut in_double = false;
+    let mut in_single = false;
+    let mut in_backtick = false;
+    let mut escape = false;
+    let mut comment_byte: Option<usize> = None;
+
+    for (byte_idx, ch) in line.char_indices() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if in_double {
+            match ch {
+                '\\' => escape = true,
+                '"' => in_double = false,
+                _ => {}
+            }
+            continue;
+        }
+        if in_single {
+            match ch {
+                '\\' => escape = true,
+                '\'' => in_single = false,
+                _ => {}
+            }
+            continue;
+        }
+        if in_backtick {
+            if ch == '`' {
+                in_backtick = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_double = true,
+            '\'' => in_single = true,
+            '`' => in_backtick = true,
+            '#' => {
+                comment_byte = Some(byte_idx);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let cutoff_byte = comment_byte.unwrap_or(line.len());
+    let meaningful = &line[..cutoff_byte];
+    let trimmed = meaningful.trim_end_matches(|c: char| c.is_whitespace());
+
+    byte_offset_to_utf16_column(line, trimmed.len())
+}
+
 /// Anchor a MISSING node's reported position back to the offending source line.
 ///
 /// Tree-sitter positions a MISSING node where the parser expected the missing
@@ -6485,8 +6547,8 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 #[cfg(test)]
 mod syntax_error_range_tests {
     use super::{
-        anchor_missing_position, collect_syntax_errors, find_first_content_line,
-        find_innermost_error,
+        anchor_missing_position, collect_syntax_errors, end_of_meaningful_content,
+        find_first_content_line, find_innermost_error,
     };
     use tower_lsp::lsp_types::Diagnostic;
 
@@ -8313,6 +8375,73 @@ mod syntax_error_range_tests {
                 );
             }
         }
+    }
+
+    // ------------------------------------------------------------------
+    // end_of_meaningful_content
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn eomc_plain_content() {
+        assert_eq!(end_of_meaningful_content("f(x, y)"), 7);
+    }
+
+    #[test]
+    fn eomc_trailing_whitespace() {
+        assert_eq!(end_of_meaningful_content("f(   "), 2);
+    }
+
+    #[test]
+    fn eomc_trailing_comment() {
+        assert_eq!(end_of_meaningful_content("f( # comment"), 2);
+    }
+
+    #[test]
+    fn eomc_content_then_comment() {
+        // last meaningful char `)` at col 3; just past = 4
+        assert_eq!(end_of_meaningful_content("f(1) # tail"), 4);
+    }
+
+    #[test]
+    fn eomc_hash_inside_double_quoted_string() {
+        assert_eq!(end_of_meaningful_content("x <- \"a # b\""), 12);
+    }
+
+    #[test]
+    fn eomc_hash_inside_single_quoted_string() {
+        assert_eq!(end_of_meaningful_content("x <- 'a # b'"), 12);
+    }
+
+    #[test]
+    fn eomc_hash_inside_backticks() {
+        assert_eq!(end_of_meaningful_content("x <- `a # b`"), 12);
+    }
+
+    #[test]
+    fn eomc_crlf_carriage_return_trimmed() {
+        assert_eq!(end_of_meaningful_content("f(\r"), 2);
+    }
+
+    #[test]
+    fn eomc_only_comment() {
+        assert_eq!(end_of_meaningful_content("# nothing here"), 0);
+    }
+
+    #[test]
+    fn eomc_empty_line() {
+        assert_eq!(end_of_meaningful_content(""), 0);
+    }
+
+    #[test]
+    fn eomc_non_ascii_identifier() {
+        // line "é <- 1" — last meaningful char `1` at UTF-16 col 5; just past = 6
+        assert_eq!(end_of_meaningful_content("é <- 1"), 6);
+    }
+
+    #[test]
+    fn eomc_astral_emoji() {
+        // 😀 = 2 UTF-16 code units; "😀 <- 1" — `1` at UTF-16 col 6; just past = 7
+        assert_eq!(end_of_meaningful_content("😀 <- 1"), 7);
     }
 }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -9549,6 +9549,70 @@ mod syntax_error_range_tests {
         );
     }
 
+    #[test]
+    fn unclosed_opener_crlf() {
+        // library(\r\n -- opener `(` at col 7, content ends at col 8 (just past `(`)
+        let diags = collect("library(\r\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_no_final_newline() {
+        let diags = collect("library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_with_bom() {
+        // BOM (U+FEFF) = 3 UTF-8 bytes, 1 UTF-16 unit. `library(` follows.
+        // `(` byte col = 3 (BOM) + 7 (library) = 10. UTF-16 col = 1 + 7 = 8.
+        let diags = collect("\u{FEFF}library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 8);
+        assert_eq!(target.range.end.character, 9);
+    }
+
+    #[test]
+    fn unclosed_opener_non_ascii_before() {
+        // `é_func(` -- `é` is 2 UTF-8 bytes, 1 UTF-16 unit at col 0.
+        // `(` at UTF-16 col 6 (é=1 + _func=5 = 6).
+        let diags = collect("é_func(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 6);
+        assert_eq!(target.range.end.character, 7);
+    }
+
+    #[test]
+    fn unclosed_opener_astral_before() {
+        // `😀_func(` -- `😀` is 4 UTF-8 bytes, 2 UTF-16 units (surrogate pair).
+        // `(` at UTF-16 col 7 (😀=2 + _func=5 = 7).
+        let diags = collect("😀_func(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
 }
 
 #[cfg(test)]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6476,6 +6476,12 @@ fn collect_syntax_errors_inner(
                             ),
                             ..Default::default()
                         });
+                    } else {
+                        debug_assert!(
+                            false,
+                            "find_opener_for_missing returned opener text {:?} that DelimiterKind::from_opener does not recognize; this is a precondition violation",
+                            opener_text
+                        );
                     }
                 }
                 return;
@@ -8475,8 +8481,11 @@ mod syntax_error_range_tests {
             // are re-anchored to the opener position and emit "Unclosed `X`...".
             // For those, we verify that at least one "Unclosed" diagnostic exists
             // for the code, rather than checking the raw MISSING position.
+            // NOTE: weak global check — passes if ANY "Unclosed" diagnostic exists,
+            // not one per bracket-kind MISSING node. If `missing_node_code()` is later
+            // extended to produce multiple unclosed brackets per code string, tighten
+            // this to verify one "Unclosed" per distinct bracket-kind MISSING.
             let has_any_unclosed = diagnostics.iter().any(|d| d.message.starts_with("Unclosed `"));
-            let mut all_missing_are_bracket_kind = true;
 
             for &(m_row, m_col) in &missing_positions {
                 // Find the MISSING node at this position to check its kind.
@@ -8503,7 +8512,6 @@ mod syntax_error_range_tests {
                     );
                     continue;
                 }
-                all_missing_are_bracket_kind = false;
 
                 let has_matching_diag = diagnostics.iter().any(|d| {
                     d.range.start.line == m_row && d.range.start.character == m_col
@@ -8529,7 +8537,6 @@ mod syntax_error_range_tests {
                         .collect::<Vec<_>>()
                 );
             }
-            let _ = all_missing_are_bracket_kind; // suppress unused warning
         }
 
         // ============================================================================

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5903,7 +5903,12 @@ fn anchor_missing_position(
 ) -> (u32, u32) {
     use crate::cross_file::types::byte_offset_to_utf16_column;
 
-    let line_at = |row: usize| -> &str { text.lines().nth(row).unwrap_or("") };
+    // Materialize lines `0..=raw_row` up front. Calling `text.lines().nth(row)`
+    // per iteration of the backwards walk is O(row) each, making the scan
+    // O(N²) on large files with long runs of blank/comment-only lines before
+    // a top-level MISSING token (see lower_bound=0 caller).
+    let lines: Vec<&str> = text.lines().take(raw_row.saturating_add(1)).collect();
+    let line_at = |row: usize| -> &str { lines.get(row).copied().unwrap_or("") };
     let is_code_line = |s: &str| {
         let t = s.trim_start();
         !t.is_empty() && !t.starts_with('#')

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6739,8 +6739,7 @@ fn extract_from_leaf(raw: &str, base_byte: usize, row: u32, out: &mut Vec<DelimE
 }
 
 /// Classify an ERROR node into a specific, actionable diagnostic where possible,
-/// falling back to `ErrorClassification::Multi(vec![])` (the sentinel for
-/// "no classifier matched — caller emits a single generic 'Syntax error'").
+/// falling back to the delimiter scan which produces per-fault diagnostics.
 ///
 /// Checks (in priority order):
 /// 1. Unclosed string literal — lone `"` / `'` as a direct child.
@@ -6749,14 +6748,13 @@ fn extract_from_leaf(raw: &str, base_byte: usize, row: u32, out: &mut Vec<DelimE
 ///    non-matching bracket (detected through a nested ERROR child).
 /// 4. Fat-arrow typo — a lone `>` immediately following an `=` token, which
 ///    arises from writing `=>` (no such operator in R).
+/// 5. Delimiter scan — stack-based processing of the event stream; emits
+///    zero or more per-fault diagnostics. An empty result causes the caller
+///    to fall back to a single generic `"Syntax error"`.
 ///
 /// Returns `ErrorClassification::Whole` when a single classifier matched, or
-/// `ErrorClassification::Multi(vec![])` when none matched. Future work (Task 5)
-/// will return non-empty `Multi` for delimiter-scan results.
-///
-/// `_state` is reserved for the delimiter-scan and mismatched-bracket coalescing
-/// tasks; rename to `state` and pass it through when those tasks land.
-fn classify_error(node: Node, text: &str, _state: &mut CollectState) -> ErrorClassification {
+/// `ErrorClassification::Multi` with the scan's results otherwise.
+fn classify_error(node: Node, text: &str, state: &mut CollectState) -> ErrorClassification {
     let range = minimize_error_range(node, text);
 
     if has_unclosed_quote_child(node) {
@@ -6774,10 +6772,199 @@ fn classify_error(node: Node, text: &str, _state: &mut CollectState) -> ErrorCla
     if let Some(msg) = detect_fat_arrow(node, text) {
         return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
-    // No classifier matched. Caller falls back to a single generic
-    // "Syntax error" at the minimized range. Returning Multi(vec![]) is
-    // the sentinel for "delimiter scan / fallback".
-    ErrorClassification::Multi(Vec::new())
+
+    // Delimiter scan: produces zero or more per-fault diagnostics. An
+    // empty Vec falls back to a single "Syntax error" in the caller.
+    let scan = classify_via_delimiter_scan(node, text, state);
+    ErrorClassification::Multi(scan)
+}
+
+/// Process the delimiter event stream from an ERROR node and produce per-fault
+/// diagnostics. Each distinct fault gets its own range and message:
+///
+/// - Stray closer with empty stack → `Missing opening X` at the closer's range.
+/// - Closer matching the stack top → pop silently (balanced pair).
+/// - Closer mismatching the stack top → `Mismatched brackets` at the closer's
+///   range; the opener's id is recorded in `state.covered_openers`.
+/// - Unclosed openers remaining at end → `Unclosed X: missing matching Y`
+///   with non-overlapping ranges derived from the next-opener-on-same-line
+///   tie-breaking rule.
+fn classify_via_delimiter_scan(
+    error: Node,
+    text: &str,
+    state: &mut CollectState,
+) -> Vec<ClassifiedSyntaxDiagnostic> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    struct StackItem {
+        kind: DelimiterKind,
+        row: u32,
+        start_byte: usize,
+        node_id: usize,
+    }
+
+    let events = delimiter_events(error, text);
+    let mut stack: Vec<StackItem> = Vec::new();
+    let mut out: Vec<ClassifiedSyntaxDiagnostic> = Vec::new();
+
+    // For mismatched-bracket coalescing we need the opener's tree-sitter
+    // Node id. Map an opener event's start byte back to a Node by scanning
+    // the error subtree (one level into nested ERRORs, matching how
+    // delimiter_events extracted the leaf).
+    fn find_node_by_byte<'a>(
+        root: Node<'a>,
+        target: usize,
+        depth: usize,
+    ) -> Option<Node<'a>> {
+        if depth > 2 {
+            return None;
+        }
+        let mut c = root.walk();
+        for ch in root.children(&mut c) {
+            if ch.start_byte() == target && ch.child_count() == 0 {
+                return Some(ch);
+            }
+            if ch.is_error() {
+                if let Some(found) = find_node_by_byte(ch, target, depth + 1) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    for ev in &events {
+        if ev.is_open {
+            stack.push(StackItem {
+                kind: ev.kind,
+                row: ev.row,
+                start_byte: ev.range_bytes.start,
+                node_id: find_node_by_byte(error, ev.range_bytes.start, 0)
+                    .map(|n| n.id())
+                    .unwrap_or(0),
+            });
+            continue;
+        }
+        // closer
+        match stack.last() {
+            None => {
+                let line = text.lines().nth(ev.row as usize).unwrap_or("");
+                let line_start = line_start_byte(text, ev.row as usize);
+                let start_col_byte = ev.range_bytes.start - line_start;
+                let end_col_byte = ev.range_bytes.end - line_start;
+                out.push(ClassifiedSyntaxDiagnostic {
+                    message: format!("Missing opening `{}`", ev.kind.opener_str()),
+                    range: Range {
+                        start: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, start_col_byte),
+                        ),
+                        end: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, end_col_byte),
+                        ),
+                    },
+                });
+            }
+            Some(top) if top.kind == ev.kind => {
+                stack.pop();
+            }
+            Some(top) => {
+                let opener_kind = top.kind;
+                let opener_node_id = top.node_id;
+                let line = text.lines().nth(ev.row as usize).unwrap_or("");
+                let line_start = line_start_byte(text, ev.row as usize);
+                let start_col_byte = ev.range_bytes.start - line_start;
+                let end_col_byte = ev.range_bytes.end - line_start;
+                out.push(ClassifiedSyntaxDiagnostic {
+                    message: format!(
+                        "Mismatched brackets: `{}` opened here; close with `{}` not `{}`.",
+                        opener_kind.opener_str(),
+                        opener_kind.closer_str(),
+                        ev.kind.closer_str(),
+                    ),
+                    range: Range {
+                        start: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, start_col_byte),
+                        ),
+                        end: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, end_col_byte),
+                        ),
+                    },
+                });
+                if opener_node_id != 0 {
+                    state.covered_openers.insert(opener_node_id);
+                }
+                stack.pop();
+            }
+        }
+    }
+
+    // Unclosed openers remaining on the stack: emit "Unclosed X" with
+    // the next-opener-on-same-line tie-breaking rule.
+    if !stack.is_empty() {
+        let row_of: Vec<u32> = stack.iter().map(|s| s.row).collect();
+        let start_byte_of: Vec<usize> = stack.iter().map(|s| s.start_byte).collect();
+
+        for (i, item) in stack.iter().enumerate() {
+            let line = text.lines().nth(item.row as usize).unwrap_or("");
+            let line_start = line_start_byte(text, item.row as usize);
+            let start_col_utf16 =
+                byte_offset_to_utf16_column(line, item.start_byte - line_start);
+
+            // Next opener at a later byte on the SAME row
+            let next_on_row = (i + 1..stack.len())
+                .find(|&j| row_of[j] == item.row && start_byte_of[j] > item.start_byte)
+                .map(|j| byte_offset_to_utf16_column(line, start_byte_of[j] - line_start));
+
+            let eomc = end_of_meaningful_content(line);
+            let mut end_col = next_on_row.unwrap_or(eomc).min(eomc);
+            if end_col <= start_col_utf16 {
+                // Collapse to opener-token width
+                let opener_len_utf16 = match item.kind {
+                    DelimiterKind::DoubleBracket => 2,
+                    _ => 1,
+                };
+                end_col = start_col_utf16 + opener_len_utf16;
+            }
+
+            out.push(ClassifiedSyntaxDiagnostic {
+                message: format!(
+                    "Unclosed `{}`: missing matching `{}`",
+                    item.kind.opener_str(),
+                    item.kind.closer_str(),
+                ),
+                range: Range {
+                    start: Position::new(item.row, start_col_utf16),
+                    end: Position::new(item.row, end_col),
+                },
+            });
+        }
+    }
+
+    out
+}
+
+/// Byte offset of the start of line `row` in `text` (0-indexed row).
+fn line_start_byte(text: &str, row: usize) -> usize {
+    let mut start = 0;
+    let mut current_row = 0;
+    for (idx, b) in text.bytes().enumerate() {
+        if current_row == row {
+            return start;
+        }
+        if b == b'\n' {
+            current_row += 1;
+            start = idx + 1;
+        }
+    }
+    if current_row == row {
+        start
+    } else {
+        text.len()
+    }
 }
 
 /// Returns a diagnostic message if `node` is an ERROR whose only non-trivial
@@ -6883,8 +7070,9 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 #[cfg(test)]
 mod syntax_error_range_tests {
     use super::{
-        anchor_missing_position, collect_syntax_errors, delimiter_events, end_of_meaningful_content,
-        find_first_content_line, find_innermost_error, find_opener_for_missing, DelimiterKind,
+        anchor_missing_position, classify_via_delimiter_scan, collect_syntax_errors,
+        delimiter_events, end_of_meaningful_content, find_first_content_line, find_innermost_error,
+        find_opener_for_missing, CollectState, DelimiterKind,
     };
     use tower_lsp::lsp_types::Diagnostic;
 
@@ -8953,6 +9141,97 @@ mod syntax_error_range_tests {
         assert_eq!(closes[0].kind, DelimiterKind::DoubleBracket);
         assert_eq!(closes[1].kind, DelimiterKind::Bracket);
     }
+
+    // ------------------------------------------------------------------
+    // classify_via_delimiter_scan (stack processing)
+    // ------------------------------------------------------------------
+
+    fn run_scan(code: &str) -> Vec<(String, tower_lsp::lsp_types::Range)> {
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).expect("expected ERROR node");
+        let mut state = CollectState::default();
+        classify_via_delimiter_scan(err, code, &mut state)
+            .into_iter()
+            .map(|d| (d.message, d.range))
+            .collect()
+    }
+
+    #[test]
+    fn scan_stray_close_brace() {
+        let diags = run_scan("x <- 1\n}\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `{`"), "got: {}", diags[0].0);
+        assert_eq!(diags[0].1.start.line, 1);
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 1);
+    }
+
+    #[test]
+    fn scan_stray_close_paren() {
+        let diags = run_scan("x <- 1\n)\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `(`"));
+    }
+
+    #[test]
+    fn scan_stray_close_bracket() {
+        let diags = run_scan("x <- 1\n]\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `[`"));
+    }
+
+    #[test]
+    fn scan_stray_double_close_bracket() {
+        let diags = run_scan("x <- 1\n]]\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `[[`"));
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 2);
+    }
+
+    #[test]
+    fn scan_homogeneous_brace_run_single_diagnostic() {
+        let diags = run_scan("}}}\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        assert!(diags[0].0.contains("Missing opening `{`"));
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 3);
+    }
+
+    #[test]
+    fn scan_flat_nested_openers_three_diagnostics() {
+        let diags = run_scan("f(g(h(\n");
+        assert_eq!(diags.len(), 3, "got: {diags:?}");
+        for d in &diags {
+            assert!(d.0.contains("Unclosed `(`"));
+        }
+        let mut sorted = diags.clone();
+        sorted.sort_by_key(|d| d.1.start.character);
+        // Per spec: cols 1..3, 3..5, 5..6 (non-overlapping)
+        assert_eq!(sorted[0].1.start.character, 1);
+        assert_eq!(sorted[0].1.end.character, 3);
+        assert_eq!(sorted[1].1.start.character, 3);
+        assert_eq!(sorted[1].1.end.character, 5);
+        assert_eq!(sorted[2].1.start.character, 5);
+        assert_eq!(sorted[2].1.end.character, 6);
+    }
+
+    #[test]
+    fn scan_flat_error_mismatched_close_coalesces() {
+        // f(}  -> outer ERROR contains "(" and ERROR("}") (or similar)
+        // Inside the delimiter scan, top-of-stack is `(`, incoming closer is `}`
+        // → mismatched-bracket sub-rule fires, one diagnostic.
+        let diags = run_scan("f(}\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        assert!(
+            diags[0].0.contains("Mismatched brackets")
+                && diags[0].0.contains("`(`")
+                && diags[0].0.contains("`}`"),
+            "got: {}",
+            diags[0].0,
+        );
+    }
+
 }
 
 #[cfg(test)]
@@ -43272,7 +43551,10 @@ result <- undefined_var
                 .iter()
                 .any(|d| d.message.to_lowercase().contains("error")
                     || d.message.to_lowercase().contains("syntax")
-                    || d.message.to_lowercase().contains("unexpected")),
+                    || d.message.to_lowercase().contains("unexpected")
+                    || d.message.starts_with("Unclosed")
+                    || d.message.starts_with("Missing opening")
+                    || d.message.starts_with("Missing")),
             "Should contain syntax-related diagnostics, got: {:?}",
             result_enabled
                 .iter()

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6805,6 +6805,9 @@ fn classify_error(node: Node, text: &str, state: &mut CollectState) -> ErrorClas
     if let Some(msg) = detect_mismatched_bracket(node, text) {
         return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
+    if let Some(diag) = detect_mismatched_via_structural_parent(node, text, state) {
+        return ErrorClassification::Whole(diag);
+    }
     if let Some(msg) = detect_fat_arrow(node, text) {
         return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
     }
@@ -7073,6 +7076,80 @@ fn detect_mismatched_bracket(node: Node, text: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Detect `f(} y` / `vec[} y` style typos where the wrong closer is an
+/// ERROR child of `arguments` / `braced_expression` / `parenthesized_expression`
+/// and a MISSING closer of the expected kind sits at the parent's end.
+/// Emits a single `Mismatched brackets` diagnostic anchored on the wrong
+/// closer and records the parent's opener in `state.covered_openers` to
+/// suppress the MISSING follow-up.
+fn detect_mismatched_via_structural_parent(
+    node: Node,
+    text: &str,
+    state: &mut CollectState,
+) -> Option<ClassifiedSyntaxDiagnostic> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    // Only fire on ERROR nodes whose text (trimmed) is a single closer token.
+    let inner_text = text.get(node.start_byte()..node.end_byte())?.trim();
+    let wrong_kind = DelimiterKind::from_closer(inner_text)?;
+
+    // Walk up one level.
+    let parent = node.parent()?;
+    if !matches!(
+        parent.kind(),
+        "arguments" | "braced_expression" | "parenthesized_expression"
+    ) {
+        return None;
+    }
+
+    // Parent's first delimiter child is the opener.
+    let mut cursor = parent.walk();
+    let opener = parent
+        .children(&mut cursor)
+        .find(|n| {
+            let t = text.get(n.start_byte()..n.end_byte()).unwrap_or("");
+            matches!(t, "(" | "{" | "[" | "[[")
+        })?;
+    let opener_text = text.get(opener.start_byte()..opener.end_byte())?;
+    let opener_kind = DelimiterKind::from_opener(opener_text)?;
+
+    if opener_kind == wrong_kind {
+        return None; // not actually a mismatch
+    }
+
+    // Parent must end with a MISSING closer of the expected kind.
+    let mut last_child = None;
+    let mut c2 = parent.walk();
+    for ch in parent.children(&mut c2) {
+        last_child = Some(ch);
+    }
+    let last = last_child?;
+    if !last.is_missing() || last.kind() != opener_kind.closer_str() {
+        return None;
+    }
+
+    state.covered_openers.insert(opener.id());
+
+    let row = node.start_position().row as u32;
+    let line = text.lines().nth(row as usize).unwrap_or("");
+    let line_start = line_start_byte(text, row as usize);
+    let start_col = byte_offset_to_utf16_column(line, node.start_byte() - line_start);
+    let end_col = byte_offset_to_utf16_column(line, node.end_byte() - line_start);
+
+    Some(ClassifiedSyntaxDiagnostic {
+        message: format!(
+            "Mismatched brackets: `{}` opened here; close with `{}` not `{}`.",
+            opener_kind.opener_str(),
+            opener_kind.closer_str(),
+            wrong_kind.closer_str(),
+        ),
+        range: Range {
+            start: Position::new(row, start_col),
+            end: Position::new(row, end_col),
+        },
+    })
 }
 
 /// Returns a diagnostic message if `node` is an ERROR consisting of a lone
@@ -9430,6 +9507,46 @@ mod syntax_error_range_tests {
             .expect("expected Unclosed ( diagnostic");
         assert_eq!(target.range.start.character, 1);
         assert_eq!(target.range.end.character, 2);
+    }
+
+    #[test]
+    fn coalesce_wrong_closer_in_arguments_with_trailing_arg() {
+        // f(} y  -> arguments("(" ERROR("}") argument MISSING ")")
+        let diags = collect("f(} y\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        let d = &diags[0];
+        assert!(
+            d.message.contains("Mismatched brackets")
+                && d.message.contains("`(`")
+                && d.message.contains("`}`"),
+            "got: {}",
+            d.message,
+        );
+    }
+
+    #[test]
+    fn coalesce_wrong_closer_for_subset() {
+        // vec[} y — analog for [
+        let diags = collect("vec[} y\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        let d = &diags[0];
+        assert!(
+            d.message.contains("Mismatched brackets")
+                && d.message.contains("`[`")
+                && d.message.contains("`}`"),
+            "got: {}",
+            d.message,
+        );
+    }
+
+    #[test]
+    fn coalesce_no_double_fire_unclosed_after_mismatch() {
+        // After coalescing, no separate "Unclosed (" follow-up
+        let diags = collect("f(} y\n");
+        assert!(
+            !diags.iter().any(|d| d.message.contains("Unclosed `(`")),
+            "should NOT have a separate 'Unclosed (' diagnostic; got: {diags:?}"
+        );
     }
 
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5885,6 +5885,54 @@ fn collect_identifier_usages_utf16<'a>(
     }
 }
 
+/// Anchor a MISSING node's reported position back to the offending source line.
+///
+/// Tree-sitter positions a MISSING node where the parser expected the missing
+/// token. For an unclosed opener (e.g. `mean(c(1, 2, 3)`) followed by blank
+/// lines and/or a trailing comment, that position can land on whitespace or on
+/// the next non-empty token — visually disconnected from the broken
+/// expression. When the MISSING node's row contains no code (blank or
+/// comment-only), walk back within `lower_bound..=raw_row` to the last line
+/// with non-comment, non-whitespace content and anchor at end-of-line there so
+/// the diagnostic squiggle lands on the offending expression. See issue #286.
+fn anchor_missing_position(
+    raw_row: usize,
+    raw_col: usize,
+    lower_bound: usize,
+    text: &str,
+) -> (u32, u32) {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    let line_at = |row: usize| -> &str { text.lines().nth(row).unwrap_or("") };
+    let is_code_line = |s: &str| {
+        let t = s.trim_start();
+        !t.is_empty() && !t.starts_with('#')
+    };
+
+    if is_code_line(line_at(raw_row)) {
+        return (
+            raw_row as u32,
+            byte_offset_to_utf16_column(line_at(raw_row), raw_col),
+        );
+    }
+
+    let lower = lower_bound.min(raw_row);
+    let mut r = raw_row;
+    while r > lower {
+        r -= 1;
+        if is_code_line(line_at(r)) {
+            let line = line_at(r);
+            let trimmed_len = line.trim_end().len();
+            return (r as u32, byte_offset_to_utf16_column(line, trimmed_len));
+        }
+    }
+
+    (
+        raw_row as u32,
+        byte_offset_to_utf16_column(line_at(raw_row), raw_col),
+    )
+}
+
 /// Find the first MISSING descendant inside a node (depth-first).
 fn find_first_missing_descendant(node: Node) -> Option<Node> {
     // Avoid recursion to prevent stack exhaustion on pathological/malicious trees.
@@ -6101,10 +6149,11 @@ fn minimize_error_range(node: Node, text: &str) -> Range {
 
     // Phase 1: If there's a MISSING descendant, point the diagnostic there.
     if let Some(missing) = find_first_missing_descendant(node) {
-        let m_row = missing.start_position().row as u32;
-        let m_col = byte_offset_to_utf16_column(
-            line_at(missing.start_position().row),
+        let (m_row, m_col) = anchor_missing_position(
+            missing.start_position().row,
             missing.start_position().column,
+            node.start_position().row,
+            text,
         );
         return Range {
             start: Position::new(m_row, m_col),
@@ -6217,8 +6266,6 @@ fn minimize_error_range(node: Node, text: &str) -> Range {
 }
 
 fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnostic>) {
-    use crate::cross_file::types::byte_offset_to_utf16_column;
-
     if node.is_error() {
         let message = classify_error(node, text);
         diagnostics.push(Diagnostic {
@@ -6234,9 +6281,12 @@ fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnosti
     }
 
     if node.is_missing() {
-        let row = node.start_position().row as u32;
-        let line_text = text.lines().nth(node.start_position().row).unwrap_or("");
-        let col = byte_offset_to_utf16_column(line_text, node.start_position().column);
+        let (row, col) = anchor_missing_position(
+            node.start_position().row,
+            node.start_position().column,
+            0,
+            text,
+        );
         let message = if is_string_quote_kind(node.kind()) {
             "Unclosed string literal".to_string()
         } else {
@@ -6549,6 +6599,42 @@ mod syntax_error_range_tests {
             "should produce exactly one diagnostic, got {}: {:?}",
             diags.len(),
             diags
+        );
+    }
+
+    #[test]
+    fn unclosed_paren_diagnostic_anchors_on_offending_line() {
+        // Regression test for issue #286.
+        //
+        // For an unclosed call followed by blank lines and/or a comment, the
+        // tree-sitter MISSING `)` descendant is positioned past the end of the
+        // offending line (often on a blank line or the next comment). Using
+        // that raw position puts the diagnostic squiggle on whitespace or on
+        // the trailing comment — far from the line a user has to fix.
+        //
+        // The diagnostic should anchor on line 0 (the line with the unmatched
+        // `(`), so the user's eye lands on the broken expression.
+        let code = "x <- mean(c(1, 2, 3)\n\n# Here is a comment\n";
+        let diags = collect(code);
+        assert!(!diags.is_empty(), "should produce a diagnostic");
+        let missing_close = diags
+            .iter()
+            .find(|d| d.message.contains("Missing") && d.message.contains(')'))
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected a 'Missing )' diagnostic, got: {:?}",
+                    diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            missing_close.range.start.line, 0,
+            "Missing ) diagnostic should anchor on line 0 (the line with the \
+             unclosed `(`), got line {}. Full range: ({},{})..({},{})",
+            missing_close.range.start.line,
+            missing_close.range.start.line,
+            missing_close.range.start.character,
+            missing_close.range.end.line,
+            missing_close.range.end.character,
         );
     }
 

--- a/demo/rmarkdown-quarto/.gitignore
+++ b/demo/rmarkdown-quarto/.gitignore
@@ -1,0 +1,5 @@
+# Rendered outputs from knit / quarto render — sources (.Rmd, .qmd) are the
+# tracked artifacts; the rendered HTML and its companion asset directory are
+# regenerated locally and should not be committed.
+*.html
+*_files/

--- a/demo/rmarkdown-quarto/analysis.Rmd
+++ b/demo/rmarkdown-quarto/analysis.Rmd
@@ -5,7 +5,7 @@ output: html_document
 
 ## Introduction
 
-This document demonstrates Raven's R Markdown chunk detection.
+This document demonstrates Raven's R Markdown chunk detection. ddd
 
 ```{r setup, include=FALSE}
 library(ggplot2)

--- a/demo/rmarkdown-quarto/analysis.Rmd
+++ b/demo/rmarkdown-quarto/analysis.Rmd
@@ -5,7 +5,7 @@ output: html_document
 
 ## Introduction
 
-This document demonstrates Raven's R Markdown chunk detection. ddd
+This document demonstrates Raven's R Markdown chunk detection.
 
 ```{r setup, include=FALSE}
 library(ggplot2)

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -26,10 +26,13 @@ Raven surfaces parse errors from the tree-sitter R grammar whenever the document
 | ``Consecutive pipe `\|>`: expected an expression before this operator.`` | Two pipe operators appear back-to-back without an intervening expression (`x \|> \|> y`) |
 | ``Mismatched brackets: `(` opened here; close with `)` not `]`.`` | A bracket opened with `(`, `[`, or `[[` is closed with a non-matching bracket (`c(1, 2]`) |
 | ``Unexpected `>`: R has no `=>` operator. For assignment use `<-`; for a pipeline use `\|>` (R 4.1+) or `%>%`.`` | A fat-arrow-style token `=>` appears where R expected an expression — common when porting code from JavaScript or other languages (`x => 1`) |
-| `Missing )` / `Missing ]` / etc. | A delimiter was opened but never closed (`library(`) |
+| `` Unclosed `(`: missing matching `)` `` / `` Unclosed `{`: missing matching `}` `` / `` Unclosed `[`: missing matching `]` `` / `` Unclosed `[[`: missing matching `]]` `` | A delimiter was opened but never closed (`library(`, `function() {`). The diagnostic is anchored on the opening delimiter, spanning to the end of meaningful content on that line. |
+| `` Missing opening `{` `` / `` Missing opening `(` `` / `` Missing opening `[` `` / `` Missing opening `[[` `` | A closing delimiter appears with no matching opener (`}` at top level, `)` after a complete expression). A run of stray closers (`}}}`) reports a single diagnostic for the whole run. |
 | `In R, 'else' must appear on the same line as the closing '}' of the if block` | `else` placed on its own line after `if (cond) { body }` — R treats the `if` as complete and the `else` becomes an unexpected token |
 | ``'else' without a preceding 'if' body: in R, 'else' must follow `if (...) {...}` on the same line`` | `else` appears anywhere R would reject a bare `else` — e.g. `else { 1 }` at the top of a file, `else { … }` inside a `{ … }` block, `(else)`, `else |> f()`, or `else` used as a function argument / assignment RHS |
 | `Syntax error` | Tree-sitter detected a parse error that doesn't match any of the specific patterns above |
+
+The `Mismatched brackets` message also covers wrong-closer typos where the user typed an unexpected closer immediately after an unclosed opener (e.g. `f(}` produces a single `` Mismatched brackets: `(` opened here; close with `)` not `}`. `` diagnostic rather than two separate ones).
 
 ### Undefined Variables
 

--- a/docs/superpowers/plans/2026-05-17-bracket-diagnostics-plan.md
+++ b/docs/superpowers/plans/2026-05-17-bracket-diagnostics-plan.md
@@ -1,0 +1,2231 @@
+# Bracket diagnostics: opener-anchored unclosed + named stray-closer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic `"Syntax error"` diagnostic for stray/unclosed brackets, braces, and parens with targeted messages anchored on the offending delimiter character. Spec: `docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md`.
+
+**Architecture:** All changes are local to `crates/raven/src/handlers.rs`. A new `CollectState` struct threads through `collect_syntax_errors` to carry per-traversal coalescing state. `classify_error` returns a new `ErrorClassification` enum (Whole vs Multi) instead of a `String`, so a single ERROR can produce multiple diagnostics when it contains multiple distinct delimiter faults. A new delimiter-scan pass walks each ERROR's direct children left-to-right with a stack, producing per-opener and per-closer diagnostics. Bracket-kind `MISSING` nodes route through a new `find_opener_for_missing` helper that walks up one level to the structural parent (`arguments` / `braced_expression` / `parenthesized_expression`) and anchors on the opener token. A new `end_of_meaningful_content` helper trims trailing comments/whitespace from the opener-line range.
+
+**Tech Stack:** Rust, `tree-sitter` 0.20.x via `tree-sitter-r` (rev `95aff097aa927a66bb357f715b58cde821be8867`), `tower-lsp` for LSP types, `proptest` for property tests.
+
+---
+
+## Working environment
+
+All work happens in this worktree:
+
+```text
+/Users/jmb/repos/Extensions/raven/.claude/worktrees/issue286-bracket-spec
+```
+
+The current branch is `issue286`. The spec lives at `docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md`. Run all commands from the worktree root.
+
+Build and test commands:
+
+```bash
+cargo build -p raven          # ~30s incremental
+cargo test  -p raven --lib    # full test suite
+cargo test  -p raven --lib syntax_error_range_tests::<NAME> -- --nocapture
+```
+
+Existing file landmarks in `crates/raven/src/handlers.rs`:
+
+- `collect_syntax_errors` — line ~6293
+- `classify_error` — line ~6369
+- `detect_consecutive_pipe`, `detect_mismatched_bracket`, `detect_fat_arrow` — adjacent
+- `has_unclosed_quote_child`, `is_string_quote_kind` — adjacent
+- `minimize_error_range` — line ~6164
+- `anchor_missing_position` — line ~5907
+- `find_first_missing_descendant` — line ~5961
+- `find_innermost_error` — line ~5999
+- `mod syntax_error_range_tests` — line ~6485
+- `prop_missing_node_priority` — line ~7802
+- `prop_missing_node_width` — line ~8098
+
+UTF-16 helpers live in `crates/raven/src/utf16.rs`:
+
+- `byte_offset_to_utf16_column(line: &str, byte_offset: usize) -> u32`
+
+---
+
+## Task 1: Add `end_of_meaningful_content` helper
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs` (add helper near other line-utility code)
+- Test: same file, inside `mod syntax_error_range_tests`
+
+**Why this is first:** Every opener-line range depends on this. Self-contained pure function, no tree-sitter dependency.
+
+**Contract:**
+
+```rust
+/// Compute the UTF-16 column just past the last non-comment, non-whitespace
+/// character on `line`. Used to trim trailing comments and whitespace from
+/// the opener-line range of an `Unclosed X` diagnostic.
+///
+/// Comment detection is string-aware: a `#` inside a string literal (`"..."`,
+/// `'...'`, or backtick-quoted) does NOT start a comment.
+///
+/// CRLF: `\r` is treated as trailing whitespace (trimmed).
+///
+/// Examples:
+///   `f( # comment`   -> 2  (just past `(`)
+///   `f(   `          -> 2  (just past `(`)
+///   `x <- "a # b"`   -> 12 (just past closing `"`)
+///   `f(x, y)`        -> 7  (just past `)`)
+fn end_of_meaningful_content(line: &str) -> u32;
+```
+
+- [ ] **Step 1: Add the failing tests**
+
+Add this block at the end of `mod syntax_error_range_tests` (just before the closing `}` of the module, line ~7470 region — confirm by grep for `^}` after `incomplete_assignment_in_block_minimized`'s helpers):
+
+```rust
+    // ------------------------------------------------------------------
+    // end_of_meaningful_content
+    // ------------------------------------------------------------------
+
+    use super::end_of_meaningful_content;
+
+    #[test]
+    fn eomc_plain_content() {
+        assert_eq!(end_of_meaningful_content("f(x, y)"), 7);
+    }
+
+    #[test]
+    fn eomc_trailing_whitespace() {
+        assert_eq!(end_of_meaningful_content("f(   "), 2);
+    }
+
+    #[test]
+    fn eomc_trailing_comment() {
+        assert_eq!(end_of_meaningful_content("f( # comment"), 2);
+    }
+
+    #[test]
+    fn eomc_content_then_comment() {
+        // last meaningful char `1` at col 4; just past = 5
+        assert_eq!(end_of_meaningful_content("f(1) # tail"), 4);
+    }
+
+    #[test]
+    fn eomc_hash_inside_double_quoted_string() {
+        // "a # b" -- the `#` is inside the string; meaningful content
+        // continues to the closing `"` at col 11; just past = 12.
+        assert_eq!(end_of_meaningful_content("x <- \"a # b\""), 12);
+    }
+
+    #[test]
+    fn eomc_hash_inside_single_quoted_string() {
+        assert_eq!(end_of_meaningful_content("x <- 'a # b'"), 12);
+    }
+
+    #[test]
+    fn eomc_hash_inside_backticks() {
+        // backticks quote identifiers in R; `#` inside them is not a comment
+        assert_eq!(end_of_meaningful_content("x <- `a # b`"), 12);
+    }
+
+    #[test]
+    fn eomc_crlf_carriage_return_trimmed() {
+        // \r is trailing whitespace
+        assert_eq!(end_of_meaningful_content("f(\r"), 2);
+    }
+
+    #[test]
+    fn eomc_only_comment() {
+        // pure comment line — meaningful content ends at col 0
+        assert_eq!(end_of_meaningful_content("# nothing here"), 0);
+    }
+
+    #[test]
+    fn eomc_empty_line() {
+        assert_eq!(end_of_meaningful_content(""), 0);
+    }
+
+    #[test]
+    fn eomc_non_ascii_identifier() {
+        // `é` is 2 UTF-8 bytes but 1 UTF-16 code unit; line "é <- 1"
+        // last meaningful char `1` at UTF-16 col 5; just past = 6.
+        assert_eq!(end_of_meaningful_content("é <- 1"), 6);
+    }
+
+    #[test]
+    fn eomc_astral_emoji() {
+        // `😀` is 4 UTF-8 bytes, 2 UTF-16 code units; line "😀 <- 1"
+        // `1` lands at UTF-16 col 6 (😀=2 + " <- "=4 = 6); just past = 7.
+        assert_eq!(end_of_meaningful_content("😀 <- 1"), 7);
+    }
+```
+
+- [ ] **Step 2: Verify the tests fail to compile (helper not yet defined)**
+
+```bash
+cargo test -p raven --lib eomc_ 2>&1 | tail -20
+```
+
+Expected: compile error: `cannot find function "end_of_meaningful_content" in module "super"`.
+
+- [ ] **Step 3: Implement `end_of_meaningful_content`**
+
+Add this function in `handlers.rs` near `anchor_missing_position` (line ~5907 region — find a natural insertion point above `anchor_missing_position` so it's available to all consumers):
+
+```rust
+/// Compute the UTF-16 column just past the last non-comment, non-whitespace
+/// character on `line`. Comment detection is string-aware: a `#` inside
+/// `"..."`, `'...'`, or `` `...` `` is not a comment. `\r` is treated as
+/// trailing whitespace.
+///
+/// Used to trim trailing comments and whitespace from the opener-line range
+/// of an `Unclosed X` diagnostic. See bracket-diagnostics design spec.
+fn end_of_meaningful_content(line: &str) -> u32 {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    // Walk forward through `line`, tracking the current "in-string" state.
+    // `comment_byte` records where a `#` outside any string was first seen.
+    let mut in_double = false;
+    let mut in_single = false;
+    let mut in_backtick = false;
+    let mut escape = false;
+    let mut comment_byte: Option<usize> = None;
+
+    for (byte_idx, ch) in line.char_indices() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if in_double {
+            match ch {
+                '\\' => escape = true,
+                '"' => in_double = false,
+                _ => {}
+            }
+            continue;
+        }
+        if in_single {
+            match ch {
+                '\\' => escape = true,
+                '\'' => in_single = false,
+                _ => {}
+            }
+            continue;
+        }
+        if in_backtick {
+            if ch == '`' { in_backtick = false; }
+            continue;
+        }
+        match ch {
+            '"' => in_double = true,
+            '\'' => in_single = true,
+            '`' => in_backtick = true,
+            '#' => {
+                comment_byte = Some(byte_idx);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    // The "meaningful" prefix ends at `comment_byte` (if a comment was
+    // found) or at the end of `line`. Then trim trailing whitespace from
+    // that prefix.
+    let cutoff_byte = comment_byte.unwrap_or(line.len());
+    let meaningful = &line[..cutoff_byte];
+    let trimmed = meaningful.trim_end_matches(|c: char| c.is_whitespace());
+
+    byte_offset_to_utf16_column(line, trimmed.len())
+}
+```
+
+- [ ] **Step 4: Run the helper tests**
+
+```bash
+cargo test -p raven --lib eomc_ -- --nocapture
+```
+
+Expected: all 12 `eomc_*` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): add end_of_meaningful_content helper
+
+String-aware trim of trailing comments and whitespace from a source line,
+returning the UTF-16 column just past the last meaningful character.
+Foundation for the new opener-anchored bracket diagnostics."
+```
+
+---
+
+## Task 2: Add `CollectState`, `ClassifiedSyntaxDiagnostic`, `ErrorClassification` types
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is second:** Subsequent tasks reference these types. No behavior change yet; just types.
+
+- [ ] **Step 1: Define the types**
+
+Insert near the existing classifier helpers (above `classify_error`, around line 6360):
+
+```rust
+/// One classified syntax-error diagnostic produced by `classify_error`.
+/// Kept separate from `tower_lsp::lsp_types::Diagnostic` so that the
+/// classifier doesn't need to fill in `source` / `severity` / etc. — the
+/// caller (`collect_syntax_errors_inner`) does that.
+#[derive(Debug, Clone)]
+struct ClassifiedSyntaxDiagnostic {
+    message: String,
+    range: Range,
+}
+
+/// Result of classifying an ERROR node. A single ERROR can now produce
+/// either one whole-error diagnostic (the existing classifiers) or
+/// multiple per-fault diagnostics (the new delimiter scan).
+#[derive(Debug, Clone)]
+enum ErrorClassification {
+    /// Single diagnostic describing the whole ERROR. Used by unclosed
+    /// string, consecutive pipe, mismatched bracket, fat-arrow.
+    Whole(ClassifiedSyntaxDiagnostic),
+    /// Zero or more diagnostics, each describing a distinct delimiter
+    /// fault inside the ERROR. An empty Vec means "no classifier matched
+    /// — caller falls back to a single generic 'Syntax error' at the
+    /// minimized range".
+    Multi(Vec<ClassifiedSyntaxDiagnostic>),
+}
+
+/// Per-traversal mutable state threaded through `collect_syntax_errors_inner`
+/// so that the mismatched-bracket coalescing rule can suppress a duplicate
+/// `Unclosed X` diagnostic for the same opener.
+#[derive(Default)]
+struct CollectState {
+    /// `Node::id()` values of opener tokens already covered by a
+    /// `Mismatched brackets` diagnostic. The MISSING-anchoring branch
+    /// skips emitting `Unclosed X` for any opener whose id appears here.
+    covered_openers: std::collections::HashSet<usize>,
+}
+```
+
+- [ ] **Step 2: Verify the crate still builds**
+
+```bash
+cargo build -p raven 2>&1 | tail -5
+```
+
+Expected: warnings about unused types, but no errors. (Warnings are OK at this stage — the types will be used in the next task.)
+
+If you see "unused" warnings on the new types, that's fine and expected. Don't suppress them; they'll resolve as soon as Task 3 lands.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): introduce ErrorClassification + CollectState types
+
+Foundation for letting a single ERROR node produce multiple diagnostics
+(one per distinct delimiter fault) while preserving the single-classifier
+contract for existing classifiers. CollectState carries the
+opener-coalescing suppression set through the recursion."
+```
+
+---
+
+## Task 3: Refactor existing classifiers + `collect_syntax_errors` to new types (no behavior change)
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs` — `classify_error`, `collect_syntax_errors`, existing detector helpers
+
+**Why this is third:** Convert `classify_error` from `String` to `ErrorClassification::Whole(...)` and thread `CollectState`. This is a pure refactor; the existing test suite must still pass byte-for-byte after this task.
+
+The public signature `pub fn collect_syntax_errors(node, text, diagnostics)` is preserved by adding an inner helper.
+
+- [ ] **Step 1: Find every existing caller of `classify_error` / `collect_syntax_errors`**
+
+```bash
+grep -n "classify_error\|collect_syntax_errors" crates/raven/src/handlers.rs | grep -v "^.*://" | head -30
+```
+
+Expected: one production caller of `classify_error` (inside `collect_syntax_errors` itself), one production caller of `collect_syntax_errors` (line 364 in this file), plus several test callsites that use the `collect()` helper in `mod syntax_error_range_tests`.
+
+The public API must NOT change. Only the internal call from `collect_syntax_errors` to `classify_error` is affected by the refactor.
+
+- [ ] **Step 2: Refactor `classify_error` to return `ErrorClassification`**
+
+Replace the current function (around line 6369):
+
+```rust
+fn classify_error(node: Node, text: &str) -> String {
+    if has_unclosed_quote_child(node) {
+        return "Unclosed string literal".to_string();
+    }
+    if let Some(msg) = detect_consecutive_pipe(node, text) {
+        return msg;
+    }
+    if let Some(msg) = detect_mismatched_bracket(node, text) {
+        return msg;
+    }
+    if let Some(msg) = detect_fat_arrow(node, text) {
+        return msg;
+    }
+    "Syntax error".to_string()
+}
+```
+
+with:
+
+```rust
+fn classify_error(node: Node, text: &str, _state: &mut CollectState) -> ErrorClassification {
+    let range = minimize_error_range(node, text);
+
+    if has_unclosed_quote_child(node) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic {
+            message: "Unclosed string literal".to_string(),
+            range,
+        });
+    }
+    if let Some(msg) = detect_consecutive_pipe(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+    if let Some(msg) = detect_mismatched_bracket(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+    if let Some(msg) = detect_fat_arrow(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+    // No classifier matched. Caller falls back to a single generic
+    // "Syntax error" at the minimized range. Returning Multi(vec![]) is
+    // the sentinel for "delimiter scan / fallback".
+    ErrorClassification::Multi(Vec::new())
+}
+```
+
+The `_state` parameter is unused for now — it's wired up so subsequent tasks (mismatched-bracket coalescing) can populate `covered_openers` without changing the signature again.
+
+- [ ] **Step 3: Refactor `collect_syntax_errors` to use an inner helper that threads state**
+
+Replace the current function (around line 6293):
+
+```rust
+fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnostic>) {
+    if node.is_error() {
+        let message = classify_error(node, text);
+        diagnostics.push(Diagnostic {
+            range: minimize_error_range(node, text),
+            severity: Some(DiagnosticSeverity::ERROR),
+            message,
+            ..Default::default()
+        });
+        // Don't recurse into ERROR children — the minimized range already
+        // accounts for nested MISSING nodes, and recursing would produce
+        // duplicate diagnostics for nested ERROR children.
+        return;
+    }
+
+    if node.is_missing() {
+        // ... existing MISSING branch ...
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_syntax_errors(child, text, diagnostics);
+    }
+}
+```
+
+with:
+
+```rust
+fn collect_syntax_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnostic>) {
+    let mut state = CollectState::default();
+    collect_syntax_errors_inner(node, text, diagnostics, &mut state);
+}
+
+fn collect_syntax_errors_inner(
+    node: Node,
+    text: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+    state: &mut CollectState,
+) {
+    if node.is_error() {
+        match classify_error(node, text, state) {
+            ErrorClassification::Whole(diag) => {
+                diagnostics.push(Diagnostic {
+                    range: diag.range,
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    message: diag.message,
+                    ..Default::default()
+                });
+            }
+            ErrorClassification::Multi(diags) if diags.is_empty() => {
+                // Fallback: generic "Syntax error" at the minimized range.
+                diagnostics.push(Diagnostic {
+                    range: minimize_error_range(node, text),
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    message: "Syntax error".to_string(),
+                    ..Default::default()
+                });
+            }
+            ErrorClassification::Multi(diags) => {
+                for diag in diags {
+                    diagnostics.push(Diagnostic {
+                        range: diag.range,
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        message: diag.message,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+        // Don't recurse into ERROR children — same reasoning as before.
+        return;
+    }
+
+    if node.is_missing() {
+        // ... preserve the existing MISSING branch verbatim ...
+        // (this task does NOT change MISSING behavior — Task 8 does)
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_syntax_errors_inner(child, text, diagnostics, state);
+    }
+}
+```
+
+Important: in this task you are NOT changing the MISSING branch. Copy-paste the existing MISSING logic from the original `collect_syntax_errors` into `collect_syntax_errors_inner` verbatim. Task 8 changes it.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+cargo test -p raven --lib 2>&1 | tail -30
+```
+
+Expected: every test still passes. Pay particular attention to:
+
+- `syntax_error_range_tests::*`
+- `prop_missing_node_priority`, `prop_missing_node_width`, `prop_diagnostic_deduplication`, `prop_error_detection_completeness`, `prop_nested_condition_errors`
+
+If any test fails, the refactor broke behavior — fix before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "refactor(diagnostics): classify_error returns ErrorClassification
+
+Pure refactor of the classifier boundary so that future delimiter-scan
+logic can emit multiple diagnostics per ERROR. Existing classifiers all
+return Whole(...); the unmatched fallthrough returns Multi(vec![]) which
+the caller maps to a single 'Syntax error' (current behavior preserved).
+CollectState is threaded but not yet consulted."
+```
+
+---
+
+## Task 4: Add `find_opener_for_missing` helper
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is fourth:** Needed by Task 8 (opener anchoring for bracket-kind MISSING).
+
+**Contract:**
+
+```rust
+/// Walk up one level from a bracket-kind MISSING node to its structural
+/// parent (`arguments`, `braced_expression`, `parenthesized_expression`)
+/// and return the parent + a Range anchored on the parent's first child
+/// (the opener token), spanning to end-of-meaningful-content on the
+/// opener's line.
+///
+/// Returns `None` for:
+/// - MISSINGs whose kind is not a bracket closer
+/// - MISSINGs whose parent isn't one of the three structural kinds
+///   (defensive: keep callers from blindly trusting the result on
+///   unknown tree shapes)
+fn find_opener_for_missing(missing: Node, text: &str) -> Option<(Node, Range)>;
+```
+
+- [ ] **Step 1: Add unit tests inside `mod syntax_error_range_tests`**
+
+```rust
+    // ------------------------------------------------------------------
+    // find_opener_for_missing
+    // ------------------------------------------------------------------
+
+    use super::find_opener_for_missing;
+
+    fn first_missing(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node> {
+        // Walks the tree and returns the first MISSING node encountered.
+        fn walk<'a>(n: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+            if n.is_missing() { return Some(n); }
+            let mut c = n.walk();
+            for child in n.children(&mut c) {
+                if let Some(m) = walk(child) {
+                    return Some(m);
+                }
+            }
+            None
+        }
+        walk(tree.root_node())
+    }
+
+    #[test]
+    fn fofm_call_arguments_paren() {
+        // library( -> arguments( "(" MISSING ")" )
+        let code = "library(";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).expect("expected MISSING");
+        let (opener, range) = find_opener_for_missing(missing, code)
+            .expect("should find opener for ( inside arguments");
+        assert_eq!(opener.kind(), "(");
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 7);  // `(` is at col 7
+        assert_eq!(range.end.line, 0);
+        assert_eq!(range.end.character, 8);    // EOL/eomc col
+    }
+
+    #[test]
+    fn fofm_subset_arguments_bracket() {
+        let code = "vec[1, 2\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "[");
+        assert_eq!(range.start.character, 3);  // `[` is at col 3
+        // end = end of meaningful content on line 0 = col 8 (just past "2")
+        assert_eq!(range.end.character, 8);
+    }
+
+    #[test]
+    fn fofm_subset2_arguments_double_bracket() {
+        let code = "vec[[1, 2\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "[[");
+        assert_eq!(range.start.character, 3);  // `[[` starts at col 3
+        assert_eq!(range.end.character, 9);    // just past "2" at col 8
+    }
+
+    #[test]
+    fn fofm_braced_expression() {
+        let code = "f <- function() {\n  x <- 1\n";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        let (opener, range) = find_opener_for_missing(missing, code).unwrap();
+        assert_eq!(opener.kind(), "{");
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 16);
+        assert_eq!(range.end.character, 17);  // opener at EOL → range collapses to `{`
+    }
+
+    #[test]
+    fn fofm_non_bracket_missing_returns_none() {
+        // `x <-` produces a MISSING identifier at end of input.
+        // Not a bracket closer kind — function returns None.
+        let code = "x <-";
+        let tree = parse_r(code);
+        let missing = first_missing(&tree).unwrap();
+        assert!(find_opener_for_missing(missing, code).is_none());
+    }
+```
+
+- [ ] **Step 2: Run them to verify failure**
+
+```bash
+cargo test -p raven --lib fofm_ 2>&1 | tail -10
+```
+
+Expected: compile error (`find_opener_for_missing` not yet defined).
+
+- [ ] **Step 3: Implement `find_opener_for_missing`**
+
+Add this near `anchor_missing_position` (line ~5907):
+
+```rust
+/// Walk up one level from a bracket-kind MISSING node to its structural
+/// parent and return that parent's opening delimiter token plus the
+/// computed UTF-16 Range from the opener column through
+/// `end_of_meaningful_content` of the opener's line.
+///
+/// Returns None when:
+/// - `missing.kind()` is not one of `)` `}` `]` `]]`
+/// - the parent's kind is not `arguments`, `braced_expression`, or
+///   `parenthesized_expression`
+fn find_opener_for_missing(missing: Node, text: &str) -> Option<(Node, Range)> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    // Only bracket-kind MISSINGs route through this helper.
+    if !matches!(missing.kind(), ")" | "}" | "]" | "]]") {
+        return None;
+    }
+
+    let parent = missing.parent()?;
+    if !matches!(
+        parent.kind(),
+        "arguments" | "braced_expression" | "parenthesized_expression"
+    ) {
+        return None;
+    }
+
+    // The opener is the parent's first child whose token text matches
+    // `(`, `{`, `[`, or `[[`. For `arguments` / `braced_expression` /
+    // `parenthesized_expression` the opener is invariably the first
+    // named or anonymous child after the structural parent's start,
+    // so we scan from the beginning.
+    let mut cursor = parent.walk();
+    let opener = parent
+        .children(&mut cursor)
+        .find(|n| {
+            let t = text.get(n.start_byte()..n.end_byte()).unwrap_or("");
+            matches!(t, "(" | "{" | "[" | "[[")
+        })?;
+
+    let opener_row = opener.start_position().row as u32;
+    let opener_start_byte = opener.start_position().column;
+
+    let line = text.lines().nth(opener_row as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(line, opener_start_byte);
+    let end_col = end_of_meaningful_content(line);
+
+    // If end_of_meaningful_content reports a column <= start, the opener
+    // is the last meaningful character on its line. Give the range a
+    // single-column width so the squiggle is visible.
+    let end_col = if end_col > start_col {
+        end_col
+    } else {
+        // For multi-char openers like `[[`, span the opener token's width.
+        let opener_end_byte = opener.end_position().column;
+        byte_offset_to_utf16_column(line, opener_end_byte).max(start_col + 1)
+    };
+
+    Some((
+        opener,
+        Range {
+            start: Position::new(opener_row, start_col),
+            end: Position::new(opener_row, end_col),
+        },
+    ))
+}
+```
+
+- [ ] **Step 4: Run the helper tests**
+
+```bash
+cargo test -p raven --lib fofm_ -- --nocapture
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): add find_opener_for_missing helper
+
+Single-level parent walk from a bracket-kind MISSING node to its
+structural parent (arguments / braced_expression /
+parenthesized_expression), returning the opener token + range anchored
+on the opener through end-of-meaningful-content."
+```
+
+---
+
+## Task 5: Delimiter-scan event extraction
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is fifth:** The delimiter scan is the core new mechanism. Build it bottom-up: events first, stack processing next.
+
+**Contract:**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DelimiterKind { Paren, Brace, Bracket, DoubleBracket }
+
+#[derive(Debug, Clone)]
+struct DelimEvent {
+    is_open: bool,
+    kind: DelimiterKind,
+    /// Byte range of the underlying source. start_byte..end_byte.
+    range_bytes: std::ops::Range<usize>,
+    /// Row of the start position (for line lookups).
+    row: u32,
+}
+
+/// Walk an ERROR node's *direct* children left-to-right and emit a
+/// flat stream of opener/closer events. Special-cases:
+///   - A leaf whose entire text is a homogeneous run of one closer
+///     character (`}}}`, `)))`, repeated `]]`) emits ONE close event
+///     covering the whole leaf.
+///   - A leaf with a *mixed* run of closer chars (`])`, `}]`, etc.)
+///     emits one event per character, with `]]` recognized greedily.
+///   - Nested ERRORs are recursed into for delimiter extraction.
+///   - Non-error, non-leaf children (identifiers, complete subtrees)
+///     are skipped — they have their own balanced delimiters which the
+///     parser has already validated.
+fn delimiter_events(error: Node, text: &str) -> Vec<DelimEvent>;
+```
+
+- [ ] **Step 1: Add the type + tests**
+
+Insert the types just above the new helper. Add tests inside `mod syntax_error_range_tests`:
+
+```rust
+    use super::{delimiter_events, DelimiterKind};
+
+    fn find_first_error(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node> {
+        fn walk<'a>(n: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+            if n.is_error() { return Some(n); }
+            let mut c = n.walk();
+            for child in n.children(&mut c) {
+                if let Some(e) = walk(child) {
+                    return Some(e);
+                }
+            }
+            None
+        }
+        walk(tree.root_node())
+    }
+
+    #[test]
+    fn devents_flat_nested_openers() {
+        // f(g(h(   -> ERROR("(" "g" "(" "h" "(")
+        let code = "f(g(h(\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        // Three opener events for the three `(`
+        assert_eq!(evs.len(), 3);
+        for ev in &evs {
+            assert!(ev.is_open);
+            assert_eq!(ev.kind, DelimiterKind::Paren);
+        }
+    }
+
+    #[test]
+    fn devents_stray_close_brace() {
+        // x <- 1\n}\n  -> sibling ERROR(ERROR "}")
+        let code = "x <- 1\n}\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        assert_eq!(evs.len(), 1);
+        assert!(!evs[0].is_open);
+        assert_eq!(evs[0].kind, DelimiterKind::Brace);
+    }
+
+    #[test]
+    fn devents_homogeneous_run() {
+        // }}}  -> ERROR(ERROR "}}}")
+        // One close event spanning the whole run.
+        let code = "}}}\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        assert_eq!(evs.len(), 1);
+        assert!(!evs[0].is_open);
+        assert_eq!(evs[0].kind, DelimiterKind::Brace);
+        assert_eq!(evs[0].range_bytes, 0..3);
+    }
+
+    #[test]
+    fn devents_mixed_closer_run() {
+        // Construct a code snippet where a leaf with mixed closer text
+        // appears inside an ERROR. The simplest reliable shape:
+        // `f(])`  -> the inner ERROR contains a "])" leaf.
+        // Verify the test against the actual parse before locking in
+        // expectations; the assertion below is what the spec requires.
+        let code = "f(])";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        // Expect at least one open `(` and two close events `]` and `)`.
+        let open_count = evs.iter().filter(|e| e.is_open).count();
+        let close_count = evs.iter().filter(|e| !e.is_open).count();
+        assert!(open_count >= 1, "expected at least one open event, got: {evs:?}");
+        assert!(close_count >= 2, "expected at least two close events, got: {evs:?}");
+        // Confirm the two closes are kinds `]` then `)`.
+        let mut closes = evs.iter().filter(|e| !e.is_open);
+        let first = closes.next().unwrap();
+        let second = closes.next().unwrap();
+        assert_eq!(first.kind, DelimiterKind::Bracket);
+        assert_eq!(second.kind, DelimiterKind::Paren);
+    }
+
+    #[test]
+    fn devents_double_bracket_run() {
+        // `]]]]`  -> homogeneous run of `]]` pairs
+        // Greedy pairing: two `]]` events.
+        let code = "]]]]\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        // Expect: two close events of kind DoubleBracket
+        let closes: Vec<_> = evs.iter().filter(|e| !e.is_open).collect();
+        assert_eq!(closes.len(), 2, "got events: {evs:?}");
+        for c in closes {
+            assert_eq!(c.kind, DelimiterKind::DoubleBracket);
+        }
+    }
+
+    #[test]
+    fn devents_triple_bracket_pairs_then_single() {
+        // `]]]`  -> one `]]` event followed by one `]` event (greedy left-to-right)
+        let code = "]]]\n";
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).unwrap();
+        let evs = delimiter_events(err, code);
+        let closes: Vec<_> = evs.iter().filter(|e| !e.is_open).collect();
+        assert_eq!(closes.len(), 2, "got events: {evs:?}");
+        assert_eq!(closes[0].kind, DelimiterKind::DoubleBracket);
+        assert_eq!(closes[1].kind, DelimiterKind::Bracket);
+    }
+```
+
+- [ ] **Step 2: Verify the tests fail to compile**
+
+```bash
+cargo test -p raven --lib devents_ 2>&1 | tail -10
+```
+
+Expected: compile error (types / function not defined).
+
+- [ ] **Step 3: Implement event extraction**
+
+Add the types + helper near `classify_error`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DelimiterKind {
+    Paren,         // ( )
+    Brace,         // { }
+    Bracket,       // [ ]
+    DoubleBracket, // [[ ]]
+}
+
+impl DelimiterKind {
+    fn opener_str(self) -> &'static str {
+        match self {
+            DelimiterKind::Paren => "(",
+            DelimiterKind::Brace => "{",
+            DelimiterKind::Bracket => "[",
+            DelimiterKind::DoubleBracket => "[[",
+        }
+    }
+    fn closer_str(self) -> &'static str {
+        match self {
+            DelimiterKind::Paren => ")",
+            DelimiterKind::Brace => "}",
+            DelimiterKind::Bracket => "]",
+            DelimiterKind::DoubleBracket => "]]",
+        }
+    }
+    fn from_opener(s: &str) -> Option<Self> {
+        match s {
+            "(" => Some(Self::Paren),
+            "{" => Some(Self::Brace),
+            "[" => Some(Self::Bracket),
+            "[[" => Some(Self::DoubleBracket),
+            _ => None,
+        }
+    }
+    fn from_closer(s: &str) -> Option<Self> {
+        match s {
+            ")" => Some(Self::Paren),
+            "}" => Some(Self::Brace),
+            "]" => Some(Self::Bracket),
+            "]]" => Some(Self::DoubleBracket),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DelimEvent {
+    is_open: bool,
+    kind: DelimiterKind,
+    range_bytes: std::ops::Range<usize>,
+    row: u32,
+}
+
+/// Walk an ERROR node's direct children and produce a flat stream of
+/// delimiter events. See doc on `delimiter_events` in the spec.
+fn delimiter_events(error: Node, text: &str) -> Vec<DelimEvent> {
+    let mut out = Vec::new();
+    walk_for_delimiters(error, text, &mut out, /*allow_recurse_into_error=*/ true);
+    out
+}
+
+fn walk_for_delimiters(
+    node: Node,
+    text: &str,
+    out: &mut Vec<DelimEvent>,
+    allow_recurse_into_error: bool,
+) {
+    // Only the ROOT ERROR is walked with `allow_recurse_into_error=true`;
+    // we recurse one level into nested ERRORs but not into balanced
+    // semantic children.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.is_error() && allow_recurse_into_error {
+            // Recurse into nested ERROR with allow=false (one level only).
+            walk_for_delimiters(child, text, out, false);
+            continue;
+        }
+        if child.child_count() == 0 {
+            // Leaf — extract delimiter events from raw text
+            let raw = text.get(child.start_byte()..child.end_byte()).unwrap_or("");
+            extract_from_leaf(raw, child.start_byte(), child.start_position().row as u32, out);
+            continue;
+        }
+        // Non-leaf, non-error child: skip (its delimiters are balanced).
+    }
+}
+
+/// Extract delimiter events from a raw leaf text slice. Implements the
+/// homogeneous-run rule (`}}}` → one event) and the mixed-run rule
+/// (`])` → per-character events with `]]` recognized greedily).
+fn extract_from_leaf(raw: &str, base_byte: usize, row: u32, out: &mut Vec<DelimEvent>) {
+    // First pass: recognize opener/closer tokens as exact matches.
+    // For most leaves (`(`, `}`, `]]`, etc.), the leaf is a single token.
+    if let Some(k) = DelimiterKind::from_opener(raw) {
+        out.push(DelimEvent {
+            is_open: true,
+            kind: k,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+    if let Some(k) = DelimiterKind::from_closer(raw) {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: k,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+
+    // Leaf contains multiple characters (run of closers or mixed).
+    // Check homogeneity for `}}}`/`)))`/`]]]...]` patterns.
+    let all_brace = !raw.is_empty() && raw.chars().all(|c| c == '}');
+    let all_paren = !raw.is_empty() && raw.chars().all(|c| c == ')');
+    if all_brace {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: DelimiterKind::Brace,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+    if all_paren {
+        out.push(DelimEvent {
+            is_open: false,
+            kind: DelimiterKind::Paren,
+            range_bytes: base_byte..base_byte + raw.len(),
+            row,
+        });
+        return;
+    }
+
+    // Otherwise: tokenize per-character left-to-right, recognizing `]]`
+    // greedily.
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b']' && i + 1 < bytes.len() && bytes[i + 1] == b']' {
+            out.push(DelimEvent {
+                is_open: false,
+                kind: DelimiterKind::DoubleBracket,
+                range_bytes: base_byte + i..base_byte + i + 2,
+                row,
+            });
+            i += 2;
+            continue;
+        }
+        let one = std::str::from_utf8(&bytes[i..i + 1]).unwrap_or("");
+        if let Some(k) = DelimiterKind::from_opener(one) {
+            out.push(DelimEvent {
+                is_open: true,
+                kind: k,
+                range_bytes: base_byte + i..base_byte + i + 1,
+                row,
+            });
+        } else if let Some(k) = DelimiterKind::from_closer(one) {
+            out.push(DelimEvent {
+                is_open: false,
+                kind: k,
+                range_bytes: base_byte + i..base_byte + i + 1,
+                row,
+            });
+        }
+        // Non-delimiter chars in a leaf are skipped silently.
+        i += 1;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test -p raven --lib devents_ -- --nocapture
+```
+
+Expected: all 6 devents_ tests PASS. If `devents_mixed_closer_run` or other tests fail, FIRST run a one-off probe to print the actual parse tree (see the probe-test pattern below) before deciding whether the implementation is wrong or the test expectation is wrong. The spec assertions are derived from probed shapes for the listed inputs; if the parser version produces something different, update the test.
+
+Probe pattern (paste into a temp `#[test]`, run, then remove):
+
+```rust
+#[test]
+fn _probe() {
+    let code = "f(])";
+    let tree = parse_r(code);
+    fn dump(n: tree_sitter::Node, src: &str, depth: usize) {
+        let kind = n.kind();
+        let txt = if n.child_count() == 0 { format!(" {:?}", &src[n.byte_range()]) } else { String::new() };
+        let flag = if n.is_error() { "[ERROR]" } else if n.is_missing() { "[MISSING]" } else { "" };
+        println!("{}{} {}{}", "  ".repeat(depth), kind, flag, txt);
+        let mut c = n.walk();
+        for ch in n.children(&mut c) { dump(ch, src, depth+1); }
+    }
+    dump(tree.root_node(), code, 0);
+    panic!("probe");
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): delimiter_events extracts open/close stream
+
+Walks an ERROR node's direct children left-to-right (one level of nested
+ERROR recursion) and produces flat opener/closer events. Handles
+homogeneous closer-runs (}}}) as a single event, mixed runs (]) as
+per-character events with ]] recognized greedily."
+```
+
+---
+
+## Task 6: Delimiter-scan stack processing → diagnostics
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is sixth:** Convert events into diagnostics with proper messages, ranges, and the next-opener tie-breaking rule.
+
+**Contract:**
+
+```rust
+/// Process a delimiter event stream through a stack and produce
+/// classified diagnostics. Records any opener covered by a
+/// `Mismatched brackets` diagnostic in `state.covered_openers`.
+fn classify_via_delimiter_scan(
+    error: Node,
+    text: &str,
+    state: &mut CollectState,
+) -> Vec<ClassifiedSyntaxDiagnostic>;
+```
+
+- [ ] **Step 1: Add tests**
+
+Inside `mod syntax_error_range_tests`:
+
+```rust
+    use super::classify_via_delimiter_scan;
+
+    fn run_scan(code: &str) -> Vec<(String, lsp_types::Range)> {
+        use super::CollectState;
+        let tree = parse_r(code);
+        let err = find_first_error(&tree).expect("expected ERROR node");
+        let mut state = CollectState::default();
+        classify_via_delimiter_scan(err, code, &mut state)
+            .into_iter()
+            .map(|d| (d.message, d.range))
+            .collect()
+    }
+
+    #[test]
+    fn scan_stray_close_brace() {
+        let diags = run_scan("x <- 1\n}\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `{`"), "got: {}", diags[0].0);
+        assert_eq!(diags[0].1.start.line, 1);
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 1);
+    }
+
+    #[test]
+    fn scan_stray_close_paren() {
+        let diags = run_scan("x <- 1\n)\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `(`"));
+    }
+
+    #[test]
+    fn scan_stray_close_bracket() {
+        let diags = run_scan("x <- 1\n]\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `[`"));
+    }
+
+    #[test]
+    fn scan_stray_double_close_bracket() {
+        let diags = run_scan("x <- 1\n]]\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].0.contains("Missing opening `[[`"));
+        // range covers both `]`s on line 1
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 2);
+    }
+
+    #[test]
+    fn scan_homogeneous_brace_run_single_diagnostic() {
+        let diags = run_scan("}}}\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        assert!(diags[0].0.contains("Missing opening `{`"));
+        assert_eq!(diags[0].1.start.character, 0);
+        assert_eq!(diags[0].1.end.character, 3);
+    }
+
+    #[test]
+    fn scan_flat_nested_openers_three_diagnostics() {
+        let diags = run_scan("f(g(h(\n");
+        assert_eq!(diags.len(), 3, "got: {diags:?}");
+        for d in &diags {
+            assert!(d.0.contains("Unclosed `(`"));
+        }
+        // Ranges per spec (next-opener tie-breaking):
+        //   outer `(` cols 1..3
+        //   middle `(` cols 3..5
+        //   inner  `(` cols 5..6
+        let mut sorted = diags.clone();
+        sorted.sort_by_key(|d| d.1.start.character);
+        assert_eq!(sorted[0].1.start.character, 1);
+        assert_eq!(sorted[0].1.end.character, 3);
+        assert_eq!(sorted[1].1.start.character, 3);
+        assert_eq!(sorted[1].1.end.character, 5);
+        assert_eq!(sorted[2].1.start.character, 5);
+        assert_eq!(sorted[2].1.end.character, 6);
+    }
+
+    #[test]
+    fn scan_flat_error_mismatched_close_coalesces() {
+        // `f(}` -> flat ERROR contains "(" and ERROR("}")
+        // Inside the delimiter scan, top-of-stack is `(`, incoming
+        // closer is `}`. The mismatched-bracket sub-rule fires:
+        // one diagnostic, "Mismatched brackets: `(` opened here;
+        // close with `)` not `}`."
+        let diags = run_scan("f(}\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        assert!(
+            diags[0].0.contains("Mismatched brackets") && diags[0].0.contains("`(`") && diags[0].0.contains("`}`"),
+            "got: {}",
+            diags[0].0,
+        );
+    }
+```
+
+- [ ] **Step 2: Verify the tests fail**
+
+```bash
+cargo test -p raven --lib scan_ 2>&1 | tail -10
+```
+
+Expected: compile error (`classify_via_delimiter_scan` not yet defined).
+
+- [ ] **Step 3: Implement `classify_via_delimiter_scan`**
+
+Add near `classify_error`:
+
+```rust
+fn classify_via_delimiter_scan(
+    error: Node,
+    text: &str,
+    state: &mut CollectState,
+) -> Vec<ClassifiedSyntaxDiagnostic> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    struct StackItem {
+        kind: DelimiterKind,
+        row: u32,
+        start_byte: usize,
+        node_id: usize,
+    }
+
+    let events = delimiter_events(error, text);
+    let mut stack: Vec<StackItem> = Vec::new();
+    let mut out: Vec<ClassifiedSyntaxDiagnostic> = Vec::new();
+
+    // Map event byte ranges back to actual tree-sitter nodes so we
+    // can record covered opener IDs. We do this by scanning the
+    // error's direct children + one level of nested ERROR children,
+    // matching by byte-range overlap with each open event.
+    fn find_node_by_byte<'a>(
+        root: Node<'a>,
+        target: usize,
+        depth: usize,
+    ) -> Option<Node<'a>> {
+        if depth > 2 { return None; }
+        let mut c = root.walk();
+        for ch in root.children(&mut c) {
+            if ch.start_byte() == target && ch.child_count() == 0 {
+                return Some(ch);
+            }
+            if ch.is_error() {
+                if let Some(found) = find_node_by_byte(ch, target, depth + 1) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    for ev in &events {
+        if ev.is_open {
+            stack.push(StackItem {
+                kind: ev.kind,
+                row: ev.row,
+                start_byte: ev.range_bytes.start,
+                node_id: find_node_by_byte(error, ev.range_bytes.start, 0)
+                    .map(|n| n.id())
+                    .unwrap_or(0),
+            });
+            continue;
+        }
+        // closer
+        match stack.last() {
+            None => {
+                // stray closer
+                let line = text.lines().nth(ev.row as usize).unwrap_or("");
+                let line_start = line_start_byte(text, ev.row as usize);
+                let start_col_byte = ev.range_bytes.start - line_start;
+                let end_col_byte = ev.range_bytes.end - line_start;
+                out.push(ClassifiedSyntaxDiagnostic {
+                    message: format!("Missing opening `{}`", ev.kind.opener_str()),
+                    range: Range {
+                        start: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, start_col_byte),
+                        ),
+                        end: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, end_col_byte),
+                        ),
+                    },
+                });
+            }
+            Some(top) if top.kind == ev.kind => {
+                stack.pop();
+            }
+            Some(top) => {
+                // mismatched — emit and pop
+                let opener_kind = top.kind;
+                let opener_node_id = top.node_id;
+                let line = text.lines().nth(ev.row as usize).unwrap_or("");
+                let line_start = line_start_byte(text, ev.row as usize);
+                let start_col_byte = ev.range_bytes.start - line_start;
+                let end_col_byte = ev.range_bytes.end - line_start;
+                out.push(ClassifiedSyntaxDiagnostic {
+                    message: format!(
+                        "Mismatched brackets: `{}` opened here; close with `{}` not `{}`.",
+                        opener_kind.opener_str(),
+                        opener_kind.closer_str(),
+                        ev.kind.closer_str(),
+                    ),
+                    range: Range {
+                        start: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, start_col_byte),
+                        ),
+                        end: Position::new(
+                            ev.row,
+                            byte_offset_to_utf16_column(line, end_col_byte),
+                        ),
+                    },
+                });
+                if opener_node_id != 0 {
+                    state.covered_openers.insert(opener_node_id);
+                }
+                stack.pop();
+            }
+        }
+    }
+
+    // Process unclosed openers remaining on the stack. Compute ranges
+    // with the "next-opener-on-same-line" tie-breaking rule.
+    //
+    // For each opener at row R, the range end is min(
+    //   next-opener-start on row R (if any),
+    //   end_of_meaningful_content of row R,
+    // ).
+    if !stack.is_empty() {
+        // Index openers on the stack by row so we can find the next
+        // opener on the same line for each one.
+        let row_of: Vec<u32> = stack.iter().map(|s| s.row).collect();
+        let start_byte_of: Vec<usize> = stack.iter().map(|s| s.start_byte).collect();
+
+        for (i, item) in stack.iter().enumerate() {
+            let line = text.lines().nth(item.row as usize).unwrap_or("");
+            let line_start = line_start_byte(text, item.row as usize);
+            let start_col_utf16 = byte_offset_to_utf16_column(line, item.start_byte - line_start);
+
+            // Next opener on the same row at a later byte offset
+            let next_on_row = (i + 1..stack.len())
+                .find(|&j| row_of[j] == item.row && start_byte_of[j] > item.start_byte)
+                .map(|j| byte_offset_to_utf16_column(line, start_byte_of[j] - line_start));
+
+            let eomc = end_of_meaningful_content(line);
+            let mut end_col = next_on_row.unwrap_or(eomc).min(eomc);
+            if end_col <= start_col_utf16 {
+                // Collapse to opener-token width (1 or 2)
+                let opener_len_utf16 = match item.kind {
+                    DelimiterKind::DoubleBracket => 2,
+                    _ => 1,
+                };
+                end_col = start_col_utf16 + opener_len_utf16;
+            }
+
+            out.push(ClassifiedSyntaxDiagnostic {
+                message: format!(
+                    "Unclosed `{}`: missing matching `{}`",
+                    item.kind.opener_str(),
+                    item.kind.closer_str(),
+                ),
+                range: Range {
+                    start: Position::new(item.row, start_col_utf16),
+                    end: Position::new(item.row, end_col),
+                },
+            });
+        }
+    }
+
+    out
+}
+
+/// Byte offset of the start of line `row` in `text` (0-indexed row).
+fn line_start_byte(text: &str, row: usize) -> usize {
+    let mut start = 0;
+    let mut current_row = 0;
+    for (idx, b) in text.bytes().enumerate() {
+        if current_row == row { return start; }
+        if b == b'\n' {
+            current_row += 1;
+            start = idx + 1;
+        }
+    }
+    if current_row == row { start } else { text.len() }
+}
+```
+
+- [ ] **Step 4: Wire the scan into `classify_error`**
+
+Modify `classify_error` (added in Task 3) so that after the existing classifiers fall through, the delimiter scan runs:
+
+```rust
+fn classify_error(node: Node, text: &str, state: &mut CollectState) -> ErrorClassification {
+    let range = minimize_error_range(node, text);
+
+    if has_unclosed_quote_child(node) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic {
+            message: "Unclosed string literal".to_string(),
+            range,
+        });
+    }
+    if let Some(msg) = detect_consecutive_pipe(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+    if let Some(msg) = detect_mismatched_bracket(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+    if let Some(msg) = detect_fat_arrow(node, text) {
+        return ErrorClassification::Whole(ClassifiedSyntaxDiagnostic { message: msg, range });
+    }
+
+    // Delimiter scan: produces zero or more per-fault diagnostics.
+    let scan = classify_via_delimiter_scan(node, text, state);
+    ErrorClassification::Multi(scan)
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p raven --lib scan_ -- --nocapture
+```
+
+Expected: all 7 scan_ tests PASS.
+
+- [ ] **Step 6: Run the full suite to surface any regression**
+
+```bash
+cargo test -p raven --lib 2>&1 | tail -30
+```
+
+Expected: most existing tests still pass. Some EXISTING tests that asserted `message == "Syntax error"` for cases now classified by the delimiter scan will fail — those are intentional behavior changes. Specifically:
+
+- `unclosed_paren_diagnostic_anchors_on_offending_line` — expected `Missing )`, now expects `Unclosed \`(\`: missing matching \`)\``. Update the test in this task.
+- Any `assert!(diag.message == "Syntax error" || diag.message.starts_with("Missing"))` patterns — relax to also accept `Unclosed`/`Missing opening`.
+
+For each affected existing test, update the assertions to reflect the new messages. Do NOT change the input or behavioral expectations beyond message text and (where applicable) the new opener-anchored ranges.
+
+If a test that doesn't involve brackets fails, that's a real regression — stop and fix.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): delimiter-scan stack processing emits per-fault diagnostics
+
+Stack-based event processing inside ERROR nodes:
+- stray closer  -> 'Missing opening X'
+- matched pair  -> popped silently
+- mismatched    -> 'Mismatched brackets' + records opener in covered_openers
+- unclosed openers at end of stream -> 'Unclosed X: missing matching Y'
+  with non-overlapping ranges (next opener on same line or eomc rule)"
+```
+
+---
+
+## Task 7: Integrate delimiter scan into MISSING-node anchoring
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is seventh:** Bracket-kind MISSING nodes need to route through `find_opener_for_missing` instead of `anchor_missing_position`. Non-bracket MISSINGs (e.g. trailing identifier of `x <-`) keep the old path. Also honors `state.covered_openers` to suppress duplicates.
+
+- [ ] **Step 1: Add the unclosed-anchor tests**
+
+Inside `mod syntax_error_range_tests`:
+
+```rust
+    #[test]
+    fn unclosed_paren_anchors_on_opener() {
+        // mean(c(1,2,3) -- opener `(` of mean( at col 9, EOL at col 20
+        let diags = collect("x <- mean(c(1, 2, 3)\n\n# comment\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 9);
+        assert_eq!(target.range.end.line, 0);
+        assert_eq!(target.range.end.character, 20);
+    }
+
+    #[test]
+    fn unclosed_brace_anchors_on_opener() {
+        // f <- function() { ... -- opener `{` at col 16, EOL at col 17
+        let diags = collect("f <- function() {\n  x <- 1\n  y <- 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `{`"))
+            .expect("expected Unclosed { diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 16);
+        assert_eq!(target.range.end.character, 17);
+    }
+
+    #[test]
+    fn unclosed_bracket_anchors_on_opener() {
+        let diags = collect("vec[1, 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `[`"))
+            .expect("expected Unclosed [ diagnostic");
+        assert_eq!(target.range.start.character, 3);
+        assert_eq!(target.range.end.character, 8); // past "2"
+    }
+
+    #[test]
+    fn unclosed_double_bracket_anchors_on_opener() {
+        let diags = collect("vec[[1, 2\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `[[`"))
+            .expect("expected Unclosed [[ diagnostic");
+        assert_eq!(target.range.start.character, 3);
+        assert_eq!(target.range.end.character, 9);
+    }
+
+    #[test]
+    fn unclosed_paren_at_end_of_file() {
+        let diags = collect("library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 7); // `(` at col 7
+        // EOL of `library(` is col 8 (after the `(`).
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_with_trailing_comment() {
+        // `f( # comment\n` -- opener `(` at col 1; comment immediately follows.
+        // Range collapses to just the `(` token (col 1..2).
+        let diags = collect("f( # comment\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 1);
+        assert_eq!(target.range.end.character, 2);
+    }
+
+    #[test]
+    fn unclosed_opener_with_trailing_whitespace() {
+        let diags = collect("f(   \n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 1);
+        assert_eq!(target.range.end.character, 2);
+    }
+```
+
+- [ ] **Step 2: Verify the tests fail**
+
+```bash
+cargo test -p raven --lib unclosed_ 2>&1 | tail -20
+```
+
+Expected: failures (current code anchors on the MISSING position, not the opener; messages may be `Missing )` instead of the new `Unclosed \`(\``).
+
+- [ ] **Step 3: Modify the MISSING branch of `collect_syntax_errors_inner`**
+
+In the MISSING branch (which you preserved verbatim during Task 3), add a bracket-kind dispatch BEFORE the existing logic:
+
+```rust
+    if node.is_missing() {
+        // Bracket-kind MISSING routes through the opener-anchoring helper
+        // unless the opener is already covered by a mismatched-bracket
+        // diagnostic emitted earlier in this traversal.
+        if matches!(node.kind(), ")" | "}" | "]" | "]]") {
+            if let Some((opener, range)) = find_opener_for_missing(node, text) {
+                if !state.covered_openers.contains(&opener.id()) {
+                    let opener_kind = DelimiterKind::from_opener(
+                        text.get(opener.start_byte()..opener.end_byte()).unwrap_or(""),
+                    );
+                    if let Some(k) = opener_kind {
+                        diagnostics.push(Diagnostic {
+                            range,
+                            severity: Some(DiagnosticSeverity::ERROR),
+                            message: format!(
+                                "Unclosed `{}`: missing matching `{}`",
+                                k.opener_str(),
+                                k.closer_str(),
+                            ),
+                            ..Default::default()
+                        });
+                    }
+                }
+                return;
+            }
+            // Bracket-kind MISSING but no structural parent: fall through
+            // to the existing default branch (defensive).
+        }
+
+        // Existing default branch for non-bracket MISSING (e.g. identifier
+        // missing after `x <-`):
+        let (row, col) = anchor_missing_position(
+            node.start_position().row,
+            node.start_position().column,
+            0,
+            node.start_byte(),
+            text,
+        );
+        let message = if is_string_quote_kind(node.kind()) {
+            "Unclosed string literal".to_string()
+        } else {
+            format!("Missing {}", node.kind())
+        };
+        diagnostics.push(Diagnostic {
+            range: Range {
+                start: Position::new(row, col),
+                end: Position::new(row, col.saturating_add(1)),
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            message,
+            ..Default::default()
+        });
+    }
+```
+
+- [ ] **Step 4: Run the unclosed_ tests**
+
+```bash
+cargo test -p raven --lib unclosed_ -- --nocapture
+```
+
+Expected: all 7 `unclosed_*` tests PASS.
+
+- [ ] **Step 5: Run the full suite + fix unavoidable existing-test message drift**
+
+```bash
+cargo test -p raven --lib 2>&1 | tail -40
+```
+
+Expected: tests that asserted exact `Missing )` / `Missing }` etc. need their assertions updated to the new `Unclosed X: missing matching Y` text. Adjust each by changing the assertion text only; don't change the input.
+
+Tests likely affected (search for `Missing )` / `Missing }` in the test sections):
+
+- `unclosed_paren_diagnostic_anchors_on_offending_line`
+- `unclosed_library_call`
+- Anything filtering by `d.message.starts_with("Missing")` — relax to also include `"Unclosed"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): anchor bracket-kind MISSING on the opener
+
+Bracket-kind MISSING nodes (), }, ], ]]) now route through
+find_opener_for_missing for an opener-anchored range with the new
+'Unclosed X: missing matching Y' message. Non-bracket MISSINGs (e.g.
+the trailing identifier of 'x <-') keep their existing path.
+
+state.covered_openers is honored: openers already covered by a
+Mismatched-brackets diagnostic are not re-reported."
+```
+
+---
+
+## Task 8: Arguments-shape coalescing for `f(} y`-style typos
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is eighth:** Handle the parse shape where the wrong closer lives in an ERROR child of `arguments` and a MISSING `)` is the last child. Without this, the user gets two diagnostics for a single typo.
+
+- [ ] **Step 1: Add the coalescing tests**
+
+```rust
+    #[test]
+    fn coalesce_wrong_closer_in_arguments_with_trailing_arg() {
+        // f(} y  -> arguments( "(" ERROR("}") argument MISSING ")" )
+        // Coalesces to a single Mismatched-brackets diagnostic.
+        let diags = collect("f(} y\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        let d = &diags[0];
+        assert!(
+            d.message.contains("Mismatched brackets") && d.message.contains("`(`") && d.message.contains("`}`"),
+            "got: {}",
+            d.message,
+        );
+    }
+
+    #[test]
+    fn coalesce_wrong_closer_for_subset() {
+        // `vec[} y` -- analog of f(} y for `[`
+        let diags = collect("vec[} y\n");
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        let d = &diags[0];
+        assert!(
+            d.message.contains("Mismatched brackets") && d.message.contains("`[`") && d.message.contains("`}`"),
+            "got: {}",
+            d.message,
+        );
+    }
+
+    #[test]
+    fn coalesce_no_double_fire_unclosed_after_mismatch() {
+        // After coalescing, the MISSING `)` follow-up MUST be suppressed.
+        let diags = collect("f(} y\n");
+        assert!(
+            !diags.iter().any(|d| d.message.contains("Unclosed `(`")),
+            "should NOT have a separate 'Unclosed (' diagnostic; got: {diags:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+cargo test -p raven --lib coalesce_ 2>&1 | tail -20
+```
+
+Expected: failures showing two diagnostics where one is expected.
+
+- [ ] **Step 3: Extend `detect_mismatched_bracket` to walk up one level when needed**
+
+Replace `detect_mismatched_bracket` (around line 6413) with the existing logic plus a structural-parent fallback. The function signature in the existing code is `(node, text) -> Option<String>`. Keep that public-message-only signature; instead, introduce a NEW path inside `classify_error` for the structural case that records the covered opener:
+
+In `classify_error`, AFTER the existing `detect_mismatched_bracket` line, insert:
+
+```rust
+    if let Some(diag) = detect_mismatched_via_structural_parent(node, text, state) {
+        return ErrorClassification::Whole(diag);
+    }
+```
+
+Then add the new helper alongside `detect_mismatched_bracket`:
+
+```rust
+/// Detect `f(} y` / `vec[} y` style typos where the wrong closer is an
+/// ERROR child of `arguments` / `braced_expression` / `parenthesized_expression`
+/// and a MISSING closer of the expected kind sits at the parent's end.
+/// Emits a single `Mismatched brackets` diagnostic anchored on the wrong
+/// closer and records the parent's opener in `state.covered_openers` to
+/// suppress the MISSING follow-up.
+fn detect_mismatched_via_structural_parent(
+    node: Node,
+    text: &str,
+    state: &mut CollectState,
+) -> Option<ClassifiedSyntaxDiagnostic> {
+    use crate::cross_file::types::byte_offset_to_utf16_column;
+
+    // Only fire on ERROR nodes whose only non-whitespace content is a
+    // single closer token (the wrong character the user typed).
+    let inner_text = text.get(node.start_byte()..node.end_byte())?.trim();
+    let wrong_kind = DelimiterKind::from_closer(inner_text)?;
+
+    // Walk up one level.
+    let parent = node.parent()?;
+    if !matches!(
+        parent.kind(),
+        "arguments" | "braced_expression" | "parenthesized_expression"
+    ) {
+        return None;
+    }
+
+    // Parent's first delimiter child is the opener.
+    let mut cursor = parent.walk();
+    let opener = parent
+        .children(&mut cursor)
+        .find(|n| {
+            let t = text.get(n.start_byte()..n.end_byte()).unwrap_or("");
+            matches!(t, "(" | "{" | "[" | "[[")
+        })?;
+    let opener_text = text.get(opener.start_byte()..opener.end_byte())?;
+    let opener_kind = DelimiterKind::from_opener(opener_text)?;
+
+    // Must actually be a mismatch (different kind from the wrong closer).
+    if opener_kind == wrong_kind {
+        return None;
+    }
+
+    // Parent must end with a MISSING closer of the expected kind. Walk
+    // children of parent to find the last child; if it's MISSING and its
+    // kind matches opener_kind's closer, we have the coalescing shape.
+    let mut last_child = None;
+    let mut c2 = parent.walk();
+    for ch in parent.children(&mut c2) {
+        last_child = Some(ch);
+    }
+    let last = last_child?;
+    if !last.is_missing() || last.kind() != opener_kind.closer_str() {
+        return None;
+    }
+
+    // Record the opener so the MISSING branch skips it.
+    state.covered_openers.insert(opener.id());
+
+    // Build the diagnostic anchored on the wrong closer (node).
+    let row = node.start_position().row as u32;
+    let line = text.lines().nth(row as usize).unwrap_or("");
+    let line_start = line_start_byte(text, row as usize);
+    let start_col = byte_offset_to_utf16_column(line, node.start_byte() - line_start);
+    let end_col = byte_offset_to_utf16_column(line, node.end_byte() - line_start);
+
+    Some(ClassifiedSyntaxDiagnostic {
+        message: format!(
+            "Mismatched brackets: `{}` opened here; close with `{}` not `{}`.",
+            opener_kind.opener_str(),
+            opener_kind.closer_str(),
+            wrong_kind.closer_str(),
+        ),
+        range: Range {
+            start: Position::new(row, start_col),
+            end: Position::new(row, end_col),
+        },
+    })
+}
+```
+
+- [ ] **Step 4: Run the coalescing tests**
+
+```bash
+cargo test -p raven --lib coalesce_ -- --nocapture
+```
+
+Expected: all 3 `coalesce_*` tests PASS.
+
+- [ ] **Step 5: Full suite**
+
+```bash
+cargo test -p raven --lib 2>&1 | tail -30
+```
+
+Expected: no new regressions beyond message-text updates already made in Task 6/7.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "feat(diagnostics): coalesce wrong-closer-for-opener typos
+
+When the wrong closer (e.g. `}` instead of `)`) lives inside the
+arguments/braced/parens shape with a MISSING expected closer, emit a
+single Mismatched-brackets diagnostic instead of two separate ones.
+The opener is recorded in CollectState::covered_openers so the MISSING
+branch doesn't re-emit 'Unclosed X: missing matching Y'."
+```
+
+---
+
+## Task 9: Encoding edge-case tests (CRLF / BOM / non-ASCII / astral)
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+**Why this is ninth:** Now that the core mechanism is in place, lock in correctness for line-ending and Unicode edge cases. These should all pass without further implementation changes (the helpers go through `byte_offset_to_utf16_column`), but they need explicit tests to prevent future regression.
+
+- [ ] **Step 1: Add the tests**
+
+```rust
+    #[test]
+    fn unclosed_opener_crlf() {
+        // library(\r\n -- the line content is "library(" (sans the \r),
+        // opener `(` at col 7, end of meaningful content at col 8.
+        let diags = collect("library(\r\n");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_no_final_newline() {
+        let diags = collect("library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+
+    #[test]
+    fn unclosed_opener_with_bom() {
+        // BOM = U+FEFF, 3 UTF-8 bytes, 1 UTF-16 code unit at col 0.
+        // `library(` follows, `(` at byte 10, UTF-16 col 8.
+        let diags = collect("\u{FEFF}library(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.line, 0);
+        assert_eq!(target.range.start.character, 8);
+        assert_eq!(target.range.end.character, 9);
+    }
+
+    #[test]
+    fn unclosed_opener_non_ascii_before() {
+        // `é_func(` -- `é` is 2 UTF-8 bytes, 1 UTF-16 unit at col 0.
+        // `(` at UTF-16 col 6.
+        let diags = collect("é_func(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 6);
+        assert_eq!(target.range.end.character, 7);
+    }
+
+    #[test]
+    fn unclosed_opener_astral_before() {
+        // `😀_func(` -- `😀` is 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair).
+        // `(` at UTF-16 col 7.
+        let diags = collect("😀_func(");
+        let target = diags
+            .iter()
+            .find(|d| d.message.contains("Unclosed `(`"))
+            .expect("expected Unclosed ( diagnostic");
+        assert_eq!(target.range.start.character, 7);
+        assert_eq!(target.range.end.character, 8);
+    }
+```
+
+- [ ] **Step 2: Run them**
+
+```bash
+cargo test -p raven --lib unclosed_opener_ -- --nocapture
+```
+
+Expected: all 5 tests PASS without further code changes (the helpers already use `byte_offset_to_utf16_column` correctly).
+
+If any fail, the bug is in earlier code — likely a missed UTF-16 conversion. Fix at the source of the bug (do NOT special-case the test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "test(diagnostics): lock encoding edge cases for unclosed-opener anchor
+
+CRLF, BOM, non-ASCII identifier, astral-plane character. All routed
+through byte_offset_to_utf16_column so columns are LSP-correct."
+```
+
+---
+
+## Task 10: Update `prop_missing_node_width` for bracket-kind MISSING
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs` — the existing property test at line ~8098
+
+**Why this is tenth:** The existing property asserts every diagnostic at a MISSING position has width 1. Our new design anchors bracket-kind MISSING on the opener with a multi-column range. The fix: scope the assertion to non-bracket MISSING kinds, then add a parallel property for bracket-kind.
+
+- [ ] **Step 1: Read the existing property to make sure you understand its current contract**
+
+```bash
+awk 'NR>=8083 && NR<=8200' crates/raven/src/handlers.rs
+```
+
+Confirm: the property maps each `MISSING` node position to a diagnostic at that exact position, asserting width 1.
+
+- [ ] **Step 2: Modify `prop_missing_node_width` to skip bracket-kind MISSING positions**
+
+The cleanest change is at the point where `missing_positions` is iterated. Before the `for &(m_row, m_col) in &missing_positions {` loop, change `missing_positions` collection to also record the MISSING's kind, then skip the bracket kinds inside the loop.
+
+Find `collect_missing_positions` and update it to also record `kind`:
+
+```bash
+grep -n "fn collect_missing_positions" crates/raven/src/handlers.rs
+```
+
+Update the signature and body to collect `(row, col, kind)` triples instead of `(row, col)` pairs. Update both call sites (in `prop_missing_node_priority` and `prop_missing_node_width`).
+
+Then in `prop_missing_node_width`'s iteration loop, add:
+
+```rust
+            for &(m_row, m_col, ref m_kind) in &missing_positions {
+                // Bracket-kind MISSING is now anchored on the opener with
+                // a multi-column range — see Task 7 of bracket-diagnostics
+                // plan. The width-1 invariant applies only to non-bracket
+                // MISSING kinds.
+                if matches!(m_kind.as_str(), ")" | "}" | "]" | "]]") {
+                    continue;
+                }
+                // ... existing match logic ...
+            }
+```
+
+For `prop_missing_node_priority`, no change is required to assertions (it counts `"Syntax error"` messages, not `"Missing X"` messages, and the count check still holds).
+
+- [ ] **Step 3: Add a parallel property test for bracket-kind MISSING**
+
+Just after `prop_missing_node_width`:
+
+```rust
+        // ============================================================================
+        // Feature: bracket-diagnostics, Property: bracket-kind MISSING anchors on opener
+        //
+        // For each bracket-kind MISSING node, the corresponding diagnostic
+        // is NOT at the MISSING's position; it's anchored on the opener
+        // (an ancestor's first delimiter child) with a range whose start
+        // <= the MISSING's column.
+        //
+        // **Validates: bracket-diagnostics design spec, section "Opener
+        // anchoring via MISSING".**
+        // ============================================================================
+
+        #[test]
+        fn prop_bracket_missing_anchors_on_opener(code in missing_node_code()) {
+            let tree = parse_r(&code);
+            let root = tree.root_node();
+
+            let mut missing_positions: Vec<(u32, u32, String)> = Vec::new();
+            collect_missing_positions(root, &mut missing_positions);
+
+            prop_assume!(
+                missing_positions.iter().any(|(_,_,k)| matches!(k.as_str(), ")" | "}" | "]" | "]]")),
+                "Generated code must produce at least one bracket-kind MISSING"
+            );
+
+            let mut diagnostics = Vec::new();
+            collect_syntax_errors(root, &code, &mut diagnostics);
+
+            for &(m_row, m_col, ref m_kind) in &missing_positions {
+                if !matches!(m_kind.as_str(), ")" | "}" | "]" | "]]") {
+                    continue;
+                }
+                // Find a diagnostic whose row == m_row and whose start.character <= m_col
+                // (anchored on the opener; if the MISSING is on a different line, allow row mismatch).
+                let matching = diagnostics.iter().find(|d| {
+                    (d.message.contains("Unclosed") || d.message.contains("Mismatched brackets"))
+                        && d.range.start.line <= m_row
+                });
+                prop_assert!(
+                    matching.is_some(),
+                    "Expected an 'Unclosed' or 'Mismatched' diagnostic anchored at or before \
+                     the MISSING position ({m_row}, {m_col}) kind {m_kind}, but none found. \
+                     Code: {code:?}, Diagnostics: {diagnostics:?}",
+                );
+            }
+        }
+```
+
+- [ ] **Step 4: Run the property tests**
+
+```bash
+cargo test -p raven --lib prop_missing_node -- --nocapture
+cargo test -p raven --lib prop_bracket_missing -- --nocapture
+```
+
+Expected: PASS. Property tests use proptest's random generation; let them run their default cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/raven/src/handlers.rs
+git commit -m "test(diagnostics): scope prop_missing_node_width to non-bracket MISSING
+
+Bracket-kind MISSING is now anchored on the opener with a multi-column
+range, breaking the existing width-1 invariant. Skip those kinds in
+the original property and add a parallel property asserting bracket-
+kind MISSING produces an Unclosed-or-Mismatched diagnostic anchored
+at or before the MISSING position."
+```
+
+---
+
+## Task 11: Update `docs/diagnostics.md` table
+
+**Files:**
+- Modify: `docs/diagnostics.md`
+
+- [ ] **Step 1: Find the current "Missing )" row**
+
+```bash
+grep -n "Missing )" docs/diagnostics.md
+```
+
+Expected: one row in the "Parse Errors" table.
+
+- [ ] **Step 2: Replace it with the two new rows**
+
+Open `docs/diagnostics.md`, locate the table row matching:
+
+```text
+| `Missing )` / `Missing ]` / etc. | A delimiter was opened but never closed (`library(`) |
+```
+
+Replace with:
+
+```text
+| `` Unclosed `(`: missing matching `)` `` / `` Unclosed `{`: missing matching `}` `` / `` Unclosed `[`: missing matching `]` `` / `` Unclosed `[[`: missing matching `]]` `` | A delimiter was opened but never closed (`library(`, `function() {`). The diagnostic is anchored on the opening delimiter, spanning to the end of meaningful content on that line. |
+| `` Missing opening `{` `` / `` Missing opening `(` `` / `` Missing opening `[` `` / `` Missing opening `[[` `` | A closing delimiter appears with no matching opener (`}` at top level, `)` after a complete expression). A run of stray closers (`}}}`) reports a single diagnostic for the whole run. |
+```
+
+- [ ] **Step 3: Extend the existing `Mismatched brackets` note**
+
+Find the existing `Mismatched brackets: ...` row. After it (or below the table), add a one-line note explaining the extended scope:
+
+```text
+The `Mismatched brackets` message now also covers wrong-closer typos where the user typed an unexpected closer immediately after an unclosed opener (e.g. `f(}` produces a single `Mismatched brackets: \`(\` opened here; close with \`)\` not \`}\`.` diagnostic rather than two separate ones).
+```
+
+- [ ] **Step 4: Sanity-check markdown rendering**
+
+```bash
+which markdownlint-cli2 2>/dev/null && markdownlint-cli2 docs/diagnostics.md || echo "(markdownlint not on PATH — skipping)"
+```
+
+Expected: no MD040 / MD013 / table errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/diagnostics.md
+git commit -m "docs(diagnostics): document new bracket-diagnostic messages
+
+Replace the 'Missing )' row with the new 'Unclosed X: missing matching Y'
+and 'Missing opening X' rows. Note the extended scope of the existing
+Mismatched-brackets message to cover f(} -style typos."
+```
+
+---
+
+## Task 12: Final integration run + cleanup
+
+**Files:**
+- None to modify; this is a verification task
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+cargo test -p raven --lib 2>&1 | tail -40
+```
+
+Expected: all tests pass. Any remaining failures should be either:
+1. A real regression — fix it before proceeding.
+2. A test that asserted old behavior (`message == "Syntax error"` for a case now classified) — update the assertion.
+
+- [ ] **Step 2: Build the release binary**
+
+```bash
+cargo build --release -p raven 2>&1 | tail -5
+```
+
+Expected: clean build.
+
+- [ ] **Step 3: Spot-check the diagnostic in a real R file**
+
+Create `/tmp/bracket_demo.R` with:
+
+```r
+library(
+x <- mean(c(1, 2, 3)
+f <- function() {
+  y <- 1
+```
+
+Run the LSP against it (or use a unit test that mirrors a real-file load).
+
+```bash
+cargo test -p raven --lib bracket_demo 2>&1 | tail -20
+```
+
+(Skip if no such test exists — this is a sanity check, not gated.)
+
+- [ ] **Step 4: Squash review**
+
+Inspect the commit log:
+
+```bash
+git log --oneline issue286 ^main
+```
+
+Expected: ~12 commits, each scoped to one of the tasks above. This commit pattern is fine for merge; do NOT amend / squash unless the user asks for it.
+
+- [ ] **Step 5: Final commit (no-op if everything was committed earlier)**
+
+If you discovered fix-ups during Step 1–3, commit them as a separate `fix(diagnostics): ...` commit before merging.
+
+---
+
+## Verification checklist
+
+After running through all tasks, the following should all be true:
+
+- [ ] `cargo test -p raven --lib` passes
+- [ ] `cargo build --release -p raven` succeeds
+- [ ] All new tests in `mod syntax_error_range_tests` are named per the spec's test tables
+- [ ] `docs/diagnostics.md` has the two new table rows
+- [ ] `git log --oneline issue286 ^main` shows ~12 atomic commits
+- [ ] No `TODO`/`TBD`/`FIXME` in the new code
+
+If any of these is false, go back and fix before declaring the work complete.

--- a/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
@@ -1,0 +1,278 @@
+# Bracket / brace / paren diagnostics: helpful messages and anchor on opener
+
+**Status:** Approved (design); ready for implementation plan
+**Date:** 2026-05-17
+**Scope:** `crates/raven/src/handlers.rs` (syntax-error pipeline) and `docs/diagnostics.md`.
+
+## Problem
+
+Two related shortcomings in how Raven reports unbalanced delimiters:
+
+1. **Stray closer** (a `}`, `)`, `]`, or `]]` that has no matching opener in the file)
+   emits the generic message `Syntax error` instead of telling the user what's
+   actually wrong. The audited table in `docs/diagnostics.md` does not list any
+   targeted message for this case — only the unclosed-opener row exists.
+
+2. **Unclosed opener** (a `{`, `(`, `[`, or `[[` with no matching closer) emits
+   the diagnostic squiggle at the *end of the offending statement* — the spot
+   where tree-sitter inserted its `MISSING` node, walked back to the last code
+   line by `anchor_missing_position`. The squiggle never lands on the opening
+   delimiter itself, so the user's eye is directed at "where parsing ran out"
+   rather than at the broken expression's actual start.
+
+Both shortcomings show up in well-formed R that's missing exactly one
+character. They're the kind of mistake users make often when typing.
+
+## Approved decisions
+
+| Decision | Value |
+|---|---|
+| Anchor for unclosed opener | On the opening `{`/`(`/`[`/`[[` character, spanning to end of opener's line |
+| Message for unclosed opener | `` Unclosed `(`: missing matching `)` `` (and `{`/`[`/`[[` variants) |
+| Anchor for stray closer | On the closer character itself (width = token width) |
+| Message for stray closer | `` Missing opening `{` `` (and `(`/`[`/`[[` variants) |
+| Multi-fault behavior | Each delimiter problem emits its own diagnostic |
+| Mismatched-bracket case | Existing `Mismatched brackets: …` message keeps priority (no double-fire) |
+| Unclosed string literal | Unchanged (separate issue) |
+
+## Architecture
+
+All changes live in `crates/raven/src/handlers.rs`, inside the existing
+syntax-error pipeline: `collect_syntax_errors` →
+`classify_error` / `minimize_error_range` / `anchor_missing_position`.
+No new modules.
+
+Two new responsibilities for the diagnostic walk:
+
+1. **Stray-closer detection.** A new classifier
+   `detect_stray_closer(node, text) -> Option<(String, Range)>`, invoked from
+   `classify_error` **after** mismatched-bracket detection so `c(1, 2]` keeps
+   its more specific message. The classifier scans the `ERROR` node's direct
+   children left-to-right for the first child whose token text matches a
+   closer (`}`, `)`, `]`, `]]`, longest-first so `]]` matches before `]`),
+   and fires only when no earlier direct sibling in the same `ERROR` is the
+   matching opener (`{` / `(` / `[` / `[[`). The diagnostic range is the
+   closer token's UTF-16 `start..end`.
+
+2. **Opener anchoring for `MISSING`.** When `minimize_error_range` finds a
+   `MISSING` descendant, route bracket/brace/paren kinds through a new helper
+   that walks upward to the structural parent and uses that parent's opening
+   delimiter token as the anchor. The opener is found by scanning the
+   structural parent's direct children left-to-right for the first child
+   whose token text matches the expected opener for that node kind:
+
+   | Structural parent (tree-sitter-r) | Opener token text |
+   |---|---|
+   | `call` | `(` |
+   | `subset` | `[` |
+   | `subset2` | `[[` |
+   | `braced_expression` | `{` |
+   | `parenthesized_expression` | `(` |
+
+   For `call`, `subset`, `subset2` the opener is NOT the first child —
+   the first child is the callee/object expression (e.g. `mean` in `mean(...)`,
+   `vec` in `vec[1]`). For `braced_expression` and `parenthesized_expression`
+   the opener IS the first child.
+
+   Range = `(opener_row, opener_col_utf16)` →
+   `(opener_row, utf16_len_of_opener_line)`. The range always spans to the
+   end of the line containing the opener; the opener token's own width is
+   irrelevant to the final range (the range subsumes it).
+
+   If no structural parent is found (defensive fallback for unrecognized tree
+   shapes), keep today's `anchor_missing_position` behavior.
+
+   Non-bracket `MISSING` kinds (e.g. the trailing identifier of `x <-`)
+   continue through the existing direct-`MISSING` branch unchanged.
+
+### Independent emission inside one ERROR
+
+Today `collect_syntax_errors` emits exactly one diagnostic per `ERROR`
+(handlers.rs:6302: "Don't recurse into ERROR children"). To honor the
+"detect each independently" decision, the `ERROR` branch becomes:
+
+- If a whole-`ERROR` classifier matches (unclosed string, consecutive pipe,
+  mismatched bracket, fat-arrow), emit that single diagnostic and stop —
+  these classifications describe the whole `ERROR`.
+- Otherwise, walk the `ERROR`'s direct children and emit:
+  - one diagnostic per `MISSING` descendant whose kind is a bracket/brace/paren
+    closer and whose structural-parent walk finds a matching opener
+    (anchored on the opener line);
+  - one diagnostic per stray closer token (anchored on the closer);
+  - fall back to a single `Syntax error` at the minimized range if neither
+    fires.
+
+This contract preserves "one diagnostic per ERROR" for everything tree-sitter
+classifies as a single coherent error, but allows separate diagnostics when an
+`ERROR` legitimately contains two distinct user mistakes (e.g. `f(} y` →
+unclosed `(` AND stray `}`).
+
+### Classifier ordering inside `classify_error`
+
+1. Unclosed string literal *(existing)*
+2. Consecutive pipe *(existing)*
+3. Mismatched bracket *(existing — consumes closers attached to mismatched openers)*
+4. Fat-arrow typo *(existing)*
+5. **Stray closer** *(new — closers that survived steps 1–4)*
+
+## Anchoring details
+
+### Unclosed opener — finding the right `(`/`{`/`[`/`[[`
+
+Walk upward from the `MISSING` node to the first ancestor whose kind is one
+of `call`, `subset`, `subset2`, `braced_expression`,
+`parenthesized_expression`. Inside that ancestor, scan direct children
+left-to-right for the first child whose token text matches the expected
+opener for that node kind (see the table in *Architecture* above). That
+token's `start_position()` is the anchor.
+
+Range: `(opener_row, opener_col_utf16)` →
+`(opener_row, utf16_len_of_opener_line)`.
+
+If no structural parent is found, fall back to today's
+`anchor_missing_position` behavior (`raw_row` walked back to the last code
+line, end-of-line column). The fallback exists for defensive coverage; we
+do not expect it to trigger on real R code.
+
+### Stray closer — finding the right `}`/`)`/`]`/`]]`
+
+Inside an `ERROR` node, scan direct children for the first token whose text
+matches `}`, `)`, `]`, or `]]` (longest-first, so `]]` matches before `]`),
+where no earlier direct sibling is a matching opener. That token is the
+stray closer. The diagnostic range is the token's `start..end` (UTF-16).
+
+The "no earlier matching opener" check is a single linear pass over earlier
+direct siblings — keeps the mismatched-bracket case (`c(1, 2]`) from being
+re-classified as a stray closer once the mismatched-bracket detector has
+already returned its more specific message. In practice, when mismatched-
+bracket fires, the whole-`ERROR` classifier short-circuits before the
+stray-closer pass runs; the per-sibling check is belt-and-braces.
+
+## Edge cases
+
+**E1. `[[` and `]]`.** Single tokens in tree-sitter-r. The stray-closer scan
+matches `]]` before `]` (longest-first). For openers, anchor at the `[[`
+token's start column, span to EOL.
+
+**E2. Top-level `MISSING` outside any `ERROR`.** `x <-` produces a lone
+`MISSING identifier` at the program level. No opener to anchor on. The
+direct-`MISSING` branch (handlers.rs:6308) is unchanged in message and
+anchor for non-bracket `MISSING` kinds. Bracket-kind `MISSING` nodes at the
+top level *are* re-routed through the new opener-walking logic so that
+`library(` still produces a useful diagnostic anchored on the `(`.
+
+**E3. Nested unclosed openers.** `f(g(h(` has three unclosed `(`.
+Tree-sitter inserts three `MISSING` `)` closers, one per level. The
+structural-parent walk from each `MISSING` finds its matching opener.
+Result: three diagnostics on three `(` characters.
+
+**E4. Mismatched-bracket case keeps priority.** `c(1, 2]` emits the existing
+`Mismatched brackets: \`(\` opened here; close with \`)\` not \`]\`.`
+diagnostic. The stray-closer pass does NOT additionally emit
+`Missing opening \`[\`` for the `]`. This is enforced by the whole-`ERROR`
+classifier short-circuit (mismatched-bracket is in the priority list above
+stray-closer).
+
+**E5. Stray closer immediately after a valid expression.** `f() }` — `f()`
+parses as a complete `call`, then `}` is its own `ERROR` sibling at the
+program level. The stray-closer detector fires on that `ERROR`. One
+diagnostic, on the `}`, `Missing opening \`{\``.
+
+**E6. Multiple stray closers in a row.** `}}}` produces three sibling
+`ERROR` nodes at the program level. Three diagnostics. Expected behavior
+per "detect each independently."
+
+**E7. Unclosed opener at end of file.** `library(` with no trailing
+newline. `MISSING` `)` is placed at the file's end byte. Structural-parent
+walk: `MISSING` → `call` → first child `(` at column 7. Range = col 7 → EOL
+of opener's line. Works.
+
+**E8. R Markdown / Quarto code chunks.** Diagnostics already operate on a
+per-chunk tree-sitter parse upstream of `collect_syntax_errors`. No
+additional handling needed — the new logic operates on the same node tree
+contract.
+
+**E9. `# @lsp-ignore` suppression.** Both new diagnostics flow through the
+same suppression path as existing parse diagnostics. The suppression marker
+must be on the line containing the *new* anchor — i.e., the opener line for
+the unclosed case, the closer line for the stray case. Document this in
+`docs/diagnostics.md` alongside the new table rows.
+
+## Out of scope
+
+- Unclosed string literal anchoring/messaging — separate issue.
+- Backtick-quoted identifier mismatches — backticks aren't brackets.
+- Heuristics like "did you mean to add `}` on line N?" — would require
+  multi-line layout analysis beyond what's needed.
+
+## Tests
+
+All new tests go in the existing `syntax_error_range_tests` module in
+`crates/raven/src/handlers.rs` (line 6485+), reusing the `collect(code)`
+helper.
+
+### Stray-closer detection (new)
+
+| Test | Input | Expected |
+|---|---|---|
+| `stray_close_brace_emits_missing_opening` | `"x <- 1\n}\n"` | exactly one diagnostic, message `` Missing opening `{` ``, range on the `}` |
+| `stray_close_paren_emits_missing_opening` | `"x <- 1\n)\n"` | exactly one diagnostic, message `` Missing opening `(` ``, range on the `)` |
+| `stray_close_bracket_emits_missing_opening` | `"x <- 1\n]\n"` | exactly one diagnostic, message `` Missing opening `[` ``, range on the `]` |
+| `stray_double_close_bracket_emits_missing_opening` | `"x <- 1\n]]\n"` | message `` Missing opening `[[` `` (longest-first match), range covers both `]]` |
+| `multiple_stray_closers_emit_one_each` | `"}}}"` | three diagnostics, each on its own `}` |
+| `mismatched_bracket_still_wins` | `"c(1, 2]"` | existing mismatched-bracket message; **no** `Missing opening \`[\`` diagnostic |
+| `stray_closer_after_valid_expr` | `"f() }"` | exactly one diagnostic for the `}`, none for `f()` |
+
+### Opener anchoring for unclosed cases (range = opener-line)
+
+| Test | Input | Expected |
+|---|---|---|
+| `unclosed_paren_anchors_on_opener` | `"x <- mean(c(1, 2, 3)\n\n# comment\n"` | range starts at the `(` of `mean(` (col 9), ends at EOL of the opener line; message `` Unclosed `(`: missing matching `)` `` |
+| `unclosed_brace_anchors_on_opener` | `"f <- function() {\n  x <- 1\n  y <- 2\n"` | range on `{` only (opener at EOL); message `` Unclosed `{`: missing matching `}` `` |
+| `unclosed_bracket_anchors_on_opener` | `"vec[1, 2\n"` | range from `[` (col 3) through EOL; message `` Unclosed `[`: missing matching `]` `` |
+| `unclosed_double_bracket_anchors_on_opener` | `"vec[[1, 2\n"` | range from `[[` start through EOL; message `` Unclosed `[[`: missing matching `]]` `` |
+| `nested_unclosed_opens_emit_per_level` | `"f(g(h(\n"` | three diagnostics, one anchored on each `(` |
+| `unclosed_paren_at_end_of_file` | `"library("` | range on the `(` through EOL; message `` Unclosed `(`: missing matching `)` `` |
+
+### Combined faults (independent emission)
+
+| Test | Input | Expected |
+|---|---|---|
+| `unclosed_opener_and_stray_closer_in_same_error` | `"f(} y\n"` | two diagnostics: one `` Unclosed `(`: missing matching `)` `` on the `(`, one `` Missing opening `{` `` on the `}` |
+
+### Regression / non-regression
+
+| Test | Input | Behavior to preserve |
+|---|---|---|
+| `unclosed_paren_diagnostic_anchors_on_offending_line` (handlers.rs:6635) | unchanged | rewrite assertions to expect new anchor on the opener instead of end-of-statement |
+| `mismatched_bracket_emits_descriptive_message` (handlers.rs:7335) | unchanged | unchanged behavior |
+| `incomplete_assignment_in_block_minimized` (handlers.rs:6509) | unchanged | unchanged behavior — non-bracket `MISSING`, uses unchanged code path |
+| `top_level_incomplete_assignment` (handlers.rs:6605) | unchanged | unchanged behavior (same reason) |
+| `unclosed_string_literal_*` tests | unchanged | string-literal anchoring untouched |
+
+### Helper-level unit test
+
+Add a unit test for the new `find_opener_for_missing(missing) -> Option<(Node, Range)>`
+helper, covering: `MISSING` inside `call`, inside `subset`, inside `subset2`,
+inside `braced_expression`, inside `parenthesized_expression`, and the
+defensive `None` case (synthetic `MISSING` with no structural parent).
+
+## Documentation
+
+`docs/diagnostics.md` — replace the current row:
+
+```text
+| `Missing )` / `Missing ]` / etc. | A delimiter was opened but never closed (`library(`) |
+```
+
+with two rows:
+
+```text
+| `` Unclosed `(`: missing matching `)` `` / `` Unclosed `{`: missing matching `}` `` / `` Unclosed `[`: missing matching `]` `` / `` Unclosed `[[`: missing matching `]]` `` | A delimiter was opened but never closed (`library(`, `function() {`). The diagnostic is anchored on the opening delimiter, spanning to the end of that line. |
+| `` Missing opening `{` `` / `` Missing opening `(` `` / `` Missing opening `[` `` / `` Missing opening `[[` `` | A closing delimiter appears with no matching opener (`}` at top level, `)` after a complete expression). |
+```
+
+No changes to `docs/development.md` — the new logic is local to
+`handlers.rs` and doesn't affect cross-file invariants, caching, or any
+architectural concerns covered there. No `CLAUDE.md` updates — the changes
+don't add a new module-spanning invariant.

--- a/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
@@ -96,7 +96,7 @@ contract emits exactly one diagnostic per `ERROR`, supporting "multiple
 diagnostics per ERROR" requires a structural refactor of that boundary
 without breaking the existing classifiers.
 
-### Internal types
+### Internal types and helper signatures
 
 ```rust
 struct ClassifiedSyntaxDiagnostic {
@@ -113,13 +113,37 @@ enum ErrorClassification {
     /// to a single generic 'Syntax error' at the minimized range".
     Multi(Vec<ClassifiedSyntaxDiagnostic>),
 }
+
+/// Per-traversal mutable state threaded through `collect_syntax_errors`.
+/// Lets the classifier coalesce a MISSING follow-up that was already
+/// reported via a mismatched-bracket diagnostic on the same opener.
+#[derive(Default)]
+struct CollectState {
+    /// Tree-sitter Node IDs of opener tokens already covered by a
+    /// `Mismatched brackets` diagnostic. The MISSING-handling branch
+    /// must skip emitting a separate `Unclosed X` for any opener whose
+    /// node ID appears here.
+    covered_openers: HashSet<usize>,
+}
+
+/// Signature of the new opener-anchoring helper. Needs the source text
+/// to compute UTF-16 columns and end-of-meaningful-content.
+fn find_opener_for_missing(missing: Node, text: &str) -> Option<(Node, Range)>;
+
+/// Compute the UTF-16 column just past the last non-comment, non-
+/// whitespace character on `line`. Used by the opener-anchoring helper
+/// to trim trailing comments and whitespace from the range.
+fn end_of_meaningful_content(line: &str) -> u32;
 ```
 
-`classify_error` returns `ErrorClassification` instead of `String`. The
-caller (`collect_syntax_errors`) decides whether to emit one or many
-diagnostics for each ERROR. This keeps the single-classifier contract for
-existing classifiers (they all return `Whole`) while allowing the new
-delimiter logic to return `Multi` when appropriate.
+`classify_error` returns `ErrorClassification` instead of `String`, and
+takes `&mut CollectState` so it can record openers covered by mismatched-
+bracket diagnostics. The single production caller (`collect_syntax_errors`
+— verified to be the only one) passes the state through its recursion.
+This keeps the single-classifier contract for existing classifiers (they
+all return `Whole` and don't touch state) while allowing the new
+delimiter logic to return `Multi` and the coalescing rule to suppress
+duplicate MISSING follow-ups.
 
 ### Classifier ordering inside `classify_error`
 
@@ -139,58 +163,111 @@ that classifies the ERROR:
 
 ### Delimiter scan rules
 
-When the delimiter scan runs on an ERROR, it does this single pass:
+The delimiter scan converts an ERROR's structure into a flat stream of
+delimiter events (`Open(kind, byte_pos)` / `Close(kind, byte_pos, end_byte)`),
+then processes the stream with a stack.
 
-1. Iterate the ERROR's *direct* children left-to-right, tracking a stack
-   of unmatched openers.
-2. For each child whose token text is an opener (`(`, `{`, `[`, `[[`),
-   push `(kind, position, line, end_of_meaningful_content_col)` onto the
-   stack.
-3. For each child whose token text is a closer (`)`, `}`, `]`, `]]`),
-   look at the top of the stack:
-   - If the stack is empty → it's a stray closer. Emit
-     `Missing opening `X`` at the closer token's range.
-   - If the top of the stack matches (same kind) → pop and discard
-     (this matched pair lived inside the ERROR; nothing to report).
-   - If the top of the stack is a mismatched opener → emit
-     `Mismatched brackets: ` and pop. (This handles e.g. `(...]` patterns
-     embedded inside a broader ERROR.)
-4. For each opener left on the stack at the end → emit
-   `Unclosed `X`: missing matching `Y`` ranged from the opener through
-   end-of-meaningful-content on the opener's line.
+**Event extraction.** Walk the ERROR's direct children left-to-right.
+For each child:
 
-This pass produces between zero and N diagnostics where N is the number of
-delimiter tokens in the ERROR. For `f(g(h(` the stack has three unclosed
-`(` at the end → three diagnostics. For `}}}` there's one ERROR whose only
-direct child is `ERROR "}}}"` (a single undifferentiated leaf) — the leaf
-is not parsed as three closer tokens, so the rule above sees one closer
-token of text `"}}}"`. We treat that whole leaf as a single stray-closer
-diagnostic and produce ONE `Missing opening `{`` ranged over the entire
-leaf.
+- **If the child is a recognized opener token** (`text == "(" | "{" | "[" | "[["`):
+  emit one `Open` event at the child's start position.
+- **If the child is a recognized closer token** (`text == ")" | "}" | "]" | "]]"`):
+  emit one `Close` event spanning the child's range.
+- **If the child is itself an ERROR or unrecognized leaf whose text
+  consists only of closer characters** (`}`, `)`, `]` — any mix or repetition):
+  treat the leaf as a sequence of closers and emit events using these rules:
+  - A **homogeneous run** of one closer kind (`}}}`, `)))`, `]]`, `]]]]`,
+    etc.) → ONE `Close` event spanning the entire run. The closer kind
+    is the single character making up the run; for `]]` and `]]]]`-style
+    runs, treat consecutive pairs as `]]` tokens left-to-right (so `]]]`
+    becomes one `]]` event covering cols 0..2 plus one `]` event at
+    col 2..3).
+  - A **mixed run** of multiple closer kinds (`])`, `}]`, `)]`, etc.) →
+    ONE `Close` event per character (or per `]]` pair), emitted in
+    source order at the appropriate byte ranges.
+- **If the child is a nested ERROR** whose direct children include
+  delimiter tokens, recurse one level into it and apply the same rules
+  to its direct children. Do NOT recurse into non-ERROR semantic
+  children — they have their own balanced structure that the parser has
+  already validated.
+- **Any other child** (identifier, literal, comment, complete semantic
+  subtree) is skipped — it cannot contribute a delimiter event.
 
-### Stray closer in unclosed-opener arguments (coalescing rule)
+**Stack processing.** Iterate the event stream:
 
-For the very common `f(}` typo, the parse shape is **NOT** the same as the
-ERROR-scan case above: the `}` lives inside the `arguments` node, not
-inside an ERROR that also contains the `(`. The mismatched-bracket
-detector at step 3 of the classifier order is extended to handle this:
+1. `Open` → push `(kind, byte_pos, row, col_utf16, line_text)` onto the stack.
+2. `Close` → consult the top of the stack:
+   - **Stack empty** → it's a stray closer. Emit
+     `` Missing opening `X` `` at the closer event's range
+     (UTF-16-converted).
+   - **Top matches (same kind)** → pop. The pair lived inside the
+     ERROR; nothing to report.
+   - **Top is mismatched** → emit
+     `` Mismatched brackets: `O` opened here; close with `C` not `W`. ``
+     (where `O` is the opener kind, `C` is the expected closer for `O`,
+     and `W` is the actual wrong-closer kind). Pop and record the
+     opener's node ID in `CollectState::covered_openers` so the
+     downstream MISSING handler suppresses any `Unclosed O` diagnostic
+     for the same opener. The diagnostic range is the closer event's
+     range (UTF-16-converted).
+3. **After the stream is exhausted**, walk the remaining openers on
+   the stack. For each opener, emit
+   `` Unclosed `X`: missing matching `Y` `` ranged from
+   `(row, col_utf16)` through the **next unclosed opener on the same
+   line, or end-of-meaningful-content on that line, whichever comes
+   first**. The "next unclosed opener on the same line" rule prevents
+   overlapping ranges when multiple openers share one line (e.g.
+   `f(g(h(`: outer `(` spans cols 1–3, middle `(` spans 3–5, inner
+   `(` spans 5–6).
 
-When the existing mismatched-bracket detector finds an ERROR whose only
-non-whitespace child is a closer token, it now also walks up one level to
-check whether the parent is `arguments`, `braced_expression`, or
-`parenthesized_expression` AND whether that parent contains an opener
-*and* a `MISSING` closer of the expected kind. If yes, emit a single
-mismatched-bracket diagnostic anchored on the stray closer, with message
-`` Mismatched brackets: `(` opened here; close with `)` not `}`. ``
-(opener character substituted from the parent's actual opener; stray-closer
-character substituted from the ERROR's child).
+This pass produces between zero and N diagnostics where N is the
+number of delimiter events in the ERROR. For `f(g(h(`: stack ends with
+three unclosed `(` → three diagnostics with non-overlapping ranges. For
+`}}}`: one homogeneous-run event → one `` Missing opening `{` ``
+diagnostic spanning the run. For `])`: two mixed events → two
+diagnostics, one per character.
 
-The diagnostic suppresses the `MISSING` follow-up that would otherwise
-produce a separate "Unclosed `(`" message for the same opener — the
-mismatched-bracket diagnostic already names it. This is implemented by
-having the `MISSING`-handling branch consult a small per-traversal set of
-"openers already covered by a mismatched-bracket diagnostic" populated at
-classification time.
+### Stray closer adjacent to an unclosed opener (coalescing)
+
+The very common `f(}` typo has two parse shapes depending on whether
+content follows the wrong closer:
+
+- **Flat-ERROR shape** (`f(}`, `f(}\n`): `program(identifier, ERROR("("
+  ERROR(ERROR "}")))`. No `arguments` node; the `(` and the `}` are
+  both inside one flat ERROR. The delimiter scan handles this via its
+  "Top is mismatched" rule (step 2.c above) — one `Mismatched brackets`
+  diagnostic, no Unclosed-X follow-up. No special coalescing rule
+  needed.
+- **Arguments shape** (`f(} y`, `f(} 1`): `program(call(identifier,
+  arguments("(" ERROR(ERROR "}") argument MISSING ")")))`. Here the
+  parser was able to extract a trailing argument, so the structure
+  partially recovered — the wrong closer sits in an ERROR child of
+  `arguments`, and the MISSING `)` is at the end. This case needs an
+  explicit coalescing rule (below) because the delimiter scan only
+  sees the `}` ERROR (not the opener `(`, which is `arguments`'s first
+  child).
+
+**Coalescing rule for the `arguments` shape.** Inside the
+mismatched-bracket detector (classifier step 3), when an ERROR has no
+opener-token child but has exactly one closer-token leaf descendant,
+walk up to the ERROR's direct parent. If the parent kind is
+`arguments`, `braced_expression`, or `parenthesized_expression`, AND
+the parent's first child is an opener token whose matching closer kind
+is *different* from the ERROR's closer leaf, AND the parent's last
+child is `MISSING` of the expected closer kind, then:
+
+1. Emit one `Mismatched brackets` diagnostic anchored on the ERROR's
+   closer leaf, with message
+   `` Mismatched brackets: `O` opened here; close with `C` not `W`. ``
+   (opener `O` and expected closer `C` from the parent's opener;
+   actual wrong-closer `W` from the ERROR leaf).
+2. Record the opener token's node ID in `CollectState::covered_openers`.
+
+The MISSING-anchoring branch checks `covered_openers` before emitting
+`Unclosed O: missing matching C` for that opener, and skips it. The set
+is mutable state on `CollectState` threaded through `classify_error` and
+the MISSING-handling code.
 
 ### Opener anchoring via MISSING (single-level parent walk)
 
@@ -355,18 +432,23 @@ All new tests go in `mod syntax_error_range_tests` in
 | `unclosed_brace_anchors_on_opener` | `"f <- function() {\n  x <- 1\n  y <- 2\n"` | range on `{` only (opener at EOL); message `` Unclosed `{`: missing matching `}` `` |
 | `unclosed_bracket_anchors_on_opener` | `"vec[1, 2\n"` | range from `[` (col 3) through end of line content (col 8); message `` Unclosed `[`: missing matching `]` `` |
 | `unclosed_double_bracket_anchors_on_opener` | `"vec[[1, 2\n"` | range from `[[` start (col 3) through end of line content (col 9); message `` Unclosed `[[`: missing matching `]]` `` |
-| `nested_flat_unclosed_emits_per_opener` | `"f(g(h(\n"` | THREE diagnostics, one anchored on each `(` (cols 1, 3, 5). Each range covers its `(` only (no content after). |
+| `nested_flat_unclosed_emits_per_opener` | `"f(g(h(\n"` | THREE diagnostics, one anchored on each `(`. Ranges: outer `(` cols 1–3, middle `(` cols 3–5, inner `(` cols 5–6 (per the "next opener on same line, or end-of-meaningful-content" rule). Ranges do NOT overlap. |
 | `unclosed_paren_at_end_of_file` | `"library("` | range on the `(`; message `` Unclosed `(`: missing matching `)` `` |
 | `unclosed_opener_with_trailing_comment` | `"f( # comment\n"` | range covers just the `(` (comment excluded); message `` Unclosed `(`: missing matching `)` `` |
 | `unclosed_opener_with_trailing_whitespace` | `"f(   \n"` | range covers just the `(` (whitespace excluded); message `` Unclosed `(`: missing matching `)` `` |
 
-### Coalescing — stray closer inside an unclosed opener
+### Coalescing — wrong closer for the surrounding opener
 
-| Test | Input | Expected |
-|---|---|---|
-| `wrong_closer_in_args_coalesces` | `"f(}\n"` | exactly ONE diagnostic, message `` Mismatched brackets: `(` opened here; close with `)` not `}`. ``, range on the `}` |
-| `wrong_closer_followed_by_content_coalesces` | `"f(} y\n"` | exactly ONE diagnostic (Mismatched brackets), NOT two |
-| `wrong_closer_for_subset_coalesces` | `"vec[}\n"` | one Mismatched-brackets diagnostic naming `[` and `}` |
+These cover both parse shapes (flat ERROR and `arguments`-with-MISSING).
+Both shapes coalesce into a single `Mismatched brackets` diagnostic.
+
+| Test | Input | Parse shape | Expected |
+|---|---|---|---|
+| `wrong_closer_flat_error_coalesces` | `"f(}\n"` | flat ERROR contains both `(` and `ERROR("}")` | exactly ONE diagnostic via delimiter-scan mismatched-bracket sub-rule. Message `` Mismatched brackets: `(` opened here; close with `)` not `}`. ``, range on the `}` |
+| `wrong_closer_in_arguments_coalesces` | `"f(} y\n"` | `arguments(`(`, ERROR(`}`), argument, MISSING `)`)` | exactly ONE diagnostic via the arguments-coalescing rule. No `Unclosed `(`` follow-up for the same opener (suppressed by `CollectState::covered_openers`). |
+| `wrong_closer_for_subset_coalesces` | `"vec[}\n"` | (flat ERROR — verify in test) | one Mismatched-brackets diagnostic naming `[` and `}` |
+| `wrong_closer_with_braced_expression` | `"function() ]\n"` | `function_definition` with `braced_expression` followed by stray `]` (verify exact shape) | Specific to the parse shape: if `]` is in `braced_expression`, coalesces against `{`; otherwise stays as a stray closer (`` Missing opening `[` ``). Test asserts whichever the verified parse shape produces. |
+| `mixed_closer_leaf_emits_per_kind` | `"]\n)"` placed as two separate stray closers OR `f(])` whose flat ERROR contains a leaf `])` | For mixed leaves like `])`: two diagnostics, one `` Missing opening `[` `` on the `]`, one `` Missing opening `(` `` on the `)`. |
 
 ### Encoding / line-ending edge cases
 
@@ -380,25 +462,36 @@ All new tests go in `mod syntax_error_range_tests` in
 
 ### Regression / non-regression
 
-| Test | Behavior to preserve |
+| Test | Behavior to preserve / change |
 |---|---|
 | `unclosed_paren_diagnostic_anchors_on_offending_line` (existing) | Rewrite to expect new anchor (on opener) instead of end-of-statement. |
 | `mismatched_bracket_emits_descriptive_message` (existing) | Unchanged behavior. |
 | `incomplete_assignment_in_block_minimized` (existing) | Unchanged — non-bracket `MISSING`, uses unchanged code path. |
 | `top_level_incomplete_assignment` (existing) | Unchanged (same reason). |
 | `unclosed_string_literal_*` (existing) | Unchanged — string-literal handling untouched. |
+| `prop_missing_node_priority` (handlers.rs:7802) | Unchanged — asserts on `"Syntax error"`-message count, not on `Missing X` ranges. Our new messages don't affect this property. |
+| `prop_missing_node_width` (handlers.rs:8098) | **Update**: the property currently asserts that every diagnostic at a `MISSING` node's reported position has width 1. The new design anchors *bracket-kind* `MISSING` on the opener (not the MISSING position) with a multi-column range. The fix is to scope the property: filter `missing_positions` to exclude bracket-kind closers (`)`, `}`, `]`, `]]`), keeping the width-1 assertion only for non-bracket `MISSING` kinds (e.g. identifiers, operators). Add a parallel property asserting that bracket-kind `MISSING` produces a diagnostic anchored on the opener, with range ending at end-of-meaningful-content. |
+| `prop_diagnostic_deduplication` (handlers.rs:7951), `prop_error_detection_completeness` (handlers.rs:8199) | Verify in implementation that these still pass; they don't assert specific messages or anchor positions. |
 
-### Helper-level unit test
+### Helper-level unit tests
 
-Add a unit test for the new helpers:
+Add unit tests for the new helpers:
 
-- `find_opener_for_missing(missing) -> Option<(Node, Range)>` — covers
-  `MISSING` inside `arguments` (with `(`/`[`/`[[` opener), inside
+- `find_opener_for_missing(missing: Node, text: &str) -> Option<(Node, Range)>`
+  — covers `MISSING` inside `arguments` (with `(`/`[`/`[[` opener), inside
   `braced_expression`, inside `parenthesized_expression`, and the
   defensive `None` case.
-- `end_of_meaningful_content(line, byte_col) -> u32` — covers a line with
-  trailing whitespace, with a trailing comment, with a `#` inside a string
-  (must not trim there), and with CRLF.
+- `end_of_meaningful_content(line: &str) -> u32` — covers: trailing
+  whitespace only, trailing comment only, content + trailing comment,
+  content + trailing whitespace, `#` inside a string literal (must NOT
+  trim there — comment detection is string-aware), `#` inside a
+  backtick-quoted identifier (must NOT trim there), CRLF (`\r` is
+  whitespace, must be trimmed).
+- Delimiter-scan event extraction — covers: opener tokens as direct
+  children of an ERROR, closer tokens as direct children, homogeneous
+  closer-run leaves (`}}}` → one event), mixed closer-run leaves (`])`
+  → two events), nested ERROR leaves, non-delimiter children that are
+  skipped (identifiers, literals, comments).
 
 ## Documentation
 

--- a/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
@@ -11,7 +11,7 @@ Two related shortcomings in how Raven reports unbalanced delimiters:
 1. **Stray closer** (a `}`, `)`, `]`, or `]]` that has no matching opener in the file)
    emits the generic message `Syntax error` instead of telling the user what's
    actually wrong. The audited table in `docs/diagnostics.md` does not list any
-   targeted message for this case — only the unclosed-opener row exists.
+   targeted message for this case.
 
 2. **Unclosed opener** (a `{`, `(`, `[`, or `[[` with no matching closer) emits
    the diagnostic squiggle at the *end of the offending statement* — the spot
@@ -27,176 +27,301 @@ character. They're the kind of mistake users make often when typing.
 
 | Decision | Value |
 |---|---|
-| Anchor for unclosed opener | On the opening `{`/`(`/`[`/`[[` character, spanning to end of opener's line |
+| Anchor for unclosed opener | On the opening `{`/`(`/`[`/`[[` character, spanning to the end of meaningful content on that line (trailing comments and trailing whitespace excluded). |
 | Message for unclosed opener | `` Unclosed `(`: missing matching `)` `` (and `{`/`[`/`[[` variants) |
-| Anchor for stray closer | On the closer character itself (width = token width) |
+| Anchor for stray closer | On the closer token's own UTF-16 `start..end` |
 | Message for stray closer | `` Missing opening `{` `` (and `(`/`[`/`[[` variants) |
-| Multi-fault behavior | Each delimiter problem emits its own diagnostic |
-| Mismatched-bracket case | Existing `Mismatched brackets: …` message keeps priority (no double-fire) |
+| Multi-fault behavior | Each *distinct* delimiter problem emits its own diagnostic — but a stray closer that lives inside an unclosed opener's arguments (e.g. `f(}`) coalesces into a single `Mismatched brackets` diagnostic, because the user almost certainly typed the wrong closer character. |
+| Closer runs (`}}}`, `)))`, etc.) | One diagnostic covering the whole run — tree-sitter does not tokenize the characters individually, and splitting them ourselves would add noise without informational value. |
+| Mismatched-bracket case | Existing `Mismatched brackets: …` message keeps priority; its scope is extended to also fire when the opener lives in a structural parent of the stray closer's ERROR (see `f(}` case). |
 | Unclosed string literal | Unchanged (separate issue) |
+
+## Empirically verified tree-sitter-r parse shapes
+
+The design depends on what tree-sitter-r actually produces. These shapes were
+verified by probe against the pinned grammar
+(`95aff097aa927a66bb357f715b58cde821be8867` per `crates/raven/Cargo.toml`):
+
+- **`x <- 1\n}\n`** → `program(binary_operator, ERROR(ERROR "}"))` — stray `}`
+  is a single ERROR leaf at top level.
+- **`}}}\n`** → `program(ERROR(ERROR "}}}"))` — runs of closers are a single
+  undifferentiated ERROR span. Tree-sitter does NOT split them into per-`}`
+  tokens.
+- **`x <- 1\n]]\n`** → `program(binary_operator, ERROR(ERROR "]]"))` — `]]` is
+  a single token even when stray.
+- **`f(g(h(\n`** → `program(identifier "f", ERROR("(" "g" "(" "h" "("))` — when
+  multiple openers are unclosed at the same nesting depth, tree-sitter
+  produces a FLAT ERROR containing each opener token as a direct child. There
+  are NO `MISSING` nodes in this shape. Any design that finds the opener only
+  by walking up from a `MISSING` will miss every level.
+- **`f <- function() { x <- 1\n y <- 2\n`** → `function_definition(...,
+  braced_expression("{" ... } [MISSING] ""))` — the unclosed `{` lives as the
+  first child of `braced_expression`; the `MISSING }` is the last child of
+  the same node. Single-level parent walk from `MISSING` finds the opener.
+- **`x <- mean(c(1, 2, 3)\n`** → `binary_operator(call(identifier,
+  arguments("(" ... ")" comment ")" [MISSING])))` — the unclosed `(` of
+  `mean(` lives in `arguments` (parent of the `MISSING )`), not in `call`.
+  The opener is `arguments`'s first child.
+- **`vec[1, 2\n`** → `subset(identifier "vec", arguments("[" ... "]"
+  [MISSING]))` — same pattern as call. The `arguments` node is the direct
+  parent of `MISSING`, opener `[` is its first child.
+- **`vec[[1, 2\n`** → `subset2(identifier "vec", arguments("[[" ... "]]"
+  [MISSING]))` — same pattern; opener `[[` (width 2 token), `MISSING ]]`.
+- **`library(`** → `program(call(identifier, arguments("(" ")" [MISSING])))`
+  — top-level unclosed call. `MISSING )` has parent `arguments`, opener `(`
+  is its first child.
+- **`f() }\n`** → `program(call(...), ERROR(ERROR "}"))` — complete call,
+  then a sibling ERROR for the stray `}`.
+- **`f(} y\n`** → `program(call(identifier "f", arguments("(" ERROR(ERROR
+  "}") argument ")" [MISSING])))` — unclosed `(` with a stray `}` and
+  trailing identifier inside its argument list. The `}` is an ERROR child of
+  `arguments`; the `MISSING )` is at the end of `arguments`. This is the
+  case that gets coalesced into a mismatched-bracket diagnostic.
+- **`c(1, 2]`** → `program(identifier, ERROR("(" arg "," arg ERROR "]"))` —
+  the existing mismatched-bracket detector handles this shape.
+- **`f( # comment\n`** → `program(call(identifier, arguments("(" comment ")"
+  [MISSING])))` — opener line has nothing of value after the `(` except a
+  comment; the spec's "spans to end of meaningful content" rule must trim
+  past the comment.
 
 ## Architecture
 
 All changes live in `crates/raven/src/handlers.rs`, inside the existing
 syntax-error pipeline: `collect_syntax_errors` →
-`classify_error` / `minimize_error_range` / `anchor_missing_position`.
-No new modules.
+`classify_error` / `minimize_error_range` / `anchor_missing_position`. No
+new modules.
 
-Two new responsibilities for the diagnostic walk:
+Because today's `classify_error` returns a single `String` and the existing
+contract emits exactly one diagnostic per `ERROR`, supporting "multiple
+diagnostics per ERROR" requires a structural refactor of that boundary
+without breaking the existing classifiers.
 
-1. **Stray-closer detection.** A new classifier
-   `detect_stray_closer(node, text) -> Option<(String, Range)>`, invoked from
-   `classify_error` **after** mismatched-bracket detection so `c(1, 2]` keeps
-   its more specific message. The classifier scans the `ERROR` node's direct
-   children left-to-right for the first child whose token text matches a
-   closer (`}`, `)`, `]`, `]]`, longest-first so `]]` matches before `]`),
-   and fires only when no earlier direct sibling in the same `ERROR` is the
-   matching opener (`{` / `(` / `[` / `[[`). The diagnostic range is the
-   closer token's UTF-16 `start..end`.
+### Internal types
 
-2. **Opener anchoring for `MISSING`.** When `minimize_error_range` finds a
-   `MISSING` descendant, route bracket/brace/paren kinds through a new helper
-   that walks upward to the structural parent and uses that parent's opening
-   delimiter token as the anchor. The opener is found by scanning the
-   structural parent's direct children left-to-right for the first child
-   whose token text matches the expected opener for that node kind:
+```rust
+struct ClassifiedSyntaxDiagnostic {
+    message: String,
+    range: Range,
+}
 
-   | Structural parent (tree-sitter-r) | Opener token text |
-   |---|---|
-   | `call` | `(` |
-   | `subset` | `[` |
-   | `subset2` | `[[` |
-   | `braced_expression` | `{` |
-   | `parenthesized_expression` | `(` |
+enum ErrorClassification {
+    /// One diagnostic describes the whole ERROR (e.g. unclosed string,
+    /// mismatched bracket). Stop iterating.
+    Whole(ClassifiedSyntaxDiagnostic),
+    /// Multiple diagnostics extracted from the ERROR's children.
+    /// Empty Vec means "no specific classification — caller falls back
+    /// to a single generic 'Syntax error' at the minimized range".
+    Multi(Vec<ClassifiedSyntaxDiagnostic>),
+}
+```
 
-   For `call`, `subset`, `subset2` the opener is NOT the first child —
-   the first child is the callee/object expression (e.g. `mean` in `mean(...)`,
-   `vec` in `vec[1]`). For `braced_expression` and `parenthesized_expression`
-   the opener IS the first child.
-
-   Range = `(opener_row, opener_col_utf16)` →
-   `(opener_row, utf16_len_of_opener_line)`. The range always spans to the
-   end of the line containing the opener; the opener token's own width is
-   irrelevant to the final range (the range subsumes it).
-
-   If no structural parent is found (defensive fallback for unrecognized tree
-   shapes), keep today's `anchor_missing_position` behavior.
-
-   Non-bracket `MISSING` kinds (e.g. the trailing identifier of `x <-`)
-   continue through the existing direct-`MISSING` branch unchanged.
-
-### Independent emission inside one ERROR
-
-Today `collect_syntax_errors` emits exactly one diagnostic per `ERROR`
-(handlers.rs:6302: "Don't recurse into ERROR children"). To honor the
-"detect each independently" decision, the `ERROR` branch becomes:
-
-- If a whole-`ERROR` classifier matches (unclosed string, consecutive pipe,
-  mismatched bracket, fat-arrow), emit that single diagnostic and stop —
-  these classifications describe the whole `ERROR`.
-- Otherwise, walk the `ERROR`'s direct children and emit:
-  - one diagnostic per `MISSING` descendant whose kind is a bracket/brace/paren
-    closer and whose structural-parent walk finds a matching opener
-    (anchored on the opener line);
-  - one diagnostic per stray closer token (anchored on the closer);
-  - fall back to a single `Syntax error` at the minimized range if neither
-    fires.
-
-This contract preserves "one diagnostic per ERROR" for everything tree-sitter
-classifies as a single coherent error, but allows separate diagnostics when an
-`ERROR` legitimately contains two distinct user mistakes (e.g. `f(} y` →
-unclosed `(` AND stray `}`).
+`classify_error` returns `ErrorClassification` instead of `String`. The
+caller (`collect_syntax_errors`) decides whether to emit one or many
+diagnostics for each ERROR. This keeps the single-classifier contract for
+existing classifiers (they all return `Whole`) while allowing the new
+delimiter logic to return `Multi` when appropriate.
 
 ### Classifier ordering inside `classify_error`
 
-1. Unclosed string literal *(existing)*
-2. Consecutive pipe *(existing)*
-3. Mismatched bracket *(existing — consumes closers attached to mismatched openers)*
-4. Fat-arrow typo *(existing)*
-5. **Stray closer** *(new — closers that survived steps 1–4)*
+The classifier runs each pass in this order, returning the first result
+that classifies the ERROR:
 
-## Anchoring details
+1. Unclosed string literal *(existing — `Whole`)*
+2. Consecutive pipe *(existing — `Whole`)*
+3. Mismatched bracket — **extended** to also detect openers in structural
+   parents (the `f(}` case). Returns `Whole` with `Mismatched brackets: …`.
+4. Fat-arrow typo *(existing — `Whole`)*
+5. **Delimiter scan** *(new — `Multi`)*. Scans the ERROR's direct children
+   for opener tokens (unclosed) and closer tokens (stray) and produces one
+   diagnostic per finding. See *Delimiter scan rules* below.
+6. Fallback: return `Multi(vec![])` → caller emits a single
+   `Syntax error` at the minimized range (today's behavior).
 
-### Unclosed opener — finding the right `(`/`{`/`[`/`[[`
+### Delimiter scan rules
 
-Walk upward from the `MISSING` node to the first ancestor whose kind is one
-of `call`, `subset`, `subset2`, `braced_expression`,
-`parenthesized_expression`. Inside that ancestor, scan direct children
-left-to-right for the first child whose token text matches the expected
-opener for that node kind (see the table in *Architecture* above). That
-token's `start_position()` is the anchor.
+When the delimiter scan runs on an ERROR, it does this single pass:
 
-Range: `(opener_row, opener_col_utf16)` →
-`(opener_row, utf16_len_of_opener_line)`.
+1. Iterate the ERROR's *direct* children left-to-right, tracking a stack
+   of unmatched openers.
+2. For each child whose token text is an opener (`(`, `{`, `[`, `[[`),
+   push `(kind, position, line, end_of_meaningful_content_col)` onto the
+   stack.
+3. For each child whose token text is a closer (`)`, `}`, `]`, `]]`),
+   look at the top of the stack:
+   - If the stack is empty → it's a stray closer. Emit
+     `Missing opening `X`` at the closer token's range.
+   - If the top of the stack matches (same kind) → pop and discard
+     (this matched pair lived inside the ERROR; nothing to report).
+   - If the top of the stack is a mismatched opener → emit
+     `Mismatched brackets: ` and pop. (This handles e.g. `(...]` patterns
+     embedded inside a broader ERROR.)
+4. For each opener left on the stack at the end → emit
+   `Unclosed `X`: missing matching `Y`` ranged from the opener through
+   end-of-meaningful-content on the opener's line.
 
-If no structural parent is found, fall back to today's
-`anchor_missing_position` behavior (`raw_row` walked back to the last code
-line, end-of-line column). The fallback exists for defensive coverage; we
-do not expect it to trigger on real R code.
+This pass produces between zero and N diagnostics where N is the number of
+delimiter tokens in the ERROR. For `f(g(h(` the stack has three unclosed
+`(` at the end → three diagnostics. For `}}}` there's one ERROR whose only
+direct child is `ERROR "}}}"` (a single undifferentiated leaf) — the leaf
+is not parsed as three closer tokens, so the rule above sees one closer
+token of text `"}}}"`. We treat that whole leaf as a single stray-closer
+diagnostic and produce ONE `Missing opening `{`` ranged over the entire
+leaf.
 
-### Stray closer — finding the right `}`/`)`/`]`/`]]`
+### Stray closer in unclosed-opener arguments (coalescing rule)
 
-Inside an `ERROR` node, scan direct children for the first token whose text
-matches `}`, `)`, `]`, or `]]` (longest-first, so `]]` matches before `]`),
-where no earlier direct sibling is a matching opener. That token is the
-stray closer. The diagnostic range is the token's `start..end` (UTF-16).
+For the very common `f(}` typo, the parse shape is **NOT** the same as the
+ERROR-scan case above: the `}` lives inside the `arguments` node, not
+inside an ERROR that also contains the `(`. The mismatched-bracket
+detector at step 3 of the classifier order is extended to handle this:
 
-The "no earlier matching opener" check is a single linear pass over earlier
-direct siblings — keeps the mismatched-bracket case (`c(1, 2]`) from being
-re-classified as a stray closer once the mismatched-bracket detector has
-already returned its more specific message. In practice, when mismatched-
-bracket fires, the whole-`ERROR` classifier short-circuits before the
-stray-closer pass runs; the per-sibling check is belt-and-braces.
+When the existing mismatched-bracket detector finds an ERROR whose only
+non-whitespace child is a closer token, it now also walks up one level to
+check whether the parent is `arguments`, `braced_expression`, or
+`parenthesized_expression` AND whether that parent contains an opener
+*and* a `MISSING` closer of the expected kind. If yes, emit a single
+mismatched-bracket diagnostic anchored on the stray closer, with message
+`` Mismatched brackets: `(` opened here; close with `)` not `}`. ``
+(opener character substituted from the parent's actual opener; stray-closer
+character substituted from the ERROR's child).
+
+The diagnostic suppresses the `MISSING` follow-up that would otherwise
+produce a separate "Unclosed `(`" message for the same opener — the
+mismatched-bracket diagnostic already names it. This is implemented by
+having the `MISSING`-handling branch consult a small per-traversal set of
+"openers already covered by a mismatched-bracket diagnostic" populated at
+classification time.
+
+### Opener anchoring via MISSING (single-level parent walk)
+
+For `MISSING` nodes whose kind is a closer (`)`, `}`, `]`, `]]`) and which
+are NOT already covered by the coalescing rule above:
+
+1. Get the `MISSING`'s direct parent.
+2. Confirm the parent kind is one of `arguments`, `braced_expression`,
+   `parenthesized_expression` (verified shapes — see above).
+3. Take that parent's first child token as the opener.
+4. Anchor range: `(opener_row, opener_col_utf16)` →
+   `(opener_row, end_of_meaningful_content_col)` (defined below).
+5. If the parent kind is unrecognized (defensive), fall back to today's
+   `anchor_missing_position` behavior.
+
+Non-bracket `MISSING` kinds (e.g. the trailing identifier of `x <-`)
+continue through the existing direct-`MISSING` branch unchanged.
+
+### End-of-meaningful-content column
+
+The opener-line range stops at the start of any trailing comment, and
+trims trailing whitespace. Concretely:
+
+1. Take the line containing the opener.
+2. Find the last non-whitespace byte before the first `#` *that is outside
+   any string or backtick* on that line.
+3. Convert that byte offset to a UTF-16 column via
+   `byte_offset_to_utf16_column`.
+4. If there is nothing meaningful after the opener (only whitespace or a
+   comment), the range collapses to the opener token's own width.
+
+This avoids underlining comments and trailing whitespace in cases like
+`f( # comment` (range = just the `(`) and `f(   ` (range = just the `(`).
 
 ## Edge cases
 
-**E1. `[[` and `]]`.** Single tokens in tree-sitter-r. The stray-closer scan
-matches `]]` before `]` (longest-first). For openers, anchor at the `[[`
-token's start column, span to EOL.
+**E1. `[[` and `]]` are single tokens.** The delimiter scan and
+mismatched-bracket detector both recognise these as one token of width 2.
 
 **E2. Top-level `MISSING` outside any `ERROR`.** `x <-` produces a lone
 `MISSING identifier` at the program level. No opener to anchor on. The
-direct-`MISSING` branch (handlers.rs:6308) is unchanged in message and
-anchor for non-bracket `MISSING` kinds. Bracket-kind `MISSING` nodes at the
-top level *are* re-routed through the new opener-walking logic so that
-`library(` still produces a useful diagnostic anchored on the `(`.
+direct-`MISSING` branch (handlers.rs:6308 today) is unchanged in message
+and anchor for non-bracket `MISSING` kinds. Bracket-kind `MISSING` nodes
+at the top level *are* re-routed through the single-level parent walk so
+that `library(` still produces a useful diagnostic anchored on the `(`.
 
-**E3. Nested unclosed openers.** `f(g(h(` has three unclosed `(`.
-Tree-sitter inserts three `MISSING` `)` closers, one per level. The
-structural-parent walk from each `MISSING` finds its matching opener.
-Result: three diagnostics on three `(` characters.
+**E3. Nested unclosed openers — flat ERROR.** `f(g(h(` parses as a flat
+ERROR containing three `(` tokens and two intervening identifiers, with
+NO `MISSING` nodes. The delimiter-scan rule handles this: stack ends with
+three unclosed `(` → three diagnostics, one anchored on each `(`. The
+spec's earlier draft assumed `MISSING` descendants; this case is now
+covered by the structural scan instead.
 
-**E4. Mismatched-bracket case keeps priority.** `c(1, 2]` emits the existing
-`Mismatched brackets: \`(\` opened here; close with \`)\` not \`]\`.`
-diagnostic. The stray-closer pass does NOT additionally emit
-`Missing opening \`[\`` for the `]`. This is enforced by the whole-`ERROR`
-classifier short-circuit (mismatched-bracket is in the priority list above
-stray-closer).
+**E4. Mismatched-bracket: extended scope.**
+- `c(1, 2]` — opener and wrong closer both inside the same ERROR;
+  existing detector handles this and returns `Whole`.
+- `f(}` — opener in `arguments`, wrong closer inside an ERROR child of
+  `arguments`; new extended detector returns `Whole` (single mismatched-
+  brackets diagnostic) and suppresses the `MISSING )` follow-up.
+- The stray-closer pass does NOT additionally emit `Missing opening `X``
+  in either case.
 
 **E5. Stray closer immediately after a valid expression.** `f() }` — `f()`
-parses as a complete `call`, then `}` is its own `ERROR` sibling at the
-program level. The stray-closer detector fires on that `ERROR`. One
-diagnostic, on the `}`, `Missing opening \`{\``.
+parses as a complete `call`, then `}` is its own ERROR sibling. The
+delimiter scan on that ERROR finds one stray closer with no preceding
+opener → one diagnostic `Missing opening `{`` on the `}`.
 
-**E6. Multiple stray closers in a row.** `}}}` produces three sibling
-`ERROR` nodes at the program level. Three diagnostics. Expected behavior
-per "detect each independently."
+**E6. Multiple stray closers in a run.** `}}}` parses as ONE `ERROR`
+containing ONE leaf ERROR whose text is `"}}}"`. The delimiter scan treats
+this leaf as a single stray closer and emits ONE diagnostic
+`Missing opening `{`` spanning the whole leaf. This was a deliberate
+design choice (see *Approved decisions*) — splitting `}}}` into three
+diagnostics adds noise without information.
 
 **E7. Unclosed opener at end of file.** `library(` with no trailing
-newline. `MISSING` `)` is placed at the file's end byte. Structural-parent
-walk: `MISSING` → `call` → first child `(` at column 7. Range = col 7 → EOL
-of opener's line. Works.
+newline. `MISSING )` is placed at the file's end byte. Direct parent is
+`arguments`; opener is `(` at column 7. Range = `(0, 7)` → end-of-
+meaningful-content on line 0 = `(0, 8)`. One column wide because nothing
+follows the `(`. Works.
 
-**E8. R Markdown / Quarto code chunks.** Diagnostics already operate on a
-per-chunk tree-sitter parse upstream of `collect_syntax_errors`. No
-additional handling needed — the new logic operates on the same node tree
-contract.
+**E8. Comment on opener line.** `f( # comment\n` — opener `(` at col 1,
+then `# comment`. End-of-meaningful-content col = 2 (just past the `(`).
+Range collapses to just the `(`. Comment is not underlined.
 
-**E9. `# @lsp-ignore` suppression.** Both new diagnostics flow through the
-same suppression path as existing parse diagnostics. The suppression marker
-must be on the line containing the *new* anchor — i.e., the opener line for
-the unclosed case, the closer line for the stray case. Document this in
-`docs/diagnostics.md` alongside the new table rows.
+**E9. Trailing whitespace on opener line.** `f(   \n` — opener `(` at
+col 1, then three spaces. End-of-meaningful-content col = 2 (just past the
+`(`). Range collapses to just the `(`.
+
+**E10. CRLF line endings.** Tree-sitter reports byte columns including
+`\r` but `byte_offset_to_utf16_column` strips line endings before
+computing UTF-16 columns. The implementation must compute
+end-of-meaningful-content using the line's logical content (no `\r`/`\n`).
+Add a regression test using `\r\n`.
+
+**E11. No final newline.** `library(` — no `\n` at EOF. The opener's line
+is the only line. End-of-meaningful-content col is computed from the line
+slice as if EOF were the line terminator. Same code path as E10.
+
+**E12. BOM at start of file.** A UTF-8 BOM (`\xEF\xBB\xBF`) shifts every
+byte column by 3. Tree-sitter reports byte columns including the BOM;
+`byte_offset_to_utf16_column` accounts for this. All range computations
+must go through that helper — no bare `column` field uses.
+
+**E13. Non-ASCII identifiers and emoji.** A line containing `é` or `😀`
+before the opener has byte columns > UTF-16 columns. The same
+`byte_offset_to_utf16_column` helper handles this. Add explicit tests for
+non-ASCII (`é`) and astral-plane (`😀`, which is a UTF-16 surrogate pair —
+two code units).
+
+**E14. R Markdown / Quarto code chunks.** Diagnostics already operate on
+a per-chunk tree-sitter parse upstream of `collect_syntax_errors`. No
+additional handling needed.
+
+**E15. `# @lsp-ignore` suppression.** Both new diagnostics flow through
+the same suppression path as existing parse diagnostics. The suppression
+marker must be on the line containing the *new* anchor — i.e., the opener
+line for the unclosed case, the closer line for the stray case. Documented
+in `docs/diagnostics.md`.
+
+## Performance
+
+Worst-case shape: deeply nested unclosed openers (e.g. `f(` repeated N
+times). Today's classifier is O(1) per ERROR; the new delimiter scan is
+O(direct-children) per ERROR. `collect_syntax_errors` walks each
+non-ERROR child recursively but does not recurse into ERROR children, so
+the total cost is bounded by O(total ERROR direct children) ≤ O(tokens).
+The single-level parent walk for `MISSING` is O(1). No O(N²) hazard.
+
+For defensive measure, the delimiter scan emits at most N diagnostics per
+ERROR where N is the number of delimiter tokens. We do not add an
+artificial cap; tree-sitter's grammar already bounds this in practice.
 
 ## Out of scope
 
@@ -207,55 +332,73 @@ the unclosed case, the closer line for the stray case. Document this in
 
 ## Tests
 
-All new tests go in the existing `syntax_error_range_tests` module in
-`crates/raven/src/handlers.rs` (line 6485+), reusing the `collect(code)`
-helper.
+All new tests go in `mod syntax_error_range_tests` in
+`crates/raven/src/handlers.rs`, reusing the `collect(code)` helper.
 
 ### Stray-closer detection (new)
 
 | Test | Input | Expected |
 |---|---|---|
-| `stray_close_brace_emits_missing_opening` | `"x <- 1\n}\n"` | exactly one diagnostic, message `` Missing opening `{` ``, range on the `}` |
-| `stray_close_paren_emits_missing_opening` | `"x <- 1\n)\n"` | exactly one diagnostic, message `` Missing opening `(` ``, range on the `)` |
-| `stray_close_bracket_emits_missing_opening` | `"x <- 1\n]\n"` | exactly one diagnostic, message `` Missing opening `[` ``, range on the `]` |
-| `stray_double_close_bracket_emits_missing_opening` | `"x <- 1\n]]\n"` | message `` Missing opening `[[` `` (longest-first match), range covers both `]]` |
-| `multiple_stray_closers_emit_one_each` | `"}}}"` | three diagnostics, each on its own `}` |
-| `mismatched_bracket_still_wins` | `"c(1, 2]"` | existing mismatched-bracket message; **no** `Missing opening \`[\`` diagnostic |
-| `stray_closer_after_valid_expr` | `"f() }"` | exactly one diagnostic for the `}`, none for `f()` |
+| `stray_close_brace_emits_missing_opening` | `"x <- 1\n}\n"` | one diagnostic, message `` Missing opening `{` ``, range on the `}` |
+| `stray_close_paren_emits_missing_opening` | `"x <- 1\n)\n"` | one diagnostic, message `` Missing opening `(` ``, range on the `)` |
+| `stray_close_bracket_emits_missing_opening` | `"x <- 1\n]\n"` | one diagnostic, message `` Missing opening `[` ``, range on the `]` |
+| `stray_double_close_bracket_emits_missing_opening` | `"x <- 1\n]]\n"` | message `` Missing opening `[[` ``, range covers `]]` (width 2) |
+| `closer_run_emits_single_diagnostic` | `"}}}"` | exactly ONE diagnostic, message `` Missing opening `{` ``, range spans the whole `}}}` leaf (cols 0-3). Replaces the earlier-considered "three diagnostics" expectation. |
+| `mismatched_bracket_still_wins` | `"c(1, 2]"` | existing `Mismatched brackets: …` message; no `Missing opening …` diagnostic |
+| `stray_closer_after_valid_expr` | `"f() }"` | one diagnostic on the `}`, none on `f()` |
 
-### Opener anchoring for unclosed cases (range = opener-line)
+### Unclosed-opener anchoring
 
 | Test | Input | Expected |
 |---|---|---|
-| `unclosed_paren_anchors_on_opener` | `"x <- mean(c(1, 2, 3)\n\n# comment\n"` | range starts at the `(` of `mean(` (col 9), ends at EOL of the opener line; message `` Unclosed `(`: missing matching `)` `` |
+| `unclosed_paren_anchors_on_opener` | `"x <- mean(c(1, 2, 3)\n\n# comment\n"` | range from `(` of `mean(` (col 9) through end of meaningful content on line 0 (col 20 = end of inner `c(1,2,3)`); message `` Unclosed `(`: missing matching `)` `` |
 | `unclosed_brace_anchors_on_opener` | `"f <- function() {\n  x <- 1\n  y <- 2\n"` | range on `{` only (opener at EOL); message `` Unclosed `{`: missing matching `}` `` |
-| `unclosed_bracket_anchors_on_opener` | `"vec[1, 2\n"` | range from `[` (col 3) through EOL; message `` Unclosed `[`: missing matching `]` `` |
-| `unclosed_double_bracket_anchors_on_opener` | `"vec[[1, 2\n"` | range from `[[` start through EOL; message `` Unclosed `[[`: missing matching `]]` `` |
-| `nested_unclosed_opens_emit_per_level` | `"f(g(h(\n"` | three diagnostics, one anchored on each `(` |
-| `unclosed_paren_at_end_of_file` | `"library("` | range on the `(` through EOL; message `` Unclosed `(`: missing matching `)` `` |
+| `unclosed_bracket_anchors_on_opener` | `"vec[1, 2\n"` | range from `[` (col 3) through end of line content (col 8); message `` Unclosed `[`: missing matching `]` `` |
+| `unclosed_double_bracket_anchors_on_opener` | `"vec[[1, 2\n"` | range from `[[` start (col 3) through end of line content (col 9); message `` Unclosed `[[`: missing matching `]]` `` |
+| `nested_flat_unclosed_emits_per_opener` | `"f(g(h(\n"` | THREE diagnostics, one anchored on each `(` (cols 1, 3, 5). Each range covers its `(` only (no content after). |
+| `unclosed_paren_at_end_of_file` | `"library("` | range on the `(`; message `` Unclosed `(`: missing matching `)` `` |
+| `unclosed_opener_with_trailing_comment` | `"f( # comment\n"` | range covers just the `(` (comment excluded); message `` Unclosed `(`: missing matching `)` `` |
+| `unclosed_opener_with_trailing_whitespace` | `"f(   \n"` | range covers just the `(` (whitespace excluded); message `` Unclosed `(`: missing matching `)` `` |
 
-### Combined faults (independent emission)
+### Coalescing — stray closer inside an unclosed opener
 
 | Test | Input | Expected |
 |---|---|---|
-| `unclosed_opener_and_stray_closer_in_same_error` | `"f(} y\n"` | two diagnostics: one `` Unclosed `(`: missing matching `)` `` on the `(`, one `` Missing opening `{` `` on the `}` |
+| `wrong_closer_in_args_coalesces` | `"f(}\n"` | exactly ONE diagnostic, message `` Mismatched brackets: `(` opened here; close with `)` not `}`. ``, range on the `}` |
+| `wrong_closer_followed_by_content_coalesces` | `"f(} y\n"` | exactly ONE diagnostic (Mismatched brackets), NOT two |
+| `wrong_closer_for_subset_coalesces` | `"vec[}\n"` | one Mismatched-brackets diagnostic naming `[` and `}` |
+
+### Encoding / line-ending edge cases
+
+| Test | Input | Expected |
+|---|---|---|
+| `unclosed_opener_crlf` | `"library(\r\n"` | range computed correctly (no `\r` in range), single diagnostic |
+| `unclosed_opener_no_final_newline` | `"library("` | works without EOF newline |
+| `unclosed_opener_with_bom` | `"\u{FEFF}library("` | UTF-16 col reflects BOM stripped; range valid |
+| `unclosed_opener_non_ascii_before` | `"é_func("` | UTF-16 col for `(` reflects single-code-unit `é`; range valid |
+| `unclosed_opener_astral_before` | `"😀_func("` | UTF-16 col for `(` accounts for the surrogate pair (`😀` = 2 code units); range valid |
 
 ### Regression / non-regression
 
-| Test | Input | Behavior to preserve |
-|---|---|---|
-| `unclosed_paren_diagnostic_anchors_on_offending_line` (handlers.rs:6635) | unchanged | rewrite assertions to expect new anchor on the opener instead of end-of-statement |
-| `mismatched_bracket_emits_descriptive_message` (handlers.rs:7335) | unchanged | unchanged behavior |
-| `incomplete_assignment_in_block_minimized` (handlers.rs:6509) | unchanged | unchanged behavior — non-bracket `MISSING`, uses unchanged code path |
-| `top_level_incomplete_assignment` (handlers.rs:6605) | unchanged | unchanged behavior (same reason) |
-| `unclosed_string_literal_*` tests | unchanged | string-literal anchoring untouched |
+| Test | Behavior to preserve |
+|---|---|
+| `unclosed_paren_diagnostic_anchors_on_offending_line` (existing) | Rewrite to expect new anchor (on opener) instead of end-of-statement. |
+| `mismatched_bracket_emits_descriptive_message` (existing) | Unchanged behavior. |
+| `incomplete_assignment_in_block_minimized` (existing) | Unchanged — non-bracket `MISSING`, uses unchanged code path. |
+| `top_level_incomplete_assignment` (existing) | Unchanged (same reason). |
+| `unclosed_string_literal_*` (existing) | Unchanged — string-literal handling untouched. |
 
 ### Helper-level unit test
 
-Add a unit test for the new `find_opener_for_missing(missing) -> Option<(Node, Range)>`
-helper, covering: `MISSING` inside `call`, inside `subset`, inside `subset2`,
-inside `braced_expression`, inside `parenthesized_expression`, and the
-defensive `None` case (synthetic `MISSING` with no structural parent).
+Add a unit test for the new helpers:
+
+- `find_opener_for_missing(missing) -> Option<(Node, Range)>` — covers
+  `MISSING` inside `arguments` (with `(`/`[`/`[[` opener), inside
+  `braced_expression`, inside `parenthesized_expression`, and the
+  defensive `None` case.
+- `end_of_meaningful_content(line, byte_col) -> u32` — covers a line with
+  trailing whitespace, with a trailing comment, with a `#` inside a string
+  (must not trim there), and with CRLF.
 
 ## Documentation
 
@@ -268,11 +411,15 @@ defensive `None` case (synthetic `MISSING` with no structural parent).
 with two rows:
 
 ```text
-| `` Unclosed `(`: missing matching `)` `` / `` Unclosed `{`: missing matching `}` `` / `` Unclosed `[`: missing matching `]` `` / `` Unclosed `[[`: missing matching `]]` `` | A delimiter was opened but never closed (`library(`, `function() {`). The diagnostic is anchored on the opening delimiter, spanning to the end of that line. |
-| `` Missing opening `{` `` / `` Missing opening `(` `` / `` Missing opening `[` `` / `` Missing opening `[[` `` | A closing delimiter appears with no matching opener (`}` at top level, `)` after a complete expression). |
+| `` Unclosed `(`: missing matching `)` `` / `` Unclosed `{`: missing matching `}` `` / `` Unclosed `[`: missing matching `]` `` / `` Unclosed `[[`: missing matching `]]` `` | A delimiter was opened but never closed (`library(`, `function() {`). The diagnostic is anchored on the opening delimiter, spanning to the end of meaningful content on that line. |
+| `` Missing opening `{` `` / `` Missing opening `(` `` / `` Missing opening `[` `` / `` Missing opening `[[` `` | A closing delimiter appears with no matching opener (`}` at top level, `)` after a complete expression). A run of stray closers (`}}}`) reports a single diagnostic for the whole run. |
 ```
+
+Also note that the existing `` Mismatched brackets: … `` row's coverage
+extends to the `f(}` case (wrong closer immediately inside an unclosed
+opener).
 
 No changes to `docs/development.md` — the new logic is local to
 `handlers.rs` and doesn't affect cross-file invariants, caching, or any
-architectural concerns covered there. No `CLAUDE.md` updates — the changes
-don't add a new module-spanning invariant.
+architectural concerns covered there. No `CLAUDE.md` updates — the
+changes don't add a new module-spanning invariant.

--- a/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
@@ -459,7 +459,7 @@ Both shapes coalesce into a single `Mismatched brackets` diagnostic.
 | `wrong_closer_in_arguments_coalesces` | `"f(} y\n"` | `arguments(`(`, ERROR(`}`), argument, MISSING `)`)` | exactly ONE diagnostic via the arguments-coalescing rule. No `Unclosed `(`` follow-up for the same opener (suppressed by `CollectState::covered_openers`). |
 | `wrong_closer_for_subset_coalesces` | `"vec[}\n"` | (flat ERROR — verify in test) | one Mismatched-brackets diagnostic naming `[` and `}` |
 | `wrong_closer_with_braced_expression` | `"function() ]\n"` | `function_definition` with `braced_expression` followed by stray `]` (verify exact shape) | Specific to the parse shape: if `]` is in `braced_expression`, coalesces against `{`; otherwise stays as a stray closer (`` Missing opening `[` ``). Test asserts whichever the verified parse shape produces. |
-| `mixed_closer_leaf_emits_per_kind` | `"]\n)"` placed as two separate stray closers OR `f(])` whose flat ERROR contains a leaf `])` | For mixed leaves like `])`: two diagnostics, one `` Missing opening `[` `` on the `]`, one `` Missing opening `(` `` on the `)`. |
+| `mixed_closer_leaf_emits_per_kind` | `"]\n)"` (two separate stray closers) OR `f(])` | flat ERROR contains a single leaf `])` | two diagnostics: `` Missing opening `[` `` on the `]`, and `` Missing opening `(` `` on the `)`. |
 
 ### Encoding / line-ending edge cases
 

--- a/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md
@@ -366,10 +366,21 @@ Add a regression test using `\r\n`.
 is the only line. End-of-meaningful-content col is computed from the line
 slice as if EOF were the line terminator. Same code path as E10.
 
-**E12. BOM at start of file.** A UTF-8 BOM (`\xEF\xBB\xBF`) shifts every
-byte column by 3. Tree-sitter reports byte columns including the BOM;
-`byte_offset_to_utf16_column` accounts for this. All range computations
-must go through that helper — no bare `column` field uses.
+**E12. BOM at start of file.** A UTF-8 BOM (`\xEF\xBB\xBF`) is 3 bytes
+of UTF-8, 1 UTF-16 code unit. Tree-sitter reports byte columns including
+the BOM. The implementation slices the raw line (BOM not stripped) and
+passes it to `byte_offset_to_utf16_column` along with the tree-sitter
+byte column. The helper's per-char iteration correctly maps the BOM to
+one UTF-16 unit at column 0, so subsequent characters land at
+LSP-correct columns. Concretely for `"\u{FEFF}library("`:
+
+- `(` byte column: 3 (BOM) + 7 (`library`) = 10
+- `(` UTF-16 column: 1 (BOM) + 7 (`library`) = 8
+- Test `unclosed_opener_with_bom` asserts range `(0, 8)..(0, 9)`
+
+No BOM stripping anywhere in the new code path. All range computations
+must go through `byte_offset_to_utf16_column` — no bare uses of
+`Point::column`.
 
 **E13. Non-ASCII identifiers and emoji.** A line containing `é` or `😀`
 before the opener has byte columns > UTF-16 columns. The same


### PR DESCRIPTION
## Summary

Replaces the generic `"Syntax error"` diagnostic for unbalanced brackets, braces, and parens with targeted messages anchored on the offending delimiter character.

**Before → After:**

| Code | Old diagnostic | New diagnostic |
|---|---|---|
| `library(` | `Missing )` at end of statement | `` Unclosed `(`: missing matching `)` `` on the `(` |
| `f <- function() {` | `Missing }` past the last code line | `` Unclosed `{`: missing matching `}` `` on the `{` |
| `}` (stray, top-level) | `Syntax error` | `` Missing opening `{` `` on the `}` |
| `f(}` | `Syntax error` + `Missing )` (two diagnostics) | Single `Mismatched brackets: ` `` `(` `` opened here; close with `` `)` `` not `` `}` ``.` |
| `}}}` | three `Syntax error` events | one `` Missing opening `{` `` spanning the run |
| `f(g(h(` | one whole-line `Syntax error` | three `` Unclosed `(` `` with non-overlapping ranges |

## Architecture

All changes local to `crates/raven/src/handlers.rs`:

- `ErrorClassification` enum (`Whole` vs `Multi`) replaces `classify_error -> String`, so one ERROR can produce per-fault diagnostics.
- `CollectState` threads `covered_openers: HashSet<usize>` through the recursion. Coalescing classifiers populate it; the MISSING branch reads it to skip duplicates.
- `delimiter_events` walks an ERROR's direct children (one level into nested ERRORs) and emits a flat open/close stream with greedy `]]` and homogeneous-run handling.
- `classify_via_delimiter_scan` stack-processes the stream → per-fault diagnostics with the next-opener-on-same-line tie-breaking rule (so nested unclosed openers don't produce overlapping ranges).
- `find_opener_for_missing` walks one level up from a bracket-kind MISSING node to its structural parent (`arguments`/`braced_expression`/`parenthesized_expression`) and returns the opener token + range.
- `end_of_meaningful_content` trims trailing comments and whitespace from the opener-line range, string-aware (a `#` inside `"..."`/`'...'`/`` `...` `` is not a comment).
- `detect_mismatched_via_structural_parent` coalesces `f(} y`-shape typos into a single Mismatched-brackets diagnostic.

Documentation: `docs/diagnostics.md` updated with the new table rows; extended note on Mismatched-brackets scope.

## Spec + plan

- Design spec: `docs/superpowers/specs/2026-05-17-bracket-diagnostics-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-17-bracket-diagnostics-plan.md`

Spec went through two Codex adversarial reviews (cross-checking tree-sitter-r parse shapes, edge cases, performance) before implementation.

## Test plan

- [x] `cargo test -p raven --lib` — 3977 passed / 0 failed
- [x] `cargo build --release -p raven` — clean
- [x] New tests cover: stray `}`/`)`/`]`/`]]`; homogeneous closer runs `}}}`; nested flat unclosed `f(g(h(` (both via `run_scan` and `collect`); unclosed at EOF (`library(`); unclosed with trailing comment/whitespace; CRLF, BOM, non-ASCII identifier, astral-plane char before opener; `f(}` flat-ERROR coalescing; `f(} y` arguments-shape coalescing
- [x] Property tests: `prop_missing_node_priority`/`prop_missing_node_width` scoped to non-bracket MISSING; new `prop_bracket_missing_anchors_on_opener` for the positive invariant
- [x] Pre-existing `unclosed_string_literal_*`, `mismatched_bracket_emits_descriptive_message`, `incomplete_assignment_in_block_minimized` unchanged behavior
- [ ] Spot-check in VS Code on real R code (reviewer)

Closes #286.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced syntax error diagnostics for bracket-matching issues, providing clearer messages for unclosed and mismatched brackets, parentheses, and braces with improved error positioning and accuracy.

* **Documentation**
  * Updated parse error documentation with expanded diagnostic guidance for delimiter-matching scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->