### PR TITLE
test(data-viewer): make toolbar 'same flex row' check robust to scrollbar height

### DIFF
--- a/editors/vscode/src/test/toolbar-wrap-layout.test.ts
+++ b/editors/vscode/src/test/toolbar-wrap-layout.test.ts
@@ -51,9 +51,22 @@ function assertSingleRow(snap: LayoutSnapshot, opts: { chipsPresent: boolean }):
     );
     assert.notStrictEqual(snap.chipsOrder, '1', 'chips must not be ordered onto row 2');
     if (opts.chipsPresent) {
+        // "Same flex row" = the two boxes' vertical extents overlap.
+        // Comparing tops directly is fragile: when the strip's inner
+        // `overflow-x: auto` shows a *classic* horizontal scrollbar
+        // (Linux/Windows Chromium, including Ubuntu CI), the chips
+        // region grows ~8 px taller than the actions box, and the
+        // toolbar's `align-items: center` then offsets the shorter
+        // actions box downward by half that — past any tight pixel
+        // threshold. On macOS overlay scrollbars take no space, which
+        // is why this passed locally and failed in CI. Mirrors
+        // `assertActionsOnTopRow`'s overlap check for lead vs actions.
+        const verticallyOverlaps =
+            snap.chipsRect.top < snap.actionsRect.bottom
+            && snap.actionsRect.top < snap.chipsRect.bottom;
         assert.ok(
-            Math.abs(snap.chipsRect.top - snap.actionsRect.top) < 4,
-            `chips should share the actions row (chips.top=${snap.chipsRect.top}, actions.top=${snap.actionsRect.top})`,
+            verticallyOverlaps,
+            `chips should share the actions row (chips=[${snap.chipsRect.top}, ${snap.chipsRect.bottom}], actions=[${snap.actionsRect.top}, ${snap.actionsRect.bottom}])`,
         );
     } else {
         // An empty chip group is a zero-height, vertically-centered flex


### PR DESCRIPTION
Fixes the mocha failure that ran after merging #335:

```
1) data-viewer toolbar chip wrapping (real layout)
     Columns badge widens actions and can flip the wrap (regression):
    AssertionError: chips should share the actions row (chips.top=6, actions.top=10)
```

## Root cause

The `assertSingleRow` helper checked that the chips and actions boxes had near-equal `top` coordinates (within 4 px). That worked on macOS — where overlay scrollbars take no space — but tripped on Ubuntu CI:

- The strip's inner `.sort-strip-chips` is `overflow-x: auto`.
- At the boundary width the regression test calibrates, Linux/Windows Chromium reserves ~8 px of vertical space for a *classic* horizontal scrollbar.
- That extra height grows the chips region taller than the actions box.
- The toolbar's `align-items: center` then centers the shorter actions box downward by half the delta (~4 px), failing the strict `< 4` threshold on the dot.

The row was, in fact, still single-row: `isWrapped===false`, `flex-wrap: nowrap`, and `chipsOrder !== '1'` all held — only the `top`-equality sanity check was fragile.

## Fix

Replace the top-equality threshold with a vertical-overlap check — the same robust 'same row' pattern `assertActionsOnTopRow` already uses for lead vs actions. Two boxes whose vertical extents overlap necessarily sit on the same flex line; a wrapped chip row drops fully below the actions and continues to fail the assertion (correctly).

No production change.

## Test plan

- [x] All 8 `data-viewer toolbar chip wrapping (real layout)` cases pass locally (macOS, Darwin 25.5.0, VS Code 1.122.0).
- [x] Full `vscode-test` suite: 299 passing / 1 pending (baseline unchanged).
- [x] `bun run typecheck` clean across all four sub-projects.
- [ ] CI passes on the Ubuntu runner where #335 hit the failure.