### PR TITLE
chore(chunks): clarify Run Next/Previous Chunk CodeLens labels

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -5,7 +5,7 @@ Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delim
 This is the daily-driver workflow for `.Rmd` / `.qmd` users coming from RStudio or vscode-R.
 
 > [!NOTE]
-> All chunk-related features — navigation commands (Go to Next/Previous Chunk, Select Current Chunk), chunk background highlighting and the active-cell indicator, `.R` cell mode (`# %%` markers and RStudio-style `# Section ----` dividers), the **run** commands (for example, Run Current Chunk, Run Above Chunks, Run All Chunks — see [Commands](#commands) for the full set), and every chunk CodeLens button (defaults `▷ Run Chunk` / `→ Run Next & Move` / `↥ Run Above`, plus any others added via `raven.chunks.codeLens.commands`) — are gated behind `raven.rConsole.activation`. The run commands and CodeLens additionally require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), none of these surfaces register, so REditorSupport / Positron handle chunks instead. See [Coexistence](./coexistence.md).
+> All chunk-related features — navigation commands (Go to Next/Previous Chunk, Select Current Chunk), chunk background highlighting and the active-cell indicator, `.R` cell mode (`# %%` markers and RStudio-style `# Section ----` dividers), the **run** commands (for example, Run Current Chunk, Run Above Chunks, Run All Chunks — see [Commands](#commands) for the full set), and every chunk CodeLens button (defaults `▷ Run Chunk` / `↘ Run Next Chunk` / `↥ Run Above`, plus any others added via `raven.chunks.codeLens.commands`) — are gated behind `raven.rConsole.activation`. The run commands and CodeLens additionally require Raven's R console because they create or reuse the R terminal Raven manages. If the R console is disabled (or `auto` defers to another R extension), none of these surfaces register, so REditorSupport / Positron handle chunks instead. See [Coexistence](./coexistence.md).
 
 ## Chunk forms
 
@@ -54,12 +54,12 @@ In `.R` files, `Cmd+Shift+Enter` keeps its usual meaning of **Source File** — 
 By default each R chunk header shows up to three buttons:
 
 ```text
-▷ Run Chunk    → Run Next & Move    ↥ Run Above
+▷ Run Chunk    ↘ Run Next Chunk    ↥ Run Above
 ```{r}
 …
 ```
 
-Sibling-targeted lenses are hidden on chunks where they have nothing to point at: the first runnable chunk drops `↥ Run Above` and `← Run Previous` (and `← Run Previous & Move`); the last runnable chunk drops `↧ Run Below`, `→ Run Next`, and `→ Run Next & Move`. Buttons for non-R languages are intentionally omitted.
+Sibling-targeted lenses are hidden on chunks where they have nothing to point at: the first runnable chunk drops `↥ Run Above` and `← Run Previous` (and `↖ Run Previous Chunk`); the last runnable chunk drops `↧ Run Below`, `→ Run Next`, and `↘ Run Next Chunk`. Buttons for non-R languages are intentionally omitted.
 
 The set of buttons (and their order) is controlled by `raven.chunks.codeLens.commands` — an array of run-command ids. The available ids are:
 
@@ -71,9 +71,9 @@ The set of buttons (and their order) is controlled by `raven.chunks.codeLens.com
 | `raven.runBelowChunks` | `↧ Run Below` |
 | `raven.runCurrentAndBelowChunks` | `▷↓ Run Current and Below` |
 | `raven.runPreviousChunk` | `← Run Previous` |
-| `raven.runPreviousChunkAndMove` | `← Run Previous & Move` |
+| `raven.runPreviousChunkAndMove` | `↖ Run Previous Chunk` |
 | `raven.runNextChunk` | `→ Run Next` |
-| `raven.runNextChunkAndMove` | `→ Run Next & Move` |
+| `raven.runNextChunkAndMove` | `↘ Run Next Chunk` |
 | `raven.runAllChunks` | `↻ Run All` |
 
 Example — show four buttons in a custom order:

--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -57,7 +57,7 @@ See [Editor Integrations](./editor-integrations.md) for setup details across edi
 
 ## Coexistence with the Quarto extension
 
-When the [Quarto extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) is installed alongside Raven, *and* Raven's R console is active, you'll see two CodeLens rows above every R chunk in a `.qmd` file: Quarto's (**Run Cell · Run Next Cell · Run Above**) and Raven's (**▷ Run Chunk · → Run Next & Move · ↥ Run Above**, configurable via `raven.chunks.codeLens.commands`).
+When the [Quarto extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) is installed alongside Raven, *and* Raven's R console is active, you'll see two CodeLens rows above every R chunk in a `.qmd` file: Quarto's (**Run Cell · Run Next Cell · Run Above**) and Raven's (**▷ Run Chunk · ↘ Run Next Chunk · ↥ Run Above**, configurable via `raven.chunks.codeLens.commands`).
 
 Raven's chunk CodeLens activates with Raven's R console — see [The `raven.rConsole.activation` setting](#the-ravenrconsoleactivation-setting). Under the default `"auto"`, Raven's R console activates only when no other R extension (REditorSupport.r, or Positron) is enabled. So the dueling-row case appears when you have Quarto installed but not REditorSupport.r, or when you've explicitly set `raven.rConsole.activation` to `"enabled"` alongside REditorSupport.r.
 

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -369,7 +369,7 @@ export const CHUNK_LENS_COMMANDS: Readonly<Record<string, ChunkLensCommand>> = O
     },
     'raven.runPreviousChunkAndMove': {
         positional_id: 'raven.runPreviousChunkAndMoveAt',
-        title: '← Run Previous & Move',
+        title: '↖ Run Previous Chunk',
         tooltip: 'Run the R chunk immediately above this one, then move the cursor into it',
         eval_aware: false,
         gate: 'requires_previous_runnable',
@@ -383,7 +383,7 @@ export const CHUNK_LENS_COMMANDS: Readonly<Record<string, ChunkLensCommand>> = O
     },
     'raven.runNextChunkAndMove': {
         positional_id: 'raven.runNextChunkAndMoveAt',
-        title: '→ Run Next & Move',
+        title: '↘ Run Next Chunk',
         tooltip: 'Run the R chunk immediately below this one, then move the cursor into it',
         eval_aware: false,
         gate: 'requires_next_runnable',

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -861,12 +861,12 @@ suite('chunk commands: registration and behavior', () => {
         }
     });
 
-    test('default codeLens row shows ▷ Run Chunk → Run Next & Move ↥ Run Above', async function () {
+    test('default codeLens row shows ▷ Run Chunk ↘ Run Next Chunk ↥ Run Above', async function () {
         // Issue #280: the out-of-the-box default lens row includes the new
-        // `→ Run Next & Move` button between `▷ Run Chunk` and `↥ Run Above`.
+        // `↘ Run Next Chunk` button between `▷ Run Chunk` and `↥ Run Above`.
         // Sibling-targeted lenses are gated by their target's existence:
         // the first runnable chunk drops `↥ Run Above` (nothing above), and
-        // the last runnable chunk drops `→ Run Next & Move` (nothing below).
+        // the last runnable chunk drops `↘ Run Next Chunk` (nothing below).
         const r_console_disabled = !(await vscode.commands.getCommands(true))
             .includes('raven.runCurrentChunkAt');
         if (r_console_disabled) return;
@@ -881,9 +881,9 @@ suite('chunk commands: registration and behavior', () => {
                 vscode.ConfigurationTarget.Global,
             );
             // 3 runnable R chunks. Expected lens counts:
-            //   first  chunk: Run Chunk + Run Next & Move          = 2 (Run Above hidden)
-            //   middle chunk: Run Chunk + Run Next & Move + Above  = 3
-            //   last   chunk: Run Chunk + Run Above                = 2 (Run Next & Move hidden)
+            //   first  chunk: Run Chunk + Run Next Chunk           = 2 (Run Above hidden)
+            //   middle chunk: Run Chunk + Run Next Chunk + Above   = 3
+            //   last   chunk: Run Chunk + Run Above                = 2 (Run Next Chunk hidden)
             // Total = 7.
             const lenses = await poll_for_lenses(
                 editor.document.uri,
@@ -892,7 +892,7 @@ suite('chunk commands: registration and behavior', () => {
             assert.strictEqual(
                 lenses.length,
                 7,
-                `expected 7 default lenses (2 + 3 + 2, first omits Run Above, last omits Run Next & Move), got ${lenses.length}`,
+                `expected 7 default lenses (2 + 3 + 2, first omits Run Above, last omits Run Next Chunk), got ${lenses.length}`,
             );
             const first_two = lenses.slice(0, 2).map((l) => l.command?.title ?? '');
             assert.ok(
@@ -900,8 +900,8 @@ suite('chunk commands: registration and behavior', () => {
                 `default lens 1 should be Run Chunk, got: ${first_two[0]}`,
             );
             assert.ok(
-                first_two[1]?.startsWith('→ Run Next & Move'),
-                `default lens 2 should be Run Next & Move, got: ${first_two[1]}`,
+                first_two[1]?.startsWith('↘ Run Next Chunk'),
+                `default lens 2 should be Run Next Chunk, got: ${first_two[1]}`,
             );
             assert.ok(
                 first_two.every((t) => !t.startsWith('↥ Run Above')),
@@ -914,7 +914,7 @@ suite('chunk commands: registration and behavior', () => {
             );
             const last_chunk_titles = lenses.slice(-2).map((l) => l.command?.title ?? '');
             assert.ok(
-                last_chunk_titles.every((t) => !t.startsWith('→ Run Next')),
+                last_chunk_titles.every((t) => !(t.startsWith('→ Run Next') || t.startsWith('↘ Run Next'))),
                 `Run Next lenses should be absent on the last chunk, got: ${last_chunk_titles.join(', ')}`,
             );
             assert.ok(
@@ -931,7 +931,7 @@ suite('chunk commands: registration and behavior', () => {
     });
 
     test('Run Next/Previous lenses are gated by target availability', async function () {
-        // The user-reported regression: clicking "→ Run Next & Move" on
+        // The user-reported regression: clicking "↘ Run Next Chunk" on
         // the LAST runnable chunk surfaced a cursor-referencing toast
         // even though the click did not involve the cursor. Fix: hide
         // sibling-targeted lenses on chunks where the target chunk
@@ -973,26 +973,30 @@ suite('chunk commands: registration and behavior', () => {
                 + lenses.map((l) => l.command?.title).join(' | '),
             );
             const titles = lenses.map((l) => l.command?.title ?? '');
+            const is_run_previous = (t: string) =>
+                t.startsWith('← Run Previous') || t.startsWith('↖ Run Previous');
+            const is_run_next = (t: string) =>
+                t.startsWith('→ Run Next') || t.startsWith('↘ Run Next');
             // First chunk: no Previous variants.
             const first_chunk = titles.slice(0, 3);
             assert.ok(
-                first_chunk.every((t) => !t.startsWith('← Run Previous')),
+                first_chunk.every((t) => !is_run_previous(t)),
                 `first chunk should not have any Run Previous lens, got: ${first_chunk.join(', ')}`,
             );
             // Last chunk: no Next variants.
             const last_chunk = titles.slice(-3);
             assert.ok(
-                last_chunk.every((t) => !t.startsWith('→ Run Next')),
+                last_chunk.every((t) => !is_run_next(t)),
                 `last chunk should not have any Run Next lens, got: ${last_chunk.join(', ')}`,
             );
             // Middle chunk has both sides.
             const middle_chunk = titles.slice(3, 8);
             assert.ok(
-                middle_chunk.some((t) => t.startsWith('← Run Previous')),
+                middle_chunk.some(is_run_previous),
                 `middle chunk should have Run Previous, got: ${middle_chunk.join(', ')}`,
             );
             assert.ok(
-                middle_chunk.some((t) => t.startsWith('→ Run Next')),
+                middle_chunk.some(is_run_next),
                 `middle chunk should have Run Next, got: ${middle_chunk.join(', ')}`,
             );
         } finally {


### PR DESCRIPTION
## Summary

Rename the "and move" CodeLens variants to use a directional icon so the cursor-moving behavior is visible at a glance, matching the existing `▷⇣ Run & Move` precedent for `runCurrentChunkAndMove`:

- `raven.runNextChunkAndMove`: `→ Run Next & Move` → **`↘ Run Next Chunk`**
- `raven.runPreviousChunkAndMove`: `← Run Previous & Move` → **`↖ Run Previous Chunk`**

The no-move variants (`→ Run Next`, `← Run Previous`) are unchanged. Tests and docs (`docs/chunks.md`, `docs/coexistence.md`) updated in lockstep.

The gating test that checked Run Next/Previous presence on edge chunks now uses an alternation predicate (`startsWith('→ Run Next') || startsWith('↘ Run Next')`) so both variants are caught.

## Test plan

- [ ] Open an `.Rmd` / `.qmd` file with multiple R chunks — verify the lens row reads `▷ Run Chunk    ↘ Run Next Chunk    ↥ Run Above` on middle chunks, drops `↘ Run Next Chunk` on the last chunk, drops `↥ Run Above` on the first.
- [ ] Enable all sibling lenses via `raven.chunks.codeLens.commands` — verify `↖ Run Previous Chunk` appears on chunks below the first.
- [ ] Click `↘ Run Next Chunk` on a middle chunk — the chunk runs and the cursor moves into the next chunk.
- [ ] Click `↖ Run Previous Chunk` on a middle chunk — the chunk runs and the cursor moves into the previous chunk.