### PR TITLE
test(vscode): make Mocha integration suite robust to the Claude Code sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,8 @@ Items here have no natural code home. For invariants tied to a specific function
 
 ### Environment / tooling
 
-- **macOS FSEvents** callbacks don't fire when the process is sandboxed by Claude Code; integration tests that depend on filesystem notifications require the sandbox to be disabled for the test runner (they pass fine in normal CI).
+- **macOS FSEvents** callbacks don't fire when the process is sandboxed by Claude Code; integration tests that depend on filesystem notifications require the sandbox to be disabled for the test runner (they pass fine in normal CI). Tests that genuinely cannot run under the sandbox (e.g. the 700K-row data-viewer scroll smoke tests, the knit iframe-load probe) self-skip via `isClaudeCodeSandbox()` in `editors/vscode/src/test/helper.ts` so a local run reports "skipped (sandbox)" rather than a flaky timeout failure.
+- **VS Code suite cumulative state** can make `vscode.window.activeTextEditor` racy: `showTextDocument(doc)`'s promise resolves before VS Code finishes promoting the editor to active, and a focused webview can leave `activeTextEditor` `undefined`. Tests whose command handlers read `activeTextEditor` (e.g. the chunks suite's `run_chunk`) must call `awaitActive(editor)` after `showTextDocument` and before each `executeCommand`. See the helper in `editors/vscode/src/test/helper.ts` and the `execute_chunk_command` wrapper in `chunks.test.ts`.
 - **Linux inotify**: libpath watching is recursive (one watch per descendant directory, ~10–20 per installed package). On old distros capped at the legacy 8192 default, warn users to raise `fs.inotify.max_user_watches`.
 
 ### Test harness

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
+import { awaitActive } from './helper';
 
 const CHUNK_COMMANDS = [
     'raven.runCurrentChunk',
@@ -77,20 +78,49 @@ async function open_doc(
     content: string,
     language: 'rmd' | 'r' = 'rmd',
 ): Promise<vscode.TextEditor> {
+    let editor: vscode.TextEditor;
     if (language === 'rmd') {
         const tmp = path.join(os.tmpdir(), `raven-chunks-${randomUUID()}.rmd`);
         fs.writeFileSync(tmp, content);
         TEMP_FIXTURE_FILES.push(tmp);
         const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmp));
-        return vscode.window.showTextDocument(doc);
+        editor = await vscode.window.showTextDocument(doc);
+    } else {
+        const doc = await vscode.workspace.openTextDocument({ language, content });
+        editor = await vscode.window.showTextDocument(doc);
     }
-    const doc = await vscode.workspace.openTextDocument({ language, content });
-    return vscode.window.showTextDocument(doc);
+    // Without this wait, `vscode.window.activeTextEditor` can still point at
+    // a prior test's editor (or a webview-focused `undefined`) when the next
+    // `executeCommand` runs — chunk handlers then read the wrong document and
+    // produce "no R chunks found in this document". See `awaitActive` doc.
+    await awaitActive(editor);
+    return editor;
 }
 
 function place_cursor(editor: vscode.TextEditor, line: number, char = 0): void {
     const pos = new vscode.Position(line, char);
     editor.selection = new vscode.Selection(pos, pos);
+}
+
+/**
+ * Re-pin `editor` as the active editor, then invoke a Raven command.
+ *
+ * Every chunk command we exercise here reads
+ * `vscode.window.activeTextEditor` to find the document to operate on
+ * (`run_chunk` in `chunk-commands.ts`, the chunk-navigation handlers).
+ * Any await between `open_doc` and the command call (e.g.
+ * `dispose_any_cached_r_terminal`'s 200 ms sleep) is an opportunity for
+ * VS Code to steal focus, leaving `activeTextEditor` `undefined` or
+ * pointing at a different editor. When that happens the command runs
+ * against the wrong document and silently produces "no R chunks found
+ * in this document". Re-pinning right before the call closes that race.
+ */
+async function execute_chunk_command(
+    editor: vscode.TextEditor,
+    command: string,
+): Promise<void> {
+    await awaitActive(editor);
+    await vscode.commands.executeCommand(command);
 }
 
 interface MessageStub {
@@ -320,11 +350,11 @@ suite('chunk commands: registration and behavior', () => {
         if (r_console_disabled) return; // command not registered in this env
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 0); // before any chunk
-        await vscode.commands.executeCommand('raven.goToNextChunk');
+        await execute_chunk_command(editor, 'raven.goToNextChunk');
         // First chunk header is line 6 ("```{r setup, ...}"), body starts at line 7.
         assert.strictEqual(editor.selection.active.line, 7);
 
-        await vscode.commands.executeCommand('raven.goToNextChunk');
+        await execute_chunk_command(editor, 'raven.goToNextChunk');
         // Second runnable chunk header is the python one at 12, but navigation walks
         // every chunk regardless of language — the next chunk is python at 12, so
         // cursor lands on line 13 (body of the python chunk). That's intentional:
@@ -338,7 +368,7 @@ suite('chunk commands: registration and behavior', () => {
         if (r_console_disabled) return;
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the second R chunk body
-        await vscode.commands.executeCommand('raven.goToPreviousChunk');
+        await execute_chunk_command(editor, 'raven.goToPreviousChunk');
         // Previous chunk is python at line 12 → body line 13.
         assert.strictEqual(editor.selection.active.line, 13);
     });
@@ -349,7 +379,7 @@ suite('chunk commands: registration and behavior', () => {
         if (r_console_disabled) return;
         const editor = await open_doc(RMD_FIXTURE, 'rmd');
         place_cursor(editor, 17); // inside the "second" R chunk
-        await vscode.commands.executeCommand('raven.selectCurrentChunk');
+        await execute_chunk_command(editor, 'raven.selectCurrentChunk');
         const text = editor.document.getText(editor.selection);
         assert.strictEqual(text, 'x <- 1\ny <- 2');
     });
@@ -362,7 +392,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 4); // prose line, not in a chunk
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runCurrentChunk');
+            await execute_chunk_command(editor, 'raven.runCurrentChunk');
         } finally {
             stub.restore();
         }
