### PR TITLE
Fix prop_case_sensitive_diagnostic_suppression flake on builtin mixed-case names

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -27208,6 +27208,17 @@ mod proptests {
         )
     }
 
+    // Uppercase the first ASCII letter, leaving the rest unchanged.
+    // Mirrors the mixed-case construction in `prop_case_sensitive_diagnostic_suppression`
+    // so the proptest filter and the test body agree on what counts as the "mixed-case" form.
+    fn capitalize_first(s: &str) -> String {
+        let mut chars: Vec<char> = s.chars().collect();
+        if let Some(first) = chars.first_mut() {
+            *first = first.to_ascii_uppercase();
+        }
+        chars.into_iter().collect()
+    }
+
     proptest! {
         #[test]
         fn test_library_require_extraction(pkg_name in "[a-z]{3,10}".prop_filter("Not reserved", |s| !is_r_reserved(s))) {
@@ -29603,19 +29614,16 @@ mod proptests {
         ///
         /// **Validates: Requirements 5.4**
         fn prop_case_sensitive_diagnostic_suppression(
-            base_name in "[a-z][a-z0-9_]{2,8}".prop_filter("Not reserved", |s| !is_r_reserved(s)),
+            base_name in "[a-z][a-z0-9_]{2,8}".prop_filter(
+                "Not reserved or builtin (in either case)",
+                |s| !is_r_reserved(s) && !super::is_builtin(s) && !super::is_builtin(&capitalize_first(s)),
+            ),
             is_function in any::<bool>()
         ) {
             use crate::state::{WorldState, Document};
 
             // Create a mixed-case version of the name
-            let mixed_case_name = {
-                let mut chars: Vec<char> = base_name.chars().collect();
-                if !chars.is_empty() {
-                    chars[0] = chars[0].to_ascii_uppercase();
-                }
-                chars.into_iter().collect::<String>()
-            };
+            let mixed_case_name = capitalize_first(&base_name);
 
             // Generate code with declaration and both exact and case-mismatched usages
             // Pattern: # @lsp-var basename\nbasename\nBasename


### PR DESCRIPTION
## Summary
- Tightens the proptest input filter for `prop_case_sensitive_diagnostic_suppression` so `base_name` is rejected when either its lowercase form OR its first-letter-uppercased form is an R builtin (e.g. `x11` → `X11`, `sys.time` → `Sys.time`). The previous filter only excluded R reserved words, so any base name whose mixed-case form was a builtin would flake on the "case-mismatched usage SHOULD produce diagnostic" assertion — the builtin filter rightly suppressed the diagnostic.
- Extracts a `capitalize_first` helper next to `is_r_reserved` and reuses it in the filter and in the existing inline mixed-case construction inside the test body, so both sites agree on exactly what counts as the "mixed-case" form.

Closes #294.

## Test plan
- [x] `cargo test -p raven --lib prop_case_sensitive_diagnostic_suppression` passes (256 fresh cases).
- [x] Re-ran with `PROPTEST_CASES=512` — passes.
- [x] Temporarily added the documented failure seed `cc 42b2b476…` (`base_name = "x11", is_function = false`) to `crates/raven/proptest-regressions/handlers.txt` and re-ran the proptest — it passes against the seed (the new filter rejects `x11` because `X11` is a builtin). Seed reverted afterwards since it serves no purpose once the filter discards it.
- [x] `cargo check -p raven --tests` clean.