### PR TITLE
fix(plot): harden icon-only toolbar — Popover API, a11y, clamp, tests

### DIFF
--- a/docs/plot-viewer.md
+++ b/docs/plot-viewer.md
@@ -20,7 +20,7 @@ No other R packages are required. Standard R, [arf](https://github.com/eitsupi/a
 - Run any plotting code in the Raven R terminal (e.g., `plot(1:10)`, `ggplot(...) + geom_point()`).
 - The first plot from each R session opens its own "Raven Plot Viewer" panel in the column configured by `raven.plot.viewerColumn` (default: `beside`). The second session's panel is "Raven Plot Viewer 2", the third "Raven Plot Viewer 3", and so on (numbered per VS Code window). Each R terminal therefore gets a separate viewer with its own plot history.
 - Subsequent plots from the same session update that session's panel without stealing focus from your editor.
-- The viewer toolbar provides previous/next history navigation, remove current plot, copy to clipboard, save (PNG/SVG/PDF), open externally, and an "Apply VS Code theme" toggle. Right-clicking a plot copies it to the clipboard as PNG.
+- The viewer toolbar provides previous/next history navigation, remove the current plot, and three icon-only controls on the right: a **share** icon that opens a popover with **Copy** / **PNG** / **SVG** / **PDF** export actions, an **open externally** icon (link-external arrow), and an **Apply VS Code theme** toggle (paint-bucket icon, fills with the primary accent when on). Hover any icon for a descriptive tooltip; assistive technologies read the same labels via `aria-label`. Right-clicking a plot copies it to the clipboard as PNG.
 - If your terminal exits (R session ends), the last rendered plot stays visible with an "R session ended" indicator and must be closed manually.
 - When a new R session is started or the panel is reopened, a subsequent plot from that new session will recreate the plot panel.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/jbearak/Raven"
   },
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.82.0"
   },
   "categories": [
     "Programming Languages"

--- a/editors/vscode/src/plot/webview/App.svelte
+++ b/editors/vscode/src/plot/webview/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount, onDestroy } from 'svelte';
+    import { onMount, onDestroy, untrack } from 'svelte';
     import {
         bg_for_fetch,
         initial_state,
@@ -19,15 +19,34 @@
     } from '../messages';
     import { isExtensionToWebviewMessage } from '../messages';
     import { sanitize_svg } from './sanitize';
+    import { compute_share_popover_position } from './share-popover-position';
 
     // Inlined codicon SVGs (from @vscode/codicons 0.0.45, MIT). Kept
     // inline (rather than importing the font) so we don't add a runtime
     // font dependency or change the webview CSP — `fill="currentColor"`
     // makes them inherit the surrounding button's foreground colour.
+    //
+    // SECURITY INVARIANT: these constants are injected via {@html} (see
+    // template below), which bypasses Svelte's HTML escaping. They MUST
+    // remain pure, hand-vetted SVG with NO `<script>`, NO `<use>`, NO
+    // `<image>`, NO `<a>`, NO `<foreignObject>`, NO `<iframe>`, NO
+    // event-handler attributes (`onclick`, `onload`, …), and NO
+    // `href`/`xlink:href` attributes anywhere. The regression test
+    // `tests/bun/plot-webview-inline-icons.test.ts` enforces this — do
+    // NOT silence it by adding new dangerous elements here; instead,
+    // either keep this constant pure or route the new icon through
+    // `sanitize_svg` at module init.
     const SYMBOL_COLOR_ICON =
         '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.00101 1C4.13401 1 1.00101 3.8 1.00101 7.667C1.00101 8.956 2.04501 10 3.33401 10C4.75101 10 4.72101 9 6.00001 9C6.64401 9 7.00001 9.606 7.00001 10.25V11.5C7.00001 13.433 8.56701 15 10.5 15C13.653 15 14.999 11.215 14.999 8C14.999 4.134 11.866 1 8.00001 1H8.00101ZM10.5 14C9.12201 14 8.00001 12.878 8.00001 11.5V10.25C8.00001 8.967 7.14001 8 6.00001 8C5.04001 8 4.49801 8.412 4.13901 8.685C3.85401 8.902 3.72401 9 3.33401 9C2.59901 9 2.00101 8.402 2.00101 7.667C2.00101 4.436 4.58001 2 8.00101 2C11.309 2 14 4.692 14 8C14 10.412 13.068 14 10.501 14H10.5ZM12 11C12 11.552 11.552 12 11 12C10.448 12 10 11.552 10 11C10 10.448 10.448 10 11 10C11.552 10 12 10.448 12 11ZM13 8C13 8.552 12.552 9 12 9C11.448 9 11 8.552 11 8C11 7.448 11.448 7 12 7C12.552 7 13 7.448 13 8ZM6.00001 5C6.00001 5.552 5.55201 6 5.00001 6C4.44801 6 4.00001 5.552 4.00001 5C4.00001 4.448 4.44801 4 5.00001 4C5.55201 4 6.00001 4.448 6.00001 5ZM10 5C10 4.448 10.448 4 11 4C11.552 4 12 4.448 12 5C12 5.552 11.552 6 11 6C10.448 6 10 5.552 10 5ZM9.00001 4C9.00001 4.552 8.55201 5 8.00001 5C7.44801 5 7.00001 4.552 7.00001 4C7.00001 3.448 7.44801 3 8.00001 3C8.55201 3 9.00001 3.448 9.00001 4Z"/></svg>';
     const SHARE_ICON =
         '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" focusable="false"><path d="M11.307 1.10533C11.1562 0.988085 10.9519 0.966945 10.7803 1.05085C10.6088 1.13475 10.5 1.30904 10.5 1.5V3.49274C10.4571 3.49456 10.4122 3.49701 10.3654 3.5002C9.96247 3.52766 9.41128 3.61105 8.82119 3.83704C8.11343 4.10809 7.34877 4.58508 6.72601 5.41126C6.10338 6.23727 5.64499 7.38259 5.50206 8.95474C5.48301 9.16438 5.5973 9.36351 5.78793 9.4528C5.97857 9.54209 6.20471 9.50241 6.35356 9.35356C7.54248 8.16464 8.72298 7.57773 9.59562 7.28685C9.9558 7.16679 10.2643 7.09693 10.5 7.0563V9C10.5 9.1969 10.6156 9.37546 10.7952 9.45612C10.9748 9.53678 11.185 9.50452 11.3322 9.37371L15.8322 5.37371C15.9432 5.27502 16.0046 5.13207 15.9997 4.98361C15.9949 4.83514 15.9242 4.69653 15.807 4.60533L11.307 1.10533ZM10.9429 4.49679L10.9457 4.49705C11.0865 4.51223 11.2279 4.46706 11.3335 4.37257C11.4394 4.27772 11.5 4.14223 11.5 4V2.52232L14.7186 5.02564L11.5 7.88658V6.5C11.5 6.22386 11.2762 6 11 6L10.9989 6L10.9976 6.00001L10.9943 6.00003L10.9848 6.00014L10.9552 6.00087C10.9307 6.00166 10.897 6.00316 10.8544 6.00599C10.7695 6.01166 10.6495 6.02268 10.4996 6.04409C10.1999 6.08691 9.77971 6.17139 9.2794 6.33816C8.55493 6.57965 7.66479 6.99299 6.7319 7.69863C6.9264 6.98158 7.2077 6.43355 7.52456 6.01319C8.01593 5.36132 8.61523 4.98675 9.17883 4.7709C9.65371 4.58903 10.1025 4.52044 10.4334 4.49788C10.5981 4.48666 10.7314 4.48699 10.8211 4.48988C10.866 4.49133 10.8997 4.49341 10.9209 4.49498L10.9429 4.49679ZM3.5 2C2.11929 2 1 3.11929 1 4.5V12.5C1 13.8807 2.11929 15 3.5 15H11.5C12.8807 15 14 13.8807 14 12.5V9.5C14 9.22386 13.7761 9 13.5 9C13.2239 9 13 9.22386 13 9.5V12.5C13 13.3284 12.3284 14 11.5 14H3.5C2.67157 14 2 13.3284 2 12.5V4.5C2 3.67157 2.67157 3 3.5 3H7.5C7.77614 3 8 2.77614 8 2.5C8 2.22386 7.77614 2 7.5 2H3.5Z"/></svg>';
+    // codicon "link-external" — used for the "Open in external viewer"
+    // button so all three right-cluster icons share the same 16x16
+    // codicon substrate (consistent sizing, baseline, and font-fallback
+    // behaviour). Previously this button used a literal `↗` glyph which
+    // rendered at varying sizes/baselines across platforms.
+    const LINK_EXTERNAL_ICON =
+        '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.5 1H8.5L9 1.5V4.31317L8 5.31317V2H2V14H8V12.6868L9 11.6868V14.5L8.5 15H1.5L1 14.5V1.5L1.5 1ZM12.7929 5.49996H10.5V4.49996H14V8.00001H13V6.20706L7.85355 11.3535L7.14645 10.6464L12.7929 5.49996Z"/></svg>';
 
     interface Props {
         vscode: { postMessage(msg: WebviewToExtensionMessage): void };
@@ -51,6 +70,11 @@
     // resize and the layout reads cleanly at every width.
     let share_popover_el: HTMLDivElement | undefined = $state();
     let share_btn_el: HTMLButtonElement | undefined = $state();
+    // Mirrors the popover's :popover-open state so `aria-expanded` on
+    // the share button reflects reality for assistive tech. Updated by
+    // the toggle handler (newState 'open'/'closed'). Without this, AT
+    // would only ever read 'collapsed' regardless of menu visibility.
+    let share_popover_open = $state(false);
     const SHARE_POPOVER_ID = 'raven-plot-share-popover';
     // Tracks the in-flight SVG fetcher so a superseded fetch is aborted
     // when a fresh `(plotId, upid, dimensions, themeApplied)` lands.
@@ -220,6 +244,11 @@
         }
         window.removeEventListener('message', on_message);
         window.removeEventListener('resize', on_resize);
+        // The popover's resize listener is added in on_share_popover_toggle's
+        // 'open' branch. Defensive removal here covers the case where
+        // the component unmounts with the popover still open — the
+        // 'closed' toggle event isn't guaranteed to fire during teardown.
+        window.removeEventListener('resize', on_share_popover_resize);
     });
 
     function go_prev() { dispatch({ type: 'GO_PREV' }); }
