### PR TITLE
Fix auto indentation unit handling

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -88,6 +88,10 @@ struct DocumentIndentUnitsChangedParams {
     units: Vec<DocumentIndentUnit>,
 }
 
+fn normalize_document_indent_unit(unit: u32) -> u32 {
+    unit.clamp(1, 8)
+}
+
 /// Parse cross-file configuration from LSP settings.
 ///
 /// Reads the top-level `crossFile`, `diagnostics`, and `packages` sections from a
@@ -6306,7 +6310,7 @@ impl Backend {
         let new_map: std::collections::HashMap<String, u32> = params
             .units
             .into_iter()
-            .map(|e| (e.uri, e.indent_unit))
+            .map(|e| (e.uri, normalize_document_indent_unit(e.indent_unit)))
             .collect();
 
         let affected_uris: Vec<Url> = {
@@ -7032,6 +7036,15 @@ async fn run_libpath_consumer(
 
 #[cfg(test)]
 mod tests {
+    mod document_indent_units {
+        #[test]
+        fn normalizes_client_supplied_indent_units() {
+            assert_eq!(super::super::normalize_document_indent_unit(0), 1);
+            assert_eq!(super::super::normalize_document_indent_unit(4), 4);
+            assert_eq!(super::super::normalize_document_indent_unit(99), 8);
+        }
+    }
+
     mod request_cancellation {
         use super::super::{
             Backend, CancellableRequestKind, RequestCancellationRegistry,

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -69,6 +69,25 @@ struct ActiveDocumentsChangedParams {
     timestamp_ms: u64,
 }
 
+/// One entry in the raven/documentIndentUnitsChanged notification.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentIndentUnit {
+    uri: String,
+    indent_unit: u32,
+}
+
+/// Parameters for the raven/documentIndentUnitsChanged notification.
+///
+/// The extension sends this whenever `raven.linting.indentationUnit` is
+/// `"auto"` and any open R document's resolved `editor.tabSize` changes.
+/// The map replaces the server's previous per-document overrides wholesale.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentIndentUnitsChangedParams {
+    units: Vec<DocumentIndentUnit>,
+}
+
 /// Parse cross-file configuration from LSP settings.
 ///
 /// Reads the top-level `crossFile`, `diagnostics`, and `packages` sections from a
@@ -6270,6 +6289,68 @@ impl Backend {
             .cross_file_activity
             .update(active_uri, visible_uris, params.timestamp_ms);
     }
+
+    /// Handle the raven/documentIndentUnitsChanged notification.
+    ///
+    /// Replaces the per-document indent unit map wholesale and triggers a
+    /// force-republish for every document whose effective indent unit changed.
+    async fn handle_document_indent_units_changed(
+        &self,
+        params: DocumentIndentUnitsChangedParams,
+    ) {
+        log::trace!(
+            "Received documentIndentUnitsChanged: {} entries",
+            params.units.len()
+        );
+
+        let new_map: std::collections::HashMap<String, u32> = params
+            .units
+            .into_iter()
+            .map(|e| (e.uri, e.indent_unit))
+            .collect();
+
+        let affected_uris: Vec<Url> = {
+            let mut state = self.state.write().await;
+
+            // Collect URIs whose effective indent unit changed.
+            let open_uris: Vec<Url> = state.documents.keys().cloned().collect();
+            let affected: Vec<Url> = open_uris
+                .into_iter()
+                .filter(|uri| {
+                    let key = uri.as_str();
+                    let old = state
+                        .per_document_indent_unit
+                        .get(key)
+                        .copied()
+                        .unwrap_or(state.lint_config.indentation_unit);
+                    let new = new_map
+                        .get(key)
+                        .copied()
+                        .unwrap_or(state.lint_config.indentation_unit);
+                    old != new
+                })
+                .collect();
+
+            state.per_document_indent_unit = new_map;
+
+            if !affected.is_empty() {
+                state
+                    .diagnostics_gate
+                    .mark_force_republish_many(affected.iter());
+            }
+
+            affected
+        };
+
+        for uri in affected_uris {
+            Backend::publish_diagnostics_via_arc(
+                self.state.clone(),
+                self.client.clone(),
+                &uri,
+            )
+            .await;
+        }
+    }
 }
 
 /// Body of [`Backend::publish_diagnostics`], factored out so that
@@ -6452,6 +6533,10 @@ pub async fn start_lsp() -> anyhow::Result<()> {
     .custom_method(
         "raven/activeDocumentsChanged",
         Backend::handle_active_documents_changed,
+    )
+    .custom_method(
+        "raven/documentIndentUnitsChanged",
+        Backend::handle_document_indent_units_changed,
     )
     .finish();
     let service = RequestCancellationService::new(service, request_cancellation);

--- a/crates/raven/src/config_file/overrides.rs
+++ b/crates/raven/src/config_file/overrides.rs
@@ -90,6 +90,15 @@ pub fn resolve_lint_for_document(
     // on top, then re-parse. This keeps semantics identical to what the LSP
     // does at startup.
     let mut effective = base_section.clone();
+    // Stamp the base's indentation_unit into the JSON so overrides that don't
+    // explicitly set indentationUnit inherit the per-document value, not the
+    // stale client placeholder that may be in the raw section.
+    if let Some(map) = effective.as_object_mut() {
+        map.insert(
+            "indentationUnit".to_string(),
+            serde_json::json!(base.indentation_unit),
+        );
+    }
     let mut matched_any = false;
     for ov in overrides {
         if ov.matchers.iter().any(|m| m.is_match(rel)) {
@@ -301,6 +310,29 @@ mod tests {
         base.enabled = false;
         let effective = resolve_lint_for_document(&base, &json!({}), &overrides, &uri);
         assert!(!effective.enabled, "override 'auto' should inherit base off");
+    }
+
+    #[test]
+    fn override_preserves_per_document_indentation_unit() {
+        // When the raw section has indentationUnit: 2 (the client placeholder)
+        // but base.indentation_unit = 4 (per-document tab size from the editor),
+        // an override that matches but doesn't set indentationUnit must not reset
+        // it back to the stale section value.
+        let mut base = LintConfig::default();
+        base.indentation_unit = 4;
+        let section = json!({ "indentationUnit": 2, "lineLength": 80, "enabled": true });
+        let root = PathBuf::from("/proj");
+        let overrides = make_overrides(
+            &root,
+            vec![("R/**/*.R", json!({ "lineLength": 120 }))],
+        );
+        let uri = Url::parse("file:///proj/R/foo.R").unwrap();
+        let out = resolve_lint_for_document(&base, &section, &overrides, &uri);
+        assert_eq!(
+            out.indentation_unit, 4,
+            "per-document indent unit must survive override re-parse"
+        );
+        assert_eq!(out.line_length, 120, "override line length must still apply");
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -246,8 +246,20 @@ impl DiagnosticsSnapshot {
         // (the common case), skip the merge + section-clone work entirely.
         // The merge+resolve only runs once per snapshot build, but a project
         // with many open documents and zero overrides shouldn't pay for it.
+        // Start with the workspace-wide lint config, patched with the per-document
+        // indent unit if present. This value has lower priority than any explicit
+        // `[[linting.overrides]]` entry: passing the patched config as the *base*
+        // to `resolve_lint_for_document` ensures an override's `indentationUnit`
+        // field overwrites the per-document value, not the other way around.
+        let base_lint_config = {
+            let mut base = state.lint_config.clone();
+            if let Some(&unit) = state.per_document_indent_unit.get(uri.as_str()) {
+                base.indentation_unit = unit;
+            }
+            base
+        };
         let lint_config = if state.lint_overrides.is_empty() {
-            state.lint_config.clone()
+            base_lint_config
         } else {
             let merged = crate::config_file::merge_settings(
                 &state.raw_client_settings,
@@ -255,7 +267,7 @@ impl DiagnosticsSnapshot {
             );
             let section = merged.get("linting").cloned().unwrap_or(serde_json::json!({}));
             crate::config_file::resolve_lint_for_document(
-                &state.lint_config,
+                &base_lint_config,
                 &section,
                 &state.lint_overrides,
                 uri,

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -578,6 +578,13 @@ pub struct WorldState {
     /// are configured. Per-document resolution scans this list.
     pub lint_overrides: Vec<crate::config_file::CompiledLintOverride>,
 
+    /// Per-document `indentation_unit` overrides sent by the client via
+    /// `raven/documentIndentUnitsChanged` when the user sets
+    /// `raven.linting.indentationUnit` to `"auto"`. Keyed by URI string.
+    /// Empty when the setting is a fixed integer; absent URIs fall back to
+    /// `lint_config.indentation_unit`.
+    pub per_document_indent_unit: std::collections::HashMap<String, u32>,
+
     pub cross_file_meta: MetadataCache,
     pub cross_file_graph: DependencyGraph,
     pub cross_file_revalidation: CrossFileRevalidationState,
@@ -705,6 +712,7 @@ impl WorldState {
             raw_project_settings: None,
             project_config_path: None,
             lint_overrides: Vec::new(),
+            per_document_indent_unit: std::collections::HashMap::new(),
             cross_file_meta: MetadataCache::new(),
             cross_file_graph: DependencyGraph::new(),
             cross_file_revalidation: CrossFileRevalidationState::new(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,7 @@ Native style/lint diagnostics. Tri-state master switch `raven.linting.enabled` (
 | `raven.linting.enabled` | `"auto"` | Master switch (`"auto"` / `"on"` / `"off"` / `true` / `false`). See the [behavior matrix](linting.md#behavior-matrix). |
 | `raven.linting.lineLength` | `80` | Maximum line length (UTF-16 code units) |
 | `raven.linting.objectLength` | `30` | Maximum identifier length for the object-length lint |
-| `raven.linting.indentationUnit` | `2` | Spaces per indent level used by the indentation lint (clamped to `1..=8`) |
+| `raven.linting.indentationUnit` | `"auto"` | Spaces per indent level used by the indentation lint. In VS Code, `"auto"` tracks each file's resolved `editor.tabSize`; set an integer `1..=8` for a fixed unit. |
 | `raven.linting.assignmentOperator` | `"<-"` | Preferred assignment operator (`"<-"` or `"="`) |
 | `raven.linting.stringDelimiter` | `"\""` | Preferred string-literal delimiter (`"\""` or `"'"`); used by the quotes lint |
 | `raven.linting.lineLengthSeverity` | `"hint"` | Severity for over-long lines (or `"off"`) |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -120,7 +120,7 @@ Native style diagnostics (a small subset of [`lintr`](https://lintr.r-lib.org/))
 | Vector logic | hint | `&` or `\|` in an `if` / `while` condition (use `&&` / `\|\|` for scalars). Scan stops at call boundaries |
 | Function left parentheses | hint | Whitespace between `function` (or `\`) and `(` (`function (x) ...`, `\ (x) ...`) |
 | Spaces inside | hint | Whitespace immediately inside `(`, `[`, or `[[` (`f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are exempt |
-| Indentation | hint | Leading whitespace doesn't match the expected indent for the line's AST scope (braced blocks, multi-line argument lists, continuation lines). Configurable indent unit via `raven.linting.indentationUnit` (default 2) |
+| Indentation | hint | Leading whitespace doesn't match the expected indent for the line's AST scope (braced blocks, multi-line argument lists, continuation lines). Configurable indent unit via `raven.linting.indentationUnit` (default `"auto"` in VS Code, tracking each file's resolved `editor.tabSize`) |
 
 Lint diagnostics carry the `source` field `raven (lint)` so they're easy to distinguish from cross-file or syntax diagnostics. Named-argument `=` inside function calls is never flagged.
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -186,7 +186,7 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 
 ### Indentation
 
-- **Raven:** `raven.linting.indentationUnit` (default `2`, clamped to `1..=8`), `raven.linting.indentationSeverity` (default `"hint"`).
+- **Raven:** `raven.linting.indentationUnit` (default `"auto"`, or a fixed integer clamped to `1..=8`), `raven.linting.indentationSeverity` (default `"hint"`). When set to `"auto"` (the default), each R file is linted against VS Code's `editor.tabSize` for that specific file, so files with different tab-size settings in the same workspace are each linted correctly. Set to a fixed integer (e.g. `2` or `4`) to use the same unit for all R files regardless of editor settings. Note: if a `[[linting.overrides]]` entry explicitly sets `indentationUnit` for a file, it takes precedence over the per-file `editor.tabSize`.
 - **`lintr` equivalent:** `lintr::indentation_linter()` with its tidy-default hanging style.
 - Flags lines whose leading whitespace doesn't match the indent expected by the AST scope the line sits in: braced blocks (one unit deeper than the line of `{`); multi-line argument lists (either aligned with the column after the opener — `foo(a,\n    b)` — or hanging one unit deeper than the opener's line); continuation lines under a binary operator (one unit deeper than the line where the chain starts). A closing delimiter (`)`, `]`, `]]`, `}`) that begins its own line aligns with the line of its opener.
 - Skipped without checks: blank lines, lines whose leading whitespace contains any tab (left to the `no_tab` rule), and lines that start strictly inside a multi-line string. Suppression markers behave as on every other rule.

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -59,7 +59,7 @@ The **`raven.toml` path** column shows where to set a key in a project's `raven.
 | `raven.linting.equalsNaSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.equalsNaSeverity` | [linting](linting.md) | Severity for the equals-NA lint. |
 | `raven.linting.functionLeftParenthesesSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.functionLeftParenthesesSeverity` | [linting](linting.md) | Severity for the function-left-parentheses lint. |
 | `raven.linting.indentationSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.indentationSeverity` | [linting](linting.md) | Severity for the indentation lint. |
-| `raven.linting.indentationUnit` | `2` | integer (1–8) | `linting.indentationUnit` | [linting](linting.md) | Number of spaces per indent level used by the indentation lint. |
+| `raven.linting.indentationUnit` | `"auto"` | any | `linting.indentationUnit` | [linting](linting.md) | Number of spaces per indent level used by the indentation lint. |
 | `raven.linting.infixSpacesSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.infixSpacesSeverity` | [linting](linting.md) | Severity for the infix-spaces lint. |
 | `raven.linting.lineLength` | `80` | integer (20–10000) | `linting.lineLength` | [linting](linting.md) | Maximum allowed line length for the line-length lint. |
 | `raven.linting.lineLengthSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.lineLengthSeverity` | [linting](linting.md) | Severity for the line-length lint. |

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -59,7 +59,7 @@ The **`raven.toml` path** column shows where to set a key in a project's `raven.
 | `raven.linting.equalsNaSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.equalsNaSeverity` | [linting](linting.md) | Severity for the equals-NA lint. |
 | `raven.linting.functionLeftParenthesesSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.functionLeftParenthesesSeverity` | [linting](linting.md) | Severity for the function-left-parentheses lint. |
 | `raven.linting.indentationSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.indentationSeverity` | [linting](linting.md) | Severity for the indentation lint. |
-| `raven.linting.indentationUnit` | `"auto"` | any | `linting.indentationUnit` | [linting](linting.md) | Number of spaces per indent level used by the indentation lint. |
+| `raven.linting.indentationUnit` | `"auto"` | integer (1–8) \| `"auto"` | `linting.indentationUnit` | [linting](linting.md) | Number of spaces per indent level used by the indentation lint. |
 | `raven.linting.infixSpacesSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.infixSpacesSeverity` | [linting](linting.md) | Severity for the infix-spaces lint. |
 | `raven.linting.lineLength` | `80` | integer (20–10000) | `linting.lineLength` | [linting](linting.md) | Maximum allowed line length for the line-length lint. |
 | `raven.linting.lineLengthSeverity` | `"hint"` | `"error"` \| `"warning"` \| `"information"` \| `"hint"` \| `"off"` | `linting.lineLengthSeverity` | [linting](linting.md) | Severity for the line-length lint. |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1777,11 +1777,19 @@
           "description": "Severity for the spaces-inside lint. Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`). Empty groupings and multi-line wrapping are left alone."
         },
         "raven.linting.indentationUnit": {
-          "type": "integer",
-          "default": 2,
-          "minimum": 1,
-          "maximum": 8,
-          "description": "Number of spaces per indent level used by the indentation lint. Mirrors `lintr::indentation_linter()`'s `indent` parameter."
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 8
+            },
+            {
+              "type": "string",
+              "const": "auto"
+            }
+          ],
+          "default": "auto",
+          "markdownDescription": "Number of spaces per indent level used by the indentation lint. Set to `\"auto\"` (default) to track each file's `editor.tabSize`; set to a fixed integer (e.g. `2` or `4`) to use the same unit for all R files. Mirrors `lintr::indentation_linter()`'s `indent` parameter."
         },
         "raven.linting.indentationSeverity": {
           "type": "string",

--- a/editors/vscode/scripts/generate-settings-reference.mjs
+++ b/editors/vscode/scripts/generate-settings-reference.mjs
@@ -105,6 +105,12 @@ function formatDefault(value) {
 }
 
 function formatType(schema) {
+  if (Array.isArray(schema.oneOf)) {
+    return schema.oneOf.map((variant) => formatType(variant)).join(" \\| ");
+  }
+  if (schema.const !== undefined) {
+    return inlineCode(JSON.stringify(schema.const));
+  }
   if (Array.isArray(schema.enum)) {
     return schema.enum.map((v) => inlineCode(JSON.stringify(v))).join(" \\| ");
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -85,6 +85,46 @@ function getServerPath(context: vscode.ExtensionContext): string {
 }
 
 /**
+ * Resolve the effective `editor.tabSize` for an R document, resource-scoped
+ * so per-file and per-language overrides are honoured.
+ */
+function resolveTabSizeForDocument(document: vscode.TextDocument): number {
+    const cfg = vscode.workspace.getConfiguration('editor', document.uri);
+    const tabSize = cfg.get<number>('tabSize', 2);
+    return tabSize;
+}
+
+/**
+ * Send raven/documentIndentUnitsChanged when `raven.linting.indentationUnit`
+ * is `"auto"`. Sends an empty list (clearing all overrides) when the setting
+ * is a fixed integer, so the server falls back to `lint_config.indentation_unit`.
+ */
+function sendDocumentIndentUnitsNotification() {
+    if (!client) {
+        return;
+    }
+
+    const ravenCfg = vscode.workspace.getConfiguration('raven');
+    const setting = ravenCfg.get<number | 'auto'>('linting.indentationUnit', 'auto');
+
+    if (setting !== 'auto') {
+        // Fixed integer: clear per-document overrides so the server uses the
+        // workspace-wide value it already received via initializationOptions.
+        client.sendNotification('raven/documentIndentUnitsChanged', { units: [] });
+        return;
+    }
+
+    const units = vscode.workspace.textDocuments
+        .filter(isRDocument)
+        .map(doc => ({
+            uri: doc.uri.toString(),
+            indentUnit: resolveTabSizeForDocument(doc),
+        }));
+
+    client.sendNotification('raven/documentIndentUnitsChanged', { units });
+}
+
+/**
  * Send activity notification to the server for cross-file revalidation prioritization.
  */
 function sendActivityNotification() {
@@ -276,7 +316,12 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         },
     );
 
-    client.start();
+    void client.start().then(() => {
+        // Send initial per-document indent units after the LSP handshake completes
+        // so the server has correct values for already-open R files when
+        // raven.linting.indentationUnit is "auto".
+        sendDocumentIndentUnitsNotification();
+    });
 
     // Activate help viewer (registers raven.openHelpPanel, raven.help.back, raven.help.forward).
     activateHelpViewer(context, client);
@@ -356,6 +401,7 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
         vscode.commands.registerCommand('raven.restart', async () => {
             (serverOptions as { options: { env: Record<string, string> | undefined } }).options.env = buildRustLogEnv();
             await client.restart();
+            sendDocumentIndentUnitsNotification();
         })
     );
 
@@ -432,6 +478,30 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
                 client.sendNotification('workspace/didChangeConfiguration', {
                     settings: settings
                 });
+            }
+            // editor.tabSize changes affect per-document indent units when
+            // raven.linting.indentationUnit is "auto".
+            if (
+                event.affectsConfiguration('raven.linting.indentationUnit') ||
+                event.affectsConfiguration('editor.tabSize')
+            ) {
+                sendDocumentIndentUnitsNotification();
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument((doc) => {
+            if (isRDocument(doc)) {
+                sendDocumentIndentUnitsNotification();
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.workspace.onDidCloseTextDocument((doc) => {
+            if (isRDocument(doc)) {
+                sendDocumentIndentUnitsNotification();
             }
         })
     );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -16,6 +16,7 @@ import {
 import {
     getUpdatedGlobalLanguageConfig,
     isRDocument,
+    resolveTabSizeForDocument,
 } from './extensionHelpers';
 import {
     shouldTriggerDirectivePathSuggest,
@@ -82,16 +83,6 @@ function getServerPath(context: vscode.ExtensionContext): string {
     const platform = process.platform;
     const binaryName = platform === 'win32' ? 'raven.exe' : 'raven';
     return path.join(context.extensionPath, 'bin', binaryName);
-}
-
-/**
- * Resolve the effective `editor.tabSize` for an R document, resource-scoped
- * so per-file and per-language overrides are honoured.
- */
-function resolveTabSizeForDocument(document: vscode.TextDocument): number {
-    const cfg = vscode.workspace.getConfiguration('editor', document.uri);
-    const tabSize = cfg.get<number>('tabSize', 2);
-    return tabSize;
 }
 
 /**

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -498,6 +498,14 @@ export function activate(context: vscode.ExtensionContext): RavenExtensionApi {
     );
 
     context.subscriptions.push(
+        vscode.window.onDidChangeTextEditorOptions((event) => {
+            if (isRDocument(event.textEditor.document)) {
+                sendDocumentIndentUnitsNotification();
+            }
+        })
+    );
+
+    context.subscriptions.push(
         vscode.workspace.onDidChangeTextDocument((event) => {
             const activeEditor = vscode.window.activeTextEditor;
             if (!activeEditor || activeEditor.document.uri.toString() !== event.document.uri.toString()) {

--- a/editors/vscode/src/extensionHelpers.ts
+++ b/editors/vscode/src/extensionHelpers.ts
@@ -31,6 +31,23 @@ export function isRDocument(
     return R_DOCUMENT_EXTENSIONS.has(path.extname(document.uri.fsPath).toLowerCase());
 }
 
+/**
+ * Resolve the effective `editor.tabSize` for a document. The scope MUST
+ * include `languageId` so VS Code returns language-scoped overrides (e.g.
+ * `[r] { "editor.tabSize": 2 }`) instead of only the resource-scoped value.
+ *
+ * The optional `getCfg` parameter exists for unit testing; callers should
+ * omit it and let the default use `vscode.workspace.getConfiguration`.
+ */
+export function resolveTabSizeForDocument(
+    document: Pick<vscode.TextDocument, 'uri' | 'languageId'>,
+    getCfg: (scope: vscode.ConfigurationScope) => vscode.WorkspaceConfiguration = (scope) =>
+        vscode.workspace.getConfiguration('editor', scope),
+): number {
+    return getCfg({ uri: document.uri, languageId: document.languageId })
+        .get<number>('tabSize', 2);
+}
+
 export function getUpdatedGlobalLanguageConfig(
     inspection: LanguageConfigurationInspection | undefined,
     wordSeparators: string,

--- a/editors/vscode/src/extensionHelpers.ts
+++ b/editors/vscode/src/extensionHelpers.ts
@@ -43,7 +43,15 @@ export function resolveTabSizeForDocument(
     document: Pick<vscode.TextDocument, 'uri' | 'languageId'>,
     getCfg: (scope: vscode.ConfigurationScope) => vscode.WorkspaceConfiguration = (scope) =>
         vscode.workspace.getConfiguration('editor', scope),
+    visibleTextEditors: readonly vscode.TextEditor[] = vscode.window.visibleTextEditors,
 ): number {
+    const editor = visibleTextEditors.find((candidate) =>
+        candidate.document.uri.toString() === document.uri.toString()
+    );
+    if (typeof editor?.options.tabSize === 'number') {
+        return editor.options.tabSize;
+    }
+
     return getCfg({ uri: document.uri, languageId: document.languageId })
         .get<number>('tabSize', 2);
 }

--- a/editors/vscode/src/initializationOptions.ts
+++ b/editors/vscode/src/initializationOptions.ts
@@ -99,7 +99,7 @@ export interface RavenInitializationOptions {
         enabled?: boolean | "auto" | "on" | "off";
         lineLength?: number;
         objectLength?: number;
-        indentationUnit?: number;
+        indentationUnit?: number | "auto";
         assignmentOperator?: "<-" | "=";
         stringDelimiter?: "\"" | "'";
         objectNameStyleFunction?: ObjectNameStyle;
@@ -372,7 +372,13 @@ export function getInitializationOptions(config: RavenWorkspaceConfiguration): R
         enabled: config.get<boolean | 'auto' | 'on' | 'off'>('linting.enabled', 'auto'),
         lineLength: config.get<number>('linting.lineLength', 80),
         objectLength: config.get<number>('linting.objectLength', 30),
-        indentationUnit: config.get<number>('linting.indentationUnit', 2),
+        indentationUnit: (() => {
+            const v = config.get<number | 'auto'>('linting.indentationUnit', 'auto');
+            // "auto" is resolved per-document via raven/documentIndentUnitsChanged.
+            // Send 2 as a placeholder so the server has a sane default until the
+            // first notification arrives.
+            return v === 'auto' ? 2 : v;
+        })(),
         assignmentOperator: config.get<"<-" | "=">('linting.assignmentOperator', '<-'),
         stringDelimiter: config.get<"\"" | "'">('linting.stringDelimiter', '"'),
         objectNameStyleFunction: config.get<ObjectNameStyle>('linting.objectNameStyleFunction', 'snake_case'),

--- a/editors/vscode/src/test/extensionHelpers.test.ts
+++ b/editors/vscode/src/test/extensionHelpers.test.ts
@@ -134,6 +134,26 @@ suite('Extension Helpers', () => {
         assert.strictEqual(tabSize, 4);
     });
 
+    test('resolveTabSizeForDocument prefers resolved visible editor tab size', () => {
+        const doc = { uri: vscode.Uri.file('/proj/foo.R'), languageId: 'r' };
+        const tabSize = resolveTabSizeForDocument(
+            doc,
+            () => ({
+                get<T>(_key: string, defaultValue: T): T { return defaultValue; },
+                has: () => true,
+                inspect: () => undefined,
+                update: () => Promise.resolve(),
+            } as unknown as vscode.WorkspaceConfiguration),
+            [
+                {
+                    document: doc,
+                    options: { tabSize: 4 },
+                } as unknown as vscode.TextEditor,
+            ],
+        );
+        assert.strictEqual(tabSize, 4);
+    });
+
     test('getUpdatedGlobalLanguageConfig ignores workspace-only overrides', () => {
         assert.deepStrictEqual(
             getUpdatedGlobalLanguageConfig(

--- a/editors/vscode/src/test/extensionHelpers.test.ts
+++ b/editors/vscode/src/test/extensionHelpers.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import {
     getUpdatedGlobalLanguageConfig,
     isRDocument,
+    resolveTabSizeForDocument,
 } from '../extensionHelpers';
 
 suite('Extension Helpers', () => {
@@ -82,6 +83,55 @@ suite('Extension Helpers', () => {
             ),
             null,
         );
+    });
+
+    test('resolveTabSizeForDocument passes language-scoped configuration scope', () => {
+        // The scope passed to getConfiguration must include `languageId` so
+        // VS Code resolves [r]-scoped overrides like `[r] { "editor.tabSize": 2 }`.
+        // A bare vscode.Uri scope only reads resource-scoped configuration and
+        // misses language-specific overrides.
+        const doc = {
+            uri: vscode.Uri.file('/proj/foo.R'),
+            languageId: 'r',
+        };
+
+        let capturedScope: vscode.ConfigurationScope | undefined;
+        resolveTabSizeForDocument(doc, (scope) => {
+            capturedScope = scope;
+            return {
+                get<T>(_key: string, defaultValue: T): T { return defaultValue; },
+                has: () => false,
+                inspect: () => undefined,
+                update: () => Promise.resolve(),
+            } as unknown as vscode.WorkspaceConfiguration;
+        });
+
+        assert.ok(
+            capturedScope !== undefined &&
+            typeof capturedScope === 'object' &&
+            !(capturedScope instanceof vscode.Uri) &&
+            'languageId' in capturedScope,
+            `getConfiguration scope must include languageId for language-scoped settings; got: ${JSON.stringify(capturedScope)}`,
+        );
+        assert.strictEqual(
+            (capturedScope as { languageId: string }).languageId,
+            'r',
+            'languageId in scope must match the document language',
+        );
+    });
+
+    test('resolveTabSizeForDocument returns tab size from configuration', () => {
+        const doc = { uri: vscode.Uri.file('/proj/foo.R'), languageId: 'r' };
+        const tabSize = resolveTabSizeForDocument(doc, () => ({
+            get<T>(key: string, defaultValue: T): T {
+                if (key === 'tabSize') return 4 as unknown as T;
+                return defaultValue;
+            },
+            has: () => true,
+            inspect: () => undefined,
+            update: () => Promise.resolve(),
+        } as unknown as vscode.WorkspaceConfiguration));
+        assert.strictEqual(tabSize, 4);
     });
 
     test('getUpdatedGlobalLanguageConfig ignores workspace-only overrides', () => {

--- a/tests/bun/settings-reference.test.ts
+++ b/tests/bun/settings-reference.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import { test } from "bun:test";
@@ -24,6 +25,24 @@ test("docs/settings-reference.md matches the generator output", () => {
       `Settings reference is stale. Run:\n` +
         `  bun editors/vscode/scripts/generate-settings-reference.mjs\n\n` +
         `Generator stderr:\n${stderr}${stdout}`,
+    );
+  }
+});
+
+test("settings reference renders indentationUnit allowed values", () => {
+  const settingsReference = readFileSync(
+    path.join(repoRoot, "docs", "settings-reference.md"),
+    "utf8",
+  );
+  const row = settingsReference
+    .split("\n")
+    .find((line) => line.startsWith("| `raven.linting.indentationUnit` |"));
+  if (!row) {
+    throw new Error("Missing raven.linting.indentationUnit row");
+  }
+  if (!row.includes("integer (1–8)") || !row.includes('`"auto"`')) {
+    throw new Error(
+      `Expected indentationUnit row to document integer 1–8 and "auto"; got:\n${row}`,
     );
   }
 });


### PR DESCRIPTION
## Summary
- Prefer VS Code's resolved visible editor tab size for auto indentation units and refresh when editor options change.
- Clamp client-supplied per-document indentation units on the server.
- Teach the settings reference generator to render oneOf/const schemas and update docs for the auto default.

## Test Plan
- git diff --check
- bun test tests/bun/settings-reference.test.ts tests/bun/vscode-config.test.ts
- bun run --cwd editors/vscode compile:test
- cargo test -p raven normalizes_client_supplied_indent_units
- cargo test -p raven override_preserves_per_document_indentation_unit
- bun run --cwd editors/vscode test -- --grep "resolveTabSizeForDocument"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Indentation unit setting now defaults to `"auto"`, automatically adjusting to match each file's editor tab size
  * Per-file indentation overrides can be configured to explicitly set values, taking precedence over automatic detection
  * Added per-document indentation synchronization with editor settings

* **Documentation**
  * Updated configuration and linting documentation to reflect the new `"auto"` default behavior and supported configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->