### PR TITLE
fix(vscode): pin @types/vscode to the 1.82 engine floor for vsce

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^20.0.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
-        "@types/vscode": "^1.110.0",
+        "@types/vscode": "^1.82.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/vsce": "^3.9.1",
@@ -1920,9 +1920,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true,
       "license": "MIT"
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1986,7 +1986,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
-    "@types/vscode": "^1.110.0",
+    "@types/vscode": "^1.82.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.3.9",
     "@vscode/vsce": "^3.9.1",

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -32,7 +32,7 @@ import { SortStateStore } from './sort-state';
 import { FilterStateStore } from './filter-state';
 import { build_csp } from './csp';
 import { render_tsv, ResolvedLabels } from './tsv';
-import { viewerTabIcon } from '../viewer-tab-icon';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 let dataViewerTraceOutput: vscode.OutputChannel | undefined;
 
@@ -126,7 +126,7 @@ export class DataViewerPanel {
                 ],
             },
         );
-        webviewPanel.iconPath = viewerTabIcon('table');
+        applyViewerTabIcon(webviewPanel, 'table');
         webviewPanel.webview.html = build_html(webviewPanel.webview, extensionUri);
         const panel = new DataViewerPanel(
             panelName, webviewPanel, reader, filePath,

--- a/editors/vscode/src/help/help-panel.ts
+++ b/editors/vscode/src/help/help-panel.ts
@@ -9,7 +9,7 @@ import {
 } from './messages';
 import { createHelpStateMachine, type FetchResponse } from './state-machine';
 import { rewriteImageSrcs, type RewriteContext } from './image-rewriter';
-import { viewerTabIcon } from '../viewer-tab-icon';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 type ViewerColumn = 'active' | 'beside';
 
@@ -172,7 +172,7 @@ export class HelpPanel {
                 ],
             },
         );
-        panel.iconPath = viewerTabIcon('question');
+        applyViewerTabIcon(panel, 'question');
         const nonce = crypto.randomBytes(16).toString('base64');
         panel.webview.html = build_html(panel.webview, this.context.extensionUri, nonce);
         panel.webview.onDidReceiveMessage((msg) => this.on_webview_message(msg));

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -20,7 +20,7 @@ import {
     resolveActiveThemePalette,
     type ThemePaletteOutcome,
 } from './vscode-theme-palette';
-import { viewerTabIcon } from '../viewer-tab-icon';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 /**
  * Webview panel that renders a single `.Rmd`'s rendered HTML output in
@@ -386,7 +386,7 @@ export class KnitOutputPanel {
                 localResourceRoots: [vscode.Uri.file(rootDir)],
             },
         );
-        panel.iconPath = viewerTabIcon('book');
+        applyViewerTabIcon(panel, 'book');
         const instance = new KnitOutputPanel(context, panel, rootDir, args);
         KnitOutputPanel.instances.set(key, instance);
 

--- a/editors/vscode/src/plot/plot-viewer-panel.ts
+++ b/editors/vscode/src/plot/plot-viewer-panel.ts
@@ -10,7 +10,7 @@ import {
 import { RSessionServer } from '../r-session-server';
 import { download_to_buffer } from './http-download';
 import { csp_sources_for_external_base } from './csp';
-import { viewerTabIcon } from '../viewer-tab-icon';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 type ViewerColumn = 'active' | 'beside';
 
@@ -209,7 +209,7 @@ export class PlotViewerPanel {
                 ],
             },
         );
-        panel.iconPath = viewerTabIcon('graph');
+        applyViewerTabIcon(panel, 'graph');
         const nonce = crypto.randomBytes(16).toString('base64');
         const initialThemeApplied = PlotViewerPanel.readThemePreference(this.context);
         panel.webview.html = build_html(

--- a/editors/vscode/src/viewer-tab-icon.ts
+++ b/editors/vscode/src/viewer-tab-icon.ts
@@ -10,8 +10,8 @@
  * keeps VSCode's default page icon (a graceful no-op, never an error).
  *
  * This is the single source of truth for that gate. New viewers should call
- * `viewerTabIcon(...)` rather than constructing a `ThemeIcon` directly, so the
- * version guard stays in one place.
+ * `applyViewerTabIcon(...)` rather than assigning `iconPath` directly, so both
+ * the version guard and the type-cast below stay in one place.
  */
 
 import * as vscode from 'vscode';
