### PR TITLE
feat(knit): add Open in Editor button and remote-aware Download on export toast

### DIFF
--- a/docs/knit.md
+++ b/docs/knit.md
@@ -234,8 +234,22 @@ button.
 The exported file is written next to the source `.Rmd` as
 `<basename>.{html,pdf,docx}`. Writes are atomic (temp file + rename),
 so a cancelled or failed export never corrupts a prior successful
-output. A notification offers an "Open in Browser" / "View PDF" /
-"Open in Word" button on success.
+output. A notification offers two buttons on success:
+
+- A format-specific external-open button — **Open in Browser**
+  (`html`), **Open PDF** (`pdf`), or **Open in Word** (`docx`) — which
+  hands the file to the OS default handler. In a remote workspace
+  (Remote SSH, Dev Containers, WSL, Codespaces) this button is
+  replaced with **Download**, which reveals the file in the file
+  explorer and runs VS Code's built-in `explorer.download` to copy
+  it from the remote machine to a local path you pick; the
+  OS-handler buttons can't reach your local apps from a remote
+  workspace.
+- **Open in Editor**, which opens the file inside your editor via
+  `vscode.open`. Useful when you don't want to leave the editor, or
+  on a remote workspace as an alternative to downloading. The viewing
+  experience for PDF/Word depends on whichever editor or extension
+  the host has registered for that file type.
 
 PDF export uses the LaTeX engine configured at `raven.pandoc.pdfEngine`
 (default `xelatex`). If the engine isn't found Raven surfaces an

--- a/editors/vscode/src/knit/open-exported-file.ts
+++ b/editors/vscode/src/knit/open-exported-file.ts
@@ -1,10 +1,35 @@
 /**
- * Shared helper for opening a finished export (HTML, PDF, or DOCX) in
- * its OS-default handler. Mirrors the existing `openInBrowser` flow's
- * remote-workspace fallback: `vscode.env.openExternal` of a `file:` URI
- * may route to the extension-host machine instead of the user's, in
- * which case we write the path to the output channel and warn rather
- * than silently fail.
+ * Shared helper for the "Saved …" toast shown after a successful
+ * Pandoc export. The toast offers up to two actions:
+ *
+ *   - Primary, format-specific external-open button:
+ *       html → "Open in Browser", pdf → "Open PDF", docx → "Open in Word"
+ *     In a remote workspace (`vscode.env.remoteName` set — Remote SSH,
+ *     Dev Containers, WSL, Codespaces, etc.) this is replaced with
+ *     "Download", which drives VS Code's built-in `explorer.download`
+ *     command (the same one the file explorer's right-click "Download…"
+ *     uses) to stream the file from the remote machine to a local path
+ *     the user picks. `explorer.download` operates on the explorer's
+ *     current selection rather than accepting a URI argument, so we
+ *     `revealInExplorer` the saved file first to seed the selection.
+ *     The OS default handlers behind `Open in …` route through the
+ *     extension-host machine in remote workspaces and so wouldn't reach
+ *     the user's local apps.
+ *
+ *   - Secondary, format-agnostic "Open in Editor" button that runs
+ *     `vscode.commands.executeCommand('vscode.open', uri)`. Useful when
+ *     the user doesn't want to leave the editor, and as a fallback
+ *     channel in remote workspaces (and in editor forks like Positron,
+ *     Cursor, or VSCodium — hence "Open in Editor", not "Open in VS
+ *     Code"). The actual viewing experience for PDF/DOCX depends on
+ *     whichever default editor / extension the host has registered for
+ *     that file type.
+ *
+ * Every action funnels through a small fallback: if the underlying
+ * VS Code API throws or returns false we log the file path to the
+ * "Raven: Knit" output channel and surface a warning toast — the
+ * rendered file is still on disk, the user just needs to reach it via a
+ * different channel.
  */
 
 import * as path from 'path';
@@ -12,37 +37,50 @@ import * as vscode from 'vscode';
 
 export type ExportFormat = 'html' | 'pdf' | 'docx';
 
