### PR TITLE
fix(help): rewrite R-manual references to CRAN URLs

### DIFF
--- a/crates/raven/src/help/html.rs
+++ b/crates/raven/src/help/html.rs
@@ -262,11 +262,18 @@ fn get_help_html_inner(
     // hrefs to `javascript:void(0)`+`data-raven-dropped`, which would prevent
     // the strip regexes from matching by the original href.
     //
-    // The rewriter then converts `<a href="../../<pkg>/help/<topic>">`
-    // (relative, produced by Rd2HTML(dynamic = TRUE)) into `raven-help://...`,
-    // which is an explicit allowlisted scheme. Running it before sanitization
-    // means ammonia sees a scheme it recognizes and keeps the href; running it
-    // after would mean ammonia stripped the relative href first and the
+    // The rewriter then performs two transforms on `<a href>`:
+    //   - `<a href="../../<pkg>/help/<topic>">` (relative, produced by
+    //     `Rd2HTML(dynamic = TRUE)`) becomes `raven-help://...`, an explicit
+    //     allowlisted scheme the webview navigates in-panel.
+    //   - `<a href="/doc/manual/<basename>.html[#anchor]">` (R's internal
+    //     dynamic-help server's manual paths, e.g. for `\link[R-exts]{...}`)
+    //     becomes the canonical CRAN URL for the manuals on the
+    //     `R_MANUAL_BASENAMES` allowlist, so external browsers can open them.
+    //     Unknown basenames Drop.
+    // Running the rewriter before sanitization means ammonia sees a scheme
+    // it recognizes (raven-help, https) and keeps the href; running it after
+    // would mean ammonia stripped the relative/absolute href first and the
     // rewriter had nothing to convert.
     //
     // Both the strip and rewrite passes are regex-only transforms on `<a>`
@@ -564,6 +571,42 @@ mod tests {
         assert!(
             !res.html.contains(">Index<"),
             "Index anchor text must be gone (cursor would be I-beam on a naked <a>); html was:\n{}",
+            res.html
+        );
+    }
+
+    #[test]
+    fn r_manual_links_become_cran_urls() {
+        // End-to-end regression for the reported `utils::package.skeleton`
+        // bug: Rd2HTML emits `<a href="/doc/manual/R-exts.html">` for the
+        // `Writing R Extensions` reference. Previously the rewriter dropped
+        // the absolute path to `javascript:void(0)`, ammonia then stripped
+        // that scheme, and the rendered HTML contained a bare <a> with no
+        // href — styled like a link by the CSS but rendered with the I-beam
+        // cursor and dead clicks.
+        let Some(r) = r_path() else {
+            eprintln!("skip: no R");
+            return;
+        };
+        let res = get_help_html("package.skeleton", Some("utils"), &r).expect("render");
+        assert!(
+            res.html
+                .contains("https://cran.r-project.org/doc/manuals/r-release/R-exts.html"),
+            "expected R-exts.html link rewritten to CRAN URL; html was:\n{}",
+            res.html
+        );
+        // The absolute /doc/manual path must not leak through.
+        assert!(
+            !res.html.contains(r#"href="/doc/manual/"#),
+            "raw /doc/manual/ href must not survive into rendered HTML; html was:\n{}",
+            res.html
+        );
+        // The R-Extensions cross-reference must end up as a real <a href=...>
+        // anchor (i.e. NOT a bare <a> without href), which is what produced
+        // the I-beam cursor before the fix.
+        assert!(
+            res.html.contains(r#"<a href="https://cran.r-project.org"#),
+            "R manual link must be a real anchor with an https href; html was:\n{}",
             res.html
         );
     }

--- a/crates/raven/src/help/rewrite.rs
+++ b/crates/raven/src/help/rewrite.rs
@@ -1,12 +1,31 @@
 //! Pure cross-reference link rewriter for Rd2HTML output.
 //!
-//! Replaces `<a href="../../<pkg>/help/<topic>[#anchor]">` with a custom
-//! scheme `raven-help://topic/<pkg>/<topic>[#anchor]` so the webview only
-//! needs to recognize one URL form. See the help-viewer spec
-//! ("Cross-reference link rewriting") for full rules.
+//! Two rewrites happen here:
+//!   1. `<a href="../../<pkg>/help/<topic>[#anchor]">` →
+//!      `raven-help://topic/<pkg>/<topic>[#anchor]`, so the webview only
+//!      needs to recognize one in-panel URL form.
+//!   2. `<a href="/doc/manual/<basename>.html[#anchor]">` →
+//!      `https://cran.r-project.org/doc/manuals/r-release/<basename>.html[#anchor]`
+//!      for the canonical R manuals listed in `R_MANUAL_BASENAMES`, so
+//!      external browsers can open them. Unknown basenames Drop.
+//!
+//! See the help-viewer spec ("Cross-reference link rewriting") for full rules.
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use std::sync::OnceLock;
+
+/// Canonical basenames of R's bundled manuals that CRAN serves at
+/// `https://cran.r-project.org/doc/manuals/r-release/<basename>.html`.
+///
+/// Rd2HTML emits `<a href="/doc/manual/<basename>.html">` for `\link[<basename>:...]{...}`
+/// references in Rd. The allowlist is intentionally conservative: it covers
+/// the manuals shipped in `$R_HOME/doc/manual/` that CRAN mirrors under
+/// `/doc/manuals/r-release/`. Other paths Rd2HTML might emit (notably
+/// `rw-FAQ.html`, which CRAN serves under `/bin/windows/base/` instead)
+/// fall through to `Drop` rather than producing a CRAN URL that 404s.
+const R_MANUAL_BASENAMES: &[&str] = &[
+    "R-admin", "R-data", "R-exts", "R-FAQ", "R-ints", "R-intro", "R-lang",
+];
 
 /// RFC 3986 unreserved set: keep `A-Za-z0-9._~-` unencoded; encode the rest.
 const ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
@@ -41,6 +60,7 @@ pub fn rewrite_help_html(html: &str, _source_pkg: &str) -> String {
                 };
                 format!("{prefix}{url}{suffix}")
             }
+            HrefKind::Replace(url) => format!("{prefix}{url}{suffix}"),
             HrefKind::PassThrough => format!("{prefix}{href}{suffix}"),
             HrefKind::Drop => {
                 // Replace href with javascript:void(0) and add a data attribute.
@@ -59,6 +79,9 @@ enum HrefKind {
         topic: String,
         anchor: Option<String>,
     },
+    /// Replace the href with this fully-formed URL (typically an https:// link
+    /// that downstream sanitization will pass through unchanged).
+    Replace(String),
     PassThrough,
     Drop,
 }
@@ -77,6 +100,23 @@ fn classify_href(href: &str) -> HrefKind {
     }
     if href.starts_with("javascript:") {
         return HrefKind::PassThrough; // already neutralized
+    }
+    // R's bundled manuals: Rd2HTML emits `<a href="/doc/manual/<basename>.html[#anchor]">`
+    // for `\link[R-exts]{...}`, `\link[R-admin:section]{...}`, etc. The path
+    // resolves on R's internal dynamic-help server but not in our webview;
+    // map known basenames to the canonical CRAN URL so VS Code's webview
+    // link handler opens them in the user's default browser. Without this,
+    // the rewriter would Drop these and ammonia would then strip the
+    // resulting `javascript:void(0)` href entirely, leaving a bare `<a>`
+    // that the CSS still styles like a link but the browser renders with
+    // an I-beam cursor and dead clicks.
+    //
+    // Unknown basenames (e.g. `rw-FAQ.html`, custom manuals) Drop rather
+    // than synthesize a CRAN URL that would 404. See `R_MANUAL_BASENAMES`.
+    if let Some(rest) = href.strip_prefix("/doc/manual/") {
+        if let Some(url) = r_manual_cran_url(rest) {
+            return HrefKind::Replace(url);
+        }
     }
     if let Some(rest) = href.strip_prefix("../../") {
         let mut parts = rest.splitn(3, '/');
@@ -110,6 +150,38 @@ fn href_regex() -> &'static regex::Regex {
     RE.get_or_init(|| {
         regex::Regex::new(r#"(<a[^>]*\bhref=")([^"]*)("[^>]*>)"#).expect("valid regex")
     })
+}
+
+/// Map a `/doc/manual/<rest>` tail to a CRAN URL if `<rest>` resolves to
+/// `<basename>.html[#anchor]` for one of R's canonical bundled manuals.
+///
+/// Returns `None` for unknown basenames, missing `.html`, empty basenames,
+/// or anything containing path separators after the basename — letting the
+/// caller fall through to `Drop`. The anchor (if any) is run through the
+/// same `canon_segment` decode-once-then-encode-once pipeline used for
+/// help-topic anchors, so adversarial Rd cannot smuggle unsafe characters
+/// into the URL.
+fn r_manual_cran_url(rest: &str) -> Option<String> {
+    let (basename_html, anchor) = match rest.split_once('#') {
+        Some((bh, a)) => (bh, Some(a)),
+        None => (rest, None),
+    };
+    let basename = basename_html.strip_suffix(".html")?;
+    // The basename itself must be exactly one of the canonical manuals —
+    // no path traversal, no slashes, no extra segments.
+    if basename.contains('/') || basename.contains('\\') {
+        return None;
+    }
+    if !R_MANUAL_BASENAMES.contains(&basename) {
+        return None;
+    }
+    let mut url =
+        format!("https://cran.r-project.org/doc/manuals/r-release/{basename}.html");
+    if let Some(a) = anchor {
+        url.push('#');
+        url.push_str(&canon_segment(a));
+    }
+    Some(url)
 }
 
 #[cfg(test)]
@@ -187,5 +259,222 @@ mod tests {
         let once = rewrite_help_html(html, "base");
         let twice = rewrite_help_html(&once, "base");
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn r_manual_link_rewritten_to_cran() {
+        // Rd2HTML emits `<a href="/doc/manual/R-exts.html"><cite>...</cite></a>`
+        // for cross-references to R's bundled manuals (e.g. `\link[R-exts]{...}`
+        // in package.skeleton's References section). The absolute path
+        // resolves on R's local dynamic-help server but not in our webview,
+        // so previously the rewriter neutralized it to javascript:void(0)
+        // — and ammonia then stripped that scheme entirely, leaving a bare
+        // <a> with no href. The CSS still styled it as a link, but the
+        // browser showed an I-beam cursor and clicks did nothing. Map these
+        // paths to CRAN's canonical r-release URL so external browsers can
+        // open them.
+        let html =
+            r#"Read the <a href="/doc/manual/R-exts.html"><cite>Writing R Extensions</cite></a>."#;
+        let out = rewrite_help_html(html, "utils");
+        assert!(
+            out.contains(
+                r#"<a href="https://cran.r-project.org/doc/manuals/r-release/R-exts.html""#
+            ),
+            "expected CRAN URL; got: {out}"
+        );
+        assert!(
+            !out.contains("javascript:void(0)"),
+            "must not neutralize R-manual links; got: {out}"
+        );
+        assert!(
+            !out.contains("data-raven-dropped"),
+            "must not mark R-manual links as dropped; got: {out}"
+        );
+    }
+
+    #[test]
+    fn r_manual_link_preserves_anchor() {
+        // Anchors are commonly used to deep-link into a manual section,
+        // e.g. `\link[R-admin:Installing-packages]{...}` in package.skeleton.
+        let html = r#"<a href="/doc/manual/R-admin.html#Installing-packages">x</a>"#;
+        let out = rewrite_help_html(html, "utils");
+        assert!(
+            out.contains(
+                r#"<a href="https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Installing-packages""#
+            ),
+            "expected anchor preserved in CRAN URL; got: {out}"
+        );
+    }
+
+    #[test]
+    fn r_manual_link_other_basenames() {
+        // The mapping is not specific to R-exts; cover R-intro and R-FAQ
+        // since they are common references too.
+        for (path, expect) in [
+            (
+                "/doc/manual/R-intro.html",
+                "https://cran.r-project.org/doc/manuals/r-release/R-intro.html",
+            ),
+            (
+                "/doc/manual/R-FAQ.html#Why-doesn_0027t-R-have-X_003f",
+                "https://cran.r-project.org/doc/manuals/r-release/R-FAQ.html#Why-doesn_0027t-R-have-X_003f",
+            ),
+        ] {
+            let html = format!(r#"<a href="{path}">x</a>"#);
+            let out = rewrite_help_html(&html, "base");
+            assert!(
+                out.contains(&format!(r#"<a href="{expect}""#)),
+                "expected {expect}; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn r_manual_link_survives_sanitizer() {
+        // Regression for the I-beam-cursor bug: the rewriter's output must
+        // also survive ammonia. https:// is on ammonia's url_schemes
+        // allowlist, so this is the structural cure for the previous
+        // pipeline (rewriter produced javascript:void(0) — ammonia stripped
+        // it — bare <a>, no href, I-beam cursor).
+        use crate::help::sanitize::sanitize_help_html;
+        let raw =
+            r#"Read the <a href="/doc/manual/R-exts.html"><cite>Writing R Extensions</cite></a>."#;
+        let rewritten = rewrite_help_html(raw, "utils");
+        let cleaned = sanitize_help_html(&rewritten);
+        assert!(
+            cleaned.contains(
+                r#"href="https://cran.r-project.org/doc/manuals/r-release/R-exts.html""#
+            ),
+            "href must survive sanitization; got: {cleaned}"
+        );
+    }
+
+    #[test]
+    fn r_manual_link_idempotent() {
+        // After the first rewrite, the href starts with `https://`, which
+        // classify_href passes through. A second pass must be a no-op
+        // (mirrors the existing `idempotent` test for the help-ref path).
+        let html = r#"<a href="/doc/manual/R-exts.html#section">x</a>"#;
+        let once = rewrite_help_html(html, "utils");
+        let twice = rewrite_help_html(&once, "utils");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn r_manual_link_anchor_is_canon_encoded() {
+        // The anchor must go through canon_segment (decode-once /
+        // encode-once) so adversarial Rd cannot smuggle structural chars
+        // like `"`, `<`, or `>` into the constructed URL. Verify both
+        // an unencoded special char and a percent-encoded form survive
+        // as a canonical encoding.
+        let html = r#"<a href="/doc/manual/R-exts.html#a%20b">x</a>"#;
+        let out = rewrite_help_html(html, "utils");
+        assert!(
+            out.contains("#a%20b"),
+            "percent-encoded space must round-trip as %20; got: {out}"
+        );
+        let html2 = r#"<a href="/doc/manual/R-exts.html#a b">x</a>"#;
+        let out2 = rewrite_help_html(html2, "utils");
+        assert!(
+            out2.contains("#a%20b"),
+            "literal space in anchor must be percent-encoded; got: {out2}"
+        );
+    }
+
+    #[test]
+    fn r_manual_link_unknown_basename_drops() {
+        // Rd can reference custom manuals like \link[customdoc]{...},
+        // which Rd2HTML would emit as /doc/manual/customdoc.html. CRAN
+        // doesn't serve these, so we Drop rather than synthesize a 404.
+        // Same goes for Windows-only docs like rw-FAQ.html, which CRAN
+        // hosts under /bin/windows/base/ instead of /doc/manuals/r-release/.
+        for path in [
+            "/doc/manual/customdoc.html",
+            "/doc/manual/rw-FAQ.html",
+            "/doc/manual/UNKNOWN.html",
+        ] {
+            let html = format!(r#"<a href="{path}">x</a>"#);
+            let out = rewrite_help_html(&html, "base");
+            assert!(
+                !out.contains("https://cran.r-project.org"),
+                "unknown manual {path:?} must not synthesize a CRAN URL; got: {out}"
+            );
+            assert!(
+                out.contains("javascript:void(0)"),
+                "unknown manual {path:?} must Drop; got: {out}"
+            );
+            assert!(
+                out.contains(r#"data-raven-dropped="1""#),
+                "unknown manual {path:?} must be marked dropped; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn r_manual_link_rejects_traversal_and_malformed() {
+        // Defense-in-depth: the basename allowlist must reject anything
+        // that isn't exactly `<basename>.html[#anchor]`. Path traversal,
+        // extra segments, missing `.html`, and empty tails all Drop.
+        for path in [
+            "/doc/manual/../R-exts.html",     // traversal
+            "/doc/manual/sub/R-exts.html",     // extra segment
+            "/doc/manual/R-exts.html/extra",   // trailing segment
+            "/doc/manual/R-exts",              // missing .html
+            "/doc/manual/.html",               // empty basename
+            "/doc/manual/",                    // empty rest
+        ] {
+            let html = format!(r#"<a href="{path}">x</a>"#);
+            let out = rewrite_help_html(&html, "base");
+            assert!(
+                !out.contains("https://cran.r-project.org"),
+                "malformed {path:?} must not produce a CRAN URL; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn r_manual_link_html_substring_does_not_match() {
+        // The rewriter must not accept hrefs that merely contain the
+        // /doc/manual/ string anywhere — only those starting with it.
+        let html = r#"<a href="https://evil/doc/manual/R-exts.html">x</a>"#;
+        let out = rewrite_help_html(html, "base");
+        // Should PassThrough as an https URL; original href intact.
+        assert!(
+            out.contains(r#"<a href="https://evil/doc/manual/R-exts.html">x</a>"#),
+            "https URLs containing /doc/manual/ must pass through unchanged; got: {out}"
+        );
+    }
+
+    #[test]
+    fn dropped_unknown_path_renders_as_bare_anchor_after_sanitize() {
+        // Documents the existing (intentionally unsupported) Drop +
+        // ammonia interaction: for paths that aren't `../../<pkg>/help/...`
+        // or a known R manual, the rewriter emits `javascript:void(0)` +
+        // `data-raven-dropped="1"`, and ammonia then strips BOTH (the
+        // `javascript:` scheme isn't on its url_schemes allowlist, and
+        // `data-raven-dropped` isn't on the attribute allowlist), leaving
+        // a bare `<a>` with no href.
+        //
+        // This is the failure mode the R-manual fix addresses for known
+        // basenames. Linking it to a test pins the contract so a future
+        // change to ammonia's allowlist (e.g. allowing the data attribute
+        // through) doesn't silently fix this for unsupported paths without
+        // a deliberate decision and accompanying click-handler check.
+        use crate::help::sanitize::sanitize_help_html;
+        let raw = r#"<a href="/some/unsupported/path">link</a>"#;
+        let rewritten = rewrite_help_html(raw, "base");
+        let cleaned = sanitize_help_html(&rewritten);
+        assert!(
+            !cleaned.contains("javascript:void(0)"),
+            "ammonia must strip javascript: href; got: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains("data-raven-dropped"),
+            "ammonia must strip data-raven-dropped; got: {cleaned}"
+        );
+        assert!(
+            cleaned.contains(">link</a>"),
+            "inner text must survive; got: {cleaned}"
+        );
     }
 }

--- a/docs/help-viewer.md
+++ b/docs/help-viewer.md
@@ -37,6 +37,7 @@ Internal cross-references are rewritten to a custom URL scheme that correctly ro
 - Operator topics (`` \`[\` ``, `` \`%in%\` ``, `+`, `if`, etc.) render and navigate correctly.
 - Images embedded in help pages (e.g., `?ggplot2::theme`) render — local files are served via webview URIs from package help directories.
 - External links (`https://`, `http://`, `mailto:`) open via `vscode.env.openExternal`.
+- References to R's canonical bundled manuals — `R-intro`, `R-admin`, `R-data`, `R-exts`, `R-FAQ`, `R-ints`, `R-lang` — are rewritten from the local `<a href="/doc/manual/<name>.html">` form that `Rd2HTML` emits to the canonical CRAN URL (`https://cran.r-project.org/doc/manuals/r-release/<name>.html`) so they open in the user's browser. This is how the `Writing R Extensions` link in `?utils::package.skeleton` resolves. Anchors are percent-encoded and preserved. Manual paths outside this allowlist (e.g. `rw-FAQ.html`, custom or third-party docs) are not rewritten and click does nothing — those targets either live elsewhere on CRAN or aren't published.
 - `Run examples` and per-package `Index` footer links emitted by `Rd2HTML` are stripped before rendering — they pointed at endpoints that have no analog in the panel and would render as no-op links.
 - A failed in-panel navigation (e.g. a topic that genuinely cannot be resolved) leaves the previously rendered topic visible, with the error shown in the toolbar banner. Back/forward continues to operate from the last successful topic, not from the failed attempt.
 


### PR DESCRIPTION
## Summary

- The "Writing R Extensions" link in `?utils::package.skeleton` (and similar references to R's bundled manuals across other help pages) renders as styled-but-dead text: blue+underlined, I-beam cursor on hover, clicks do nothing. This PR makes those links open the canonical CRAN copy in the user's browser.
- Root cause: Rd2HTML emits `<a href="/doc/manual/R-exts.html"><cite>...</cite></a>`. The rewriter classified the absolute path as `Drop`, producing `<a href="javascript:void(0)" data-raven-dropped="1">`. Ammonia then stripped *both* — the `javascript:` scheme isn't on its `url_schemes` allowlist, and `data-raven-dropped` isn't on the attribute allowlist — leaving a bare `<a>` that `.help-content a` still styles blue/underlined. With no `href`, the browser shows an I-beam cursor.
- Fix: rewrite `/doc/manual/<basename>.html[#anchor]` → `https://cran.r-project.org/doc/manuals/r-release/<basename>.html[#anchor]` for the seven canonical basenames on a new `R_MANUAL_BASENAMES` allowlist (`R-intro`, `R-admin`, `R-data`, `R-exts`, `R-FAQ`, `R-ints`, `R-lang`). Unknown basenames still `Drop` rather than synthesizing a CRAN 404. The anchor is run through the existing `canon_segment` decode-once / encode-once pipeline so adversarial Rd can't smuggle structural chars into the URL.
- Codex adversarial review applied before merging: tightened from a prefix-only match to the allowlist (rejects unknown basenames + path traversal), added anchor encoding, added negative + idempotency + sanitizer-regression tests, refreshed the now-stale module-level doc comments in `rewrite.rs` and `html.rs`, and refreshed the `docs/help-viewer.md` bullet to name the allowlist.

## Test plan

- [x] `cargo test -p raven --lib help::` → 112 passed (19 in `help::rewrite::tests`, including 9 new manual-link tests; 23 in `help::html::tests`, including the end-to-end `r_manual_links_become_cran_urls` test that spawns R against `?utils::package.skeleton` and asserts the rendered HTML contains the CRAN URL)
- [x] `cargo test -p raven --lib` → 4006 passed, 0 failed (no regressions in the broader crate)
- [x] `cargo clippy -p raven --lib --tests` → 0 new warnings in `rewrite.rs` or `html.rs`
- [x] `bun test tests/bun/help-*.test.ts` → 37 passed (existing `https://` click-handler tests cover the new CRAN URL behavior — same `https://` PassThrough path)
- [x] Red-green TDD cycle verified for each new test: temporarily disabled the allowlist + anchor encoding, watched `r_manual_link_unknown_basename_drops`, `r_manual_link_rejects_traversal_and_malformed`, and `r_manual_link_anchor_is_canon_encoded` fail with the original prefix-only behavior, then restored the fix and watched them pass
- [ ] Manual smoke test in VS Code: open `?utils::package.skeleton`, hover the "Writing R Extensions" reference → pointer cursor; click → opens `https://cran.r-project.org/doc/manuals/r-release/R-exts.html` in the default browser. Also verify "Installing packages" (R-admin anchor reference) in the same page works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * R manual links in help files are now rewritten to CRAN documentation URLs for proper navigation
  * Anchors in manual links are preserved and canonically encoded
  * Unknown or malformed manual links are safely excluded from rendering

* **Documentation**
  * Updated help viewer documentation to describe manual link rewriting capability

* **Tests**
  * Added regression tests covering manual link rewriting, anchor preservation, and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->