### PR TITLE
feat(knit): per-`.Rmd` output panels + iframe input UX fixes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -274,6 +274,7 @@ Brief orientation for modules outside the cross-file and package-library subsyst
 - **`parameter_resolver.rs`** — Resolves function parameter info for completion suggestions. Extracts parameters from AST for user-defined functions; queries R subprocess `formals()` for package functions. Uses an LRU cache for subprocess results.
 - **`roxygen.rs`** — Parses roxygen2 (`#'`) and plain comment blocks above function definitions. Extracts title, description, and `@param` entries for hover and completion documentation.
 - **`content_provider.rs`** — Unified file access abstraction. Respects the "open docs are authoritative" rule: open documents are read from the document store; closed files fall through to disk/cache.
+- **`editors/vscode/src/knit/knit-output-panel.ts`** — Per-source-path webview-panel registry for the `Raven: Knit` output viewer. Keyed by `sourceUri.fsPath` (aligned with the in-flight gate in `knit-commands.ts`). Tracks a `previewColumn` static so new panels stack as tabs in a single column rather than scattering; `recomputePreviewColumn` runs on every `onDidChangeViewState` / `onDidDispose` and adopts a surviving panel's column when the recorded one empties. The companion `help/help-panel.ts` remains a singleton (one R-help context per session is the right shape for that domain). See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`.
 
 ## Coding conventions (repo-level)
 

--- a/docs/knit.md
+++ b/docs/knit.md
@@ -67,11 +67,14 @@ explorer-context-menu hook is opt-in via your own keybindings).
    instead of POSIX signals.
 10. **Reveal.** On a clean exit Raven parses `Output created: <path>`
     out of stdout. When the primary output is HTML (or there's any HTML
-    in a multi-output knit), Raven opens it in the **Knit Output**
+    in a multi-output knit), Raven opens it in a **Knit Output**
     webview panel beside the editor — no success popover, the panel
-    itself is the signal. For multi-output knits the additional output
-    paths are written to the `Raven: Knit` output channel. The panel
-    toolbar has three buttons:
+    itself is the signal. Each `.Rmd` gets its own panel; knitting a
+    second `.Rmd` opens a separate panel that stacks as a tab in the
+    same "preview" column rather than replacing the first. Re-knitting
+    the same `.Rmd` updates its panel in place. For multi-output knits
+    the additional output paths are written to the `Raven: Knit`
+    output channel. The panel toolbar has three buttons:
 
     - **Knit again** — re-knits the source `.Rmd` (the same code path
       as invoking `Raven: Knit` from the palette).

--- a/docs/knit.md
+++ b/docs/knit.md
@@ -68,24 +68,51 @@ explorer-context-menu hook is opt-in via your own keybindings).
 10. **Reveal.** On a clean exit Raven parses `Output created: <path>`
     out of stdout. When the primary output is HTML (or there's any HTML
     in a multi-output knit), Raven opens it in the **Knit Output**
-    webview panel beside the editor. The panel toolbar has two buttons:
+    webview panel beside the editor — no success popover, the panel
+    itself is the signal. For multi-output knits the additional output
+    paths are written to the `Raven: Knit` output channel. The panel
+    toolbar has three buttons:
 
-    - **Refresh** — re-knits the source `.Rmd` (the same code path as
-      invoking `Raven: Knit` from the palette).
+    - **Knit again** — re-knits the source `.Rmd` (the same code path
+      as invoking `Raven: Knit` from the palette).
     - **Open in Browser** — opens the rendered file in your OS default
       browser. In remote workspaces (SSH, Codespaces, dev containers)
       this may not work because `file://` URIs target the remote
       machine; Raven warns and writes the path to the `Raven: Knit`
       output channel as a fallback.
+    - **Apply VS Code theme** — toggle that overlays the rendered
+      document with VS Code's active editor background, foreground,
+      and link colors. The button keeps its label and conveys the
+      active state visually (pressed-button styling, `aria-pressed`
+      for screen readers) — Rmd output doesn't have a "document
+      theme" to switch back to, so the toggle simply represents
+      whether the overlay is on. The preference is persisted to
+      `globalState` so subsequent knits restore it, and it tracks
+      VS Code theme switches in real time.
 
-    The rendered HTML loads inside an `<iframe sandbox="">` — scripts,
-    forms, and external navigation are blocked. Intra-document anchor
-    links (`#section`) work; clicking an external `<a>` does nothing
-    (use **Open in Browser** for full interactivity, including
-    htmlwidgets). For PDF / Word / etc., Raven still reveals the file
-    in your OS file browser. When the output-path parse fails Raven
-    surfaces "Knit succeeded (output path unknown)" — the subprocess
-    exit code is the ground truth.
+    Standard text copy works inside the rendered output:
+    Cmd/Ctrl-C copies the current iframe selection to the system
+    clipboard, Cmd/Ctrl-A selects all, and right-clicking opens a
+    small menu with **Copy**, **Select All**, and **Open in
+    Browser**. VS Code suppresses the browser's default context menu
+    and does not forward Cmd-C from a nested iframe to its own
+    clipboard command, so Raven wires these by hand on the iframe's
+    same-origin `contentWindow`.
+
+    The rendered HTML loads inside an `<iframe srcdoc="..."
+    sandbox="allow-same-origin">` — scripts, forms, popups, and
+    top-navigation are blocked. The HTML is inlined into the iframe
+    via `srcdoc` (a nested webview iframe cannot navigate to
+    `webview.asWebviewUri(...)` URLs — Electron's resource handler
+    does not intercept nested-frame navigations); a `<base href>`
+    injected at the top of the inlined HTML lets relative images,
+    CSS, and fonts resolve through the webview's resource handler.
+    Intra-document anchor links (`#section`) work; clicking an
+    external `<a>` does nothing (use **Open in Browser** for full
+    interactivity, including htmlwidgets). For PDF / Word / etc.,
+    Raven still reveals the file in your OS file browser. When the
+    output-path parse fails Raven surfaces "Knit succeeded (output
+    path unknown)" — the subprocess exit code is the ground truth.
 
 ## Settings
 

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -119,16 +119,29 @@ panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
 
 ```ts
 private static recomputePreviewColumn(): void {
+    if (KnitOutputPanel.instances.size === 0) {
+        KnitOutputPanel.previewColumn = undefined;
+        return;
+    }
     const target = KnitOutputPanel.previewColumn;
-    if (target === undefined) return;
-    let stillThere = false;
-    for (const inst of KnitOutputPanel.instances.values()) {
-        if (inst.panel.viewColumn === target) {
-            stillThere = true;
-            break;
+    if (target !== undefined) {
+        for (const inst of KnitOutputPanel.instances.values()) {
+            if (inst.panel.viewColumn === target) return; // still occupied
         }
     }
-    if (!stillThere) KnitOutputPanel.previewColumn = undefined;
+    // Either no preview column was set, or the recorded one is no longer
+    // occupied. Adopt the column of any surviving panel so the next new
+    // knit lands next to the existing one rather than scattering to
+    // ViewColumn.Beside. (Pick the first iteration order; in practice all
+    // panels cluster in the same column.)
+    for (const inst of KnitOutputPanel.instances.values()) {
+        const col = inst.panel.viewColumn;
+        if (col !== undefined) {
+            KnitOutputPanel.previewColumn = col;
+            return;
+        }
+    }
+    KnitOutputPanel.previewColumn = undefined;
 }
 ```
 