-const LABELS: Record<ExportFormat, string> = {
+const OPEN_LABELS: Record<ExportFormat, string> = {
     html: 'Open in Browser',
-    pdf: 'View PDF',
+    pdf: 'Open PDF',
     docx: 'Open in Word',
 };
-
-export interface OpenExportedFileOptions {
-    /**
-     * Set to `false` to skip the "Saved …" info toast and go straight
-     * to the open-external call. The existing `openInBrowser` flow uses
-     * this for the toolbar button — the panel itself is the "you have
-     * a result" signal there.
-     */
-    showSavedToast?: boolean;
-}
+const DOWNLOAD_LABEL = 'Download';
+const OPEN_IN_EDITOR_LABEL = 'Open in Editor';
 
 export async function openExportedFile(
     savedUri: vscode.Uri,
     format: ExportFormat,
     output: vscode.OutputChannel,
-    options: OpenExportedFileOptions = {},
 ): Promise<void> {
-    const label = LABELS[format];
-    if (options.showSavedToast !== false) {
-        const action = await vscode.window.showInformationMessage(
-            `Saved ${path.basename(savedUri.fsPath)}`,
-            label,
-        );
-        if (action !== label) return;
-    }
+    const remote = isRemoteWorkspace();
+    const primaryLabel = remote ? DOWNLOAD_LABEL : OPEN_LABELS[format];
 
+    const action = await vscode.window.showInformationMessage(
+        `Saved ${path.basename(savedUri.fsPath)}`,
+        primaryLabel,
+        OPEN_IN_EDITOR_LABEL,
+    );
+    if (action === undefined) return;
+
+    if (action === DOWNLOAD_LABEL) {
+        await downloadFile(savedUri, output);
+        return;
+    }
+    if (action === OPEN_IN_EDITOR_LABEL) {
+        await openInEditor(savedUri, output);
+        return;
+    }
+    await openExternal(savedUri, primaryLabel, output);
+}
+
+function isRemoteWorkspace(): boolean {
+    const name = vscode.env.remoteName;
+    return typeof name === 'string' && name.length > 0;
+}
+
+async function openExternal(
+    savedUri: vscode.Uri,
+    label: string,
+    output: vscode.OutputChannel,
+): Promise<void> {
     let opened = false;
     try {
         opened = await vscode.env.openExternal(savedUri);
@@ -56,4 +94,43 @@ export async function openExportedFile(
     void vscode.window.showWarningMessage(
         `${label} is not available for this workspace. The file path has been written to the Raven: Knit output channel.`,
     );
+}
+
+async function openInEditor(
+    savedUri: vscode.Uri,
+    output: vscode.OutputChannel,
+): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('vscode.open', savedUri);
+    } catch (err) {
+        output.appendLine(
+            `[Export] vscode.open threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        output.appendLine(`[Export] Output is at: ${savedUri.fsPath}`);
+        void vscode.window.showWarningMessage(
+            `${OPEN_IN_EDITOR_LABEL} failed. The file path has been written to the Raven: Knit output channel.`,
+        );
+    }
+}
+
+async function downloadFile(
+    savedUri: vscode.Uri,
+    output: vscode.OutputChannel,
+): Promise<void> {
+    try {
+        // `explorer.download` reads the explorer's current selection
+        // instead of accepting a URI argument, so we seed the selection
+        // via `revealInExplorer` first. Awaiting the reveal ensures the
+        // selection is in place before download fires.
+        await vscode.commands.executeCommand('revealInExplorer', savedUri);
+        await vscode.commands.executeCommand('explorer.download');
+    } catch (err) {
+        output.appendLine(
+            `[Export] download command threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        output.appendLine(`[Export] Output is at: ${savedUri.fsPath}`);
+        void vscode.window.showWarningMessage(
+            `${DOWNLOAD_LABEL} is not available for this workspace. The file path has been written to the Raven: Knit output channel.`,
+        );
+    }
 }

--- a/tests/bun/open-exported-file.test.ts
+++ b/tests/bun/open-exported-file.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { openExportedFile, type ExportFormat } from '../../editors/vscode/src/knit/open-exported-file';
+
+const state: {
+    remoteName: string | undefined;
+    infoMessageLabels: string[];
+    infoMessageResponse: string | undefined;
+    warningMessages: string[];
+    executedCommands: Array<{ id: string; args: unknown[] }>;
+    executeCommandImpl: ((id: string, ...args: unknown[]) => unknown) | undefined;
+    openExternalResult: boolean;
+    openExternalImpl: ((uri: unknown) => Promise<boolean>) | undefined;
+    outputLines: string[];
+} = {
+    remoteName: undefined,
+    infoMessageLabels: [],
+    infoMessageResponse: undefined,
+    warningMessages: [],
+    executedCommands: [],
+    executeCommandImpl: undefined,
+    openExternalResult: true,
+    openExternalImpl: undefined,
+    outputLines: [],
+};
+
+mock.module('vscode', () => ({
+    Uri: {
+        file: (fsPath: string) => ({ fsPath, path: fsPath, scheme: 'file', toString: () => `file://${fsPath}` }),
+    },
+    commands: {
+        executeCommand: async (id: string, ...args: unknown[]) => {
+            state.executedCommands.push({ id, args });
+            if (state.executeCommandImpl) return state.executeCommandImpl(id, ...args);
+            return undefined;
+        },
+    },
+    env: {
+        get remoteName() {
+            return state.remoteName;
+        },
+        openExternal: async (uri: unknown) => {
+            if (state.openExternalImpl) return state.openExternalImpl(uri);
+            return state.openExternalResult;
+        },
+    },
+    window: {
+        showInformationMessage: async (_message: string, ...labels: string[]) => {
+            state.infoMessageLabels.push(...labels);
+            return state.infoMessageResponse;
+        },
+        showWarningMessage: async (message: string) => {
+            state.warningMessages.push(message);
+            return undefined;
+        },
+    },
+}));
+
+function outputChannel() {
+    return {
+        append() {},
+        appendLine: (line: string) => state.outputLines.push(line),
+        show() {},
+    };
+}
+
+function fileUri(fsPath: string) {
+    return { fsPath, path: fsPath, scheme: 'file', toString: () => `file://${fsPath}` };
+}
+
+beforeEach(() => {
+    state.remoteName = undefined;
+    state.infoMessageLabels = [];
+    state.infoMessageResponse = undefined;
+    state.warningMessages = [];
+    state.executedCommands = [];
+    state.executeCommandImpl = undefined;
+    state.openExternalResult = true;
+    state.openExternalImpl = undefined;
+    state.outputLines = [];
+});
+
+describe('openExportedFile — local workspace', () => {
+    it.each<[ExportFormat, string]>([
+        ['html', 'Open in Browser'],
+        ['pdf', 'Open PDF'],
+        ['docx', 'Open in Word'],
+    ])(
+        'offers "%s → %s" as the primary button',
+        async (format: ExportFormat, expectedPrimary: string) => {
+            state.remoteName = undefined;
+            state.infoMessageResponse = undefined;
+            await openExportedFile(fileUri('/tmp/report.out') as never, format, outputChannel() as never);
+            expect(state.infoMessageLabels).toEqual([expectedPrimary, 'Open in Editor']);
+        },
+    );
+
+    it('does not include "Download" in any local label set', async () => {
+        for (const format of ['html', 'pdf', 'docx'] as ExportFormat[]) {
+            state.remoteName = undefined;
+            state.infoMessageLabels = [];
+            state.infoMessageResponse = undefined;
+            await openExportedFile(fileUri('/tmp/report.out') as never, format, outputChannel() as never);
+            expect(state.infoMessageLabels).not.toContain('Download');
+        }
+    });
+
+    it('primary "Open in …" calls vscode.env.openExternal with the saved URI', async () => {
+        state.remoteName = undefined;
+        state.infoMessageResponse = 'Open PDF';
+        const calls: unknown[] = [];
+        state.openExternalImpl = async (uri) => {
+            calls.push(uri);
+            return true;
+        };
+        await openExportedFile(fileUri('/tmp/report.pdf') as never, 'pdf', outputChannel() as never);
+        expect(calls).toHaveLength(1);
+        expect((calls[0] as { fsPath: string }).fsPath).toBe('/tmp/report.pdf');
+        expect(state.executedCommands).toEqual([]);
+        expect(state.warningMessages).toEqual([]);
+    });
+
+    it('warns when openExternal returns false', async () => {
+        state.remoteName = undefined;
+        state.infoMessageResponse = 'Open in Browser';
+        state.openExternalResult = false;
+        await openExportedFile(fileUri('/tmp/report.html') as never, 'html', outputChannel() as never);
+        expect(state.warningMessages).toHaveLength(1);
+        expect(state.warningMessages[0]).toContain('Open in Browser');
+        expect(state.warningMessages[0]).toContain('Raven: Knit output channel');
+    });
+
+    it('does nothing when the user dismisses the toast', async () => {
+        state.remoteName = undefined;
+        state.infoMessageResponse = undefined;
+        await openExportedFile(fileUri('/tmp/report.html') as never, 'html', outputChannel() as never);
+        expect(state.executedCommands).toEqual([]);
+        expect(state.warningMessages).toEqual([]);
+    });
+});
+
+describe('openExportedFile — Open in Editor', () => {
+    it.each<ExportFormat>(['html', 'pdf', 'docx'])(
+        'invokes vscode.open with the saved URI for format=%s (local)',
+        async (format: ExportFormat) => {
+            state.remoteName = undefined;
+            state.infoMessageResponse = 'Open in Editor';
+            await openExportedFile(fileUri('/tmp/report.out') as never, format, outputChannel() as never);
+            expect(state.executedCommands).toHaveLength(1);
+            expect(state.executedCommands[0].id).toBe('vscode.open');
+            expect((state.executedCommands[0].args[0] as { fsPath: string }).fsPath).toBe('/tmp/report.out');
+        },
+    );
+
+    it('invokes vscode.open in a remote workspace too', async () => {
+        state.remoteName = 'ssh-remote';
+        state.infoMessageResponse = 'Open in Editor';
+        await openExportedFile(fileUri('/home/user/report.html') as never, 'html', outputChannel() as never);
+        expect(state.executedCommands).toHaveLength(1);
+        expect(state.executedCommands[0].id).toBe('vscode.open');
+    });
+
+    it('warns when vscode.open throws', async () => {
+        state.remoteName = undefined;
+        state.infoMessageResponse = 'Open in Editor';
+        state.executeCommandImpl = (id: string) => {
+            if (id === 'vscode.open') throw new Error('boom');
+            return undefined;
+        };
+        await openExportedFile(fileUri('/tmp/report.html') as never, 'html', outputChannel() as never);
+        expect(state.warningMessages).toHaveLength(1);
+        expect(state.warningMessages[0]).toContain('Open in Editor');
+    });
+});
+
+describe('openExportedFile — remote workspace', () => {
+    it.each<string>([
+        'ssh-remote',
+        'dev-container',
+        'attached-container',
+        'wsl',
+        'codespaces',
+    ])('swaps the primary button to "Download" when remoteName=%s', async (remoteName: string) => {
+        state.remoteName = remoteName;
+        state.infoMessageResponse = undefined;
+        for (const format of ['html', 'pdf', 'docx'] as ExportFormat[]) {
+            state.infoMessageLabels = [];
+            await openExportedFile(fileUri('/home/user/report.out') as never, format, outputChannel() as never);
+            expect(state.infoMessageLabels).toEqual(['Download', 'Open in Editor']);
+        }
+    });
+
+    it('Download seeds the explorer selection then invokes explorer.download', async () => {
+        // `explorer.download` reads the explorer's current selection
+        // instead of accepting a URI argument, so we expect a
+        // `revealInExplorer(savedUri)` call to fire first, then a bare
+        // `explorer.download` with no args. The reveal must complete
+        // (i.e. resolve) before the download runs.
+        state.remoteName = 'ssh-remote';
+        state.infoMessageResponse = 'Download';
+        await openExportedFile(fileUri('/home/user/report.pdf') as never, 'pdf', outputChannel() as never);
+        expect(state.executedCommands).toHaveLength(2);
+        expect(state.executedCommands[0].id).toBe('revealInExplorer');
+        expect((state.executedCommands[0].args[0] as { fsPath: string }).fsPath).toBe('/home/user/report.pdf');
+        expect(state.executedCommands[1].id).toBe('explorer.download');
+        expect(state.executedCommands[1].args).toEqual([]);
+    });
+
+    it('does not run explorer.download if revealInExplorer throws', async () => {
+        state.remoteName = 'ssh-remote';
+        state.infoMessageResponse = 'Download';
+        state.executeCommandImpl = (id: string) => {
+            if (id === 'revealInExplorer') throw new Error('no such command');
+            return undefined;
+        };
+        await openExportedFile(fileUri('/home/user/report.docx') as never, 'docx', outputChannel() as never);
+        expect(state.executedCommands.map((c) => c.id)).toEqual(['revealInExplorer']);
+        expect(state.warningMessages).toHaveLength(1);
+        expect(state.warningMessages[0]).toContain('Download');
+    });
+
+    it('does not invoke openExternal when Download is chosen', async () => {
+        state.remoteName = 'ssh-remote';
+        state.infoMessageResponse = 'Download';
+        let openExternalCalls = 0;
+        state.openExternalImpl = async () => {
+            openExternalCalls += 1;
+            return true;
+        };
+        await openExportedFile(fileUri('/home/user/report.docx') as never, 'docx', outputChannel() as never);
+        expect(openExternalCalls).toBe(0);
+    });
+
+    it('warns when explorer.download throws', async () => {
+        state.remoteName = 'ssh-remote';
+        state.infoMessageResponse = 'Download';
+        state.executeCommandImpl = (id: string) => {
+            if (id === 'explorer.download') throw new Error('no such command');
+            return undefined;
+        };
+        await openExportedFile(fileUri('/home/user/report.html') as never, 'html', outputChannel() as never);
+        expect(state.warningMessages).toHaveLength(1);
+        expect(state.warningMessages[0]).toContain('Download');
+    });
+
+    it('treats remoteName="" as local', async () => {
+        state.remoteName = '';
+        await openExportedFile(fileUri('/tmp/report.html') as never, 'html', outputChannel() as never);
+        expect(state.infoMessageLabels).toEqual(['Open in Browser', 'Open in Editor']);
+    });
+});

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -40,6 +40,7 @@
   },
   "include": [
     "r-expression.test.ts",
-    "r-expression-chunk-opts.test.ts"
+    "r-expression-chunk-opts.test.ts",
+    "open-exported-file.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Three changes to the "Saved …" toast that appears after a successful Pandoc export of an `.Rmd`:

- **`View PDF` → `Open PDF`** for parallel structure with `Open in Browser` / `Open in Word`.
- **New `Open in Editor` button** (always present, all formats). Runs `vscode.commands.executeCommand('vscode.open', uri)`, so users can stay inside the editor instead of bouncing to an external app. Labelled `Open in Editor` rather than `View in VS Code` since the extension also runs in Positron, Cursor, and VSCodium.
- **`Download` swap on remote workspaces.** When `vscode.env.remoteName` is set (Remote SSH, Dev Containers, WSL, Codespaces, …), the primary `Open in …` button is replaced with `Download`. The OS handlers behind `Open in Browser` / `Open in Word` / `Open PDF` route through the extension-host machine in a remote workspace and can't reach the user's local apps, so offering them would just fail.

## Implementation notes for the reviewer

`Download` drives VS Code's built-in file-explorer download flow:

```ts
await vscode.commands.executeCommand('revealInExplorer', savedUri);
await vscode.commands.executeCommand('explorer.download');
```

This is intentional — there is **no public, URI-accepting download command** in `microsoft/vscode`. Two independent passes through the VS Code source confirmed:

- The canonical id is `explorer.download` (NOT `workbench.files.action.downloadFile`, which doesn't exist).
- Its handler signature is `(accessor: ServicesAccessor)` — args passed to `executeCommand` are silently discarded; it reads the explorer's current selection only.
- The reason we can't roll our own `showSaveDialog` + `vscode.workspace.fs.copy` flow is that the trick which makes the dialog target the **local** filesystem is `availableFileSystems: [Schemas.file]` — an option on the internal `IFileDialogService.showSaveDialog`, not exposed on the public `vscode.window.showSaveDialog`.

So the only way to give the user the right experience (local Save-As dialog, stream from remote) is to seed the explorer's selection via `revealInExplorer` and then fire `explorer.download`. UX side effect: clicking `Download` briefly focuses the file explorer with the saved file selected before the Save-As dialog opens — same flow as right-click → Download on the Remote SSH explorer.

Also removes the unused `showSavedToast` option from `openExportedFile` (no callers).

## Files

- `editors/vscode/src/knit/open-exported-file.ts` — rewrote.
- `docs/knit.md` — updated the "Exporting" section's button description.
- `tests/bun/open-exported-file.test.ts` — new, 21 cases.
- `tests/bun/tsconfig.json` — added the new test file to the include list.

## Test plan

- [x] `bun test ./tests/bun/open-exported-file.test.ts ./tests/bun/export-commands.test.ts` — 27 pass
- [x] Full `bun test` — 955 pass
- [x] `tsc --noEmit` in `editors/vscode/` — clean
- [x] `tsc --project tests/bun/tsconfig.json --noEmit` — clean
- [ ] Manual: local workspace, export to each of HTML/PDF/DOCX → toast shows `Open in <handler>` + `Open in Editor`; each button works.
- [ ] Manual: Remote SSH workspace, export to HTML → toast shows `Download` + `Open in Editor`; `Download` opens explorer + local save dialog; `Open in Editor` opens the file in a remote editor tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Export notifications now display format-specific actions: "Open in Browser" for HTML, "Open PDF" for PDF, "Open in Word" for DOCX.
  * Added "Open in Editor" option to directly open exported files.
  * Remote workspace support: primary actions intelligently switch to "Download" with improved download workflow.

* **Documentation**
  * Updated export-notification documentation with format- and environment-specific behavior details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->