### PR TITLE
fix(knit): strip YAML front matter from Knit Preview output

### DIFF
--- a/docs/knit.md
+++ b/docs/knit.md
@@ -100,10 +100,17 @@ explorer-context-menu hook is opt-in via your own keybindings).
    (`raven.knit.timeoutMs = 600000`). Windows uses `taskkill /T /F`
    instead of POSIX signals.
 10. **Post-knit render.** `knitr::knit` writes `<basename>.md` next to
-    the source. Raven reads that markdown, calls VS Code's
-    `markdown.api.render` to convert it to HTML (KaTeX math, image
-    rewriting, scroll-sync metadata, and any registered `markdown-it`
-    plugins all happen here), and then walks the result for
+    the source. Raven reads that markdown, strips the leading
+    `---...---` YAML front-matter block when the source had one
+    (otherwise VS Code's markdown renderer would wrap it in a styled
+    `<pre class="frontmatter">` box at the top of the preview — the
+    `output:` and other YAML fields are configuration, not document
+    content). The strip is gated on the source's front matter so a
+    no-YAML `.Rmd` whose first chunk emits `---…---`-shaped content
+    flows through unchanged. Raven then calls VS Code's
+    `markdown.api.render` to convert the body to HTML (KaTeX math,
+    image rewriting, scroll-sync metadata, and any registered
+    `markdown-it` plugins all happen here), and walks the result for
     `<pre><code class="language-X">` blocks. Each block is
     re-highlighted using:
 
@@ -377,6 +384,7 @@ those checks live in the runtime sanitizer only.
 | `.qmd` rendering | `quarto.quarto`'s `Quarto: Render` |
 | `.qmd` grammar / LSP | `quarto.quarto` |
 | html_document-specific YAML options (`theme`, `code_folding`, `df_print`, …) | Out of scope. Honoring them requires becoming `rmarkdown::html_document` (Bootstrap + JS runtime). Use `rmarkdown::render(...)` in the R console for full template fidelity. |
+| YAML document metadata (`title:`, `author:`, `date:`, `abstract:`, …) in the rendered preview | Out of scope. Pandoc renders these as a styled title block when it consumes the YAML; Raven's preview drops the YAML entirely along with VS Code's `<pre class="frontmatter">` artifact. Use `rmarkdown::render(...)` in the R console for a Pandoc-rendered title block. |
 | `pandoc_args:` *full* passthrough | The editor menu picks export destination (always sibling of the source `.Rmd`) and format, so `-o`/`--output`/`-t`/`--to`/`-w`/`--write` are stripped from YAML's `pandoc_args` and logged. Everything else flows through — see the honored-options table above. |
 | Custom YAML `knit:` hook dispatch | Run the hook function manually in the R console. |
 | Knit-with-Parameters dialog | Edit YAML defaults, or call `rmarkdown::render(params = list(...))`. |

--- a/editors/vscode/src/knit/knit-commands.ts
+++ b/editors/vscode/src/knit/knit-commands.ts
@@ -307,7 +307,14 @@ async function runKnitCommand(
     }
 
     // [2] Parse YAML front matter.
