### PR TITLE
fix(knit): pin .Rmd files to the rmd language via files.associations

### DIFF
--- a/docs/coexistence.md
+++ b/docs/coexistence.md
@@ -69,3 +69,21 @@ What each row does depends on whether REditorSupport.r is installed:
 Both extensions register CodeLens providers for `.qmd`, and VS Code doesn't expose a way for one extension to suppress another's lenses, so when both rows appear they stay independent. Quarto's check looks for the REditorSupport extension by ID, so Raven can't satisfy it from this side regardless of which commands Raven registers — the only clean fix lives upstream in the Quarto extension.
 
 If the duplication bothers you and you're not relying on Quarto's other features (preview, format conversion, project tooling, or the Python / Julia / Observable cell executors), disabling the Quarto extension removes its row entirely — Raven's R console, chunk navigation, run commands, and CodeLens cover the same execution surface for `.qmd` files. Otherwise, the simplest habit is to use Raven's row for R chunks; Quarto's row remains useful for cells in other languages when their respective extensions are installed.
+
+### `.Rmd` files belong to the `rmd` language
+
+The Quarto extension contributes both `.qmd` and `.rmd` under `editorLangId == quarto`. When only Raven and Quarto are installed, VS Code's `contributes.languages` extension resolver can pick Quarto's claim over Raven's `rmd` contribution — the resolution order across extensions is not a documented invariant — so `.Rmd` files can end up tagged as `quarto`. Most Raven affordances handle both lang ids (run-line, navigation, CodeLens, the send-to-R menus), but **Knit Preview** is gated on `editorLangId == rmd || == r` and silently stops firing. The visible symptom is `Shift+Cmd+Enter` (`Shift+Ctrl+Enter` on Linux/Windows) triggering Quarto's "Editor selection is not within an executable cell" message instead of opening the knit preview.
+
+Raven ships a `files.associations` default pinning `*.rmd` (the pattern is case-insensitive on VS Code's lookup, but Raven's `contributes.languages` extension list lives alongside as `.rmd` / `.Rmd` / `.RMD` for consistency) to the `rmd` language. `files.associations` is registered ahead of `contributes.languages` in VS Code's resolver, so this anchors `.Rmd` to `rmd` regardless of whether REditorSupport.r-syntax is installed alongside.
+
+Trade-off: this also disables Quarto's `.Rmd`-targeted UI (Run Cell, Insert Cell, preview-related menus, the chunk CodeLens) for users who keep the default, because those gate on `editorLangId == quarto`. Quarto's `.qmd` handling is untouched. If you'd rather hand `.rmd` files back to Quarto, override the default explicitly in user or workspace settings:
+
+```json
+"files.associations": {
+  "*.rmd": "quarto",
+  "*.Rmd": "quarto",
+  "*.RMD": "quarto"
+}
+```
+
+`files.associations` is an object-merge setting, so the override above replaces only the keys it lists — other Raven `files.associations` defaults (none today, but possible in the future) stay in effect.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -789,6 +789,11 @@
       },
       "[quarto]": {
         "editor.formatOnType": true
+      },
+      "files.associations": {
+        "*.rmd": "rmd",
+        "*.Rmd": "rmd",
+        "*.RMD": "rmd"
       }
     },
     "colors": [

--- a/editors/vscode/src/test/rmarkdown-quarto.test.ts
+++ b/editors/vscode/src/test/rmarkdown-quarto.test.ts
@@ -17,7 +17,7 @@ function demoPath(file: string): string {
 async function openAndGetCodeLenses(
     filePath: string,
     timeoutMs = 15000,
-): Promise<vscode.CodeLens[]> {
+): Promise<{ lenses: vscode.CodeLens[]; languageId: string }> {
     const uri = vscode.Uri.file(filePath);
     const doc = await vscode.workspace.openTextDocument(uri);
     await vscode.window.showTextDocument(doc);
@@ -33,7 +33,7 @@ async function openAndGetCodeLenses(
         )) ?? [];
         if (lenses.length > 0) break;
     }
-    return lenses;
+    return { lenses, languageId: doc.languageId };
 }
 
 suite('rmarkdown-quarto chunk detection', function (this: Mocha.Suite) {
@@ -55,7 +55,19 @@ suite('rmarkdown-quarto chunk detection', function (this: Mocha.Suite) {
             return;
         }
 
-        const lenses = await openAndGetCodeLenses(demoPath('analysis.Rmd'));
+        const { lenses, languageId } = await openAndGetCodeLenses(demoPath('analysis.Rmd'));
+        // Pin the language id so the `files.associations` configurationDefaults
+        // entry (or Raven's `contributes.languages` claim) can't silently drift
+        // back to a state where `.Rmd` resolves to something other than `rmd`.
+        // The Quarto extension is not present in the vscode-test host, so this
+        // is a baseline-not-regressed check rather than the full reproduction
+        // of the Quarto-installed bug, but it still catches an accidental
+        // removal of either contribution.
+        assert.strictEqual(
+            languageId,
+            'rmd',
+            `Expected .Rmd file to resolve to languageId 'rmd', got '${languageId}'`,
+        );
         assert.ok(
             lenses.length >= 2,
             `Expected at least 2 CodeLens entries for .Rmd chunks; got ${lenses.length}`,
@@ -69,7 +81,7 @@ suite('rmarkdown-quarto chunk detection', function (this: Mocha.Suite) {
             return;
         }
 
-        const lenses = await openAndGetCodeLenses(demoPath('report.qmd'));
+        const { lenses } = await openAndGetCodeLenses(demoPath('report.qmd'));
         assert.ok(
             lenses.length >= 2,
             `Expected at least 2 CodeLens entries for .qmd chunks; got ${lenses.length}`,

--- a/tests/bun/vscode-config.test.ts
+++ b/tests/bun/vscode-config.test.ts
@@ -102,6 +102,51 @@ test("VS Code package metadata activates on JAGS and Stan languages", () => {
   expect(pkg.activationEvents).toContain("onLanguage:stan");
 });
 
+test("VS Code package metadata pins .Rmd files to the rmd language via files.associations", () => {
+  // The Quarto extension contributes `editorLangId == quarto` for `.rmd` (it
+  // accepts both `.qmd` and `.rmd`). When only Raven and Quarto are installed,
+  // VS Code's `contributes.languages` resolver can pick Quarto's claim over
+  // Raven's, leaving `.Rmd` files tagged as `quarto` — at which point Raven's
+  // `raven.knit` keybinding (gated on `editorLangId == rmd || == r`) silently
+  // stops firing on `.Rmd`. `contributes.languages` resolution order is not a
+  // documented invariant, so we don't rely on outvoting Quarto there.
+  //
+  // REditorSupport.r-syntax used to mask the bug by contributing another `rmd`
+  // claim, but Raven vendors its own grammars now, so users who uninstall
+  // r-syntax can hit the latent ordering issue.
+  //
+  // `files.associations` is registered through VS Code's
+  // `registerConfiguredLanguageAssociation` path, which takes precedence over
+  // `contributes.languages` extension lookup. Shipping it as a
+  // `configurationDefaults` entry fixes the resolution at the source and lets
+  // users opt out with their own `files.associations`. Pin the contribution.
+  const packageJsonPath = path.join(
+    import.meta.dir,
+    "..",
+    "..",
+    "editors",
+    "vscode",
+    "package.json",
+  );
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const associations = pkg.contributes.configurationDefaults?.[
+    "files.associations"
+  ] as Record<string, string> | undefined;
+
+  expect(associations).toBeDefined();
+  expect(associations).toMatchObject({
+    "*.rmd": "rmd",
+    "*.Rmd": "rmd",
+    "*.RMD": "rmd",
+  });
+
+  // Never claim `.qmd` — Quarto owns that extension and its preview / render
+  // commands live there.
+  expect(associations).not.toHaveProperty("*.qmd");
+  expect(associations).not.toHaveProperty("*.Qmd");
+  expect(associations).not.toHaveProperty("*.QMD");
+});
+
 test("VS Code package metadata exposes send method setting", () => {
   const packageJsonPath = path.join(
     import.meta.dir,


### PR DESCRIPTION
## Summary
- Quarto's `contributes.languages` claim on `.rmd` was shadowing Raven's `rmd` contribution whenever REditorSupport.r-syntax wasn't installed. `.Rmd` files ended up tagged as `editorLangId == quarto`, and `raven.knit` (gated on `rmd || r`) silently stopped firing — Shift+Cmd+Enter surfaced Quarto's "Editor selection is not within an executable cell" instead of the knit preview.
- Ship `contributes.configurationDefaults["files.associations"]` mapping `*.rmd` / `*.Rmd` / `*.RMD` → `rmd`. `files.associations` is registered ahead of `contributes.languages` in VS Code's resolver, so this anchors the language regardless of extension load order. User-set `files.associations` still wins, so anyone who wants Quarto to handle `.Rmd` can opt out from settings.

## Trade-off
This also disables Quarto's `.Rmd`-targeted UI (Run Cell, Insert Cell, preview menus, chunk CodeLens) for users on the default — those gates are tied to `editorLangId == quarto`. `.qmd` handling is untouched. Documented in `docs/coexistence.md` with the explicit opt-out snippet.

## Test plan
- [x] Bun: `tests/bun/vscode-config.test.ts` adds a pin on the new contribution (6/6 pass).
- [x] Codex adversarial review pass, then follow-up confirmation pass (no blockers).
- [ ] Integration suite (`editors/vscode/src/test/rmarkdown-quarto.test.ts`) — added a baseline `doc.languageId === 'rmd'` assertion; needs the vscode-test runner to verify.
- [ ] Manual: open an `.Rmd` file with the Quarto extension installed but without REditorSupport.r-syntax — confirm `editorLangId == rmd` and Shift+Cmd+Enter triggers Knit Preview.