@@ -136,20 +149,25 @@ private static recomputePreviewColumn(): void {
 
 ```ts
 panel.onDidDispose(() => {
-    KnitOutputPanel.instances.delete(key);
-    if (KnitOutputPanel.instances.size === 0) {
-        KnitOutputPanel.previewColumn = undefined;
-    } else {
-        KnitOutputPanel.recomputePreviewColumn();
+    // Guard against a stale dispose listener for an instance that has
+    // since been replaced under the same key (the rootDir-mismatch
+    // branch disposes the old panel and inserts a new one). VS Code's
+    // dispose() is synchronous today, but the guard makes the
+    // invariant explicit and survives any future async change.
+    if (KnitOutputPanel.instances.get(key) === instance) {
+        KnitOutputPanel.instances.delete(key);
     }
+    KnitOutputPanel.recomputePreviewColumn();
 });
 ```
+
+The dispose handler captures the instance it was registered for (closure over `instance`). The replacement panel registers its own `onDidDispose` for the *new* instance.
 
 ## Per-instance behavior (unchanged)
 
 - The constructor captures `context`, `panel`, `rootDir`, `sourceUri`, `outputPath`, `output` exactly as today.
 - `updateContent` regenerates the shell HTML each call. Title is `Knit Output: ${path.basename(outputPath)}` — same as today, which already disambiguates panels in the tab strip.
-- `handleMessage` dispatches `refresh`, `openInBrowser`, `themeChanged` against the captured `sourceUri` / `outputPath` of *that* instance. No registry lookups.
+- `handleMessage` dispatches three message types against the captured `sourceUri` / `outputPath` of *that* instance: `{type: 'refresh'}`, `{type: 'openInBrowser'}`, `{type: 'themeChanged', applied: boolean}`. No registry lookups. The `themeChanged` message updates the global theme preference (see below) and is *not* documented in the prior spec's protocol section (which lists only `refresh` / `openInBrowser`); it was added in `4270fc8 feat(knit): fix white iframe + overhaul panel UX`. This spec treats the implemented three-message protocol as authoritative.
 - Theme preference is global (lives in `context.globalState`, key `raven.knit.applyVSCodeTheme`). Changing the toggle on one panel does not retro-apply to other open panels in this session — applies on the next `updateContent` (i.e. the next knit of that file). Documented as the intentional shape, mirroring how the existing singleton already behaves across knits.
 
 ## Edge cases
@@ -158,7 +176,7 @@ panel.onDidDispose(() => {
 |--|--|
 | Knit `A.Rmd`, close A's editor, knit `A.Rmd` again via explorer context menu | Panel for A is found in the Map by `sourceUri.toString()` and reused. The closed editor is irrelevant. |
 | Same `.Rmd` opened in two VS Code windows | Each window has its own extension host and `instances` Map. No cross-window interference. |
-| User drags A's panel into the editor column (column 1) where A.Rmd lives | `onDidChangeViewState` fires; `recomputePreviewColumn` checks whether any other knit panel still occupies the old preview column. If not, `previewColumn = undefined` and the next *new* knit re-anchors to `Beside`. |
+| User drags A's panel into a different column (e.g. column 1 where A.Rmd lives) | `onDidChangeViewState` fires; `recomputePreviewColumn` runs. If any other knit panel still occupies the old preview column, `previewColumn` stays put (subsequent knits stack with the cluster that didn't move). If A was the only one, `previewColumn` *adopts* A's new column so the next knit lands next to A rather than scattering to `Beside`. |
 | Same `.Rmd` knit produces output to a different directory on the second run | A's existing panel is disposed and recreated in *its* current column (the `rootDir`-mismatch branch). Other panels are untouched. |
 | Multi-output knit (HTML + PDF) | Unchanged: HTML wins for the panel, additional paths go to the `Raven: Knit` output channel. The Map is keyed by source, not output. |
 | `Refresh` invoked while a knit of the same file is in flight | Existing `inFlight` Set in `knit-commands.ts` fires the "already being knitted" toast. Unchanged. |
@@ -167,13 +185,13 @@ panel.onDidDispose(() => {
 
 ## Security model
 
-Unchanged from `2026-05-17-knit-output-webview-design.md`. Each panel has the same three independent layers:
+Each panel reuses the three-layer model already implemented in `knit-output-panel.ts` + `knit-output.ts`. Going from one to many panels does not widen the security surface; each layer is per-instance.
 
-1. **`iframe sandbox=""`** — blocks scripts, forms, popups, top-navigation, same-origin access in the rendered HTML.
+1. **`iframe sandbox="allow-same-origin"`** — blocks scripts, forms, popups, and top-navigation in the rendered HTML. `allow-same-origin` is set (rather than the empty `sandbox=""` that the prior spec described) because an opaque-origin sandbox bypasses the VS Code webview service worker, causing `ERR_NAME_NOT_RESOLVED` on `vscode-cdn.net` resources; `allow-same-origin` re-enters the SW scope without enabling scripts or forms. The trade-off (rendered HTML inside the iframe can read its own DOM via JS that we would otherwise have allowed — but `sandbox` strips script execution regardless, so this is moot) is documented in the doc comment on `buildShellHtml`.
 2. **Outer-shell CSP** in `<head>` — `default-src 'none'`, `frame-src ${cspSource}`, `script-src 'nonce-${nonce}'`, `connect-src 'none'`.
-3. **`localResourceRoots`** confined to *that panel's* `path.dirname(outputPath)`.
+3. **`localResourceRoots`** confined to *that panel's* `path.dirname(outputPath)`. Two panels for `A.Rmd` and `B.Rmd` whose outputs live in different directories receive different roots — neither can resolve resources from the other's directory.
 
-Because each instance owns its own `localResourceRoots`, panels cannot read each other's output directories. Going from one to many panels does not widen the security surface.
+**Loading mechanism** (also unchanged from the implementation, but worth restating because the prior spec is imprecise): the rendered HTML is read from disk via `fs.readFileSync` and embedded as `srcdoc` on the iframe, with a `<base href>` set to the webview URI of the output's directory so relative subresources resolve through `localResourceRoots`. This is *not* iframe `src` loading; the prior spec's `src="${asWebviewUri(outputPath)}"` text described a design that was changed during implementation to work around nested-iframe navigation issues with `webview.asWebviewUri`. The security properties (sandbox + CSP + roots) hold for srcdoc the same way they hold for src.
 
 ## Error handling
 
@@ -209,8 +227,20 @@ No changes. `knit-output-shell.test.ts`, `knit-output-message.test.ts`, `knit-ou
 
 **New:**
 
-- **`knit-multi-panel.test.ts`** — knit `A.Rmd`, knit `B.Rmd`. Assert: `getInstancesForTesting().size === 2`, both panels share `viewColumn === previewColumn`. Re-knit `A.Rmd` and assert `instances.size === 2` still (no new panel for the same key) and that A's panel reference is identical to the pre-existing one.
+- **`knit-multi-panel.test.ts`** — knit `A.Rmd`, knit `B.Rmd` (with outputs under distinct directories). Assert:
+  - `getInstancesForTesting().size === 2`;
+  - both panels share `viewColumn === previewColumn`;
+  - A's and B's panels have *distinct* `webview.options.localResourceRoots`, each containing only its own output directory (per-panel isolation claim);
+  - re-knit `A.Rmd` and assert `instances.size === 2` still (no new panel for the same key) and that A's panel reference is identical to the pre-existing one.
 - **`knit-preview-column.test.ts`** — knit `A.Rmd`, capture the column VS Code assigned, dispose A's panel; knit `B.Rmd`, assert it opens in `ViewColumn.Beside` (preview column was reset on Map-empty). Then knit `A.Rmd` again and assert A's new panel lands in B's column (the new preview column).
+- **`knit-rootdir-change.test.ts`** — knit `A.Rmd` so its output lives under `/tmp/dir1/`. Assert the panel's `localResourceRoots` contains `/tmp/dir1`. Re-invoke `showOrUpdate` with the *same* sourceUri but an `outputPath` under `/tmp/dir2/`. Assert: the original panel is disposed (the `WebviewPanel` reference observed earlier is now disposed), a new panel exists for the same key, the new panel's `localResourceRoots` contains `/tmp/dir2`, the new panel's `viewColumn` matches the old panel's `viewColumn`, and `instances.size === 1`. This is the highest-risk lifecycle branch and was previously only manually smoked.
+- **`knit-recompute-preview-column.test.ts`** — unit test for `recomputePreviewColumn` driven through a test-only harness that injects fake instances with controlled `viewColumn` values. Cases:
+  - empty Map → `previewColumn = undefined`;
+  - one panel in column X, `previewColumn` was X → stays X;
+  - one panel in column X, `previewColumn` was Y (no panels at Y) → adopts X;
+  - two panels split between X and Y, `previewColumn` was X → stays X;
+  - two panels, both move to Z, `previewColumn` was X → adopts Z.
+  Drives the panel-drag scenario without needing VS Code to simulate a real drag.
 
 Test-only statics on `KnitOutputPanel`:
 
@@ -237,10 +267,25 @@ The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed and u
 
 - `docs/knit.md`, step 10 ("Reveal") — change "the **Knit Output** webview panel" to "a **Knit Output** webview panel for that `.Rmd`," and add one sentence: "Multiple `.Rmd` files can have panels open at once; new panels stack as tabs alongside any existing knit panels."
 - `docs/knit.md` non-goals — remove any wording implying the panel is a singleton.
-- `docs/development.md` — short note: `KnitOutputPanel` keeps a per-`sourceUri` registry and tracks a "preview column" for new panels. Cross-link from `help-panel.ts`'s doc comment (which remains singleton — distinct domain, only one R-help context per session).
+- `docs/development.md` — **supersedes** the singleton-panel pattern note that the prior 2026-05-17 spec added (so the two specs do not leave the development docs describing two contradictory architectures). New text: `KnitOutputPanel` keeps a per-`sourceUri` registry and tracks a "preview column" for new panels. Cross-link from `help-panel.ts`'s doc comment (which remains singleton — distinct domain, only one R-help context per session).
 - `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` — link this spec in the header as a successor for the singleton paragraphs.
 
 ## Open questions
 
 1. **`onDidChangeViewState` cost** — fires on every visibility / state change, not just column moves. The handler does an O(n) Map walk; with realistic n ≤ ~10, the overhead is negligible. If users report panel-switching jank with many panels, debounce or compare against a cached column before walking.
 2. **Tab grouping (drag-as-group)** — VS Code does not expose programmatic tab grouping. Users can manually group knit panels via the tab-strip context menu. Out of scope.
+
+## v1 → v2 changes (response to Codex adversarial review)
+
+| Codex finding | v2 disposition |
+| --            | --             |
+| #1 `sandbox=""` claim contradicts implementation's `allow-same-origin` | Security section rewritten to describe `sandbox="allow-same-origin"` and why (VS Code service-worker / `ERR_NAME_NOT_RESOLVED`). |
+| #2 Spec describes iframe `src` loading; implementation uses `srcdoc` + `<base href>` | New "Loading mechanism" paragraph explicitly documents `srcdoc` + `baseHref` and notes the security properties hold for both. |
+| #3 `themeChanged` message type not in prior protocol but used in implementation | Per-instance behavior section enumerates all three messages (`refresh`, `openInBrowser`, `themeChanged`) and points to the commit that introduced the third. |
+| #4 Prior spec's `Promise<void>` signature vs. current `{ok, error?}` union | Acknowledged as drift in the *prior* spec. This spec uses the current correct signature; no change needed here. |
+| #5 `previewColumn` resets to undefined when the only panel is dragged → scatters | `recomputePreviewColumn` now *adopts* a surviving panel's column instead of resetting to undefined whenever the Map is non-empty. Reset only happens when the Map is empty. Edge-case row updated to match. |
+| #6 `onDidDispose` could delete a replacement instance under the same key | Dispose handler now guards with `if (instances.get(key) === instance)` before deleting. Documented as defense-in-depth against any future async dispose. |
+| #7 Drag-recompute behavior only in manual smoke | New `knit-recompute-preview-column.test.ts` exercises `recomputePreviewColumn` directly via a test-only harness with controlled fake instances. |
+| #8 No automated test for `rootDir`-mismatch dispose-and-recreate | New `knit-rootdir-change.test.ts` covers the highest-risk lifecycle branch with `localResourceRoots` and column assertions. |
+| #9 `localResourceRoots` isolation claim untested | `knit-multi-panel.test.ts` now asserts each panel's `webview.options.localResourceRoots` contains only its own output directory. |
+| #10 `docs/development.md` contradicts the prior spec's singleton note | Doc-update section now explicitly *supersedes* the prior singleton note rather than adding alongside it. |

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -16,7 +16,7 @@ This spec replaces the singleton with a per-source-path registry: each `.Rmd` ge
 1. Knitting `A.Rmd` and `B.Rmd` in the same window produces two distinct panels, both visible until the user closes them.
 2. Re-knitting `A.Rmd` updates A's panel in place — the `Refresh` button on each panel remains bound to *its* source `.Rmd` for the life of the panel.
 3. New panels open in the same column as existing knit panels (they stack as tabs), so the user does not have to rearrange the workspace after each knit.
-4. No new commands, no new settings. The webview shell HTML, CSP, sandbox, message protocol, theme handling, and security model are unchanged.
+4. No new commands, no new settings. The CSP `<head>` placement, `localResourceRoots` confinement, theme-preference key, and `pickPrimaryOutput` semantics are unchanged from the implementation today. The sandbox attribute, loading mechanism, and message-protocol membership match the *implementation* (not the prior spec's text) — see "Security model" and "Per-instance behavior" for the precise inventory.
 
 ## Non-goals
 
@@ -37,7 +37,7 @@ editors/vscode/src/knit/
   ...
 ```
 
-No changes to `package.json`, settings schema, context keys, or the message protocol. No changes to the iframe shell HTML or CSP. No changes outside `knit-output-panel.ts` and its tests.
+No changes to `package.json`, settings schema, context keys, the message protocol, the iframe shell HTML template in `knit-output.ts`, or the CSP. The only production source file this work touches is `knit-output-panel.ts`. Test files are added or modified per the "Testing" section.
 
 ## State model
 
@@ -58,7 +58,7 @@ export class KnitOutputPanel {
 ```
 
 - **`instances` key**: `sourceUri.toString()`. Using the URI rather than `fsPath` gives free, platform-correct normalization (Windows drive-letter case, URI-encoding of spaces, etc.) and is the same value the rest of the extension keys on.
-- **`previewColumn`**: the concrete `vscode.ViewColumn` (1, 2, 3, …) that the first surviving knit panel was placed in. Used to anchor subsequent *new* panels. Reset to `undefined` whenever no surviving panel occupies it.
+- **`previewColumn`**: the concrete `vscode.ViewColumn` (1, 2, 3, …) that subsequent *new* knit panels anchor to. Initially `undefined`. On every state change (`onDidChangeViewState`, `onDidDispose`) `recomputePreviewColumn` runs: if any panel still occupies the recorded column, it stays put; otherwise it *adopts* the column of any surviving panel (so a dragged-away lone panel keeps siblings clustered with it); if the Map is empty, it resets to `undefined`. The full algorithm is shown in "Column tracking" below; the table in "Edge cases" enumerates the user-visible consequences.
 
 ## `showOrUpdate` flow
 
@@ -98,24 +98,41 @@ static async showOrUpdate(
 }
 ```
 
-## Column tracking
+## `create` registration
 
-Inside `create`, after `vscode.window.createWebviewPanel(...)`:
+`KnitOutputPanel.create` is the only path that constructs an instance. It must register the new instance in the static Map under `args.sourceUri.toString()` *before* returning, and must wire `onDidChangeViewState` / `onDidDispose` listeners. Equivalent to today's `KnitOutputPanel.instance = instance` line in the singleton implementation, but Map-keyed:
 
 ```ts
-const resolved = panel.viewColumn;
-if (resolved !== undefined && KnitOutputPanel.previewColumn === undefined) {
-    KnitOutputPanel.previewColumn = resolved;
+private static create(context, args, rootDir, column): KnitOutputPanel {
+    const key = args.sourceUri.toString();
+    const panel = vscode.window.createWebviewPanel(/* unchanged options */);
+    const instance = new KnitOutputPanel(context, panel, rootDir, args);
+    KnitOutputPanel.instances.set(key, instance);
+
+    // Anchor the preview column on the first panel that has one resolved.
+    const resolved = panel.viewColumn;
+    if (resolved !== undefined && KnitOutputPanel.previewColumn === undefined) {
+        KnitOutputPanel.previewColumn = resolved;
+    }
+
+    panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
+    panel.onDidDispose(() => {
+        if (KnitOutputPanel.instances.get(key) === instance) {
+            KnitOutputPanel.instances.delete(key);
+        }
+        KnitOutputPanel.recomputePreviewColumn();
+    });
+
+    instance.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+    return instance;
 }
 ```
 
-The first surviving knit anchors the preview column. From then on, `previewColumn` stays put until the registry stops occupying it.
+Without the `instances.set(key, instance)` call, every knit would be treated as new (`existing` always `undefined`), re-knit would never reuse, and the registry would never function. The dispose handler's `===` guard prevents a stale dispose event for a replaced instance from evicting the replacement under the same key (see "rootDir-mismatch" edge case).
 
-**`onDidChangeViewState`** — when a panel is dragged to a different column:
+## Column tracking
 
-```ts
-panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
-```
+The `create` registration above wires `onDidChangeViewState` and `onDidDispose` and does the initial anchoring. This section specifies the shared recompute routine those listeners call.
 
 ```ts
 private static recomputePreviewColumn(): void {
@@ -145,23 +162,7 @@ private static recomputePreviewColumn(): void {
 }
 ```
 
-**`onDidDispose`** per instance:
-
-```ts
-panel.onDidDispose(() => {
-    // Guard against a stale dispose listener for an instance that has
-    // since been replaced under the same key (the rootDir-mismatch
-    // branch disposes the old panel and inserts a new one). VS Code's
-    // dispose() is synchronous today, but the guard makes the
-    // invariant explicit and survives any future async change.
-    if (KnitOutputPanel.instances.get(key) === instance) {
-        KnitOutputPanel.instances.delete(key);
-    }
-    KnitOutputPanel.recomputePreviewColumn();
-});
-```
-
-The dispose handler captures the instance it was registered for (closure over `instance`). The replacement panel registers its own `onDidDispose` for the *new* instance.
+The `onDidDispose` handler that calls this routine is shown in the `create` registration block above.
 
 ## Per-instance behavior (unchanged)
 
@@ -188,7 +189,7 @@ The dispose handler captures the instance it was registered for (closure over `i
 Each panel reuses the three-layer model already implemented in `knit-output-panel.ts` + `knit-output.ts`. Going from one to many panels does not widen the security surface; each layer is per-instance.
 
 1. **`iframe sandbox="allow-same-origin"`** — blocks scripts, forms, popups, and top-navigation in the rendered HTML. `allow-same-origin` is set (rather than the empty `sandbox=""` that the prior spec described) because an opaque-origin sandbox bypasses the VS Code webview service worker, causing `ERR_NAME_NOT_RESOLVED` on `vscode-cdn.net` resources; `allow-same-origin` re-enters the SW scope without enabling scripts or forms. The trade-off (rendered HTML inside the iframe can read its own DOM via JS that we would otherwise have allowed — but `sandbox` strips script execution regardless, so this is moot) is documented in the doc comment on `buildShellHtml`.
-2. **Outer-shell CSP** in `<head>` — `default-src 'none'`, `frame-src ${cspSource}`, `script-src 'nonce-${nonce}'`, `connect-src 'none'`.
+2. **Outer-shell CSP** in `<head>` — exactly the directives currently emitted by `buildShellHtml` (`knit-output.ts:139-145`): `default-src 'none'`, `frame-src ${cspSource}`, `img-src ${cspSource} https: data:`, `style-src ${cspSource} 'unsafe-inline'`, `font-src ${cspSource} https: data:`, `script-src 'nonce-${nonce}'`, `connect-src 'none'`. Subresource directives (`img-src` / `style-src` / `font-src`) are required for figures, themed CSS, and webfonts inside the rendered HTML to load — the prior spec's 4-directive summary was an abbreviation that would block all of them if implemented literally. `style-src 'unsafe-inline'` is required by rmarkdown's stock highlight themes; safe inside the iframe sandbox because the inline styles cannot reach the outer toolbar.
 3. **`localResourceRoots`** confined to *that panel's* `path.dirname(outputPath)`. Two panels for `A.Rmd` and `B.Rmd` whose outputs live in different directories receive different roots — neither can resolve resources from the other's directory.
 
 **Loading mechanism** (also unchanged from the implementation, but worth restating because the prior spec is imprecise): the rendered HTML is read from disk via `fs.readFileSync`, run through `rewriteFragmentAnchors` (see below), and embedded as `srcdoc` on the iframe, with a `<base href>` set to the webview URI of the output's directory so relative subresources resolve through `localResourceRoots`. This is *not* iframe `src` loading; the prior spec's `src="${asWebviewUri(outputPath)}"` text described a design that was changed during implementation to work around nested-iframe navigation issues with `webview.asWebviewUri`.
@@ -204,6 +205,7 @@ Same as the prior spec, scoped per source:
 | Condition | Surface |
 |--|--|
 | Rendered HTML not readable (`fs.access` fails) | `showOrUpdate` returns `{ ok: false, error }`. Caller in `knit-commands.ts` logs to the output channel and falls back to `revealFileInOS`. Other panels untouched. |
+| File deleted / becomes unreadable between `fs.access` (in `showOrUpdate`) and `fs.readFileSync` (in `updateContent`) | The `try { fs.readFileSync }` inside `updateContent` already catches and writes an inline error `<p>` into the panel ("Raven: Knit — could not read the rendered output. Use Open in Browser instead.") and logs the error to the channel. The panel is *not* disposed, so the user can still re-knit via the toolbar. `showOrUpdate` does **not** retroactively return `{ ok: false }` for this case — the panel has already been opened/revealed and shows the inline error. This matches the singleton's existing behavior at `knit-output-panel.ts:158-168`. |
 | Refresh on a file whose source `.Rmd` was deleted | `raven.knit` runs and fails its YAML parse / file-existence check; the panel stays visible showing the last successful render. |
 | `vscode.env.openExternal` returns false on Open in Browser | Warning toast + path written to the output channel. Unchanged. |
 
@@ -270,7 +272,15 @@ static recomputePreviewColumnForTesting(): void;
 static setPreviewColumnForTesting(col: vscode.ViewColumn | undefined): void;
 ```
 
-`setInstancesForTesting` installs lightweight stand-ins (objects shaped like `{ panel: { viewColumn } }`) into the static `instances` Map, bypassing real `createWebviewPanel`. The recompute logic only reads `inst.panel.viewColumn`, so duck-typing is sufficient. `disposeAllForTesting` clears the Map and `previewColumn` regardless of how entries were inserted (real or fake), so production tests can interleave with recompute tests.
+`setInstancesForTesting` installs lightweight stand-ins (objects shaped like `{ panel: { viewColumn } }`) into the static `instances` Map, bypassing real `createWebviewPanel`. The recompute logic only reads `inst.panel.viewColumn`, so duck-typing is sufficient.
+
+`disposeAllForTesting` semantics:
+
+1. For each entry in `instances`, if the entry has a real `vscode.WebviewPanel` (i.e. was not inserted via `setInstancesForTesting`), call `entry.panel.dispose()`. This is detected by `typeof entry.panel.dispose === 'function'` — fakes injected by `setInstancesForTesting` do not have `dispose`, so they are skipped.
+2. Clear the Map (`instances.clear()`) regardless of dispose results.
+3. Set `previewColumn = undefined`.
+
+This guarantees no live orphan `WebviewPanel` is left behind after tests that opened real panels, while still allowing recompute tests to reset their fake-instance fixtures cheaply. If a future test inserts a fake that *does* expose a `dispose` shim, that shim runs — fine, and the contract is "if you give me something disposable, I dispose it."
 
 The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed (`disposeAllForTesting` / `getInstancesForTesting`) and the existing test callers update accordingly.
 
@@ -293,6 +303,17 @@ The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed (`dis
 
 1. **`onDidChangeViewState` cost** — fires on every visibility / state change, not just column moves. The handler does an O(n) Map walk; with realistic n ≤ ~10, the overhead is negligible. If users report panel-switching jank with many panels, debounce or compare against a cached column before walking.
 2. **Tab grouping (drag-as-group)** — VS Code does not expose programmatic tab grouping. Users can manually group knit panels via the tab-strip context menu. Out of scope.
+
+## v3 → v4 changes (response to third Codex pass)
+
+| Codex finding | v4 disposition |
+| --            | --             |
+| #1 Stale "unchanged" framing in Goals / Architecture still claimed shell HTML, CSP, sandbox, message protocol unchanged | Goal #4 rewritten to enumerate what is *actually* unchanged (CSP placement, `localResourceRoots`, theme key, `pickPrimaryOutput`); Architecture paragraph rewritten to list the unchanged surfaces and point at the security/per-instance sections for the divergences. |
+| #2 `create` never specified to insert into `instances` Map | New "`create` registration" section shows the full `create` body including `instances.set(key, instance)`, the preview-column anchoring, and the wiring of `onDidChangeViewState` / `onDidDispose` with the identity-guarded delete. Without this, the registry would never function. |
+| #3 State-model "Reset to undefined whenever no surviving panel occupies it" contradicted the adopt-on-drag algorithm | State-model bullet rewritten to describe the actual three-step algorithm (occupied → stay; empty old / non-empty Map → adopt; empty Map → undefined). |
+| #4 CSP listed only 4 directives, would block figures/CSS/fonts | Security model now quotes the full 7-directive CSP from `knit-output.ts:139-145` verbatim and notes why each subresource directive is required. |
+| #5 No error surface for fs.access-then-readFileSync TOCTOU | New edge-case row documents the existing inline-error fallback in `updateContent` and notes `showOrUpdate` does *not* retroactively return `{ok: false}` for that case. |
+| #6 `disposeAllForTesting` did not say it disposes real panels before clearing | Test-only API section now spells out the three-step contract (dispose real panels detected by `typeof entry.panel.dispose === 'function'`, clear Map, reset previewColumn). |
 
 ## v2 → v3 changes (response to second Codex pass)
 

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -57,7 +57,7 @@ export class KnitOutputPanel {
 }
 ```
 
-- **`instances` key**: `sourceUri.toString()`. Using the URI rather than `fsPath` gives free, platform-correct normalization (Windows drive-letter case, URI-encoding of spaces, etc.) and is the same value the rest of the extension keys on.
+- **`instances` key**: `sourceUri.fsPath`. This matches the in-flight gate in `knit-commands.ts:228-235` (the `inFlight: Set<string>` keyed by `fsPath`, with the comment "fsPath so the same file under different relative URIs collapses"). Keeping the two keying strategies aligned is load-bearing: a `Refresh` from a panel calls `vscode.commands.executeCommand('raven.knit', sourceUri)`, which then consults `inFlight` via `fsPath`; if the panel registry keyed by `sourceUri.toString()` while the in-flight gate keyed by `fsPath`, the same `.Rmd` reached via two slightly different URIs (e.g. `vscode://…` redirects, explorer vs. active-editor variants) would produce two panels but a single in-flight slot. Use the same key the in-flight tracker uses. `fsPath` is platform-correct for case-sensitive filesystems; on case-insensitive ones it has the same limitation the in-flight tracker already has (the user-visible behavior is consistent across both surfaces — out of scope to fix here).
 - **`previewColumn`**: the concrete `vscode.ViewColumn` (1, 2, 3, …) that subsequent *new* knit panels anchor to. Initially `undefined`. On every state change (`onDidChangeViewState`, `onDidDispose`) `recomputePreviewColumn` runs: if any panel still occupies the recorded column, it stays put; otherwise it *adopts* the column of any surviving panel (so a dragged-away lone panel keeps siblings clustered with it); if the Map is empty, it resets to `undefined`. The full algorithm is shown in "Column tracking" below; the table in "Edge cases" enumerates the user-visible consequences.
 
 ## `showOrUpdate` flow
@@ -73,7 +73,7 @@ static async showOrUpdate(
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
 
-    const key = args.sourceUri.toString();
+    const key = args.sourceUri.fsPath;
     const rootDir = path.dirname(args.outputPath);
     const existing = KnitOutputPanel.instances.get(key);
 
@@ -100,11 +100,11 @@ static async showOrUpdate(
 
 ## `create` registration
 
-`KnitOutputPanel.create` is the only path that constructs an instance. It must register the new instance in the static Map under `args.sourceUri.toString()` *before* returning, and must wire `onDidChangeViewState` / `onDidDispose` listeners. Equivalent to today's `KnitOutputPanel.instance = instance` line in the singleton implementation, but Map-keyed:
+`KnitOutputPanel.create` is the only path that constructs an instance. It must register the new instance in the static Map under `args.sourceUri.fsPath` *before* returning, and must wire `onDidChangeViewState` / `onDidDispose` listeners. Equivalent to today's `KnitOutputPanel.instance = instance` line in the singleton implementation, but Map-keyed:
 
 ```ts
 private static create(context, args, rootDir, column): KnitOutputPanel {
-    const key = args.sourceUri.toString();
+    const key = args.sourceUri.fsPath;
     const panel = vscode.window.createWebviewPanel(/* unchanged options */);
     const instance = new KnitOutputPanel(context, panel, rootDir, args);
     KnitOutputPanel.instances.set(key, instance);
@@ -175,7 +175,7 @@ The `onDidDispose` handler that calls this routine is shown in the `create` regi
 
 | Scenario | Behavior |
 |--|--|
-| Knit `A.Rmd`, close A's editor, knit `A.Rmd` again via explorer context menu | Panel for A is found in the Map by `sourceUri.toString()` and reused. The closed editor is irrelevant. |
+| Knit `A.Rmd`, close A's editor, knit `A.Rmd` again via explorer context menu | Panel for A is found in the Map by `sourceUri.fsPath` and reused. The closed editor is irrelevant. |
 | Same `.Rmd` opened in two VS Code windows | Each window has its own extension host and `instances` Map. No cross-window interference. |
 | User drags A's panel into a different column (e.g. column 1 where A.Rmd lives) | `onDidChangeViewState` fires; `recomputePreviewColumn` runs. If any other knit panel still occupies the old preview column, `previewColumn` stays put (subsequent knits stack with the cluster that didn't move). If A was the only one, `previewColumn` *adopts* A's new column so the next knit lands next to A rather than scattering to `Beside`. |
 | Same `.Rmd` knit produces output to a different directory on the second run | A's existing panel is disposed and recreated in *its* current column (the `rootDir`-mismatch branch). Other panels are untouched. |
@@ -303,6 +303,13 @@ The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed (`dis
 
 1. **`onDidChangeViewState` cost** — fires on every visibility / state change, not just column moves. The handler does an O(n) Map walk; with realistic n ≤ ~10, the overhead is negligible. If users report panel-switching jank with many panels, debounce or compare against a cached column before walking.
 2. **Tab grouping (drag-as-group)** — VS Code does not expose programmatic tab grouping. Users can manually group knit panels via the tab-strip context menu. Out of scope.
+
+## v4 → v5 changes (response to fourth Codex pass)
+
+| Codex finding | v5 disposition |
+| --            | --             |
+| #2 Registry key `sourceUri.toString()` diverged from `inFlight: Set<string>` keyed by `fsPath` in `knit-commands.ts:228-235` | Registry key changed to `sourceUri.fsPath` throughout. State-model bullet now explains the alignment with the in-flight tracker and why it is load-bearing for `Refresh` round-trips. All in-spec snippets and edge-case rows updated. |
+| #1 v3→v4 row #2 phrasing slightly overclaimed "the full `create` body" | Acknowledged as cosmetic; left in place. The section *does* show the full body relative to the singleton equivalent (`createWebviewPanel` options identical to today's are not duplicated). |
 
 ## v3 → v4 changes (response to third Codex pass)
 

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -296,7 +296,7 @@ The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed (`dis
 
 - `docs/knit.md`, step 10 ("Reveal") — change "the **Knit Output** webview panel" to "a **Knit Output** webview panel for that `.Rmd`," and add one sentence: "Multiple `.Rmd` files can have panels open at once; new panels stack as tabs alongside any existing knit panels."
 - `docs/knit.md` non-goals — remove any wording implying the panel is a singleton.
-- `docs/development.md` — **supersedes** the singleton-panel pattern note that the prior 2026-05-17 spec added (so the two specs do not leave the development docs describing two contradictory architectures). New text: `KnitOutputPanel` keeps a per-`sourceUri` registry and tracks a "preview column" for new panels. Cross-link from `help-panel.ts`'s doc comment (which remains singleton — distinct domain, only one R-help context per session).
+- `docs/development.md` — **supersedes** the singleton-panel pattern note that the prior 2026-05-17 spec added (so the two specs do not leave the development docs describing two contradictory architectures). New text: `KnitOutputPanel` keeps a registry of panels keyed by `sourceUri.fsPath` (aligned with the in-flight gate in `knit-commands.ts`) and tracks a "preview column" for new panels. Cross-link from `help-panel.ts`'s doc comment (which remains singleton — distinct domain, only one R-help context per session).
 - `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` — link this spec in the header as a successor for the singleton paragraphs.
 
 ## Open questions

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -1,0 +1,246 @@
+# R Markdown Knit — Per-`.Rmd` Output Panels
+
+**Status**: Design.
+**Date**: 2026-05-17.
+**Branch**: `further-improve-knit`.
+**Amends**: [`2026-05-17-knit-output-webview-design.md`](2026-05-17-knit-output-webview-design.md) — supersedes the singleton paragraphs of that spec (the non-goal "A multi-tab 'history' of past knits. The panel is a singleton…" and the "Singleton: one panel per VS Code window" doc comment). Everything else in the 2026-05-17 spec (iframe-sandbox shell, CSP, progress-lifecycle fix, message protocol, security model) is unchanged.
+
+## Why this spec exists
+
+When a user is editing two or more `.Rmd` files in one VS Code window, the current singleton `KnitOutputPanel` shows whichever was knit last. Knitting `B.Rmd` blows away the view of `A.Rmd`'s output, and the toolbar's `Refresh` button silently retargets from A to B. A side-by-side view of two rendered outputs is impossible without splitting the editor manually and re-knitting.
+
+This spec replaces the singleton with a per-source-path registry: each `.Rmd` gets its own `Knit Output` webview panel, all anchored in a tracked "preview column" so they stack as tabs in one place rather than scattering across the workspace.
+
+## Goals
+
+1. Knitting `A.Rmd` and `B.Rmd` in the same window produces two distinct panels, both visible until the user closes them.
+2. Re-knitting `A.Rmd` updates A's panel in place — the `Refresh` button on each panel remains bound to *its* source `.Rmd` for the life of the panel.
+3. New panels open in the same column as existing knit panels (they stack as tabs), so the user does not have to rearrange the workspace after each knit.
+4. No new commands, no new settings. The webview shell HTML, CSP, sandbox, message protocol, theme handling, and security model are unchanged.
+
+## Non-goals
+
+- Hard cap on the number of simultaneous panels. (VS Code's own tab-strip limits apply.)
+- Restoring panels across window reloads. `retainContextWhenHidden: true` continues to handle hide/show within a session; full session restore requires a webview serializer and is deferred.
+- Cross-window coordination. Each VS Code window has its own extension host and its own panel registry.
+- Auto-disposing a panel when the source `.Rmd` editor closes. The panel survives until the user closes it manually. The `Refresh` button continues to work because `sourceUri` was captured at panel creation.
+- A "history" of past renders for the same `.Rmd`. Re-knitting `A.Rmd` always replaces A's panel content — there is one panel per source path, not one per knit invocation.
+
+## Architecture
+
+```text
+editors/vscode/src/knit/
+  knit-output-panel.ts    # CHANGED: singleton → per-source-path registry + preview-column tracking
+  knit-commands.ts        # UNCHANGED: still calls KnitOutputPanel.showOrUpdate(context, args)
+  knit-output.ts          # UNCHANGED
+  knit-engine.ts          # UNCHANGED
+  ...
+```
+
+No changes to `package.json`, settings schema, context keys, or the message protocol. No changes to the iframe shell HTML or CSP. No changes outside `knit-output-panel.ts` and its tests.
+
+## State model
+
+```ts
+export class KnitOutputPanel {
+    private static instances = new Map<string, KnitOutputPanel>();
+    private static previewColumn: vscode.ViewColumn | undefined;
+
+    // Per-instance fields are unchanged from the singleton design:
+    private panel: vscode.WebviewPanel;
+    private rootDir: string;
+    private sourceUri: vscode.Uri;
+    private outputPath: string;
+    private readonly output: vscode.OutputChannel;
+    private readonly context: vscode.ExtensionContext;
+    // …
+}
+```
+
+- **`instances` key**: `sourceUri.toString()`. Using the URI rather than `fsPath` gives free, platform-correct normalization (Windows drive-letter case, URI-encoding of spaces, etc.) and is the same value the rest of the extension keys on.
+- **`previewColumn`**: the concrete `vscode.ViewColumn` (1, 2, 3, …) that the first surviving knit panel was placed in. Used to anchor subsequent *new* panels. Reset to `undefined` whenever no surviving panel occupies it.
+
+## `showOrUpdate` flow
+
+```ts
+static async showOrUpdate(
+    context: vscode.ExtensionContext,
+    args: { sourceUri: vscode.Uri; outputPath: string; output: vscode.OutputChannel },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+    try {
+        await fs.promises.access(args.outputPath, fs.constants.R_OK);
+    } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    const key = args.sourceUri.toString();
+    const rootDir = path.dirname(args.outputPath);
+    const existing = KnitOutputPanel.instances.get(key);
+
+    if (existing && existing.rootDir === rootDir) {
+        existing.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
+        existing.panel.reveal(existing.panel.viewColumn ?? vscode.ViewColumn.Beside, true);
+        return { ok: true };
+    }
+
+    if (existing) {
+        // localResourceRoots is immutable post-creation — dispose+recreate in
+        // the same column. Scoped to this source; other panels untouched.
+        const column = existing.panel.viewColumn ?? vscode.ViewColumn.Beside;
+        existing.panel.dispose(); // onDidDispose deletes the Map entry.
+        KnitOutputPanel.create(context, args, rootDir, column);
+        return { ok: true };
+    }
+
+    const column = KnitOutputPanel.previewColumn ?? vscode.ViewColumn.Beside;
+    KnitOutputPanel.create(context, args, rootDir, column);
+    return { ok: true };
+}
+```
+
+## Column tracking
+
+Inside `create`, after `vscode.window.createWebviewPanel(...)`:
+
+```ts
+const resolved = panel.viewColumn;
+if (resolved !== undefined && KnitOutputPanel.previewColumn === undefined) {
+    KnitOutputPanel.previewColumn = resolved;
+}
+```
+
+The first surviving knit anchors the preview column. From then on, `previewColumn` stays put until the registry stops occupying it.
+
+**`onDidChangeViewState`** — when a panel is dragged to a different column:
+
+```ts
+panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
+```
+
+```ts
+private static recomputePreviewColumn(): void {
+    const target = KnitOutputPanel.previewColumn;
+    if (target === undefined) return;
+    let stillThere = false;
+    for (const inst of KnitOutputPanel.instances.values()) {
+        if (inst.panel.viewColumn === target) {
+            stillThere = true;
+            break;
+        }
+    }
+    if (!stillThere) KnitOutputPanel.previewColumn = undefined;
+}
+```
+
+**`onDidDispose`** per instance:
+
+```ts
+panel.onDidDispose(() => {
+    KnitOutputPanel.instances.delete(key);
+    if (KnitOutputPanel.instances.size === 0) {
+        KnitOutputPanel.previewColumn = undefined;
+    } else {
+        KnitOutputPanel.recomputePreviewColumn();
+    }
+});
+```
+
+## Per-instance behavior (unchanged)
+
+- The constructor captures `context`, `panel`, `rootDir`, `sourceUri`, `outputPath`, `output` exactly as today.
+- `updateContent` regenerates the shell HTML each call. Title is `Knit Output: ${path.basename(outputPath)}` — same as today, which already disambiguates panels in the tab strip.
+- `handleMessage` dispatches `refresh`, `openInBrowser`, `themeChanged` against the captured `sourceUri` / `outputPath` of *that* instance. No registry lookups.
+- Theme preference is global (lives in `context.globalState`, key `raven.knit.applyVSCodeTheme`). Changing the toggle on one panel does not retro-apply to other open panels in this session — applies on the next `updateContent` (i.e. the next knit of that file). Documented as the intentional shape, mirroring how the existing singleton already behaves across knits.
+
+## Edge cases
+
+| Scenario | Behavior |
+|--|--|
+| Knit `A.Rmd`, close A's editor, knit `A.Rmd` again via explorer context menu | Panel for A is found in the Map by `sourceUri.toString()` and reused. The closed editor is irrelevant. |
+| Same `.Rmd` opened in two VS Code windows | Each window has its own extension host and `instances` Map. No cross-window interference. |
+| User drags A's panel into the editor column (column 1) where A.Rmd lives | `onDidChangeViewState` fires; `recomputePreviewColumn` checks whether any other knit panel still occupies the old preview column. If not, `previewColumn = undefined` and the next *new* knit re-anchors to `Beside`. |
+| Same `.Rmd` knit produces output to a different directory on the second run | A's existing panel is disposed and recreated in *its* current column (the `rootDir`-mismatch branch). Other panels are untouched. |
+| Multi-output knit (HTML + PDF) | Unchanged: HTML wins for the panel, additional paths go to the `Raven: Knit` output channel. The Map is keyed by source, not output. |
+| `Refresh` invoked while a knit of the same file is in flight | Existing `inFlight` Set in `knit-commands.ts` fires the "already being knitted" toast. Unchanged. |
+| 20+ different `.Rmd`s knit in one session | No hard cap. VS Code's tab-strip handles overflow. Documented as expected. |
+| User reloads the VS Code window | All panels are lost (no webview serializer). On the next knit, fresh panels are created. Same as today. |
+
+## Security model
+
+Unchanged from `2026-05-17-knit-output-webview-design.md`. Each panel has the same three independent layers:
+
+1. **`iframe sandbox=""`** — blocks scripts, forms, popups, top-navigation, same-origin access in the rendered HTML.
+2. **Outer-shell CSP** in `<head>` — `default-src 'none'`, `frame-src ${cspSource}`, `script-src 'nonce-${nonce}'`, `connect-src 'none'`.
+3. **`localResourceRoots`** confined to *that panel's* `path.dirname(outputPath)`.
+
+Because each instance owns its own `localResourceRoots`, panels cannot read each other's output directories. Going from one to many panels does not widen the security surface.
+
+## Error handling
+
+Same as the prior spec, scoped per source:
+
+| Condition | Surface |
+|--|--|
+| Rendered HTML not readable (`fs.access` fails) | `showOrUpdate` returns `{ ok: false, error }`. Caller in `knit-commands.ts` logs to the output channel and falls back to `revealFileInOS`. Other panels untouched. |
+| Refresh on a file whose source `.Rmd` was deleted | `raven.knit` runs and fails its YAML parse / file-existence check; the panel stays visible showing the last successful render. |
+| `vscode.env.openExternal` returns false on Open in Browser | Warning toast + path written to the output channel. Unchanged. |
+
+## Configuration
+
+No new settings.
+
+## Commands
+
+No new commands. `Refresh` continues to invoke `raven.knit` against each panel's captured `sourceUri`.
+
+## Testing
+
+### Bun unit tests (`tests/bun/`)
+
+No changes. `knit-output-shell.test.ts`, `knit-output-message.test.ts`, `knit-output-classify.test.ts`, `knit-output-pick-primary.test.ts`, `knit-output-shell.test.ts` exercise pure functions that do not touch the registry.
+
+### VS Code suite (`editors/vscode/src/test/`)
+
+**Updated:**
+
+- **`knit-output-panel.test.ts`** — the existing "second knit reuses the same panel reference" case splits into:
+  - re-knit *same* `sourceUri` reuses the same `WebviewPanel`;
+  - knit a *different* `sourceUri` produces a second instance in the Map; both `WebviewPanel`s are alive.
+
+**New:**
+
+- **`knit-multi-panel.test.ts`** — knit `A.Rmd`, knit `B.Rmd`. Assert: `getInstancesForTesting().size === 2`, both panels share `viewColumn === previewColumn`. Re-knit `A.Rmd` and assert `instances.size === 2` still (no new panel for the same key) and that A's panel reference is identical to the pre-existing one.
+- **`knit-preview-column.test.ts`** — knit `A.Rmd`, capture the column VS Code assigned, dispose A's panel; knit `B.Rmd`, assert it opens in `ViewColumn.Beside` (preview column was reset on Map-empty). Then knit `A.Rmd` again and assert A's new panel lands in B's column (the new preview column).
+
+Test-only statics on `KnitOutputPanel`:
+
+```ts
+static getInstancesForTesting(): ReadonlyMap<string, KnitOutputPanel> { return KnitOutputPanel.instances; }
+static getPreviewColumnForTesting(): vscode.ViewColumn | undefined { return KnitOutputPanel.previewColumn; }
+static disposeAllForTesting(): void {
+    for (const inst of [...KnitOutputPanel.instances.values()]) inst.panel.dispose();
+    KnitOutputPanel.previewColumn = undefined;
+}
+```
+
+The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed and updated. Callers in the test suite update accordingly.
+
+### Manual smoke
+
+- Open two `.Rmd`s. Knit one, then the other. Verify both panels appear in the same column, stacked as tabs.
+- Re-knit the first. Verify its tab updates in place and the second panel is untouched.
+- Drag the first panel into the editor column. Knit a third `.Rmd`. Verify the third panel anchors to whichever column the second panel occupies (the preview column was recomputed when the first was dragged).
+- Close all knit panels. Knit any `.Rmd`. Verify the panel opens `Beside` again (preview column was reset).
+- Reload the window with two knit panels open. Verify both vanish (expected, no serializer). Knit either `.Rmd` and verify fresh panels are created.
+
+## Documentation updates
+
+- `docs/knit.md`, step 10 ("Reveal") — change "the **Knit Output** webview panel" to "a **Knit Output** webview panel for that `.Rmd`," and add one sentence: "Multiple `.Rmd` files can have panels open at once; new panels stack as tabs alongside any existing knit panels."
+- `docs/knit.md` non-goals — remove any wording implying the panel is a singleton.
+- `docs/development.md` — short note: `KnitOutputPanel` keeps a per-`sourceUri` registry and tracks a "preview column" for new panels. Cross-link from `help-panel.ts`'s doc comment (which remains singleton — distinct domain, only one R-help context per session).
+- `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md` — link this spec in the header as a successor for the singleton paragraphs.
+
+## Open questions
+
+1. **`onDidChangeViewState` cost** — fires on every visibility / state change, not just column moves. The handler does an O(n) Map walk; with realistic n ≤ ~10, the overhead is negligible. If users report panel-switching jank with many panels, debounce or compare against a cached column before walking.
+2. **Tab grouping (drag-as-group)** — VS Code does not expose programmatic tab grouping. Users can manually group knit panels via the tab-strip context menu. Out of scope.

--- a/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
+++ b/docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md
@@ -3,7 +3,7 @@
 **Status**: Design.
 **Date**: 2026-05-17.
 **Branch**: `further-improve-knit`.
-**Amends**: [`2026-05-17-knit-output-webview-design.md`](2026-05-17-knit-output-webview-design.md) — supersedes the singleton paragraphs of that spec (the non-goal "A multi-tab 'history' of past knits. The panel is a singleton…" and the "Singleton: one panel per VS Code window" doc comment). Everything else in the 2026-05-17 spec (iframe-sandbox shell, CSP, progress-lifecycle fix, message protocol, security model) is unchanged.
+**Amends**: [`2026-05-17-knit-output-webview-design.md`](2026-05-17-knit-output-webview-design.md) — supersedes the singleton paragraphs of that spec (the non-goal "A multi-tab 'history' of past knits. The panel is a singleton…" and the "Singleton: one panel per VS Code window" doc comment). The CSP `<head>` placement, `localResourceRoots` confinement, progress-lifecycle fix, and `pickPrimaryOutput` semantics from the 2026-05-17 spec are unchanged. The sandbox attribute (`allow-same-origin`, not `""`), the loading mechanism (`srcdoc` + `<base href>` + a narrow fragment-anchor rewrite, not iframe `src`), and the message protocol (three typed messages plus two diagnostic-only messages, not two) all diverged from the prior spec's text during implementation; this spec describes what is actually in the code today and treats those as authoritative. See "Security model" and "Per-instance behavior" below.
 
 ## Why this spec exists
 
@@ -167,7 +167,7 @@ The dispose handler captures the instance it was registered for (closure over `i
 
 - The constructor captures `context`, `panel`, `rootDir`, `sourceUri`, `outputPath`, `output` exactly as today.
 - `updateContent` regenerates the shell HTML each call. Title is `Knit Output: ${path.basename(outputPath)}` — same as today, which already disambiguates panels in the tab strip.
-- `handleMessage` dispatches three message types against the captured `sourceUri` / `outputPath` of *that* instance: `{type: 'refresh'}`, `{type: 'openInBrowser'}`, `{type: 'themeChanged', applied: boolean}`. No registry lookups. The `themeChanged` message updates the global theme preference (see below) and is *not* documented in the prior spec's protocol section (which lists only `refresh` / `openInBrowser`); it was added in `4270fc8 feat(knit): fix white iframe + overhaul panel UX`. This spec treats the implemented three-message protocol as authoritative.
+- `handleMessage` dispatches three typed message types against the captured `sourceUri` / `outputPath` of *that* instance: `{type: 'refresh'}`, `{type: 'openInBrowser'}`, `{type: 'themeChanged', applied: boolean}`. No registry lookups. The `themeChanged` message updates the global theme preference (see below) and is *not* documented in the prior spec's protocol section (which lists only `refresh` / `openInBrowser`); it was added in `4270fc8 feat(knit): fix white iframe + overhaul panel UX`. The webview shell additionally posts `{type: 'iframeProbe', …}` and `{type: 'cspViolation', …}` messages for in-iframe load diagnostics and CSP-violation surfacing. These are *not* members of `KnitOutputMessage` and `isKnitOutputMessage` returns false for them, so the extension-side handler silently drops them. They exist only so tests / future telemetry can observe iframe state via a dedicated listener; the per-file-panel work does not touch them. This spec treats the implemented three-typed-message + two-diagnostic-message protocol as authoritative.
 - Theme preference is global (lives in `context.globalState`, key `raven.knit.applyVSCodeTheme`). Changing the toggle on one panel does not retro-apply to other open panels in this session — applies on the next `updateContent` (i.e. the next knit of that file). Documented as the intentional shape, mirroring how the existing singleton already behaves across knits.
 
 ## Edge cases
@@ -191,7 +191,11 @@ Each panel reuses the three-layer model already implemented in `knit-output-pane
 2. **Outer-shell CSP** in `<head>` — `default-src 'none'`, `frame-src ${cspSource}`, `script-src 'nonce-${nonce}'`, `connect-src 'none'`.
 3. **`localResourceRoots`** confined to *that panel's* `path.dirname(outputPath)`. Two panels for `A.Rmd` and `B.Rmd` whose outputs live in different directories receive different roots — neither can resolve resources from the other's directory.
 
-**Loading mechanism** (also unchanged from the implementation, but worth restating because the prior spec is imprecise): the rendered HTML is read from disk via `fs.readFileSync` and embedded as `srcdoc` on the iframe, with a `<base href>` set to the webview URI of the output's directory so relative subresources resolve through `localResourceRoots`. This is *not* iframe `src` loading; the prior spec's `src="${asWebviewUri(outputPath)}"` text described a design that was changed during implementation to work around nested-iframe navigation issues with `webview.asWebviewUri`. The security properties (sandbox + CSP + roots) hold for srcdoc the same way they hold for src.
+**Loading mechanism** (also unchanged from the implementation, but worth restating because the prior spec is imprecise): the rendered HTML is read from disk via `fs.readFileSync`, run through `rewriteFragmentAnchors` (see below), and embedded as `srcdoc` on the iframe, with a `<base href>` set to the webview URI of the output's directory so relative subresources resolve through `localResourceRoots`. This is *not* iframe `src` loading; the prior spec's `src="${asWebviewUri(outputPath)}"` text described a design that was changed during implementation to work around nested-iframe navigation issues with `webview.asWebviewUri`.
+
+**`rewriteFragmentAnchors`** is a single targeted regex rewrite that only touches `<a href="#frag">` attribute values, replacing them with `<a href="about:srcdoc#frag">`. It is required because the `<base href>` we inject — needed for relative subresources — would otherwise turn intra-document fragment clicks into full document navigations, which fail in the nested-frame setup. The rewrite is documented in detail on the function itself (`knit-output.ts:583-618`) including the *intentionally* unrewritten cases (`href="page.html#x"`, empty/`"#"` hrefs, non-`<a>` elements, hrefs containing `<`/`>`/whitespace).
+
+Security implication: the prior spec disfavored Raven-side HTML rewriting because a *general* rewriter that misses cases could re-serialize untrusted HTML through Raven's hands. `rewriteFragmentAnchors` is narrow enough that the failure mode is "TOC anchor falls back to a no-op navigation," not script-execution. The sandbox + CSP + `localResourceRoots` stack still governs everything the iframe does, regardless of whether the rewrite succeeds or partially fails on adversarial input. This spec does not change the rewriter; it is documented here so future maintainers do not "discover" it and undo it.
 
 ## Error handling
 
@@ -229,31 +233,46 @@ No changes. `knit-output-shell.test.ts`, `knit-output-message.test.ts`, `knit-ou
 
 - **`knit-multi-panel.test.ts`** — knit `A.Rmd`, knit `B.Rmd` (with outputs under distinct directories). Assert:
   - `getInstancesForTesting().size === 2`;
-  - both panels share `viewColumn === previewColumn`;
-  - A's and B's panels have *distinct* `webview.options.localResourceRoots`, each containing only its own output directory (per-panel isolation claim);
-  - re-knit `A.Rmd` and assert `instances.size === 2` still (no new panel for the same key) and that A's panel reference is identical to the pre-existing one.
-- **`knit-preview-column.test.ts`** — knit `A.Rmd`, capture the column VS Code assigned, dispose A's panel; knit `B.Rmd`, assert it opens in `ViewColumn.Beside` (preview column was reset on Map-empty). Then knit `A.Rmd` again and assert A's new panel lands in B's column (the new preview column).
-- **`knit-rootdir-change.test.ts`** — knit `A.Rmd` so its output lives under `/tmp/dir1/`. Assert the panel's `localResourceRoots` contains `/tmp/dir1`. Re-invoke `showOrUpdate` with the *same* sourceUri but an `outputPath` under `/tmp/dir2/`. Assert: the original panel is disposed (the `WebviewPanel` reference observed earlier is now disposed), a new panel exists for the same key, the new panel's `localResourceRoots` contains `/tmp/dir2`, the new panel's `viewColumn` matches the old panel's `viewColumn`, and `instances.size === 1`. This is the highest-risk lifecycle branch and was previously only manually smoked.
-- **`knit-recompute-preview-column.test.ts`** — unit test for `recomputePreviewColumn` driven through a test-only harness that injects fake instances with controlled `viewColumn` values. Cases:
-  - empty Map → `previewColumn = undefined`;
-  - one panel in column X, `previewColumn` was X → stays X;
-  - one panel in column X, `previewColumn` was Y (no panels at Y) → adopts X;
-  - two panels split between X and Y, `previewColumn` was X → stays X;
-  - two panels, both move to Z, `previewColumn` was X → adopts Z.
+  - both `getPanelForTesting().viewColumn` values equal `getPreviewColumnForTesting()`;
+  - A's and B's `getPanelForTesting().webview.options.localResourceRoots` are *distinct*, each containing only its own output directory (per-panel isolation claim);
+  - re-knit `A.Rmd` and assert `instances.size === 2` still (no new panel for the same key) and that the `WebviewPanel` reference from `getPanelForTesting()` is identical to the pre-existing one.
+- **`knit-preview-column.test.ts`** — knit `A.Rmd`, capture the column VS Code assigned via `getPreviewColumnForTesting()`, dispose A's panel via `disposeAllForTesting()`; knit `B.Rmd`, assert it opens in `ViewColumn.Beside` (preview column was reset on Map-empty). Then knit `A.Rmd` again and assert A's new panel lands in B's column (the new preview column).
+- **`knit-rootdir-change.test.ts`** — knit `A.Rmd` so its output lives under `/tmp/dir1/`. Assert `getPanelForTesting().webview.options.localResourceRoots` contains `/tmp/dir1`. Re-invoke `showOrUpdate` with the *same* sourceUri but an `outputPath` under `/tmp/dir2/`. Assert: the original `WebviewPanel` reference observed earlier no longer matches what `getInstancesForTesting().get(key)?.getPanelForTesting()` returns (it has been disposed and replaced); the new panel's `localResourceRoots` contains `/tmp/dir2`; the new panel's `viewColumn` matches the captured old `viewColumn`; `instances.size === 1`. This is the highest-risk lifecycle branch and was previously only manually smoked.
+- **`knit-recompute-preview-column.test.ts`** — unit test for `recomputePreviewColumn` driven via `setInstancesForTesting(fakes)` + `setPreviewColumnForTesting(col)` + `recomputePreviewColumnForTesting()`. Cases (each starts with `disposeAllForTesting()` to reset state):
+  - empty fakes, previewColumn = One → previewColumn becomes undefined;
+  - one fake in One, previewColumn = One → stays One;
+  - one fake in One, previewColumn = Two (no fakes at Two) → adopts One;
+  - two fakes split (One, Two), previewColumn = One → stays One;
+  - two fakes both in Three, previewColumn = One → adopts Three.
   Drives the panel-drag scenario without needing VS Code to simulate a real drag.
 
-Test-only statics on `KnitOutputPanel`:
+### Test-only API on `KnitOutputPanel`
+
+The new tests require accessors that the production interface does not expose. All are gated by name suffix `…ForTesting`, mirroring the existing `disposeForTesting` / `getInstanceForTesting` conventions:
 
 ```ts
-static getInstancesForTesting(): ReadonlyMap<string, KnitOutputPanel> { return KnitOutputPanel.instances; }
-static getPreviewColumnForTesting(): vscode.ViewColumn | undefined { return KnitOutputPanel.previewColumn; }
-static disposeAllForTesting(): void {
-    for (const inst of [...KnitOutputPanel.instances.values()]) inst.panel.dispose();
-    KnitOutputPanel.previewColumn = undefined;
-}
+// Registry inspection.
+static getInstancesForTesting(): ReadonlyMap<string, KnitOutputPanel>;
+static getPreviewColumnForTesting(): vscode.ViewColumn | undefined;
+static disposeAllForTesting(): void;
+
+// Per-instance inspection — needed because `panel` and its `webview.options`
+// are private. Returns the underlying objects so tests can assert on
+// viewColumn and localResourceRoots without unsafe casts.
+getPanelForTesting(): vscode.WebviewPanel;
+getRootDirForTesting(): string;
+
+// Recompute driver — enables knit-recompute-preview-column.test.ts to
+// exercise the column-tracking state machine through controlled fake
+// instances rather than relying on VS Code to simulate a real drag.
+static setInstancesForTesting(fakes: ReadonlyArray<{ key: string; viewColumn: vscode.ViewColumn | undefined }>): void;
+static recomputePreviewColumnForTesting(): void;
+static setPreviewColumnForTesting(col: vscode.ViewColumn | undefined): void;
 ```
 
-The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed and updated. Callers in the test suite update accordingly.
+`setInstancesForTesting` installs lightweight stand-ins (objects shaped like `{ panel: { viewColumn } }`) into the static `instances` Map, bypassing real `createWebviewPanel`. The recompute logic only reads `inst.panel.viewColumn`, so duck-typing is sufficient. `disposeAllForTesting` clears the Map and `previewColumn` regardless of how entries were inserted (real or fake), so production tests can interleave with recompute tests.
+
+The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed (`disposeAllForTesting` / `getInstancesForTesting`) and the existing test callers update accordingly.
 
 ### Manual smoke
 
@@ -274,6 +293,16 @@ The existing `disposeForTesting()` / `getInstanceForTesting()` are renamed and u
 
 1. **`onDidChangeViewState` cost** — fires on every visibility / state change, not just column moves. The handler does an O(n) Map walk; with realistic n ≤ ~10, the overhead is negligible. If users report panel-switching jank with many panels, debounce or compare against a cached column before walking.
 2. **Tab grouping (drag-as-group)** — VS Code does not expose programmatic tab grouping. Users can manually group knit panels via the tab-strip context menu. Out of scope.
+
+## v2 → v3 changes (response to second Codex pass)
+
+| Codex finding | v3 disposition |
+| --            | --             |
+| #1 Header "unchanged" framing contradicts the patched sandbox/protocol/loading details | Header rewritten to enumerate what is *actually* unchanged (CSP placement, `localResourceRoots`, progress-lifecycle fix, `pickPrimaryOutput`) and what diverged (sandbox attribute, loading mechanism, message protocol), with pointers to the relevant sections. |
+| #2 `iframeProbe` / `cspViolation` messages omitted | Per-instance behavior section now documents both diagnostic messages, notes they are *not* members of `KnitOutputMessage`, and notes `isKnitOutputMessage` silently drops them at the extension boundary. |
+| #3 `rewriteFragmentAnchors` step omitted from loading-mechanism description | New paragraph documents the rewriter, its narrow surface (regex on `<a href="#…">` only), the intentional non-rewrite cases, and why "narrow rewrite for fragment-only anchors" is safe in a way "general HTML rewriter" is not. |
+| #4 `recomputePreviewColumn` test seam missing | Test-only API section adds `setInstancesForTesting`, `recomputePreviewColumnForTesting`, `setPreviewColumnForTesting`. The recompute test now exercises the state machine directly without VS Code drag simulation. |
+| #5 `panel` / `localResourceRoots` test access undefined | Test-only API section adds `getPanelForTesting()` / `getRootDirForTesting()` on the instance so tests can read `viewColumn` and `webview.options.localResourceRoots` without unsafe casts. The three new tests' assertions are rewritten to use these accessors explicitly. |
 
 ## v1 → v2 changes (response to Codex adversarial review)
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -461,17 +461,17 @@
         {
           "command": "raven.runAllChunks",
           "when": "editorLangId == rmd || editorLangId == quarto || (editorLangId == r && resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/)",
-          "group": "4_file@1"
+          "group": "3_chunk_directional@3"
         },
         {
           "command": "raven.knit",
           "when": "raven.rmdKnit.enabled && resourceExtname =~ /\\.(rmd|Rmd|RMD)$/",
-          "group": "4_file@2"
+          "group": "4_file@1"
         },
         {
           "command": "raven.sourceFile",
           "when": "editorLangId == r && !(resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/)",
-          "group": "4_file@3"
+          "group": "4_file@2"
         },
         {
           "submenu": "raven.sendToR.terminal",
@@ -516,12 +516,12 @@
         {
           "command": "raven.terminal.runAllChunks",
           "when": "editorLangId == rmd || editorLangId == quarto || (editorLangId == r && resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/)",
-          "group": "4_file@1"
+          "group": "3_chunk_directional@3"
         },
         {
           "command": "raven.terminal.sourceFile",
           "when": "editorLangId == r && !(resourceExtname =~ /\\.(rmd|Rmd|RMD|qmd|Qmd|QMD)$/)",
-          "group": "4_file@2"
+          "group": "4_file@1"
         }
       ]
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1812,7 +1812,7 @@
     "compile": "bun run bundle",
     "compile:test": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "bun run compile:test && bun run bundle",
+    "pretest": "bun run compile:test && bun run bundle && bun run copy-binary",
     "test": "vscode-test",
     "package": "bun run bundle && bun run copy-binary && vsce package --allow-missing-repository",
     "package:target": "bun run bundle && bun run copy-binary && vsce package --target",

--- a/editors/vscode/scripts/bundle-binary.js
+++ b/editors/vscode/scripts/bundle-binary.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const binDir = path.join(__dirname, '..', 'bin');
 const binaryName = process.platform === 'win32' ? 'raven.exe' : 'raven';
 const destBinary = path.join(binDir, binaryName);
-const srcBinary = path.join(__dirname, '..', '..', '..', 'target', 'release', binaryName);
+const repoRoot = path.join(__dirname, '..', '..', '..');
+const srcBinary = path.join(repoRoot, 'target', 'release', binaryName);
 
 if (!fs.existsSync(binDir)) {
     fs.mkdirSync(binDir, { recursive: true });
@@ -18,11 +20,46 @@ if (fs.existsSync(destBinary) || fs.existsSync(path.join(binDir, 'raven')) || fs
     process.exit(0);
 }
 
-if (fs.existsSync(srcBinary)) {
+function copyAndChmod() {
     fs.copyFileSync(srcBinary, destBinary);
     fs.chmodSync(destBinary, 0o755);
     console.log('Bundled raven binary');
-} else {
-    console.error('raven binary not found. Run: cargo build --release -p raven');
+}
+
+if (fs.existsSync(srcBinary)) {
+    copyAndChmod();
+    process.exit(0);
+}
+
+// No pre-bundled binary, no target/release build. Try cargo build before
+// giving up — this is what dev / pretest needs so `bun run pretest` can
+// produce a working LSP without the developer remembering to run cargo
+// manually. `RAVEN_BUNDLE_NO_BUILD=1` opts out for environments that
+// must not invoke cargo (e.g. CI release pipelines that build the binary
+// in a separate step).
+if (process.env.RAVEN_BUNDLE_NO_BUILD === '1') {
+    console.error('raven binary not found and RAVEN_BUNDLE_NO_BUILD=1 — refusing to build. Run: cargo build --release -p raven');
     process.exit(1);
 }
+
+console.log(`raven binary not found at ${srcBinary}; running "cargo build --release -p raven"…`);
+const result = spawnSync('cargo', ['build', '--release', '-p', 'raven'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+});
+
+if (result.error && result.error.code === 'ENOENT') {
+    console.error('cargo not found in PATH. Install Rust (https://rustup.rs) or set RAVEN_BUNDLE_NO_BUILD=1 and provide a pre-built binary.');
+    process.exit(1);
+}
+if (result.status !== 0) {
+    console.error(`cargo build --release -p raven failed (exit ${result.status}).`);
+    process.exit(result.status || 1);
+}
+
+if (!fs.existsSync(srcBinary)) {
+    console.error(`cargo build succeeded but ${srcBinary} is missing. This is a build-script bug.`);
+    process.exit(1);
+}
+
+copyAndChmod();

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -91,15 +91,31 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         const lines: string[] = [];
         for (let i = 0; i < document.lineCount; i++) lines.push(document.lineAt(i).text);
         const chunks = detect_chunks(lines, kind);
+        // Pre-compute, for each chunk header line, whether any runnable
+        // chunk exists strictly before or after it. We need this to drop
+        // sibling-targeted lenses (Run Next/Previous &c.) on chunks
+        // that have no target — clicking them would otherwise produce
+        // a "no runnable chunk below the cursor" toast that talks
+        // about a cursor the CodeLens click did not place.
+        const runnable_indices: number[] = [];
+        for (let i = 0; i < chunks.length; i++) {
+            if (is_runnable_chunk(chunks[i])) runnable_indices.push(i);
+        }
+        const first_runnable_idx = runnable_indices[0] ?? -1;
+        const last_runnable_idx = runnable_indices[runnable_indices.length - 1] ?? -1;
         const lenses: vscode.CodeLens[] = [];
-        let chunk_index = 0;
-        for (const c of chunks) {
-            chunk_index++;
+        for (let i = 0; i < chunks.length; i++) {
+            const c = chunks[i];
+            const chunk_index = i + 1;
             if (!is_runnable_chunk(c)) continue;
+            const has_previous_runnable = i > first_runnable_idx;
+            const has_next_runnable = i < last_runnable_idx;
             const range = new vscode.Range(c.header_line, 0, c.header_line, 0);
             for (const id of lens_command_ids) {
                 const meta = CHUNK_LENS_COMMANDS[id];
                 if (!meta) continue;
+                if (meta.gate === 'requires_next_runnable' && !has_next_runnable) continue;
+                if (meta.gate === 'requires_previous_runnable' && !has_previous_runnable) continue;
                 const eval_suffix = meta.eval_aware && c.is_eval_false ? ' (eval = FALSE)' : '';
                 lenses.push(new vscode.CodeLens(range, {
                     title: `${meta.title}${eval_suffix}`,

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -316,6 +316,15 @@ export interface ChunkLensCommand {
     readonly tooltip: string;
     /** Whether to append a `(eval = FALSE)` suffix when the chunk skips eval. */
     readonly eval_aware: boolean;
+    /**
+     * Optional gate. When set, the CodeLens provider suppresses the lens
+     * on chunks for which the gate would always fail at click time —
+     * e.g. "Run Next" on the last runnable chunk would have nowhere to
+     * go, so we drop the button rather than surface a confusing
+     * "no runnable chunk below the cursor" toast that talks about a
+     * cursor the user didn't use.
+     */
+    readonly gate?: 'requires_next_runnable' | 'requires_previous_runnable';
 }
 
 export const CHUNK_LENS_COMMANDS: Readonly<Record<string, ChunkLensCommand>> = Object.freeze({
@@ -354,24 +363,28 @@ export const CHUNK_LENS_COMMANDS: Readonly<Record<string, ChunkLensCommand>> = O
         title: '← Run Previous',
         tooltip: 'Run the R chunk immediately above this one',
         eval_aware: false,
+        gate: 'requires_previous_runnable',
     },
     'raven.runPreviousChunkAndMove': {
         positional_id: 'raven.runPreviousChunkAndMoveAt',
         title: '← Run Previous & Move',
         tooltip: 'Run the R chunk immediately above this one, then move the cursor into it',
         eval_aware: false,
+        gate: 'requires_previous_runnable',
     },
     'raven.runNextChunk': {
         positional_id: 'raven.runNextChunkAt',
         title: '→ Run Next',
         tooltip: 'Run the R chunk immediately below this one',
         eval_aware: false,
+        gate: 'requires_next_runnable',
     },
     'raven.runNextChunkAndMove': {
         positional_id: 'raven.runNextChunkAndMoveAt',
         title: '→ Run Next & Move',
         tooltip: 'Run the R chunk immediately below this one, then move the cursor into it',
         eval_aware: false,
+        gate: 'requires_next_runnable',
     },
     'raven.runAllChunks': {
         positional_id: 'raven.runAllChunksAt',

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -48,6 +48,7 @@ import {
 import { registerKnit } from './knit';
 import { registerInstallNags } from './recommendations/install-nag';
 import { registerWalkthroughCommands } from './recommendations/walkthrough';
+import { validateServerBinary } from './server-binary-check';
 
 /**
  * Read all raven.* settings from VS Code configuration and construct
@@ -230,6 +231,13 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         clientOptions
     );
 
+    // Pre-check the binary before starting the LSP. vscode-languageclient's
+    // generic "couldn't create connection to server" toast hides the real
+    // cause (missing binary, no exec bit, wrong target). Surface the actual
+    // reason here and skip the start so the user gets one clear message.
+    const binaryCheck = validateServerBinary(serverPath);
+    const configuredPath = vscode.workspace.getConfiguration('raven').get<string>('server.path');
+
     // The server emits `raven/projectConfigLoaded` whenever it picks up (or
     // re-picks up) a portable `raven.toml` / `.lintr` — and now also when
     // the file is removed. `path: null` + `source: null` is the cleared
@@ -276,7 +284,15 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         },
     );
 
-    client.start();
+    if (binaryCheck.ok) {
+        client.start();
+    } else {
+        const detail = configuredPath
+            ? `Raven LSP cannot start: configured raven.server.path "${serverPath}" is not a usable binary (${binaryCheck.reason}). Update raven.server.path or clear it to use the bundled binary.`
+            : `Raven LSP cannot start: bundled binary at "${serverPath}" is unusable (${binaryCheck.reason}). Build it with "cargo build --release -p raven" and re-bundle the extension, or set raven.server.path to a built binary.`;
+        outputChannel.appendLine(detail);
+        void vscode.window.showErrorMessage(detail);
+    }
 
     // Activate help viewer (registers raven.openHelpPanel, raven.help.back, raven.help.forward).
     activateHelpViewer(context, client);

--- a/editors/vscode/src/knit/knit-commands.ts
+++ b/editors/vscode/src/knit/knit-commands.ts
@@ -365,7 +365,6 @@ async function renderOutcome(outcome: KnitOutcome, ctx: RenderOutcomeCtx): Promi
     const baseLabel = path.basename(primary);
     const isHtml = ext === '.html' || ext === '.htm';
     const SHOW_ALL = 'Show All';
-    const SHOW_PANEL = 'Show Output Panel';
     const OPEN = 'Open';
 
     if (isHtml) {
@@ -380,20 +379,20 @@ async function renderOutcome(outcome: KnitOutcome, ctx: RenderOutcomeCtx): Promi
             void revealKnitOutput(primary);
             return;
         }
-        const buttons = absolutized.length > 1 ? [SHOW_PANEL, SHOW_ALL] : [SHOW_PANEL];
-        const label = absolutized.length > 1
-            ? `Raven: Knit succeeded: ${baseLabel} (and ${absolutized.length - 1} more).`
-            : `Raven: Knit succeeded: ${baseLabel}.`;
-        const choice = await vscode.window.showInformationMessage(label, ...buttons);
-        if (choice === SHOW_PANEL) {
-            // Idempotent re-reveal; same rootDir → reuses the panel.
-            await ctx.showOrUpdatePanel(ctx.context, {
-                sourceUri: ctx.sourceUri,
-                outputPath: primary,
-                output: ctx.output,
-            });
-        } else if (choice === SHOW_ALL) {
-            ctx.output.show(true);
+        // No success popover here: the panel itself is the success
+        // signal, and a toast with a "Show Output Panel" button just
+        // points at content that's already on screen. For multi-
+        // output knits we still want the additional output paths
+        // discoverable — log them to the channel so the user can
+        // find them via `Raven: Knit — Show Output Channel` or by
+        // clicking the channel directly.
+        if (absolutized.length > 1) {
+            ctx.output.appendLine(
+                `[outputs] knit produced ${absolutized.length} files; primary shown in panel:`,
+            );
+            for (const p of absolutized) {
+                ctx.output.appendLine(`  - ${p}${p === primary ? ' (primary)' : ''}`);
+            }
         }
         return;
     }

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -5,36 +5,41 @@ import * as vscode from 'vscode';
 import { buildShellHtml, isKnitOutputMessage } from './knit-output';
 
 /**
- * Singleton webview panel that renders the most recent HTML knit output
- * inside an `<iframe sandbox="allow-same-origin">` with Refresh and
- * Open-in-Browser toolbar buttons.
+ * Webview panel that renders a single `.Rmd`'s rendered HTML output in
+ * an `<iframe sandbox="allow-same-origin">` with Refresh / Open-in-
+ * Browser / theme-toggle toolbar buttons.
  *
- * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`.
+ * See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`
+ * and the prior `2026-05-17-knit-output-webview-design.md`.
  *
- * Architecture:
+ * Per-source registry: one panel per `.Rmd`, keyed by `sourceUri.fsPath`
+ * to match the in-flight gate in `knit-commands.ts` (which also keys by
+ * fsPath so the same file under different relative URIs collapses).
+ * New panels anchor to `previewColumn` so they stack as tabs in a
+ * single "preview" column rather than scattering.
+ *
+ * Architecture (unchanged from the singleton implementation):
  *  - Outer Raven-controlled shell document owns the CSP (in `<head>`),
  *    the toolbar, and a nonce'd `<script>` that posts messages.
- *  - Inner `<iframe>` loads the rendered HTML via
- *    `webview.asWebviewUri(outputPath)`. The sandbox blocks scripts,
- *    forms, popups, and top-navigation. `allow-same-origin` is
- *    required: VS Code serves `vscode-cdn.net` webview resources via
- *    a service worker scoped to that origin, and a sandboxed iframe
- *    with a unique opaque origin bypasses the service worker (Electron
- *    falls back to DNS resolution, which fails with
- *    `ERR_NAME_NOT_RESOLVED`). `allow-same-origin` re-enters the SW
- *    scope without enabling scripts/forms.
- *    `frame-src ${cspSource}` on the outer CSP prevents iframe
- *    navigation to external hosts.
+ *  - Inner `<iframe sandbox="allow-same-origin" srcdoc="…">` embeds the
+ *    rendered HTML inline. `allow-same-origin` is required because a
+ *    bare `sandbox=""` would give the iframe an opaque origin that
+ *    bypasses VS Code's webview service worker (Electron falls back
+ *    to DNS resolution, which fails with `ERR_NAME_NOT_RESOLVED`).
+ *    Scripts, forms, and popups are still blocked.
  *  - `localResourceRoots` is confined to `path.dirname(outputPath)`,
- *    which is also where rmarkdown's `_files/` figure directories sit.
+ *    where rmarkdown's `_files/` figure directories sit.
  *
- * Singleton: one panel per VS Code window. Subsequent knits replace the
- * iframe `src`. If the new output's `rootDir` differs, the panel is
- * disposed and recreated (VS Code does not allow updating
- * `localResourceRoots` post-creation — see `help-panel.ts`).
+ * Singleton → per-source: subsequent knits of the *same* source reuse
+ * the panel and swap iframe content. Knits of different sources open
+ * separate panels. If a panel's `outputPath` rootDir changes (rare —
+ * e.g. user edited `output_dir`), only that panel is disposed and
+ * recreated in its current column (`localResourceRoots` is immutable
+ * post-creation — same workaround `help-panel.ts` uses).
  */
 export class KnitOutputPanel {
-    private static instance: KnitOutputPanel | undefined;
+    private static instances = new Map<string, KnitOutputPanel>();
+    private static previewColumn: vscode.ViewColumn | undefined;
 
     private panel: vscode.WebviewPanel;
     private rootDir: string;
@@ -43,9 +48,10 @@ export class KnitOutputPanel {
     private readonly output: vscode.OutputChannel;
 
     /**
-     * Open or update the singleton panel. Returns `{ ok: true }` on
-     * success, `{ ok: false, error }` if the rendered file cannot be
-     * accessed (caller should fall back to `revealFileInOS`).
+     * Open or update the panel for `args.sourceUri`. Returns
+     * `{ ok: true }` on success, `{ ok: false, error }` if the rendered
+     * file cannot be accessed (caller should fall back to
+     * `revealFileInOS`).
      */
     static async showOrUpdate(
         context: vscode.ExtensionContext,
@@ -61,8 +67,9 @@ export class KnitOutputPanel {
             return { ok: false, error: err instanceof Error ? err.message : String(err) };
         }
 
+        const key = args.sourceUri.fsPath;
         const rootDir = path.dirname(args.outputPath);
-        const existing = KnitOutputPanel.instance;
+        const existing = KnitOutputPanel.instances.get(key);
 
         if (existing && existing.rootDir === rootDir) {
             existing.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
@@ -71,27 +78,83 @@ export class KnitOutputPanel {
         }
 
         if (existing) {
-            // localResourceRoots is immutable after panel creation — dispose
-            // and recreate in the same column. Same workaround as help-panel.
+            // localResourceRoots is immutable post-creation — dispose
+            // and recreate in the same column. Scoped to this source;
+            // other panels untouched.
             const column = existing.panel.viewColumn ?? vscode.ViewColumn.Beside;
             existing.panel.dispose();
-            // panel.dispose() fires onDidDispose, which clears `instance`.
             KnitOutputPanel.create(context, args, rootDir, column);
             return { ok: true };
         }
 
-        KnitOutputPanel.create(context, args, rootDir, vscode.ViewColumn.Beside);
+        const column = KnitOutputPanel.previewColumn ?? vscode.ViewColumn.Beside;
+        KnitOutputPanel.create(context, args, rootDir, column);
         return { ok: true };
     }
 
     /** Visible only for tests. */
-    static getInstanceForTesting(): KnitOutputPanel | undefined {
-        return KnitOutputPanel.instance;
+    static getInstancesForTesting(): ReadonlyMap<string, KnitOutputPanel> {
+        return KnitOutputPanel.instances;
     }
 
-    /** Visible only for tests — destroys the singleton. */
-    static disposeForTesting(): void {
-        KnitOutputPanel.instance?.panel.dispose();
+    /** Visible only for tests. */
+    static getPreviewColumnForTesting(): vscode.ViewColumn | undefined {
+        return KnitOutputPanel.previewColumn;
+    }
+
+    /**
+     * Visible only for tests — disposes every real `WebviewPanel` in
+     * the registry, clears the Map, and resets `previewColumn`. Fakes
+     * inserted via `setInstancesForTesting` do not expose `dispose`
+     * and are skipped.
+     */
+    static disposeAllForTesting(): void {
+        for (const inst of [...KnitOutputPanel.instances.values()]) {
+            const maybePanel = inst.panel as unknown as { dispose?: () => void };
+            if (typeof maybePanel?.dispose === 'function') {
+                maybePanel.dispose();
+            }
+        }
+        KnitOutputPanel.instances.clear();
+        KnitOutputPanel.previewColumn = undefined;
+    }
+
+    /**
+     * Visible only for tests — inject lightweight stand-ins into the
+     * Map so `recomputePreviewColumn` can be exercised without real
+     * `createWebviewPanel` calls. The recompute logic only reads
+     * `inst.panel.viewColumn`, so duck-typing is sufficient.
+     */
+    static setInstancesForTesting(
+        fakes: ReadonlyArray<{ key: string; viewColumn: vscode.ViewColumn | undefined }>,
+    ): void {
+        KnitOutputPanel.instances.clear();
+        for (const f of fakes) {
+            const stub = {
+                panel: { viewColumn: f.viewColumn } as unknown as vscode.WebviewPanel,
+            } as unknown as KnitOutputPanel;
+            KnitOutputPanel.instances.set(f.key, stub);
+        }
+    }
+
+    /** Visible only for tests. */
+    static setPreviewColumnForTesting(col: vscode.ViewColumn | undefined): void {
+        KnitOutputPanel.previewColumn = col;
+    }
+
+    /** Visible only for tests. */
+    static recomputePreviewColumnForTesting(): void {
+        KnitOutputPanel.recomputePreviewColumn();
+    }
+
+    /** Visible only for tests. */
+    getPanelForTesting(): vscode.WebviewPanel {
+        return this.panel;
+    }
+
+    /** Visible only for tests. */
+    getRootDirForTesting(): string {
+        return this.rootDir;
     }
 
     private static create(
@@ -104,6 +167,7 @@ export class KnitOutputPanel {
         rootDir: string,
         column: vscode.ViewColumn,
     ): KnitOutputPanel {
+        const key = args.sourceUri.fsPath;
         const panel = vscode.window.createWebviewPanel(
             'raven.knitOutput',
             'Knit Output',
@@ -116,9 +180,60 @@ export class KnitOutputPanel {
             },
         );
         const instance = new KnitOutputPanel(context, panel, rootDir, args);
-        KnitOutputPanel.instance = instance;
+        KnitOutputPanel.instances.set(key, instance);
+
+        // Anchor the preview column on the first panel that has a
+        // resolved column. Subsequent new panels open in this column
+        // so they stack as tabs rather than scattering to Beside.
+        const resolved = panel.viewColumn;
+        if (resolved !== undefined && KnitOutputPanel.previewColumn === undefined) {
+            KnitOutputPanel.previewColumn = resolved;
+        }
+
+        panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
+        panel.onDidDispose(() => {
+            // Guard against a stale dispose listener for an instance
+            // that has since been replaced under the same key (the
+            // rootDir-mismatch branch disposes the old panel and
+            // inserts a new one). VS Code's dispose() is synchronous
+            // today, but the guard makes the invariant explicit and
+            // survives any future async change.
+            if (KnitOutputPanel.instances.get(key) === instance) {
+                KnitOutputPanel.instances.delete(key);
+            }
+            KnitOutputPanel.recomputePreviewColumn();
+        });
+
         instance.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
         return instance;
+    }
+
+    /**
+     * Three-step preview-column recompute:
+     *  - empty registry  → previewColumn = undefined
+     *  - previewColumn still occupied by some panel → stays put
+     *  - otherwise → adopts any surviving panel's column (so a
+     *    dragged-away lone panel keeps siblings clustered with it)
+     */
+    private static recomputePreviewColumn(): void {
+        if (KnitOutputPanel.instances.size === 0) {
+            KnitOutputPanel.previewColumn = undefined;
+            return;
+        }
+        const target = KnitOutputPanel.previewColumn;
+        if (target !== undefined) {
+            for (const inst of KnitOutputPanel.instances.values()) {
+                if (inst.panel.viewColumn === target) return;
+            }
+        }
+        for (const inst of KnitOutputPanel.instances.values()) {
+            const col = inst.panel.viewColumn;
+            if (col !== undefined) {
+                KnitOutputPanel.previewColumn = col;
+                return;
+            }
+        }
+        KnitOutputPanel.previewColumn = undefined;
     }
 
     private readonly context: vscode.ExtensionContext;
@@ -141,11 +256,6 @@ export class KnitOutputPanel {
         this.output = args.output;
 
         this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg));
-        this.panel.onDidDispose(() => {
-            if (KnitOutputPanel.instance === this) {
-                KnitOutputPanel.instance = undefined;
-            }
-        });
     }
 
     private updateContent(args: { sourceUri: vscode.Uri; outputPath: string }): void {

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -6,8 +6,8 @@ import { buildShellHtml, isKnitOutputMessage } from './knit-output';
 
 /**
  * Singleton webview panel that renders the most recent HTML knit output
- * inside an `<iframe sandbox="">` with Refresh and Open-in-Browser
- * toolbar buttons.
+ * inside an `<iframe sandbox="allow-same-origin">` with Refresh and
+ * Open-in-Browser toolbar buttons.
  *
  * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`.
  *
@@ -15,8 +15,14 @@ import { buildShellHtml, isKnitOutputMessage } from './knit-output';
  *  - Outer Raven-controlled shell document owns the CSP (in `<head>`),
  *    the toolbar, and a nonce'd `<script>` that posts messages.
  *  - Inner `<iframe>` loads the rendered HTML via
- *    `webview.asWebviewUri(outputPath)`. `sandbox=""` (empty, most
- *    restrictive) blocks scripts, forms, popups, and top-navigation.
+ *    `webview.asWebviewUri(outputPath)`. The sandbox blocks scripts,
+ *    forms, popups, and top-navigation. `allow-same-origin` is
+ *    required: VS Code serves `vscode-cdn.net` webview resources via
+ *    a service worker scoped to that origin, and a sandboxed iframe
+ *    with a unique opaque origin bypasses the service worker (Electron
+ *    falls back to DNS resolution, which fails with
+ *    `ERR_NAME_NOT_RESOLVED`). `allow-same-origin` re-enters the SW
+ *    scope without enabling scripts/forms.
  *    `frame-src ${cspSource}` on the outer CSP prevents iframe
  *    navigation to external hosts.
  *  - `localResourceRoots` is confined to `path.dirname(outputPath)`,
@@ -115,8 +121,10 @@ export class KnitOutputPanel {
         return instance;
     }
 
+    private readonly context: vscode.ExtensionContext;
+
     private constructor(
-        _context: vscode.ExtensionContext,
+        context: vscode.ExtensionContext,
         panel: vscode.WebviewPanel,
         rootDir: string,
         args: {
@@ -125,6 +133,7 @@ export class KnitOutputPanel {
             output: vscode.OutputChannel;
         },
     ) {
+        this.context = context;
         this.panel = panel;
         this.rootDir = rootDir;
         this.sourceUri = args.sourceUri;
@@ -143,16 +152,56 @@ export class KnitOutputPanel {
         this.sourceUri = args.sourceUri;
         this.outputPath = args.outputPath;
         const nonce = crypto.randomBytes(16).toString('base64');
-        const iframeSrc = this.panel.webview
-            .asWebviewUri(vscode.Uri.file(args.outputPath))
+        // Read the rendered HTML from disk; inlining via `srcdoc`
+        // bypasses the nested-iframe navigation issue (see
+        // buildShellHtml's doc comment).
+        let htmlContent: string;
+        try {
+            htmlContent = fs.readFileSync(args.outputPath, 'utf-8');
+        } catch (err) {
+            this.output.appendLine(
+                `[panel] read failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            htmlContent = '<!doctype html><html><body><p>Raven: Knit — '
+                + 'could not read the rendered output. Use Open in Browser instead.'
+                + '</p></body></html>';
+        }
+        // Subresources in the rendered HTML (CSS, images, fonts)
+        // resolve relative to the document's directory. Setting the
+        // base href to the webview URI for that directory makes those
+        // requests go through the outer webview's resource handler.
+        // The trailing slash is required so relative paths like
+        // `img.png` resolve to `${dir}/img.png` rather than replacing
+        // the last URL segment.
+        const baseHref = this.panel.webview
+            .asWebviewUri(vscode.Uri.file(path.dirname(args.outputPath) + path.sep))
             .toString();
         this.panel.webview.html = buildShellHtml({
-            iframeSrc,
+            htmlContent,
+            baseHref,
             cspSource: this.panel.webview.cspSource,
             outputPath: args.outputPath,
             nonce,
+            initialThemeApplied: KnitOutputPanel.readThemePreference(this.context),
         });
         this.panel.title = `Knit Output: ${path.basename(args.outputPath)}`;
+    }
+
+    /**
+     * Storage key for the "Apply VS Code theme" toggle. Lives in
+     * `globalState` so the choice persists across panel disposal /
+     * recreation, across knits, and across VS Code restarts.
+     */
+    private static readonly THEME_PREFERENCE_KEY = 'raven.knit.applyVSCodeTheme';
+
+    private static readThemePreference(context: vscode.ExtensionContext): boolean {
+        // `globalState` is undefined in some test paths that stub
+        // ExtensionContext with `{}`; treat that the same as
+        // "preference not yet stored" rather than crashing.
+        const gs = context.globalState as vscode.Memento | undefined;
+        if (!gs || typeof gs.get !== 'function') return false;
+        const v = gs.get<unknown>(KnitOutputPanel.THEME_PREFERENCE_KEY);
+        return typeof v === 'boolean' ? v : false;
     }
 
     private handleMessage(msg: unknown): void {
@@ -163,6 +212,13 @@ export class KnitOutputPanel {
         }
         if (msg.type === 'openInBrowser') {
             void openInBrowser(this.outputPath, this.output);
+            return;
+        }
+        if (msg.type === 'themeChanged') {
+            void this.context.globalState.update(
+                KnitOutputPanel.THEME_PREFERENCE_KEY,
+                msg.applied,
+            );
         }
     }
 }

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -46,6 +46,17 @@ export class KnitOutputPanel {
     private sourceUri: vscode.Uri;
     private outputPath: string;
     private readonly output: vscode.OutputChannel;
+    /**
+     * The most recent concrete `ViewColumn` this panel was observed in.
+     * `panel.viewColumn` is documented as "only set if the webview is
+     * in one of the editor view columns" — it can transiently be
+     * `undefined` (newly created panel, mid-drag) even when the panel
+     * is in a real column. We snapshot the column whenever VS Code
+     * reports a defined value, so reuse / reveal logic and the
+     * preview-column recompute can fall back to "where the panel
+     * last was" instead of `ViewColumn.Beside`.
+     */
+    private lastKnownColumn: vscode.ViewColumn | undefined;
 
     /**
      * Open or update the panel for `args.sourceUri`. Returns
@@ -73,23 +84,53 @@ export class KnitOutputPanel {
 
         if (existing && existing.rootDir === rootDir) {
             existing.updateContent({ sourceUri: args.sourceUri, outputPath: args.outputPath });
-            existing.panel.reveal(existing.panel.viewColumn ?? vscode.ViewColumn.Beside, true);
+            // Prefer the panel's *current* column; fall back to the
+            // last-known column so re-knitting a hidden panel does
+            // not relocate it to `Beside` (which moves the panel
+            // away from its prior tab group).
+            const revealCol =
+                existing.panel.viewColumn
+                ?? existing.lastKnownColumn
+                ?? vscode.ViewColumn.Beside;
+            existing.panel.reveal(revealCol, true);
             return { ok: true };
         }
 
         if (existing) {
             // localResourceRoots is immutable post-creation — dispose
             // and recreate in the same column. Scoped to this source;
-            // other panels untouched.
-            const column = existing.panel.viewColumn ?? vscode.ViewColumn.Beside;
+            // other panels untouched. Same column fallback chain as
+            // the reuse branch above.
+            const column =
+                existing.panel.viewColumn
+                ?? existing.lastKnownColumn
+                ?? vscode.ViewColumn.Beside;
             existing.panel.dispose();
             KnitOutputPanel.create(context, args, rootDir, column);
             return { ok: true };
         }
 
-        const column = KnitOutputPanel.previewColumn ?? vscode.ViewColumn.Beside;
+        // Anchor priority for a brand-new panel:
+        //  1. recorded `previewColumn` (already resolved by at least
+        //     one prior knit's `onDidChangeViewState`)
+        //  2. any surviving instance's panel.viewColumn or
+        //     lastKnownColumn (handles back-to-back knits before the
+        //     first panel's column has resolved yet)
+        //  3. `ViewColumn.Beside`
+        const column =
+            KnitOutputPanel.previewColumn
+            ?? KnitOutputPanel.findExistingColumn()
+            ?? vscode.ViewColumn.Beside;
         KnitOutputPanel.create(context, args, rootDir, column);
         return { ok: true };
+    }
+
+    private static findExistingColumn(): vscode.ViewColumn | undefined {
+        for (const inst of KnitOutputPanel.instances.values()) {
+            const col = inst.panel.viewColumn ?? inst.lastKnownColumn;
+            if (col !== undefined) return col;
+        }
+        return undefined;
     }
 
     /** Visible only for tests. */
@@ -186,11 +227,18 @@ export class KnitOutputPanel {
         // resolved column. Subsequent new panels open in this column
         // so they stack as tabs rather than scattering to Beside.
         const resolved = panel.viewColumn;
-        if (resolved !== undefined && KnitOutputPanel.previewColumn === undefined) {
-            KnitOutputPanel.previewColumn = resolved;
+        if (resolved !== undefined) {
+            instance.lastKnownColumn = resolved;
+            if (KnitOutputPanel.previewColumn === undefined) {
+                KnitOutputPanel.previewColumn = resolved;
+            }
         }
 
-        panel.onDidChangeViewState(() => KnitOutputPanel.recomputePreviewColumn());
+        panel.onDidChangeViewState(() => {
+            const col = panel.viewColumn;
+            if (col !== undefined) instance.lastKnownColumn = col;
+            KnitOutputPanel.recomputePreviewColumn();
+        });
         panel.onDidDispose(() => {
             // Guard against a stale dispose listener for an instance
             // that has since been replaced under the same key (the
@@ -209,7 +257,12 @@ export class KnitOutputPanel {
     }
 
     /**
-     * Three-step preview-column recompute:
+     * Three-step preview-column recompute. Uses
+     * `panel.viewColumn ?? lastKnownColumn` so a panel that is hidden
+     * behind another tab (and therefore has `viewColumn === undefined`
+     * per the VS Code API contract) still counts as occupying its
+     * column.
+     *
      *  - empty registry  → previewColumn = undefined
      *  - previewColumn still occupied by some panel → stays put
      *  - otherwise → adopts any surviving panel's column (so a
@@ -223,11 +276,12 @@ export class KnitOutputPanel {
         const target = KnitOutputPanel.previewColumn;
         if (target !== undefined) {
             for (const inst of KnitOutputPanel.instances.values()) {
-                if (inst.panel.viewColumn === target) return;
+                const col = inst.panel.viewColumn ?? inst.lastKnownColumn;
+                if (col === target) return;
             }
         }
         for (const inst of KnitOutputPanel.instances.values()) {
-            const col = inst.panel.viewColumn;
+            const col = inst.panel.viewColumn ?? inst.lastKnownColumn;
             if (col !== undefined) {
                 KnitOutputPanel.previewColumn = col;
                 return;

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -184,22 +184,54 @@ export function buildShellHtml(args: {
                                border: 1px solid var(--vscode-button-border, transparent);
                                cursor: pointer; }
   #raven-knit-toolbar button:hover { background: var(--vscode-button-hoverBackground); }
-  /* Toggle styling: when the theme button is "off" (aria-pressed=false)
-     we render it as a quieter secondary button. When "on" it gets the
-     normal primary button colors. Rmd output has no document theme to
-     "switch back to" -- the toggle simply represents whether VS Code
-     theming is active. */
-  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="false"] {
-    background: var(--vscode-button-secondaryBackground,
-                    var(--vscode-editorWidget-background));
-    color: var(--vscode-button-secondaryForeground,
-                var(--vscode-foreground));
+  /*
+   * Theme toggle: visually distinct from action buttons.
+   * Uses the VS Code "inputOption" CSS variables -- the same vars
+   * the Find widget toggles (case-sensitive, whole-word, regex)
+   * use. The active state gets a bordered, accent-tinted look
+   * that does not collide with the primary action buttons.
+   */
+  #raven-knit-toolbar button#raven-knit-theme {
+    background: transparent;
+    color: var(--vscode-foreground);
+    border: 1px solid transparent;
+    /* Push the toggle to the right edge of the toolbar so it sits
+       away from the action buttons -- "Apply theme" is a viewing
+       preference, not an action. */
+    margin-left: auto;
   }
-  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="false"]:hover {
-    background: var(--vscode-button-secondaryHoverBackground,
-                    var(--vscode-button-hoverBackground));
+  #raven-knit-toolbar button#raven-knit-theme:hover {
+    background: var(--vscode-inputOption-hoverBackground,
+                    var(--vscode-toolbar-hoverBackground,
+                        var(--vscode-list-hoverBackground)));
   }
-  #raven-knit-filename { margin-left: 0.5rem; opacity: 0.8; font-size: 0.9em; }
+  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="true"] {
+    background: var(--vscode-inputOption-activeBackground,
+                    var(--vscode-button-background));
+    color: var(--vscode-inputOption-activeForeground,
+                var(--vscode-button-foreground));
+    border: 1px solid var(--vscode-inputOption-activeBorder,
+                          var(--vscode-focusBorder));
+  }
+  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="true"]:hover {
+    background: var(--vscode-inputOption-activeBackground,
+                    var(--vscode-button-background));
+  }
+  /*
+   * The ::before pseudo-element holds the checkmark prefix and an
+   * empty placeholder when the toggle is off. Pre-allocating the
+   * width with "visibility: hidden" for the inactive state keeps
+   * the button's pixel width stable across toggles so the toolbar
+   * does not reflow on every click.
+   */
+  #raven-knit-toolbar button#raven-knit-theme::before {
+    content: "✓";
+    margin-right: 0.35em;
+    visibility: hidden;
+  }
+  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="true"]::before {
+    visibility: visible;
+  }
   #raven-knit-frame { flex: 1 1 auto; width: 100%; border: 0; background: white; }
   #raven-knit-context-menu {
     position: fixed; min-width: 160px; z-index: 9999;
@@ -246,7 +278,6 @@ export function buildShellHtml(args: {
     <button id="raven-knit-theme" type="button"
             aria-pressed="${initialThemeApplied ? 'true' : 'false'}"
             title="Toggle VS Code editor colors on the rendered output">Apply VS Code theme</button>
-    <span id="raven-knit-filename" aria-live="polite">${safeName}</span>
   </div>
   <iframe id="raven-knit-frame"
           srcdoc="${escapeHtml(srcdocHtml)}"

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -285,6 +285,7 @@ export function buildShellHtml(args: {
           title="Rendered output: ${safeName}"></iframe>
   <div id="raven-knit-context-menu" role="menu" hidden>
     <button type="button" role="menuitem" data-action="copy">Copy</button>
+    <button type="button" role="menuitem" data-action="copy-image">Copy image</button>
     <button type="button" role="menuitem" data-action="select-all">Select All</button>
     <button type="button" role="menuitem" data-action="open-in-browser">Open in Browser</button>
   </div>
@@ -401,6 +402,11 @@ export function buildShellHtml(args: {
       // the selection.
       const ctxMenu = document.getElementById('raven-knit-context-menu');
       const ctxCopyBtn = ctxMenu.querySelector('[data-action="copy"]');
+      const ctxCopyImageBtn = ctxMenu.querySelector('[data-action="copy-image"]');
+      // Source URL of the <img> the user right-clicked, captured at
+      // contextmenu time. Cleared when the menu hides so a stale src
+      // can't leak into a follow-up Copy from a text selection.
+      let pendingImageSrc = null;
 
       function copyIframeSelection() {
         const win = iframe.contentWindow;
@@ -443,15 +449,50 @@ export function buildShellHtml(args: {
         }
       }
 
-      function hideContextMenu() {
-        ctxMenu.hidden = true;
+      // Copy the image at pendingImageSrc onto the system clipboard.
+      // Uses the async Clipboard API's ClipboardItem flavor so that
+      // the OS clipboard receives a real image bitmap (paste into
+      // Slack / Preview / Photoshop yields the image, not the URL).
+      // We fetch the URL — it resolves through the webview's
+      // localResourceRoots since rendered figures live in the
+      // panel's rootDir.
+      function copyImageFromIframe() {
+        const src = pendingImageSrc;
+        if (!src) return;
+        // navigator.clipboard.write is gated behind a user gesture;
+        // the contextmenu click satisfies that. ClipboardItem itself
+        // is widely supported in Electron-based webviews.
+        const w = window;
+        if (!w.ClipboardItem || !navigator.clipboard || !navigator.clipboard.write) {
+          return;
+        }
+        fetch(src)
+          .then(function (r) { return r.blob(); })
+          .then(function (blob) {
+            const type = blob.type || 'image/png';
+            const item = new w.ClipboardItem({ [type]: blob });
+            return navigator.clipboard.write([item]);
+          })
+          .catch(function () { /* swallow — best-effort */ });
       }
 
-      function showContextMenu(clientX, clientY, hasSelection) {
+      function hideContextMenu() {
+        ctxMenu.hidden = true;
+        pendingImageSrc = null;
+      }
+
+      function showContextMenu(clientX, clientY, hasSelection, imageSrc) {
         if (hasSelection) {
           ctxCopyBtn.removeAttribute('disabled');
         } else {
           ctxCopyBtn.setAttribute('disabled', 'true');
+        }
+        if (imageSrc) {
+          ctxCopyImageBtn.removeAttribute('disabled');
+          pendingImageSrc = imageSrc;
+        } else {
+          ctxCopyImageBtn.setAttribute('disabled', 'true');
+          pendingImageSrc = null;
         }
         // Render off-screen first to measure, then clamp into the
         // viewport so the menu never spills past the right/bottom
@@ -476,6 +517,7 @@ export function buildShellHtml(args: {
         if (!btn || btn.hasAttribute('disabled')) return;
         const action = btn.getAttribute('data-action');
         if (action === 'copy') copyIframeSelection();
+        else if (action === 'copy-image') copyImageFromIframe();
         else if (action === 'select-all') selectAllInIframe();
         else if (action === 'open-in-browser') vscode.postMessage({ type: 'openInBrowser' });
         hideContextMenu();
@@ -496,18 +538,47 @@ export function buildShellHtml(args: {
         const doc = iframe.contentDocument;
         if (!win || !doc) return;
         // Cmd/Ctrl-C and Cmd/Ctrl-A while the iframe has focus.
+        // For every other shortcut we synthesize the keydown event
+        // on the outer shell document so VS Code's keybinding
+        // handler sees it. The iframe is sandboxed and keystrokes
+        // that fire inside it don't reach VS Code's chrome
+        // otherwise; the same-origin sandbox lets us reach across
+        // the document boundary to re-dispatch.
         win.addEventListener('keydown', function (e) {
           const mod = e.metaKey || e.ctrlKey;
-          if (!mod) return;
           const k = (e.key || '').toLowerCase();
-          if (k === 'c') {
+          if (mod && k === 'c') {
             if (copyIframeSelection()) e.preventDefault();
             return;
           }
-          if (k === 'a') {
+          if (mod && k === 'a') {
             selectAllInIframe();
             e.preventDefault();
+            return;
           }
+          // Re-dispatch on the outer shell document. We clone the
+          // relevant fields so VS Code's keybinding matcher receives
+          // an equivalent event. The synthetic event has
+          // isTrusted=false, but VS Code's webview keybinding
+          // handler matches on key fields rather than the trust
+          // flag, so this is enough to make Cmd+J / Cmd+= / Cmd+- /
+          // Cmd+B / Cmd+P / Cmd+S / etc. behave the same way as
+          // when the focus is in a regular editor.
+          const cloned = new KeyboardEvent('keydown', {
+            key: e.key,
+            code: e.code,
+            keyCode: e.keyCode,
+            which: e.which,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+            shiftKey: e.shiftKey,
+            altKey: e.altKey,
+            repeat: e.repeat,
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+          });
+          document.dispatchEvent(cloned);
         });
         // Right-click → custom menu in the outer shell. Use mousedown
         // for the dismiss handler ordering; contextmenu still fires
@@ -519,7 +590,12 @@ export function buildShellHtml(args: {
           const y = e.clientY + rect.top;
           const sel = win.getSelection();
           const hasSel = !!(sel && sel.toString().length > 0);
-          showContextMenu(x, y, hasSel);
+          // If the user right-clicked on an <img>, capture its src
+          // so the Copy image action knows what to fetch.
+          let imageSrc = null;
+          const tgt = e.target;
+          if (tgt && tgt.tagName === 'IMG' && tgt.src) imageSrc = tgt.src;
+          showContextMenu(x, y, hasSel, imageSrc);
         });
         // A new click inside the iframe should dismiss the menu so
         // it does not linger after the user moves on.

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -469,27 +469,37 @@ export function buildShellHtml(args: {
         const img = pendingImage;
         if (!img) return;
         const w = window;
-        if (!w.ClipboardItem || !navigator.clipboard || !navigator.clipboard.write) {
-          return;
+        const hasClipboardImage = !!(w.ClipboardItem
+          && navigator.clipboard && navigator.clipboard.write);
+        // Fall back to copying the URL when ClipboardItem is
+        // unavailable or when the image is cross-origin (canvas
+        // would taint and toBlob would throw). The user can still
+        // paste the URL into another tool to pick the image up.
+        function copyUrlFallback() {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(img.src).catch(function () { /* swallow */ });
+          }
         }
+        if (!hasClipboardImage) { copyUrlFallback(); return; }
         try {
           const canvas = document.createElement('canvas');
           canvas.width = img.naturalWidth || img.width;
           canvas.height = img.naturalHeight || img.height;
-          if (canvas.width === 0 || canvas.height === 0) return;
+          if (canvas.width === 0 || canvas.height === 0) { copyUrlFallback(); return; }
           const ctx = canvas.getContext('2d');
-          if (!ctx) return;
+          if (!ctx) { copyUrlFallback(); return; }
           ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          // canvas.toBlob throws SecurityError (or yields null
+          // depending on platform) when the canvas is tainted by a
+          // cross-origin image without CORS headers.
           canvas.toBlob(function (blob) {
-            if (!blob) return;
+            if (!blob) { copyUrlFallback(); return; }
             try {
               const item = new w.ClipboardItem({ 'image/png': blob });
-              navigator.clipboard.write([item]).catch(function () {
-                /* swallow — best-effort */
-              });
-            } catch (e) { /* swallow */ }
+              navigator.clipboard.write([item]).catch(copyUrlFallback);
+            } catch (e) { copyUrlFallback(); }
           }, 'image/png');
-        } catch (e) { /* swallow */ }
+        } catch (e) { copyUrlFallback(); }
       }
 
       function hideContextMenu() {
@@ -566,15 +576,19 @@ export function buildShellHtml(args: {
         // and silently trigger a single-key keybinding the user
         // may have configured in VS Code.
         win.addEventListener('keydown', function (e) {
-          const mod = e.metaKey || e.ctrlKey || e.altKey;
+          const mod = e.metaKey || e.ctrlKey;
           if (!mod) return;
+          // AltGr on Windows / many Linux layouts fires as Ctrl+Alt
+          // for typing characters like @, €, or accented letters.
+          // The platform reports the AltGraph modifier state on
+          // those keypresses; skip them so the user can type.
+          if (e.getModifierState && e.getModifierState('AltGraph')) return;
           const k = (e.key || '').toLowerCase();
-          const primary = e.metaKey || e.ctrlKey;
-          if (primary && k === 'c') {
+          if (k === 'c') {
             if (copyIframeSelection()) e.preventDefault();
             return;
           }
-          if (primary && k === 'a') {
+          if (k === 'a') {
             selectAllInIframe();
             e.preventDefault();
             return;

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -403,10 +403,15 @@ export function buildShellHtml(args: {
       const ctxMenu = document.getElementById('raven-knit-context-menu');
       const ctxCopyBtn = ctxMenu.querySelector('[data-action="copy"]');
       const ctxCopyImageBtn = ctxMenu.querySelector('[data-action="copy-image"]');
-      // Source URL of the <img> the user right-clicked, captured at
-      // contextmenu time. Cleared when the menu hides so a stale src
+      // The <img> the user right-clicked, captured at contextmenu
+      // time. Cleared when the menu hides so a stale reference
       // can't leak into a follow-up Copy from a text selection.
-      let pendingImageSrc = null;
+      // We capture the element (not just its src) because the
+      // canvas-based copy below reads pixels from the already-
+      // loaded image — fetch() is blocked by the outer-shell CSP's
+      // connect-src 'none', so going back to the network would
+      // fail for every supported source kind.
+      let pendingImage = null;
 
       function copyIframeSelection() {
         const win = iframe.contentWindow;
@@ -449,50 +454,61 @@ export function buildShellHtml(args: {
         }
       }
 
-      // Copy the image at pendingImageSrc onto the system clipboard.
-      // Uses the async Clipboard API's ClipboardItem flavor so that
-      // the OS clipboard receives a real image bitmap (paste into
-      // Slack / Preview / Photoshop yields the image, not the URL).
-      // We fetch the URL — it resolves through the webview's
-      // localResourceRoots since rendered figures live in the
-      // panel's rootDir.
+      // Copy the right-clicked image onto the system clipboard.
+      // Draws the already-loaded image onto an offscreen canvas
+      // and writes the canvas as a PNG blob via the async
+      // Clipboard API. We use canvas rather than fetch because the
+      // outer-shell CSP sets connect-src 'none', which blocks any
+      // JS-initiated request (including same-origin local-resource
+      // URLs). The image element has already loaded its pixels by
+      // the time the user right-clicks, so the canvas approach
+      // needs no further network access. Output is always PNG so
+      // the clipboard MIME type is deterministic and supported on
+      // every platform.
       function copyImageFromIframe() {
-        const src = pendingImageSrc;
-        if (!src) return;
-        // navigator.clipboard.write is gated behind a user gesture;
-        // the contextmenu click satisfies that. ClipboardItem itself
-        // is widely supported in Electron-based webviews.
+        const img = pendingImage;
+        if (!img) return;
         const w = window;
         if (!w.ClipboardItem || !navigator.clipboard || !navigator.clipboard.write) {
           return;
         }
-        fetch(src)
-          .then(function (r) { return r.blob(); })
-          .then(function (blob) {
-            const type = blob.type || 'image/png';
-            const item = new w.ClipboardItem({ [type]: blob });
-            return navigator.clipboard.write([item]);
-          })
-          .catch(function () { /* swallow — best-effort */ });
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = img.naturalWidth || img.width;
+          canvas.height = img.naturalHeight || img.height;
+          if (canvas.width === 0 || canvas.height === 0) return;
+          const ctx = canvas.getContext('2d');
+          if (!ctx) return;
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          canvas.toBlob(function (blob) {
+            if (!blob) return;
+            try {
+              const item = new w.ClipboardItem({ 'image/png': blob });
+              navigator.clipboard.write([item]).catch(function () {
+                /* swallow — best-effort */
+              });
+            } catch (e) { /* swallow */ }
+          }, 'image/png');
+        } catch (e) { /* swallow */ }
       }
 
       function hideContextMenu() {
         ctxMenu.hidden = true;
-        pendingImageSrc = null;
+        pendingImage = null;
       }
 
-      function showContextMenu(clientX, clientY, hasSelection, imageSrc) {
+      function showContextMenu(clientX, clientY, hasSelection, image) {
         if (hasSelection) {
           ctxCopyBtn.removeAttribute('disabled');
         } else {
           ctxCopyBtn.setAttribute('disabled', 'true');
         }
-        if (imageSrc) {
+        if (image) {
           ctxCopyImageBtn.removeAttribute('disabled');
-          pendingImageSrc = imageSrc;
+          pendingImage = image;
         } else {
           ctxCopyImageBtn.setAttribute('disabled', 'true');
-          pendingImageSrc = null;
+          pendingImage = null;
         }
         // Render off-screen first to measure, then clamp into the
         // viewport so the menu never spills past the right/bottom
@@ -538,20 +554,27 @@ export function buildShellHtml(args: {
         const doc = iframe.contentDocument;
         if (!win || !doc) return;
         // Cmd/Ctrl-C and Cmd/Ctrl-A while the iframe has focus.
-        // For every other shortcut we synthesize the keydown event
-        // on the outer shell document so VS Code's keybinding
-        // handler sees it. The iframe is sandboxed and keystrokes
-        // that fire inside it don't reach VS Code's chrome
-        // otherwise; the same-origin sandbox lets us reach across
-        // the document boundary to re-dispatch.
+        // For every other *modifier* shortcut we synthesize the
+        // keydown event on the outer shell document so VS Code's
+        // keybinding handler sees it. The iframe is sandboxed and
+        // keystrokes that fire inside it don't reach VS Code's
+        // chrome otherwise; the same-origin sandbox lets us reach
+        // across the document boundary to re-dispatch.
+        //
+        // We gate on the modifier so plain typing inside any
+        // input/widget rendered in the report does NOT bubble out
+        // and silently trigger a single-key keybinding the user
+        // may have configured in VS Code.
         win.addEventListener('keydown', function (e) {
-          const mod = e.metaKey || e.ctrlKey;
+          const mod = e.metaKey || e.ctrlKey || e.altKey;
+          if (!mod) return;
           const k = (e.key || '').toLowerCase();
-          if (mod && k === 'c') {
+          const primary = e.metaKey || e.ctrlKey;
+          if (primary && k === 'c') {
             if (copyIframeSelection()) e.preventDefault();
             return;
           }
-          if (mod && k === 'a') {
+          if (primary && k === 'a') {
             selectAllInIframe();
             e.preventDefault();
             return;
@@ -590,12 +613,15 @@ export function buildShellHtml(args: {
           const y = e.clientY + rect.top;
           const sel = win.getSelection();
           const hasSel = !!(sel && sel.toString().length > 0);
-          // If the user right-clicked on an <img>, capture its src
-          // so the Copy image action knows what to fetch.
-          let imageSrc = null;
+          // If the user right-clicked on an <img>, capture the
+          // element itself so the Copy image action can draw it
+          // onto a canvas (fetch() is blocked by the outer-shell
+          // CSP's connect-src 'none', so we read pixels from the
+          // already-loaded image rather than re-requesting).
+          let image = null;
           const tgt = e.target;
-          if (tgt && tgt.tagName === 'IMG' && tgt.src) imageSrc = tgt.src;
-          showContextMenu(x, y, hasSel, imageSrc);
+          if (tgt && tgt.tagName === 'IMG') image = tgt;
+          showContextMenu(x, y, hasSel, image);
         });
         // A new click inside the iframe should dismiss the menu so
         // it does not linger after the user moves on.

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -3,7 +3,8 @@ import { parseRenderedOutputPath } from './output-path';
 
 export type KnitOutputMessage =
     | { type: 'refresh' }
-    | { type: 'openInBrowser' };
+    | { type: 'openInBrowser' }
+    | { type: 'themeChanged'; applied: boolean };
 
 /**
  * Strict type-narrowing for messages posted from the Knit Output webview.
@@ -13,8 +14,10 @@ export type KnitOutputMessage =
  */
 export function isKnitOutputMessage(msg: unknown): msg is KnitOutputMessage {
     if (msg === null || typeof msg !== 'object') return false;
-    const t = (msg as { type?: unknown }).type;
-    return t === 'refresh' || t === 'openInBrowser';
+    const m = msg as { type?: unknown; applied?: unknown };
+    if (m.type === 'refresh' || m.type === 'openInBrowser') return true;
+    if (m.type === 'themeChanged' && typeof m.applied === 'boolean') return true;
+    return false;
 }
 
 /**
@@ -79,31 +82,59 @@ function escapeHtml(s: string): string {
  * Build the outer-shell HTML for the Knit Output webview.
  *
  * The shell is Raven-controlled and owns the CSP in `<head>`; the
- * rendered HTML loads inside `<iframe sandbox="">`. Three independent
- * containment layers (sandbox attribute, outer-shell CSP,
- * `localResourceRoots`) make the security model robust to either layer
- * failing.
+ * rendered HTML loads inside `<iframe srcdoc="..." sandbox="allow-
+ * same-origin">`. Three independent containment layers (sandbox
+ * attribute, outer-shell CSP, `localResourceRoots`) make the security
+ * model robust to either layer failing.
+ *
+ * Why `srcdoc` rather than `src`: a nested `<iframe>` inside a VS Code
+ * webview cannot navigate to a `webview.asWebviewUri(...)` URL —
+ * Electron's resource handler does not intercept the nested-frame
+ * navigation, so the network stack tries DNS resolution on
+ * `file+.vscode-resource.vscode-cdn.net` and fails with
+ * `ERR_NAME_NOT_RESOLVED`. Inlining the HTML via `srcdoc` avoids the
+ * URL navigation entirely; relative subresource URLs in the rendered
+ * HTML resolve via the injected `<base href="...">` (which IS a
+ * subresource request, and those go through the SW happily).
+ *
+ * `sandbox="allow-same-origin"` is required (rather than `sandbox=""`)
+ * so the srcdoc document inherits the parent webview origin instead of
+ * a unique opaque origin. Scripts, forms, popups, and top-navigation
+ * remain blocked.
  *
  * Pure helper — no dependency on the vscode module. The caller
- * (`KnitOutputPanel`) is responsible for converting the output path via
- * `webview.asWebviewUri(vscode.Uri.file(...))` and passing the result
- * here as `iframeSrc`, and for forwarding `webview.cspSource`.
+ * (`KnitOutputPanel`) reads the rendered HTML from disk and converts
+ * the output's parent directory via `webview.asWebviewUri(...)`,
+ * passing the results as `htmlContent` and `baseHref`.
  *
  * See `docs/superpowers/specs/2026-05-17-knit-output-webview-design.md`
  * for the threat model.
  */
 export function buildShellHtml(args: {
-    iframeSrc: string;
+    htmlContent: string;
+    baseHref: string;
     cspSource: string;
     outputPath: string;
     nonce: string;
+    /**
+     * Persisted theme-toggle state. Caller reads it from
+     * `context.globalState` so the choice survives panel disposal /
+     * recreation between knits.
+     */
+    initialThemeApplied: boolean;
 }): string {
-    const { iframeSrc, cspSource, outputPath, nonce } = args;
+    const { htmlContent, baseHref, cspSource, outputPath, nonce, initialThemeApplied } = args;
     // path.basename handles both POSIX and Windows separators.
     const lastSep = Math.max(outputPath.lastIndexOf('/'), outputPath.lastIndexOf('\\'));
     const basename = lastSep >= 0 ? outputPath.slice(lastSep + 1) : outputPath;
     const safeName = escapeHtml(basename);
 
+    // about:srcdoc bypasses `frame-src` per CSP3, but VS Code's webview
+    // can occasionally route the inline document through a real URL
+    // (e.g. when the iframe resolves a base-relative resource), so we
+    // keep `frame-src ${cspSource}` to whitelist subresource frames as
+    // well. `img-src`/`style-src`/`font-src` already permit
+    // `${cspSource}` for the rendered HTML's assets.
     const csp = [
         `default-src 'none'`,
         `frame-src ${cspSource}`,
@@ -113,6 +144,25 @@ export function buildShellHtml(args: {
         `script-src 'nonce-${nonce}'`,
         `connect-src 'none'`,
     ].join('; ');
+
+    // Inject the base href so relative URLs in the rendered HTML
+    // resolve through `webview.asWebviewUri(...)`, picking up the
+    // outer webview's resource handler. Browsers honour a `<base>` tag
+    // that appears anywhere in the head; HTML5 parsing creates an
+    // implicit head when needed, so prepending is safe even for HTML
+    // that already starts with `<!doctype html><html>...`.
+    //
+    // A `<base href>` also changes how *fragment-only* anchors
+    // (`<a href="#section">`) are resolved: instead of resolving
+    // against the document URL (`about:srcdoc`), they resolve against
+    // the base URL, turning an in-document scroll into a full
+    // navigation that fails for nested webview iframes. To preserve
+    // intra-document anchor navigation, rewrite fragment-only hrefs
+    // to be `about:srcdoc#…` — once the resolved URL matches the
+    // document URL (sans fragment), the browser treats the click as
+    // a same-document fragment navigation again.
+    const srcdocHtml = `<base href="${escapeHtml(baseHref)}">`
+        + rewriteFragmentAnchors(htmlContent);
 
     return `<!doctype html>
 <html lang="en">
@@ -134,34 +184,406 @@ export function buildShellHtml(args: {
                                border: 1px solid var(--vscode-button-border, transparent);
                                cursor: pointer; }
   #raven-knit-toolbar button:hover { background: var(--vscode-button-hoverBackground); }
+  /* Toggle styling: when the theme button is "off" (aria-pressed=false)
+     we render it as a quieter secondary button. When "on" it gets the
+     normal primary button colors. Rmd output has no document theme to
+     "switch back to" -- the toggle simply represents whether VS Code
+     theming is active. */
+  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="false"] {
+    background: var(--vscode-button-secondaryBackground,
+                    var(--vscode-editorWidget-background));
+    color: var(--vscode-button-secondaryForeground,
+                var(--vscode-foreground));
+  }
+  #raven-knit-toolbar button#raven-knit-theme[aria-pressed="false"]:hover {
+    background: var(--vscode-button-secondaryHoverBackground,
+                    var(--vscode-button-hoverBackground));
+  }
   #raven-knit-filename { margin-left: 0.5rem; opacity: 0.8; font-size: 0.9em; }
   #raven-knit-frame { flex: 1 1 auto; width: 100%; border: 0; background: white; }
+  #raven-knit-context-menu {
+    position: fixed; min-width: 160px; z-index: 9999;
+    padding: 0.25rem 0;
+    background: var(--vscode-menu-background, var(--vscode-editorWidget-background));
+    color: var(--vscode-menu-foreground, var(--vscode-foreground));
+    border: 1px solid var(--vscode-menu-border, var(--vscode-editorWidget-border));
+    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0,0,0,0.3));
+    font-family: var(--vscode-font-family); font-size: 13px;
+  }
+  #raven-knit-context-menu[hidden] { display: none; }
+  #raven-knit-context-menu button {
+    display: block; width: 100%; text-align: left;
+    padding: 0.3rem 1rem;
+    background: transparent; color: inherit; border: 0;
+    font: inherit; cursor: pointer;
+  }
+  /*
+   * :focus-visible (not plain :focus) -- when the menu opens we
+   * programmatically focus the first enabled item for accessibility,
+   * but we do NOT want to paint a "this item is hovered" highlight
+   * just because the focus moved there. :focus-visible activates
+   * only when the focus came from a keyboard interaction (Tab, arrow
+   * keys), which is the right time to show the selection ring.
+   */
+  #raven-knit-context-menu button:hover:not([disabled]),
+  #raven-knit-context-menu button:focus-visible:not([disabled]) {
+    background: var(--vscode-menu-selectionBackground,
+                    var(--vscode-list-activeSelectionBackground));
+    color: var(--vscode-menu-selectionForeground,
+                var(--vscode-list-activeSelectionForeground));
+    outline: none;
+  }
+  #raven-knit-context-menu button:focus:not(:focus-visible) {
+    outline: none;
+  }
+  #raven-knit-context-menu button[disabled] { opacity: 0.5; cursor: default; }
 </style>
 </head>
 <body>
   <div id="raven-knit-toolbar" role="toolbar" aria-label="Knit output">
-    <button id="raven-knit-refresh" type="button" title="Re-knit the source document">Refresh</button>
+    <button id="raven-knit-refresh" type="button" title="Re-knit the source document">Knit again</button>
     <button id="raven-knit-open-browser" type="button" title="Open the rendered file in your default browser">Open in Browser</button>
+    <button id="raven-knit-theme" type="button"
+            aria-pressed="${initialThemeApplied ? 'true' : 'false'}"
+            title="Toggle VS Code editor colors on the rendered output">Apply VS Code theme</button>
     <span id="raven-knit-filename" aria-live="polite">${safeName}</span>
   </div>
   <iframe id="raven-knit-frame"
-          src="${escapeHtml(iframeSrc)}"
-          sandbox=""
-          referrerpolicy="no-referrer"
+          srcdoc="${escapeHtml(srcdocHtml)}"
+          sandbox="allow-same-origin"
           title="Rendered output: ${safeName}"></iframe>
+  <div id="raven-knit-context-menu" role="menu" hidden>
+    <button type="button" role="menuitem" data-action="copy">Copy</button>
+    <button type="button" role="menuitem" data-action="select-all">Select All</button>
+    <button type="button" role="menuitem" data-action="open-in-browser">Open in Browser</button>
+  </div>
   <script nonce="${nonce}">
     (function () {
       const vscode = acquireVsCodeApi();
+      const iframe = document.getElementById('raven-knit-frame');
+      const themeBtn = document.getElementById('raven-knit-theme');
+      let loadFired = false;
+      let errorFired = false;
+      iframe.addEventListener('load', function () { loadFired = true; });
+      iframe.addEventListener('error', function () { errorFired = true; });
       document.getElementById('raven-knit-refresh').addEventListener('click', function () {
         vscode.postMessage({ type: 'refresh' });
       });
       document.getElementById('raven-knit-open-browser').addEventListener('click', function () {
         vscode.postMessage({ type: 'openInBrowser' });
       });
+
+      // --- VS Code theme overlay -------------------------------------
+      // The iframe is srcdoc + sandbox=allow-same-origin, which gives
+      // the inner document the same origin as this outer shell. That
+      // same-origin relationship is what lets the outer script inject
+      // a style tag into the iframe contentDocument when the user
+      // toggles the theme on. The injected stylesheet uses RESOLVED
+      // color values from VS Code CSS variables (those variables are
+      // defined on the outer shell html and do not propagate into the
+      // iframe document), so when VS Code's active theme changes the
+      // body class on the outer shell flips and we re-resolve + re-
+      // inject.
+      //
+      // The initial value comes from the extension (which reads it
+      // from globalState), embedded into the template literal below.
+      // A toggle posts the new state back to the extension, which
+      // persists it. We do not also call webview setState — every
+      // shell render embeds the latest persisted value, and a hide/
+      // show cycle leaves the in-memory variable intact.
+      let themeApplied = ${initialThemeApplied ? 'true' : 'false'};
+
+      function syncThemeBtn() {
+        // Rmd output has no "document theme" — the toggle just
+        // controls whether VS Code theming is overlaid. Keep the
+        // button label constant; the active state is conveyed
+        // visually via aria-pressed (which CSS styles).
+        themeBtn.setAttribute('aria-pressed', themeApplied ? 'true' : 'false');
+      }
+
+      function readThemeColors() {
+        const cs = getComputedStyle(document.documentElement);
+        function v(name, fallback) {
+          const x = cs.getPropertyValue(name).trim();
+          return x.length > 0 ? x : fallback;
+        }
+        return {
+          bg: v('--vscode-editor-background', '#1e1e1e'),
+          fg: v('--vscode-editor-foreground', '#cccccc'),
+          link: v('--vscode-textLink-foreground', '#3794ff'),
+        };
+      }
+
+      function applyTheme() {
+        const doc = iframe.contentDocument;
+        if (!doc || !doc.documentElement) return;
+        // contentDocument's head exists on parsed HTML; for srcdoc
+        // iframes we may race the parser, so fall back to <html>.
+        const host = doc.head || doc.documentElement;
+        let style = doc.getElementById('raven-vscode-theme-overrides');
+        if (!themeApplied) {
+          if (style) style.remove();
+          iframe.style.background = '';
+          syncThemeBtn();
+          return;
+        }
+        if (!style) {
+          style = doc.createElement('style');
+          style.id = 'raven-vscode-theme-overrides';
+          host.appendChild(style);
+        }
+        const c = readThemeColors();
+        style.textContent =
+          'html, body { background: ' + c.bg + ' !important; '
+          + 'color: ' + c.fg + ' !important; }'
+          + ' a { color: ' + c.link + ' !important; }';
+        // Paint the iframe element itself too so the brief flash
+        // before the inner document parses also matches the theme.
+        iframe.style.background = c.bg;
+        syncThemeBtn();
+      }
+
+      themeBtn.addEventListener('click', function () {
+        themeApplied = !themeApplied;
+        // Tell the extension so it can persist the choice in
+        // globalState; the next panel render reads the saved value
+        // back via initialThemeApplied.
+        vscode.postMessage({ type: 'themeChanged', applied: themeApplied });
+        applyTheme();
+      });
+
+      iframe.addEventListener('load', applyTheme);
+      // The srcdoc parse may have completed before our script ran;
+      // try immediately in that case.
+      if (iframe.contentDocument
+          && iframe.contentDocument.readyState !== 'loading') {
+        applyTheme();
+      }
+
+      // --- Copy / Select All / context menu ------------------------
+      // VS Code disables the browser's default context menu inside
+      // webviews and does not forward Cmd/Ctrl-C to the host clipboard
+      // command when the keyboard focus is in a nested iframe. Since
+      // the iframe is same-origin (sandbox=allow-same-origin + srcdoc
+      // gives it the parent webview's origin), the outer shell can
+      // attach handlers to iframe.contentWindow directly and reach
+      // the selection.
+      const ctxMenu = document.getElementById('raven-knit-context-menu');
+      const ctxCopyBtn = ctxMenu.querySelector('[data-action="copy"]');
+
+      function copyIframeSelection() {
+        const win = iframe.contentWindow;
+        if (!win) return false;
+        const sel = win.getSelection();
+        const text = sel ? sel.toString() : '';
+        if (!text) return false;
+        // Prefer the async Clipboard API; fall back to execCommand
+        // for older webviews. The keypress / contextmenu-click that
+        // triggers this counts as a user gesture, satisfying both
+        // browser permission models.
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text);
+            return true;
+          }
+        } catch (e) { /* fall through */ }
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        let ok = false;
+        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+        document.body.removeChild(ta);
+        return ok;
+      }
+
+      function selectAllInIframe() {
+        const doc = iframe.contentDocument;
+        const win = iframe.contentWindow;
+        if (!doc || !win || !doc.body) return;
+        const range = doc.createRange();
+        range.selectNodeContents(doc.body);
+        const sel = win.getSelection();
+        if (sel) {
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      }
+
+      function hideContextMenu() {
+        ctxMenu.hidden = true;
+      }
+
+      function showContextMenu(clientX, clientY, hasSelection) {
+        if (hasSelection) {
+          ctxCopyBtn.removeAttribute('disabled');
+        } else {
+          ctxCopyBtn.setAttribute('disabled', 'true');
+        }
+        // Render off-screen first to measure, then clamp into the
+        // viewport so the menu never spills past the right/bottom
+        // edge of the webview.
+        ctxMenu.style.left = '-9999px';
+        ctxMenu.style.top = '0';
+        ctxMenu.hidden = false;
+        const r = ctxMenu.getBoundingClientRect();
+        const vw = window.innerWidth, vh = window.innerHeight;
+        const x = Math.max(0, Math.min(clientX, vw - r.width - 2));
+        const y = Math.max(0, Math.min(clientY, vh - r.height - 2));
+        ctxMenu.style.left = x + 'px';
+        ctxMenu.style.top = y + 'px';
+        const firstEnabled = ctxMenu.querySelector('button:not([disabled])');
+        if (firstEnabled) firstEnabled.focus();
+      }
+
+      ctxMenu.addEventListener('click', function (e) {
+        const btn = e.target.closest
+          ? e.target.closest('button[data-action]')
+          : null;
+        if (!btn || btn.hasAttribute('disabled')) return;
+        const action = btn.getAttribute('data-action');
+        if (action === 'copy') copyIframeSelection();
+        else if (action === 'select-all') selectAllInIframe();
+        else if (action === 'open-in-browser') vscode.postMessage({ type: 'openInBrowser' });
+        hideContextMenu();
+      });
+
+      // Outer-shell dismiss handlers — click anywhere outside the
+      // menu, scroll the toolbar, or hit Escape.
+      document.addEventListener('mousedown', function (e) {
+        if (ctxMenu.hidden) return;
+        if (!ctxMenu.contains(e.target)) hideContextMenu();
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') hideContextMenu();
+      });
+
+      function attachIframeInputHandlers() {
+        const win = iframe.contentWindow;
+        const doc = iframe.contentDocument;
+        if (!win || !doc) return;
+        // Cmd/Ctrl-C and Cmd/Ctrl-A while the iframe has focus.
+        win.addEventListener('keydown', function (e) {
+          const mod = e.metaKey || e.ctrlKey;
+          if (!mod) return;
+          const k = (e.key || '').toLowerCase();
+          if (k === 'c') {
+            if (copyIframeSelection()) e.preventDefault();
+            return;
+          }
+          if (k === 'a') {
+            selectAllInIframe();
+            e.preventDefault();
+          }
+        });
+        // Right-click → custom menu in the outer shell. Use mousedown
+        // for the dismiss handler ordering; contextmenu still fires
+        // after, and we preventDefault to suppress any host menu.
+        win.addEventListener('contextmenu', function (e) {
+          e.preventDefault();
+          const rect = iframe.getBoundingClientRect();
+          const x = e.clientX + rect.left;
+          const y = e.clientY + rect.top;
+          const sel = win.getSelection();
+          const hasSel = !!(sel && sel.toString().length > 0);
+          showContextMenu(x, y, hasSel);
+        });
+        // A new click inside the iframe should dismiss the menu so
+        // it does not linger after the user moves on.
+        win.addEventListener('mousedown', hideContextMenu);
+        win.addEventListener('scroll', hideContextMenu, true);
+        // Re-attach is required after every iframe reload (Knit
+        // again, or singleton-panel content swap).
+      }
+
+      iframe.addEventListener('load', attachIframeInputHandlers);
+      if (iframe.contentDocument
+          && iframe.contentDocument.readyState !== 'loading') {
+        attachIframeInputHandlers();
+      }
+      // Re-apply when VS Code switches its active theme. The outer
+      // shell body class flips between vscode-light, vscode-dark, or
+      // vscode-high-contrast, which updates the CSS variables read
+      // by readThemeColors.
+      new MutationObserver(applyTheme).observe(document.body, {
+        attributes: true, attributeFilter: ['class'],
+      });
+      syncThemeBtn();
+      // Diagnostic probe — the extension host can verify the iframe
+      // successfully navigated to the rendered file rather than
+      // silently staying on about:blank.
+      window.addEventListener('message', function (event) {
+        var data = event && event.data;
+        if (!data || data.__ravenKnitProbe !== true) return;
+        var locationHref = '';
+        try {
+          locationHref = iframe.contentWindow ? iframe.contentWindow.location.href : '';
+        } catch (e) {
+          // SecurityError accessing cross-origin location → iframe
+          // navigated to its (cross-origin) src; report that
+          // sentinel so the extension treats it as success.
+          locationHref = 'cross-origin-blocked';
+        }
+        vscode.postMessage({
+          type: 'iframeProbe',
+          locationHref: locationHref,
+          loadFired: loadFired,
+          errorFired: errorFired,
+          src: iframe.getAttribute('src'),
+        });
+      });
+      // Surface CSP violations so the test/diagnostic layer can
+      // distinguish "blocked by CSP" from "blocked by network".
+      window.addEventListener('securitypolicyviolation', function (e) {
+        vscode.postMessage({
+          type: 'cspViolation',
+          violatedDirective: String(e.violatedDirective || ''),
+          blockedURI: String(e.blockedURI || ''),
+        });
+      });
     })();
   </script>
 </body>
 </html>`;
+}
+
+/**
+ * Rewrite fragment-only anchor hrefs (`<a href="#x">`) so they target
+ * `about:srcdoc#x` — the srcdoc iframe's actual document URL.
+ *
+ * Why this is needed: the outer-shell injects a `<base href>` so the
+ * rendered HTML's relative subresource paths (CSS, images, fonts)
+ * resolve through `webview.asWebviewUri(...)`. But the base href also
+ * changes how fragment-only anchors are resolved — instead of
+ * resolving against the iframe's document URL (`about:srcdoc`), they
+ * resolve against the base URL, which turns a click on a TOC link
+ * into a full cross-document navigation that fails (the nested-frame
+ * navigation issue this whole module exists to work around).
+ *
+ * Rewriting `href="#x"` to `href="about:srcdoc#x"` produces a URL
+ * whose non-fragment portion already matches the iframe's document
+ * URL, so the browser treats the click as a same-document fragment
+ * navigation again and scrolls to the target element.
+ *
+ * Edge cases NOT rewritten (intentionally):
+ *  - `href="page.html#x"` — combined path+fragment, not a pure
+ *    in-document anchor.
+ *  - `href=""` or `href="#"` — empty or no-op anchors.
+ *  - Non-`<a>` elements that happen to have an `href` attribute.
+ *  - `href` values containing `<`, `>`, or whitespace — those are
+ *    pathological and reject rather than rewrite.
+ */
+export function rewriteFragmentAnchors(html: string): string {
+    // Match `<a ...href="#fragment"...>` and `<a ...href='#fragment'...>`.
+    // The lookahead-free pattern matches `<a` followed by anything up
+    // to `href=`, then a quoted `#…` value. `[^>]*?` is non-greedy so
+    // the regex does not jump across `>` boundaries.
+    const re = /(<a\b[^>]*?\shref\s*=\s*)("|')(#[^"'<>\s]+)\2/gi;
+    return html.replace(re, (_match, prefix: string, quote: string, fragment: string) =>
+        `${prefix}${quote}about:srcdoc${fragment}${quote}`,
+    );
 }
 
 /**

--- a/editors/vscode/src/server-binary-check.ts
+++ b/editors/vscode/src/server-binary-check.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+
+export type ServerBinaryCheck = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Verify that a path points to a usable LSP server binary before we try to
+ * spawn it. The vscode-languageclient library produces a generic "couldn't
+ * create connection to server" toast on any spawn failure, which gives the
+ * user no actionable information. Running this check first lets `activate()`
+ * surface the actual cause (missing file, wrong target, no exec bit) and
+ * skip the LSP start that's guaranteed to fail.
+ *
+ * Pure — no vscode dependency — so it can be exercised from Bun tests.
+ */
+export function validateServerBinary(serverPath: string): ServerBinaryCheck {
+    let stats: fs.Stats;
+    try {
+        stats = fs.statSync(serverPath);
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, reason: `not found: ${msg}` };
+    }
+    if (!stats.isFile()) {
+        return { ok: false, reason: `not a regular file (is a directory or special file): ${serverPath}` };
+    }
+    if (process.platform !== 'win32') {
+        try {
+            fs.accessSync(serverPath, fs.constants.X_OK);
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return { ok: false, reason: `not executable: ${msg}` };
+        }
+    }
+    return { ok: true };
+}

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -830,6 +830,8 @@ suite('chunk commands: registration and behavior', () => {
     test('default codeLens row shows ▷ Run Chunk → Run Next & Move ↥ Run Above', async function () {
         // Issue #280: the out-of-the-box default lens row includes the new
         // `→ Run Next & Move` button between `▷ Run Chunk` and `↥ Run Above`.
+        // The last runnable chunk drops the `Run Next & Move` lens (it has
+        // nothing to point at) — see the dedicated gating test below.
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunkAt');
         if (r_console_disabled) return;
@@ -843,15 +845,16 @@ suite('chunk commands: registration and behavior', () => {
                 undefined,
                 vscode.ConfigurationTarget.Global,
             );
-            // 3 runnable R chunks × 3 default lenses = 9.
+            // 3 runnable R chunks; the first two carry all 3 default lenses,
+            // the last carries 2 (Run Next & Move hidden). 3 + 3 + 2 = 8.
             const lenses = await poll_for_lenses(
                 editor.document.uri,
-                (ls) => ls.length === 9,
+                (ls) => ls.length === 8,
             );
             assert.strictEqual(
                 lenses.length,
-                9,
-                `expected 9 default lenses (3 R chunks × 3 buttons), got ${lenses.length}`,
+                8,
+                `expected 8 default lenses (3 + 3 + 2, last chunk omits Run Next & Move), got ${lenses.length}`,
             );
             const first_three = lenses.slice(0, 3).map((l) => l.command?.title ?? '');
             assert.ok(
@@ -865,6 +868,85 @@ suite('chunk commands: registration and behavior', () => {
             assert.ok(
                 first_three[2]?.startsWith('↥ Run Above'),
                 `default lens 3 should be Run Above, got: ${first_three[2]}`,
+            );
+            const last_chunk_titles = lenses.slice(-2).map((l) => l.command?.title ?? '');
+            assert.ok(
+                last_chunk_titles.every((t) => !t.startsWith('→ Run Next')),
+                `Run Next lenses should be absent on the last chunk, got: ${last_chunk_titles.join(', ')}`,
+            );
+        } finally {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                previous,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
+    });
+
+    test('Run Next/Previous lenses are gated by target availability', async function () {
+        // The user-reported regression: clicking "→ Run Next & Move" on
+        // the LAST runnable chunk surfaced a cursor-referencing toast
+        // even though the click did not involve the cursor. Fix: hide
+        // sibling-targeted lenses on chunks where the target chunk
+        // does not exist. Symmetric for "← Run Previous" on the first.
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunkAt');
+        if (r_console_disabled) return;
+        const editor = await open_doc(RMD_FIXTURE, 'rmd');
+        const config = vscode.workspace.getConfiguration();
+        const previous = config.inspect<string[]>('raven.chunks.codeLens.commands')?.globalValue;
+        try {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                [
+                    'raven.runPreviousChunk',
+                    'raven.runPreviousChunkAndMove',
+                    'raven.runCurrentChunk',
+                    'raven.runNextChunk',
+                    'raven.runNextChunkAndMove',
+                ],
+                vscode.ConfigurationTarget.Global,
+            );
+            // RMD_FIXTURE has 3 R chunks. Expected lens counts:
+            //   first  chunk: Current + Next + Next&Move           = 3
+            //                 (Previous + Previous&Move suppressed)
+            //   middle chunk: Previous + Previous&Move + Current
+            //                 + Next + Next&Move                    = 5
+            //   last   chunk: Previous + Previous&Move + Current   = 3
+            //                 (Next + Next&Move suppressed)
+            // Total = 11.
+            const lenses = await poll_for_lenses(
+                editor.document.uri,
+                (ls) => ls.length === 11,
+            );
+            assert.strictEqual(
+                lenses.length,
+                11,
+                `expected 11 lenses (3 + 5 + 3), got ${lenses.length}: `
+                + lenses.map((l) => l.command?.title).join(' | '),
+            );
+            const titles = lenses.map((l) => l.command?.title ?? '');
+            // First chunk: no Previous variants.
+            const first_chunk = titles.slice(0, 3);
+            assert.ok(
+                first_chunk.every((t) => !t.startsWith('← Run Previous')),
+                `first chunk should not have any Run Previous lens, got: ${first_chunk.join(', ')}`,
+            );
+            // Last chunk: no Next variants.
+            const last_chunk = titles.slice(-3);
+            assert.ok(
+                last_chunk.every((t) => !t.startsWith('→ Run Next')),
+                `last chunk should not have any Run Next lens, got: ${last_chunk.join(', ')}`,
+            );
+            // Middle chunk has both sides.
+            const middle_chunk = titles.slice(3, 8);
+            assert.ok(
+                middle_chunk.some((t) => t.startsWith('← Run Previous')),
+                `middle chunk should have Run Previous, got: ${middle_chunk.join(', ')}`,
+            );
+            assert.ok(
+                middle_chunk.some((t) => t.startsWith('→ Run Next')),
+                `middle chunk should have Run Next, got: ${middle_chunk.join(', ')}`,
             );
         } finally {
             await config.update(

--- a/editors/vscode/src/test/knit-multi-panel.test.ts
+++ b/editors/vscode/src/test/knit-multi-panel.test.ts
@@ -114,6 +114,28 @@ suite('KnitOutputPanel multi-panel registry', () => {
                 panelB,
                 'B\'s panel is untouched by re-knit of A',
             );
+
+            // User closes A's panel directly (not via the testing
+            // helper). The instance's `onDidDispose` handler must
+            // run and remove A from the registry without touching B.
+            panelA.dispose();
+            // onDidDispose is synchronous, but allow a tick for any
+            // listener queue to drain.
+            await sleep(50);
+            const instances3 = KnitOutputPanel.getInstancesForTesting();
+            assert.strictEqual(
+                instances3.size, 1,
+                'user-closed panel A is removed from the registry',
+            );
+            assert.strictEqual(
+                instances3.get(srcA.fsPath), undefined,
+                'A\'s entry is gone after panelA.dispose()',
+            );
+            assert.strictEqual(
+                instances3.get(srcB.fsPath)?.getPanelForTesting(),
+                panelB,
+                'B\'s panel is untouched by A\'s dispose',
+            );
         } finally {
             output.dispose();
         }

--- a/editors/vscode/src/test/knit-multi-panel.test.ts
+++ b/editors/vscode/src/test/knit-multi-panel.test.ts
@@ -1,0 +1,121 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, sleep } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+/**
+ * Poll until `previewColumn` is anchored, or fail after timeoutMs. The
+ * panel is created with `ViewColumn.Beside` + `preserveFocus: true`, so
+ * VS Code may not assign a concrete `viewColumn` until the panel
+ * becomes visible (fires `onDidChangeViewState`, which triggers
+ * `recomputePreviewColumn`).
+ */
+async function waitForPreviewColumn(timeoutMs = 2000): Promise<vscode.ViewColumn> {
+    const deadline = Date.now() + timeoutMs;
+    let last: vscode.ViewColumn | undefined;
+    while (Date.now() < deadline) {
+        last = KnitOutputPanel.getPreviewColumnForTesting();
+        if (last !== undefined) return last;
+        await sleep(50);
+    }
+    throw new Error(`previewColumn never anchored within ${timeoutMs}ms`);
+}
+
+/**
+ * Per-source-path registry: knitting two different `.Rmd` files in one
+ * window must produce two distinct panels. Re-knitting the first must
+ * reuse its panel. Each panel must own a distinct `localResourceRoots`.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`.
+ */
+suite('KnitOutputPanel multi-panel registry', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-multi-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeAllForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('two sources produce two panels in the same preview column with distinct roots', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const dirA = path.join(tmp, 'a');
+            const dirB = path.join(tmp, 'b');
+            fs.mkdirSync(dirA, { recursive: true });
+            fs.mkdirSync(dirB, { recursive: true });
+            const outA = path.join(dirA, 'a.html');
+            const outB = path.join(dirB, 'b.html');
+            fs.writeFileSync(outA, '<html><body>A</body></html>', 'utf-8');
+            fs.writeFileSync(outB, '<html><body>B</body></html>', 'utf-8');
+            const srcA = vscode.Uri.file(path.join(tmp, 'a.Rmd'));
+            const srcB = vscode.Uri.file(path.join(tmp, 'b.Rmd'));
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcA, outputPath: outA, output },
+            );
+            // Wait for A's panel to resolve its viewColumn before
+            // opening B — otherwise previewColumn is still undefined
+            // when B's showOrUpdate runs and B falls back to Beside,
+            // which may land in a different column than A.
+            await waitForPreviewColumn();
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcB, outputPath: outB, output },
+            );
+
+            const instances = KnitOutputPanel.getInstancesForTesting();
+            assert.strictEqual(instances.size, 2, 'two distinct sources → two panels');
+
+            const instA = instances.get(srcA.fsPath);
+            const instB = instances.get(srcB.fsPath);
+            assert.ok(instA, 'panel for A.Rmd should exist');
+            assert.ok(instB, 'panel for B.Rmd should exist');
+            assert.notStrictEqual(instA, instB, 'panels for different sources are distinct');
+
+            const panelA = instA.getPanelForTesting();
+            const panelB = instB.getPanelForTesting();
+            const previewColumn = await waitForPreviewColumn();
+            assert.strictEqual(panelA.viewColumn, previewColumn);
+            assert.strictEqual(panelB.viewColumn, previewColumn);
+
+            // Per-panel localResourceRoots isolation: neither panel can
+            // resolve resources from the other's output directory.
+            const rootsA = panelA.webview.options.localResourceRoots!;
+            const rootsB = panelB.webview.options.localResourceRoots!;
+            assert.strictEqual(rootsA.length, 1);
+            assert.strictEqual(rootsB.length, 1);
+            assert.strictEqual(rootsA[0].fsPath, dirA);
+            assert.strictEqual(rootsB[0].fsPath, dirB);
+            assert.notStrictEqual(rootsA[0].fsPath, rootsB[0].fsPath);
+
+            // Re-knit A — reuses A's panel, B's panel untouched.
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcA, outputPath: outA, output },
+            );
+            const instances2 = KnitOutputPanel.getInstancesForTesting();
+            assert.strictEqual(instances2.size, 2, 're-knit of A does not add a panel');
+            assert.strictEqual(
+                instances2.get(srcA.fsPath)?.getPanelForTesting(),
+                panelA,
+                're-knit of A reuses the same WebviewPanel reference',
+            );
+            assert.strictEqual(
+                instances2.get(srcB.fsPath)?.getPanelForTesting(),
+                panelB,
+                'B\'s panel is untouched by re-knit of A',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+});

--- a/editors/vscode/src/test/knit-output-iframe-load.test.ts
+++ b/editors/vscode/src/test/knit-output-iframe-load.test.ts
@@ -1,0 +1,204 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, sleep } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+/**
+ * Runtime integration test for the Knit Output webview iframe.
+ *
+ * Original bug: the panel rendered the toolbar correctly but the
+ * iframe area showed pure white instead of the rendered HTML. Root
+ * cause: a nested `<iframe>` inside a VS Code webview cannot navigate
+ * to a `webview.asWebviewUri(...)` URL — Electron's resource handler
+ * does not intercept nested-frame navigations, so the network stack
+ * tries a real DNS lookup on `file+.vscode-resource.vscode-cdn.net`
+ * and fails with `ERR_NAME_NOT_RESOLVED`. The fix inlines the rendered
+ * HTML via `srcdoc` and uses `sandbox="allow-same-origin"` so the
+ * iframe inherits the parent webview origin (scripts/forms/popups
+ * stay blocked).
+ *
+ * The assertions check:
+ *  1. A recognizable marker from the rendered HTML appears in
+ *     `panel.webview.html` — i.e. the content was inlined, not
+ *     reached via URL navigation.
+ *  2. The shell instruments the iframe with load/error listeners and
+ *     a `probe` message; the probe round-trip reports `loadFired`
+ *     without firing the `error` event or surfacing CSP violations.
+ */
+suite('KnitOutputPanel iframe loads rendered HTML', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-iframe-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('rendered HTML content is inlined into the webview shell', async function () {
+        this.timeout(20000);
+        await activate();
+
+        const marker = 'RAVEN-IFRAME-TEST-MARKER';
+        // Include a fragment-only anchor + a target with that id so we
+        // can assert that intra-document anchor navigation survives
+        // the `<base href>` injection (Codex review #1).
+        const body = '<!doctype html><html><head><title>t</title></head>'
+            + '<body>'
+            + '<a id="toc-link" href="#results">Jump to results</a>'
+            + `<h1 id="results">${marker}</h1>`
+            + '</body></html>';
+        const outputPath = path.join(tmp, 'analysis.html');
+        fs.writeFileSync(outputPath, body, 'utf-8');
+
+        const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const r = await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath, output },
+            );
+            assert.deepStrictEqual(r, { ok: true });
+            const inst = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst, 'panel instance should exist');
+            const panel = (inst as unknown as { panel: vscode.WebviewPanel }).panel;
+
+            // The marker is the strongest signal that content actually
+            // reaches the iframe — `srcdoc` embeds the rendered HTML
+            // inline in `panel.webview.html`, so a missing marker
+            // means the content was never wired through.
+            assert.ok(
+                panel.webview.html.includes(marker),
+                'expected the rendered HTML marker to appear in panel.webview.html',
+            );
+
+            // The iframe element uses `srcdoc` (inline HTML) rather
+            // than `src` (URL navigation). This is the fix — `src` on
+            // a nested iframe inside a VS Code webview fails with
+            // `ERR_NAME_NOT_RESOLVED`.
+            assert.ok(
+                /<iframe[^>]*srcdoc=/.test(panel.webview.html),
+                'iframe should use srcdoc to inline the content',
+            );
+            assert.ok(
+                !/<iframe[^>]*\ssrc=/.test(panel.webview.html),
+                'iframe should not use src= (broken for nested iframes in webviews)',
+            );
+
+            // Fragment-only anchors must be rewritten to point at
+            // `about:srcdoc#…`. Without this rewrite, the injected
+            // `<base href>` would route a click on a TOC link into a
+            // full cross-document navigation (Codex review).
+            assert.ok(
+                panel.webview.html.includes('href=&quot;about:srcdoc#results&quot;'),
+                'fragment anchor should be rewritten to about:srcdoc#…',
+            );
+            assert.ok(
+                !panel.webview.html.includes('href=&quot;#results&quot;'),
+                'raw fragment-only href should not survive into the srcdoc',
+            );
+
+            const probeResult = await probeIframe(panel.webview, 10000);
+            assert.ok(
+                probeResult.loadFired,
+                `iframe never fired a 'load' event. Diagnostics: ${JSON.stringify(probeResult)}`,
+            );
+            assert.ok(
+                !probeResult.errorFired,
+                `iframe fired an 'error' event. Diagnostics: ${JSON.stringify(probeResult)}`,
+            );
+            // Same-origin access to the iframe document is what
+            // allows the theme overlay to inject CSS — locationHref
+            // accessible AND equal to 'about:srcdoc' confirms the
+            // sandbox=allow-same-origin + srcdoc setup is working.
+            assert.strictEqual(
+                probeResult.locationHref,
+                'about:srcdoc',
+                'iframe should be same-origin (about:srcdoc) so the theme overlay can inject CSS',
+            );
+            assert.strictEqual(
+                probeResult.cspViolations.length,
+                0,
+                `CSP violations observed: ${JSON.stringify(probeResult.cspViolations)}`,
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+});
+
+interface ProbeResult {
+    locationHref: string;
+    loadFired: boolean;
+    errorFired: boolean;
+    src: string | null;
+    cspViolations: Array<{ violatedDirective: string; blockedURI: string }>;
+}
+
+/**
+ * Round-trip a `probe` message into the webview shell and wait for the
+ * shell's diagnostic reply.
+ */
+async function probeIframe(
+    webview: vscode.Webview,
+    timeoutMs: number,
+): Promise<ProbeResult> {
+    await sleep(750);
+
+    const violations: Array<{ violatedDirective: string; blockedURI: string }> = [];
+
+    return await new Promise<ProbeResult>((resolve, reject) => {
+        let settled = false;
+        let pokeTimer: NodeJS.Timeout | undefined;
+        let timeoutTimer: NodeJS.Timeout | undefined;
+        let sub: vscode.Disposable | undefined;
+
+        const cleanup = () => {
+            settled = true;
+            if (pokeTimer) clearInterval(pokeTimer);
+            if (timeoutTimer) clearTimeout(timeoutTimer);
+            if (sub) sub.dispose();
+        };
+
+        timeoutTimer = setTimeout(() => {
+            if (settled) return;
+            cleanup();
+            reject(new Error(
+                `Timed out waiting for iframeProbe. ` +
+                `Violations: ${JSON.stringify(violations)}.`,
+            ));
+        }, timeoutMs);
+
+        sub = webview.onDidReceiveMessage((raw: unknown) => {
+            if (!raw || typeof raw !== 'object') return;
+            const msg = raw as Record<string, unknown>;
+            if (msg.type === 'cspViolation') {
+                violations.push({
+                    violatedDirective: String(msg.violatedDirective ?? ''),
+                    blockedURI: String(msg.blockedURI ?? ''),
+                });
+                return;
+            }
+            if (msg.type === 'iframeProbe') {
+                if (settled) return;
+                cleanup();
+                resolve({
+                    locationHref: String(msg.locationHref ?? ''),
+                    loadFired: Boolean(msg.loadFired),
+                    errorFired: Boolean(msg.errorFired),
+                    src: msg.src == null ? null : String(msg.src),
+                    cspViolations: violations,
+                });
+            }
+        });
+
+        const poke = () => { void webview.postMessage({ __ravenKnitProbe: true }); };
+        poke();
+        pokeTimer = setInterval(poke, 250);
+    });
+}

--- a/editors/vscode/src/test/knit-output-iframe-load.test.ts
+++ b/editors/vscode/src/test/knit-output-iframe-load.test.ts
@@ -36,7 +36,7 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
     });
 
     teardown(() => {
-        KnitOutputPanel.disposeForTesting();
+        KnitOutputPanel.disposeAllForTesting();
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
     });
 
@@ -64,9 +64,9 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
                 { sourceUri: src, outputPath, output },
             );
             assert.deepStrictEqual(r, { ok: true });
-            const inst = KnitOutputPanel.getInstanceForTesting();
+            const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst, 'panel instance should exist');
-            const panel = (inst as unknown as { panel: vscode.WebviewPanel }).panel;
+            const panel = inst.getPanelForTesting();
 
             // The marker is the strongest signal that content actually
             // reaches the iframe — `srcdoc` embeds the rendered HTML

--- a/editors/vscode/src/test/knit-output-iframe-load.test.ts
+++ b/editors/vscode/src/test/knit-output-iframe-load.test.ts
@@ -41,7 +41,7 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
     });
 
     test('rendered HTML content is inlined into the webview shell', async function () {
-        this.timeout(20000);
+        this.timeout(30000);
         await activate();
 
         const marker = 'RAVEN-IFRAME-TEST-MARKER';
@@ -103,7 +103,15 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
                 'raw fragment-only href should not survive into the srcdoc',
             );
 
-            const probeResult = await probeIframe(panel.webview, 10000);
+            // Force the panel to the front of its tab group before
+            // probing — when this test runs after the per-source-
+            // panel suites (knit-multi-panel, knit-rootdir-change,
+            // etc.) have already churned several webviews, the new
+            // panel can be created hidden, and VS Code throttles
+            // message delivery to hidden webviews.
+            panel.reveal(panel.viewColumn ?? vscode.ViewColumn.Beside, false);
+            // 25s probe budget within the 30s mocha timeout.
+            const probeResult = await probeIframe(panel.webview, 25000);
             assert.ok(
                 probeResult.loadFired,
                 `iframe never fired a 'load' event. Diagnostics: ${JSON.stringify(probeResult)}`,

--- a/editors/vscode/src/test/knit-output-panel.test.ts
+++ b/editors/vscode/src/test/knit-output-panel.test.ts
@@ -125,4 +125,58 @@ suite('KnitOutputPanel integration', () => {
             output.dispose();
         }
     });
+
+    test('theme preference from globalState renders the button pressed', async () => {
+        // The toggle must persist across panel disposal/recreation:
+        // KnitOutputPanel.updateContent reads
+        // raven.knit.applyVSCodeTheme from globalState and threads
+        // it into buildShellHtml. With the preference set to true,
+        // the rendered shell HTML must reflect that initial state
+        // so users don't see a flicker on each knit.
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        const stored: Record<string, unknown> = {
+            'raven.knit.applyVSCodeTheme': true,
+        };
+        const fakeGlobalState = {
+            get: <T>(key: string, defaultValue?: T) =>
+                (stored[key] as T) ?? defaultValue,
+            update: (key: string, value: unknown) => {
+                stored[key] = value;
+                return Promise.resolve();
+            },
+            keys: () => Object.keys(stored),
+            setKeysForSync: () => undefined,
+        } as unknown as vscode.Memento & { setKeysForSync(keys: readonly string[]): void };
+        const fakeContext = {
+            globalState: fakeGlobalState,
+            subscriptions: [],
+        } as unknown as vscode.ExtensionContext;
+        try {
+            const html = writeFixture(tmp, 'a.html');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+            const r = await KnitOutputPanel.showOrUpdate(
+                fakeContext,
+                { sourceUri: src, outputPath: html, output },
+            );
+            assert.deepStrictEqual(r, { ok: true });
+            const inst = KnitOutputPanel.getInstanceForTesting();
+            assert.ok(inst);
+            const panel = (inst as unknown as { panel: vscode.WebviewPanel }).panel;
+            assert.ok(
+                /<button[^>]*id="raven-knit-theme"[^>]*aria-pressed="true"/
+                    .test(panel.webview.html),
+                'theme button should render in pressed state when globalState has the toggle on',
+            );
+            // The button label stays constant; only aria-pressed
+            // flips, which is what CSS keys off for the visual
+            // active state.
+            assert.ok(
+                !panel.webview.html.includes('Use document theme'),
+                'button label should not switch (no document theme to switch back to)',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
 });

--- a/editors/vscode/src/test/knit-output-panel.test.ts
+++ b/editors/vscode/src/test/knit-output-panel.test.ts
@@ -21,11 +21,11 @@ suite('KnitOutputPanel integration', () => {
     });
 
     teardown(() => {
-        KnitOutputPanel.disposeForTesting();
+        KnitOutputPanel.disposeAllForTesting();
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
     });
 
-    test('showOrUpdate reuses the singleton when rootDir is unchanged', async () => {
+    test('showOrUpdate reuses the panel when rootDir is unchanged', async () => {
         await activate();
         const output = vscode.window.createOutputChannel('Knit Test');
         try {
@@ -38,7 +38,7 @@ suite('KnitOutputPanel integration', () => {
                 { sourceUri: src, outputPath: a, output },
             );
             assert.deepStrictEqual(r1, { ok: true });
-            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            const inst1 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst1);
 
             const r2 = await KnitOutputPanel.showOrUpdate(
@@ -46,8 +46,12 @@ suite('KnitOutputPanel integration', () => {
                 { sourceUri: src, outputPath: b, output },
             );
             assert.deepStrictEqual(r2, { ok: true });
-            const inst2 = KnitOutputPanel.getInstanceForTesting();
-            assert.strictEqual(inst1, inst2, 'singleton instance should be reused');
+            const inst2 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
+            assert.strictEqual(inst1, inst2, 'panel instance for this source should be reused');
+            assert.strictEqual(
+                KnitOutputPanel.getInstancesForTesting().size, 1,
+                'only one panel exists for one source',
+            );
         } finally {
             output.dispose();
         }
@@ -66,16 +70,16 @@ suite('KnitOutputPanel integration', () => {
                 {} as vscode.ExtensionContext,
                 { sourceUri: src, outputPath: a, output },
             );
-            const inst1 = KnitOutputPanel.getInstanceForTesting();
+            const inst1 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst1);
 
             await KnitOutputPanel.showOrUpdate(
                 {} as vscode.ExtensionContext,
                 { sourceUri: src, outputPath: b, output },
             );
-            const inst2 = KnitOutputPanel.getInstanceForTesting();
+            const inst2 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst2);
-            assert.notStrictEqual(inst1, inst2, 'a new singleton should be created when rootDir changes');
+            assert.notStrictEqual(inst1, inst2, 'a new panel should be created when rootDir changes');
         } finally {
             output.dispose();
         }
@@ -93,14 +97,10 @@ suite('KnitOutputPanel integration', () => {
                 { sourceUri: src, outputPath: a, output },
             );
             assert.deepStrictEqual(r, { ok: true });
-            const inst = KnitOutputPanel.getInstanceForTesting();
+            const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst);
 
-            // Access the panel via the singleton — the panel field is
-            // private but the only public surface, `panel.webview`, is
-            // reachable via `WebviewPanel.webview`. We assert the
-            // *options* set at creation time.
-            const opts = (inst as unknown as { panel: vscode.WebviewPanel }).panel.webview.options;
+            const opts = inst.getPanelForTesting().webview.options;
             assert.strictEqual(opts.enableScripts, true);
             assert.ok(opts.localResourceRoots, 'localResourceRoots is set');
             assert.strictEqual(opts.localResourceRoots!.length, 1);
@@ -160,9 +160,9 @@ suite('KnitOutputPanel integration', () => {
                 { sourceUri: src, outputPath: html, output },
             );
             assert.deepStrictEqual(r, { ok: true });
-            const inst = KnitOutputPanel.getInstanceForTesting();
+            const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst);
-            const panel = (inst as unknown as { panel: vscode.WebviewPanel }).panel;
+            const panel = inst.getPanelForTesting();
             assert.ok(
                 /<button[^>]*id="raven-knit-theme"[^>]*aria-pressed="true"/
                     .test(panel.webview.html),

--- a/editors/vscode/src/test/knit-preview-column.test.ts
+++ b/editors/vscode/src/test/knit-preview-column.test.ts
@@ -1,0 +1,111 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, sleep } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+async function waitForPreviewColumn(timeoutMs = 2000): Promise<vscode.ViewColumn> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const col = KnitOutputPanel.getPreviewColumnForTesting();
+        if (col !== undefined) return col;
+        await sleep(50);
+    }
+    throw new Error(`previewColumn never anchored within ${timeoutMs}ms`);
+}
+
+async function waitForPanelColumn(
+    panel: vscode.WebviewPanel,
+    timeoutMs = 2000,
+): Promise<vscode.ViewColumn> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (panel.viewColumn !== undefined) return panel.viewColumn;
+        await sleep(50);
+    }
+    throw new Error(`panel.viewColumn never resolved within ${timeoutMs}ms`);
+}
+
+/**
+ * `previewColumn` is the anchor for new panels — they stack as tabs in
+ * one column instead of scattering. When the registry empties, the
+ * preview column resets to `undefined`; the next knit re-anchors to
+ * `ViewColumn.Beside`.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`.
+ */
+suite('KnitOutputPanel preview column anchoring', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-prev-col-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeAllForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('previewColumn resets when registry empties, then re-anchors on next knit', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const outA = path.join(tmp, 'a.html');
+            const outB = path.join(tmp, 'b.html');
+            fs.writeFileSync(outA, '<html><body>A</body></html>', 'utf-8');
+            fs.writeFileSync(outB, '<html><body>B</body></html>', 'utf-8');
+            const srcA = vscode.Uri.file(path.join(tmp, 'a.Rmd'));
+            const srcB = vscode.Uri.file(path.join(tmp, 'b.Rmd'));
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcA, outputPath: outA, output },
+            );
+            const anchoredAfterA = await waitForPreviewColumn();
+
+            // Dispose A's panel via the testing API — simulates the
+            // user closing the only knit panel.
+            KnitOutputPanel.disposeAllForTesting();
+            // anchoredAfterA is referenced for the contract narrative
+            // below; not asserted directly because VS Code's column
+            // assignment for a single Beside panel is implementation-
+            // defined under tests (typically ViewColumn.Two).
+            void anchoredAfterA;
+            assert.strictEqual(
+                KnitOutputPanel.getPreviewColumnForTesting(),
+                undefined,
+                'preview column resets to undefined when registry empties',
+            );
+            assert.strictEqual(KnitOutputPanel.getInstancesForTesting().size, 0);
+
+            // Knit B — re-anchors. The new column may or may not be
+            // the same as anchoredAfterA depending on VS Code's
+            // current focus; the contract is only that it is now
+            // defined.
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcB, outputPath: outB, output },
+            );
+            const anchoredAfterB = await waitForPreviewColumn();
+
+            // Knit A again — A's new panel lands in B's column (the
+            // current preview column).
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: srcA, outputPath: outA, output },
+            );
+            const panelA = KnitOutputPanel.getInstancesForTesting()
+                .get(srcA.fsPath)?.getPanelForTesting();
+            assert.ok(panelA);
+            const panelAColumn = await waitForPanelColumn(panelA);
+            assert.strictEqual(
+                panelAColumn, anchoredAfterB,
+                'subsequent new knit lands in the current preview column',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+});

--- a/editors/vscode/src/test/knit-recompute-preview-column.test.ts
+++ b/editors/vscode/src/test/knit-recompute-preview-column.test.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { activate } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+/**
+ * Drive `recomputePreviewColumn` directly via `setInstancesForTesting`
+ * + `setPreviewColumnForTesting` + `recomputePreviewColumnForTesting`,
+ * exercising the column-tracking state machine without relying on VS
+ * Code to simulate a real drag.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`.
+ */
+suite('KnitOutputPanel recomputePreviewColumn', () => {
+    teardown(() => {
+        KnitOutputPanel.disposeAllForTesting();
+    });
+
+    test('empty registry → previewColumn becomes undefined', async () => {
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.One);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(KnitOutputPanel.getPreviewColumnForTesting(), undefined);
+    });
+
+    test('one panel in current preview column → stays put', async () => {
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([
+            { key: 'a', viewColumn: vscode.ViewColumn.One },
+        ]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.One);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(
+            KnitOutputPanel.getPreviewColumnForTesting(),
+            vscode.ViewColumn.One,
+        );
+    });
+
+    test('one panel in a different column → adopts that column', async () => {
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([
+            { key: 'a', viewColumn: vscode.ViewColumn.One },
+        ]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.Two);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(
+            KnitOutputPanel.getPreviewColumnForTesting(),
+            vscode.ViewColumn.One,
+            'adopt the surviving panel\'s column so the next knit clusters with it',
+        );
+    });
+
+    test('two panels split across columns → previewColumn stays where it still has occupants', async () => {
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([
+            { key: 'a', viewColumn: vscode.ViewColumn.One },
+            { key: 'b', viewColumn: vscode.ViewColumn.Two },
+        ]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.One);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(
+            KnitOutputPanel.getPreviewColumnForTesting(),
+            vscode.ViewColumn.One,
+        );
+    });
+
+    test('two panels both moved to a third column → adopts that column', async () => {
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([
+            { key: 'a', viewColumn: vscode.ViewColumn.Three },
+            { key: 'b', viewColumn: vscode.ViewColumn.Three },
+        ]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.One);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(
+            KnitOutputPanel.getPreviewColumnForTesting(),
+            vscode.ViewColumn.Three,
+        );
+    });
+
+    test('survivor without a viewColumn → previewColumn becomes undefined', async () => {
+        // Edge case: VS Code reports `undefined` for a panel that is
+        // currently hidden / not visible. If no surviving panel has a
+        // concrete column, there is nothing to anchor to.
+        await activate();
+        KnitOutputPanel.setInstancesForTesting([
+            { key: 'a', viewColumn: undefined },
+        ]);
+        KnitOutputPanel.setPreviewColumnForTesting(vscode.ViewColumn.One);
+        KnitOutputPanel.recomputePreviewColumnForTesting();
+        assert.strictEqual(
+            KnitOutputPanel.getPreviewColumnForTesting(),
+            undefined,
+        );
+    });
+});

--- a/editors/vscode/src/test/knit-rootdir-change.test.ts
+++ b/editors/vscode/src/test/knit-rootdir-change.test.ts
@@ -3,8 +3,20 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { activate } from './helper';
+import { activate, sleep } from './helper';
 import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+async function waitForPanelColumn(
+    panel: vscode.WebviewPanel,
+    timeoutMs = 2000,
+): Promise<vscode.ViewColumn> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (panel.viewColumn !== undefined) return panel.viewColumn;
+        await sleep(50);
+    }
+    throw new Error(`panel.viewColumn never resolved within ${timeoutMs}ms`);
+}
 
 /**
  * Highest-risk lifecycle branch: same source URI, different `rootDir`.
@@ -48,7 +60,7 @@ suite('KnitOutputPanel rootDir change recreates panel in place', () => {
             const inst1 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst1);
             const panel1 = inst1.getPanelForTesting();
-            const col1 = panel1.viewColumn;
+            const col1 = await waitForPanelColumn(panel1);
             const rootsBefore = panel1.webview.options.localResourceRoots!;
             assert.strictEqual(rootsBefore[0].fsPath, dir1);
 
@@ -69,8 +81,9 @@ suite('KnitOutputPanel rootDir change recreates panel in place', () => {
                 panel2, panel1,
                 'a new WebviewPanel was created (old was disposed)',
             );
+            const col2 = await waitForPanelColumn(panel2);
             assert.strictEqual(
-                panel2.viewColumn, col1,
+                col2, col1,
                 'replacement panel lands in the same column as the disposed one',
             );
 

--- a/editors/vscode/src/test/knit-rootdir-change.test.ts
+++ b/editors/vscode/src/test/knit-rootdir-change.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+
+/**
+ * Highest-risk lifecycle branch: same source URI, different `rootDir`.
+ * `localResourceRoots` is immutable post-creation, so the existing
+ * panel must be disposed and recreated in its current column. The
+ * dispose handler's identity guard must not delete the replacement
+ * under the same key.
+ *
+ * See `docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`.
+ */
+suite('KnitOutputPanel rootDir change recreates panel in place', () => {
+    let tmp: string;
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-rootdir-'));
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeAllForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('same source, different rootDir → disposes old panel, creates new in same column', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        try {
+            const dir1 = path.join(tmp, 'dir1');
+            const dir2 = path.join(tmp, 'dir2');
+            fs.mkdirSync(dir1, { recursive: true });
+            fs.mkdirSync(dir2, { recursive: true });
+            const out1 = path.join(dir1, 'out.html');
+            const out2 = path.join(dir2, 'out.html');
+            fs.writeFileSync(out1, '<html><body>1</body></html>', 'utf-8');
+            fs.writeFileSync(out2, '<html><body>2</body></html>', 'utf-8');
+            const src = vscode.Uri.file(path.join(tmp, 'src.Rmd'));
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: out1, output },
+            );
+            const inst1 = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
+            assert.ok(inst1);
+            const panel1 = inst1.getPanelForTesting();
+            const col1 = panel1.viewColumn;
+            const rootsBefore = panel1.webview.options.localResourceRoots!;
+            assert.strictEqual(rootsBefore[0].fsPath, dir1);
+
+            await KnitOutputPanel.showOrUpdate(
+                {} as vscode.ExtensionContext,
+                { sourceUri: src, outputPath: out2, output },
+            );
+            const instances = KnitOutputPanel.getInstancesForTesting();
+            assert.strictEqual(
+                instances.size, 1,
+                'still exactly one panel for this source after rootDir change',
+            );
+
+            const inst2 = instances.get(src.fsPath);
+            assert.ok(inst2);
+            const panel2 = inst2.getPanelForTesting();
+            assert.notStrictEqual(
+                panel2, panel1,
+                'a new WebviewPanel was created (old was disposed)',
+            );
+            assert.strictEqual(
+                panel2.viewColumn, col1,
+                'replacement panel lands in the same column as the disposed one',
+            );
+
+            const rootsAfter = panel2.webview.options.localResourceRoots!;
+            assert.strictEqual(
+                rootsAfter[0].fsPath, dir2,
+                'replacement panel has the new rootDir in localResourceRoots',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+});

--- a/editors/vscode/src/test/knit-success-no-popover.test.ts
+++ b/editors/vscode/src/test/knit-success-no-popover.test.ts
@@ -1,0 +1,148 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate, getFixtureUri, sleep } from './helper';
+import { __runKnitCommandForTest, type KnitDeps } from '../knit/knit-commands';
+
+/**
+ * When a knit succeeds and produces an HTML output, the panel itself
+ * is the success signal — the user is staring at the rendered content.
+ * The previous code surfaced a `Raven: Knit succeeded: X.html` toast
+ * with a "Show Output Panel" button, which (a) duplicates an obvious
+ * affordance the user can already see, and (b) costs an explicit
+ * dismissal click. This test pins the contract: no popover on HTML
+ * success.
+ *
+ * Failures, timeouts, cancellation, and non-HTML success keep their
+ * popovers — those are the only outcomes the user wouldn't otherwise
+ * see.
+ */
+suite('knit success: no popover when HTML output is shown', () => {
+    test('HTML success does not call showInformationMessage', async () => {
+        await activate();
+
+        const docUri = getFixtureUri('sample.Rmd');
+        const doc = await vscode.workspace.openTextDocument(docUri);
+        await vscode.window.showTextDocument(doc);
+
+        const calls: unknown[][] = [];
+        const origShow = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            ...args: unknown[]
+        ): Thenable<string | undefined> => {
+            calls.push(args);
+            return Promise.resolve(undefined);
+        };
+
+        const inFlight = new Set<string>();
+        const output = vscode.window.createOutputChannel('Knit Test');
+        const fakeContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        const deps: KnitDeps = {
+            runKnit: (async () => ({
+                spawnError: null,
+                cancelled: false,
+                timedOut: false,
+                exitCode: 0,
+                stdout: `Output created: ${path.join(path.dirname(docUri.fsPath), 'sample.html')}\n`,
+                stderr: '',
+            })) as KnitDeps['runKnit'],
+            showOrUpdatePanel: (async () => ({ ok: true })) as KnitDeps['showOrUpdatePanel'],
+        };
+
+        try {
+            await __runKnitCommandForTest({
+                uri: docUri,
+                output,
+                inFlight,
+                context: fakeContext,
+                deps,
+            });
+            await sleep(50);
+
+            // We tolerate a single info-message for the workspace-
+            // trust prompt if it fires in CI; assert no toast text
+            // contains the success label, which is what the user
+            // explicitly objected to.
+            for (const args of calls) {
+                const label = String(args[0] ?? '');
+                assert.ok(
+                    !label.startsWith('Raven: Knit succeeded'),
+                    `Unexpected success toast: ${label}`,
+                );
+            }
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = origShow;
+            output.dispose();
+        }
+    });
+
+    test('multi-output HTML success logs all paths to the output channel', async () => {
+        await activate();
+
+        const docUri = getFixtureUri('sample.Rmd');
+        const dir = path.dirname(docUri.fsPath);
+
+        const lines: string[] = [];
+        const fakeOutput = {
+            append: (s: string) => lines.push(s),
+            appendLine: (s: string) => lines.push(s),
+            replace: () => undefined,
+            clear: () => undefined,
+            show: () => undefined,
+            hide: () => undefined,
+            dispose: () => undefined,
+            name: 'Knit Test',
+        } as unknown as vscode.OutputChannel;
+
+        const origShow = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            ..._args: unknown[]
+        ): Thenable<string | undefined> => Promise.resolve(undefined);
+
+        const inFlight = new Set<string>();
+        const fakeContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        const html = path.join(dir, 'sample.html');
+        const pdf = path.join(dir, 'sample.pdf');
+
+        const deps: KnitDeps = {
+            runKnit: (async () => ({
+                spawnError: null,
+                cancelled: false,
+                timedOut: false,
+                exitCode: 0,
+                stdout: `Output created: ${html}\nOutput created: ${pdf}\n`,
+                stderr: '',
+            })) as KnitDeps['runKnit'],
+            showOrUpdatePanel: (async () => ({ ok: true })) as KnitDeps['showOrUpdatePanel'],
+        };
+
+        try {
+            await __runKnitCommandForTest({
+                uri: docUri,
+                output: fakeOutput,
+                inFlight,
+                context: fakeContext,
+                deps,
+            });
+            await sleep(50);
+
+            const joined = lines.join('\n');
+            assert.ok(
+                joined.includes('sample.html'),
+                'multi-output knit should log the HTML primary path',
+            );
+            assert.ok(
+                joined.includes('sample.pdf'),
+                'multi-output knit should log the secondary PDF path',
+            );
+            assert.ok(
+                /primary/i.test(joined),
+                'output channel should mark the primary output',
+            );
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = origShow;
+        }
+    });
+});

--- a/tests/bun/knit-output-message.test.ts
+++ b/tests/bun/knit-output-message.test.ts
@@ -10,6 +10,19 @@ describe('isKnitOutputMessage', () => {
         expect(isKnitOutputMessage({ type: 'openInBrowser' })).toBe(true);
     });
 
+    // Keyboard shortcuts that the iframe captures (Cmd+J to toggle
+    // the panel, Cmd+= / Cmd+- to zoom, etc.) are re-dispatched on
+    // the outer shell document as synthetic KeyboardEvents — VS
+    // Code's keybinding handler matches them the same way as native
+    // editor keystrokes. No extension-side message is needed; the
+    // round-trip is entirely inside the webview. See
+    // knit-output-shell.test.ts for the structural assertions.
+
+    // Image copy is handled in-iframe via the async Clipboard API
+    // (ClipboardItem with image/* MIME) — no extension-side message
+    // round-trip is needed. The Copy image button lives in the
+    // existing context menu (asserted in knit-output-shell.test.ts).
+
     test('rejects unknown type', () => {
         expect(isKnitOutputMessage({ type: 'evil' })).toBe(false);
     });

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -255,6 +255,26 @@ describe('buildShellHtml', () => {
         expect(html).toMatch(/if\s*\(!mod\)\s*return/);
     });
 
+    test('re-dispatch skips AltGr-typed characters', () => {
+        // AltGr on Windows / many Linux layouts fires as Ctrl+Alt
+        // when typing characters like @, €, or accented letters.
+        // The handler must consult getModifierState('AltGraph') and
+        // skip those keystrokes so users can type.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain("getModifierState('AltGraph')");
+    });
+
+    test('copy-image falls back to copying the URL for cross-origin images', () => {
+        // Drawing a cross-origin image without CORS headers onto a
+        // canvas taints the canvas, and toBlob then throws (or
+        // yields null on some platforms). The handler must catch
+        // and fall back to copying the image's src as plain text
+        // so the user can at least paste the URL.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('copyUrlFallback');
+        expect(html).toContain('writeText(img.src)');
+    });
+
     test('script wires Cmd/Ctrl-C and Cmd/Ctrl-A on the iframe', () => {
         // VS Code does not forward Cmd-C / Cmd-A from a nested
         // iframe to the host clipboard command, so we attach our

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -1,11 +1,16 @@
 import { describe, test, expect } from 'bun:test';
-import { buildShellHtml } from '../../editors/vscode/src/knit/knit-output';
+import {
+    buildShellHtml,
+    rewriteFragmentAnchors,
+} from '../../editors/vscode/src/knit/knit-output';
 
-const args = (outputPath: string, nonce = 'NONCE123') => ({
-    iframeSrc: `https://webview.test${outputPath}`,
+const args = (outputPath: string, nonce = 'NONCE123', initialThemeApplied = false) => ({
+    htmlContent: '<!doctype html><html><body><h1>Hi</h1></body></html>',
+    baseHref: `https://webview.test${outputPath.replace(/[^/]+$/, '')}`,
     cspSource: 'https://webview.test',
     outputPath,
     nonce,
+    initialThemeApplied,
 });
 
 describe('buildShellHtml', () => {
@@ -26,30 +31,305 @@ describe('buildShellHtml', () => {
         expect(html).toContain("connect-src 'none'");
     });
 
-    test('iframe src is the supplied iframeSrc', () => {
+    test('iframe inlines content via srcdoc (not src)', () => {
+        // Nested iframes inside VS Code webviews cannot navigate to
+        // `webview.asWebviewUri(...)` URLs — Electron's resource
+        // handler does not intercept the navigation. Inlining via
+        // `srcdoc` is the fix; assert that `src=` is not used.
         const html = buildShellHtml(args('/work/report.html'));
-        expect(html).toContain('src="https://webview.test/work/report.html"');
+        expect(html).toMatch(/<iframe[^>]*\bsrcdoc=/);
+        expect(html).not.toMatch(/<iframe[^>]*\ssrc=/);
     });
 
-    test('iframe sandbox attribute is empty (most restrictive)', () => {
-        const html = buildShellHtml(args('/work/report.html'));
-        expect(html).toMatch(/<iframe\b[^>]*\bsandbox=""/);
+    test('srcdoc includes the rendered HTML and a base href', () => {
+        const a = {
+            htmlContent: '<body><p>UNIQ-MARKER-Q4Z9</p></body>',
+            baseHref: 'https://webview.test/work/',
+            cspSource: 'https://webview.test',
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+            initialThemeApplied: false,
+        };
+        const html = buildShellHtml(a);
+        // srcdoc content is HTML-attribute-escaped, so the marker
+        // appears verbatim once unescaped — but the raw escaped text
+        // still contains the un-escaped letters of the marker.
+        expect(html).toContain('UNIQ-MARKER-Q4Z9');
+        // base href appears inside the srcdoc value, escaped for HTML.
+        expect(html).toContain('&lt;base href=&quot;https://webview.test/work/&quot;&gt;');
     });
 
-    test('toolbar contains refresh and open-in-browser buttons', () => {
+    test('iframe sandbox is allow-same-origin (scripts still blocked)', () => {
+        // `sandbox=""` (no flags) gives the iframe a unique opaque
+        // origin, which bypasses VS Code's webview resource handler.
+        // `allow-same-origin` lets the iframe inherit the parent
+        // webview origin; scripts/forms/popups remain blocked because
+        // no `allow-scripts` / `allow-forms` / `allow-popups` are set.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/<iframe[^>]*\bsandbox="allow-same-origin"/);
+        expect(html).not.toMatch(/<iframe[^>]*\ballow-scripts\b/);
+        expect(html).not.toMatch(/<iframe[^>]*\ballow-forms\b/);
+        expect(html).not.toMatch(/<iframe[^>]*\ballow-popups\b/);
+        expect(html).not.toMatch(/<iframe[^>]*\ballow-top-navigation\b/);
+    });
+
+    test('toolbar contains re-knit, open-in-browser, and theme buttons', () => {
         const html = buildShellHtml(args('/work/report.html'));
         expect(html).toContain('id="raven-knit-refresh"');
         expect(html).toContain('id="raven-knit-open-browser"');
+        expect(html).toContain('id="raven-knit-theme"');
     });
 
-    test('filename is HTML-escaped', () => {
-        const html = buildShellHtml(args('/work/<script>alert(1)</script>.html'));
-        expect(html).not.toContain('<script>alert(1)</script>.html');
-        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;.html');
+    test('re-knit button is labelled "Knit again"', () => {
+        // "Refresh" was the original label; the document-rendering
+        // analogy doesn't fit because the button re-runs knit (re-
+        // executes R code, regenerates the file) rather than
+        // refetching the same URL.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/<button[^>]*id="raven-knit-refresh"[^>]*>Knit again<\/button>/);
+        expect(html).not.toMatch(/>Refresh</);
+    });
+
+    test('theme toggle button starts in unpressed state when not persisted', () => {
+        const html = buildShellHtml(args('/work/report.html'));
+        // Button must declare aria-pressed so screen readers report
+        // the toggle state; on first render the theme has not been
+        // applied yet so it should read "false".
+        expect(html).toMatch(/<button[^>]*id="raven-knit-theme"[^>]*aria-pressed="false"/);
+        expect(html).toContain('>Apply VS Code theme<');
+    });
+
+    test('initialThemeApplied=true renders the button in the pressed state', () => {
+        // The extension reads the persisted preference from
+        // globalState and threads it through here; the rendered
+        // button should immediately reflect "theme applied" so the
+        // user does not see a one-frame flicker between renders.
+        // Note: the button label does NOT change with state — Rmd
+        // output has no "document theme" to switch back to, so the
+        // active state is conveyed only via aria-pressed + CSS.
+        const html = buildShellHtml(args('/work/report.html', 'N', true));
+        expect(html).toMatch(/<button[^>]*id="raven-knit-theme"[^>]*aria-pressed="true"/);
+        expect(html).toContain('>Apply VS Code theme<');
+        // The script's local state variable starts at the same value.
+        expect(html).toContain('let themeApplied = true;');
+    });
+
+    test('theme button label is constant; state is visual only', () => {
+        const off = buildShellHtml(args('/work/r.html', 'N', false));
+        const on = buildShellHtml(args('/work/r.html', 'N', true));
+        // Both renderings carry the same visible label — only
+        // aria-pressed flips. The label never says "Use document
+        // theme" since there isn't one.
+        expect(off).toContain('>Apply VS Code theme<');
+        expect(on).toContain('>Apply VS Code theme<');
+        expect(off).not.toContain('Use document theme');
+        expect(on).not.toContain('Use document theme');
+    });
+
+    test('script reads computed vscode-editor CSS variables', () => {
+        // The injected stylesheet uses RESOLVED color values pulled
+        // from the outer shell's computed style — CSS variables do
+        // not propagate into a srcdoc iframe, so we resolve them
+        // here and inject literal values.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('--vscode-editor-background');
+        expect(html).toContain('--vscode-editor-foreground');
+        expect(html).toContain('--vscode-textLink-foreground');
+    });
+
+    test('script observes outer-shell body class for theme switches', () => {
+        // VS Code flips body classList between vscode-light /
+        // vscode-dark / vscode-high-contrast on theme change. We
+        // observe that mutation so the overlay re-injects with the
+        // new resolved colors instead of going stale.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/MutationObserver\([\s\S]*?\)\.observe\(document\.body/);
+    });
+
+    test('context menu element exposes Copy / Select All / Open in Browser', () => {
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/id="raven-knit-context-menu"[^>]*hidden/);
+        expect(html).toContain('role="menuitem" data-action="copy"');
+        expect(html).toContain('role="menuitem" data-action="select-all"');
+        expect(html).toContain('role="menuitem" data-action="open-in-browser"');
+    });
+
+    test('script wires Cmd/Ctrl-C and Cmd/Ctrl-A on the iframe', () => {
+        // VS Code does not forward Cmd-C / Cmd-A from a nested
+        // iframe to the host clipboard command, so we attach our
+        // own keydown handler on iframe.contentWindow. The presence
+        // of these tokens in the shell script is a structural
+        // guarantee that the wiring exists.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/iframe\.contentWindow[\s\S]*?addEventListener\(['"]keydown['"]/);
+        // Both the modifier check and the key dispatch must be in
+        // place — guarding either alone is not enough.
+        expect(html).toMatch(/metaKey\s*\|\|\s*e\.ctrlKey/);
+        expect(html).toContain("k === 'c'");
+        expect(html).toContain("k === 'a'");
+    });
+
+    test('script wires contextmenu listener that suppresses the host menu', () => {
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/addEventListener\(['"]contextmenu['"]/);
+        expect(html).toMatch(/e\.preventDefault\(\)/);
+    });
+
+    test('copy path includes Clipboard API with execCommand fallback', () => {
+        // navigator.clipboard.writeText is the modern path; we keep
+        // execCommand('copy') as a fallback for older webview hosts
+        // that block the async API.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('navigator.clipboard');
+        expect(html).toContain("execCommand('copy')");
+    });
+
+    test('theme toggle posts themeChanged message instead of using setState', () => {
+        // Persistence lives in the extension's globalState so the
+        // choice survives panel disposal/recreation across knits.
+        // The webview only posts a message; the extension writes.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain("type: 'themeChanged'");
+        expect(html).toMatch(/postMessage\(\s*\{\s*type:\s*['"]themeChanged['"]/);
+        expect(html).not.toContain('vscode.setState');
+    });
+
+    test('filename in toolbar is HTML-escaped', () => {
+        // Use a basename that contains HTML-special characters but no
+        // path separators, so we're isolating the toolbar-label escape.
+        const html = buildShellHtml(args('/work/re<port>&.html'));
+        expect(html).toContain('aria-live="polite">re&lt;port&gt;&amp;.html<');
     });
 
     test('toolbar script is nonce-tagged', () => {
         const html = buildShellHtml(args('/work/report.html'));
         expect(html).toMatch(/<script\s+nonce="NONCE123">/);
+    });
+});
+
+describe('rewriteFragmentAnchors', () => {
+    test('rewrites fragment-only double-quoted hrefs', () => {
+        const out = rewriteFragmentAnchors('<a href="#results">jump</a>');
+        expect(out).toBe('<a href="about:srcdoc#results">jump</a>');
+    });
+
+    test('rewrites fragment-only single-quoted hrefs', () => {
+        const out = rewriteFragmentAnchors("<a href='#results'>jump</a>");
+        expect(out).toBe("<a href='about:srcdoc#results'>jump</a>");
+    });
+
+    test('rewrites uppercase tag and attribute names', () => {
+        const out = rewriteFragmentAnchors('<A HREF="#x">jump</A>');
+        // Replacement preserves the original `<A HREF=` prefix.
+        expect(out).toBe('<A HREF="about:srcdoc#x">jump</A>');
+    });
+
+    test('handles whitespace around the equals sign', () => {
+        const out = rewriteFragmentAnchors('<a href = "#x">jump</a>');
+        expect(out).toBe('<a href = "about:srcdoc#x">jump</a>');
+    });
+
+    test('rewrites multiple anchors', () => {
+        const out = rewriteFragmentAnchors(
+            '<a href="#a">A</a> and <a href="#b">B</a>',
+        );
+        expect(out).toBe(
+            '<a href="about:srcdoc#a">A</a> and <a href="about:srcdoc#b">B</a>',
+        );
+    });
+
+    test('rewrites anchors with extra attributes before href', () => {
+        const out = rewriteFragmentAnchors(
+            '<a class="toc-link" href="#sec">Sec</a>',
+        );
+        expect(out).toBe('<a class="toc-link" href="about:srcdoc#sec">Sec</a>');
+    });
+
+    test('rewrites anchors with extra attributes after href', () => {
+        const out = rewriteFragmentAnchors(
+            '<a href="#sec" class="toc-link">Sec</a>',
+        );
+        expect(out).toBe('<a href="about:srcdoc#sec" class="toc-link">Sec</a>');
+    });
+
+    test('does NOT rewrite combined path+fragment hrefs', () => {
+        // `page.html#x` is not an in-document anchor; leaving it
+        // alone preserves the existing "external links fail silently"
+        // behavior (rather than turning it into an in-document
+        // navigation that scrolls to the wrong place).
+        const original = '<a href="page.html#x">other</a>';
+        expect(rewriteFragmentAnchors(original)).toBe(original);
+    });
+
+    test('does NOT rewrite empty hrefs or bare hashes', () => {
+        // The regex requires at least one character after `#`, so
+        // `<a href="#">` is left alone — typical "no-op" anchors.
+        const empty = '<a href="">x</a> <a href="#">y</a>';
+        expect(rewriteFragmentAnchors(empty)).toBe(empty);
+    });
+
+    test('does NOT rewrite href on non-<a> elements', () => {
+        // `<link href="#">` and `<base href="#">` aren't navigation
+        // targets in the same sense; rewriting them would be wrong.
+        const original = '<link href="#x"><base href="#y">';
+        expect(rewriteFragmentAnchors(original)).toBe(original);
+    });
+
+    test('does NOT rewrite absolute or scheme-prefixed URLs', () => {
+        const original = '<a href="https://example.com/#x">ext</a>';
+        expect(rewriteFragmentAnchors(original)).toBe(original);
+    });
+
+    test('does not cross > boundaries', () => {
+        // The non-greedy `[^>]*?` must not let one anchor "absorb"
+        // surrounding tags. Adversarial input here would be HTML
+        // already containing `>` between `<a` and `href=`.
+        const original = '<a class="x">text</a><span> href="#">x</span>';
+        // The fragment-anchor regex should not match here at all —
+        // the only `href="#"` lives inside the <span>, not an <a>.
+        expect(rewriteFragmentAnchors(original)).toBe(original);
+    });
+
+    test('fragment-only anchors are rewritten so they navigate inside about:srcdoc', () => {
+        // With `<base href>` set, fragment-only hrefs would resolve
+        // against the base URL and trigger a full cross-document
+        // navigation (which fails for nested webview iframes).
+        // Rewriting them to `about:srcdoc#…` keeps fragment scroll
+        // working.
+        const a = {
+            htmlContent: '<a href="#results">Jump to results</a>',
+            baseHref: 'https://webview.test/work/',
+            cspSource: 'https://webview.test',
+            outputPath: '/work/report.html',
+            nonce: 'N',
+            initialThemeApplied: false,
+        };
+        const html = buildShellHtml(a);
+        expect(html).toContain('href=&quot;about:srcdoc#results&quot;');
+        // The naked `href="#results"` must not appear in the
+        // srcdoc attribute — that would mean we forgot to rewrite.
+        expect(html).not.toContain('href=&quot;#results&quot;');
+    });
+
+    test('srcdoc value is HTML-attribute escaped (no breakout)', () => {
+        // A `"` in the rendered HTML must not close the srcdoc
+        // attribute. Constructing a payload that would, if
+        // unescaped, escape from the attribute and inject a new
+        // attribute lets us verify the escaping.
+        const a = {
+            htmlContent: '<body>"><script>alert(1)</script><x foo="</body>',
+            baseHref: 'https://webview.test/work/',
+            cspSource: 'https://webview.test',
+            outputPath: '/work/report.html',
+            nonce: 'NONCE123',
+            initialThemeApplied: false,
+        };
+        const html = buildShellHtml(a);
+        // The raw quote-bracket-script sequence MUST NOT appear in
+        // the outer shell — that would mean the srcdoc closed early
+        // and a script was injected into the outer shell.
+        expect(html).not.toContain('"><script>alert(1)</script>');
+        // The escaped form is what we expect.
+        expect(html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
     });
 });

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -223,12 +223,36 @@ describe('buildShellHtml', () => {
         // The handler must read e.target and check whether the
         // right-clicked element is an HTMLImageElement so the
         // Copy image button can be enabled / disabled and so the
-        // image src is captured for the copy action.
+        // image is captured for the copy action.
         const html = buildShellHtml(args('/work/report.html'));
-        // The webview script must reach for the image src via the
-        // target element; a regex check on the source pattern is the
-        // structural guarantee.
         expect(html).toMatch(/tagName[\s\S]*?===[\s\S]*?['"]IMG['"]/i);
+    });
+
+    test('copy-image uses canvas (not fetch) to bypass connect-src CSP', () => {
+        // The outer-shell CSP sets `connect-src 'none'`, which blocks
+        // JS-initiated network requests (including fetch of local
+        // webview resources). The Copy image action draws the
+        // already-loaded image onto an offscreen canvas instead so
+        // it needs no further network access, then writes the canvas
+        // as a PNG blob via ClipboardItem.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('createElement(\'canvas\')');
+        expect(html).toContain('drawImage(');
+        expect(html).toMatch(/canvas\.toBlob\([\s\S]*?['"]image\/png['"]/);
+        expect(html).toContain("'image/png'");
+        // No fetch() call in the image-copy path.
+        expect(html).not.toContain('fetch(src)');
+        expect(html).not.toMatch(/fetch\(pending/);
+    });
+
+    test('re-dispatch is gated on a modifier (no plain typing forwarded)', () => {
+        // Without the modifier gate, plain letters typed into any
+        // input/widget rendered in the report would be re-dispatched
+        // on the outer document and could fire single-key
+        // keybindings the user has configured in VS Code.
+        const html = buildShellHtml(args('/work/report.html'));
+        // The handler must early-exit when no modifier is held.
+        expect(html).toMatch(/if\s*\(!mod\)\s*return/);
     });
 
     test('script wires Cmd/Ctrl-C and Cmd/Ctrl-A on the iframe', () => {

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -126,6 +126,30 @@ describe('buildShellHtml', () => {
         expect(on).not.toContain('Use document theme');
     });
 
+    test('toggle is right-aligned in the toolbar', () => {
+        // The toolbar uses flex layout; `margin-left: auto` on the
+        // toggle pushes it to the right edge, separating it from the
+        // two action buttons on the left.
+        const html = buildShellHtml(args('/work/r.html'));
+        expect(html).toMatch(/#raven-knit-theme\s*\{[\s\S]*?margin-left:\s*auto/);
+    });
+
+    test('toggle uses input-option styling and a checkmark prefix', () => {
+        // Pin the visual contract: the toggle uses VS Code's
+        // input-option CSS variables (the same vars the Find widget
+        // toggles use), and the active state prepends a ✓ via a
+        // ::before pseudo-element. Action buttons must remain on
+        // the button-background palette.
+        const html = buildShellHtml(args('/work/r.html'));
+        expect(html).toContain('--vscode-inputOption-activeBackground');
+        expect(html).toContain('--vscode-inputOption-activeBorder');
+        expect(html).toContain('--vscode-inputOption-activeForeground');
+        expect(html).toMatch(/#raven-knit-theme::before\s*\{[\s\S]*?content:\s*"✓"/);
+        expect(html).toMatch(
+            /#raven-knit-theme\[aria-pressed="true"\]::before\s*\{\s*visibility:\s*visible/,
+        );
+    });
+
     test('script reads computed vscode-editor CSS variables', () => {
         // The injected stylesheet uses RESOLVED color values pulled
         // from the outer shell's computed style — CSS variables do
@@ -194,11 +218,20 @@ describe('buildShellHtml', () => {
         expect(html).not.toContain('vscode.setState');
     });
 
-    test('filename in toolbar is HTML-escaped', () => {
-        // Use a basename that contains HTML-special characters but no
-        // path separators, so we're isolating the toolbar-label escape.
+    test('filename does not appear in the toolbar (panel title already shows it)', () => {
+        const html = buildShellHtml(args('/work/report.html'));
+        // The toolbar previously carried a `<span id="raven-knit-filename">`
+        // showing the basename, which duplicated the panel tab title.
+        expect(html).not.toContain('raven-knit-filename');
+        expect(html).not.toMatch(/<span[^>]*aria-live=/);
+    });
+
+    test('iframe title still carries the basename for accessibility', () => {
+        // We still pass the basename through to the iframe's title
+        // attribute so screen readers and the find widget can refer
+        // to "Rendered output: report.html".
         const html = buildShellHtml(args('/work/re<port>&.html'));
-        expect(html).toContain('aria-live="polite">re&lt;port&gt;&amp;.html<');
+        expect(html).toContain('title="Rendered output: re&lt;port&gt;&amp;.html"');
     });
 
     test('toolbar script is nonce-tagged', () => {

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -178,6 +178,59 @@ describe('buildShellHtml', () => {
         expect(html).toContain('role="menuitem" data-action="open-in-browser"');
     });
 
+    test('script re-dispatches unhandled keystrokes on the outer document', () => {
+        // VS Code-level shortcuts (Cmd+J, Cmd+=, Cmd+-, Cmd+\, etc.)
+        // are eaten by the iframe when it has keyboard focus because
+        // VS Code's chrome never sees keystrokes that fire inside a
+        // nested iframe. The webview re-dispatches a synthetic
+        // KeyboardEvent on the outer shell document so VS Code's
+        // keybinding handler matches it just like a native keystroke.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toMatch(/new KeyboardEvent\(\s*['"]keydown['"]/);
+        expect(html).toMatch(/document\.dispatchEvent\(/);
+        // The relevant modifier and identity fields must be cloned
+        // so VS Code's keybinding matcher sees an equivalent event.
+        expect(html).toContain('key: e.key');
+        expect(html).toContain('metaKey: e.metaKey');
+        expect(html).toContain('ctrlKey: e.ctrlKey');
+        expect(html).toContain('shiftKey: e.shiftKey');
+        expect(html).toContain('altKey: e.altKey');
+    });
+
+    test('re-dispatch does not eat the C and A handlers', () => {
+        // C / A are still handled in-iframe (copy / select all of the
+        // iframe selection). They must not also be re-dispatched.
+        const html = buildShellHtml(args('/work/report.html'));
+        const dispatchIdx = html.indexOf('document.dispatchEvent(');
+        const handleCIdx = html.indexOf("k === 'c'");
+        const handleAIdx = html.indexOf("k === 'a'");
+        expect(handleCIdx).toBeGreaterThan(0);
+        expect(handleAIdx).toBeGreaterThan(0);
+        expect(dispatchIdx).toBeGreaterThan(handleCIdx);
+        expect(dispatchIdx).toBeGreaterThan(handleAIdx);
+    });
+
+    test('context menu exposes a Copy image action', () => {
+        // Right-clicking an <img> in the rendered output offers a
+        // Copy image action in addition to the text-selection Copy /
+        // Select All / Open in Browser items.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('data-action="copy-image"');
+        expect(html).toContain('>Copy image<');
+    });
+
+    test('contextmenu listener detects image targets', () => {
+        // The handler must read e.target and check whether the
+        // right-clicked element is an HTMLImageElement so the
+        // Copy image button can be enabled / disabled and so the
+        // image src is captured for the copy action.
+        const html = buildShellHtml(args('/work/report.html'));
+        // The webview script must reach for the image src via the
+        // target element; a regex check on the source pattern is the
+        // structural guarantee.
+        expect(html).toMatch(/tagName[\s\S]*?===[\s\S]*?['"]IMG['"]/i);
+    });
+
     test('script wires Cmd/Ctrl-C and Cmd/Ctrl-A on the iframe', () => {
         // VS Code does not forward Cmd-C / Cmd-A from a nested
         // iframe to the host clipboard command, so we attach our

--- a/tests/bun/server-binary-check.test.ts
+++ b/tests/bun/server-binary-check.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { validateServerBinary } from '../../editors/vscode/src/server-binary-check';
+
+describe('validateServerBinary', () => {
+    let tmp: string;
+    let executable: string;
+    let nonExecutable: string;
+    let dir: string;
+
+    beforeAll(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-binarycheck-'));
+        executable = path.join(tmp, 'good');
+        nonExecutable = path.join(tmp, 'bad');
+        dir = path.join(tmp, 'a-directory');
+        fs.writeFileSync(executable, '#!/bin/sh\necho hi\n');
+        fs.chmodSync(executable, 0o755);
+        fs.writeFileSync(nonExecutable, 'not a script');
+        fs.chmodSync(nonExecutable, 0o644);
+        fs.mkdirSync(dir);
+    });
+
+    afterAll(() => {
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    });
+
+    test('returns ok for an existing executable file', () => {
+        expect(validateServerBinary(executable)).toEqual({ ok: true });
+    });
+
+    test('returns ok: false when the path does not exist', () => {
+        const result = validateServerBinary(path.join(tmp, 'missing'));
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toMatch(/missing|ENOENT|no such/i);
+        }
+    });
+
+    test('returns ok: false when the path is a directory', () => {
+        const result = validateServerBinary(dir);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toMatch(/directory|not.*file/i);
+        }
+    });
+
+    test('returns ok: false when the file is not executable (POSIX)', () => {
+        if (process.platform === 'win32') return;
+        const result = validateServerBinary(nonExecutable);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toMatch(/not executable|EACCES|permission/i);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- **Per-`.Rmd` output panels**: replaces the singleton `KnitOutputPanel` with a registry keyed by `sourceUri.fsPath` (aligned with `knit-commands.ts`'s in-flight gate). Each `.Rmd` gets its own webview panel that persists alongside others; re-knitting the same `.Rmd` updates its panel in place. A tracked `previewColumn` anchors new panels so they stack as tabs in one column rather than scattering, and `recomputePreviewColumn` adopts a surviving panel's column when the recorded one empties.
- **Iframe keyboard re-dispatch**: VS Code shortcuts like Cmd+J, Cmd+=/-, Cmd+B, Cmd+P, Cmd+S, Cmd+W, and user-customized keybindings now work even when the iframe has keyboard focus. The handler synthesizes a `KeyboardEvent` and `dispatchEvent`s it on the outer shell document instead of forwarding through a whitelist. Cmd/Ctrl+C and Cmd/Ctrl+A remain handled in-iframe for selection copy/select-all. AltGr-typed characters (`@`, `€`, accented letters on Windows/Linux) are skipped so users can type into rendered inputs.
- **Right-click → Copy image**: new context-menu entry copies the image bitmap onto the OS clipboard via an offscreen canvas + `ClipboardItem({'image/png': blob})`. Bypasses the outer-shell CSP's `connect-src 'none'` by reading pixels from the already-loaded `<img>` (no `fetch`). Cross-origin canvas taint falls back to copying the URL as plain text.

Design spec: [`docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md`](docs/superpowers/specs/2026-05-17-knit-panel-per-file-design.md). The spec went through 5 Codex adversarial review passes; the implementation through 4. Both ship-ready per Codex's final pass.

## Test plan

- [ ] Open two `.Rmd` files in the same window; knit each; verify both panels stay open and stack as tabs in the same column.
- [ ] Re-knit the first `.Rmd`; verify its tab updates in place and the second is untouched.
- [ ] Click `Knit again` on the first panel while the second is in flight; verify only the first re-runs.
- [ ] Drag the only knit panel to a different column; knit a third `.Rmd`; verify the new panel anchors to the dragged column.
- [ ] Knit an `.Rmd` whose `output_dir` you then change; verify the panel is replaced in the same column with the new `localResourceRoots`.
- [ ] In the knit panel, press Cmd/Ctrl+J (toggle panel), Cmd/Ctrl+= and Cmd/Ctrl+- (zoom), Cmd/Ctrl+B (sidebar), Cmd/Ctrl+P (quick open), Cmd/Ctrl+Shift+P (command palette), Cmd/Ctrl+S, Cmd/Ctrl+W. All should reach VS Code.
- [ ] In the knit panel, select text and press Cmd/Ctrl+C; verify text is on the clipboard. Press Cmd/Ctrl+A; verify all iframe text is selected.
- [ ] On a Windows or Linux keyboard with AltGr (or simulate via DevTools): type `@` / `€` inside a rendered input; verify the character appears and no VS Code shortcut fires.
- [ ] Right-click an image in a rendered report; click `Copy image`; paste into Preview/Slack/Photos and verify the bitmap appears.
- [ ] Right-click an external `https://` image without CORS headers; verify `Copy image` falls back to copying the URL as text.
- [ ] Verify the spec is current with the implementation by re-reading the v3→v4 and v4→v5 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)