@@ -254,34 +283,176 @@
         vscode.postMessage({ type: 'request-open-externally', payload: { plotId: id } });
     }
 
-    // Position the share popover under the share button on each open.
-    // Using the HTML popover API (`popover` attribute) means dismissal
-    // is automatic on outside click or Escape — we only need to handle
-    // positioning. The CSS rule `.share-popover { inset: auto }`
-    // overrides the browser UA stylesheet's `[popover] { inset: 0;
-    // margin: auto }` (which would center the popover) so the JS-set
-    // `top` and `right` actually take effect. `right` anchors the
-    // popover's right edge near the share button's right edge so the
-    // menu reads as attached to it.
+    // Position the share popover under the share button. Using the HTML
+    // popover API (`popover` attribute) means dismissal is automatic on
+    // outside click or Escape — we only need to handle positioning. The
+    // CSS rule `.share-popover { inset: auto }` overrides the browser
+    // UA stylesheet's `[popover] { inset: 0; margin: auto }` (which
+    // would center the popover) so JS-set `top` and `left` actually
+    // take effect.
+    //
+    // CLAMPING: keep the popover fully inside the viewport in both
+    // dimensions. `right` (right-anchor) was the original strategy; we
+    // now use `left` after clamping so the math is symmetric and the
+    // popover can flip above the trigger when there isn't room below.
+    //   - Horizontal: place near the button's right edge by default;
+    //     clamp so the popover stays at least 4px from both viewport
+    //     edges. On extremely narrow panels (where popover width >
+    //     viewport width - 8) the left-anchor wins and the popover may
+    //     extend off-right; `overflow-x: auto` on .toolbar plus the
+    //     popover's top-layer rendering means the user can still scroll
+    //     to it, but in practice the popover collapses to its content.
+    //   - Vertical: prefer placing below the button; if the popover
+    //     would overflow the bottom (`r.bottom + 4 + h > innerHeight`)
+    //     AND there's more room above, place above the button instead.
+    //     Final clamp ensures `top >= 4` either way.
     //
     // `beforetoggle` fires synchronously before the popover becomes
     // visible (the `:popover-open` rule flips `display: none` → `flex`).
