### PR TITLE
feat(chunks): bind Cmd/Ctrl+Alt+Enter to Run Current Chunk

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -24,12 +24,13 @@ Chunks also appear in the document outline (`Cmd/Ctrl+Shift+O`) as a distinct sy
 
 | Mac | Windows/Linux | Action |
 |-----|---------------|--------|
-| `Cmd+Shift+Enter` | `Ctrl+Shift+Enter` | Run Current Chunk (in `.Rmd` / `.qmd`) |
+| `Cmd+Alt+Enter` | `Ctrl+Alt+Enter` | Run Current Chunk |
+| `Cmd+Alt+Shift+Enter` | `Ctrl+Alt+Shift+Enter` | Run Current Chunk and Move |
 | `Cmd+Alt+P` | `Ctrl+Alt+P` | Run Above Chunks |
 | `Cmd+Alt+N` | `Ctrl+Alt+N` | Go to Next Chunk |
 | `Cmd+Alt+Shift+N` | `Ctrl+Alt+Shift+N` | Go to Previous Chunk |
 
-In `.R` files, `Cmd+Shift+Enter` keeps its usual meaning of **Source File** — to run a single cell, use the command palette or the CodeLens "Run Chunk" button.
+In `.R` files without `# %%` cell markers the current-chunk shortcuts surface a warning; use [cell mode](#plain-r-cell-mode) to make them useful in plain `.R` files.
 
 ## Commands
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -317,6 +317,18 @@
         "when": "editorTextFocus && raven.rConsoleEnabled && raven.rmdKnit.enabled && (editorLangId == rmd || editorLangId == r) && resourceExtname =~ /\\.(rmd|Rmd|RMD)$/"
       },
       {
+        "command": "raven.runCurrentChunk",
+        "key": "ctrl+alt+enter",
+        "mac": "cmd+alt+enter",
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
+      },
+      {
+        "command": "raven.runCurrentChunkAndMove",
+        "key": "ctrl+alt+shift+enter",
+        "mac": "cmd+alt+shift+enter",
+        "when": "editorTextFocus && (editorLangId == r || editorLangId == rmd || editorLangId == quarto) && raven.rConsoleEnabled"
+      },
+      {
         "command": "raven.runAboveChunks",
         "key": "ctrl+alt+p",
         "mac": "cmd+alt+p",


### PR DESCRIPTION
## Summary

- Adds `Cmd+Alt+Enter` / `Ctrl+Alt+Enter` → `raven.runCurrentChunk`
- Adds `Cmd+Alt+Shift+Enter` / `Ctrl+Alt+Shift+Enter` → `raven.runCurrentChunkAndMove`
- Both gated on `editorTextFocus && (editorLangId == r || rmd || quarto) && raven.rConsoleEnabled`, matching the rest of the chunk keybindings.
- Drops an obsolete row in [docs/chunks.md](docs/chunks.md) that listed `Cmd+Shift+Enter` as Run Current Chunk — that chord is bound to `raven.knit` (Knit Preview) on `.Rmd`, already documented in [docs/r-console.md](docs/r-console.md).

## Test plan

- [ ] In an `.Rmd` chunk: `Cmd+Alt+Enter` runs the current chunk
- [ ] In an `.Rmd` chunk: `Cmd+Alt+Shift+Enter` runs the current chunk and moves to the next
- [ ] In a `.qmd` chunk: same chords behave the same way
- [ ] In a `.R` cell-mode buffer (`# %%`): same chords run the current cell
- [ ] With `raven.rConsole.activation` resolved to disabled (e.g. REditorSupport active): chords are inert