@@ -380,7 +410,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 13); // inside the python chunk
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runCurrentChunk');
+            await execute_chunk_command(editor, 'raven.runCurrentChunk');
         } finally {
             stub.restore();
         }
@@ -398,7 +428,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 0);
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runCurrentChunk');
+            await execute_chunk_command(editor, 'raven.runCurrentChunk');
         } finally {
             stub.restore();
         }
@@ -421,7 +451,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runCurrentChunk');
+            await execute_chunk_command(editor, 'raven.runCurrentChunk');
         } finally {
             term.restore();
         }
@@ -448,7 +478,7 @@ suite('chunk commands: registration and behavior', () => {
         if (r_console_disabled) return;
         const editor = await open_doc(R_CELL_FIXTURE, 'r');
         place_cursor(editor, 1); // inside cell "one"
-        await vscode.commands.executeCommand('raven.selectCurrentChunk');
+        await execute_chunk_command(editor, 'raven.selectCurrentChunk');
         const text = editor.document.getText(editor.selection);
         assert.strictEqual(text, 'a <- 1\nb <- 2');
     });
@@ -480,7 +510,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunk');
+            await execute_chunk_command(editor, 'raven.runNextChunk');
         } finally {
             term.restore();
         }
@@ -502,7 +532,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runPreviousChunk');
+            await execute_chunk_command(editor, 'raven.runPreviousChunk');
         } finally {
             term.restore();
         }
@@ -523,7 +553,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runBelowChunks');
+            await execute_chunk_command(editor, 'raven.runBelowChunks');
         } finally {
             term.restore();
         }
@@ -549,7 +579,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runCurrentAndBelowChunks');
+            await execute_chunk_command(editor, 'raven.runCurrentAndBelowChunks');
         } finally {
             term.restore();
         }
@@ -572,7 +602,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 22); // after the last chunk
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunk');
+            await execute_chunk_command(editor, 'raven.runNextChunk');
         } finally {
             stub.restore();
         }
@@ -590,7 +620,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 0); // before any chunk
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runPreviousChunk');
+            await execute_chunk_command(editor, 'raven.runPreviousChunk');
         } finally {
             stub.restore();
         }
@@ -611,7 +641,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runNextChunkAndMove');
         } finally {
             term.restore();
         }
@@ -638,7 +668,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runPreviousChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runPreviousChunkAndMove');
         } finally {
             term.restore();
         }
@@ -663,7 +693,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 22); // inside the last (noeval) chunk; no chunk below
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runNextChunkAndMove');
         } finally {
             stub.restore();
         }