@@ -19,6 +19,22 @@ import { meetsMinVersion } from './version-gate';
 
 /** First VSCode version whose runtime renders a `ThemeIcon` as a webview tab icon. */
 const THEME_ICON_TAB_MIN = { major: 1, minor: 110 } as const;
+
+/**
+ * Locally-widened view of `WebviewPanel.iconPath`.
+ *
+ * `@types/vscode` is pinned to the `engines.vscode` floor (1.82), whose
+ * `iconPath` is typed `Uri | { light; dark }` only — assigning a `ThemeIcon`
+ * to it would not type-check, even though VSCode >= 1.110 accepts one at
+ * runtime. A `WebviewPanel` is structurally assignable to this interface (its
+ * narrower `iconPath` fits this wider union), so the cast in
+ * `applyViewerTabIcon` needs no `unknown` and the assigned value stays fully
+ * type-checked. Cannot be a `declare module 'vscode'` merge: interface merging
+ * adds members but cannot re-type an existing property like `iconPath`.
+ */
+interface WebviewPanelWithThemeIcon {
+    iconPath?: vscode.Uri | { readonly light: vscode.Uri; readonly dark: vscode.Uri } | vscode.ThemeIcon;
+}
 
 /**
  * A codicon to assign to a webview panel's `iconPath`, or `undefined` on
@@ -32,4 +48,14 @@ export function viewerTabIcon(codiconId: string): vscode.ThemeIcon | undefined {
     return meetsMinVersion(vscode.version, THEME_ICON_TAB_MIN.major, THEME_ICON_TAB_MIN.minor)
         ? new vscode.ThemeIcon(codiconId)
         : undefined;
+}
+
+/**
+ * Assign a codicon to `panel`'s editor tab, or leave VSCode's default page
+ * icon in place on hosts older than 1.110. Use this rather than assigning
+ * `panel.iconPath` directly so the version guard and the floor-pinned-types
+ * cast stay centralized here.
+ */
+export function applyViewerTabIcon(panel: vscode.WebviewPanel, codiconId: string): void {
+    (panel as WebviewPanelWithThemeIcon).iconPath = viewerTabIcon(codiconId);
 }


### PR DESCRIPTION
`vsce package` refused to build with `@types/vscode ^1.110.0 greater than
engines.vscode ^1.82.0` (an unconditional throw in vsce's
validateVSCodeTypesCompatibility, no bypass flag). The 1.110 bump in
ab536997 was deliberate-but-only for the compile-time ThemeIcon iconPath
type; the engine floor intentionally stays at 1.82 with a runtime guard.

Pin @types/vscode back to the floor (^1.82.0 range, lockfile pinned to
1.82.0 so CI builds against the declared floor) so vsce is satisfied and
the build honestly compiles against 1.82 types.

A `declare module 'vscode'` augmentation can't restore the ThemeIcon
iconPath type: interface merging adds members but cannot re-type an
existing property (TS2717). Instead, centralize the one needed cast in
`applyViewerTabIcon(panel, codiconId)`, which upcasts the panel to a
locally-widened `iconPath` interface (a safe structural cast, no
`as unknown`) so the assigned icon stays fully type-checked. The four
viewer panels (help/data/plot/knit) call it instead of assigning
`iconPath` directly; the runtime version guard is unchanged.

Verified: tsc --noEmit against pinned 1.82.0 passes; vsce validation
passes for ^1.82.0 and still throws for ^1.110.0; version-gate test 4/4.
