### PR TITLE
Port Sight #172: responsive toolbar chip wrapping in the data viewer

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -78,6 +78,13 @@ rows: 12,345 | Sort: mpg▲ cyl▼ ✕ | Filter: cyl ∈ {6,8} ✕ | [Labels] [F
 
 The `Sort` and `Filter` strips are hidden entirely when no sort or filter is active.
 
+When the panel is too narrow to fit the chip strips beside the action
+buttons, the strips drop onto their own second row so Labels / Format /
+Columns stay reachable. Each strip still scrolls horizontally on its own
+row when its chips overflow even that full-width row. The wrap decision
+holds a small hysteresis band so the toolbar doesn't flap between one
+and two rows as the panel is resized across the boundary.
+
 Each toggle is filled when active; clicking flips it. The Labels and
 Format buttons are disabled (dimmed) when no column in the current data
 set would be affected by them — e.g. an all-integer matrix disables

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,6 +60,18 @@ cargo build --release -p raven
 - VS Code extension tests: `cd editors/vscode && bun run test`
 - Setup (build + install + package): `./scripts/setup.sh`
 
+The VS Code extension tests include a real-layout webview harness for the
+data-viewer toolbar's responsive chip-wrap behavior
+(`editors/vscode/src/test/toolbar-wrap-layout.test.ts` +
+`toolbar-wrap-harness-panel.ts`). The harness mounts the production
+toolbar JSX in a webview, pins its width via `postMessage`, and posts the
+measured geometry back to the host for assertions. The harness bundle
+lives at `editors/vscode/dist-test/toolbar-wrap-harness/` — separate from
+the shipped `dist/`, built by `bun run bundle:webview-test` (already
+wired into `pretest`), excluded from the VSIX. Set
+`RAVEN_SKIP_LAYOUT_TESTS=1` to skip the suite in sandboxes that can't
+render a webview.
+
 ### Benchmarks
 
 All benchmarks except `startup` require `--features test-support`. Set `RAVEN_BENCH_ALLOC=1` for allocation tracking.

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 out/
 dist/
+dist-test/
 bin/
 *.vsix
 bun.lock

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 src/**
 out/**
+dist-test/**
 node_modules/**
 .gitignore
 .yarnrc

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1950,11 +1950,12 @@
   "scripts": {
     "vscode:prepublish": "bun run bundle && bun run copy-binary",
     "bundle": "bun scripts/build.js",
+    "bundle:webview-test": "bun scripts/build-test-harness.js",
     "copy-binary": "bun scripts/bundle-binary.js",
     "compile": "bun run bundle",
     "compile:test": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "bun run compile:test && bun run bundle && bun run copy-binary",
+    "pretest": "bun run compile:test && bun run bundle && bun run bundle:webview-test && bun run copy-binary",
     "test": "vscode-test",
     "package": "bun run bundle && bun run copy-binary && vsce package --allow-missing-repository",
     "package:target": "bun run bundle && bun run copy-binary && vsce package --target",

--- a/editors/vscode/scripts/build-test-harness.js
+++ b/editors/vscode/scripts/build-test-harness.js
@@ -1,0 +1,46 @@
+// Bundle the toolbar-wrap real-layout test harness webview. Output goes
+// to `dist-test/`, NOT `dist/`, so the harness is never shipped — vsce
+// only walks `dist/` for the runtime webviews. Mirrors the esbuild config
+// of `buildReactWebview` in `build.js`. Invoked by `bun run
+// bundle:webview-test`, which is wired into `pretest` only — `vsce
+// package` runs `bun run bundle`, which does NOT touch this.
+
+const path = require('path');
+const esbuild = require('esbuild');
+
+const root = path.resolve(__dirname, '..');
+const distTest = path.join(root, 'dist-test');
+
+async function buildHarnessWebview() {
+    const entry = path.join(
+        root,
+        'src',
+        'data-viewer',
+        'webview',
+        'test-harness',
+        'index.tsx',
+    );
+    const outdir = path.join(distTest, 'toolbar-wrap-harness');
+    await esbuild.build({
+        entryPoints: [entry],
+        bundle: true,
+        platform: 'browser',
+        target: 'chrome108',
+        format: 'iife',
+        // esbuild's CSS loader emits a sibling .css next to the IIFE
+        // (`harness-panel.ts` links it like production does).
+        loader: { '.css': 'css' },
+        sourcemap: true,
+        outfile: path.join(outdir, 'index.js'),
+        logLevel: 'info',
+    });
+}
+
+(async () => {
+    try {
+        await buildHarnessWebview();
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+})();

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -62,6 +62,7 @@ import { ColumnContextMenu } from './column-context-menu';
 import { ToolbarSortStrip } from './sort-strip';
 import { FilterStrip } from './filter-strip';
 import { FilterPopover } from './filter-popover';
+import { useToolbarWrap } from './use-toolbar-wrap';
 
 type VscodeApi = {
     postMessage(msg: WebviewToExtension): void;
@@ -303,6 +304,13 @@ export function App({
     const toolbarBootstrappedRef = useRef(false);
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
     const missingRowRequestTimerRef = useRef<number | null>(null);
+    /** Toolbar wrap measurement refs: when the sort/filter chips can't fit
+     *  beside the action buttons, the chip group drops to its own second row
+     *  via `.toolbar.is-wrapped`. See `useToolbarWrap` for the policy. */
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const rowCountRef = useRef<HTMLSpanElement>(null);
+    const toolbarChipsRef = useRef<HTMLDivElement>(null);
+    const toolbarActionsRef = useRef<HTMLDivElement>(null);
 
     const [panelGeneration, setPanelGeneration] = useState(restored?.panelGeneration ?? 0);
     const [nrow, setNrow] = useState(restored?.nrow ?? 0);
@@ -361,6 +369,18 @@ export function App({
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
     const rowCountText = describeVisibleRows(effectiveNrow, visibleRange);
+    /** Whether the chip group must wrap onto its own second row. `layout.hiddenColumns.length`
+     *  is in the deps because the Columns count badge widens the action buttons without
+     *  changing the toolbar width — without that the wrap state can be stale. */
+    const toolbarChipsWrapped = useToolbarWrap(
+        {
+            toolbar: toolbarRef,
+            lead: rowCountRef,
+            chips: toolbarChipsRef,
+            actions: toolbarActionsRef,
+        },
+        [sort.keys, filter.entries, rowCountText, layout.hiddenColumns.length],
+    );
     /** Summary text appended to the status bar when a sort is active.
      *  Truncates to 4 keys with an ellipsis so the bar never wraps; the
      *  toolbar chip strip is the full picture. */
@@ -1343,70 +1363,77 @@ export function App({
 
     return (
         <div className="data-viewer-root">
-            <div className="toolbar">
-                <span className="row-count">{rowCountText}</span>
-                <ToolbarSortStrip
-                    sort={sort}
-                    columns={columns}
-                    onChange={applySort}
-                    onClearAll={clearAllSorts}
-                />
-                <FilterStrip
-                    filter={filter}
-                    columns={columns}
-                    onEdit={onEditFilter}
-                    onToggleEnabled={onToggleFilterEnabled}
-                    onRemove={onRemoveFilter}
-                    onClearAll={onClearAllFilters}
-                />
-                <button
-                    type="button"
-                    className={toolbar.labelsOn ? 'toggle active' : 'toggle'}
-                    disabled={!labelsHaveEffect}
-                    onClick={() => setToolbar(t => ({ ...t, labelsOn: !t.labelsOn }))}
-                >
-                    Labels
-                </button>
-                <button
-                    type="button"
-                    className={toolbar.formatOn ? 'toggle active' : 'toggle'}
-                    disabled={!formatHasEffect}
-                    onClick={() => setToolbar(t => ({ ...t, formatOn: !t.formatOn }))}
-                >
-                    Format
-                </button>
-                <select
-                    className="digits"
-                    value={toolbar.digits}
-                    disabled={!toolbar.formatOn || !formatHasEffect}
-                    onChange={event => setToolbar(t => ({ ...t, digits: Number(event.target.value) }))}
-                    aria-label="Digits"
-                >
-                    {[0, 1, 2, 3, 4, 5, 6].map(d => (
-                        <option key={d} value={d}>{d}</option>
-                    ))}
-                </select>
-                <div className="columns-popover-anchor">
+            <div
+                className={toolbarChipsWrapped ? 'toolbar is-wrapped' : 'toolbar'}
+                ref={toolbarRef}
+            >
+                <span className="row-count" ref={rowCountRef}>{rowCountText}</span>
+                <div className="toolbar-chips" ref={toolbarChipsRef}>
+                    <ToolbarSortStrip
+                        sort={sort}
+                        columns={columns}
+                        onChange={applySort}
+                        onClearAll={clearAllSorts}
+                    />
+                    <FilterStrip
+                        filter={filter}
+                        columns={columns}
+                        onEdit={onEditFilter}
+                        onToggleEnabled={onToggleFilterEnabled}
+                        onRemove={onRemoveFilter}
+                        onClearAll={onClearAllFilters}
+                    />
+                </div>
+                <div className="toolbar-actions" ref={toolbarActionsRef}>
                     <button
                         type="button"
-                        className={columnsPopoverOpen ? 'toggle active' : 'toggle'}
-                        onClick={() => setColumnsPopoverOpen(open => !open)}
+                        className={toolbar.labelsOn ? 'toggle active' : 'toggle'}
+                        disabled={!labelsHaveEffect}
+                        onClick={() => setToolbar(t => ({ ...t, labelsOn: !t.labelsOn }))}
                     >
-                        Columns
-                        {layout.hiddenColumns.length > 0 && (
-                            <span className="hidden-count-badge">{layout.hiddenColumns.length}</span>
-                        )}
+                        Labels
                     </button>
-                    {columnsPopoverOpen && (
-                        <ColumnVisibilityPopover
-                            columns={columns}
-                            hiddenColumns={layout.hiddenColumns}
-                            onToggle={index => updateHiddenColumns(toggleColumnHidden(layout.hiddenColumns, index))}
-                            onShowAll={() => updateHiddenColumns(showAllColumns())}
-                            onHideAll={() => updateHiddenColumns(hideAllColumns(columns))}
-                            onClose={() => setColumnsPopoverOpen(false)}
-                        />
-                    )}
+                    <button
+                        type="button"
+                        className={toolbar.formatOn ? 'toggle active' : 'toggle'}
+                        disabled={!formatHasEffect}
+                        onClick={() => setToolbar(t => ({ ...t, formatOn: !t.formatOn }))}
+                    >
+                        Format
+                    </button>
+                    <select
+                        className="digits"
+                        value={toolbar.digits}
+                        disabled={!toolbar.formatOn || !formatHasEffect}
+                        onChange={event => setToolbar(t => ({ ...t, digits: Number(event.target.value) }))}
+                        aria-label="Digits"
+                    >
+                        {[0, 1, 2, 3, 4, 5, 6].map(d => (
+                            <option key={d} value={d}>{d}</option>
+                        ))}
+                    </select>
+                    <div className="columns-popover-anchor">
+                        <button
+                            type="button"
+                            className={columnsPopoverOpen ? 'toggle active' : 'toggle'}
+                            onClick={() => setColumnsPopoverOpen(open => !open)}
+                        >
+                            Columns
+                            {layout.hiddenColumns.length > 0 && (
+                                <span className="hidden-count-badge">{layout.hiddenColumns.length}</span>
+                            )}
+                        </button>
+                        {columnsPopoverOpen && (
+                            <ColumnVisibilityPopover
+                                columns={columns}
+                                hiddenColumns={layout.hiddenColumns}
+                                onToggle={index => updateHiddenColumns(toggleColumnHidden(layout.hiddenColumns, index))}
+                                onShowAll={() => updateHiddenColumns(showAllColumns())}
+                                onHideAll={() => updateHiddenColumns(hideAllColumns(columns))}
+                                onClose={() => setColumnsPopoverOpen(false)}
+                            />
+                        )}
+                    </div>
                 </div>
             </div>
             <div className="grid-shell" ref={gridShellRef}>

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -40,13 +40,50 @@ body,
 }
 
 .row-count {
-    flex: 1 1 auto;
+    /* `flex: 0 1 auto` — won't grow, can shrink under pressure. The toolbar
+       wrap measurement reads `scrollWidth` as intrinsic content width; a
+       flex-grown element instead reports its grown width and the decision
+       would flap. See `use-toolbar-wrap.ts`. */
+    flex: 0 1 auto;
     min-width: 80px;
     overflow: hidden;
     color: var(--vscode-descriptionForeground, var(--vscode-foreground, #cccccc));
     text-overflow: ellipsis;
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
+}
+
+/* Sort + filter chip strips. Sits between the row count and the action
+   buttons on a single row, and drops to its own full-width row (via the
+   .is-wrapped modifier below) when it would otherwise crowd the buttons. */
+.toolbar-chips {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+/* Action buttons (Labels / Format / digits / Columns) stay pinned to the
+   right, even when the sort/filter chips are open to their left. */
+.toolbar-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* When the chips don't fit beside the buttons, allow the toolbar to wrap
+   and push the chip group onto its own second row. Row-count and the
+   action buttons (order 0) stay on the top row; the chips (order 1,
+   full width) wrap below. Each strip then scrolls via its own
+   overflow-x. The wrap decision is driven by `use-toolbar-wrap.ts`. */
+.toolbar.is-wrapped {
+    flex-wrap: wrap;
+}
+
+.toolbar.is-wrapped .toolbar-chips {
+    order: 1;
+    flex-basis: 100%;
 }
 
 .toggle {

--- a/editors/vscode/src/data-viewer/webview/test-harness/harness-app.tsx
+++ b/editors/vscode/src/data-viewer/webview/test-harness/harness-app.tsx
@@ -1,0 +1,408 @@
+/**
+ * Real-layout test harness for the data-viewer toolbar chip wrapping.
+ *
+ * Mounts the *production* toolbar markup — the real `.toolbar` structure
+ * with the real `useToolbarWrap` hook, the real `ToolbarSortStrip` /
+ * `FilterStrip`, and the real `styles.css` — inside the real
+ * `.data-viewer-root` grid (mirroring `App.tsx`), itself inside a
+ * width-pinnable `#harness-root` (the viewport analog). Running in a real
+ * VS Code webview (real Chromium), it measures its own layout and posts
+ * the numbers back to the extension-host test, which asserts. This is the
+ * "self-measure" pattern: the host cannot read the sandboxed webview's
+ * DOM, so the webview reads itself and `postMessage`s the result.
+ *
+ * Reproducing the real `.data-viewer-root` grid is load-bearing: the
+ * toolbar is a grid item, and its automatic minimum size is what would
+ * otherwise overflow the viewport (pushing the action buttons off-screen
+ * and defeating the chip strips' scroll). A plain width-pinned block
+ * wrapper would mask that.
+ *
+ * Deliberately NOT shipped: built to `dist-test/` and excluded from the
+ * packaged extension. It imports neither glide-data-grid nor any
+ * row-loading code: the grid below the toolbar (the data layer) is
+ * omitted; only the toolbar's own containing grid matters.
+ */
+
+import {
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+    type CSSProperties,
+} from 'react';
+import '../styles.css';
+import { ToolbarSortStrip } from '../sort-strip';
+import { FilterStrip } from '../filter-strip';
+import { intrinsicWidthPx, useToolbarWrap } from '../use-toolbar-wrap';
+import type { ColumnSchema } from '../../arrow-reader';
+import type { FilterState, SortState } from '../../messages';
+
+// Injected by VS Code in the real webview. Declared module-scoped here
+// with a permissive `postMessage` so the harness can post `test:*`
+// messages that are not part of the production WebviewToExtension union.
+declare function acquireVsCodeApi(): {
+    postMessage(message: unknown): void;
+};
+
+// acquireVsCodeApi may be called only once per webview, so acquire it
+// once at module load and reuse it for every outbound message.
+const vscodeApi = acquireVsCodeApi();
+
+// Synthetic columns with fixed labels so each chip's intrinsic width is
+// real-font-rendered and stable across machines. Sized well beyond the
+// chip counts any test uses, so `columnIndex` always resolves to a column.
+const HARNESS_COLUMN_COUNT = 64;
+
+const HARNESS_COLUMNS: ColumnSchema[] = Array.from(
+    { length: HARNESS_COLUMN_COUNT },
+    // Short, uniform-width labels keep each chip narrow and stable, so
+    // ~10 chips comfortably fit a single row at 1200px yet overflow at
+    // 400px (the margins the suite relies on).
+    (_unused, i) => ({
+        name: `c${String(i).padStart(2, '0')}`,
+        arrowType: 'Int32',
+        dictionaryShipped: false,
+        isInteger: true,
+    }),
+);
+
+// ----- Inbound message protocol (host → webview) -----
+
+interface ResetMessage {
+    type: 'test:reset';
+}
+interface SetWidthMessage {
+    type: 'test:setWidth';
+    widthPx: number;
+}
+interface SetStateMessage {
+    type: 'test:setState';
+    sortChipCount: number;
+    filterChipCount: number;
+    hiddenColCount: number;
+    rowCountText: string;
+}
+interface RequestSnapshotMessage {
+    type: 'test:requestSnapshot';
+}
+
+type InboundMessage =
+    | ResetMessage
+    | SetWidthMessage
+    | SetStateMessage
+    | RequestSnapshotMessage;
+
+// ----- Outbound snapshot payload (webview → host) -----
+
+interface PlainRect {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+}
+
+function plainRect(element: Element | null): PlainRect | null {
+    if (!element) return null;
+    const r = element.getBoundingClientRect();
+    return {
+        top: r.top,
+        bottom: r.bottom,
+        left: r.left,
+        right: r.right,
+        width: r.width,
+        height: r.height,
+    };
+}
+
+export function HarnessApp() {
+    const [widthPx, setWidthPx] = useState<number | null>(null);
+    const [sortChipCount, setSortChipCount] = useState(0);
+    const [filterChipCount, setFilterChipCount] = useState(0);
+    const [hiddenColCount, setHiddenColCount] = useState(0);
+    const [rowCountText, setRowCountText] = useState('');
+    // Bumped per setWidth/reset so a snapshot is emitted even when the
+    // wrap state does not change (e.g. wide → wider, both single-row).
+    const [widthSetCounter, setWidthSetCounter] = useState(0);
+    // Bumped on an explicit snapshot request.
+    const [snapshotRequestCounter, setSnapshotRequestCounter] = useState(0);
+
+    const rootRef = useRef<HTMLDivElement>(null);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const rowCountRef = useRef<HTMLSpanElement>(null);
+    const toolbarChipsRef = useRef<HTMLDivElement>(null);
+    const toolbarActionsRef = useRef<HTMLDivElement>(null);
+    const snapshotSeqRef = useRef(0);
+
+    // Build synthetic SortState / FilterState from the requested counts.
+    // Memoized on the counts so their identity (and thus the hook's
+    // contentDeps) is stable until a count changes — matching production,
+    // where `sort.keys` / `filter.entries` change identity only when the
+    // user edits them.
+    const sort = useMemo<SortState>(
+        () => ({
+            keys: Array.from({ length: sortChipCount }, (_unused, i) => ({
+                columnIndex: i,
+                direction: 'asc' as const,
+            })),
+            labelsOnWhenSorted: true,
+        }),
+        [sortChipCount],
+    );
+
+    const filter = useMemo<FilterState>(
+        () => ({
+            entries: Array.from({ length: filterChipCount }, (_unused, i) => ({
+                id: `f${i}`,
+                columnIndex: i,
+                predicate: {
+                    kind: 'numCompare' as const,
+                    op: '>' as const,
+                    value: 0,
+                },
+                enabled: true,
+                includeMissing: false,
+            })),
+            labelsOnWhenFiltered: true,
+        }),
+        [filterChipCount],
+    );
+
+    // The real hook, wired with the same four refs and contentDeps shape
+    // as App.tsx.
+    const isWrapped = useToolbarWrap(
+        {
+            toolbar: toolbarRef,
+            lead: rowCountRef,
+            chips: toolbarChipsRef,
+            actions: toolbarActionsRef,
+        },
+        [sort.keys, filter.entries, rowCountText, hiddenColCount],
+    );
+
+    const noop = useCallback(() => {}, []);
+
+    // Read the live layout from the DOM (not React state) and post it to
+    // the host. Reading `is-wrapped` and the computed styles directly is
+    // the ground truth the assertions check.
+    const postSnapshot = useCallback(() => {
+        const toolbar = toolbarRef.current;
+        const chips = toolbarChipsRef.current;
+        if (!toolbar || !chips) return;
+
+        // For the "row-2 scroll tier" assertion, point at the element that
+        // actually carries the horizontal scrollbar. Raven puts overflow-x
+        // on an inner `.sort-strip-chips` / `.filter-strip-chips` (so the
+        // strip label and clear-all stay visible while chips scroll); a
+        // flat strip without that inner container falls back to itself.
+        const sortStrip = chips.querySelector('.sort-strip-chips')
+            ?? chips.querySelector('.sort-strip');
+        const filterStrip = chips.querySelector('.filter-strip-chips')
+            ?? chips.querySelector('.filter-strip');
+        const toolbarStyle = getComputedStyle(toolbar);
+        const chipsStyle = getComputedStyle(chips);
+
+        // Compute the same intrinsic widths the hook uses, so calibration
+        // tests can place themselves precisely at the wrap boundary even
+        // when strips contain nested overflow:auto scroll containers
+        // (bounding-rect widths would under-report by the clipped chip
+        // content). See `intrinsicWidthPx` in `use-toolbar-wrap.ts`.
+        const leadIntrinsic = rowCountRef.current
+            ? intrinsicWidthPx(rowCountRef.current) : 0;
+        const chipsIntrinsic = Array.from(chips.children as HTMLCollectionOf<HTMLElement>)
+            .reduce((sum, strip) => sum + intrinsicWidthPx(strip), 0)
+            + Math.max(0, chips.children.length - 1) * 8;
+        const actionsIntrinsic = toolbarActionsRef.current
+            ? intrinsicWidthPx(toolbarActionsRef.current) : 0;
+
+        snapshotSeqRef.current += 1;
+        vscodeApi.postMessage({
+            type: 'test:layoutSnapshot',
+            seq: snapshotSeqRef.current,
+            isWrapped: toolbar.classList.contains('is-wrapped'),
+            toolbarRect: plainRect(toolbar),
+            chipsRect: plainRect(chips),
+            actionsRect: plainRect(toolbarActionsRef.current),
+            leadRect: plainRect(rowCountRef.current),
+            leadIntrinsicWidth: leadIntrinsic,
+            chipsIntrinsicWidth: chipsIntrinsic,
+            actionsIntrinsicWidth: actionsIntrinsic,
+            // The width-pinned viewport analog (mirrors the production
+            // `#root`): the toolbar and its action buttons must stay
+            // inside this box.
+            rootRect: plainRect(rootRef.current),
+            chipsScrollWidth: chips.scrollWidth,
+            chipsClientWidth: chips.clientWidth,
+            sortStripScrollWidth: sortStrip?.scrollWidth ?? 0,
+            // The strip's own client width: a strip is genuinely
+            // horizontally scrollable only when its scrollWidth exceeds
+            // *this* (not the chip container's width).
+            sortStripClientWidth: (sortStrip as HTMLElement | null)?.clientWidth ?? 0,
+            filterStripScrollWidth: filterStrip?.scrollWidth ?? 0,
+            toolbarFlexWrap: toolbarStyle.flexWrap,
+            chipsOrder: chipsStyle.order,
+            chipsFlexBasis: chipsStyle.flexBasis,
+        });
+    }, []);
+
+    // Keep a ref to the latest `postSnapshot` so the message handler
+    // (subscribed once) can read the live DOM synchronously on an explicit
+    // `test:requestSnapshot`. The host only requests after its change has
+    // been applied, so a synchronous read is already settled — and it does
+    // NOT depend on `requestAnimationFrame` firing, which stalls when the
+    // webview panel is not actively painting (headless/backgrounded runs).
+    const postSnapshotRef = useRef(postSnapshot);
+    useLayoutEffect(() => {
+        postSnapshotRef.current = postSnapshot;
+    });
+
+    // Emit a snapshot after each state/width change settles. A double
+    // requestAnimationFrame lets the ResizeObserver callback →
+    // setIsWrapped → React commit finish before we read the layout.
+    useLayoutEffect(() => {
+        let raf2 = 0;
+        const raf1 = requestAnimationFrame(() => {
+            raf2 = requestAnimationFrame(() => {
+                postSnapshot();
+            });
+        });
+        return () => {
+            cancelAnimationFrame(raf1);
+            cancelAnimationFrame(raf2);
+        };
+    }, [
+        isWrapped,
+        sortChipCount,
+        filterChipCount,
+        hiddenColCount,
+        rowCountText,
+        widthSetCounter,
+        snapshotRequestCounter,
+        postSnapshot,
+    ]);
+
+    // Announce readiness only after the first ResizeObserver callback
+    // sees a non-zero width, so the host never measures a pre-layout
+    // 0-width toolbar.
+    useEffect(() => {
+        const toolbar = toolbarRef.current;
+        if (!toolbar || typeof ResizeObserver === 'undefined') return;
+        let announced = false;
+        const observer = new ResizeObserver(() => {
+            if (announced) return;
+            if (toolbar.clientWidth > 0) {
+                announced = true;
+                observer.disconnect();
+                vscodeApi.postMessage({ type: 'test:ready' });
+            }
+        });
+        observer.observe(toolbar);
+        return () => observer.disconnect();
+    }, []);
+
+    // Inbound test control messages.
+    useEffect(() => {
+        const onMessage = (event: MessageEvent) => {
+            const message = event.data as InboundMessage | undefined;
+            if (!message || typeof message.type !== 'string') return;
+            switch (message.type) {
+                case 'test:reset':
+                    setWidthPx(null);
+                    setSortChipCount(0);
+                    setFilterChipCount(0);
+                    setHiddenColCount(0);
+                    setRowCountText('');
+                    setWidthSetCounter(c => c + 1);
+                    break;
+                case 'test:setWidth':
+                    setWidthPx(message.widthPx);
+                    setWidthSetCounter(c => c + 1);
+                    break;
+                case 'test:setState':
+                    setSortChipCount(message.sortChipCount);
+                    setFilterChipCount(message.filterChipCount);
+                    setHiddenColCount(message.hiddenColCount);
+                    setRowCountText(message.rowCountText);
+                    break;
+                case 'test:requestSnapshot':
+                    // Read synchronously now (robust against stalled rAF),
+                    // and also bump the counter so the rAF-settled path
+                    // emits a follow-up snapshot.
+                    postSnapshotRef.current();
+                    setSnapshotRequestCounter(c => c + 1);
+                    break;
+            }
+        };
+        window.addEventListener('message', onMessage);
+        return () => window.removeEventListener('message', onMessage);
+    }, []);
+
+    // `#harness-root` is the viewport analog (mirrors the production
+    // `#root`): `display: block` + `overflow: hidden`, with a pinned
+    // `widthPx`. The toolbar lives inside a real `.data-viewer-root` grid
+    // (mirroring `App.tsx`) so the harness reproduces the production
+    // containing block — a single auto-track grid — not a width-pinned
+    // block. Setting the width here makes the real ResizeObserver fire on
+    // each change; a null width leaves the baseline at full-webview width.
+    const wrapperStyle: CSSProperties = {
+        display: 'block',
+        overflow: 'hidden',
+        width: widthPx === null ? undefined : `${widthPx}px`,
+    };
+
+    return (
+        <div id="harness-root" ref={rootRef} style={wrapperStyle}>
+            {/* Mirror the production container (`App.tsx`): the toolbar is
+                a grid item in `.data-viewer-root`, not a child of a
+                width-pinned block. */}
+            <div className="data-viewer-root">
+                <div
+                    className={isWrapped ? 'toolbar is-wrapped' : 'toolbar'}
+                    ref={toolbarRef}
+                >
+                    <span className="row-count" ref={rowCountRef}>
+                        {rowCountText}
+                    </span>
+                    <div className="toolbar-chips" ref={toolbarChipsRef}>
+                        <ToolbarSortStrip
+                            sort={sort}
+                            columns={HARNESS_COLUMNS}
+                            onChange={noop}
+                            onClearAll={noop}
+                        />
+                        <FilterStrip
+                            filter={filter}
+                            columns={HARNESS_COLUMNS}
+                            onEdit={noop}
+                            onToggleEnabled={noop}
+                            onRemove={noop}
+                            onClearAll={noop}
+                        />
+                    </div>
+                    <div className="toolbar-actions" ref={toolbarActionsRef}>
+                        <button className="toggle" type="button">Labels</button>
+                        <button className="toggle" type="button">Format</button>
+                        <select className="digits" aria-label="Digits" defaultValue={3}>
+                            {[0, 1, 2, 3, 4, 5, 6].map(d => (
+                                <option key={d} value={d}>{d}</option>
+                            ))}
+                        </select>
+                        <div className="columns-popover-anchor">
+                            <button className="toggle" type="button">
+                                Columns
+                                {hiddenColCount > 0 && (
+                                    <span className="hidden-count-badge">
+                                        {hiddenColCount}
+                                    </span>
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/editors/vscode/src/data-viewer/webview/test-harness/index.tsx
+++ b/editors/vscode/src/data-viewer/webview/test-harness/index.tsx
@@ -1,0 +1,15 @@
+/**
+ * Entry point for the toolbar-wrap real-layout test harness webview.
+ * Mirrors `webview/main.tsx` but mounts `HarnessApp` (toolbar-only, no
+ * data/grid layer). Built to `dist-test/` and never shipped.
+ */
+
+import { createRoot } from 'react-dom/client';
+import { HarnessApp } from './harness-app';
+
+const container = document.getElementById('root');
+if (!container) {
+    throw new Error('Toolbar wrap harness root element not found');
+}
+
+createRoot(container).render(<HarnessApp />);

--- a/editors/vscode/src/data-viewer/webview/use-toolbar-wrap.ts
+++ b/editors/vscode/src/data-viewer/webview/use-toolbar-wrap.ts
@@ -1,0 +1,191 @@
+/**
+ * Decides when the data-viewer toolbar's sort/filter chip group must
+ * drop onto its own second row so the action buttons stay pinned
+ * top-right.
+ *
+ * The pure `shouldWrap` holds the policy and is unit-tested; the
+ * `useToolbarWrap` hook feeds it widths measured from the DOM and
+ * re-measures on resize and on chip/row-count changes.
+ */
+
+import {
+    useLayoutEffect,
+    useRef,
+    useState,
+    type RefObject,
+} from 'react';
+
+/**
+ * Once wrapped, the content must shrink this many pixels below the
+ * available width before we unwrap again. The band keeps sub-pixel
+ * layout jitter at the boundary from flapping the toolbar between one
+ * and two rows.
+ */
+export const WRAP_HYSTERESIS_PX = 8;
+
+/** Flex `gap` on `.toolbar` and `.toolbar-chips`, in px (see styles.css). */
+const TOOLBAR_GAP_PX = 8;
+
+/** Intrinsic (content) widths of the three toolbar regions, in px. */
+export interface ToolbarPartWidths {
+    leadPx: number; // the row-count span
+    chipsPx: number; // sort + filter strips (summed content + inner gaps)
+    actionsPx: number; // the Labels / Format / digits / Columns controls
+}
+
+/**
+ * Decide whether the chip group should wrap to its own row.
+ *
+ * `wasWrapped` is the current state, used only for the hysteresis
+ * band. The decision is otherwise a fixed point — and so does not
+ * oscillate — only as long as the measured `parts` widths are the same
+ * whether or not the toolbar is currently wrapped. The hook below holds
+ * up its end of that bargain by summing each strip's `scrollWidth`
+ * (intrinsic content width); see the precondition documented there.
+ */
+export function shouldWrap(
+    parts: ToolbarPartWidths,
+    availablePx: number,
+    gapPx: number,
+    wasWrapped: boolean,
+): boolean {
+    // With no chips there is nothing to move to a second row, so
+    // wrapping could never relieve a row-1 overflow.
+    if (parts.chipsPx <= 0) {
+        return false;
+    }
+
+    const presentWidths = [parts.leadPx, parts.chipsPx, parts.actionsPx]
+        .filter(width => width > 0);
+
+    const contentPx = presentWidths.reduce((sum, width) => sum + width, 0);
+    const gapsPx = Math.max(0, presentWidths.length - 1) * gapPx;
+    const neededPx = contentPx + gapsPx;
+
+    const thresholdPx = wasWrapped
+        ? availablePx - WRAP_HYSTERESIS_PX
+        : availablePx;
+    return neededPx > thresholdPx;
+}
+
+interface ToolbarWrapRefs {
+    toolbar: RefObject<HTMLElement | null>;
+    lead: RefObject<HTMLElement | null>;
+    chips: RefObject<HTMLElement | null>;
+    actions: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Track whether the toolbar chip group must wrap onto its own row.
+ *
+ * Measures intrinsic content widths — each region's `scrollWidth`, and
+ * for the chips the sum of the individual strips' intrinsic widths (not
+ * the `.toolbar-chips` container's `scrollWidth`, which stretches to full
+ * width when wrapped and would then read as overflowing) — and compares
+ * them to the toolbar's client width via `shouldWrap`.
+ *
+ * PRECONDITION (keeps `shouldWrap` from oscillating): every measured
+ * region's reported intrinsic width must be stable regardless of how
+ * wide its parent is. Each region's "intrinsic width" is its own
+ * `scrollWidth` plus the clipped overflow of any nested `overflow:auto`
+ * / `overflow:scroll` descendant — Raven's chip strips have an inner
+ * scrollable `.sort-strip-chips` / `.filter-strip-chips` so the strip
+ * label and clear-all stay visible while the chips themselves scroll,
+ * and the outer strip's own `scrollWidth` would otherwise collapse to
+ * the strip's constrained allocation. Adding back the inner
+ * `scrollWidth − clientWidth` recovers the full chip content width,
+ * and is independent of the parent's width.
+ *
+ * Re-measures on toolbar width changes (ResizeObserver, ignoring
+ * height-only churn from wrapping) and whenever `contentDeps` change.
+ * Callers must include in `contentDeps` anything that changes a
+ * region's width without changing the toolbar's width — e.g. the Columns
+ * count badge, which widens the action buttons.
+ */
+
+/** Intrinsic width of an element, including any content clipped by a
+ *  nested `overflow:auto` / `overflow:scroll` descendant. The element's
+ *  own `scrollWidth` already counts visible content; for each inner
+ *  scroll container we add back `scrollWidth − clientWidth`, the portion
+ *  the container hides. This is independent of the parent's width — as
+ *  the parent shrinks, the element's `scrollWidth` shrinks and the
+ *  hidden portion grows by the same amount, so their sum stays fixed.
+ *  Exported so the real-layout test harness can self-calibrate boundary
+ *  widths against the same number the hook uses. */
+export function intrinsicWidthPx(element: HTMLElement): number {
+    let widthPx = element.scrollWidth;
+    element.querySelectorAll<HTMLElement>('*').forEach(el => {
+        const overflowX = getComputedStyle(el).overflowX;
+        if (overflowX === 'auto' || overflowX === 'scroll') {
+            widthPx += Math.max(0, el.scrollWidth - el.clientWidth);
+        }
+    });
+    return widthPx;
+}
+export function useToolbarWrap(
+    refs: ToolbarWrapRefs,
+    contentDeps: readonly unknown[],
+): boolean {
+    const [isWrapped, setIsWrapped] = useState(false);
+
+    const measure = (): void => {
+        const toolbar = refs.toolbar.current;
+        if (!toolbar) return;
+
+        const lead = refs.lead.current;
+        const actions = refs.actions.current;
+        const leadPx = lead ? intrinsicWidthPx(lead) : 0;
+        const actionsPx = actions ? intrinsicWidthPx(actions) : 0;
+
+        let chipsPx = 0;
+        const chips = refs.chips.current;
+        if (chips) {
+            const strips = Array.from(chips.children) as HTMLElement[];
+            for (const strip of strips) {
+                chipsPx += intrinsicWidthPx(strip);
+            }
+            chipsPx += Math.max(0, strips.length - 1) * TOOLBAR_GAP_PX;
+        }
+
+        const parts = { leadPx, chipsPx, actionsPx };
+        const availablePx = toolbar.clientWidth;
+        // Decide against the committed `prev`, not a closed-over value, so
+        // the hysteresis band always sees the true current wrap state.
+        setIsWrapped(prev => {
+            const next = shouldWrap(parts, availablePx, TOOLBAR_GAP_PX, prev);
+            return prev === next ? prev : next;
+        });
+    };
+
+    // Keep a ref to the latest `measure` (closing over the current
+    // `refs`) so the one-time observer below can call it without
+    // re-subscribing.
+    const measureRef = useRef<() => void>(() => {});
+    useLayoutEffect(() => {
+        measureRef.current = measure;
+    });
+
+    // Re-measure when chip/row-count content changes (width may be
+    // unchanged, so the ResizeObserver would not fire on its own).
+    useLayoutEffect(() => {
+        measureRef.current();
+    }, contentDeps);
+
+    // Observe toolbar width once. Wrapping changes the toolbar's height
+    // but not its width, so a width guard avoids a feedback callback.
+    useLayoutEffect(() => {
+        const toolbar = refs.toolbar.current;
+        if (!toolbar || typeof ResizeObserver === 'undefined') return;
+        let lastWidthPx = -1;
+        const observer = new ResizeObserver(() => {
+            const widthPx = toolbar.clientWidth;
+            if (widthPx === lastWidthPx) return;
+            lastWidthPx = widthPx;
+            measureRef.current();
+        });
+        observer.observe(toolbar);
+        return () => observer.disconnect();
+    }, [refs.toolbar]);
+
+    return isWrapped;
+}

--- a/editors/vscode/src/test/toolbar-wrap-harness-panel.ts
+++ b/editors/vscode/src/test/toolbar-wrap-harness-panel.ts
@@ -1,0 +1,240 @@
+/**
+ * Extension-host helper for the data-viewer toolbar-wrap real-layout suite.
+ *
+ * Opens a webview panel that loads the test harness bundle from
+ * `dist-test/toolbar-wrap-harness/` (built by `bun run bundle:webview-test`),
+ * and exposes the `test:*` message protocol the harness implements:
+ *
+ *   host → webview: test:reset, test:setWidth, test:setState,
+ *                   test:requestSnapshot
+ *   webview → host: test:ready, test:layoutSnapshot
+ *
+ * The host cannot read the sandboxed webview's DOM, so the webview measures
+ * its own layout and posts the numbers back; this helper collects them and
+ * resolves the higher-level `apply()` / `waitForReady()` promises the test
+ * cases consume.
+ *
+ * NOTE: filename intentionally lacks `.test.` so the `.vscode-test.mjs`
+ * glob (`out/test/**\/*.test.js`) does not load it as a suite.
+ */
+
+import * as crypto from 'crypto';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+// From `editors/vscode/out/test/toolbar-wrap-harness-panel.js`, the
+// harness bundle lives at `editors/vscode/dist-test/toolbar-wrap-harness/`.
+const HARNESS_DIR = path.resolve(__dirname, '..', '..', 'dist-test', 'toolbar-wrap-harness');
+
+interface PlainRect {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+}
+
+export interface LayoutSnapshot {
+    type: 'test:layoutSnapshot';
+    seq: number;
+    isWrapped: boolean;
+    toolbarRect: PlainRect;
+    chipsRect: PlainRect;
+    actionsRect: PlainRect;
+    leadRect: PlainRect;
+    rootRect: PlainRect;
+    /** Intrinsic widths the hook itself uses — see `intrinsicWidthPx`
+     *  in use-toolbar-wrap.ts. Calibration tests rely on these. */
+    leadIntrinsicWidth: number;
+    chipsIntrinsicWidth: number;
+    actionsIntrinsicWidth: number;
+    chipsScrollWidth: number;
+    chipsClientWidth: number;
+    sortStripScrollWidth: number;
+    sortStripClientWidth: number;
+    filterStripScrollWidth: number;
+    toolbarFlexWrap: string;
+    chipsOrder: string;
+    chipsFlexBasis: string;
+}
+
+export interface HarnessController {
+    panel: vscode.WebviewPanel;
+    send(message: unknown): Thenable<boolean>;
+    waitForReady(timeoutMs?: number): Promise<void>;
+    apply(
+        message: unknown,
+        predicate?: (snap: LayoutSnapshot) => boolean,
+        timeoutMs?: number,
+    ): Promise<LayoutSnapshot>;
+    reset(): Promise<LayoutSnapshot>;
+    readonly latestSnapshot: LayoutSnapshot | null;
+    dispose(): Promise<void>;
+}
+
+function generateNonce(): string {
+    return crypto.randomBytes(16).toString('hex');
+}
+
+function buildHarnessHtml(webview: vscode.Webview, nonce: string): string {
+    const jsUri = webview.asWebviewUri(vscode.Uri.file(path.join(HARNESS_DIR, 'index.js')));
+    const cssUri = webview.asWebviewUri(vscode.Uri.file(path.join(HARNESS_DIR, 'index.css')));
+
+    // Per-panel nonce in script-src; the harness bundle emits a sibling
+    // index.css (esbuild's css loader does not inline CSS into the IIFE),
+    // so we link it just like production webviews do.
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none';
+               style-src ${webview.cspSource} 'nonce-${nonce}';
+               script-src 'nonce-${nonce}';
+               img-src ${webview.cspSource} https: data:;
+               font-src ${webview.cspSource};">
+<title>Toolbar Wrap Harness</title>
+<link nonce="${nonce}" rel="stylesheet" href="${cssUri}">
+</head>
+<body>
+<div id="root"></div>
+<script nonce="${nonce}" src="${jsUri}"></script>
+</body>
+</html>`;
+}
+
+function withTimeout<T>(p: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    });
+    return Promise.race([p, timeout]).finally(() => {
+        if (timer) clearTimeout(timer);
+    });
+}
+
+/** Open the harness panel and wire up the message protocol. */
+export function openHarnessPanel(): HarnessController {
+    const panel = vscode.window.createWebviewPanel(
+        'raven.toolbarWrapHarness',
+        'Toolbar Wrap Harness',
+        vscode.ViewColumn.One,
+        {
+            enableScripts: true,
+            retainContextWhenHidden: true,
+            localResourceRoots: [vscode.Uri.file(HARNESS_DIR)],
+        },
+    );
+
+    let isReady = false;
+    const readyWaiters: Array<() => void> = [];
+    const snapshotWaiters: Array<(snap: LayoutSnapshot) => void> = [];
+    let latestSnapshot: LayoutSnapshot | null = null;
+
+    // Register BEFORE setting html so the test:ready handshake and the
+    // initial snapshot can never be missed.
+    panel.webview.onDidReceiveMessage((message: unknown) => {
+        if (!message || typeof message !== 'object') return;
+        const m = message as { type?: unknown };
+        if (typeof m.type !== 'string') return;
+        if (m.type === 'test:ready') {
+            isReady = true;
+            while (readyWaiters.length > 0) readyWaiters.shift()!();
+            return;
+        }
+        if (m.type === 'test:layoutSnapshot') {
+            const snap = message as LayoutSnapshot;
+            latestSnapshot = snap;
+            while (snapshotWaiters.length > 0) snapshotWaiters.shift()!(snap);
+        }
+    });
+
+    const nonce = generateNonce();
+    panel.webview.html = buildHarnessHtml(panel.webview, nonce);
+
+    function send(message: unknown): Thenable<boolean> {
+        return panel.webview.postMessage(message);
+    }
+
+    function waitForReady(timeoutMs = 30000): Promise<void> {
+        if (isReady) return Promise.resolve();
+        return withTimeout(
+            new Promise<void>(resolve => { readyWaiters.push(resolve); }),
+            timeoutMs,
+            'Timed out waiting for harness test:ready',
+        );
+    }
+
+    // Resolves on the next layoutSnapshot received after this call. The
+    // waiter is registered synchronously so callers can register it before
+    // posting and never miss the reply.
+    function nextSnapshot(timeoutMs: number): Promise<LayoutSnapshot> {
+        return new Promise<LayoutSnapshot>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                const i = snapshotWaiters.indexOf(entry);
+                if (i >= 0) snapshotWaiters.splice(i, 1);
+                reject(new Error('Timed out waiting for test:layoutSnapshot'));
+            }, timeoutMs);
+            const entry = (snap: LayoutSnapshot) => {
+                clearTimeout(timer);
+                resolve(snap);
+            };
+            snapshotWaiters.push(entry);
+        });
+    }
+
+    /**
+     * Send a control message, then poll snapshots (via test:requestSnapshot)
+     * until `predicate(snap)` holds or the deadline passes. Each requested
+     * snapshot is posted after the change is applied, so it reflects the
+     * settled DOM. With no predicate, returns the first post-change snapshot.
+     * Returns the last snapshot seen if the predicate never matches (the
+     * caller's assertion then reports the mismatch).
+     */
+    async function apply(
+        message: unknown,
+        predicate?: (snap: LayoutSnapshot) => boolean,
+        timeoutMs = 5000,
+    ): Promise<LayoutSnapshot> {
+        const deadline = Date.now() + timeoutMs;
+        await send(message);
+        let snap: LayoutSnapshot | null = null;
+        while (Date.now() < deadline) {
+            const wait = nextSnapshot(1500);
+            await send({ type: 'test:requestSnapshot' });
+            try {
+                snap = await wait;
+            } catch {
+                continue;
+            }
+            if (!predicate || predicate(snap)) return snap;
+        }
+        if (snap) return snap;
+        throw new Error('apply: no snapshot received within timeout');
+    }
+
+    function reset(): Promise<LayoutSnapshot> {
+        // Wait for the cleared state to settle. With zero chips the toolbar
+        // can never wrap, so each test starts from a known single-row
+        // baseline and a stray late snapshot can't leak into the next case.
+        return apply({ type: 'test:reset' }, snap => snap.isWrapped === false);
+    }
+
+    async function dispose(): Promise<void> {
+        panel.dispose();
+        // Let VS Code settle the panel teardown before the next suite.
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    return {
+        panel,
+        send,
+        waitForReady,
+        apply,
+        reset,
+        get latestSnapshot() { return latestSnapshot; },
+        dispose,
+    };
+}

--- a/editors/vscode/src/test/toolbar-wrap-layout.test.ts
+++ b/editors/vscode/src/test/toolbar-wrap-layout.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Real-layout test for the data-viewer toolbar chip wrapping.
+ *
+ * Runs inside a real VS Code webview (real Chromium, real flexbox). The
+ * harness mounts the production toolbar markup with the real
+ * `useToolbarWrap` hook and `styles.css`, pins its width, and posts its
+ * measured layout back here. These cases assert the geometry the fast unit
+ * tests (`tests/bun/data-viewer-toolbar-wrap.test.ts`) cannot reach: that
+ * the real CSS actually wraps, the real ResizeObserver fires, and the hook
+ * toggles `is-wrapped` in a real browser.
+ *
+ * Skipped when `RAVEN_SKIP_LAYOUT_TESTS=1` (escape hatch for sandboxes
+ * that can't render a webview).
+ */
+
+import * as assert from 'assert';
+import { openHarnessPanel, type HarnessController, type LayoutSnapshot } from './toolbar-wrap-harness-panel';
+
+const ROW_TEXT = '74 rows';
+
+// Distinct widths so the hook's clientWidth-change guard always fires
+// between transitions.
+const WIDE_PX = 1200;
+const NARROW_PX = 400;
+const MANY_CHIPS = 10;
+
+interface SetStateOverrides {
+    sortChipCount?: number;
+    filterChipCount?: number;
+    hiddenColCount?: number;
+    rowCountText?: string;
+}
+
+function state(overrides: SetStateOverrides): Record<string, unknown> {
+    return {
+        type: 'test:setState',
+        sortChipCount: overrides.sortChipCount ?? 0,
+        filterChipCount: overrides.filterChipCount ?? 0,
+        hiddenColCount: overrides.hiddenColCount ?? 0,
+        rowCountText: overrides.rowCountText ?? ROW_TEXT,
+    };
+}
+
+// ----- Invariant assertions -----
+
+function assertSingleRow(snap: LayoutSnapshot, opts: { chipsPresent: boolean }): void {
+    assert.strictEqual(snap.isWrapped, false, 'expected isWrapped === false');
+    assert.ok(
+        snap.toolbarFlexWrap === 'nowrap' || snap.toolbarFlexWrap === '',
+        `expected flex-wrap nowrap/'' got "${snap.toolbarFlexWrap}"`,
+    );
+    assert.notStrictEqual(snap.chipsOrder, '1', 'chips must not be ordered onto row 2');
+    if (opts.chipsPresent) {
+        assert.ok(
+            Math.abs(snap.chipsRect.top - snap.actionsRect.top) < 4,
+            `chips should share the actions row (chips.top=${snap.chipsRect.top}, actions.top=${snap.actionsRect.top})`,
+        );
+    } else {
+        // An empty chip group is a zero-height, vertically-centered flex
+        // item, so its top won't match the taller actions box; the
+        // meaningful single-row invariant is just that it is not on a row
+        // below the actions.
+        assert.ok(
+            snap.chipsRect.top < snap.actionsRect.bottom,
+            `empty chips should not be on a row below actions (chips.top=${snap.chipsRect.top}, actions.bottom=${snap.actionsRect.bottom})`,
+        );
+    }
+}
+
+function assertWrapped(snap: LayoutSnapshot): void {
+    assert.strictEqual(snap.isWrapped, true, 'expected isWrapped === true');
+    assert.strictEqual(
+        snap.toolbarFlexWrap,
+        'wrap',
+        `expected flex-wrap wrap got "${snap.toolbarFlexWrap}"`,
+    );
+    assert.strictEqual(snap.chipsOrder, '1', 'wrapped chips should have order 1');
+    assert.strictEqual(
+        snap.chipsFlexBasis,
+        '100%',
+        `expected chips flex-basis 100% got "${snap.chipsFlexBasis}"`,
+    );
+    assert.ok(
+        snap.chipsRect.top > snap.actionsRect.bottom,
+        `wrapped chips should sit below the actions row (chips.top=${snap.chipsRect.top}, actions.bottom=${snap.actionsRect.bottom})`,
+    );
+}
+
+// The toolbar lives in the production `.data-viewer-root` grid, itself
+// inside the width-pinned `#harness-root` (the viewport analog,
+// `overflow:hidden` like the real `#root`). Nothing the user needs may sit
+// past its right edge — if the toolbar grows to its content's width and
+// overflows the grid container, the action buttons are clipped off-screen.
+function assertWithinViewport(snap: LayoutSnapshot): void {
+    assert.ok(
+        snap.toolbarRect.right <= snap.rootRect.right + 2,
+        `toolbar must not overflow the viewport (toolbar.right=${snap.toolbarRect.right}, root.right=${snap.rootRect.right})`,
+    );
+    assert.ok(
+        snap.actionsRect.right <= snap.rootRect.right + 2,
+        `action buttons must stay within the viewport (actions.right=${snap.actionsRect.right}, root.right=${snap.rootRect.right})`,
+    );
+}
+
+function assertActionsPinnedRight(snap: LayoutSnapshot): void {
+    assert.ok(
+        snap.actionsRect.right >= snap.toolbarRect.right - 12,
+        `actions should stay pinned to the right edge (actions.right=${snap.actionsRect.right}, toolbar.right=${snap.toolbarRect.right})`,
+    );
+}
+
+function assertActionsOnTopRow(snap: LayoutSnapshot): void {
+    // The row-count text is shorter than the action buttons and both are
+    // vertically centered, so their tops differ by the centering offset
+    // (~half the height delta), not zero. The robust "same top row"
+    // invariant is that their vertical extents overlap — which still
+    // fails (correctly) if the actions were pushed down onto the wrapped
+    // chip row, since that row does not overlap the row count.
+    const verticallyOverlaps =
+        snap.actionsRect.top < snap.leadRect.bottom
+        && snap.leadRect.top < snap.actionsRect.bottom;
+    assert.ok(
+        verticallyOverlaps,
+        `actions should remain on the top row with the row count (actions=[${snap.actionsRect.top}, ${snap.actionsRect.bottom}], lead=[${snap.leadRect.top}, ${snap.leadRect.bottom}])`,
+    );
+}
+
+// Mirror the hook's needed_px so the columns-badge and hysteresis cases
+// can self-calibrate a width at the wrap boundary from a measured
+// single-row snapshot (taken wide enough that no region overflows).
+// Uses the same intrinsic widths the hook does — bounding-rect widths
+// would under-report when strips contain nested overflow:auto.
+const TOOLBAR_GAP_PX = 8;
+function measureNeededPx(snap: LayoutSnapshot): number {
+    const widths = [snap.leadIntrinsicWidth, snap.chipsIntrinsicWidth, snap.actionsIntrinsicWidth]
+        .filter(w => w > 0);
+    const contentPx = widths.reduce((sum, w) => sum + w, 0);
+    const gapsPx = Math.max(0, widths.length - 1) * TOOLBAR_GAP_PX;
+    return contentPx + gapsPx;
+}
+
+suite('data-viewer toolbar chip wrapping (real layout)', function () {
+    // Real-layout cases open a webview and await settled layout, so give
+    // each case generous headroom over the snapshot polling.
+    this.timeout(60000);
+
+    let harness: HarnessController | undefined;
+
+    suiteSetup(async function () {
+        if (process.env.RAVEN_SKIP_LAYOUT_TESTS === '1') {
+            // eslint-disable-next-line no-invalid-this
+            this.skip();
+        }
+        harness = openHarnessPanel();
+        await harness.waitForReady();
+    });
+
+    suiteTeardown(async () => {
+        if (harness) {
+            await harness.dispose();
+            harness = undefined;
+        }
+    });
+
+    setup(async () => {
+        assert.ok(harness, 'harness not initialized');
+        await harness!.reset();
+    });
+
+    test('no chips, wide → single row', async () => {
+        await harness!.apply({ type: 'test:setWidth', widthPx: WIDE_PX });
+        const snap = await harness!.apply(state({}), s => s.isWrapped === false);
+        assertSingleRow(snap, { chipsPresent: false });
+        assertActionsPinnedRight(snap);
+    });
+
+    test('many sort chips, narrow → wrapped, buttons pinned right', async () => {
+        await harness!.apply({ type: 'test:setWidth', widthPx: NARROW_PX });
+        const snap = await harness!.apply(
+            state({ sortChipCount: MANY_CHIPS }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(snap);
+        assertActionsPinnedRight(snap);
+        assertActionsOnTopRow(snap);
+    });
+
+    test('resizes wide → unwraps, then narrow → re-wraps', async () => {
+        // Start wrapped at a narrow width with chips present.
+        await harness!.apply({ type: 'test:setWidth', widthPx: NARROW_PX });
+        const wrapped = await harness!.apply(
+            state({ sortChipCount: MANY_CHIPS }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(wrapped);
+
+        // Widen: chips fit again, so the toolbar unwraps and chips return
+        // to the actions row.
+        const unwrapped = await harness!.apply(
+            { type: 'test:setWidth', widthPx: WIDE_PX },
+            s => s.isWrapped === false,
+        );
+        assertSingleRow(unwrapped, { chipsPresent: true });
+        assertActionsPinnedRight(unwrapped);
+
+        // Re-narrow to NARROW_PX (distinct from the preceding WIDE_PX, so
+        // the hook's clientWidth-change guard fires): re-wraps.
+        const rewrapped = await harness!.apply(
+            { type: 'test:setWidth', widthPx: NARROW_PX },
+            s => s.isWrapped === true,
+        );
+        assertWrapped(rewrapped);
+    });
+
+    test('many filter chips only, narrow → wrapped', async () => {
+        await harness!.apply({ type: 'test:setWidth', widthPx: NARROW_PX });
+        const snap = await harness!.apply(
+            state({ filterChipCount: MANY_CHIPS }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(snap);
+        assertActionsPinnedRight(snap);
+        assertActionsOnTopRow(snap);
+        assert.ok(
+            snap.filterStripScrollWidth > 0,
+            'filter strip should be present and measured',
+        );
+    });
+
+    test('wrapped chips that overflow row 2 keep actions on-screen', async () => {
+        // The reported bug: with enough sort+filter chips at a narrow
+        // width, the toolbar grew to its content's width inside the
+        // `.data-viewer-root` grid and overflowed, pushing
+        // Labels/Format/Columns off-screen instead of constraining the
+        // chip row.
+        await harness!.apply({ type: 'test:setWidth', widthPx: NARROW_PX });
+        const snap = await harness!.apply(
+            state({ sortChipCount: MANY_CHIPS, filterChipCount: MANY_CHIPS }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(snap);
+        assertWithinViewport(snap);
+        assertActionsPinnedRight(snap);
+        assertActionsOnTopRow(snap);
+    });
+
+    test('overflowing chips on row 2 expose the scroll tier', async () => {
+        // Many sort chips (only) at a mid width: even on its own
+        // full-width row the strip overflows, so the strip is
+        // horizontally scrollable.
+        const MID_PX = 520;
+        const OVERFLOW_CHIPS = 24;
+        await harness!.apply({ type: 'test:setWidth', widthPx: MID_PX });
+        const snap = await harness!.apply(
+            state({ sortChipCount: OVERFLOW_CHIPS }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(snap);
+        // The strip must fit within the viewport so its scrollbar is
+        // reachable — not be sized to its content and clipped off-screen.
+        assertWithinViewport(snap);
+        assert.ok(
+            snap.sortStripClientWidth <= snap.rootRect.width + 2,
+            `sort strip should fit within the viewport (sortStripClientWidth=${snap.sortStripClientWidth}, root.width=${snap.rootRect.width})`,
+        );
+        // Genuine horizontal scroll: the strip's own content exceeds its
+        // own client width.
+        assert.ok(
+            snap.sortStripScrollWidth > snap.sortStripClientWidth,
+            `sort strip should be horizontally scrollable (scroll=${snap.sortStripScrollWidth}, client=${snap.sortStripClientWidth})`,
+        );
+    });
+
+    test('Columns badge widens actions and can flip the wrap (regression)', async () => {
+        // The bug guarded by `layout.hiddenColumns.length` in the
+        // App.tsx contentDeps: the Columns count badge widens the action
+        // buttons without changing the toolbar width, so the wrap must
+        // re-measure on the hiddenColCount content-dep.
+        const CHIPS = 6;
+        const BADGE = 999;
+
+        // Measure intrinsic widths at a width wide enough that nothing
+        // wraps or overflows, with and without the badge.
+        await harness!.apply({ type: 'test:setWidth', widthPx: 2000 });
+        const noBadge = await harness!.apply(
+            state({ sortChipCount: CHIPS, hiddenColCount: 0 }),
+            s => s.isWrapped === false,
+        );
+        const withBadge = await harness!.apply(
+            state({ sortChipCount: CHIPS, hiddenColCount: BADGE }),
+            s => s.isWrapped === false,
+        );
+
+        // (a) The badge makes the actions region wider.
+        assert.ok(
+            withBadge.actionsRect.width > noBadge.actionsRect.width,
+            `Columns badge should widen the actions region (no=${noBadge.actionsRect.width}, with=${withBadge.actionsRect.width})`,
+        );
+
+        // (b) Tune the width to the boundary so the badge alone flips
+        // the decision.
+        const neededNoBadge = measureNeededPx(noBadge);
+        const neededWithBadge = measureNeededPx(withBadge);
+        const boundaryPx = Math.round((neededNoBadge + neededWithBadge) / 2);
+
+        await harness!.reset();
+        await harness!.apply({ type: 'test:setWidth', widthPx: boundaryPx });
+        const single = await harness!.apply(
+            state({ sortChipCount: CHIPS, hiddenColCount: 0 }),
+            s => s.isWrapped === false,
+        );
+        assertSingleRow(single, { chipsPresent: true });
+
+        // Adding the badge (a content-dep change, NOT a width change)
+        // must push it over the boundary and wrap.
+        const wrapped = await harness!.apply(
+            state({ sortChipCount: CHIPS, hiddenColCount: BADGE }),
+            s => s.isWrapped === true,
+        );
+        assertWrapped(wrapped);
+    });
+
+    test('does not flap within the hysteresis band', async () => {
+        const CHIPS = MANY_CHIPS;
+
+        // Measure the wrap boundary from a wide single-row snapshot.
+        await harness!.apply({ type: 'test:setWidth', widthPx: 2000 });
+        const wide = await harness!.apply(
+            state({ sortChipCount: CHIPS }),
+            s => s.isWrapped === false,
+        );
+        const neededPx = measureNeededPx(wide);
+
+        // Comfortably wide → single-row.
+        const single = await harness!.apply(
+            { type: 'test:setWidth', widthPx: neededPx + 60 },
+            s => s.isWrapped === false,
+        );
+        assertSingleRow(single, { chipsPresent: true });
+
+        // Just under needed → wraps.
+        const wrapped = await harness!.apply(
+            { type: 'test:setWidth', widthPx: neededPx - 20 },
+            s => s.isWrapped === true,
+        );
+        assertWrapped(wrapped);
+
+        // Back up but still inside the 8px hysteresis band → stays
+        // wrapped. Poll for a settled snapshot rather than accepting the
+        // first one: if the band logic were broken and it unwrapped, the
+        // is_wrapped===true predicate never matches and the returned
+        // (is_wrapped===false) snapshot fails the assertion below.
+        const stillWrapped = await harness!.apply(
+            { type: 'test:setWidth', widthPx: neededPx + 4 },
+            s => s.isWrapped === true,
+            3000,
+        );
+        assert.strictEqual(
+            stillWrapped.isWrapped,
+            true,
+            `should stay wrapped within the hysteresis band (needed≈${neededPx}, width=${neededPx + 4})`,
+        );
+
+        // Clearly past the band → unwraps.
+        const unwrapped = await harness!.apply(
+            { type: 'test:setWidth', widthPx: neededPx + 60 },
+            s => s.isWrapped === false,
+        );
+        assertSingleRow(unwrapped, { chipsPresent: true });
+    });
+});

--- a/tests/bun/data-viewer-toolbar-wrap.test.ts
+++ b/tests/bun/data-viewer-toolbar-wrap.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    shouldWrap,
+    WRAP_HYSTERESIS_PX,
+} from '../../editors/vscode/src/data-viewer/webview/use-toolbar-wrap';
+
+const parts = (lead: number, chips: number, actions: number) => ({
+    leadPx: lead,
+    chipsPx: chips,
+    actionsPx: actions,
+});
+
+const GAP = 8;
+
+describe('data-viewer shouldWrap', () => {
+    test('does not wrap when content fits within the available width', () => {
+        // 80 + 200 + 200 + 2*8 = 496 <= 800
+        expect(shouldWrap(parts(80, 200, 200), 800, GAP, false)).toBe(false);
+    });
+
+    test('wraps when content exceeds the available width', () => {
+        // 80 + 600 + 200 + 2*8 = 896 > 800
+        expect(shouldWrap(parts(80, 600, 200), 800, GAP, false)).toBe(true);
+    });
+
+    test('does not wrap when content fits exactly', () => {
+        // 100 + 100 + 100 + 2*8 = 316; available 316 -> not greater
+        expect(shouldWrap(parts(100, 100, 100), 316, GAP, false)).toBe(false);
+    });
+
+    test('wraps when content overflows by a single pixel', () => {
+        // needed 316, available 315
+        expect(shouldWrap(parts(100, 100, 100), 315, GAP, false)).toBe(true);
+    });
+
+    test('never wraps when there are no chips, even on a tiny width', () => {
+        // Wrapping an empty chip group cannot relieve a row-1 overflow.
+        expect(shouldWrap(parts(80, 0, 200), 50, GAP, false)).toBe(false);
+        expect(shouldWrap(parts(80, 0, 200), 50, GAP, true)).toBe(false);
+    });
+
+    test('counts only one gap when the lead is absent', () => {
+        // chips 300 + actions 300 + 1*8 = 608 > 600
+        expect(shouldWrap(parts(0, 300, 300), 600, GAP, false)).toBe(true);
+        // chips 296 + actions 296 + 1*8 = 600 -> not greater
+        expect(shouldWrap(parts(0, 296, 296), 600, GAP, false)).toBe(false);
+    });
+
+    describe('hysteresis', () => {
+        // needed = 80 + 500 + 200 + 2*8 = 796
+        const near = parts(80, 500, 200);
+
+        test('stays wrapped within the hysteresis band', () => {
+            // available 800: needed 796 is below available but within
+            // the 8px band, so a currently-wrapped toolbar stays wrapped.
+            expect(WRAP_HYSTERESIS_PX).toBeGreaterThan(0);
+            expect(shouldWrap(near, 800, GAP, true)).toBe(true);
+        });
+
+        test('stays unwrapped within the hysteresis band', () => {
+            // Same geometry, but currently unwrapped: 796 <= 800 so it
+            // does not wrap. The band makes the state sticky.
+            expect(shouldWrap(near, 800, GAP, false)).toBe(false);
+        });
+
+        test('unwraps once content shrinks below the band', () => {
+            // needed 796, available 810: 796 <= 810 - 8 (=802) -> unwrap
+            expect(shouldWrap(near, 810, GAP, true)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Ports the toolbar-chip-wrapping feature from [Sight PR #172](https://github.com/jbearak/sight/pull/172) to Raven's data viewer.

## Summary

- When the Sort/Filter chip strips would crowd the action buttons off a narrow panel, chips drop onto a full-width second row while the row-count and Labels / Format / Columns buttons stay pinned on the top row.
- Strips still scroll horizontally on row 2 when their chips overflow even that full-width row.
- An 8 px hysteresis band keeps the toolbar from flapping between one and two rows as the panel is resized across the boundary.
- Toolbar layout aligns with Sight: chips now sit on the left next to the row-count; action buttons are pinned right via `margin-left: auto` on `.toolbar-actions`. The row-count's flex changed from `1 1 auto` to `0 1 auto` so its `scrollWidth` reads as intrinsic content width (required for measurement stability).

## Notable deviation from a pure port

Raven's strips contain an inner `.sort-strip-chips` / `.filter-strip-chips` with `overflow-x: auto` so the strip label and clear-all stay visible while chips scroll within. That collapses the outer strip's `scrollWidth` to its constrained allocation, breaking the wrap measurement's documented precondition. The hook adds back the clipped overflow of any nested scroll container, so each region's reported intrinsic width is stable regardless of parent width. The doc comment on `intrinsicWidthPx` explains why.

## What's new

- `editors/vscode/src/data-viewer/webview/use-toolbar-wrap.ts` — pure `shouldWrap` + `useToolbarWrap` hook with `WRAP_HYSTERESIS_PX = 8` and the `intrinsicWidthPx` helper.
- `App.tsx` — four refs (`toolbarRef`, `rowCountRef`, `toolbarChipsRef`, `toolbarActionsRef`), the hook call, and a toolbar JSX restructure into `.toolbar-chips` and `.toolbar-actions`.
- `styles.css` — `.row-count` flex change plus new `.toolbar-chips`, `.toolbar-actions`, and `.toolbar.is-wrapped` rules.
- Real-layout test harness in a non-shipped `dist-test/` bundle, plus a TypeScript host controller and an 8-case Mocha geometry suite.
- 9-case `shouldWrap` unit test under `tests/bun/`.
- Docs updates in `docs/data-viewer.md` (user-facing UX) and `docs/development.md` (harness mechanics + `RAVEN_SKIP_LAYOUT_TESTS=1` escape hatch).

## Test Plan

- [x] `bun test` — 1313 pass, 0 fail (includes the 8-case real-layout suite via the vscode-test wrapper). Two consecutive clean runs.
- [x] `bun test tests/bun/data-viewer-toolbar-wrap.test.ts` — 9/9 pass.
- [x] `cd editors/vscode && bun run typecheck` — clean across all four sub-projects (extension + plot/help/data-viewer webviews).
- [x] `cd editors/vscode && bun run bundle && bun run bundle:webview-test` — production bundle plus `dist-test/toolbar-wrap-harness/{index.js,index.css}` emitted; harness build is wired into `pretest` only and is excluded from `vsce package` via `.vscodeignore` (`dist-test/**`) and `.gitignore`.
- [ ] Manual sanity check: open a wide data frame in the data viewer, add several sort + filter chips, narrow the panel — chips drop to row 2, Labels / Format / Columns stay reachable; widen — chips return to row 1.

## Real-layout suite coverage

1. No chips, wide → single row, actions pinned right.
2. Many sort chips, narrow → wrapped, actions pinned right and on the top row.
3. Resize wide → unwraps, narrow → re-wraps.
4. Filter-only narrow → wraps.
5. Sort + filter narrow → toolbar stays within the viewport (no chips overflow the grid).
6. Many sort chips at mid width → row-2 chips expose the strip's own scroll tier.
7. Columns-badge widening → triggers re-wrap at a width-stable boundary (regression for the content-deps inclusion).
8. Hysteresis: wraps below `neededPx`, stays wrapped just inside the 8 px band, unwraps clearly past it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data viewer toolbar now responds responsively to narrow panels: chip controls move to a second row while remaining horizontally scrollable. Hysteresis prevents flickering when resizing.

* **Tests**
  * Added comprehensive layout test suite validating toolbar wrapping behavior across different viewport widths and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->