### PR TITLE
refactor(plot): structural background tagging, drop color allowlist

### DIFF
--- a/editors/vscode/src/plot/webview/App.svelte
+++ b/editors/vscode/src/plot/webview/App.svelte
@@ -19,6 +19,7 @@
     } from '../messages';
     import { isExtensionToWebviewMessage } from '../messages';
     import { sanitize_svg } from './sanitize';
+    import { tag_background_rects } from './tag-backgrounds';
 
     interface Props {
         vscode: { postMessage(msg: WebviewToExtensionMessage): void };
@@ -392,10 +393,18 @@
                 if (existing && existing.upid >= capturedUpid) return;
                 const sanitized = sanitize_svg(text);
                 if (!sanitized) return;
+                // Heuristic structural tagging of canvas/panel
+                // background rects (see ./tag-backgrounds for the
+                // rules). The overlay CSS targets `rect.raven-bg` so
+                // we get colour-agnostic background hiding without a
+                // hand-maintained allowlist. The tagger is a pure
+                // function of the SVG text, so caching the post-tag
+                // bytes is sound.
+                const tagged = tag_background_rects(sanitized);
                 dispatch({
                     type: 'SET_SVG_CACHE_ENTRY',
                     cacheKey,
-                    entry: { svgText: sanitized, upid: capturedUpid },
+                    entry: { svgText: tagged, upid: capturedUpid },
                 });
             })
             .catch(() => {
@@ -528,11 +537,6 @@
         max-height: 100%;
     }
 
-    .plot-host.apply-vscode-theme :global(svg.httpgd > rect:first-of-type) {
-        fill: none !important;
-        stroke: none !important;
-    }
-
     .plot-host.apply-vscode-theme :global(svg.httpgd text) {
         fill: var(--vscode-editor-foreground) !important;
         font-family: var(--vscode-editor-font-family) !important;
@@ -543,39 +547,22 @@
     .plot-host.apply-vscode-theme :global(svg.httpgd polygon),
     .plot-host.apply-vscode-theme :global(svg.httpgd path),
     .plot-host.apply-vscode-theme :global(svg.httpgd circle),
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect:not(:first-of-type)) {
+    .plot-host.apply-vscode-theme :global(svg.httpgd rect:not(.raven-bg)) {
         stroke: var(--vscode-editor-foreground) !important;
     }
 
-    /* httpgd-rendered plots paint multiple background rects under the
-     * data layer; the toggle has to hide all of them so
-     * `--vscode-editor-background` can show through.
+    /* Hide the canvas/panel background rects that `tag_background_rects`
+     * (in ./tag-backgrounds.ts) flagged with `class="raven-bg"`. The
+     * webview body's `--vscode-editor-background` shows through.
      *
-     *   - `#FFFFFF` covers two distinct rects on every plot: the
-     *     first-of-type direct child of <svg> (httpgd's canvas, also
-     *     hit by the `:first-of-type` rule above) AND an inner rect
-     *     wrapped in a `<g clip-path>` that the `:first-of-type`
-     *     selector cannot reach.
-     *   - `#EBEBEB` is `grey92`, the ggplot2 `theme_gray()` default
-     *     for `panel.background`. ggplot2 is the dominant R plot
-     *     ecosystem; without this entry the cartesian grid stays
-     *     painted light-gray over the editor background.
-     *
-     * Extending the allowlist is intentionally conservative: we'd
-     * rather miss a non-default ggplot theme's background (and have
-     * the user toggle off) than hide a deliberate white/grey-filled
-     * shape in their data (e.g. a `geom_rect()` panel) once the toggle
-     * is on. Add new colors only when a real plot demonstrates the
-     * miss. The `i` flag is CSS4 case-insensitive matching — defensive
-     * against a future httpgd version emitting lowercase hex.
-     *
-     * Source order matters: this rule lives AFTER the stroke-recolor
-     * rule above so the `stroke: none !important` here overrides the
-     * editor-foreground stroke that would otherwise outline the inner
-     * background rects (the two rules have equal CSS specificity, so
-     * later-in-source wins). */
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect[fill="#FFFFFF" i]),
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect[fill="#EBEBEB" i]) {
+     * The previous mechanism was a `rect[fill="#FFFFFF" i],
+     * rect[fill="#EBEBEB" i]` allowlist: every non-default ggplot theme
+     * (`theme_dark()` → grey50, user-customized themes, theme_minimal
+     * with no panel bg at all) required a new entry, and any user-drawn
+     * shape that happened to match an allowlisted colour silently
+     * disappeared. Structural tagging is colour-agnostic and stable
+     * across themes — see `tag-backgrounds.ts` for the heuristic. */
+    .plot-host.apply-vscode-theme :global(svg.httpgd rect.raven-bg) {
         fill: none !important;
         stroke: none !important;
     }

--- a/editors/vscode/src/plot/webview/tag-backgrounds.ts
+++ b/editors/vscode/src/plot/webview/tag-backgrounds.ts
@@ -34,30 +34,34 @@ export function tag_background_rects(svgText: string): string {
     const doc = (globalThis as { document?: Document }).document;
     if (!doc) return svgText;
 
-    // Parse via a detached <div> + innerHTML rather than DOMParser:
-    // DOMPurify's output is HTML-style (not strictly well-formed XML
-    // — closing tags, attribute quote conventions, etc.), and an
-    // HTML-aware parser is the forgiving path. The browser's HTML
-    // parser switches to foreign-content mode for `<svg>`, so the SVG
-    // namespace and element semantics are preserved.
+    // Parse via a detached <div> + innerHTML: DOMPurify's output is
+    // HTML-style (not strictly well-formed XML), and the HTML parser
+    // is the forgiving path. `<svg>` triggers foreign-content insertion,
+    // so the SVG namespace and element semantics are preserved.
     const container = doc.createElement('div');
     container.innerHTML = svgText;
     const svg = container.querySelector('svg');
     if (!svg) return svgText;
 
-    // `getElementsByTagName` returns a live HTMLCollection. We add
-    // class attributes only (no element insertions/removals), so the
-    // collection length stays stable and the index-based iteration is
-    // safe.
-    const rects = svg.getElementsByTagName('rect');
-    for (let i = 0; i < rects.length; i++) {
-        const rect = rects[i];
+    // `querySelectorAll` returns a static NodeList and handles
+    // namespaced (SVG) elements consistently across browsers — safer
+    // than `getElementsByTagName` for descendant-of-SVG queries.
+    const rects = svg.querySelectorAll('rect');
+    for (const rect of rects) {
         if (is_background_rect(rect)) {
-            add_class(rect, 'raven-bg');
+            // classList.add() is idempotent, handles whitespace
+            // normalization, and works uniformly on SVG and HTML
+            // elements.
+            rect.classList.add('raven-bg');
         }
     }
 
-    return container.innerHTML;
+    // Serialize the SVG element directly, not the wrapping <div>.
+    // Reading `container.innerHTML` would re-serialize the SVG inside
+    // the HTML <div>, which in some browsers strips the `xmlns`
+    // declaration when the namespace is implicit. `svg.outerHTML`
+    // preserves attribute fidelity.
+    return svg.outerHTML;
 }
 
 function is_background_rect(rect: Element): boolean {
@@ -99,19 +103,4 @@ function collect_direct_rect_children(parent: Element): Element[] {
         if (n.localName === 'rect') out.push(n);
     }
     return out;
-}
-
-function add_class(el: Element, cls: string): void {
-    const existing = el.getAttribute('class');
-    if (!existing) {
-        el.setAttribute('class', cls);
-        return;
-    }
-    // Idempotent: a caller that runs the tagger twice should not get a
-    // doubled class token.
-    const tokens = existing.split(/\s+/);
-    for (const t of tokens) {
-        if (t === cls) return;
-    }
-    el.setAttribute('class', `${existing} ${cls}`);
 }

--- a/editors/vscode/src/plot/webview/tag-backgrounds.ts
+++ b/editors/vscode/src/plot/webview/tag-backgrounds.ts
@@ -8,12 +8,24 @@
  *   1. It is the first <rect> direct child of <svg> — httpgd's outer
  *      canvas always sits in that slot, regardless of fill.
  *
- *   2. It is the only <rect> direct child of a <g> parent AND has
- *      `stroke="none"` (or no stroke attribute). This catches panel
- *      backgrounds (e.g. ggplot2's `panel.background` rect, sitting
- *      alone before the data layer) while leaving bar-chart bars
- *      (multiple <rect> siblings in a <g>) and `geom_rect()`
- *      annotations (which typically carry a stroke) untouched.
+ *   2. It is a <rect> direct child of a <g> AND has neither
+ *      `stroke-linejoin` nor `stroke-linecap` attributes. ggplot2's
+ *      element_rect (used for `panel.background`, `plot.background`,
+ *      etc.) and httpgd's inner canvas rect render with no linejoin/
+ *      linecap (their grid defaults match httpgd's defaults). Data
+ *      rects (geom_rect / geom_bar / geom_col / geom_tile) ALWAYS
+ *      carry both attributes because GeomRect's defaults
+ *      (`linejoin = "mitre"`, `lineend = "butt"`) differ from
+ *      httpgd's "round" / "round" defaults and are therefore emitted.
+ *
+ * This was verified empirically by capturing real httpgd output for
+ * ggplot's `theme_gray()` scatter and bar charts (see the
+ * `tests/fixtures/httpgd/ggplot-*.svg` snapshots): the inner-canvas
+ * rect arrives as `stroke="#FFFFFF" fill="#FFFFFF"` (stroke matches
+ * fill, not "none"), and the panel.bg rect lives alongside data bars
+ * in the same `<g>`. A "stroke=none AND only-rect-in-g" rule misses
+ * both. Filtering by linejoin/linecap presence catches them and
+ * rejects the bars correctly.
  *
  * The previous mechanism was a CSS `rect[fill="#FFFFFF" i], rect[fill=
  * "#EBEBEB" i]` allowlist — brittle: every non-default ggplot theme
@@ -77,14 +89,18 @@ function is_background_rect(rect: Element): boolean {
     }
 
     if (parent.localName === 'g') {
-        // Rule 2: a single <rect> direct child of <g> with no stroke
-        // is a background. Bar-chart bars come in multiples (count > 1
-        // disqualifies); geom_rect() annotations typically carry a
-        // stroke (non-`none` stroke disqualifies).
-        const directRects = collect_direct_rect_children(parent);
-        if (directRects.length !== 1) return false;
-        const stroke = rect.getAttribute('stroke');
-        return stroke === null || stroke === 'none';
+        // Rule 2: ggplot2 backgrounds (element_rect) and httpgd's
+        // inner canvas render WITHOUT `stroke-linejoin` / `stroke-
+        // linecap` attributes — their R-side defaults match httpgd's
+        // SVG defaults, so the attributes aren't emitted. Data rects
+        // (GeomRect / GeomBar / GeomCol / GeomTile) ALWAYS carry both
+        // attributes because GeomRect defaults to `linejoin = "mitre"`
+        // / `lineend = "butt"`, which differ from httpgd's defaults
+        // and get emitted explicitly. The presence test cleanly
+        // separates them.
+        if (rect.hasAttribute('stroke-linejoin')) return false;
+        if (rect.hasAttribute('stroke-linecap')) return false;
+        return true;
     }
 
     return false;
@@ -95,12 +111,4 @@ function first_rect_child(parent: Element): Element | null {
         if (n.localName === 'rect') return n;
     }
     return null;
-}
-
-function collect_direct_rect_children(parent: Element): Element[] {
-    const out: Element[] = [];
-    for (let n = parent.firstElementChild; n !== null; n = n.nextElementSibling) {
-        if (n.localName === 'rect') out.push(n);
-    }
-    return out;
 }

--- a/editors/vscode/src/plot/webview/tag-backgrounds.ts
+++ b/editors/vscode/src/plot/webview/tag-backgrounds.ts
@@ -1,0 +1,117 @@
+/**
+ * Tag canvas/panel "background" rects in a sanitized httpgd SVG with
+ * `class="raven-bg"` so the plot viewer's "Apply VS Code theme" overlay
+ * can hide them without a hand-maintained colour allowlist.
+ *
+ * A <rect> is tagged when EITHER:
+ *
+ *   1. It is the first <rect> direct child of <svg> — httpgd's outer
+ *      canvas always sits in that slot, regardless of fill.
+ *
+ *   2. It is the only <rect> direct child of a <g> parent AND has
+ *      `stroke="none"` (or no stroke attribute). This catches panel
+ *      backgrounds (e.g. ggplot2's `panel.background` rect, sitting
+ *      alone before the data layer) while leaving bar-chart bars
+ *      (multiple <rect> siblings in a <g>) and `geom_rect()`
+ *      annotations (which typically carry a stroke) untouched.
+ *
+ * The previous mechanism was a CSS `rect[fill="#FFFFFF" i], rect[fill=
+ * "#EBEBEB" i]` allowlist — brittle: every non-default ggplot theme
+ * (`theme_dark()` = grey50, user-customized themes) needed a new entry,
+ * and a legitimate `geom_rect()` annotation that happened to land on
+ * an allowlisted colour would silently vanish. Tagging by structure
+ * generalizes across themes and is colour-agnostic.
+ *
+ * Determinism: this function is a pure transform of the SVG text, so
+ * the fetch effect's cache (keyed by `(sessionId, plotId, width, height)`)
+ * can store the post-tag bytes alongside any other tagged output for
+ * the same input.
+ */
+export function tag_background_rects(svgText: string): string {
+    if (!svgText) return svgText;
+    // The webview's document is the real browser document; in bun tests
+    // it's jsdom's document installed into globalThis via beforeAll.
+    const doc = (globalThis as { document?: Document }).document;
+    if (!doc) return svgText;
+
+    // Parse via a detached <div> + innerHTML rather than DOMParser:
+    // DOMPurify's output is HTML-style (not strictly well-formed XML
+    // — closing tags, attribute quote conventions, etc.), and an
+    // HTML-aware parser is the forgiving path. The browser's HTML
+    // parser switches to foreign-content mode for `<svg>`, so the SVG
+    // namespace and element semantics are preserved.
+    const container = doc.createElement('div');
+    container.innerHTML = svgText;
+    const svg = container.querySelector('svg');
+    if (!svg) return svgText;
+
+    // `getElementsByTagName` returns a live HTMLCollection. We add
+    // class attributes only (no element insertions/removals), so the
+    // collection length stays stable and the index-based iteration is
+    // safe.
+    const rects = svg.getElementsByTagName('rect');
+    for (let i = 0; i < rects.length; i++) {
+        const rect = rects[i];
+        if (is_background_rect(rect)) {
+            add_class(rect, 'raven-bg');
+        }
+    }
+
+    return container.innerHTML;
+}
+
+function is_background_rect(rect: Element): boolean {
+    const parent = rect.parentElement;
+    if (!parent) return false;
+
+    if (parent.localName === 'svg') {
+        // Rule 1: tag the first <rect> direct child of <svg> regardless
+        // of fill — httpgd's outer canvas is always there. A subsequent
+        // <rect> direct child of <svg> (rare in practice) is treated
+        // as content and left alone.
+        return first_rect_child(parent) === rect;
+    }
+
+    if (parent.localName === 'g') {
+        // Rule 2: a single <rect> direct child of <g> with no stroke
+        // is a background. Bar-chart bars come in multiples (count > 1
+        // disqualifies); geom_rect() annotations typically carry a
+        // stroke (non-`none` stroke disqualifies).
+        const directRects = collect_direct_rect_children(parent);
+        if (directRects.length !== 1) return false;
+        const stroke = rect.getAttribute('stroke');
+        return stroke === null || stroke === 'none';
+    }
+
+    return false;
+}
+
+function first_rect_child(parent: Element): Element | null {
+    for (let n = parent.firstElementChild; n !== null; n = n.nextElementSibling) {
+        if (n.localName === 'rect') return n;
+    }
+    return null;
+}
+
+function collect_direct_rect_children(parent: Element): Element[] {
+    const out: Element[] = [];
+    for (let n = parent.firstElementChild; n !== null; n = n.nextElementSibling) {
+        if (n.localName === 'rect') out.push(n);
+    }
+    return out;
+}
+
+function add_class(el: Element, cls: string): void {
+    const existing = el.getAttribute('class');
+    if (!existing) {
+        el.setAttribute('class', cls);
+        return;
+    }
+    // Idempotent: a caller that runs the tagger twice should not get a
+    // doubled class token.
+    const tokens = existing.split(/\s+/);
+    for (const t of tokens) {
+        if (t === cls) return;
+    }
+    el.setAttribute('class', `${existing} ${cls}`);
+}

--- a/tests/bun/plot-tag-backgrounds.test.ts
+++ b/tests/bun/plot-tag-backgrounds.test.ts
@@ -1,0 +1,211 @@
+// Heuristic background-tagging for the "Apply VS Code theme" overlay.
+//
+// `tag_background_rects` walks a sanitized SVG and adds `class="raven-bg"`
+// to every <rect> that looks like a canvas or panel background:
+//
+//   1. The first <rect> direct child of <svg> — httpgd's outer canvas,
+//      regardless of fill.
+//   2. The only <rect> direct child of a <g> parent AND with
+//      `stroke="none"` (or no stroke attribute) — a panel background
+//      sitting alone before its data layer.
+//
+// The overlay CSS then targets `rect.raven-bg` instead of a colour
+// allowlist, so new ggplot themes (theme_dark, theme_minimal, user-
+// customized) work without an extra hex entry per theme.
+//
+// Negatives the heuristic must respect:
+//   - Bar-chart bars (multiple rect siblings in a <g>) stay un-tagged.
+//   - geom_rect() annotations carrying a stroke stay un-tagged.
+
+import { describe, test, expect, beforeAll } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+beforeAll(() => {
+    // Same jsdom-into-globalThis pattern the sanitize tests use. The
+    // tagger relies on `globalThis.document` so it can create a
+    // detached container element and walk parsed DOM.
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const g = globalThis as Record<string, unknown>;
+    g.window = dom.window;
+    g.document = dom.window.document;
+    g.Node = dom.window.Node;
+    g.NodeFilter = dom.window.NodeFilter;
+    g.HTMLElement = dom.window.HTMLElement;
+    g.SVGElement = dom.window.SVGElement;
+    g.Element = dom.window.Element;
+    g.DocumentFragment = dom.window.DocumentFragment;
+});
+
+const tag_background_rects: (text: string) => string = await (async () => {
+    const mod = await import('../../editors/vscode/src/plot/webview/tag-backgrounds');
+    return mod.tag_background_rects;
+})();
+const sanitize_svg: (text: string) => string = await (async () => {
+    const mod = await import('../../editors/vscode/src/plot/webview/sanitize');
+    return mod.sanitize_svg;
+})();
+
+const FIXTURE_PATH = resolve(
+    (import.meta as unknown as { dir: string }).dir,
+    '..',
+    'fixtures',
+    'httpgd',
+    'plot-1-10.svg',
+);
+
+function parse_rects(svgText: string): Element[] {
+    const dom = new JSDOM(`<!doctype html><html><body>${svgText}</body></html>`);
+    return Array.from(dom.window.document.querySelectorAll('rect'));
+}
+
+describe('tag_background_rects — heuristic identifies canvas + panel rects', () => {
+    test('httpgd fixture: both canvas rects gain class="raven-bg"; data circles untouched', () => {
+        const fixture = readFileSync(FIXTURE_PATH, 'utf-8');
+        const sanitized = sanitize_svg(fixture);
+        const tagged = tag_background_rects(sanitized);
+        const rects = parse_rects(tagged);
+        const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
+        // Outer canvas (first-of-type direct child of <svg>) + inner
+        // canvas (single rect under <g clip-path>, stroke=none) = 2.
+        // The <clipPath><rect/></clipPath> defs rects sit under
+        // <clipPath>, not under <g> or directly under <svg>, so the
+        // heuristic skips them.
+        expect(taggedRects.length).toBe(2);
+        // Data circles aren't rects; the tagger never visits them.
+        const dom = new JSDOM(`<!doctype html><html><body>${tagged}</body></html>`);
+        const circles = Array.from(dom.window.document.querySelectorAll('circle'));
+        expect(circles.length).toBeGreaterThan(0);
+        for (const c of circles) {
+            expect(c.classList.contains('raven-bg')).toBe(false);
+        }
+    });
+
+    test('ggplot2 panel.background: outer canvas + panel rect both tagged regardless of fill', () => {
+        // Synthetic mirror of ggplot2 theme_gray output: outer #FFFFFF
+        // canvas + a single #EBEBEB panel.background rect alone in its
+        // <g clip-path>. Note: the heuristic must NOT look at fill —
+        // theme_dark's #7F7F7F or a user-customized colour would fail
+        // an allowlist but pass the structural rules.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
+            + '<defs><clipPath id="cp"><rect /></clipPath></defs>'
+            + '<g clip-path="url(#cp)">'
+            + '<rect fill="#EBEBEB" stroke="none" />'
+            + '</g>'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
+        // 2 expected: outer canvas (Rule 1) + panel rect (Rule 2).
+        // The <clipPath><rect/></clipPath> defs rect is not tagged —
+        // its parent is <clipPath>, not <g> or <svg>.
+        expect(taggedRects.length).toBe(2);
+    });
+
+    test('theme_dark()-style panel (fill=#7F7F7F, stroke=none alone in <g>) is tagged', () => {
+        // Generalization probe: the WHOLE POINT of the heuristic is
+        // that it works for ggplot2 themes the colour allowlist never
+        // saw — theme_dark, theme_minimal (which has no panel bg at
+        // all so nothing to tag), user-customized themes. #7F7F7F is
+        // theme_dark's panel default.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
+            + '<g clip-path="url(#cp)">'
+            + '<rect fill="#7F7F7F" stroke="none" />'
+            + '</g>'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        const panelBg = rects.find(r => r.getAttribute('fill') === '#7F7F7F');
+        expect(panelBg).toBeDefined();
+        expect(panelBg!.classList.contains('raven-bg')).toBe(true);
+    });
+
+    test('bar chart: multiple <rect> siblings in <g> are NOT tagged (data, not background)', () => {
+        // ggplot2 geom_bar() with default colour=NA emits multiple
+        // rects with stroke=none inside one clip-path <g>. A naive
+        // "all stroke=none rects" rule would erase the bars; the
+        // :only-of-type constraint of Rule 2 is what saves us.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
+            + '<g clip-path="url(#cp)">'
+            + '<rect x="0" width="20" fill="#0000FF" stroke="none" />'
+            + '<rect x="30" width="20" fill="#0000FF" stroke="none" />'
+            + '<rect x="60" width="20" fill="#0000FF" stroke="none" />'
+            + '</g>'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        // The outer canvas is still tagged (Rule 1 always applies).
+        const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
+        expect(taggedRects).toHaveLength(1);
+        expect(taggedRects[0].getAttribute('width')).toBe('100%');
+        // None of the inner bars are tagged.
+        const bars = rects.filter(r => r.getAttribute('fill') === '#0000FF');
+        expect(bars).toHaveLength(3);
+        for (const bar of bars) {
+            expect(bar.classList.contains('raven-bg')).toBe(false);
+        }
+    });
+
+    test('geom_rect() annotation with stroke is NOT tagged even when alone in <g>', () => {
+        // A deliberate single annotation rect with a stroke colour
+        // (the typical geom_rect() shape when colour aesthetic is set)
+        // looks structurally like a panel-bg under Rule 2 if we ignore
+        // stroke. The stroke check is what distinguishes them.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
+            + '<g clip-path="url(#cp)">'
+            + '<rect fill="#FF0000" stroke="#000000" />'
+            + '</g>'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        const annotation = rects.find(r => r.getAttribute('fill') === '#FF0000');
+        expect(annotation).toBeDefined();
+        expect(annotation!.classList.contains('raven-bg')).toBe(false);
+    });
+
+    test('existing class attribute is preserved alongside raven-bg', () => {
+        // Defensive: a future httpgd version (or third-party SVG)
+        // might pre-emit a class on the canvas rect. The tagger must
+        // append `raven-bg` rather than clobber the existing value.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect class="httpgd-extra" fill="#FFFFFF" stroke="none" />'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        expect(rects).toHaveLength(1);
+        const classes = (rects[0].getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+        expect(classes).toContain('httpgd-extra');
+        expect(classes).toContain('raven-bg');
+    });
+
+    test('repeated invocation does not duplicate the raven-bg class', () => {
+        // The fetch effect caches the post-tag bytes, so repeated
+        // application is rare — but a future caller might (e.g. for
+        // diagnostics) and the result should still be idempotent.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect fill="#FFFFFF" stroke="none" />'
+            + '</svg>';
+        const once = tag_background_rects(input);
+        const twice = tag_background_rects(once);
+        const rects = parse_rects(twice);
+        const tokens = (rects[0].getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+        const bgCount = tokens.filter(t => t === 'raven-bg').length;
+        expect(bgCount).toBe(1);
+    });
+
+    test('empty input returns empty output without throwing', () => {
+        expect(tag_background_rects('')).toBe('');
+    });
+
+    test('input lacking <svg> is returned unchanged', () => {
+        // Defensive: sanitize_svg can hand us non-SVG text on malformed
+        // input. The tagger must not silently corrupt that.
+        const input = 'hello world';
+        expect(tag_background_rects(input)).toBe(input);
+    });
+});

--- a/tests/bun/plot-tag-backgrounds.test.ts
+++ b/tests/bun/plot-tag-backgrounds.test.ts
@@ -5,17 +5,18 @@
 //
 //   1. The first <rect> direct child of <svg> — httpgd's outer canvas,
 //      regardless of fill.
-//   2. The only <rect> direct child of a <g> parent AND with
-//      `stroke="none"` (or no stroke attribute) — a panel background
-//      sitting alone before its data layer.
+//   2. A <rect> direct child of a <g> AND with neither `stroke-linejoin`
+//      nor `stroke-linecap` attributes. ggplot2's element_rect (used
+//      for panel.background, plot.background, etc.) and httpgd's inner
+//      canvas render without these attributes (their grid defaults
+//      match httpgd's defaults). Data rects (GeomRect / GeomBar /
+//      GeomCol / GeomTile) ALWAYS carry both because GeomRect defaults
+//      to `linejoin = "mitre"` / `lineend = "butt"` and httpgd emits
+//      non-default join/cap values explicitly.
 //
-// The overlay CSS then targets `rect.raven-bg` instead of a colour
-// allowlist, so new ggplot themes (theme_dark, theme_minimal, user-
-// customized) work without an extra hex entry per theme.
-//
-// Negatives the heuristic must respect:
-//   - Bar-chart bars (multiple rect siblings in a <g>) stay un-tagged.
-//   - geom_rect() annotations carrying a stroke stay un-tagged.
+// This distinguisher is validated against captured real httpgd 2.1.4
+// output for both `theme_gray()` scatter and bar plots — see the
+// `tests/fixtures/httpgd/ggplot-*.svg` fixtures.
 
 import { describe, test, expect, beforeAll } from 'bun:test';
 import { JSDOM } from 'jsdom';
@@ -23,9 +24,6 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 beforeAll(() => {
-    // Same jsdom-into-globalThis pattern the sanitize tests use. The
-    // tagger relies on `globalThis.document` so it can create a
-    // detached container element and walk parsed DOM.
     const dom = new JSDOM('<!doctype html><html><body></body></html>');
     const g = globalThis as Record<string, unknown>;
     g.window = dom.window;
@@ -47,12 +45,11 @@ const sanitize_svg: (text: string) => string = await (async () => {
     return mod.sanitize_svg;
 })();
 
-const FIXTURE_PATH = resolve(
+const FIXTURES_DIR = resolve(
     (import.meta as unknown as { dir: string }).dir,
     '..',
     'fixtures',
     'httpgd',
-    'plot-1-10.svg',
 );
 
 function parse_rects(svgText: string): Element[] {
@@ -61,19 +58,17 @@ function parse_rects(svgText: string): Element[] {
 }
 
 describe('tag_background_rects — heuristic identifies canvas + panel rects', () => {
-    test('httpgd fixture: both canvas rects gain class="raven-bg"; data circles untouched', () => {
-        const fixture = readFileSync(FIXTURE_PATH, 'utf-8');
+    test('existing httpgd fixture: both canvas rects gain class="raven-bg"; data circles untouched', () => {
+        const fixture = readFileSync(resolve(FIXTURES_DIR, 'plot-1-10.svg'), 'utf-8');
         const sanitized = sanitize_svg(fixture);
         const tagged = tag_background_rects(sanitized);
         const rects = parse_rects(tagged);
         const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
-        // Outer canvas (first-of-type direct child of <svg>) + inner
-        // canvas (single rect under <g clip-path>, stroke=none) = 2.
-        // The <clipPath><rect/></clipPath> defs rects sit under
-        // <clipPath>, not under <g> or directly under <svg>, so the
-        // heuristic skips them.
+        // Outer canvas (Rule 1) + inner canvas (Rule 2, no linejoin/
+        // linecap, direct child of <g>) = 2. The <clipPath><rect/></clipPath>
+        // defs rect is not tagged — its parent is <clipPath>, neither
+        // <svg> nor <g>.
         expect(taggedRects.length).toBe(2);
-        // Data circles aren't rects; the tagger never visits them.
         const dom = new JSDOM(`<!doctype html><html><body>${tagged}</body></html>`);
         const circles = Array.from(dom.window.document.querySelectorAll('circle'));
         expect(circles.length).toBeGreaterThan(0);
@@ -82,12 +77,61 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
         }
     });
 
-    test('ggplot2 panel.background: outer canvas + panel rect both tagged regardless of fill', () => {
-        // Synthetic mirror of ggplot2 theme_gray output: outer #FFFFFF
-        // canvas + a single #EBEBEB panel.background rect alone in its
-        // <g clip-path>. Note: the heuristic must NOT look at fill —
-        // theme_dark's #7F7F7F or a user-customized colour would fail
-        // an allowlist but pass the structural rules.
+    test('real httpgd ggplot scatter: outer canvas + inner canvas + panel.background all tagged', () => {
+        // Captured live from R via `ggplot(mtcars, aes(wt, mpg)) +
+        // geom_point()` against httpgd 2.1.4. The inner canvas rect
+        // arrives as `stroke="#FFFFFF" fill="#FFFFFF"` (matching
+        // stroke/fill, not "none") — the original "stroke=none AND
+        // only-rect-in-g" heuristic missed it. This is the regression
+        // pin for the user-reported "always white" bug.
+        const fixture = readFileSync(resolve(FIXTURES_DIR, 'ggplot-scatter.svg'), 'utf-8');
+        const sanitized = sanitize_svg(fixture);
+        const tagged = tag_background_rects(sanitized);
+        const rects = parse_rects(tagged);
+        const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
+        // 3 expected: outer canvas (#FFFFFF, Rule 1), inner canvas
+        // (#FFFFFF/#FFFFFF, Rule 2), panel.background (#EBEBEB, Rule 2).
+        // The 3 <clipPath><rect/></clipPath> defs rects sit under
+        // <clipPath> and are skipped.
+        expect(taggedRects.length).toBe(3);
+        // Spot-check each by fill colour.
+        const fills = taggedRects.map(r => r.getAttribute('fill')).sort();
+        expect(fills).toEqual(['#EBEBEB', '#FFFFFF', '#FFFFFF']);
+    });
+
+    test('real httpgd ggplot bar chart: backgrounds tagged, bars (with linejoin/linecap) untouched', () => {
+        // Captured live: `ggplot(mtcars, aes(factor(cyl))) + geom_bar()`.
+        // The c1 <g> holds the panel.background rect AND 3 bar rects
+        // as siblings. A naive "only-rect-in-g" rule would miss the
+        // panel.background; an "all stroke=none rects" rule would
+        // erase the bars. The linejoin/linecap distinguisher cleanly
+        // separates them: GeomBar emits `stroke-linejoin="miter"`
+        // and `stroke-linecap="butt"`; element_rect does not.
+        const fixture = readFileSync(resolve(FIXTURES_DIR, 'ggplot-bar.svg'), 'utf-8');
+        const sanitized = sanitize_svg(fixture);
+        const tagged = tag_background_rects(sanitized);
+        const rects = parse_rects(tagged);
+        const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
+        // 3 expected: outer canvas, inner canvas, panel.background.
+        expect(taggedRects.length).toBe(3);
+        // The 3 bar rects (#595959) must NOT be tagged.
+        const bars = rects.filter(r => r.getAttribute('fill') === '#595959');
+        expect(bars).toHaveLength(3);
+        for (const bar of bars) {
+            expect(bar.classList.contains('raven-bg')).toBe(false);
+        }
+        // Pin the structural signal: each bar carries stroke-linejoin
+        // (this is what makes the heuristic work).
+        for (const bar of bars) {
+            expect(bar.hasAttribute('stroke-linejoin')).toBe(true);
+            expect(bar.hasAttribute('stroke-linecap')).toBe(true);
+        }
+    });
+
+    test('ggplot2 panel.background synthetic: outer canvas + panel rect both tagged', () => {
+        // Synthetic mirror of theme_gray output. The heuristic must
+        // NOT look at fill — theme_dark's #7F7F7F or a user-customized
+        // colour would fail an allowlist but pass the structural rules.
         const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
             + '<defs><clipPath id="cp"><rect /></clipPath></defs>'
@@ -99,17 +143,13 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
         const rects = parse_rects(out);
         const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
         // 2 expected: outer canvas (Rule 1) + panel rect (Rule 2).
-        // The <clipPath><rect/></clipPath> defs rect is not tagged —
-        // its parent is <clipPath>, not <g> or <svg>.
+        // The defs clipPath rect's parent is <clipPath>, not <g>.
         expect(taggedRects.length).toBe(2);
     });
 
-    test('theme_dark()-style panel (fill=#7F7F7F, stroke=none alone in <g>) is tagged', () => {
-        // Generalization probe: the WHOLE POINT of the heuristic is
-        // that it works for ggplot2 themes the colour allowlist never
-        // saw — theme_dark, theme_minimal (which has no panel bg at
-        // all so nothing to tag), user-customized themes. #7F7F7F is
-        // theme_dark's panel default.
+    test('theme_dark()-style panel (fill=#7F7F7F, no linejoin/linecap alone in <g>) is tagged', () => {
+        // Generalization probe: themes the colour allowlist never
+        // saw should still get their panel.background tagged.
         const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
             + '<g clip-path="url(#cp)">'
@@ -123,26 +163,30 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
         expect(panelBg!.classList.contains('raven-bg')).toBe(true);
     });
 
-    test('bar chart: multiple <rect> siblings in <g> are NOT tagged (data, not background)', () => {
-        // ggplot2 geom_bar() with default colour=NA emits multiple
-        // rects with stroke=none inside one clip-path <g>. A naive
-        // "all stroke=none rects" rule would erase the bars; the
-        // :only-of-type constraint of Rule 2 is what saves us.
+    test('bar chart synthetic: rects with stroke-linejoin/stroke-linecap are NOT tagged', () => {
+        // ggplot2 GeomBar / GeomRect / GeomCol / GeomTile always emit
+        // `stroke-linejoin="miter"` and `stroke-linecap="butt"` because
+        // their grid defaults differ from httpgd's "round" defaults.
+        // Background rects (element_rect themes, inner canvas) never
+        // emit these attributes. The presence check is the load-bearing
+        // distinguisher.
         const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
             + '<g clip-path="url(#cp)">'
-            + '<rect x="0" width="20" fill="#0000FF" stroke="none" />'
-            + '<rect x="30" width="20" fill="#0000FF" stroke="none" />'
-            + '<rect x="60" width="20" fill="#0000FF" stroke="none" />'
+            // Panel.bg — alone-or-not is no longer the criterion, only
+            // attr-presence. Lives alongside bars in the same <g>.
+            + '<rect fill="#EBEBEB" stroke="none" />'
+            + '<rect x="0" width="20" fill="#0000FF" stroke="none" stroke-linejoin="miter" stroke-linecap="butt" />'
+            + '<rect x="30" width="20" fill="#0000FF" stroke="none" stroke-linejoin="miter" stroke-linecap="butt" />'
+            + '<rect x="60" width="20" fill="#0000FF" stroke="none" stroke-linejoin="miter" stroke-linecap="butt" />'
             + '</g>'
             + '</svg>';
         const out = tag_background_rects(input);
         const rects = parse_rects(out);
-        // The outer canvas is still tagged (Rule 1 always applies).
         const taggedRects = rects.filter(r => r.classList.contains('raven-bg'));
-        expect(taggedRects).toHaveLength(1);
-        expect(taggedRects[0].getAttribute('width')).toBe('100%');
-        // None of the inner bars are tagged.
+        // 2 tagged: outer canvas + panel.bg (no linejoin/linecap).
+        // The 3 bars (with linejoin/linecap) stay un-tagged.
+        expect(taggedRects).toHaveLength(2);
         const bars = rects.filter(r => r.getAttribute('fill') === '#0000FF');
         expect(bars).toHaveLength(3);
         for (const bar of bars) {
@@ -150,15 +194,16 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
         }
     });
 
-    test('geom_rect() annotation with stroke is NOT tagged even when alone in <g>', () => {
-        // A deliberate single annotation rect with a stroke colour
-        // (the typical geom_rect() shape when colour aesthetic is set)
-        // looks structurally like a panel-bg under Rule 2 if we ignore
-        // stroke. The stroke check is what distinguishes them.
+    test('geom_rect() annotation (with stroke-linejoin) is NOT tagged', () => {
+        // GeomRect's default linejoin="mitre" / lineend="butt" gets
+        // emitted by httpgd, so the annotation carries the
+        // distinguishing attributes even when colour=NA produces
+        // stroke="none". The presence-of-linejoin check keeps it out
+        // of the background bucket.
         const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
             + '<g clip-path="url(#cp)">'
-            + '<rect fill="#FF0000" stroke="#000000" />'
+            + '<rect fill="#FF0000" stroke="none" stroke-linejoin="miter" stroke-linecap="butt" />'
             + '</g>'
             + '</svg>';
         const out = tag_background_rects(input);
@@ -166,6 +211,25 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
         const annotation = rects.find(r => r.getAttribute('fill') === '#FF0000');
         expect(annotation).toBeDefined();
         expect(annotation!.classList.contains('raven-bg')).toBe(false);
+    });
+
+    test('inner-canvas-style rect (stroke=fill, no linejoin/linecap) is tagged — pins the user-reported regression', () => {
+        // The httpgd ggplot inner canvas emits
+        // `stroke="#FFFFFF" fill="#FFFFFF"` (stroke matches fill, NOT
+        // "none"). The original heuristic's `stroke === 'none'` check
+        // dropped this rect, leaving the panel area white over the
+        // editor background once the panel.background was hidden.
+        const input = '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
+            + '<g clip-path="url(#cp)">'
+            + '<rect fill="#FFFFFF" stroke="#FFFFFF" />'
+            + '</g>'
+            + '</svg>';
+        const out = tag_background_rects(input);
+        const rects = parse_rects(out);
+        const innerCanvas = rects.find(r => r.getAttribute('stroke') === '#FFFFFF');
+        expect(innerCanvas).toBeDefined();
+        expect(innerCanvas!.classList.contains('raven-bg')).toBe(true);
     });
 
     test('existing class attribute is preserved alongside raven-bg', () => {
@@ -203,8 +267,6 @@ describe('tag_background_rects — heuristic identifies canvas + panel rects', (
     });
 
     test('input lacking <svg> is returned unchanged', () => {
-        // Defensive: sanitize_svg can hand us non-SVG text on malformed
-        // input. The tagger must not silently corrupt that.
         const input = 'hello world';
         expect(tag_background_rects(input)).toBe(input);
     });

--- a/tests/bun/plot-theme-overlay.test.ts
+++ b/tests/bun/plot-theme-overlay.test.ts
@@ -66,6 +66,10 @@ const sanitize_svg: (text: string) => string = await (async () => {
     const mod = await import('../../editors/vscode/src/plot/webview/sanitize');
     return mod.sanitize_svg;
 })();
+const tag_background_rects: (text: string) => string = await (async () => {
+    const mod = await import('../../editors/vscode/src/plot/webview/tag-backgrounds');
+    return mod.tag_background_rects;
+})();
 
 /**
  * Extract every CSS rule under `.apply-vscode-theme` from App.svelte's
@@ -152,12 +156,16 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
     });
 
     test('overlay covers the inner clip-path canvas rect, not just the first-of-type direct child', () => {
-        // The actual contract: when `.apply-vscode-theme` is on, the
-        // selector(s) in App.svelte's <style> block that set
-        // `fill: none` must match the inner background rect — the
-        // one inside `<g clip-path>`, NOT a direct child of <svg>.
-        // The pre-fix overlay only had `svg.httpgd > rect:first-of-type`,
-        // which is structurally insufficient.
+        // Contract: when `.apply-vscode-theme` is on, the selector(s)
+        // in App.svelte's <style> block that set `fill: none` must
+        // match the inner background rect — the one inside
+        // `<g clip-path>`, NOT a direct child of <svg>. With the new
+        // structural-tagging mechanism, the rect carries
+        // `class="raven-bg"` once the SVG has been through
+        // `tag_background_rects`; the CSS selector hits via that
+        // class. We run the synthetic SVG through the tagger so the
+        // assertion exercises the same end-to-end behavior the
+        // webview sees.
         const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
         const selectors = extract_fill_none_selectors_under_theme(source);
         // Sanity: we should have AT LEAST one fill-none rule under
@@ -165,26 +173,23 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
         // style block was reshaped in a way that broke the parser.
         expect(selectors.length).toBeGreaterThan(0);
 
-        // Build a representative DOM mirroring httpgd's output: an
-        // outer `:first-of-type` canvas rect and an inner rect inside
-        // `<g clip-path>`. Use `id` attrs so the test doesn't rely on
-        // `:first-of-type` ordering of arbitrary `<rect>` nodes inside
-        // the harness page.
-        const dom = new JSDOM(
-            '<!doctype html><html><body>'
-            + '<div class="plot-host apply-vscode-theme">'
-            + '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+        const svgSource =
+            '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect id="canvas" width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
             + '<defs><clipPath id="cp"><rect /></clipPath></defs>'
             + '<g clip-path="url(#cp)">'
             + '<rect id="inner" fill="#FFFFFF" stroke="none" />'
             + '</g>'
-            + '</svg>'
-            + '</div>'
-            + '</body></html>',
+            + '</svg>';
+        const tagged = tag_background_rects(svgSource);
+        const dom = new JSDOM(
+            `<!doctype html><html><body><div class="plot-host apply-vscode-theme">${tagged}</div></body></html>`,
         );
         const innerRect = dom.window.document.getElementById('inner');
         expect(innerRect).not.toBeNull();
+        // Pin the tagger end-to-end: the inner rect MUST carry the
+        // class before the CSS selector can hit it.
+        expect(innerRect!.classList.contains('raven-bg')).toBe(true);
         const matched = selectors.some(sel => {
             try {
                 return innerRect!.matches(sel);
@@ -202,31 +207,58 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
     test('overlay covers the ggplot2 panel.background rect (fill="#EBEBEB")', () => {
         // ggplot2's `theme_gray()` is the package default; its
         // `panel.background = element_rect(fill = "grey92")` emits as
-        // `fill="#EBEBEB"` (grey92 in hex). The overlay must cover this
-        // rect too, otherwise the gray panel slab paints over the
-        // editor background inside the cartesian grid — visible as a
-        // light gray rectangle inside an otherwise themed plot.
-        //
-        // We don't ship a real ggplot2 httpgd fixture (would require
-        // running R), but the contract is the rect's fill attribute:
-        // the overlay's selector(s) must match a rect with the grey92
-        // fill regardless of where it sits in the SVG tree.
+        // `fill="#EBEBEB"` (grey92 in hex). Under the structural-
+        // tagging mechanism the panel rect is tagged by Rule 2
+        // (only-rect-in-<g> with stroke=none) — fill colour is no
+        // longer load-bearing.
         const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
         const selectors = extract_fill_none_selectors_under_theme(source);
-        const dom = new JSDOM(
-            '<!doctype html><html><body>'
-            + '<div class="plot-host apply-vscode-theme">'
-            + '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+        const svgSource =
+            '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect id="canvas" fill="#FFFFFF" stroke="none" />'
             + '<g clip-path="url(#panel-clip)">'
             + '<rect id="panel-bg" fill="#EBEBEB" stroke="none" />'
             + '</g>'
-            + '</svg>'
-            + '</div>'
-            + '</body></html>',
+            + '</svg>';
+        const tagged = tag_background_rects(svgSource);
+        const dom = new JSDOM(
+            `<!doctype html><html><body><div class="plot-host apply-vscode-theme">${tagged}</div></body></html>`,
         );
         const panelBg = dom.window.document.getElementById('panel-bg');
         expect(panelBg).not.toBeNull();
+        expect(panelBg!.classList.contains('raven-bg')).toBe(true);
+        const matched = selectors.some(sel => {
+            try { return panelBg!.matches(sel); }
+            catch { return false; }
+        });
+        expect(matched).toBe(true);
+    });
+
+    test('overlay covers a theme_dark()-style panel rect (fill="#7F7F7F") — proves heuristic beats the old colour allowlist', () => {
+        // The whole point of switching from a colour allowlist to
+        // structural tagging: themes the allowlist never saw should
+        // still get their panel.background hidden. `theme_dark()`'s
+        // grey50 = `#7F7F7F` wasn't in the previous allowlist —
+        // before this refactor the panel would have stayed painted
+        // dark-grey over the editor background. After: tagged by
+        // Rule 2 (only-rect-in-<g> with stroke=none), hidden by
+        // `.raven-bg`.
+        const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
+        const selectors = extract_fill_none_selectors_under_theme(source);
+        const svgSource =
+            '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+            + '<rect id="canvas" fill="#FFFFFF" stroke="none" />'
+            + '<g clip-path="url(#panel-clip)">'
+            + '<rect id="panel-bg" fill="#7F7F7F" stroke="none" />'
+            + '</g>'
+            + '</svg>';
+        const tagged = tag_background_rects(svgSource);
+        const dom = new JSDOM(
+            `<!doctype html><html><body><div class="plot-host apply-vscode-theme">${tagged}</div></body></html>`,
+        );
+        const panelBg = dom.window.document.getElementById('panel-bg');
+        expect(panelBg).not.toBeNull();
+        expect(panelBg!.classList.contains('raven-bg')).toBe(true);
         const matched = selectors.some(sel => {
             try { return panelBg!.matches(sel); }
             catch { return false; }
@@ -235,22 +267,24 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
     });
 
     test('overlay still covers the first-of-type direct-child canvas rect (regression guard)', () => {
-        // Negative-space companion to the inner-rect test: don't let a
-        // future change replace the `:first-of-type` selector with one
-        // that misses the original canvas rect. The two assertions
-        // together pin both rects as in-scope.
+        // Negative-space companion: the outer canvas rect (Rule 1,
+        // first-of-type direct child of <svg>) must still be hidden.
+        // Pre-refactor this was a dedicated `:first-of-type` selector;
+        // now the rect is tagged by Rule 1 and hidden by the same
+        // `.raven-bg` rule that covers every other background rect.
         const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
         const selectors = extract_fill_none_selectors_under_theme(source);
-        const dom = new JSDOM(
-            '<!doctype html><html><body>'
-            + '<div class="plot-host apply-vscode-theme">'
-            + '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
+        const svgSource =
+            '<svg class="httpgd" xmlns="http://www.w3.org/2000/svg">'
             + '<rect id="canvas" width="100%" height="100%" fill="#FFFFFF" stroke="none" />'
-            + '</svg>'
-            + '</div>'
-            + '</body></html>',
+            + '</svg>';
+        const tagged = tag_background_rects(svgSource);
+        const dom = new JSDOM(
+            `<!doctype html><html><body><div class="plot-host apply-vscode-theme">${tagged}</div></body></html>`,
         );
         const canvasRect = dom.window.document.getElementById('canvas');
+        expect(canvasRect).not.toBeNull();
+        expect(canvasRect!.classList.contains('raven-bg')).toBe(true);
         const matched = selectors.some(sel => {
             try { return canvasRect!.matches(sel); }
             catch { return false; }

--- a/tests/bun/plot-theme-overlay.test.ts
+++ b/tests/bun/plot-theme-overlay.test.ts
@@ -209,8 +209,8 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
         // `panel.background = element_rect(fill = "grey92")` emits as
         // `fill="#EBEBEB"` (grey92 in hex). Under the structural-
         // tagging mechanism the panel rect is tagged by Rule 2
-        // (only-rect-in-<g> with stroke=none) — fill colour is no
-        // longer load-bearing.
+        // (direct-child <g> rect lacking stroke-linejoin and
+        // stroke-linecap) — fill colour is no longer load-bearing.
         const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
         const selectors = extract_fill_none_selectors_under_theme(source);
         const svgSource =
@@ -241,8 +241,8 @@ describe('plot-host theme overlay — multi-rect canvas hiding', () => {
         // grey50 = `#7F7F7F` wasn't in the previous allowlist —
         // before this refactor the panel would have stayed painted
         // dark-grey over the editor background. After: tagged by
-        // Rule 2 (only-rect-in-<g> with stroke=none), hidden by
-        // `.raven-bg`.
+        // Rule 2 (direct-child <g> rect lacking stroke-linejoin and
+        // stroke-linecap), hidden by `.raven-bg`.
         const source = readFileSync(APP_SVELTE_PATH, 'utf-8');
         const selectors = extract_fill_none_selectors_under_theme(source);
         const svgSource =

--- a/tests/fixtures/httpgd/ggplot-bar.svg
+++ b/tests/fixtures/httpgd/ggplot-bar.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="httpgd" width="480.00" height="360.00" viewBox="0 0 480.00 360.00">
+<defs>
+  <style type='text/css'><![CDATA[
+    .httpgd line, .httpgd polyline, .httpgd polygon, .httpgd path, .httpgd rect, .httpgd circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+<clipPath id="c0"><rect x="0.00" y="0.00" width="480.00" height="360.00"/></clipPath>
+<clipPath id="c1"><rect x="33.27" y="5.48" width="441.25" height="322.79"/></clipPath>
+<clipPath id="c2"><rect x="0.00" y="0.00" width="480.00" height="360.00"/></clipPath>
+</defs>
+<rect width="100%" height="100%" style="stroke: none;fill: #FFFFFF;"/>
+<g clip-path="url(#c0)">
+<rect x="0.00" y="0.00" width="480.00" height="360.00" style="stroke-width: 1.07;stroke: #FFFFFF;fill: #FFFFFF;"/>
+</g><g clip-path="url(#c1)">
+<rect x="33.27" y="5.48" width="441.25" height="322.79" style="stroke-width: 1.07;stroke: none;fill: #EBEBEB;"/>
+<polyline points="33.27,261.19 474.52,261.19" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,156.39 474.52,156.39" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,51.59 474.52,51.59" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,313.59 474.52,313.59" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,208.79 474.52,208.79" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,103.99 474.52,103.99" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="116.00,328.27 116.00,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="253.89,328.27 253.89,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="391.79,328.27 391.79,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<rect x="53.95" y="83.03" width="124.10" height="230.56" style="stroke-width: 1.07;stroke: none;stroke-linecap: butt;stroke-linejoin: miter;fill: #595959;"/>
+<rect x="191.84" y="166.87" width="124.10" height="146.72" style="stroke-width: 1.07;stroke: none;stroke-linecap: butt;stroke-linejoin: miter;fill: #595959;"/>
+<rect x="329.73" y="20.15" width="124.10" height="293.44" style="stroke-width: 1.07;stroke: none;stroke-linecap: butt;stroke-linejoin: miter;fill: #595959;"/>
+</g><g clip-path="url(#c2)">
+<g><text x="28.34" y="316.75" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">0</text></g>
+<g><text x="28.34" y="211.95" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">5</text></g>
+<g><text x="28.34" y="107.15" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">10</text></g>
+<polyline points="30.53,313.59 33.27,313.59" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,208.79 33.27,208.79" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,103.99 33.27,103.99" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="116.00,331.01 116.00,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="253.89,331.01 253.89,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="391.79,331.01 391.79,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<g><text x="116.00" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">4</text></g>
+<g><text x="253.89" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">6</text></g>
+<g><text x="391.79" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">8</text></g>
+<g><text x="253.89" y="352.09" text-anchor="middle" style="font-family: Arial;font-size: 11.00px;" textLength="48.28px" lengthAdjust="spacingAndGlyphs">factor(cyl)</text></g>
+<g><text transform="translate(13.37,166.87) rotate(-90.00)" text-anchor="middle" style="font-family: Arial;font-size: 11.00px;" textLength="26.91px" lengthAdjust="spacingAndGlyphs">count</text></g>
+</g>
+</svg>

--- a/tests/fixtures/httpgd/ggplot-scatter.svg
+++ b/tests/fixtures/httpgd/ggplot-scatter.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="httpgd" width="480.00" height="360.00" viewBox="0 0 480.00 360.00">
+<defs>
+  <style type='text/css'><![CDATA[
+    .httpgd line, .httpgd polyline, .httpgd polygon, .httpgd path, .httpgd rect, .httpgd circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+<clipPath id="c0"><rect x="0.00" y="0.00" width="480.00" height="360.00"/></clipPath>
+<clipPath id="c1"><rect x="33.27" y="5.48" width="441.25" height="322.79"/></clipPath>
+<clipPath id="c2"><rect x="0.00" y="0.00" width="480.00" height="360.00"/></clipPath>
+</defs>
+<rect width="100%" height="100%" style="stroke: none;fill: #FFFFFF;"/>
+<g clip-path="url(#c0)">
+<rect x="0.00" y="0.00" width="480.00" height="360.00" style="stroke-width: 1.07;stroke: #FFFFFF;fill: #FFFFFF;"/>
+</g><g clip-path="url(#c1)">
+<rect x="33.27" y="5.48" width="441.25" height="322.79" style="stroke-width: 1.07;stroke: none;fill: #EBEBEB;"/>
+<polyline points="33.27,287.37 474.52,287.37" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,224.94 474.52,224.94" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,162.50 474.52,162.50" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,100.07 474.52,100.07" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,37.63 474.52,37.63" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="51.99,328.27 51.99,5.48" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="154.56,328.27 154.56,5.48" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="257.12,328.27 257.12,5.48" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="359.69,328.27 359.69,5.48" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="462.26,328.27 462.26,5.48" style="stroke-width: 0.53;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,318.59 474.52,318.59" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,256.15 474.52,256.15" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,193.72 474.52,193.72" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,131.29 474.52,131.29" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,68.85 474.52,68.85" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="33.27,6.42 474.52,6.42" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="103.27,328.27 103.27,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="205.84,328.27 205.84,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="308.41,328.27 308.41,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<polyline points="410.98,328.27 410.98,5.48" style="stroke-width: 1.07;stroke: #FFFFFF;stroke-linecap: butt;"/>
+<circle cx="166.87" cy="181.23" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="193.02" cy="181.23" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="136.10" cy="158.76" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="227.89" cy="176.24" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="250.97" cy="209.95" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="253.02" cy="217.44" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="264.30" cy="264.90" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="225.33" cy="138.78" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="221.23" cy="158.76" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="250.97" cy="203.71" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="250.97" cy="221.19" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="315.59" cy="238.67" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="280.72" cy="227.43" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="285.84" cy="253.66" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="436.62" cy="313.59" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="454.46" cy="313.59" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="446.36" cy="259.90" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="123.79" cy="38.88" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="63.79" cy="63.86" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="86.35" cy="20.15" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="150.97" cy="174.99" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="259.18" cy="249.91" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="250.46" cy="253.66" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="292.00" cy="277.38" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="292.51" cy="203.71" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="96.61" cy="102.57" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="117.63" cy="118.80" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="53.32" cy="63.86" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="223.28" cy="246.16" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="182.25" cy="197.47" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="264.30" cy="256.15" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+<circle cx="183.28" cy="176.24" r="1.95" style="stroke-width: 0.71;fill: #000000;"/>
+</g><g clip-path="url(#c2)">
+<g><text x="28.34" y="321.74" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">10</text></g>
+<g><text x="28.34" y="259.31" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">15</text></g>
+<g><text x="28.34" y="196.87" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">20</text></g>
+<g><text x="28.34" y="134.44" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">25</text></g>
+<g><text x="28.34" y="72.00" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">30</text></g>
+<g><text x="28.34" y="9.57" text-anchor="end" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="9.79px" lengthAdjust="spacingAndGlyphs">35</text></g>
+<polyline points="30.53,318.59 33.27,318.59" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,256.15 33.27,256.15" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,193.72 33.27,193.72" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,131.29 33.27,131.29" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,68.85 33.27,68.85" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="30.53,6.42 33.27,6.42" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="103.27,331.01 103.27,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="205.84,331.01 205.84,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="308.41,331.01 308.41,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<polyline points="410.98,331.01 410.98,328.27" style="stroke-width: 1.07;stroke: #333333;stroke-linecap: butt;"/>
+<g><text x="103.27" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">2</text></g>
+<g><text x="205.84" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">3</text></g>
+<g><text x="308.41" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">4</text></g>
+<g><text x="410.98" y="339.50" text-anchor="middle" style="font-family: Arial;font-size: 8.80px;fill: #4D4D4D;" textLength="4.90px" lengthAdjust="spacingAndGlyphs">5</text></g>
+<g><text x="253.89" y="352.09" text-anchor="middle" style="font-family: Arial;font-size: 11.00px;" textLength="10.99px" lengthAdjust="spacingAndGlyphs">wt</text></g>
+<g><text transform="translate(13.37,166.87) rotate(-90.00)" text-anchor="middle" style="font-family: Arial;font-size: 11.00px;" textLength="21.41px" lengthAdjust="spacingAndGlyphs">mpg</text></g>
+</g>
+</svg>


### PR DESCRIPTION
## Summary

- Replaces the hand-maintained CSS color allowlist (`rect[fill="#FFFFFF" i], rect[fill="#EBEBEB" i]`) with a runtime SVG transform that tags canvas/panel background rects with `class="raven-bg"`. The overlay CSS now targets that class — colour-agnostic, generalizes to `theme_dark()` / `theme_minimal()` / user-customized themes without per-theme bug fixes.
- Heuristic (validated against captured live httpgd 2.1.4 output, snapshotted into `tests/fixtures/httpgd/ggplot-{scatter,bar}.svg`):
  - **Rule 1** — first `<rect>` direct child of `<svg>` is httpgd's outer canvas, always tagged.
  - **Rule 2** — `<rect>` direct child of `<g>` with NO `stroke-linejoin` and NO `stroke-linecap` attributes. ggplot2's `element_rect` (themes) + httpgd's inner canvas render without these attributes (grid defaults match httpgd's); `GeomRect`/`GeomBar`/`GeomCol`/`GeomTile` always carry both because their defaults (`linejoin = "mitre"`, `lineend = "butt"`) differ from httpgd's.

## Bug fixed mid-PR

First attempt at the heuristic ("stroke=none AND only-rect-in-g") missed two real ggplot cases — caught after the user pulled the branch and reported the panel staying white:
- httpgd's ggplot inner canvas emits `stroke="#FFFFFF" fill="#FFFFFF"` (stroke matches the fill, not `"none"`).
- ggplot bar charts put `panel.background` and the data bars in the same `<g clip-path>`, so a sibling-count check rejected the background whenever bars were present.

The committed heuristic (linejoin/linecap presence) handles both. Captured fixtures pin it as regression tests.

## Test plan

- [x] `bun test` — 1065/1065 pass, including new tagger tests and the ggplot fixture regressions.
- [x] `bun run typecheck` (in `editors/vscode/`) — clean.
- [x] `bun run bundle` — bundle includes `tag_background_rects` and the new `.raven-bg` CSS.
- [x] User manually verified the "Apply VS Code theme" toggle now hides the panel background on a real ggplot scatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent background detection in plot visualizations to enable more precise theme styling.

* **Bug Fixes**
  * Improved plot background recoloring reliability across VS Code light and dark themes. Background elements are now identified structurally instead of using hardcoded rules, ensuring consistent appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->