### PR TITLE
data viewer: filter popover reflects the active filter on open

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -235,6 +235,14 @@ Right-click a column header and choose **Filter…** to open the filter editor
 for that column. You can also press **⇧⌥F** to open the editor for the
 currently focused column.
 
+When the column already has an active filter, the editor opens pre-populated
+with that filter's current settings — the same predicate, values, and **Include
+NA / NaN** state it had when you last applied it — so you edit in place rather
+than starting over. In that case the context-menu item reads **Edit filter…**,
+and applying updates the existing filter (it does not add a second one — see
+[Composition](#composition)). On an unfiltered column the item reads
+**Filter…** and the editor opens empty.
+
 ### Per-type predicates
 
 | Column type | Available predicates |

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -1627,6 +1627,10 @@ export function App({
                     if (!editorColumn) return null;
                     return (
                         <FilterPopover
+                            // Key by target column so switching columns forces a
+                            // remount and re-seeds the form from that column's
+                            // filter; the seed runs only in useState initializers.
+                            key={editorColumnIndex}
                             column={editorColumn}
                             columnIndex={editorColumnIndex}
                             histogram={histograms[editorColumnIndex]}

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -700,6 +700,19 @@ export function App({
         setFilterEditor({ entry });
     }, []);
 
+    /** Open the filter popover for a column, pre-seeded with its active filter
+     *  (one-filter-per-column invariant) so editing reflects the live settings.
+     *  When the column is unfiltered, `existing` is undefined and the popover
+     *  opens blank — the "add new" path. Keyed on `filter.entries` so callers
+     *  inside effects (e.g. the keyboard handler) never read a stale snapshot. */
+    const openFilterEditor = useCallback(
+        (columnIndex: number, leftPx: number, topPx: number) => {
+            const existing = filter.entries.find(e => e.columnIndex === columnIndex);
+            setFilterEditor({ entry: existing, columnIndex, leftPx, topPx });
+        },
+        [filter.entries],
+    );
+
     const onToggleFilterEnabled = useCallback((id: string) => {
         applyFilters(filter.entries.map(e => e.id === id ? { ...e, enabled: !e.enabled } : e));
     }, [applyFilters, filter.entries]);
@@ -1163,7 +1176,7 @@ export function App({
                     const focused = gridSelection.current?.cell[0];
                     const sourceIndex = focused !== undefined ? visibleCols[focused] : undefined;
                     if (sourceIndex !== undefined) {
-                        setFilterEditor({ columnIndex: sourceIndex, leftPx: 100, topPx: 100 });
+                        openFilterEditor(sourceIndex, 100, 100);
                     }
                     return;
                 }
@@ -1199,8 +1212,8 @@ export function App({
         copySelection,
         gridSelection,
         onClearAllFilters,
+        openFilterEditor,
         postLifecycle,
-        setFilterEditor,
         sortColumn,
         visibleCols,
         visibleRange,
@@ -1586,11 +1599,11 @@ export function App({
                                 ),
                                 anyFiltered: filter.entries.length > 0,
                                 onAddFilter: () => {
-                                    setFilterEditor({
-                                        columnIndex: contextMenu.columnIndex,
-                                        leftPx: contextMenu.leftPx,
-                                        topPx: contextMenu.topPx,
-                                    });
+                                    openFilterEditor(
+                                        contextMenu.columnIndex!,
+                                        contextMenu.leftPx,
+                                        contextMenu.topPx,
+                                    );
                                     setContextMenu(null);
                                 },
                                 onClearColumn: () => {

--- a/editors/vscode/src/data-viewer/webview/column-context-menu.tsx
+++ b/editors/vscode/src/data-viewer/webview/column-context-menu.tsx
@@ -199,7 +199,7 @@ export function ColumnContextMenu({
                         onClick={filter.onAddFilter}
                         role="menuitem"
                     >
-                        Filter…
+                        {filter.hasFilter ? 'Edit filter…' : 'Filter…'}
                         <span className="context-menu-shortcut">⇧⌥F</span>
                     </button>
                     {filter.hasFilter && (

--- a/editors/vscode/src/data-viewer/webview/filter-popover-seed.ts
+++ b/editors/vscode/src/data-viewer/webview/filter-popover-seed.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure seed/build helpers for the FilterPopover form — the bidirectional
+ * mapping between a persisted FilterPredicate and the editor's per-kind form
+ * state. Extracted from filter-popover.tsx (no React) so the round-trip
+ * (predicate → form state → predicate) is unit-testable.
+ *
+ * Invariant: `predicateToKindValue`, `seedFromEntry`, and `buildPredicate` must
+ * stay in lockstep with the FilterPredicate union in messages.ts and the
+ * kind-select option values in filter-column-kind.ts. Adding a predicate kind
+ * means touching all three; the round-trip test in
+ * tests/bun/data-viewer-filter-popover-seed.test.ts guards that.
+ */
+import type { FilterPredicate } from '../messages';
+
+// ── Value-editor state shapes ───────────────────────────────────────────────
+
+export type NumCompareState = { op: '=' | '!=' | '<' | '<=' | '>' | '>='; value: string };
+export type NumBetweenState = { lo: string; hi: string; inclusive: boolean };
+export type SetState = { selected: (string | number)[] };
+export type StrState = { value: string; caseSensitive: boolean };
+export type StrRegexState = { pattern: string; caseSensitive: boolean; regexError: string | null };
+export type DateCompareState = { op: '=' | '!=' | '<' | '<=' | '>' | '>='; value: string };
+export type DateBetweenState = { lo: string; hi: string; inclusive: boolean };
+export type BoolState = { value: boolean };
+export type SetFreeTextState = { text: string };
+
+/** The popover's full per-kind form state. All sub-states are kept alive so
+ *  switching the kind-select and switching back doesn't lose typed values. */
+export type FormState = {
+    numCompare: NumCompareState;
+    numBetween: NumBetweenState;
+    set: SetState;
+    str: StrState;
+    strRegex: StrRegexState;
+    dateCompare: DateCompareState;
+    dateBetween: DateBetweenState;
+    bool: BoolState;
+    freeText: SetFreeTextState;
+};
+
+/** Blank state — what the popover opens with when adding a filter to an
+ *  unfiltered column. */
+export function defaultFormState(): FormState {
+    return {
+        numCompare: { op: '=', value: '' },
+        numBetween: { lo: '', hi: '', inclusive: true },
+        set: { selected: [] },
+        str: { value: '', caseSensitive: false },
+        strRegex: { pattern: '', caseSensitive: false, regexError: null },
+        dateCompare: { op: '=', value: '' },
+        dateBetween: { lo: '', hi: '', inclusive: true },
+        bool: { value: true },
+        freeText: { text: '' },
+    };
+}
+
+/** Map a persisted FilterPredicate back to the kind-select option value. */
+export function predicateToKindValue(p: FilterPredicate): string {
+    switch (p.kind) {
+        case 'numCompare': return 'numCompare';
+        case 'numBetween': return 'numBetween';
+        case 'numNotBetween': return 'numNotBetween';
+        case 'setIn': return 'setIn';
+        case 'setNotIn': return 'setNotIn';
+        case 'strContains': return p.negate ? 'strNotContains' : 'strContains';
+        case 'strStartsWith': return 'strStartsWith';
+        case 'strEndsWith': return 'strEndsWith';
+        case 'strCompare': return p.op === '=' ? 'strCompareEq' : 'strCompareNe';
+        case 'strRegex': return 'strRegex';
+        case 'dateCompare': return 'dateCompare';
+        case 'dateBetween': return 'dateBetween';
+        case 'dateNotBetween': return 'dateNotBetween';
+        case 'bool': return 'bool';
+        case 'isEmpty': return 'isEmpty';
+        case 'isNotEmpty': return 'isNotEmpty';
+    }
+}
+
+/** Recover the initial editor state from a persisted FilterPredicate. The
+ *  matching sub-state is filled; all others keep their blank defaults. */
+export function seedFromEntry(p: FilterPredicate): FormState {
+    const base = defaultFormState();
+    switch (p.kind) {
+        case 'numCompare':
+            base.numCompare = { op: p.op, value: String(p.value) };
+            break;
+        case 'numBetween':
+            base.numBetween = { lo: String(p.lo), hi: String(p.hi), inclusive: p.inclusive };
+            break;
+        case 'numNotBetween':
+            base.numBetween = { lo: String(p.lo), hi: String(p.hi), inclusive: p.inclusive };
+            break;
+        case 'setIn':
+        case 'setNotIn':
+            base.set = { selected: p.values };
+            base.freeText = { text: p.values.join('\n') };
+            break;
+        case 'strContains':
+        case 'strStartsWith':
+        case 'strEndsWith':
+            base.str = { value: p.value, caseSensitive: p.caseSensitive };
+            break;
+        case 'strCompare':
+            base.str = { value: p.value, caseSensitive: p.caseSensitive };
+            break;
+        case 'strRegex':
+            base.strRegex = { pattern: p.pattern, caseSensitive: p.caseSensitive, regexError: null };
+            break;
+        case 'dateCompare':
+            base.dateCompare = { op: p.op, value: p.value };
+            break;
+        case 'dateBetween':
+        case 'dateNotBetween':
+            base.dateBetween = { lo: p.lo, hi: p.hi, inclusive: p.inclusive };
+            break;
+        case 'bool':
+            base.bool = { value: p.value };
+            break;
+    }
+    return base;
+}
+
+/** Resolve set-membership values. Checklist columns (labelled-numeric, shipped
+ *  dictionary) carry the selected codes/labels directly — preserving numeric
+ *  types; free-text columns parse the comma/newline list into strings. */
+function effectiveSetValues(s: FormState, setUsesChecklist: boolean): (string | number)[] {
+    if (setUsesChecklist) {
+        return s.set.selected;
+    }
+    return s.freeText.text
+        .split(/[\n,]+/)
+        .map(t => t.trim())
+        .filter(Boolean);
+}
+
+/** Build the FilterPredicate from the form state, or null when the input is
+ *  incomplete (empty value, unparseable number, regex error). `kind` is the
+ *  kind-select option value; `setUsesChecklist` reflects the column kind. */
+export function buildPredicate(
+    kind: string,
+    s: FormState,
+    opts: { setUsesChecklist: boolean },
+): FilterPredicate | null {
+    switch (kind) {
+        case 'isEmpty': return { kind: 'isEmpty' };
+        case 'isNotEmpty': return { kind: 'isNotEmpty' };
+        case 'numCompare': {
+            const v = parseFloat(s.numCompare.value);
+            if (isNaN(v)) return null;
+            return { kind: 'numCompare', op: s.numCompare.op, value: v };
+        }
+        case 'numBetween': {
+            const lo = parseFloat(s.numBetween.lo);
+            const hi = parseFloat(s.numBetween.hi);
+            if (isNaN(lo) || isNaN(hi)) return null;
+            return { kind: 'numBetween', lo, hi, inclusive: s.numBetween.inclusive };
+        }
+        case 'numNotBetween': {
+            const lo = parseFloat(s.numBetween.lo);
+            const hi = parseFloat(s.numBetween.hi);
+            if (isNaN(lo) || isNaN(hi)) return null;
+            return { kind: 'numNotBetween', lo, hi, inclusive: s.numBetween.inclusive };
+        }
+        case 'setIn': {
+            const vals = effectiveSetValues(s, opts.setUsesChecklist);
+            if (vals.length === 0) return null;
+            return { kind: 'setIn', values: vals };
+        }
+        case 'setNotIn': {
+            const vals = effectiveSetValues(s, opts.setUsesChecklist);
+            if (vals.length === 0) return null;
+            return { kind: 'setNotIn', values: vals };
+        }
+        case 'strContains':
+            if (!s.str.value) return null;
+            return { kind: 'strContains', value: s.str.value, caseSensitive: s.str.caseSensitive, negate: false };
+        case 'strNotContains':
+            if (!s.str.value) return null;
+            return { kind: 'strContains', value: s.str.value, caseSensitive: s.str.caseSensitive, negate: true };
+        case 'strStartsWith':
+            if (!s.str.value) return null;
+            return { kind: 'strStartsWith', value: s.str.value, caseSensitive: s.str.caseSensitive };
+        case 'strEndsWith':
+            if (!s.str.value) return null;
+            return { kind: 'strEndsWith', value: s.str.value, caseSensitive: s.str.caseSensitive };
+        case 'strCompareEq':
+            if (!s.str.value) return null;
+            return { kind: 'strCompare', op: '=', value: s.str.value, caseSensitive: s.str.caseSensitive };
+        case 'strCompareNe':
+            if (!s.str.value) return null;
+            return { kind: 'strCompare', op: '!=', value: s.str.value, caseSensitive: s.str.caseSensitive };
+        case 'strRegex':
+            if (!s.strRegex.pattern || s.strRegex.regexError) return null;
+            return { kind: 'strRegex', pattern: s.strRegex.pattern, caseSensitive: s.strRegex.caseSensitive };
+        case 'dateCompare':
+            if (!s.dateCompare.value) return null;
+            return { kind: 'dateCompare', op: s.dateCompare.op, value: s.dateCompare.value };
+        case 'dateBetween':
+            if (!s.dateBetween.lo || !s.dateBetween.hi) return null;
+            return { kind: 'dateBetween', lo: s.dateBetween.lo, hi: s.dateBetween.hi, inclusive: s.dateBetween.inclusive };
+        case 'dateNotBetween':
+            if (!s.dateBetween.lo || !s.dateBetween.hi) return null;
+            return { kind: 'dateNotBetween', lo: s.dateBetween.lo, hi: s.dateBetween.hi, inclusive: s.dateBetween.inclusive };
+        case 'bool':
+            return { kind: 'bool', value: s.bool.value };
+    }
+    return null;
+}

--- a/editors/vscode/src/data-viewer/webview/filter-popover.tsx
+++ b/editors/vscode/src/data-viewer/webview/filter-popover.tsx
@@ -25,10 +25,25 @@ import React, {
     useState,
 } from 'react';
 import type { ColumnSchema } from '../arrow-reader';
-import type { FilterEntry, FilterPredicate, HistogramBin } from '../messages';
+import type { FilterEntry, HistogramBin } from '../messages';
 import { useDismiss } from './use-dismiss';
 import { FilterHistogram } from './filter-histogram';
 import { colKind, kindOptions, labelledNumericChoices } from './filter-column-kind';
+import {
+    buildPredicate,
+    defaultFormState,
+    predicateToKindValue,
+    seedFromEntry,
+    type BoolState,
+    type DateBetweenState,
+    type DateCompareState,
+    type NumBetweenState,
+    type NumCompareState,
+    type SetFreeTextState,
+    type SetState,
+    type StrRegexState,
+    type StrState,
+} from './filter-popover-seed';
 
 /** A small uid helper that avoids a `crypto` availability issue in older
  *  webview runtimes. Falls back gracefully if crypto.randomUUID is present. */
@@ -50,133 +65,6 @@ type Props = {
     anchor: { leftPx: number; topPx: number };
 };
 
-/** Map a persisted FilterPredicate back to our internal kind-select value. */
-function predicateToKindValue(p: FilterPredicate): string {
-    switch (p.kind) {
-        case 'numCompare': return 'numCompare';
-        case 'numBetween': return 'numBetween';
-        case 'numNotBetween': return 'numNotBetween';
-        case 'setIn': return 'setIn';
-        case 'setNotIn': return 'setNotIn';
-        case 'strContains': return p.negate ? 'strNotContains' : 'strContains';
-        case 'strStartsWith': return 'strStartsWith';
-        case 'strEndsWith': return 'strEndsWith';
-        case 'strCompare': return p.op === '=' ? 'strCompareEq' : 'strCompareNe';
-        case 'strRegex': return 'strRegex';
-        case 'dateCompare': return 'dateCompare';
-        case 'dateBetween': return 'dateBetween';
-        case 'dateNotBetween': return 'dateNotBetween';
-        case 'bool': return 'bool';
-        case 'isEmpty': return 'isEmpty';
-        case 'isNotEmpty': return 'isNotEmpty';
-    }
-}
-
-// ── Value-editor state shapes ───────────────────────────────────────────────
-
-type NumCompareState = { op: '=' | '!=' | '<' | '<=' | '>' | '>='; value: string };
-type NumBetweenState = { lo: string; hi: string; inclusive: boolean };
-type SetState = { selected: (string | number)[] };
-type StrState = { value: string; caseSensitive: boolean };
-type StrRegexState = { pattern: string; caseSensitive: boolean; regexError: string | null };
-type DateCompareState = { op: '=' | '!=' | '<' | '<=' | '>' | '>='; value: string };
-type DateBetweenState = { lo: string; hi: string; inclusive: boolean };
-type BoolState = { value: boolean };
-type SetFreeTextState = { text: string };
-
-// ── Default states ──────────────────────────────────────────────────────────
-
-function defaultNumCompare(): NumCompareState {
-    return { op: '=', value: '' };
-}
-function defaultNumBetween(): NumBetweenState {
-    return { lo: '', hi: '', inclusive: true };
-}
-function defaultSet(): SetState {
-    return { selected: [] };
-}
-function defaultStr(): StrState {
-    return { value: '', caseSensitive: false };
-}
-function defaultStrRegex(): StrRegexState {
-    return { pattern: '', caseSensitive: false, regexError: null };
-}
-function defaultDateCompare(): DateCompareState {
-    return { op: '=', value: '' };
-}
-function defaultDateBetween(): DateBetweenState {
-    return { lo: '', hi: '', inclusive: true };
-}
-function defaultBool(): BoolState {
-    return { value: true };
-}
-function defaultFreeText(): SetFreeTextState {
-    return { text: '' };
-}
-
-/** Recover the initial editor state from a persisted FilterEntry. */
-function seedFromEntry(p: FilterPredicate): {
-    numCompare: NumCompareState;
-    numBetween: NumBetweenState;
-    set: SetState;
-    str: StrState;
-    strRegex: StrRegexState;
-    dateCompare: DateCompareState;
-    dateBetween: DateBetweenState;
-    bool: BoolState;
-    freeText: SetFreeTextState;
-} {
-    const base = {
-        numCompare: defaultNumCompare(),
-        numBetween: defaultNumBetween(),
-        set: defaultSet(),
-        str: defaultStr(),
-        strRegex: defaultStrRegex(),
-        dateCompare: defaultDateCompare(),
-        dateBetween: defaultDateBetween(),
-        bool: defaultBool(),
-        freeText: defaultFreeText(),
-    };
-    switch (p.kind) {
-        case 'numCompare':
-            base.numCompare = { op: p.op, value: String(p.value) };
-            break;
-        case 'numBetween':
-            base.numBetween = { lo: String(p.lo), hi: String(p.hi), inclusive: p.inclusive };
-            break;
-        case 'numNotBetween':
-            base.numBetween = { lo: String(p.lo), hi: String(p.hi), inclusive: p.inclusive };
-            break;
-        case 'setIn':
-        case 'setNotIn':
-            base.set = { selected: p.values };
-            base.freeText = { text: p.values.join('\n') };
-            break;
-        case 'strContains':
-        case 'strStartsWith':
-        case 'strEndsWith':
-            base.str = { value: p.value, caseSensitive: p.caseSensitive };
-            break;
-        case 'strCompare':
-            base.str = { value: p.value, caseSensitive: p.caseSensitive };
-            break;
-        case 'strRegex':
-            base.strRegex = { pattern: p.pattern, caseSensitive: p.caseSensitive, regexError: null };
-            break;
-        case 'dateCompare':
-            base.dateCompare = { op: p.op, value: p.value };
-            break;
-        case 'dateBetween':
-        case 'dateNotBetween':
-            base.dateBetween = { lo: p.lo, hi: p.hi, inclusive: p.inclusive };
-            break;
-        case 'bool':
-            base.bool = { value: p.value };
-            break;
-    }
-    return base;
-}
-
 // ── Main component ──────────────────────────────────────────────────────────
 
 export function FilterPopover({ column, columnIndex, histogram, initial, onApply, onCancel, anchor }: Props) {
@@ -190,18 +78,19 @@ export function FilterPopover({ column, columnIndex, histogram, initial, onApply
     });
 
     // Per-kind value state (we keep all sub-states alive so switching kind and
-    // switching back doesn't lose values the user typed).
-    const seed = initial ? seedFromEntry(initial.predicate) : null;
+    // switching back doesn't lose values the user typed). When editing an
+    // existing entry, the matching sub-state is seeded from its predicate.
+    const seed = initial ? seedFromEntry(initial.predicate) : defaultFormState();
 
-    const [numCompare, setNumCompare] = useState<NumCompareState>(seed?.numCompare ?? defaultNumCompare());
-    const [numBetween, setNumBetween] = useState<NumBetweenState>(seed?.numBetween ?? defaultNumBetween());
-    const [setSelected, setSetSelected] = useState<SetState>(seed?.set ?? defaultSet());
-    const [str, setStr] = useState<StrState>(seed?.str ?? defaultStr());
-    const [strRegex, setStrRegex] = useState<StrRegexState>(seed?.strRegex ?? defaultStrRegex());
-    const [dateCompare, setDateCompare] = useState<DateCompareState>(seed?.dateCompare ?? defaultDateCompare());
-    const [dateBetween, setDateBetween] = useState<DateBetweenState>(seed?.dateBetween ?? defaultDateBetween());
-    const [boolVal, setBoolVal] = useState<BoolState>(seed?.bool ?? defaultBool());
-    const [freeText, setFreeText] = useState<SetFreeTextState>(seed?.freeText ?? defaultFreeText());
+    const [numCompare, setNumCompare] = useState<NumCompareState>(seed.numCompare);
+    const [numBetween, setNumBetween] = useState<NumBetweenState>(seed.numBetween);
+    const [setSelected, setSetSelected] = useState<SetState>(seed.set);
+    const [str, setStr] = useState<StrState>(seed.str);
+    const [strRegex, setStrRegex] = useState<StrRegexState>(seed.strRegex);
+    const [dateCompare, setDateCompare] = useState<DateCompareState>(seed.dateCompare);
+    const [dateBetween, setDateBetween] = useState<DateBetweenState>(seed.dateBetween);
+    const [boolVal, setBoolVal] = useState<BoolState>(seed.bool);
+    const [freeText, setFreeText] = useState<SetFreeTextState>(seed.freeText);
     const [includeMissing, setIncludeMissing] = useState(initial?.includeMissing ?? false);
 
     // Popover ref + positioning
@@ -262,86 +151,15 @@ export function FilterPopover({ column, columnIndex, histogram, initial, onApply
     };
 
     // ── Build predicate ───────────────────────────────────────────────────
-    function buildPredicate(): FilterPredicate | null {
-        switch (selectedKind) {
-            case 'isEmpty': return { kind: 'isEmpty' };
-            case 'isNotEmpty': return { kind: 'isNotEmpty' };
-            case 'numCompare': {
-                const v = parseFloat(numCompare.value);
-                if (isNaN(v)) return null;
-                return { kind: 'numCompare', op: numCompare.op, value: v };
-            }
-            case 'numBetween': {
-                const lo = parseFloat(numBetween.lo);
-                const hi = parseFloat(numBetween.hi);
-                if (isNaN(lo) || isNaN(hi)) return null;
-                return { kind: 'numBetween', lo, hi, inclusive: numBetween.inclusive };
-            }
-            case 'numNotBetween': {
-                const lo = parseFloat(numBetween.lo);
-                const hi = parseFloat(numBetween.hi);
-                if (isNaN(lo) || isNaN(hi)) return null;
-                return { kind: 'numNotBetween', lo, hi, inclusive: numBetween.inclusive };
-            }
-            case 'setIn': {
-                const vals = effectiveSetValues();
-                if (vals.length === 0) return null;
-                return { kind: 'setIn', values: vals };
-            }
-            case 'setNotIn': {
-                const vals = effectiveSetValues();
-                if (vals.length === 0) return null;
-                return { kind: 'setNotIn', values: vals };
-            }
-            case 'strContains':
-                if (!str.value) return null;
-                return { kind: 'strContains', value: str.value, caseSensitive: str.caseSensitive, negate: false };
-            case 'strNotContains':
-                if (!str.value) return null;
-                return { kind: 'strContains', value: str.value, caseSensitive: str.caseSensitive, negate: true };
-            case 'strStartsWith':
-                if (!str.value) return null;
-                return { kind: 'strStartsWith', value: str.value, caseSensitive: str.caseSensitive };
-            case 'strEndsWith':
-                if (!str.value) return null;
-                return { kind: 'strEndsWith', value: str.value, caseSensitive: str.caseSensitive };
-            case 'strCompareEq':
-                if (!str.value) return null;
-                return { kind: 'strCompare', op: '=', value: str.value, caseSensitive: str.caseSensitive };
-            case 'strCompareNe':
-                if (!str.value) return null;
-                return { kind: 'strCompare', op: '!=', value: str.value, caseSensitive: str.caseSensitive };
-            case 'strRegex':
-                if (!strRegex.pattern || strRegex.regexError) return null;
-                return { kind: 'strRegex', pattern: strRegex.pattern, caseSensitive: strRegex.caseSensitive };
-            case 'dateCompare':
-                if (!dateCompare.value) return null;
-                return { kind: 'dateCompare', op: dateCompare.op, value: dateCompare.value };
-            case 'dateBetween':
-                if (!dateBetween.lo || !dateBetween.hi) return null;
-                return { kind: 'dateBetween', lo: dateBetween.lo, hi: dateBetween.hi, inclusive: dateBetween.inclusive };
-            case 'dateNotBetween':
-                if (!dateBetween.lo || !dateBetween.hi) return null;
-                return { kind: 'dateNotBetween', lo: dateBetween.lo, hi: dateBetween.hi, inclusive: dateBetween.inclusive };
-            case 'bool':
-                return { kind: 'bool', value: boolVal.value };
-        }
-        return null;
-    }
-
-    function effectiveSetValues(): (string | number)[] {
-        if (isLabelledNumeric || hasShippedDictionary) {
-            // labelled-numeric → numeric codes; shipped dictionary → label strings.
-            return setSelected.selected;
-        }
-        // Free-text: split on comma or newline
-        return freeText.text
-            .split(/[\n,]+/)
-            .map(s => s.trim())
-            .filter(Boolean);
-    }
-
-    const predicate = buildPredicate();
+    // Set membership resolves per column kind: checklist columns
+    // (labelled-numeric or shipped dictionary) carry the selected codes/labels
+    // directly; others parse the free-text value list.
+    const setUsesChecklist = isLabelledNumeric || hasShippedDictionary === true;
+    const predicate = buildPredicate(
+        selectedKind,
+        { numCompare, numBetween, set: setSelected, str, strRegex, dateCompare, dateBetween, bool: boolVal, freeText },
+        { setUsesChecklist },
+    );
     const canApply = predicate !== null && !(selectedKind === 'strRegex' && strRegex.regexError);
 
     const handleApply = () => {

--- a/tests/bun/data-viewer-filter-popover-seed.test.ts
+++ b/tests/bun/data-viewer-filter-popover-seed.test.ts
@@ -32,9 +32,15 @@ describe('seed/build round-trip — every predicate kind survives open → apply
     // [name, predicate, setUsesChecklist?]
     const cases: [string, FilterPredicate, boolean?][] = [
         ['numCompare', { kind: 'numCompare', op: '>=', value: 42 }],
+        // value 0 is falsy — guards against truthiness checks dropping it.
+        ['numCompare zero', { kind: 'numCompare', op: '=', value: 0 }],
         ['numBetween', { kind: 'numBetween', lo: 1, hi: 9, inclusive: true }],
+        ['numBetween zero-width at origin', { kind: 'numBetween', lo: 0, hi: 0, inclusive: true }],
         ['numNotBetween', { kind: 'numNotBetween', lo: -3.5, hi: 2.5, inclusive: false }],
         ['setIn numeric codes (checklist)', { kind: 'setIn', values: [1, 2, 8] }, true],
+        // code 0 is a valid labelled-numeric level and must survive (checklist
+        // mode bypasses the free-text filter(Boolean) that would drop it).
+        ['setIn numeric codes incl. zero (checklist)', { kind: 'setIn', values: [0, 1, 2] }, true],
         ['setNotIn string labels (checklist)', { kind: 'setNotIn', values: ['Male', 'Female'] }, true],
         ['setIn string values (free-text)', { kind: 'setIn', values: ['a', 'b'] }, false],
         ['strContains', { kind: 'strContains', value: 'foo', caseSensitive: false, negate: false }],

--- a/tests/bun/data-viewer-filter-popover-seed.test.ts
+++ b/tests/bun/data-viewer-filter-popover-seed.test.ts
@@ -1,0 +1,89 @@
+/**
+ * filter-popover-seed — the bidirectional mapping between a persisted
+ * FilterPredicate and the FilterPopover's per-kind form state. Pure, no React,
+ * so it runs under bun directly.
+ *
+ * The round-trip property (predicate → seedFromEntry → buildPredicate ≡
+ * predicate) is the regression guard for "reopening a filtered column shows its
+ * active settings": if a new predicate kind is added to messages.ts without
+ * wiring predicateToKindValue / seedFromEntry / buildPredicate in lockstep, a
+ * round-trip case breaks.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+    predicateToKindValue,
+    seedFromEntry,
+    buildPredicate,
+    defaultFormState,
+} from '../../editors/vscode/src/data-viewer/webview/filter-popover-seed';
+import type { FilterPredicate } from '../../editors/vscode/src/data-viewer/messages';
+
+/** Open a saved predicate into the form, then rebuild it — what the popover
+ *  does on Edit → Apply with no user change. `setUsesChecklist` mirrors the
+ *  column kind: true for labelled-numeric / shipped-dictionary columns whose
+ *  set membership is a checklist; false for the free-text value list. */
+function roundTrip(p: FilterPredicate, setUsesChecklist = false): FilterPredicate | null {
+    const kind = predicateToKindValue(p);
+    const state = seedFromEntry(p);
+    return buildPredicate(kind, state, { setUsesChecklist });
+}
+
+describe('seed/build round-trip — every predicate kind survives open → apply', () => {
+    // [name, predicate, setUsesChecklist?]
+    const cases: [string, FilterPredicate, boolean?][] = [
+        ['numCompare', { kind: 'numCompare', op: '>=', value: 42 }],
+        ['numBetween', { kind: 'numBetween', lo: 1, hi: 9, inclusive: true }],
+        ['numNotBetween', { kind: 'numNotBetween', lo: -3.5, hi: 2.5, inclusive: false }],
+        ['setIn numeric codes (checklist)', { kind: 'setIn', values: [1, 2, 8] }, true],
+        ['setNotIn string labels (checklist)', { kind: 'setNotIn', values: ['Male', 'Female'] }, true],
+        ['setIn string values (free-text)', { kind: 'setIn', values: ['a', 'b'] }, false],
+        ['strContains', { kind: 'strContains', value: 'foo', caseSensitive: false, negate: false }],
+        ['strContains negated', { kind: 'strContains', value: 'bar', caseSensitive: true, negate: true }],
+        ['strStartsWith', { kind: 'strStartsWith', value: 'pre', caseSensitive: false }],
+        ['strEndsWith', { kind: 'strEndsWith', value: 'suf', caseSensitive: true }],
+        ['strCompare =', { kind: 'strCompare', op: '=', value: 'x', caseSensitive: false }],
+        ['strCompare !=', { kind: 'strCompare', op: '!=', value: 'y', caseSensitive: true }],
+        ['strRegex', { kind: 'strRegex', pattern: '^a.*z$', caseSensitive: false }],
+        ['dateCompare', { kind: 'dateCompare', op: '<', value: '2024-01-01' }],
+        ['dateBetween', { kind: 'dateBetween', lo: '2024-01-01', hi: '2024-12-31', inclusive: true }],
+        ['dateNotBetween', { kind: 'dateNotBetween', lo: '2024-06-01', hi: '2024-06-30', inclusive: false }],
+        ['bool true', { kind: 'bool', value: true }],
+        ['bool false', { kind: 'bool', value: false }],
+        ['isEmpty', { kind: 'isEmpty' }],
+        ['isNotEmpty', { kind: 'isNotEmpty' }],
+    ];
+    for (const [name, p, checklist] of cases) {
+        test(name, () => {
+            expect(roundTrip(p, checklist ?? false)).toEqual(p);
+        });
+    }
+});
+
+describe('predicateToKindValue — disambiguates the negate/op pairs', () => {
+    test('setIn vs setNotIn', () => {
+        expect(predicateToKindValue({ kind: 'setIn', values: [1] })).toBe('setIn');
+        expect(predicateToKindValue({ kind: 'setNotIn', values: [1] })).toBe('setNotIn');
+    });
+    test('strContains negate flag maps to two kinds', () => {
+        expect(predicateToKindValue({ kind: 'strContains', value: 'x', caseSensitive: false, negate: false })).toBe('strContains');
+        expect(predicateToKindValue({ kind: 'strContains', value: 'x', caseSensitive: false, negate: true })).toBe('strNotContains');
+    });
+    test('strCompare op maps to eq/ne kinds', () => {
+        expect(predicateToKindValue({ kind: 'strCompare', op: '=', value: 'x', caseSensitive: false })).toBe('strCompareEq');
+        expect(predicateToKindValue({ kind: 'strCompare', op: '!=', value: 'x', caseSensitive: false })).toBe('strCompareNe');
+    });
+});
+
+describe('buildPredicate — incomplete input yields no predicate', () => {
+    test('blank value-requiring kinds build to null', () => {
+        const blank = defaultFormState();
+        for (const kind of ['numCompare', 'numBetween', 'setIn', 'strContains', 'strRegex', 'dateCompare']) {
+            expect(buildPredicate(kind, blank, { setUsesChecklist: false })).toBeNull();
+        }
+    });
+    test('isEmpty / isNotEmpty need no input', () => {
+        const blank = defaultFormState();
+        expect(buildPredicate('isEmpty', blank, { setUsesChecklist: false })).toEqual({ kind: 'isEmpty' });
+        expect(buildPredicate('isNotEmpty', blank, { setUsesChecklist: false })).toEqual({ kind: 'isNotEmpty' });
+    });
+});

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -43,6 +43,7 @@
     "r-expression-chunk-opts.test.ts",
     "open-exported-file.test.ts",
     "plot-webview-inline-icons.test.ts",
-    "plot-share-popover-position.test.ts"
+    "plot-share-popover-position.test.ts",
+    "data-viewer-filter-popover-seed.test.ts"
   ]
 }


### PR DESCRIPTION
## Problem

In the data viewer, right-clicking a column header → **Filter…** (or pressing **⇧⌥F**) opened the filter editor **blank** even when that column already had an active filter. The live settings were invisible, so to tweak a filter you had to mentally reconstruct it or clear and re-enter it.

## Fix

The popover already supported pre-fill via its `initial` prop — the chip **Edit** path used it — but the two *open-from-column* entry points passed only the column index. Both now route through a new `openFilterEditor` helper that looks up the column's active entry (one-filter-per-column invariant) and seeds the popover with it. When no filter exists, it opens blank as before.

- Keyed on `filter.entries` and added to the keydown effect deps, so the ⇧⌥F path can't read a stale snapshot.
- The existing `onApply` merge preserves the entry `id`, so editing updates the **same** chip — no duplicate.
- The column context-menu item now reads **Edit filter…** when a filter is active, **Filter…** otherwise.

## Refactor + regression guard

The predicate ↔ form-state mapping is extracted out of `FilterPopover` into a pure `filter-popover-seed.ts` module (`predicateToKindValue`, `seedFromEntry`, `buildPredicate`, `defaultFormState`) — `buildPredicate` now takes an explicit `setUsesChecklist` flag instead of closing over column-kind state. No behavior change; the component delegates.

A new bun round-trip test asserts the core property: for every predicate kind, `seedFromEntry → buildPredicate` reconstructs the original predicate (so reopening a filter and re-applying it unchanged is a no-op). Adding a predicate kind to `messages.ts` without wiring all three functions breaks a case. Includes falsy-`0` edge cases (value 0, `[0,0]` range, set codes including 0).

## Commits

1. `feat` — the behavior fix (App wiring, menu relabel, docs).
2. `refactor` — pure seed/build module + round-trip test.
3. `fix` — adversarial-review follow-ups: `key={editorColumnIndex}` on the popover (its seed runs only in mount-time initializers, so a column switch without unmount could show stale form state) + falsy-zero test coverage.

## Verification

- `bun run typecheck` — clean across all 4 projects.
- `tsc --project tests/bun/tsconfig.json --noEmit` — clean (CLAUDE.md gate for the new test file).
- Full data-viewer bun suite — green (362 tests).
- An Opus adversarial review pass found no Critical/High issues; its one actionable finding (the missing `key`) is addressed in commit 3.

### Manual check (not unit-testable — webview wiring)

On a data frame, for a few column kinds (numeric range, labelled-numeric checklist, string contains, factor set): apply a filter → right-click the column (item reads **Edit filter…**) → the popover shows the active predicate + values + Include NA/NaN. Repeat via **⇧⌥F**. Change a value, Apply → the same chip updates (no duplicate). On an unfiltered column the item reads **Filter…** and the editor opens blank.

## Note (not a regression)

Reopening a **disabled** filter and clicking Apply re-enables it (`handleApply` hardcodes `enabled: true`). This is pre-existing behavior — the chip-Edit path already did it — and within what the docs promise. Flagging in case preserving the disabled state on edit is preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter editor now pre-populates with existing filter settings (including Include NA/NaN state) when editing, preventing duplicate filters
  * Context menu label intelligently updates to "Edit filter…" for columns with active filters, remains "Filter…" for unfiltered columns

* **Documentation**
  * Updated filtering documentation to clarify behavior when editing existing filters versus creating new ones

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->