@@ -686,7 +716,7 @@ suite('chunk commands: registration and behavior', () => {
         place_cursor(editor, 0); // before any chunk
         const stub = stub_information_message();
         try {
-            await vscode.commands.executeCommand('raven.runPreviousChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runPreviousChunkAndMove');
         } finally {
             stub.restore();
         }
@@ -710,7 +740,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunk');
+            await execute_chunk_command(editor, 'raven.runNextChunk');
         } finally {
             term.restore();
         }
@@ -743,7 +773,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runNextChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runNextChunkAndMove');
         } finally {
             term.restore();
         }
@@ -765,7 +795,7 @@ suite('chunk commands: registration and behavior', () => {
         await dispose_any_cached_r_terminal();
         const term = stub_create_terminal();
         try {
-            await vscode.commands.executeCommand('raven.runPreviousChunk');
+            await execute_chunk_command(editor, 'raven.runPreviousChunk');
         } finally {
             term.restore();
         }

--- a/editors/vscode/src/test/data-viewer.test.ts
+++ b/editors/vscode/src/test/data-viewer.test.ts
@@ -16,7 +16,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { spawnSync } from 'child_process';
 import type { RavenExtensionApi } from '../extension';
-import { activate, sleep } from './helper';
+import { activate, isClaudeCodeSandbox, sleep } from './helper';
 
 async function pollForPanel(
     api: RavenExtensionApi,
@@ -209,6 +209,15 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
     });
 
     test('End key reaches the last row in a 700K-row data frame', async function () {
+        // Under the Claude Code sandbox, CPU contention and the FSEvents
+        // disablement push this scenario past the 60 s scroll-budget. The
+        // test passes on CI and in isolation; under the sandbox it times
+        // out non-deterministically. Self-skip so local runs report
+        // "skipped (sandbox)" rather than a misleading timeout failure.
+        if (isClaudeCodeSandbox()) {
+            this.skip();
+            return;
+        }
         // R startup + 700K rnorm + arrow write + scroll round-trip can run
         // up against the suite's 120 s default when earlier suites have put
         // the runner under load. Give this test its own larger budget so
@@ -268,6 +277,11 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
     });
 
     test('Drag scrollbar to bottom reaches last row in 700K-row data frame', async function () {
+        // Sandbox self-skip — same reason as the End-key 700K test above.
+        if (isClaudeCodeSandbox()) {
+            this.skip();
+            return;
+        }
         // R startup + 700K rnorm + arrow write + scroll round-trip can
         // run up against the suite's 120 s default when earlier suites
         // have put the runner under load.
@@ -352,6 +366,14 @@ suite('data-viewer smoke tests', function (this: Mocha.Suite) {
     });
 
     test('Drag scrollbar to 50% lands near row N/2 in 700K-row data frame', async function () {
+        // Sandbox self-skip — same reason as the other two 700K-row tests
+        // above. Without the panel pre-warming the earlier tests provided
+        // (now skipped under sandbox), this one's cold start on top of
+        // sandbox CPU contention reliably overruns its budget too.
+        if (isClaudeCodeSandbox()) {
+            this.skip();
+            return;
+        }
         this.timeout(240000);
         const N = 700_000;
 

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -41,3 +41,91 @@ export async function waitForDiagnostics(uri: vscode.Uri, timeout = 10000): Prom
 export function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Ensure `vscode.window.activeTextEditor` is an editor for `editor.document`.
+ *
+ * `vscode.window.showTextDocument(doc)`'s promise resolves before VS Code
+ * has finished promoting the new editor to "active" — under suite-cumulative
+ * load (other webviews focused, prior tests' panels lingering, output
+ * channels stealing focus), the `activeTextEditor` pointer can still
+ * reference a different editor (or `undefined`) when the next
+ * `executeCommand` runs. Command handlers that read
+ * `vscode.window.activeTextEditor` then operate on the wrong document and
+ * produce confusing failures like "no R chunks found in this document".
+ *
+ * Strategy: poll up to ~250 ms (handles the common "just resolved a tick
+ * ago" race cheaply), and on any longer delay actively re-focus by
+ * re-calling `showTextDocument`. Output channels (`output:` scheme) and
+ * other non-test editors do not yield to a polling-only wait — they have
+ * to be displaced explicitly.
+ *
+ * Comparison is by document URI, not by `TextEditor` reference identity.
+ * `showTextDocument` on an already-open document is documented to return
+ * "an existing editor that is showing the document", but VS Code does not
+ * guarantee the returned object is `===` to the caller's prior reference —
+ * a strict-equality wait would spin to the timeout in those cases even
+ * though the right document is focused.
+ *
+ * Call this right after `showTextDocument`, and before any `executeCommand`
+ * that depends on the active editor.
+ */
+export async function awaitActive(
+    editor: vscode.TextEditor,
+    timeoutMs = 5000,
+): Promise<void> {
+    const targetUri = editor.document.uri.toString();
+    const matches = (): boolean => {
+        const active = vscode.window.activeTextEditor;
+        return active !== undefined && active.document.uri.toString() === targetUri;
+    };
+    const started = Date.now();
+    let lastForceFocusAt = 0;
+    while (!matches()) {
+        const elapsed = Date.now() - started;
+        if (elapsed > timeoutMs) {
+            const active = vscode.window.activeTextEditor?.document.uri.toString() ?? 'none';
+            throw new Error(
+                `Editor for ${targetUri} never became active (active: ${active})`,
+            );
+        }
+        // Re-focus the test's document after a short initial poll budget,
+        // then at most every 500 ms. The two-phase shape keeps the common
+        // case (`showTextDocument` just resolved) cheap, while displacing
+        // a focused output channel or webview when polling alone won't.
+        if (elapsed >= 250 && Date.now() - lastForceFocusAt >= 500) {
+            lastForceFocusAt = Date.now();
+            try {
+                await vscode.window.showTextDocument(editor.document, {
+                    viewColumn: editor.viewColumn,
+                    preserveFocus: false,
+                    preview: false,
+                });
+            } catch {
+                // Document may have been closed externally; the next poll
+                // tick will detect the mismatch and time out with a
+                // diagnostic error rather than swallowing this silently.
+            }
+        }
+        await sleep(25);
+    }
+}
+
+/**
+ * True when the test runner is invoked under a local Claude Code sandbox.
+ *
+ * The sandbox env disables FSEvents callbacks on macOS and adds CPU
+ * contention that pushes long-running smoke tests past their timeouts.
+ * Suites that fail purely because of those constraints (e.g. the 700K-row
+ * data-viewer scrolling tests, the knit iframe-load probe) self-skip when
+ * this returns `true` so a local run reports "skipped (sandbox)" rather
+ * than "failed (timeout)".
+ *
+ * `CLAUDECODE=1` alone is not enough — Claude-backed CI agents and review
+ * lanes also set it (see the `LlmReporter` note in `problemMatchers.test.ts`).
+ * Gating additionally on `!process.env.CI` keeps real CI lanes — including
+ * Claude-backed ones — running the full suite, where they should.
+ */
+export function isClaudeCodeSandbox(): boolean {
+    return process.env.CLAUDECODE === '1' && !process.env.CI;
+}

--- a/editors/vscode/src/test/knit-output-iframe-load.test.ts
+++ b/editors/vscode/src/test/knit-output-iframe-load.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { activate, sleep } from './helper';
+import { activate, isClaudeCodeSandbox, sleep } from './helper';
 import { KnitOutputPanel } from '../knit/knit-output-panel';
 
 /**
@@ -103,6 +103,16 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
                 'raw fragment-only href should not survive into the srcdoc',
             );
 
+            // Skip the probe section under the Claude Code sandbox — the
+            // `probe` postMessage handshake intermittently misses its
+            // budget there. The deterministic webview-HTML assertions
+            // above already ran, so we still catch any regression in
+            // marker inlining, `srcdoc` selection, or fragment-anchor
+            // rewriting; only the runtime iframe-loaded check is skipped.
+            if (isClaudeCodeSandbox()) {
+                this.skip();
+                return;
+            }
             // Force the panel to the front of its tab group before
             // probing — when this test runs after the per-source-
             // panel suites (knit-multi-panel, knit-rootdir-change,
@@ -140,6 +150,17 @@ suite('KnitOutputPanel iframe loads rendered HTML', () => {
     });
 
     test('relative <img> in the rendered HTML loads inside the iframe', async function () {
+        // Under the Claude Code sandbox the webview's `probe` postMessage
+        // handshake intermittently misses the 25 s budget under CPU
+        // contention. The test's image assertions all depend on the probe
+        // round-trip, so there's no deterministic portion to keep under
+        // sandbox — skip the whole test there. Self-skip locally so the
+        // suite reports "skipped (sandbox)" rather than a flaky timeout
+        // failure; CI is unaffected (gated on `!process.env.CI`).
+        if (isClaudeCodeSandbox()) {
+            this.skip();
+            return;
+        }
         this.timeout(30000);
         await activate();
 

--- a/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
+++ b/editors/vscode/src/test/send-to-r/inspect-commands.test.ts
@@ -4,6 +4,7 @@ import {
     INSPECTION_COMMANDS,
     get_inspection_target,
 } from '../../send-to-r/inspect-commands';
+import { awaitActive } from '../helper';
 
 suite('quick inspection commands', () => {
     test('INSPECTION_COMMANDS wraps target in the documented R calls', () => {
@@ -135,6 +136,13 @@ suite('quick inspection commands', () => {
             return Promise.resolve(undefined);
         };
         try {
+            // `executeCommand` reads `vscode.window.activeTextEditor` to
+            // pick the document to inspect. `showTextDocument`'s promise
+            // resolves before VS Code finishes promoting the new editor to
+            // active under suite-cumulative load, so wait until our editor
+            // is actually active before firing the command — otherwise the
+            // assertion below may misattribute a stale R-editor's response.
+            await awaitActive(editor);
             await vscode.commands.executeCommand('raven.inspect.nrow');
         } finally {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #299.

## Summary

The full VS Code Mocha suite has been failing locally under the Claude
Code sandbox even though CI is green. After three rounds of investigation
(including a Codex adversarial review), three independent root causes
were identified and addressed:

1. **`activeTextEditor` race in chunk command tests (17–18 failures).**
   Suite-cumulative state — a prior `output:tasks` channel from the
   build-commands suite, a webview from an earlier knit test — left
   `vscode.window.activeTextEditor` pointing somewhere other than the
   editor the test had just shown. Chunk command handlers read
   `activeTextEditor` to find the document to operate on, then
   surfaced "no R chunks found in this document".

   **Fix:** a new `awaitActive(editor)` helper in
   [editors/vscode/src/test/helper.ts](editors/vscode/src/test/helper.ts).
   It polls `vscode.window.activeTextEditor` (comparing by document URI,
   not editor reference) and after ~250 ms actively re-focuses via
   `showTextDocument`. `open_doc` and a new
   `execute_chunk_command(editor, cmd)` wrapper use it; all 22
   `executeCommand('raven.*')` call sites in
   [chunks.test.ts](editors/vscode/src/test/chunks.test.ts) were
   migrated. The `inspect-commands.test.ts` "no-op when non-R" test
   has the same structural race and gets the same fix.

2. **700K-row data-viewer scroll tests time out under sandbox CPU
   contention (2–3 failures).** They pass on CI and in isolation.

   **Fix:** all three 700K-row tests in
   [data-viewer.test.ts](editors/vscode/src/test/data-viewer.test.ts)
   (`End` key, drag-to-bottom, drag-to-50%) self-skip via a new
   `isClaudeCodeSandbox()` helper. The 10M-row test stays live because
   it currently passes; if that flips, it's a one-line follow-up.

3. **Knit iframe `probe` postMessage handshake misses its budget (1
   failure).** Documented as historically flaky.

   **Fix:** the relative-`<img>` test self-skips entirely; the first
   iframe test keeps running its deterministic webview-HTML asserts
   (marker inlining, `srcdoc`, fragment-anchor rewriting) and only
   skips the probe round-trip section. Coverage of any regression in
   the generated webview HTML is preserved.

The sandbox-detection helper is gated `process.env.CLAUDECODE === '1'
&& !process.env.CI` so Claude-backed CI / review lanes (which also set
`CLAUDECODE=1` — see the existing `LlmReporter` note in
`problemMatchers.test.ts`) still run the full suite.

[AGENTS.md](AGENTS.md) is updated under Environment / tooling.

## Test plan

- [x] `npx vscode-test` under the sandbox: 3 consecutive runs green
      (269 passing, 6 pending, 0 failing).
- [x] `npx vscode-test -g 'chunk commands'` in isolation: 31/31 green.
- [x] TypeScript compile clean.
- [x] Codex adversarial review pass; all 7 findings addressed:
      sandbox-detection CI gate, active re-focus in `awaitActive`,
      URI comparison, third 700K-row test, narrower iframe-test skip,
      `inspect-commands.test.ts` parallel fix, accurate root-cause
      comments.
- [ ] CI green on GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and stability by reducing race conditions in editor activation sequences.
  * Added conditional test skipping for sandbox environments to prevent non-deterministic timeouts.

* **Documentation**
  * Updated development guidance with notes on VS Code editor state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->