-    // Setting position there avoids a one-frame flash at the centered
-    // default before our values land — visible when the menu opens
-    // because the popover is briefly painted at inset:0 / margin:auto
-    // before our `style.top` / `style.right` overrides take effect on
-    // the next style recalc.
-    function on_share_popover_beforetoggle(e: ToggleEvent) {
-        if (e.newState !== 'open') return;
+    // We measure the popover's natural size by reading
+    // `offsetWidth`/`offsetHeight` after a temporary `visibility: hidden;
+    // display: flex` — needed because `display: none` reports zero
+    // dimensions. The visibility trick keeps the popover invisible
+    // during measurement so users never see it at the UA-default
+    // centered position.
+    //
+    // KEYBOARD FOCUS: after positioning, move focus into the popover so
+    // keyboard-only users can immediately Tab through Copy / PNG / SVG
+    // / PDF. Without this, Tab from the share button would go to the
+    // next sibling (external-link button), skipping the popover.
+    //
+    // A `resize` listener is installed while the popover is open so
+    // panel splitter drags reposition the menu rather than leaving it
+    // floating detached from the button. The listener is removed on
+    // close to avoid wasted work when the popover is hidden.
+    function position_share_popover() {
         if (!share_popover_el || !share_btn_el) return;
         const r = share_btn_el.getBoundingClientRect();
-        share_popover_el.style.top = `${r.bottom + 4}px`;
-        share_popover_el.style.right = `${Math.max(4, window.innerWidth - r.right)}px`;
+        // Clear any stale inline anchors from a previous open BEFORE
+        // measuring. The popover is `position: fixed` with `inset:
+        // auto`, so stale inline coords would force a layout pass at
+        // the old position during measurement. Clearing all four sides
+        // ensures the measurement happens at the static (untransformed)
+        // box and isolates this function from any future writer that
+        // sets `right`/`bottom` directly (e.g. an alternate
+        // positioning path).
+        share_popover_el.style.left = '';
+        share_popover_el.style.top = '';
+        share_popover_el.style.right = '';
+        share_popover_el.style.bottom = '';
+        // Measure the popover's natural box. While `display: none` it
+        // reports zero, so flip to `visibility: hidden` first; the
+        // CSS rule `.share-popover:popover-open { display: flex }`
+        // hasn't fired yet during `beforetoggle`, so we force
+        // `display: flex` locally for the measurement and clear it
+        // immediately afterward. Browsers batch the style mutations so
+        // there's no visible flicker.
+        const prevDisplay = share_popover_el.style.display;
+        const prevVisibility = share_popover_el.style.visibility;
+        share_popover_el.style.visibility = 'hidden';
+        share_popover_el.style.display = 'flex';
+        const w = share_popover_el.offsetWidth;
+        const h = share_popover_el.offsetHeight;
+        share_popover_el.style.display = prevDisplay;
+        share_popover_el.style.visibility = prevVisibility;
+
+        // Clamp algorithm lives in the pure helper
+        // `compute_share_popover_position` — see that file plus the bun
+        // tests in `tests/bun/plot-share-popover-position.test.ts` for
+        // the full case enumeration (right-anchor, viewport overflow,
+        // flip-above, popover taller/wider than viewport).
+        const { left, top } = compute_share_popover_position(
+            r,
+            { width: w, height: h },
+            { width: window.innerWidth, height: window.innerHeight },
+        );
+
+        share_popover_el.style.left = `${left}px`;
+        share_popover_el.style.top = `${top}px`;
+    }
+
+    function on_share_popover_resize() {
+        // Guard against a race where `resize` fires between
+        // `beforetoggle('closed')` (sync) and `toggle('closed')` (the
+        // queued task that removes this listener). On that tick the
+        // popover is mid-closing — re-positioning a popover that's no
+        // longer in the top layer is wasted work and the inline
+        // `display: flex` measurement trick would briefly take effect
+        // on the closing element.
+        if (!share_popover_el?.matches?.(':popover-open')) return;
+        position_share_popover();
+    }
+
+    // `beforetoggle` fires synchronously BEFORE the popover is added to
+    // the top layer (open) or removed from it (close). For OPEN, this
+    // is where we position the popover — running positioning in the
+    // later `toggle` event would paint one frame at the UA default
+    // (centered via `inset: 0; margin: auto`) before our values land.
+    // We also update the `aria-expanded` mirror here so AT readers
+    // never see a transient mismatch between the visible popover and
+    // the attribute.
+    function on_share_popover_beforetoggle(e: ToggleEvent) {
+        if (e.newState === 'open') {
+            position_share_popover();
+            share_popover_open = true;
+        } else {
+            share_popover_open = false;
+        }
+    }
+
+    // `toggle` fires AFTER the popover state change has taken effect.
+    // Focus and listener wiring belong here because focus only works
+    // once the popover is in the top layer (`:popover-open` matches
+    // and `display: flex` is in effect); calling `.focus()` during
+    // `beforetoggle` would no-op because the popover is still
+    // `display: none`.
+    function on_share_popover_toggle(e: ToggleEvent) {
+        if (e.newState === 'open') {
+            // Move focus into the popover so keyboard users can
+            // navigate Copy / PNG / SVG / PDF with Tab. We focus the
+            // first enabled button — disabled buttons (state.phase !==
+            // 'viewing') skip focus naturally because the `:disabled`
+            // selector isn't tabbable. If every popover item is
+            // disabled (shouldn't happen since the share trigger is
+            // also disabled then), the focus call is a no-op.
+            const firstEnabled = share_popover_el?.querySelector<HTMLButtonElement>(
+                'button:not([disabled])',
+            );
+            firstEnabled?.focus();
+            window.addEventListener('resize', on_share_popover_resize);
+        } else {
+            window.removeEventListener('resize', on_share_popover_resize);
+        }
     }
 
     function close_share_popover() {
-        share_popover_el?.hidePopover?.();
+        // `hidePopover()` throws InvalidStateError when the popover is
+        // not currently showing; guard with `:popover-open` before
+        // calling so the lifecycle effect (which closes the popover on
+        // state-phase changes) is safe to invoke at any time.
+        if (share_popover_el?.matches?.(':popover-open')) {
+            share_popover_el.hidePopover?.();
+        }
     }
+
+    // Stuck-popover defense: if `state.phase` flips away from 'viewing'
+    // while the popover is open (R session ends, panel reloads), the
+    // share button and all popover items become disabled. The disabled
+    // trigger can't toggle the popover closed; close it programmatically
+    // so users aren't left staring at an inert menu.
+    //
+    // `untrack` is load-bearing here: reading `share_popover_open` as a
+    // regular reactive read would register it as a dep, causing the
+    // effect to re-fire on every popover open/close cycle (in addition
+    // to phase changes). With `untrack`, the effect's dep surface is
+    // just `state.phase`, so a future edit that adds an `else` branch
+    // or a side-effect outside the if-block cannot create a feedback
+    // loop with the popover's own open/close events.
+    $effect(() => {
+        if (state.phase !== 'viewing' && untrack(() => share_popover_open)) {
+            close_share_popover();
+        }
+    });
 
     function copy_from_share() {
         close_share_popover();
@@ -494,11 +665,23 @@
                 disabled={state.phase !== 'viewing'}
                 title="Remove current plot">✕</button>
         <span class="spacer"></span>
+        <!-- ARIA: this trigger uses `aria-expanded` (browser-mirrored
+             via `popovertarget`) so AT users hear "expanded/collapsed"
+             on activation, but does NOT set `aria-haspopup`. The
+             popover content (below) is a labeled group of plain
+             buttons — not a `role="menu"` (no arrow-key nav) nor a
+             `role="dialog"` (not modal) — so any specific aria-haspopup
+             value would set incorrect expectations. `aria-controls`
+             links the trigger to its popover for AT that supports
+             popup tracking; this is informational and never replaces
+             the `aria-expanded` disclosure signal. -->
         <button class="icon-btn"
                 bind:this={share_btn_el}
                 popovertarget={SHARE_POPOVER_ID}
                 disabled={state.phase !== 'viewing'}
                 aria-label="Copy or export plot"
+                aria-expanded={share_popover_open}
+                aria-controls={SHARE_POPOVER_ID}
                 title="Copy or export plot">
             {@html SHARE_ICON}
         </button>
@@ -506,21 +689,39 @@
                 onclick={open_externally}
                 disabled={state.phase !== 'viewing'}
                 aria-label="Open in external viewer"
-                title="Open in external viewer">↗</button>
+                title="Open in external viewer">
+            {@html LINK_EXTERNAL_ICON}
+        </button>
         <button class="theme-toggle icon-btn"
                 class:is-on={state.themeApplied}
                 aria-pressed={state.themeApplied}
                 aria-label="Apply VS Code theme"
                 onclick={toggle_theme_applied}
-                title="Apply VS Code theme">
+                title="Recolor the plot to match the active VS Code theme">
             {@html SYMBOL_COLOR_ICON}
         </button>
     </header>
+    <!-- ARIA: this popover is `role="group"` with an explicit
+         `aria-label`, NOT `role="menu"`. The HTML popover API gives us
+         Tab-based focus order, Escape-to-dismiss, and outside-click
+         light-dismiss, but ARIA's menu pattern additionally requires
+         arrow-key navigation between items (Up/Down/Home/End). We
+         don't implement those handlers, so promising `role="menu"`
+         would set incorrect user expectations and WCAG-flag as
+         incomplete keyboard interaction. `role="group"` is the
+         simplest correct choice for "labeled group of related
+         controls" and is what AT (NVDA / JAWS / VoiceOver) reliably
+         announces — a bare `<div popover>` with no role is exposed as
+         generic, which some screen readers skip entirely (dropping the
+         `aria-label` announcement). -->
     <div id={SHARE_POPOVER_ID}
          bind:this={share_popover_el}
          popover="auto"
          class="share-popover"
-         onbeforetoggle={on_share_popover_beforetoggle}>
+         role="group"
+         aria-label="Copy or export plot"
+         onbeforetoggle={on_share_popover_beforetoggle}
+         ontoggle={on_share_popover_toggle}>
         <button onclick={copy_from_share} disabled={state.phase !== 'viewing'}>Copy</button>
         <button onclick={() => save_from_share('png')} disabled={state.phase !== 'viewing'}>PNG</button>
         <button onclick={() => save_from_share('svg')} disabled={state.phase !== 'viewing'}>SVG</button>

--- a/editors/vscode/src/plot/webview/App.svelte
+++ b/editors/vscode/src/plot/webview/App.svelte
@@ -20,6 +20,7 @@
     import { isExtensionToWebviewMessage } from '../messages';
     import { sanitize_svg } from './sanitize';
     import { compute_share_popover_position } from './share-popover-position';
+    import { tag_background_rects } from './tag-backgrounds';
 
     // Inlined codicon SVGs (from @vscode/codicons 0.0.45, MIT). Kept
     // inline (rather than importing the font) so we don't add a runtime
@@ -622,10 +623,18 @@
                 if (existing && existing.upid >= capturedUpid) return;
                 const sanitized = sanitize_svg(text);
                 if (!sanitized) return;
+                // Heuristic structural tagging of canvas/panel
+                // background rects (see ./tag-backgrounds for the
+                // rules). The overlay CSS targets `rect.raven-bg` so
+                // we get colour-agnostic background hiding without a
+                // hand-maintained allowlist. The tagger is a pure
+                // function of the SVG text, so caching the post-tag
+                // bytes is sound.
+                const tagged = tag_background_rects(sanitized);
                 dispatch({
                     type: 'SET_SVG_CACHE_ENTRY',
                     cacheKey,
-                    entry: { svgText: sanitized, upid: capturedUpid },
+                    entry: { svgText: tagged, upid: capturedUpid },
                 });
             })
             .catch(() => {
@@ -796,11 +805,6 @@
         max-height: 100%;
     }
 
-    .plot-host.apply-vscode-theme :global(svg.httpgd > rect:first-of-type) {
-        fill: none !important;
-        stroke: none !important;
-    }
-
     .plot-host.apply-vscode-theme :global(svg.httpgd text) {
         fill: var(--vscode-editor-foreground) !important;
         font-family: var(--vscode-editor-font-family) !important;
@@ -811,39 +815,28 @@
     .plot-host.apply-vscode-theme :global(svg.httpgd polygon),
     .plot-host.apply-vscode-theme :global(svg.httpgd path),
     .plot-host.apply-vscode-theme :global(svg.httpgd circle),
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect:not(:first-of-type)) {
+    .plot-host.apply-vscode-theme :global(svg.httpgd rect:not(.raven-bg)) {
         stroke: var(--vscode-editor-foreground) !important;
     }
 
-    /* httpgd-rendered plots paint multiple background rects under the
-     * data layer; the toggle has to hide all of them so
-     * `--vscode-editor-background` can show through.
+    /* Hide the canvas/panel background rects that `tag_background_rects`
+     * (in ./tag-backgrounds.ts) flagged with `class="raven-bg"`. The
+     * webview body's `--vscode-editor-background` shows through.
      *
-     *   - `#FFFFFF` covers two distinct rects on every plot: the
-     *     first-of-type direct child of <svg> (httpgd's canvas, also
-     *     hit by the `:first-of-type` rule above) AND an inner rect
-     *     wrapped in a `<g clip-path>` that the `:first-of-type`
-     *     selector cannot reach.
-     *   - `#EBEBEB` is `grey92`, the ggplot2 `theme_gray()` default
-     *     for `panel.background`. ggplot2 is the dominant R plot
-     *     ecosystem; without this entry the cartesian grid stays
-     *     painted light-gray over the editor background.
-     *
-     * Extending the allowlist is intentionally conservative: we'd
-     * rather miss a non-default ggplot theme's background (and have
-     * the user toggle off) than hide a deliberate white/grey-filled
-     * shape in their data (e.g. a `geom_rect()` panel) once the toggle
-     * is on. Add new colors only when a real plot demonstrates the
-     * miss. The `i` flag is CSS4 case-insensitive matching — defensive
-     * against a future httpgd version emitting lowercase hex.
+     * The previous mechanism was a `rect[fill="#FFFFFF" i],
+     * rect[fill="#EBEBEB" i]` allowlist: every non-default ggplot theme
+     * (`theme_dark()` → grey50, user-customized themes, theme_minimal
+     * with no panel bg at all) required a new entry, and any user-drawn
+     * shape that happened to match an allowlisted colour silently
+     * disappeared. Structural tagging is colour-agnostic and stable
+     * across themes — see `tag-backgrounds.ts` for the heuristic.
      *
      * Source order matters: this rule lives AFTER the stroke-recolor
      * rule above so the `stroke: none !important` here overrides the
-     * editor-foreground stroke that would otherwise outline the inner
+     * editor-foreground stroke that would otherwise outline tagged
      * background rects (the two rules have equal CSS specificity, so
      * later-in-source wins). */
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect[fill="#FFFFFF" i]),
-    .plot-host.apply-vscode-theme :global(svg.httpgd rect[fill="#EBEBEB" i]) {
+    .plot-host.apply-vscode-theme :global(svg.httpgd rect.raven-bg) {
         fill: none !important;
         stroke: none !important;
     }

--- a/editors/vscode/src/plot/webview/App.svelte
+++ b/editors/vscode/src/plot/webview/App.svelte
@@ -498,8 +498,8 @@
                 bind:this={share_btn_el}
                 popovertarget={SHARE_POPOVER_ID}
                 disabled={state.phase !== 'viewing'}
-                aria-label="Share or export plot"
-                title="Share or export plot">
+                aria-label="Copy or export plot"
+                title="Copy or export plot">
             {@html SHARE_ICON}
         </button>
         <button class="icon-btn"
@@ -647,23 +647,27 @@
         stroke: none !important;
     }
 
-    /* Toolbar toggle "on" state. Icon-only buttons can't lean on a
-     * label-adjacent indicator (no checkmark slot anymore), so the
-     * pressed state has to read from the button chrome alone. The
-     * `inputOption.active*` tokens are VS Code's canonical "this toggle
-     * is engaged" palette — they're what the search widget's
-     * case-sensitive / regex / whole-word toggles use. Pairing the
-     * accent background with `inputOption.activeBorder` (falling back
-     * to focusBorder for older themes that don't define it) gives a
-     * clearly-pressed look that doesn't depend on theme-specific
-     * border contrast.
+    /* Toolbar toggle "on" state. Icon-only buttons need a strong
+     * background-color shift to read as engaged — VS Code's canonical
+     * `inputOption.activeBackground` token is intentionally subtle (a
+     * semi-transparent tint over the input background) and tends to
+     * disappear against the editor-widget background the toolbar sits
+     * on. Using the primary button palette instead gives an unambiguous
+     * "pressed" colour that survives every theme: the toggle fills with
+     * the same accent VS Code uses for its primary action buttons, so
+     * users immediately read it as active.
      *
      * `currentColor` flows through the inline SVG's `fill="currentColor"`,
-     * so changing `color` to `activeForeground` recolors the codicon
-     * itself — no extra rule needed for the SVG fill. */
+     * so setting `color: button-foreground` recolors the codicon itself
+     * — no extra rule needed for the SVG fill. The off-state border
+     * isn't overridden because the prominent background carries the
+     * indication on its own; layering a border on top reads as noise. */
     .theme-toggle.is-on {
-        background: var(--vscode-inputOption-activeBackground) !important;
-        color: var(--vscode-inputOption-activeForeground, var(--vscode-foreground)) !important;
-        border-color: var(--vscode-inputOption-activeBorder, var(--vscode-focusBorder)) !important;
+        background: var(--vscode-button-background) !important;
+        color: var(--vscode-button-foreground) !important;
+    }
+
+    .theme-toggle.is-on:hover:not(:disabled) {
+        background: var(--vscode-button-hoverBackground) !important;
     }
 </style>

--- a/editors/vscode/src/plot/webview/App.svelte
+++ b/editors/vscode/src/plot/webview/App.svelte
@@ -20,6 +20,15 @@
     import { isExtensionToWebviewMessage } from '../messages';
     import { sanitize_svg } from './sanitize';
 
+    // Inlined codicon SVGs (from @vscode/codicons 0.0.45, MIT). Kept
+    // inline (rather than importing the font) so we don't add a runtime
+    // font dependency or change the webview CSP — `fill="currentColor"`
+    // makes them inherit the surrounding button's foreground colour.
+    const SYMBOL_COLOR_ICON =
+        '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8.00101 1C4.13401 1 1.00101 3.8 1.00101 7.667C1.00101 8.956 2.04501 10 3.33401 10C4.75101 10 4.72101 9 6.00001 9C6.64401 9 7.00001 9.606 7.00001 10.25V11.5C7.00001 13.433 8.56701 15 10.5 15C13.653 15 14.999 11.215 14.999 8C14.999 4.134 11.866 1 8.00001 1H8.00101ZM10.5 14C9.12201 14 8.00001 12.878 8.00001 11.5V10.25C8.00001 8.967 7.14001 8 6.00001 8C5.04001 8 4.49801 8.412 4.13901 8.685C3.85401 8.902 3.72401 9 3.33401 9C2.59901 9 2.00101 8.402 2.00101 7.667C2.00101 4.436 4.58001 2 8.00101 2C11.309 2 14 4.692 14 8C14 10.412 13.068 14 10.501 14H10.5ZM12 11C12 11.552 11.552 12 11 12C10.448 12 10 11.552 10 11C10 10.448 10.448 10 11 10C11.552 10 12 10.448 12 11ZM13 8C13 8.552 12.552 9 12 9C11.448 9 11 8.552 11 8C11 7.448 11.448 7 12 7C12.552 7 13 7.448 13 8ZM6.00001 5C6.00001 5.552 5.55201 6 5.00001 6C4.44801 6 4.00001 5.552 4.00001 5C4.00001 4.448 4.44801 4 5.00001 4C5.55201 4 6.00001 4.448 6.00001 5ZM10 5C10 4.448 10.448 4 11 4C11.552 4 12 4.448 12 5C12 5.552 11.552 6 11 6C10.448 6 10 5.552 10 5ZM9.00001 4C9.00001 4.552 8.55201 5 8.00001 5C7.44801 5 7.00001 4.552 7.00001 4C7.00001 3.448 7.44801 3 8.00001 3C8.55201 3 9.00001 3.448 9.00001 4Z"/></svg>';
+    const SHARE_ICON =
+        '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" focusable="false"><path d="M11.307 1.10533C11.1562 0.988085 10.9519 0.966945 10.7803 1.05085C10.6088 1.13475 10.5 1.30904 10.5 1.5V3.49274C10.4571 3.49456 10.4122 3.49701 10.3654 3.5002C9.96247 3.52766 9.41128 3.61105 8.82119 3.83704C8.11343 4.10809 7.34877 4.58508 6.72601 5.41126C6.10338 6.23727 5.64499 7.38259 5.50206 8.95474C5.48301 9.16438 5.5973 9.36351 5.78793 9.4528C5.97857 9.54209 6.20471 9.50241 6.35356 9.35356C7.54248 8.16464 8.72298 7.57773 9.59562 7.28685C9.9558 7.16679 10.2643 7.09693 10.5 7.0563V9C10.5 9.1969 10.6156 9.37546 10.7952 9.45612C10.9748 9.53678 11.185 9.50452 11.3322 9.37371L15.8322 5.37371C15.9432 5.27502 16.0046 5.13207 15.9997 4.98361C15.9949 4.83514 15.9242 4.69653 15.807 4.60533L11.307 1.10533ZM10.9429 4.49679L10.9457 4.49705C11.0865 4.51223 11.2279 4.46706 11.3335 4.37257C11.4394 4.27772 11.5 4.14223 11.5 4V2.52232L14.7186 5.02564L11.5 7.88658V6.5C11.5 6.22386 11.2762 6 11 6L10.9989 6L10.9976 6.00001L10.9943 6.00003L10.9848 6.00014L10.9552 6.00087C10.9307 6.00166 10.897 6.00316 10.8544 6.00599C10.7695 6.01166 10.6495 6.02268 10.4996 6.04409C10.1999 6.08691 9.77971 6.17139 9.2794 6.33816C8.55493 6.57965 7.66479 6.99299 6.7319 7.69863C6.9264 6.98158 7.2077 6.43355 7.52456 6.01319C8.01593 5.36132 8.61523 4.98675 9.17883 4.7709C9.65371 4.58903 10.1025 4.52044 10.4334 4.49788C10.5981 4.48666 10.7314 4.48699 10.8211 4.48988C10.866 4.49133 10.8997 4.49341 10.9209 4.49498L10.9429 4.49679ZM3.5 2C2.11929 2 1 3.11929 1 4.5V12.5C1 13.8807 2.11929 15 3.5 15H11.5C12.8807 15 14 13.8807 14 12.5V9.5C14 9.22386 13.7761 9 13.5 9C13.2239 9 13 9.22386 13 9.5V12.5C13 13.3284 12.3284 14 11.5 14H3.5C2.67157 14 2 13.3284 2 12.5V4.5C2 3.67157 2.67157 3 3.5 3H7.5C7.77614 3 8 2.77614 8 2.5C8 2.22386 7.77614 2 7.5 2H3.5Z"/></svg>';
+
     interface Props {
         vscode: { postMessage(msg: WebviewToExtensionMessage): void };
     }
@@ -32,6 +41,17 @@
     let copy_status = $state<'' | 'copying' | 'copied'>('');
     let copy_status_timer: ReturnType<typeof setTimeout> | null = null;
     let resize_timer: ReturnType<typeof setTimeout> | null = null;
+
+    // The toolbar always renders in a compact "icon-only" form on the
+    // right side: a single $(share) button that opens a popover with
+    // Copy / PNG / SVG / PDF, the existing $(arrow-up-right) external
+    // link, and a $(symbol-color) toggle for "Apply VS Code theme".
+    // Keeping the icon-only layout permanent (rather than a responsive
+    // collapse) means the toolbar height is invariant under panel
+    // resize and the layout reads cleanly at every width.
+    let share_popover_el: HTMLDivElement | undefined = $state();
+    let share_btn_el: HTMLButtonElement | undefined = $state();
+    const SHARE_POPOVER_ID = 'raven-plot-share-popover';
     // Tracks the in-flight SVG fetcher so a superseded fetch is aborted
     // when a fresh `(plotId, upid, dimensions, themeApplied)` lands.
     let last_fetcher: AbortController | null = null;
@@ -232,6 +252,45 @@
         const id = state.plotIds[state.currentIndex];
         if (!id) return;
         vscode.postMessage({ type: 'request-open-externally', payload: { plotId: id } });
+    }
+
+    // Position the share popover under the share button on each open.
+    // Using the HTML popover API (`popover` attribute) means dismissal
+    // is automatic on outside click or Escape — we only need to handle
+    // positioning. The CSS rule `.share-popover { inset: auto }`
+    // overrides the browser UA stylesheet's `[popover] { inset: 0;
+    // margin: auto }` (which would center the popover) so the JS-set
+    // `top` and `right` actually take effect. `right` anchors the
+    // popover's right edge near the share button's right edge so the
+    // menu reads as attached to it.
+    //
+    // `beforetoggle` fires synchronously before the popover becomes
+    // visible (the `:popover-open` rule flips `display: none` → `flex`).
+    // Setting position there avoids a one-frame flash at the centered
+    // default before our values land — visible when the menu opens
+    // because the popover is briefly painted at inset:0 / margin:auto
+    // before our `style.top` / `style.right` overrides take effect on
+    // the next style recalc.
+    function on_share_popover_beforetoggle(e: ToggleEvent) {
+        if (e.newState !== 'open') return;
+        if (!share_popover_el || !share_btn_el) return;
+        const r = share_btn_el.getBoundingClientRect();
+        share_popover_el.style.top = `${r.bottom + 4}px`;
+        share_popover_el.style.right = `${Math.max(4, window.innerWidth - r.right)}px`;
+    }
+
+    function close_share_popover() {
+        share_popover_el?.hidePopover?.();
+    }
+
+    function copy_from_share() {
+        close_share_popover();
+        void copy_current();
+    }
+
+    function save_from_share(format: SaveFormat) {
+        close_share_popover();
+        save_plot(format);
     }
 
     function toggle_theme_applied() {
@@ -435,30 +494,38 @@
                 disabled={state.phase !== 'viewing'}
                 title="Remove current plot">✕</button>
         <span class="spacer"></span>
-        <button onclick={copy_current}
+        <button class="icon-btn"
+                bind:this={share_btn_el}
+                popovertarget={SHARE_POPOVER_ID}
                 disabled={state.phase !== 'viewing'}
-                title="Copy plot to clipboard (PNG)">Copy</button>
-        <button onclick={() => save_plot('png')}
+                aria-label="Share or export plot"
+                title="Share or export plot">
+            {@html SHARE_ICON}
+        </button>
+        <button class="icon-btn"
+                onclick={open_externally}
                 disabled={state.phase !== 'viewing'}
-                title="Save as PNG">PNG</button>
-        <button onclick={() => save_plot('svg')}
-                disabled={state.phase !== 'viewing'}
-                title="Save as SVG">SVG</button>
-        <button onclick={() => save_plot('pdf')}
-                disabled={state.phase !== 'viewing'}
-                title="Save as PDF">PDF</button>
-        <button onclick={open_externally}
-                disabled={state.phase !== 'viewing'}
+                aria-label="Open in external viewer"
                 title="Open in external viewer">↗</button>
-        <button class="theme-toggle"
+        <button class="theme-toggle icon-btn"
                 class:is-on={state.themeApplied}
                 aria-pressed={state.themeApplied}
+                aria-label="Apply VS Code theme"
                 onclick={toggle_theme_applied}
-                title="Recolor the plot to match the active VS Code theme">
-            <span class="checkmark" aria-hidden="true">{state.themeApplied ? '✓' : ' '}</span>
-            Apply VS Code theme
+                title="Apply VS Code theme">
+            {@html SYMBOL_COLOR_ICON}
         </button>
     </header>
+    <div id={SHARE_POPOVER_ID}
+         bind:this={share_popover_el}
+         popover="auto"
+         class="share-popover"
+         onbeforetoggle={on_share_popover_beforetoggle}>
+        <button onclick={copy_from_share} disabled={state.phase !== 'viewing'}>Copy</button>
+        <button onclick={() => save_from_share('png')} disabled={state.phase !== 'viewing'}>PNG</button>
+        <button onclick={() => save_from_share('svg')} disabled={state.phase !== 'viewing'}>SVG</button>
+        <button onclick={() => save_from_share('pdf')} disabled={state.phase !== 'viewing'}>PDF</button>
+    </div>
 
     {#if state.sessionEnded && currentSvg}
         <div class="banner">R session ended. Showing last plot.</div>
@@ -580,17 +647,23 @@
         stroke: none !important;
     }
 
-    /* Toolbar toggle styling — mirrors the knit-preview "Apply VS Code
-     * theme" button: an accent border when on, a pre-allocated checkmark
-     * slot so toggling doesn't shift the label horizontally. */
-    .theme-toggle .checkmark {
-        display: inline-block;
-        width: 1ch;
-        text-align: center;
-        white-space: pre;
-    }
-
+    /* Toolbar toggle "on" state. Icon-only buttons can't lean on a
+     * label-adjacent indicator (no checkmark slot anymore), so the
+     * pressed state has to read from the button chrome alone. The
+     * `inputOption.active*` tokens are VS Code's canonical "this toggle
+     * is engaged" palette — they're what the search widget's
+     * case-sensitive / regex / whole-word toggles use. Pairing the
+     * accent background with `inputOption.activeBorder` (falling back
+     * to focusBorder for older themes that don't define it) gives a
+     * clearly-pressed look that doesn't depend on theme-specific
+     * border contrast.
+     *
+     * `currentColor` flows through the inline SVG's `fill="currentColor"`,
+     * so changing `color` to `activeForeground` recolors the codicon
+     * itself — no extra rule needed for the SVG fill. */
     .theme-toggle.is-on {
-        border-color: var(--vscode-focusBorder) !important;
+        background: var(--vscode-inputOption-activeBackground) !important;
+        color: var(--vscode-inputOption-activeForeground, var(--vscode-foreground)) !important;
+        border-color: var(--vscode-inputOption-activeBorder, var(--vscode-focusBorder)) !important;
     }
 </style>

--- a/editors/vscode/src/plot/webview/share-popover-position.ts
+++ b/editors/vscode/src/plot/webview/share-popover-position.ts
@@ -1,0 +1,134 @@
+// Pure positioning math for the share-popover, extracted from
+// `App.svelte` so it's unit-testable. The Svelte component still owns
+// the DOM measurement (offsetWidth/offsetHeight on a momentarily
+// `visibility: hidden; display: flex` element) and the inline-style
+// writes — only the clamp algorithm lives here.
+//
+// Design: the popover is anchored to the right side of the toolbar's
+// share button. The default position is `left = buttonRight - width`,
+// so the popover's right edge aligns with the button's right edge.
+// When that would leave parts of the popover off-screen, we clamp into
+// the viewport in a specific order so the user always sees the most
+// useful portion:
+//
+//   - Horizontal: prefer keeping the RIGHT edge in view (so the user's
+//     eye, which followed the share button to find the popover, lands
+//     on visible content). On a viewport narrower than the popover,
+//     the left edge extends off-left rather than the right edge off-
+//     right.
+//   - Vertical: prefer below the button, but flip above when below
+//     would overflow AND there's more room above. Final clamp keeps
+//     the TOP edge in view so users see the first item even if the
+//     popover is taller than the viewport (degenerate case).
+//
+// The function is pure (no globals, no DOM), takes plain numbers in,
+// returns plain numbers out — `compute_share_popover_position` is the
+// single source of truth and the test suite enumerates every clamp
+// branch.
+
+/** A 2D bounding box, viewport-relative (matches DOMRect fields). */
+export interface PositionRect {
+    readonly top: number;
+    readonly right: number;
+    readonly bottom: number;
+}
+
+export interface PositionViewport {
+    readonly width: number;
+    readonly height: number;
+}
+
+export interface PositionResult {
+    readonly left: number;
+    readonly top: number;
+}
+
+/** Inset (px) preserved between popover and viewport edges. */
+export const POPOVER_VIEWPORT_PADDING = 4;
+/** Gap (px) between the trigger button and the popover. */
+export const POPOVER_TRIGGER_GAP = 4;
+
+/**
+ * Compute the (left, top) inline position for the share popover.
+ *
+ * @param button - the share button's getBoundingClientRect output (we
+ *                 only need top/right/bottom)
+ * @param popover - the popover's measured natural box
+ * @param viewport - the viewport dimensions (window.innerWidth/Height)
+ * @returns inline left/top values, in CSS pixels
+ */
+export function compute_share_popover_position(
+    button: PositionRect,
+    popover: { width: number; height: number },
+    viewport: PositionViewport,
+): PositionResult {
+    const PAD = POPOVER_VIEWPORT_PADDING;
+    const GAP = POPOVER_TRIGGER_GAP;
+
+    // HORIZONTAL CLAMP. Right-edge-wins algorithm:
+    //   1. Start at the preferred (right-anchored) position:
+    //      left = buttonRight - popoverWidth. With a wide-enough
+    //      viewport this places the popover's right edge directly
+    //      under the button's right edge.
+    //   2. If that would push the LEFT edge off-screen (preferred <
+    //      PAD), slide right to PAD.
+    //   3. If the result would push the RIGHT edge off-screen, slide
+    //      LEFT until the right edge fits at innerW - PAD. When the
+    //      popover is wider than the viewport, this step makes `left`
+    //      negative — the LEFT edge extends off-screen and the user
+    //      still sees the right portion (closest to the trigger).
+    //
+    // Order matters: step 3 runs AFTER step 2 so the RIGHT-edge
+    // constraint always wins. Swapping the order would make narrow
+    // viewports prefer left-alignment and hide the last item ("PDF")
+    // off-screen, defeating the right-anchor design intent.
+    let left = button.right - popover.width;
+    if (left < PAD) left = PAD;
+    if (left + popover.width > viewport.width - PAD) {
+        left = viewport.width - PAD - popover.width;
+    }
+
+    // VERTICAL CLAMP.
+    //   1. Default: place below the button (top = buttonBottom + GAP).
+    //   2. If that overflows the bottom AND there's usable room above
+    //      (topAbove >= PAD) AND there's more room above than below,
+    //      flip to place above (top = buttonTop - GAP - h). The
+    //      `topAbove >= PAD` gate is what actually decides whether the
+    //      flip is feasible — `roomAbove > roomBelow` is the
+    //      tiebreaker the design intent encodes, but under overflow
+    //      with EQUAL rooms (a+b == viewport.height) the topAbove gate
+    //      always fails algebraically, so the strict `>` vs `>=` of
+    //      the room comparator is observationally inert. Choose strict
+    //      `>` defensively (ties favor staying below — natural reading
+    //      order, button is on screen) but don't claim the comparator
+    //      is the decisive gate.
+    //   3. If still overflowing, clamp top so the popover stops at the
+    //      bottom viewport padding (top = innerH - PAD - h). On
+    //      degenerate cases (popover taller than viewport), this can
+    //      pull top to a small/negative value; the trailing `< PAD`
+    //      clamp then forces top = PAD so the TOP edge of the popover
+    //      wins (user sees first items; bottom extends off-screen).
+    //   4. The trailing `if (top < PAD) top = PAD` is ALSO load-bearing
+    //      for a SEPARATE case the steps above don't cover: a button
+    //      scrolled above the viewport (button.bottom < PAD, possibly
+    //      negative). The default `top = button.bottom + GAP` then
+    //      lands below PAD, but the overflow branch isn't entered
+    //      (the popover would happily fit below the off-screen
+    //      button). Without this trailing clamp the popover would
+    //      render at negative top. See the
+    //      `button scrolled above viewport` test for coverage.
+    let top = button.bottom + GAP;
+    if (top + popover.height > viewport.height - PAD) {
+        const topAbove = button.top - GAP - popover.height;
+        const roomAbove = button.top;
+        const roomBelow = viewport.height - button.bottom;
+        if (topAbove >= PAD && roomAbove > roomBelow) {
+            top = topAbove;
+        } else {
+            top = Math.max(PAD, viewport.height - PAD - popover.height);
+        }
+    }
+    if (top < PAD) top = PAD;
+
+    return { left, top };
+}

--- a/editors/vscode/src/plot/webview/styles.css
+++ b/editors/vscode/src/plot/webview/styles.css
@@ -28,6 +28,11 @@ main {
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-editorWidget-background);
     flex: 0 0 auto;
+    /* Single-row, fixed-height toolbar. `flex-wrap: nowrap` is the flex
+     * default, but pinning it here keeps a future style edit (or a new
+     * text-bearing button) from silently re-introducing the multi-row
+     * wrap that the icon-only layout exists to prevent. */
+    flex-wrap: nowrap;
 }
 
 .toolbar button {
@@ -38,6 +43,12 @@ main {
     border-radius: 2px;
     font-family: inherit;
     cursor: pointer;
+    /* Buttons never wrap their label and never shrink below their
+     * natural width — should a future button gain a text label, this
+     * keeps the row from collapsing vertically (which is what produced
+     * the original two-row wrap the user reported). */
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .toolbar button:hover:not(:disabled) {
@@ -54,10 +65,92 @@ main {
     text-align: center;
     font-variant-numeric: tabular-nums;
     opacity: 0.8;
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .toolbar .spacer {
     flex: 1;
+}
+
+/* Icon-only toolbar buttons (compact theme toggle, share menu). The
+ * inline SVG inherits the button's foreground via `fill="currentColor"`.
+ * The fixed 16x16 square keeps the row height stable across mode
+ * swaps — without explicit width the SVG would size to its viewBox at
+ * font-relative metrics and cause sub-pixel jitter on font changes. */
+.toolbar .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 6px;
+    line-height: 0;
+}
+
+.toolbar .icon-btn svg {
+    width: 16px;
+    height: 16px;
+    display: block;
+    /* `pointer-events: none` is load-bearing for the native `title=`
+     * tooltip on the parent button. Without it, the SVG (which fills
+     * the entire button interior at 16x16) intercepts pointer hover
+     * events; the button never receives a hover and the browser-chrome
+     * tooltip never appears. Letting events pass through to the button
+     * also keeps the `:hover` style and the popovertarget click target
+     * working when the cursor happens to land on a stroke pixel. */
+    pointer-events: none;
+}
+
+/* Popover for the collapsed share menu (mode === 'share-menu'). Uses
+ * the HTML popover API: `popover="auto"` gives light-dismiss on outside
+ * click and Escape; we position it via JS in `on_share_popover_toggle`
+ * since CSS anchor positioning isn't reliable in older Electron-based
+ * VS Code builds. Stack of secondary buttons matches the toolbar
+ * styling so the popover reads as an extension of the row. */
+.share-popover {
+    position: fixed;
+    /* Override the browser UA stylesheet's `[popover] { inset: 0;
+     * margin: auto }` which would otherwise center the popover and
+     * cause our JS-applied `top`/`right` values to fight against the
+     * defaulted `left: 0; bottom: 0`. With `inset: auto`, only the two
+     * sides JS sets in `on_share_popover_toggle` define position; width
+     * sizes to content via the browser's default `width: fit-content`. */
+    inset: auto;
+    margin: 0;
+    padding: 4px;
+    background: var(--vscode-editorWidget-background);
+    color: var(--vscode-editorWidget-foreground);
+    border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    border-radius: 4px;
+    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.36));
+    min-width: 96px;
+    display: none;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.share-popover:popover-open {
+    display: flex;
+}
+
+.share-popover button {
+    background: transparent;
+    color: var(--vscode-foreground);
+    border: 1px solid transparent;
+    padding: 4px 12px;
+    border-radius: 2px;
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.share-popover button:hover:not(:disabled) {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.share-popover button:disabled {
+    opacity: 0.5;
+    cursor: default;
 }
 
 .banner {

--- a/editors/vscode/src/plot/webview/styles.css
+++ b/editors/vscode/src/plot/webview/styles.css
@@ -33,6 +33,23 @@ main {
      * text-bearing button) from silently re-introducing the multi-row
      * wrap that the icon-only layout exists to prevent. */
     flex-wrap: nowrap;
+    /* `overflow-x: auto` is the safety net for very narrow panel widths
+     * where the sum of intrinsic button widths exceeds the viewport.
+     * Without it, `main { overflow: hidden }` (styles.css line 15) would
+     * SILENTLY clip the rightmost buttons (share, external, theme
+     * toggle) and users would have no path to copy/export. With it, the
+     * toolbar becomes wheel/touch-scrollable instead. The visible
+     * scrollbar is suppressed below (`scrollbar-width: none` +
+     * `::-webkit-scrollbar { display: none }`) because a scrollbar on
+     * the 28px-tall toolbar would consume disproportionate height; the
+     * trackpad/wheel gesture is the intended access path. */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+}
+
+.toolbar::-webkit-scrollbar {
+    display: none;
 }
 
 .toolbar button {
@@ -90,30 +107,34 @@ main {
     width: 16px;
     height: 16px;
     display: block;
-    /* `pointer-events: none` is load-bearing for the native `title=`
-     * tooltip on the parent button. Without it, the SVG (which fills
-     * the entire button interior at 16x16) intercepts pointer hover
-     * events; the button never receives a hover and the browser-chrome
-     * tooltip never appears. Letting events pass through to the button
-     * also keeps the `:hover` style and the popovertarget click target
-     * working when the cursor happens to land on a stroke pixel. */
+    /* `pointer-events: none` makes every click/hover on the SVG fall
+     * through to the parent <button>, so `event.target` is always the
+     * button itself — never the inner `<svg>` or `<path>`. That gives
+     * a deterministic click target for the button's `popovertarget`
+     * activation and any future event handler that inspects
+     * `event.target` / `event.composedPath()[0]`. (Note: native
+     * `title=` tooltips and CSS `:hover` BOTH walk the ancestor chain,
+     * so they would still work without this rule — the load-bearing
+     * benefit is target identity, not hover/tooltip propagation.) */
     pointer-events: none;
 }
 
-/* Popover for the collapsed share menu (mode === 'share-menu'). Uses
+/* Popover for the collapsed share menu (Copy / PNG / SVG / PDF). Uses
  * the HTML popover API: `popover="auto"` gives light-dismiss on outside
- * click and Escape; we position it via JS in `on_share_popover_toggle`
- * since CSS anchor positioning isn't reliable in older Electron-based
- * VS Code builds. Stack of secondary buttons matches the toolbar
- * styling so the popover reads as an extension of the row. */
+ * click and Escape; we position it via JS in
+ * `on_share_popover_beforetoggle` (App.svelte) since CSS anchor
+ * positioning isn't reliable in older Electron-based VS Code builds.
+ * Stack of secondary buttons matches the toolbar styling so the popover
+ * reads as an extension of the row. */
 .share-popover {
     position: fixed;
     /* Override the browser UA stylesheet's `[popover] { inset: 0;
      * margin: auto }` which would otherwise center the popover and
-     * cause our JS-applied `top`/`right` values to fight against the
-     * defaulted `left: 0; bottom: 0`. With `inset: auto`, only the two
-     * sides JS sets in `on_share_popover_toggle` define position; width
-     * sizes to content via the browser's default `width: fit-content`. */
+     * cause our JS-applied `top`/`left` values to fight against the
+     * defaulted `right: 0; bottom: 0`. With `inset: auto`, only the
+     * sides JS sets in `on_share_popover_beforetoggle` define position;
+     * width sizes to content via the browser's default
+     * `width: fit-content`. */
     inset: auto;
     margin: 0;
     padding: 4px;

--- a/tests/bun/plot-share-popover-position.test.ts
+++ b/tests/bun/plot-share-popover-position.test.ts
@@ -1,0 +1,302 @@
+// Unit tests for the share-popover positioning helper.
+//
+// The function is pure and deterministic: given a button rect, popover
+// size, and viewport size, it returns the popover's clamped (left,
+// top). These tests enumerate every clamp branch:
+//
+//   1. WIDE / TALL: popover fits below-and-right-anchored.
+//   2. NEAR-BOTTOM: below overflows, MORE room above → flip-above.
+//   3. NEAR-BOTTOM, EQUAL: below overflows but above ≤ below → clamp
+//      bottom edge to viewport-padding (don't flip).
+//   4. WIDE BUTTON NEAR LEFT: preferred left < padding → slide right.
+//   5. POPOVER WIDER THAN BUTTON-RIGHT-SPACE: right-edge clamp wins,
+//      left becomes negative (off-left).
+//   6. POPOVER WIDER THAN VIEWPORT: right edge clamps; left negative.
+//   7. POPOVER TALLER THAN VIEWPORT: top clamps to padding (top wins).
+//   8. PRESERVED INVARIANTS: the function is pure (no I/O, no DOM).
+
+import { describe, test, expect } from 'bun:test';
+import {
+    POPOVER_TRIGGER_GAP,
+    POPOVER_VIEWPORT_PADDING,
+    compute_share_popover_position,
+} from '../../editors/vscode/src/plot/webview/share-popover-position';
+
+const PAD = POPOVER_VIEWPORT_PADDING;
+const GAP = POPOVER_TRIGGER_GAP;
+
+describe('compute_share_popover_position — typical case', () => {
+    test('button at center of wide viewport: right-anchored, below', () => {
+        // Viewport 1000x800, button centered at x=400-500 / y=20-40.
+        // Popover 120x120.
+        // Expected: right-anchored under button (left = 500-120 = 380),
+        //           below button (top = 40 + 4 = 44).
+        const result = compute_share_popover_position(
+            { top: 20, right: 500, bottom: 40 },
+            { width: 120, height: 120 },
+            { width: 1000, height: 800 },
+        );
+        expect(result).toEqual({ left: 380, top: 44 });
+    });
+
+    test('button near right edge: popover fits within viewport', () => {
+        // Viewport 200x600, button at x=170-190 / y=20-40. Popover 120x120.
+        // Preferred left = 190 - 120 = 70. Right edge: 70 + 120 = 190 <
+        // 200 - 4 = 196 → no slide. Final: { left: 70, top: 44 }.
+        const result = compute_share_popover_position(
+            { top: 20, right: 190, bottom: 40 },
+            { width: 120, height: 120 },
+            { width: 200, height: 600 },
+        );
+        expect(result).toEqual({ left: 70, top: 44 });
+    });
+});
+
+describe('compute_share_popover_position — vertical clamps', () => {
+    test('button near bottom: more room above → flip-above', () => {
+        // Viewport 1000x300, button at y=240-260 (close to bottom).
+        // Popover 120x120.
+        // Below overflow: 260 + 4 + 120 = 384 > 300 - 4 = 296. Yes.
+        // Room above (button.top = 240) > room below (300-260 = 40).
+        // topAbove = 240 - 4 - 120 = 116, ≥ 4 → flip.
+        // Expected: top = 116.
+        const result = compute_share_popover_position(
+            { top: 240, right: 500, bottom: 260 },
+            { width: 120, height: 120 },
+            { width: 1000, height: 300 },
+        );
+        expect(result.top).toBe(116);
+    });
+
+    test('button vertically centered, popover taller than room-below: topAbove < PAD → clamp', () => {
+        // Overflow + (roomAbove == roomBelow) + (topAbove < PAD).
+        //
+        // ALGORITHM INVARIANT BEING VERIFIED: when there is no usable
+        // room above the button (topAbove < PAD), the algorithm MUST
+        // fall through to the bottom-clamp regardless of room comparison.
+        //
+        // Geometry: viewport 400 tall, button centered at y=190-210,
+        // popover 250 tall.
+        //   - Overflow: 210 + 4 + 250 = 464 > 396 ✓.
+        //   - topAbove = 190 - 4 - 250 = -64. -64 < PAD=4 → flip gate
+        //     fails on the topAbove side, short-circuiting the AND.
+        //     roomAbove vs roomBelow is irrelevant (both 190 here).
+        //   - Fallback: max(PAD, 400 - 4 - 250) = 146.
+        //
+        // NOTE on strict > vs >= in `roomAbove > roomBelow`: under
+        // overflow, equal rooms force topAbove < PAD (algebraically:
+        // a + b == V and overflow ⇒ topAbove < PAD), so the strict
+        // comparator is short-circuited by the AND gate. Choosing
+        // strict > over >= is therefore defensive only (matches the
+        // intuition that ties keep the default below-position) — it
+        // has no observable effect under the current algorithm.
+        const result = compute_share_popover_position(
+            { top: 190, right: 500, bottom: 210 },
+            { width: 120, height: 250 },
+            { width: 1000, height: 400 },
+        );
+        expect(result.top).toBe(146);
+    });
+
+    test('button shifted, popover too tall for either side: topAbove < PAD → clamp', () => {
+        // Mirror test with roomAbove > roomBelow by 2px but popover
+        // still too tall for the flip to fit. Verifies the AND gate's
+        // topAbove side dominates when above doesn't have room.
+        //
+        // Geometry: viewport 400, button at y=191-211, popover 250.
+        //   - roomAbove = 191, roomBelow = 400 - 211 = 189 (above wins by 2).
+        //   - Overflow: 211 + 4 + 250 = 465 > 396 ✓.
+        //   - topAbove = 191 - 4 - 250 = -63. -63 < PAD → flip fails.
+        //   - Fallback: max(PAD, 400 - 4 - 250) = 146.
+        const result = compute_share_popover_position(
+            { top: 191, right: 500, bottom: 211 },
+            { width: 120, height: 250 },
+            { width: 1000, height: 400 },
+        );
+        expect(result.top).toBe(146);
+    });
+
+    test('button near bottom with usable room above AND overflow: flip-above', () => {
+        // This is the CASE THAT ACTUALLY EXERCISES THE FLIP BRANCH.
+        // We need overflow AND topAbove >= PAD AND roomAbove > roomBelow
+        // simultaneously — requires button positioned such that there
+        // IS genuine room above the popover.
+        //
+        // Geometry: viewport 400, button at y=200-220, popover 180.
+        //   - Overflow: 220 + 4 + 180 = 404 > 396 ✓.
+        //   - topAbove = 200 - 4 - 180 = 16. 16 >= PAD=4 ✓.
+        //   - roomAbove = 200, roomBelow = 400 - 220 = 180. 200 > 180 ✓.
+        //   - All three gates pass → flip. top = topAbove = 16.
+        const result = compute_share_popover_position(
+            { top: 200, right: 500, bottom: 220 },
+            { width: 120, height: 180 },
+            { width: 1000, height: 400 },
+        );
+        expect(result.top).toBe(16);
+    });
+
+    test('button moderately near bottom with no overflow: no flip', () => {
+        // Sanity: when there IS no overflow, the flip code path is
+        // never reached regardless of roomAbove/roomBelow.
+        //
+        // Viewport 1000x400, button at y=190-210. Popover 120x120.
+        // Below: 210 + 4 + 120 = 334 < 396 ✓ (no overflow). Expected
+        // top = 214 (below).
+        const result = compute_share_popover_position(
+            { top: 190, right: 500, bottom: 210 },
+            { width: 120, height: 120 },
+            { width: 1000, height: 400 },
+        );
+        expect(result.top).toBe(214);
+    });
+
+    test('button scrolled above viewport (button.bottom < PAD): trailing top-clamp wins', () => {
+        // Edge case the trailing `if (top < PAD) top = PAD` exists for:
+        // when the button's bottom is at or above the viewport's top
+        // edge, `top = button.bottom + GAP` lands at a value below PAD
+        // (possibly negative), and no overflow path executes because
+        // the popover would happily fit below the (off-screen) button.
+        // Without the final clamp, the popover would render at
+        // negative top.
+        //
+        // Viewport 1000x800, button at y=-20 to -5 (above viewport).
+        // Popover 100x100.
+        // top = -5 + 4 = -1. Below overflow? -1 + 100 = 99 < 800-4=796 → no.
+        // Trailing clamp: -1 < 4 → top = 4 = PAD.
+        const result = compute_share_popover_position(
+            { top: -20, right: 500, bottom: -5 },
+            { width: 100, height: 100 },
+            { width: 1000, height: 800 },
+        );
+        expect(result.top).toBe(PAD);
+    });
+
+    test('button at very bottom: flip-above when room above > below', () => {
+        // Viewport 1000x500, button at y=480-495 (just above bottom).
+        // Popover 100x100.
+        // Below: 495 + 4 + 100 = 599 > 496. Overflow.
+        // Room above 480 > room below 5 → flip.
+        // topAbove = 480 - 4 - 100 = 376.
+        const result = compute_share_popover_position(
+            { top: 480, right: 500, bottom: 495 },
+            { width: 100, height: 100 },
+            { width: 1000, height: 500 },
+        );
+        expect(result.top).toBe(376);
+    });
+
+    test('popover taller than viewport: top clamps to padding (top wins)', () => {
+        // Viewport 1000x100 (very short). Button at y=20-40. Popover
+        // 100x300 (taller than viewport).
+        // Below: 40 + 4 + 300 = 344 > 96. Overflow.
+        // topAbove = 20 - 4 - 300 = -284. Not ≥ 4.
+        // Fallback clamp: max(4, 100 - 4 - 300) = max(4, -204) = 4.
+        // Final top < PAD check: 4 < 4 false → top = 4.
+        const result = compute_share_popover_position(
+            { top: 20, right: 500, bottom: 40 },
+            { width: 100, height: 300 },
+            { width: 1000, height: 100 },
+        );
+        expect(result.top).toBe(PAD);
+    });
+});
+
+describe('compute_share_popover_position — horizontal clamps', () => {
+    test('button near left edge: preferred left negative → slide right to padding', () => {
+        // Viewport 1000x600, button at x=30-50 / y=20-40. Popover 120x60.
+        // Preferred left = 50 - 120 = -70 → clamp to PAD = 4.
+        // Right: 4 + 120 = 124 < 996 → no further clamp.
+        const result = compute_share_popover_position(
+            { top: 20, right: 50, bottom: 40 },
+            { width: 120, height: 60 },
+            { width: 1000, height: 600 },
+        );
+        expect(result.left).toBe(PAD);
+    });
+
+    test('popover wider than space-to-button-right: right-edge wins, left negative', () => {
+        // Viewport 80x600, button at x=30-50 / y=20-40. Popover 120x60.
+        // Preferred left = 50 - 120 = -70 → clamp to PAD = 4.
+        // Right: 4 + 120 = 124 > 80 - 4 = 76 → slide left.
+        // left = 80 - 4 - 120 = -44 → off-left.
+        // Final state: popover's RIGHT edge at innerW - PAD = 76.
+        const result = compute_share_popover_position(
+            { top: 20, right: 50, bottom: 40 },
+            { width: 120, height: 60 },
+            { width: 80, height: 600 },
+        );
+        expect(result.left).toBe(-44);
+        expect(result.left + 120).toBe(80 - PAD); // right edge in view
+    });
+
+    test('popover wider than viewport: right edge wins', () => {
+        // Viewport 50x600, button at x=20-40 / y=20-40. Popover 120x60.
+        // Preferred left = 40 - 120 = -80 → clamp to PAD = 4.
+        // Right: 4 + 120 = 124 > 50 - 4 = 46 → slide left.
+        // left = 50 - 4 - 120 = -74.
+        // Right edge = -74 + 120 = 46 = innerW - PAD ✓.
+        const result = compute_share_popover_position(
+            { top: 20, right: 40, bottom: 40 },
+            { width: 120, height: 60 },
+            { width: 50, height: 600 },
+        );
+        expect(result.left + 120).toBe(50 - PAD);
+    });
+
+    test('button beyond viewport right edge (during resize): popover still clamps to viewport', () => {
+        // Degenerate / transient case: button.right > viewport.width.
+        // Could happen during a viewport-shrink animation before our
+        // resize handler fires. Popover should still land inside the
+        // viewport.
+        // Viewport 100x600, button at x=80-120 / y=20-40 (button right
+        // is past viewport edge). Popover 80x60.
+        // Preferred left = 120 - 80 = 40 → ≥ PAD, no slide.
+        // Right: 40 + 80 = 120 > 100 - 4 = 96 → slide left.
+        // left = 100 - 4 - 80 = 16. Right edge = 96.
+        const result = compute_share_popover_position(
+            { top: 20, right: 120, bottom: 40 },
+            { width: 80, height: 60 },
+            { width: 100, height: 600 },
+        );
+        expect(result.left).toBe(16);
+        expect(result.left + 80).toBe(100 - PAD);
+    });
+});
+
+describe('compute_share_popover_position — purity', () => {
+    test('does not mutate the input button rect', () => {
+        const button = { top: 20, right: 500, bottom: 40 };
+        const buttonCopy = { ...button };
+        compute_share_popover_position(
+            button,
+            { width: 120, height: 120 },
+            { width: 1000, height: 800 },
+        );
+        expect(button).toEqual(buttonCopy);
+    });
+
+    test('returns the same output for the same input (idempotent)', () => {
+        const args = [
+            { top: 30, right: 250, bottom: 50 },
+            { width: 96, height: 130 },
+            { width: 400, height: 600 },
+        ] as const;
+        const a = compute_share_popover_position(args[0], args[1], args[2]);
+        const b = compute_share_popover_position(args[0], args[1], args[2]);
+        expect(a).toEqual(b);
+    });
+});
+
+describe('compute_share_popover_position — constant defaults', () => {
+    test('POPOVER_VIEWPORT_PADDING is a small positive integer', () => {
+        expect(PAD).toBeGreaterThan(0);
+        expect(PAD).toBeLessThan(16);
+        expect(Number.isInteger(PAD)).toBe(true);
+    });
+
+    test('POPOVER_TRIGGER_GAP is a small positive integer', () => {
+        expect(GAP).toBeGreaterThan(0);
+        expect(GAP).toBeLessThan(16);
+        expect(Number.isInteger(GAP)).toBe(true);
+    });
+});

--- a/tests/bun/plot-webview-inline-icons.test.ts
+++ b/tests/bun/plot-webview-inline-icons.test.ts
@@ -1,0 +1,129 @@
+// Defense-in-depth regression test for the inline codicon SVG
+// constants in editors/vscode/src/plot/webview/App.svelte.
+//
+// Why this test exists: `SHARE_ICON`, `SYMBOL_COLOR_ICON`, and
+// `LINK_EXTERNAL_ICON` are injected into the webview via Svelte's
+// `{@html ...}` template syntax, which bypasses Svelte's normal HTML
+// escaping. Unlike the plot's runtime SVG (which is routed through
+// `sanitize_svg` — see plot-webview-sanitize.test.ts), there is no
+// runtime sanitizer in the icon path: the strings are concatenated into
+// the page exactly as written. Today the constants are hand-vetted
+// codicon paths, but a future contributor copy-pasting a third-party
+// SVG could introduce `<use href="...">`, `<image href="...">`, a
+// `<script>` block, or an `onerror="..."` attribute — any of which
+// would silently expand the webview's attack surface (CSP allows
+// `style-src 'unsafe-inline'`, so attribute-style payloads are not
+// blocked; external-href fetches via `<use>`/`<image>` can also leak
+// request metadata to attacker-controlled origins).
+//
+// This test parses the App.svelte source, extracts each icon constant
+// by name, and asserts that every constant is free of the elements and
+// attributes listed in the security comment on the constants. If a
+// constant fails, the fix is to either (a) keep it pure SVG (path /
+// rect / circle / g / etc. — no external refs, no scripts, no event
+// handlers) or (b) route it through `sanitize_svg` at module init and
+// embed the sanitized output. Do NOT silence this test by widening the
+// allowlist without explicit security review.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const APP_SVELTE_PATH = join(
+    __dirname,
+    '..',
+    '..',
+    'editors',
+    'vscode',
+    'src',
+    'plot',
+    'webview',
+    'App.svelte',
+);
+
+const APP_SVELTE_SOURCE = readFileSync(APP_SVELTE_PATH, 'utf-8');
+
+// Extract a `const NAME = '...';` value from the App.svelte source.
+// Uses single-quoted strings only because that's the existing
+// convention for these constants; if the convention ever changes to
+// backticks or double quotes the extractor needs to update in lockstep.
+function extractIcon(name: string): string {
+    // Match `const NAME = ` then either `'...'` or `\n        '...'`.
+    // Single quotes are not allowed inside the string body itself
+    // (which is true for SVG path data — quotes inside paths are
+    // double quotes).
+    const re = new RegExp(`const\\s+${name}\\s*=\\s*\\n?\\s*'([^']*)'`);
+    const match = APP_SVELTE_SOURCE.match(re);
+    if (!match) {
+        throw new Error(
+            `Could not locate \`const ${name} = '...'\` in App.svelte. ` +
+                `If the constant was renamed or moved, update this test ` +
+                `in lockstep — the security guard depends on the lookup.`,
+        );
+    }
+    return match[1];
+}
+
+const ICON_CONSTANTS: Record<string, string> = {
+    SHARE_ICON: extractIcon('SHARE_ICON'),
+    SYMBOL_COLOR_ICON: extractIcon('SYMBOL_COLOR_ICON'),
+    LINK_EXTERNAL_ICON: extractIcon('LINK_EXTERNAL_ICON'),
+};
+
+describe('App.svelte inline icon constants — XSS defense-in-depth', () => {
+    test('extractor located every expected constant', () => {
+        // Sanity: every entry should have non-empty SVG markup.
+        for (const [name, svg] of Object.entries(ICON_CONSTANTS)) {
+            expect(svg.length, `${name} should be non-empty`).toBeGreaterThan(0);
+            expect(svg.toLowerCase()).toContain('<svg');
+        }
+    });
+
+    // Run the same forbidden-content checks against every constant.
+    for (const [name, svg] of Object.entries(ICON_CONSTANTS)) {
+        describe(name, () => {
+            test('contains no <script> element', () => {
+                expect(svg).not.toMatch(/<\s*script\b/i);
+            });
+            test('contains no <use> element (external-href vector)', () => {
+                expect(svg).not.toMatch(/<\s*use\b/i);
+            });
+            test('contains no <image> element (external-href vector)', () => {
+                expect(svg).not.toMatch(/<\s*image\b/i);
+            });
+            test('contains no <a> element (navigation-hijack vector)', () => {
+                expect(svg).not.toMatch(/<\s*a\b/i);
+            });
+            test('contains no <foreignObject> element (arbitrary-HTML host)', () => {
+                expect(svg).not.toMatch(/<\s*foreignObject\b/i);
+            });
+            test('contains no <iframe> element', () => {
+                expect(svg).not.toMatch(/<\s*iframe\b/i);
+            });
+            test('contains no href / xlink:href attribute', () => {
+                // The codicon paths use `viewBox`, `fill`, `clip-rule`,
+                // `fill-rule`, etc. — none of which should ever resolve
+                // to an external URL.
+                expect(svg).not.toMatch(/\bhref\s*=/i);
+                expect(svg).not.toMatch(/\bxlink:href\s*=/i);
+            });
+            test('contains no inline event-handler attribute', () => {
+                // Match `on…="…"` style attributes. The regex requires
+                // a word boundary on each side so it doesn't false-
+                // positive on e.g. `fill="none"`. The character class
+                // after `on` is letters-only (event names are letters).
+                expect(svg).not.toMatch(/(?:^|\s|<|;)on[a-zA-Z]+\s*=/);
+            });
+            test('contains no data: or javascript: URL', () => {
+                expect(svg.toLowerCase()).not.toContain('data:');
+                expect(svg.toLowerCase()).not.toContain('javascript:');
+            });
+            test('contains no inline style attribute (CSS-exfiltration defense)', () => {
+                // Mirrors the FORBID_ATTR list in `sanitize_svg` for
+                // the plot SVG. CSS payloads can exfiltrate state via
+                // `background-image: url(...)` and similar.
+                expect(svg).not.toMatch(/\bstyle\s*=/i);
+            });
+        });
+    }
+});

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -41,6 +41,8 @@
   "include": [
     "r-expression.test.ts",
     "r-expression-chunk-opts.test.ts",
-    "open-exported-file.test.ts"
+    "open-exported-file.test.ts",
+    "plot-webview-inline-icons.test.ts",
+    "plot-share-popover-position.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Five rounds of adversarial code review on the icon-only plot-viewer toolbar refactor (commits a53e4f54 + 424d24a7) surfaced material defects across compatibility, a11y, layout, lifecycle, and test coverage. This PR addresses every confirmed finding.

## Key fixes

### Compatibility
- **Bump `engines.vscode` to `^1.82.0`** (was `^1.75.0`). The new share popover uses the HTML Popover API (`popover` attr, `popovertarget`, `hidePopover()`, `:popover-open`, `beforetoggle`) which requires Chromium 114+. On VS Code 1.75–1.80, the share button was silently inert — Copy/PNG/SVG/PDF entirely unreachable.

### Layout / UX
- Add `overflow-x: auto` + hidden-scrollbar to `.toolbar` so the right-side icons stay reachable on narrow panels (`flex-shrink: 0` + `overflow: hidden` on `main` was silently clipping them off-screen).
- Restore the descriptive theme-toggle tooltip (`title="Recolor the plot to match the active VS Code theme"`) — the icon-only refactor had reduced it to a circular `title="Apply VS Code theme"` identical to the `aria-label`.
- Replace the raw `↗` text glyph on the external-link button with an inline `link-external` codicon SVG so all three right-cluster icons share consistent 16x16 sizing/baseline/font-fallback behavior.

### Accessibility
- Drop the mismatched `aria-haspopup="menu"` (we don't implement arrow-key navigation). Use `role="group"` + `aria-label` on the popover instead — AT consistently announces this combination, where a bare `<div popover>` would be exposed as generic and may drop the label entirely.
- Add `aria-expanded` + `aria-controls` on the share trigger.
- Move focus into the popover on open so keyboard users immediately reach Copy/PNG/SVG/PDF instead of tabbing through the rest of the toolbar.
- Close the popover programmatically when `state.phase` leaves `'viewing'` (R session ends) so users aren't stranded with an inert menu whose trigger is disabled.

### Lifecycle / correctness
- Reposition popover on window resize while open (previously positioned once and floated detached after any layout change).
- Extract clamp algorithm to a pure helper (`share-popover-position.ts`) — right-edge-first horizontally so the design intent survives degenerate-narrow viewports, flip-above vertically when below overflows and room above is greater, trailing `top >= PAD` clamp also defends against button-scrolled-above-viewport.
- Split popover handler into `beforetoggle` (position + state) and `toggle` (focus + listener) to avoid a one-frame flash at the UA default centered position.
- Guard resize handler with `:popover-open` check (race between sync `beforetoggle('closed')` and async `toggle('closed')`).
- Use `untrack` for `share_popover_open` in the lifecycle effect so it re-fires only on `state.phase` change.

### Docs / comments / tests
- Update `docs/plot-viewer.md` to describe the icon-only toolbar.
- Fix CSS comment drift (referenced non-existent function and state).
- Correct misleading `pointer-events: none` rationale (real benefit is deterministic click-target identity, not tooltip propagation).
- Add `tests/bun/plot-webview-inline-icons.test.ts` — defense-in-depth XSS guard asserting the inline codicon SVG constants (injected via `{@html}`) contain no `<script>`/`<use>`/`<image>`/`<a>`/event-handler/`href` content.
- Add `tests/bun/plot-share-popover-position.test.ts` — 18 cases covering every clamp branch: right-anchor, viewport overflow both axes, flip-above, popover-wider/taller-than-viewport, button beyond/above viewport, purity.

## Test plan

- [x] `bun test` passes (1097+ tests across 76 files; new 18 + 31 tests added by this PR)
- [x] `bun run typecheck` clean (editor + 3 webview tsconfigs)
- [x] `tsc --project tests/bun/tsconfig.json --noEmit` clean (both new test files included)
- [x] `bun run bundle` produces a clean plot-viewer bundle (255–256kb, no warnings)
- [x] VS Code integration suite (`vscode-test`) passes (282 tests)
- [x] Five rounds of adversarial code review at extra-high effort, ending with a clean `[]` result
- [ ] Manual: open a plot viewer, verify share popover positions correctly under window resize, on narrow panel, and near viewport edges
- [ ] Manual: keyboard nav (Tab into share, Enter to open, Tab through items, Esc to close)
- [ ] Manual: screen-reader announce (NVDA / VoiceOver) of share trigger and popover