### PR TITLE
refactor(knit): drop dead palette-threading API surface

### DIFF
--- a/editors/vscode/src/knit/code-highlighter.ts
+++ b/editors/vscode/src/knit/code-highlighter.ts
@@ -121,31 +121,14 @@ export function semanticOverlaysFromLspData(
 }
 
 /**
- * Resolve the active palette. `vscode-light` and high-contrast-light
- * map to `githubLight`; everything else (default dark, vscode-dark,
- * hc-black) maps to `githubDark`. The Knit Output webview shell sets a
- * `body.vscode-light` / `body.vscode-dark` / `body.vscode-high-contrast-light`
- * class which the caller passes in via `themeClasses`.
- *
- * For the standalone HTML file that `Open in Browser` opens, the
- * caller passes `null` here and emits both palettes wrapped in
- * `@media (prefers-color-scheme: ...)` rules. See `render-html.ts`.
- */
-export function paletteForThemeClasses(themeClasses: string | null): GithubPalette {
-    if (themeClasses === null) return githubLight; // browser default — light
-    if (/\bvscode-(light|high-contrast-light)\b/.test(themeClasses)) return githubLight;
-    return githubDark;
-}
-
-/**
  * Highlight a single code block.
  *
  * `languageId` is the lower-cased language tag (from
  * `<code class="language-XXX">`). When the grammar registry can't
  * produce a grammar for it (e.g. an obscure language not contributed
  * by any installed extension), the source is HTML-escaped and emitted
- * with no per-token coloring — the palette's `foreground` covers the
- * default text color via the surrounding `<pre>` style.
+ * with no per-token coloring — the surrounding `<pre>` palette
+ * variables cover the default text color.
  *
  * The output is a plain HTML string — no extra `<pre>` or `<code>`
  * wrappers, no whitespace munging — meant to be placed inside the
@@ -154,11 +137,10 @@ export function paletteForThemeClasses(themeClasses: string | null): GithubPalet
 export async function highlightCodeBlock(args: {
     source: string;
     languageId: string;
-    palette: GithubPalette;
     registry: GrammarRegistry;
     overlays?: readonly SemanticOverlay[];
 }): Promise<string> {
-    const { source, languageId, palette, registry, overlays = [] } = args;
+    const { source, languageId, registry, overlays = [] } = args;
 
     // Empty input → empty output. vscode-textmate handles empty
     // strings but the early return saves a grammar fetch.
@@ -203,7 +185,6 @@ export async function highlightCodeBlock(args: {
                 lineStart: lineStarts[lineIdx],
                 tokens: result.tokens,
                 overlays,
-                palette,
             }),
         );
         if (lineIdx + 1 < lines.length) out.push('\n');
@@ -228,12 +209,7 @@ function paintLine(args: {
     lineStart: number;
     tokens: readonly ScopeToken[];
     overlays: readonly SemanticOverlay[];
-    palette: GithubPalette;
 }): string {
-    // `palette` is no longer read here — spans use CSS variables now
-    // (see comment on the `<span>` emit below). It stays in the
-    // argument shape because `highlightCodeBlock` callers still pass
-    // it and may want to depend on this signature.
     const { line, lineStart, tokens, overlays } = args;
     if (line.length === 0) return '';
 

--- a/editors/vscode/src/knit/github-colors.ts
+++ b/editors/vscode/src/knit/github-colors.ts
@@ -136,12 +136,3 @@ function roleForScope(scope: string): TokenRole | null {
     ) return 'constant';
     return null;
 }
-
-/**
- * Render a single CSS color for a role under the given palette. Falls
- * back to the palette foreground when `role` is null.
- */
-export function colorFor(palette: GithubPalette, role: TokenRole | null): string {
-    if (role === null) return palette.foreground;
-    return palette.roles[role];
-}