-    const fmText = extractFrontmatter(documentText) ?? '';
+    const fmRaw = extractFrontmatter(documentText);
+    // Whether the source document had a terminated front-matter fence
+    // at all (an empty fence counts). The post-knit renderer uses this
+    // to gate stripping the leading `---...---` block from the
+    // intermediate `.md` — see `renderKnitHtml`'s `hadSourceFrontmatter`
+    // docstring for why we must NOT strip blindly.
+    const hadSourceFrontmatter = fmRaw !== null;
+    const fmText = fmRaw ?? '';
     const parsed = parseFrontmatter(fmText);
     if (!parsed.ok) {
         output.show(true);
@@ -575,6 +582,7 @@ async function runKnitCommand(
             rBinary,
             timeoutMs,
             context,
+            hadSourceFrontmatter,
             showOrUpdatePanel: deps.showOrUpdatePanel,
             getLanguageClient: deps.getLanguageClient,
             runPostKnitRender: deps.runPostKnitRender,
@@ -606,6 +614,8 @@ interface RenderOutcomeCtx {
     rBinary: string;
     timeoutMs: number;
     context: vscode.ExtensionContext;
+    /** See the matching field on `runPostKnitRender`. */
+    hadSourceFrontmatter: boolean;
     showOrUpdatePanel: KnitDeps['showOrUpdatePanel'];
     getLanguageClient: KnitDeps['getLanguageClient'];
     runPostKnitRender: KnitDeps['runPostKnitRender'];
@@ -691,6 +701,7 @@ async function renderOutcome(outcome: KnitOutcome, ctx: RenderOutcomeCtx): Promi
             client: ctx.getLanguageClient(),
             sourceUri: ctx.sourceUri,
             sourceLanguageId: ctx.sourceLanguageId,
+            hadSourceFrontmatter: ctx.hadSourceFrontmatter,
             // The same `.html` is loaded by both the panel iframe
             // AND "Open in Browser", so the file can't carry
             // surface-specific theme logic — it's a frozen

--- a/editors/vscode/src/knit/post-knit-renderer.ts
+++ b/editors/vscode/src/knit/post-knit-renderer.ts
@@ -168,8 +168,27 @@ export async function runPostKnitRender(args: {
      * still honored.
      */
     sourceLanguageId?: string;
+    /**
+     * Whether the source `.Rmd` actually started with a terminated
+     * `---...---` YAML front-matter fence. Passed through to
+     * `renderKnitHtml`, which strips the leading fence from the
+     * post-knit `.md` only when this is `true`. See the
+     * `hadSourceFrontmatter` docstring on `renderKnitHtml` for why
+     * gating matters (chunk-generated `---…---` content in a no-YAML
+     * document must NOT be silently stripped).
+     */
+    hadSourceFrontmatter: boolean;
 }): Promise<void> {
-    const { mdPath, htmlPath, context, client, themeClasses, sourceUri, sourceLanguageId } = args;
+    const {
+        mdPath,
+        htmlPath,
+        context,
+        client,
+        themeClasses,
+        sourceUri,
+        sourceLanguageId,
+        hadSourceFrontmatter,
+    } = args;
 
     const markdownSource = await fs.promises.readFile(mdPath, 'utf-8');
 
@@ -248,6 +267,7 @@ export async function runPostKnitRender(args: {
         katexCss,
         themeClasses: themeClasses ?? null,
         fonts,
+        hadSourceFrontmatter,
     });
 
     await writeFileAtomic(htmlPath, finalHtml);

--- a/editors/vscode/src/knit/render-html.ts
+++ b/editors/vscode/src/knit/render-html.ts
@@ -35,6 +35,7 @@ import {
     semanticOverlaysFromLspData,
     type GithubPalette,
 } from './code-highlighter';
+import { stripFrontmatter } from './yaml-frontmatter';
 
 /** Per-language CSS class prefix `markdown-it` emits. */
 const LANG_CLASS_PREFIX = 'language-';
@@ -191,8 +192,37 @@ export async function renderKnitHtml(args: {
      * defaults that match the historical behavior.
      */
     fonts?: ResolvedFonts;
+
+    /**
+     * Whether the source `.Rmd` actually started with a terminated
+     * `---...---` YAML front-matter fence. When `true`, the renderer
+     * strips the leading fence from `markdownSource` before handing
+     * it to `renderMarkdown` (VS Code's `markdown.api.render` would
+     * otherwise wrap the YAML in a styled `<pre class="frontmatter">`
+     * box — the table-like artifact at the top of the preview).
+     *
+     * Required so callers can't accidentally strip chunk-generated
+     * `---…---` content from a no-YAML document. Tests with no
+     * front matter in `markdownSource` can safely pass either
+     * value; production callers must pass the result of
+     * `extractFrontmatter(documentText) !== null` on the original
+     * `.Rmd` text.
+     */
+    hadSourceFrontmatter: boolean;
 }): Promise<string> {
-    const html = await args.renderMarkdown(args.markdownSource);
+    // `knitr::knit` leaves the source `---...---` block in its output
+    // `.md`. VS Code's `markdown.api.render` then renders that block
+    // as a styled `<pre class="frontmatter">` box at the top of the
+    // preview. The YAML is already consumed upstream for output-format
+    // detection and blocker checks, so it has no purpose in the
+    // rendered HTML — strip it here. Gate on `hadSourceFrontmatter`
+    // so we never swallow chunk-generated content that happens to
+    // look like a fence in a no-YAML document. Mirrors what
+    // `rmarkdown::render` + pandoc do natively.
+    const source = args.hadSourceFrontmatter
+        ? stripFrontmatter(args.markdownSource)
+        : args.markdownSource;
+    const html = await args.renderMarkdown(source);
     const rewritten = await rewriteCodeBlocks(html, args);
     return assembleDocument(rewritten, args);
 }

--- a/editors/vscode/src/knit/yaml-frontmatter.ts
+++ b/editors/vscode/src/knit/yaml-frontmatter.ts
@@ -33,23 +33,97 @@ export interface Blocker {
 const BOM = '﻿';
 
 /**
+ * Split a document into its YAML front-matter fence (if any) and the
+ * remaining body. `fence` is the inner body of the fence (with a
+ * trailing `\n`); `body` is what follows the closing `---`. When no
+ * terminated front matter is present `fence` is `null` and `body` is
+ * the input text, returned as-is.
+ *
+ * BOM stripping and CRLF normalization happen only on the
+ * front-matter path. Avoiding them on the no-front-matter path lets a
+ * large knit output (data frames, big tables) pass through this
+ * function without a full-string normalization allocation, and
+ * preserves CRLF endings for any downstream consumer that cares.
+ */
+function splitFrontmatter(text: string): { fence: string | null; body: string } {
+    // Fast path: if the document cannot possibly start with a
+    // front-matter fence (after an optional BOM), return as-is.
+    const afterBom = text.startsWith(BOM) ? text.slice(BOM.length) : text;
+    if (!afterBom.startsWith('---\n') && !afterBom.startsWith('---\r\n')) {
+        return { fence: null, body: text };
+    }
+
+    // Slow path: BOM-strip + CRLF→LF normalize, then scan for the
+    // closing fence.
+    let normalized = afterBom;
+    normalized = normalized.replace(/\r\n/g, '\n');
+
+    const rest = normalized.slice(4); // skip the opening "---\n"
+
+    // Empty front matter: the close fence sits immediately after the
+    // open fence (`---\n---\n…` or `---\n---` at EOF). The regex
+    // below requires a leading `\n` before the close, which isn't
+    // present in that case — handle it explicitly so we still strip
+    // the visible artifact (`<pre class="frontmatter">` in VS Code's
+    // markdown renderer) that this gate is here to prevent.
+    if (rest.startsWith('---\n')) {
+        return { fence: '', body: rest.slice(4) };
+    }
+    if (rest === '---') {
+        return { fence: '', body: '' };
+    }
+
+    const closeMatch = rest.match(/\n---(?:\n|$)/);
+    if (!closeMatch || closeMatch.index === undefined) {
+        // Unterminated fence: behave like the no-front-matter path
+        // and return the input as-is. Important for the (admittedly
+        // unreachable in production) case of an unterminated CRLF
+        // fence — we don't want to silently LF-normalize a body that
+        // the caller is about to flow into a downstream consumer.
+        return { fence: null, body: text };
+    }
+    const inner = rest.slice(0, closeMatch.index);
+    const fence = inner.endsWith('\n') ? inner : inner + '\n';
+    const after = rest.slice(closeMatch.index + closeMatch[0].length);
+    return { fence, body: after };
+}
+
+/**
  * Strip the YAML front-matter block from the document text. Returns the
  * inner body of the fence with a normalized trailing newline, or `null`
- * when no terminated front-matter block is present. CRLF line endings are
- * normalized to LF so downstream parsing is line-ending-agnostic.
+ * when no terminated front-matter block is present. When a fence IS
+ * present, CRLF line endings inside the fence are normalized to LF so
+ * downstream YAML parsing is line-ending-agnostic.
+ *
+ * An empty fence (`---\n---\n`) returns an empty string, not `null`:
+ * the document declared an empty YAML block and downstream
+ * `parseFrontmatter('')` yields an empty map, matching how
+ * rmarkdown / pandoc treat the same shape.
  */
 export function extractFrontmatter(text: string): string | null {
-    let body = text;
-    if (body.startsWith(BOM)) body = body.slice(BOM.length);
-    body = body.replace(/\r\n/g, '\n');
+    return splitFrontmatter(text).fence;
+}
 
-    if (!body.startsWith('---\n')) return null;
-
-    const rest = body.slice(4);
-    const closeMatch = rest.match(/\n---(?:\n|$)/);
-    if (!closeMatch || closeMatch.index === undefined) return null;
-    const inner = rest.slice(0, closeMatch.index);
-    return inner.endsWith('\n') ? inner : inner + '\n';
+/**
+ * Return the document body with the leading `--- ... ---` front-matter
+ * block removed. When no terminated front matter is present the input
+ * is returned as-is (no BOM stripping, no CRLF normalization).
+ *
+ * Used by the knit pipeline to keep the YAML out of the post-knit
+ * markdown handed to VS Code's `markdown.api.render`: that pipeline
+ * renders front matter as a styled `<pre class="frontmatter">` block
+ * (visible as a table-like box at the top of the preview), but we
+ * already consume the YAML separately upstream. Mirrors what
+ * `rmarkdown::render` + pandoc do natively.
+ *
+ * Callers MUST only invoke this when they know the source `.Rmd`
+ * actually contained a front-matter fence: otherwise a no-YAML
+ * document whose first chunk emits `---\n…\n---\n` content would
+ * silently lose that output. `renderKnitHtml`'s `hadSourceFrontmatter`
+ * flag enforces that contract.
+ */
+export function stripFrontmatter(text: string): string {
+    return splitFrontmatter(text).body;
 }
 
 /**

--- a/editors/vscode/src/test/post-knit-renderer.test.ts
+++ b/editors/vscode/src/test/post-knit-renderer.test.ts
@@ -68,6 +68,7 @@ suite('runPostKnitRender end-to-end', () => {
             htmlPath,
             context: fakeContext,
             client: undefined,
+            hadSourceFrontmatter: false,
         });
 
         assert.ok(
@@ -183,6 +184,7 @@ suite('runPostKnitRender end-to-end', () => {
             htmlPath,
             context: fakeContext,
             client: undefined,
+            hadSourceFrontmatter: false,
         });
 
         const html = fs.readFileSync(htmlPath, 'utf-8');
@@ -199,6 +201,72 @@ suite('runPostKnitRender end-to-end', () => {
             stragglers,
             [],
             `expected no stray .tmp files in ${tmp}, found ${JSON.stringify(stragglers)}`,
+        );
+    });
+
+    test('strips YAML front matter so it does not render as a styled box', async function () {
+        this.timeout(30000);
+        await activate();
+
+        // Regression: `knitr::knit` leaves the source `---...---`
+        // block in its output `.md`. Without the gate added in
+        // `renderKnitHtml`, VS Code's `markdown.api.render` wraps
+        // that block in `<pre class="frontmatter">…</pre>` — visible
+        // at the top of the preview as an unwanted table-like box.
+        // This case exercises the REAL `markdown.api.render` (the
+        // bun unit test in `render-html.test.ts` uses a fake renderer
+        // and can't see the live markdown-it plugin behavior).
+        const mdPath = path.join(tmp, 'frontmatter.md');
+        const htmlPath = path.join(tmp, 'frontmatter.html');
+        const mdSource = [
+            '---',
+            'title: My Document',
+            'author: Test Author',
+            'output: html_document',
+            '---',
+            '',
+            'POST-KNIT-RENDERER-MARKER',
+            '',
+        ].join('\n');
+        fs.writeFileSync(mdPath, mdSource, 'utf-8');
+
+        const ravenExt = vscode.extensions.getExtension('jbearak.raven-r');
+        assert.ok(ravenExt);
+        const fakeContext = {
+            extensionUri: ravenExt.extensionUri,
+            subscriptions: [],
+        } as unknown as vscode.ExtensionContext;
+
+        await runPostKnitRender({
+            mdPath,
+            htmlPath,
+            context: fakeContext,
+            client: undefined,
+            hadSourceFrontmatter: true,
+        });
+
+        const html = fs.readFileSync(htmlPath, 'utf-8');
+        // The body must still appear.
+        assert.ok(
+            html.includes('POST-KNIT-RENDERER-MARKER'),
+            'body marker should survive the strip',
+        );
+        // VS Code's frontmatter plugin tags the block with the
+        // `frontmatter` class — that class must NOT appear in the
+        // rendered HTML.
+        assert.ok(
+            !/class="frontmatter\b/.test(html),
+            `expected no <pre class="frontmatter"> in output; got:\n${html}`,
+        );
+        // And the raw YAML values must not leak through as visible
+        // prose either.
+        assert.ok(
+            !/title:\s*My Document/.test(html),
+            'YAML `title:` line should not appear in rendered HTML',
+        );
+        assert.ok(
+            !/author:\s*Test Author/.test(html),
+            'YAML `author:` line should not appear in rendered HTML',
         );
     });
 
@@ -227,6 +295,7 @@ suite('runPostKnitRender end-to-end', () => {
             htmlPath,
             context: fakeContext,
             client: undefined,
+            hadSourceFrontmatter: false,
         });
 
         const html = fs.readFileSync(htmlPath, 'utf-8');

--- a/tests/bun/render-html-real-grammar.test.ts
+++ b/tests/bun/render-html-real-grammar.test.ts
@@ -126,6 +126,7 @@ describe('renderKnitHtml against the real R grammar', () => {
             registry,
             // No LSP overlay — we want to see whether the grammar
             // alone paints anything.
+            hadSourceFrontmatter: false,
         });
 
         // Extract the highlighted code block body. `rewriteCodeBlocks`

--- a/tests/bun/render-html.test.ts
+++ b/tests/bun/render-html.test.ts
@@ -469,6 +469,7 @@ describe('renderKnitHtml', () => {
             markdownSource: 'irrelevant — renderMarkdown returns a fixed value',
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
+            hadSourceFrontmatter: false,
         });
 
         // The body must include a function-role span. Spans
@@ -487,6 +488,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code>raw text &amp; symbols</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
         });
@@ -512,6 +514,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code class="language-r">library</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
         });
@@ -526,6 +529,7 @@ describe('renderKnitHtml', () => {
         // visual is unique to input chunks.
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => '<p>hi</p>',
             registry: fakeRegistry({}),
         });
@@ -551,6 +555,7 @@ describe('renderKnitHtml', () => {
         const tokensData = [0, 0, 7, 0, 0];
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: flatTokenizer }),
             fetchRSemanticTokens: async () => tokensData,
@@ -566,6 +571,7 @@ describe('renderKnitHtml', () => {
         let fetchCalled = false;
         await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ python: toyRTokenizer }),
             fetchRSemanticTokens: async () => {
@@ -580,6 +586,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<p>math</p>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({}),
             katexCss: '.katex { color: blue; }',
@@ -591,6 +598,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<p>hi</p>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({}),
         });
@@ -598,6 +606,76 @@ describe('renderKnitHtml', () => {
         expect(out).toContain('<head>');
         expect(out).toContain('<body>');
         expect(out).toContain('<p>hi</p>');
+    });
+
+    test('strips YAML front matter when hadSourceFrontmatter is true', async () => {
+        // The `knitr::knit` output `.md` retains the source `---...---`
+        // front-matter block, and VS Code's `markdown.api.render`
+        // turns that block into a styled `<pre class="frontmatter">`
+        // box at the top of the preview. Strip it here so the YAML
+        // never reaches the renderer.
+        const source =
+            '---\ntitle: My Doc\noutput: html_document\n---\n\n# Hello\n\nbody\n';
+        let received: string | undefined;
+        await renderKnitHtml({
+            markdownSource: source,
+            renderMarkdown: async (src) => {
+                received = src;
+                return '<h1>Hello</h1>\n<p>body</p>';
+            },
+            registry: fakeRegistry({}),
+            hadSourceFrontmatter: true,
+        });
+        // The renderer must never see the YAML fence or its inner
+        // lines, so VS Code's frontmatter plugin has nothing to
+        // latch onto.
+        expect(received).toBeDefined();
+        expect(received).not.toContain('---');
+        expect(received).not.toContain('title:');
+        expect(received).not.toContain('output:');
+        // The body must still flow through unchanged.
+        expect(received).toContain('# Hello');
+        expect(received).toContain('body');
+    });
+
+    test('does NOT strip a leading `---…---` block when hadSourceFrontmatter is false', async () => {
+        // Regression guard: a no-YAML `.Rmd` whose first chunk emits
+        // `---\n…\n---\n` as output content used to be silently
+        // stripped by an unconditional `stripFrontmatter` call. Now
+        // the strip is gated on whether the source document actually
+        // had a front-matter fence — chunk-generated content shaped
+        // like a fence must flow through verbatim.
+        const source = '---\nnot metadata — real chunk output\n---\n\nrest of body\n';
+        let received: string | undefined;
+        await renderKnitHtml({
+            markdownSource: source,
+            renderMarkdown: async (src) => {
+                received = src;
+                return '<p>ignored</p>';
+            },
+            registry: fakeRegistry({}),
+            hadSourceFrontmatter: false,
+        });
+        expect(received).toBe(source);
+    });
+
+    test('strips an empty front-matter block (`---\\n---\\n…`) when hadSourceFrontmatter is true', async () => {
+        // An empty YAML fence still produces VS Code's
+        // `<pre class="frontmatter">` artifact — the gate must
+        // recognize it. The body following the empty fence must
+        // survive.
+        const source = '---\n---\n# Heading\n';
+        let received: string | undefined;
+        await renderKnitHtml({
+            markdownSource: source,
+            renderMarkdown: async (src) => {
+                received = src;
+                return '<h1>Heading</h1>';
+            },
+            registry: fakeRegistry({}),
+            hadSourceFrontmatter: true,
+        });
+        expect(received).toBe('# Heading\n');
     });
 
     test('decodes HTML entities in the code block before tokenizing', async () => {
@@ -608,6 +686,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code class="language-r">f &lt;- 1</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
         });
@@ -624,6 +703,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code class="language-r">library</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
             themeClasses: 'vscode-dark',
@@ -661,6 +741,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code class="language-r">library</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
             themeClasses: null, // standalone (Open in Browser path)
@@ -686,6 +767,7 @@ describe('renderKnitHtml', () => {
         const fakeHtml = '<pre><code class="language-r">library</code></pre>';
         const out = await renderKnitHtml({
             markdownSource: 'x',
+            hadSourceFrontmatter: false,
             renderMarkdown: async () => fakeHtml,
             registry: fakeRegistry({ r: toyRTokenizer }),
             fetchRSemanticTokens: async () => {

--- a/tests/bun/yaml-frontmatter.test.ts
+++ b/tests/bun/yaml-frontmatter.test.ts
@@ -5,6 +5,7 @@ import {
     detectFormat,
     detectBlockers,
     isSupportedHtmlFormat,
+    stripFrontmatter,
 } from '../../editors/vscode/src/knit/yaml-frontmatter';
 
 describe('extractFrontmatter', () => {
@@ -29,6 +30,71 @@ describe('extractFrontmatter', () => {
     test('accepts CRLF line endings', () => {
         const text = '---\r\ntitle: x\r\n---\r\nbody\r\n';
         expect(extractFrontmatter(text)).toBe('title: x\n');
+    });
+
+    test('treats an empty fence (`---\\n---\\n`) as an empty front matter', () => {
+        // Pandoc and rmarkdown both accept an empty YAML block. The
+        // original regex required a `\n` before the close fence, so
+        // `---\n---\n` slipped through as "no front matter". Fix:
+        // recognize the immediate close and return an empty string.
+        expect(extractFrontmatter('---\n---\nbody\n')).toBe('');
+    });
+
+    test('treats `---\\n---` at EOF as an empty fence', () => {
+        expect(extractFrontmatter('---\n---')).toBe('');
+    });
+});
+
+describe('stripFrontmatter', () => {
+    test('removes a fenced front-matter block and returns the body', () => {
+        const text = '---\ntitle: example\noutput: html_document\n---\n\nbody\n';
+        expect(stripFrontmatter(text)).toBe('\nbody\n');
+    });
+
+    test('returns the document unchanged when no front matter is present', () => {
+        expect(stripFrontmatter('# heading\n\nbody\n')).toBe('# heading\n\nbody\n');
+    });
+
+    test('returns the document as-is when the fence is unterminated', () => {
+        // No closing `---`, so we leave the body alone rather than
+        // swallow content that isn't really front matter. The
+        // contract matches the no-front-matter fast path: the input
+        // is returned unchanged, including CRLF endings.
+        expect(stripFrontmatter('---\ntitle: x\nno close\n'))
+            .toBe('---\ntitle: x\nno close\n');
+        expect(stripFrontmatter('---\r\ntitle: x\r\nno close\r\n'))
+            .toBe('---\r\ntitle: x\r\nno close\r\n');
+    });
+
+    test('strips BOM and normalizes CRLF', () => {
+        const text = '﻿---\r\ntitle: x\r\n---\r\nbody\r\n';
+        expect(stripFrontmatter(text)).toBe('body\n');
+    });
+
+    test('returns an empty string when the document is only front matter', () => {
+        expect(stripFrontmatter('---\ntitle: x\n---\n')).toBe('');
+    });
+
+    test('keeps `---` thematic breaks deeper in the body intact', () => {
+        // Once the leading front matter is stripped, subsequent `---`
+        // lines in the body are markdown thematic breaks, not a second
+        // fence. We must not touch them.
+        const text = '---\ntitle: x\n---\n# heading\n\n---\n\nmore\n';
+        expect(stripFrontmatter(text)).toBe('# heading\n\n---\n\nmore\n');
+    });
+
+    test('strips an empty fence (`---\\n---\\n…`)', () => {
+        expect(stripFrontmatter('---\n---\nbody\n')).toBe('body\n');
+    });
+
+    test('preserves CRLF endings on the no-front-matter fast path', () => {
+        // The no-FM fast path returns the input unchanged. That keeps
+        // a large knit output (data frames, big tables) from being
+        // re-allocated every time, AND preserves CRLF endings for any
+        // downstream consumer that prefers them. markdown-it handles
+        // either.
+        const text = '# heading\r\n\r\nbody\r\n';
+        expect(stripFrontmatter(text)).toBe(text);
     });
 });
 


### PR DESCRIPTION
## Summary
- Strip the leading `---...---` YAML block from the post-knit `.md` before handing it to VS Code's `markdown.api.render`. Without this, the renderer wraps the YAML in a styled `<pre class="frontmatter">` box (the table-like artifact at the top of the preview).
- Gate the strip on whether the source `.Rmd` actually had a terminated front-matter fence (`hadSourceFrontmatter`), so a no-YAML document whose first chunk emits `---…---`-shaped content is not silently mangled. The flag is required at every internal call site so TypeScript catches a missed plumbing point.
- Handle the empty-fence shape (`---\n---\n` and `---\n---` at EOF) — the original close-fence regex required a leading `\n` and missed these.
- Add a no-front-matter fast path that skips BOM stripping and CRLF normalization, so large knit outputs (big data frames / tables) are not re-allocated.
- Document the metadata-omission tradeoff in `docs/knit.md` (`title`/`author`/`date` don't render as a Pandoc title block — that requires `rmarkdown::render`).

This was reviewed adversarially by Codex twice; the first pass surfaced 4 should-fixes (eager-strip, empty fence, perf, metadata) and 1 nit (integration coverage), all addressed. The second pass flagged one nit (unterminated CRLF fence) about a code path not reachable in production, also fixed.

## Test plan
- [x] `bun test` — 972 pass, 0 fail
- [x] `editors/vscode` mocha suite via vscode-test — 272 pass, 0 fail
- [x] `tsc --noEmit` on `editors/vscode` — clean
- [x] New regression tests:
  - bun: "does NOT strip … when hadSourceFrontmatter is false" (no-YAML guard)
  - bun: "strips an empty front-matter block when hadSourceFrontmatter is true"
  - bun: empty-fence cases for `extractFrontmatter` / `stripFrontmatter`
  - bun: "preserves CRLF endings on the no-front-matter fast path"
  - mocha: end-to-end through real `markdown.api.render`, asserts no `class="frontmatter"` and no leaked YAML values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YAML front matter is now properly stripped from R Markdown previews in VS Code, preventing it from rendering as a styled box.

* **Documentation**
  * Clarified that YAML document metadata (title, author, date, abstract) is not preserved in the rendered preview; use `rmarkdown::render()` to render with metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->