--- a/editors/vscode/src/knit/render-html.ts
+++ b/editors/vscode/src/knit/render-html.ts
@@ -112,7 +112,6 @@ async function rewriteCodeBlocks(
         themeClasses?: string | null;
     },
 ): Promise<string> {
-    const palette = paletteForTheme(args.themeClasses ?? null);
     const out: string[] = [];
     let cursor = 0;
     // Loose regex: VS Code's pipeline emits attributes in different
@@ -159,7 +158,6 @@ async function rewriteCodeBlocks(
         const highlighted = await highlightCodeBlock({
             source: rawSource,
             languageId,
-            palette,
             registry: args.registry,
             overlays,
         });
@@ -352,10 +350,4 @@ code {
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 `.trim();
-}
-
-function paletteForTheme(themeClasses: string | null): GithubPalette {
-    if (themeClasses === null) return githubLight;
-    if (/\bvscode-(light|high-contrast-light)\b/.test(themeClasses)) return githubLight;
-    return githubDark;
 }

--- a/tests/bun/code-highlighter.test.ts
+++ b/tests/bun/code-highlighter.test.ts
@@ -1,10 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
     escapeHtml,
-    githubDark,
-    githubLight,
     highlightCodeBlock,
-    paletteForThemeClasses,
     scopeToRole,
     semanticOverlaysFromLspData,
     type SemanticOverlay,
@@ -66,23 +63,6 @@ describe('scopeToRole', () => {
 
     test('support.function maps to function', () => {
         expect(scopeToRole(['source.r', 'support.function.r'])).toBe('function');
-    });
-});
-
-describe('paletteForThemeClasses', () => {
-    test('null (browser) defaults to light palette', () => {
-        expect(paletteForThemeClasses(null)).toBe(githubLight);
-    });
-
-    test('vscode-light → light', () => {
-        expect(paletteForThemeClasses('vscode-light')).toBe(githubLight);
-        expect(paletteForThemeClasses('vscode-high-contrast-light extra-class')).toBe(githubLight);
-    });
-
-    test('default and dark → dark', () => {
-        expect(paletteForThemeClasses('vscode-dark')).toBe(githubDark);
-        expect(paletteForThemeClasses('vscode-high-contrast')).toBe(githubDark);
-        expect(paletteForThemeClasses('something-else')).toBe(githubDark);
     });
 });
 
@@ -228,7 +208,6 @@ describe('highlightCodeBlock', () => {
         const html = await highlightCodeBlock({
             source: 'add <- 1',
             languageId: 'r',
-            palette: githubLight,
             registry,
         });
         // `add` → function, `<-` → operator, `1` → number, spaces stay
@@ -261,7 +240,6 @@ describe('highlightCodeBlock', () => {
         const html = await highlightCodeBlock({
             source: 'library',
             languageId: 'r',
-            palette: githubLight,
             registry: flatRegistry,
             overlays: [{ start: 0, end: 7, role: 'function' }],
         });
@@ -276,7 +254,6 @@ describe('highlightCodeBlock', () => {
         const html = await highlightCodeBlock({
             source: 'a\nb',
             languageId: 'r',
-            palette: githubLight,
             registry,
         });
         expect(html).toBe(
@@ -301,7 +278,6 @@ describe('highlightCodeBlock', () => {
         const html = await highlightCodeBlock({
             source: '',
             languageId: 'r',
-            palette: githubLight,
             registry,
         });
         expect(html).toBe('');
@@ -313,7 +289,6 @@ describe('highlightCodeBlock', () => {
         const html = await highlightCodeBlock({
             source: 'a < b > c',
             languageId: 'no-such-language',
-            palette: githubLight,
             registry,
         });
         expect(html).toBe('a &lt; b &gt; c');


### PR DESCRIPTION
Follow-up to [#297](https://github.com/jbearak/raven/pull/297), addressing a Codex adversarial-review finding.

## Summary

- After [`f16814f2`](https://github.com/jbearak/raven/commit/f16814f2) switched code spans to `--raven-c-${role}` CSS variables, the `palette` argument threaded through `paintLine` → `highlightCodeBlock` → `rewriteCodeBlocks` was no longer read. Callers could pass any palette (or the wrong one) and silently get identical output.
- This PR removes that dead surface (the `palette` arg, the `paletteForTheme`/`paletteForThemeClasses` helpers that only existed to derive it, and `colorFor` which had zero callers after the same fix).
- `composeStylesheet` and `paletteAsCssVars` are left alone — they are still load-bearing for the stylesheet itself.

Stacked on top of `worktree-rmd-html-syntax-highlighting`. Base will need updating to `main` once #297 merges.

## Test plan

- [x] `bun test ../../tests/bun/` from `editors/vscode/` — 731 pass, 0 fail (includes the VS Code Mocha suite via the workspace wrapper, 270 mocha tests).
- [x] `bun run typecheck` (`tsc --noEmit` for the main project, plot webview, and help webview) — clean.
- [x] `grep -rn 'colorFor\|paletteForTheme\|paletteForThemeClasses\|palette: GithubPalette'` confirms the only remaining match is `paletteAsCssVars(palette: GithubPalette)` — the legitimate stylesheet-emitting helper we explicitly want to keep.