### PR TITLE
Add `raven check` for full workspace diagnostics in CI; unify package-library init

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Raven takes a static-analysis approach rather than attaching to a live R session
 - **Available immediately, even for code you haven't run** — answers the moment you open a file, including code that errors halfway, is missing a dependency, or that you're only reading (onboarding to a repo, reviewing a pull request). A session-based tool can offer little until the code runs cleanly.
 - **Reflects what your code says, not what your session remembers** — a tool tied to a live session sees whatever is in `globalenv()` right now, possibly stale. Comment out `library(dplyr)` while it's still attached in your session and a session-based tool keeps completing `dplyr` functions; Raven reads the file and knows it isn't loaded there.
 - **Read-only and side-effect-free** — computing scope never runs your code, so nothing it does (writing files, hitting a database, a long job) can be triggered. This is also what makes Raven safe to run behind an agentic/AI tool.
-- **Runs in CI and other headless environments** — scope resolution needs no live R session, so Raven's diagnostics and lints run in a CI pipeline or any headless context (see the [`raven lint` CLI](docs/cli.md)).
+- **Runs in CI and other headless environments** — scope resolution needs no live R session, so Raven's diagnostics and lints run in a CI pipeline or any headless context. Use [`raven check`](docs/cli.md#raven-check) for the full diagnostic set (cross-file, undefined-variable, package) and [`raven lint`](docs/cli.md#raven-lint) for style-only gating.
 
 See [Why Raven exists](docs/comparison.md#why-raven-exists) for the origin and rationale.
 
@@ -81,7 +81,7 @@ Each feature above links to its own page. Beyond those:
 
 - [Editor Integrations](docs/editor-integrations.md) — VS Code, Zed, Neovim, AI agents
 - [Configuration](docs/configuration.md) — All settings and options ([alphabetical reference](docs/settings-reference.md))
-- [CLI](docs/cli.md) — `raven lint` for CI and other command-line usage
+- [CLI](docs/cli.md) — `raven check` (full diagnostics) and `raven lint` (style) for CI and command-line usage
 - [R Package Development](docs/r-package-dev.md) — Package mode, visibility rules, and build commands
 - [Coexistence](docs/coexistence.md) — Running alongside REditorSupport (vscode-R) and Positron
 - [Comparison](docs/comparison.md) — How Raven compares to other R tools

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -1172,25 +1172,25 @@ impl Backend {
         };
 
         log::trace!("Initializing PackageLibrary on demand (not yet ready)");
-        let r_subprocess = crate::r_subprocess::RSubprocess::new(packages_r_path);
-        let r_subprocess = match (r_subprocess, workspace_root) {
-            (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
-            (sub, _) => sub,
-        };
-        let mut lib = crate::package_library::PackageLibrary::with_subprocess(r_subprocess);
-        let ready = match lib.initialize().await {
-            Ok(()) => !lib.lib_paths().is_empty(),
-            Err(e) => {
-                log::warn!("Failed to initialize PackageLibrary: {}", e);
-                false
-            }
-        };
-        lib.add_library_paths(&additional_paths);
+        // We only get here with packages enabled (early-returned above), so pass
+        // `true`. The shared helper runs R discovery in spawn_blocking and
+        // computes readiness after applying additional paths.
+        let outcome = crate::package_library::build_package_library(
+            packages_r_path,
+            &additional_paths,
+            workspace_root,
+            true,
+        )
+        .await;
+        if let crate::package_library::PackageLibraryStatus::InitFailed(e) = &outcome.status {
+            log::warn!("Failed to initialize PackageLibrary: {}", e);
+        }
+        let ready = outcome.status.is_ready();
         let mut state = self.state.write().await;
         // Re-check under write lock: `initialized()` may have raced ahead
         // and already written a library with prefetched caches.
         if !state.package_library_ready {
-            state.package_library = std::sync::Arc::new(lib);
+            state.package_library = outcome.library;
             state.package_library_ready = ready;
         } else {
             log::trace!("PackageLibrary already initialized (race), keeping existing");
@@ -2305,50 +2305,45 @@ impl LanguageServer for Backend {
             let pkg_start = std::time::Instant::now();
             let r_calls_before = crate::perf::get_r_subprocess_calls();
 
-            if packages_enabled {
-                // Get workspace root from folders (if available) for R working directory (e.g. for renv)
-                let workspace_root = folders.first().and_then(|url| url.to_file_path().ok());
+            // Get workspace root from folders (if available) for R working
+            // directory (e.g. for renv).
+            let workspace_root = folders.first().and_then(|url| url.to_file_path().ok());
 
-                // Move R discovery to blocking task since it performs synchronous IO (which/where/R --version)
-                let r_subprocess = tokio::task::spawn_blocking(move || {
-                    let subprocess = crate::r_subprocess::RSubprocess::new(packages_r_path);
-                    match (subprocess, workspace_root) {
-                        (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
-                        (sub, _) => sub,
-                    }
-                })
-                .await
-                .unwrap_or(None);
+            // The shared helper self-gates on `packages_enabled` (returning
+            // `Disabled` with an empty library and no R discovery), moves R
+            // discovery into spawn_blocking, and computes readiness after
+            // applying additional paths. Perf metrics, the count log, and the
+            // "disabled" log stay here — the helper never logs.
+            let outcome = crate::package_library::build_package_library(
+                packages_r_path,
+                &additional_paths,
+                workspace_root,
+                packages_enabled,
+            )
+            .await;
 
-                // Create and initialize library
-                let mut lib = crate::package_library::PackageLibrary::with_subprocess(r_subprocess);
-                let ready = match lib.initialize().await {
-                    Ok(()) => !lib.lib_paths().is_empty(),
-                    Err(e) => {
-                        log::warn!("Failed to initialize PackageLibrary: {}", e);
-                        false
-                    }
-                };
-                // Add additional library paths (dedup)
-                lib.add_library_paths(&additional_paths);
-
+            use crate::package_library::PackageLibraryStatus;
+            let status = outcome.status;
+            let library = outcome.library;
+            if status == PackageLibraryStatus::Disabled {
+                log::info!("Package function awareness disabled");
+                (library, false)
+            } else {
+                if let PackageLibraryStatus::InitFailed(e) = &status {
+                    log::warn!("Failed to initialize PackageLibrary: {}", e);
+                }
                 let pkg_duration = pkg_start.elapsed();
                 let r_calls = crate::perf::get_r_subprocess_calls() - r_calls_before;
                 crate::perf::record_package_init(pkg_duration, r_calls);
 
                 log::info!(
                     "PackageLibrary initialized: {} lib_paths, {} base_packages, {} base_exports",
-                    lib.lib_paths().len(),
-                    lib.base_packages().len(),
-                    lib.base_exports().len()
+                    library.lib_paths().len(),
+                    library.base_packages().len(),
+                    library.base_exports().len()
                 );
-                (std::sync::Arc::new(lib), ready)
-            } else {
-                log::info!("Package function awareness disabled");
-                (
-                    std::sync::Arc::new(crate::package_library::PackageLibrary::new_empty()),
-                    false,
-                )
+                let ready = status.is_ready();
+                (library, ready)
             }
         };
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -1149,6 +1149,16 @@ impl Backend {
             )
         };
 
+        // Disabled-preserve gate (load-bearing — do NOT collapse into a
+        // `build_package_library(..., enabled)` call). When packages are
+        // disabled this returns without touching `state.package_library`, so a
+        // library the user built before disabling is left intact. Routing
+        // through the helper instead would build `new_empty()` and, under the
+        // race re-check below, could swap it in — clobbering that library. This
+        // is the same hazard the `raven.refreshPackages` early-return guards
+        // against; the two disabled-preserve gates are intentionally kept out
+        // of the shared helper for this reason. (The helper still owns the
+        // *install-empty-when-disabled* policy for the rebuild/startup sites.)
         if !enabled {
             return false;
         }
@@ -1944,24 +1954,20 @@ impl LanguageServer for Backend {
             .unwrap_or(serde_json::Value::Null);
         let mut loaded_project: Option<(std::path::PathBuf, serde_json::Value)> = None;
         if let Some(root) = &project_root {
-            match crate::config_file::find_config(root) {
-                crate::config_file::DiscoveredConfig::RavenToml(p) => {
-                    if let Some(loaded) = crate::config_file::load_toml(&p) {
-                        for w in &loaded.warnings {
-                            log::warn!("{w}");
-                        }
-                        loaded_project = Some((p, loaded.settings));
-                    }
+            // Discovery + load is shared with `raven check` via
+            // `discover_and_load`. The server treats a discovered-but-unloadable
+            // config as "no project layer" (collapse `LoadFailed`/`None`), since
+            // a startup config error should degrade gracefully, not abort.
+            if let crate::config_file::DiscoveredLoad::Loaded {
+                path,
+                settings,
+                warnings,
+            } = crate::config_file::discover_and_load(root)
+            {
+                for w in &warnings {
+                    log::warn!("{w}");
                 }
-                crate::config_file::DiscoveredConfig::Lintr(p) => {
-                    if let Some(loaded) = crate::config_file::load_lintr(&p) {
-                        for w in &loaded.warnings {
-                            log::warn!("{w}");
-                        }
-                        loaded_project = Some((p, loaded.settings));
-                    }
-                }
-                crate::config_file::DiscoveredConfig::None => {}
+                loaded_project = Some((path, settings));
             }
         }
 
@@ -4171,24 +4177,19 @@ impl LanguageServer for Backend {
 
             let mut loaded_project: Option<(std::path::PathBuf, serde_json::Value)> = None;
             if let Some(root) = &project_root {
-                match crate::config_file::find_config(root) {
-                    crate::config_file::DiscoveredConfig::RavenToml(p) => {
-                        if let Some(loaded) = crate::config_file::load_toml(&p) {
-                            for w in &loaded.warnings {
-                                log::warn!("{w}");
-                            }
-                            loaded_project = Some((p, loaded.settings));
-                        }
+                // Same shared discovery+load seam as startup (`discover_and_load`);
+                // a discovered-but-unloadable config collapses to "no project
+                // layer" so a bad edit degrades gracefully rather than aborting.
+                if let crate::config_file::DiscoveredLoad::Loaded {
+                    path,
+                    settings,
+                    warnings,
+                } = crate::config_file::discover_and_load(root)
+                {
+                    for w in &warnings {
+                        log::warn!("{w}");
                     }
-                    crate::config_file::DiscoveredConfig::Lintr(p) => {
-                        if let Some(loaded) = crate::config_file::load_lintr(&p) {
-                            for w in &loaded.warnings {
-                                log::warn!("{w}");
-                            }
-                            loaded_project = Some((p, loaded.settings));
-                        }
-                    }
-                    crate::config_file::DiscoveredConfig::None => {}
+                    loaded_project = Some((path, settings));
                 }
             }
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -1498,7 +1498,7 @@ fn is_package_relevant_open_uri(uri: &Url, root: &std::path::Path) -> bool {
     })
 }
 
-fn collect_package_r_file_inputs_from_disk(
+pub(crate) fn collect_package_r_file_inputs_from_disk(
     root: &std::path::Path,
 ) -> std::collections::BTreeMap<std::path::PathBuf, crate::package_state::RFileInput> {
     let mut r_files = std::collections::BTreeMap::new();
@@ -1588,7 +1588,7 @@ fn hydrate_package_r_files_from_state(
     r_files
 }
 
-fn initialize_package_inputs_from_state(
+pub(crate) fn initialize_package_inputs_from_state(
     state: &mut WorldState,
     root: std::path::PathBuf,
     desc_text: Option<Arc<str>>,

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -1498,7 +1498,7 @@ fn is_package_relevant_open_uri(uri: &Url, root: &std::path::Path) -> bool {
     })
 }
 
-pub(crate) fn collect_package_r_file_inputs_from_disk(
+fn collect_package_r_file_inputs_from_disk(
     root: &std::path::Path,
 ) -> std::collections::BTreeMap<std::path::PathBuf, crate::package_state::RFileInput> {
     let mut r_files = std::collections::BTreeMap::new();

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2453,6 +2453,13 @@ impl LanguageServer for Backend {
                 // same wrong paths.
                 let packages_enabled =
                     { self.state.read().await.cross_file_config.packages_enabled };
+                // Load-bearing gate (do not collapse into `rebuild_package_library`
+                // the way the settings-reload site does): here the swap into
+                // `state` happens *inside* this `if`. Routing through the helper
+                // unconditionally would swap in `new_empty()` when packages are
+                // disabled, clobbering the library the user built before
+                // disabling — a `refreshPackages` issued while disabled must
+                // leave the existing library untouched.
                 if packages_enabled {
                     let (new_lib, ready) = rebuild_package_library(&self.state).await;
                     let mut state = self.state.write().await;
@@ -5690,14 +5697,13 @@ impl Backend {
         if package_settings_changed {
             log::info!("Package settings changed, reinitializing PackageLibrary");
 
-            let (new_package_library, package_library_ready) = if packages_enabled {
-                rebuild_package_library(&self.state).await
-            } else {
-                (
-                    std::sync::Arc::new(crate::package_library::PackageLibrary::new_empty()),
-                    false,
-                )
-            };
+            // No `packages_enabled` gate here: `rebuild_package_library`
+            // self-gates and returns `(new_empty(), false)` when packages are
+            // disabled, which is exactly what the old `else` branch produced.
+            // Unconditionally swapping the result in is therefore behavior-
+            // neutral and keeps the disabled→empty decision in one place.
+            let (new_package_library, package_library_ready) =
+                rebuild_package_library(&self.state).await;
 
             // Replace under brief write lock.
             {
@@ -9985,6 +9991,124 @@ mod refresh_packages_tests {
                     "libPaths element must be a string, got {p:?}"
                 );
             }
+        }
+    }
+
+    // ============================================================================
+    // Regression tests for the two adjacent `packages_enabled` gates around
+    // `rebuild_package_library` (design Decision 4).
+    // ============================================================================
+    mod package_enabled_gates {
+        use std::sync::mpsc;
+        use std::sync::Arc;
+        use tower_lsp::lsp_types::{
+            DidChangeConfigurationParams, ExecuteCommandParams, InitializeParams, InitializeResult,
+        };
+        use tower_lsp::{LanguageServer, LspService};
+
+        use super::super::{Backend, RequestCancellationRegistry};
+        use crate::package_library::PackageLibrary;
+
+        struct StubServer;
+
+        #[tower_lsp::async_trait]
+        impl LanguageServer for StubServer {
+            async fn initialize(
+                &self,
+                _: InitializeParams,
+            ) -> tower_lsp::jsonrpc::Result<InitializeResult> {
+                Ok(InitializeResult::default())
+            }
+            async fn shutdown(&self) -> tower_lsp::jsonrpc::Result<()> {
+                Ok(())
+            }
+        }
+
+        fn make_backend() -> Arc<Backend> {
+            let (client_tx, client_rx) = mpsc::channel();
+            let (_service, _socket) = LspService::new(|client| {
+                client_tx.send(client).expect("capture client");
+                StubServer
+            });
+            let client = client_rx.recv().expect("client captured");
+            Arc::new(Backend::new_with_request_cancellation(
+                client,
+                Arc::new(RequestCancellationRegistry::new()),
+            ))
+        }
+
+        /// Build a populated, ready library so a clobber is observable.
+        fn ready_library(path: std::path::PathBuf) -> Arc<PackageLibrary> {
+            let mut lib = PackageLibrary::new_empty();
+            lib.set_lib_paths(vec![path]);
+            Arc::new(lib)
+        }
+
+        /// Settings-reload site (redundant gate removed): flipping
+        /// `packages.enabled` to false must leave the library empty and
+        /// not-ready. Locks in that the now-unconditional
+        /// `rebuild_package_library` call still produces the disabled outcome.
+        #[tokio::test]
+        async fn settings_reload_disabled_yields_empty_not_ready() {
+            let backend = make_backend();
+            {
+                let mut state = backend.state.write().await;
+                state.package_library = ready_library(std::path::PathBuf::from("/tmp/libs"));
+                state.package_library_ready = true;
+            }
+
+            // packages_enabled defaults to true, so flipping it to false makes
+            // `package_settings_changed` fire and routes through the rebuild.
+            backend
+                .did_change_configuration(DidChangeConfigurationParams {
+                    settings: serde_json::json!({ "packages": { "enabled": false } }),
+                })
+                .await;
+
+            let state = backend.state.read().await;
+            assert!(
+                !state.package_library_ready,
+                "reload with packages disabled must leave the library not-ready"
+            );
+            assert!(
+                state.package_library.lib_paths().is_empty(),
+                "reload with packages disabled must swap in an empty library; got {:?}",
+                state.package_library.lib_paths()
+            );
+        }
+
+        /// refreshPackages site (load-bearing gate kept): a refresh issued while
+        /// packages are disabled must NOT clobber an already-populated library.
+        /// The gate skips the swap entirely, so the same library Arc survives.
+        #[tokio::test]
+        async fn refresh_packages_disabled_keeps_existing_library() {
+            let backend = make_backend();
+            let original = ready_library(std::path::PathBuf::from("/tmp/libs"));
+            {
+                let mut state = backend.state.write().await;
+                state.cross_file_config.packages_enabled = false;
+                state.package_library = Arc::clone(&original);
+                state.package_library_ready = true;
+            }
+
+            backend
+                .execute_command(ExecuteCommandParams {
+                    command: "raven.refreshPackages".into(),
+                    arguments: vec![],
+                    work_done_progress_params: Default::default(),
+                })
+                .await
+                .expect("execute_command must not error");
+
+            let state = backend.state.read().await;
+            assert!(
+                Arc::ptr_eq(&state.package_library, &original),
+                "refresh while disabled must not swap the library Arc"
+            );
+            assert!(
+                !state.package_library.lib_paths().is_empty() && state.package_library_ready,
+                "refresh while disabled must leave lib_paths and readiness intact"
+            );
         }
     }
 }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -338,10 +338,7 @@ pub(crate) fn parse_cross_file_config(
             config.undefined_variable_severity = parse_severity(sev);
         }
         // Parse diagnostics.mixedLogicalSeverity
-        if let Some(sev) = diag
-            .get("mixedLogicalSeverity")
-            .and_then(|v| v.as_str())
-        {
+        if let Some(sev) = diag.get("mixedLogicalSeverity").and_then(|v| v.as_str()) {
             config.mixed_logical_severity = parse_severity(sev);
         }
         // Parse diagnostics.conditionAssignmentSeverity
@@ -502,9 +499,7 @@ fn parse_lint_enabled(raw: Option<&serde_json::Value>) -> crate::linting::LintEn
             "on" | "true" => LintEnabled::On,
             "off" | "false" => LintEnabled::Off,
             other => {
-                log::warn!(
-                    "Unrecognised linting.enabled value '{other}'; defaulting to 'auto'."
-                );
+                log::warn!("Unrecognised linting.enabled value '{other}'; defaulting to 'auto'.");
                 LintEnabled::Auto
             }
         },
@@ -645,9 +640,7 @@ pub(crate) fn parse_lint_config(
             "\"" => crate::linting::StringDelimiter::Double,
             "'" => crate::linting::StringDelimiter::Single,
             other => {
-                log::warn!(
-                    "Unrecognised linting.stringDelimiter '{other}', defaulting to '\"'."
-                );
+                log::warn!("Unrecognised linting.stringDelimiter '{other}', defaulting to '\"'.");
                 crate::linting::StringDelimiter::Double
             }
         };
@@ -680,19 +673,22 @@ pub(crate) fn parse_lint_config(
         .get("objectNameStyleFunction")
         .and_then(|v| v.as_str())
     {
-        config.object_name_style_function = parse_object_name_style(style, "objectNameStyleFunction");
+        config.object_name_style_function =
+            parse_object_name_style(style, "objectNameStyleFunction");
     }
     if let Some(style) = linting
         .get("objectNameStyleVariable")
         .and_then(|v| v.as_str())
     {
-        config.object_name_style_variable = parse_object_name_style(style, "objectNameStyleVariable");
+        config.object_name_style_variable =
+            parse_object_name_style(style, "objectNameStyleVariable");
     }
     if let Some(style) = linting
         .get("objectNameStyleArgument")
         .and_then(|v| v.as_str())
     {
-        config.object_name_style_argument = parse_object_name_style(style, "objectNameStyleArgument");
+        config.object_name_style_argument =
+            parse_object_name_style(style, "objectNameStyleArgument");
     }
     if let Some(sev) = linting.get("objectNameSeverity").and_then(|v| v.as_str()) {
         config.object_name_severity = parse_severity(sev);
@@ -712,10 +708,7 @@ pub(crate) fn parse_lint_config(
     if let Some(sev) = linting.get("commasSeverity").and_then(|v| v.as_str()) {
         config.commas_severity = parse_severity(sev);
     }
-    if let Some(sev) = linting
-        .get("tAndFSymbolSeverity")
-        .and_then(|v| v.as_str())
-    {
+    if let Some(sev) = linting.get("tAndFSymbolSeverity").and_then(|v| v.as_str()) {
         config.t_and_f_symbol_severity = parse_severity(sev);
     }
     if let Some(sev) = linting.get("semicolonSeverity").and_then(|v| v.as_str()) {
@@ -724,10 +717,7 @@ pub(crate) fn parse_lint_config(
     if let Some(sev) = linting.get("equalsNaSeverity").and_then(|v| v.as_str()) {
         config.equals_na_severity = parse_severity(sev);
     }
-    if let Some(sev) = linting
-        .get("objectLengthSeverity")
-        .and_then(|v| v.as_str())
-    {
+    if let Some(sev) = linting.get("objectLengthSeverity").and_then(|v| v.as_str()) {
         config.object_length_severity = parse_severity(sev);
     }
     if let Some(sev) = linting.get("vectorLogicSeverity").and_then(|v| v.as_str()) {
@@ -739,16 +729,10 @@ pub(crate) fn parse_lint_config(
     {
         config.function_left_parentheses_severity = parse_severity(sev);
     }
-    if let Some(sev) = linting
-        .get("spacesInsideSeverity")
-        .and_then(|v| v.as_str())
-    {
+    if let Some(sev) = linting.get("spacesInsideSeverity").and_then(|v| v.as_str()) {
         config.spaces_inside_severity = parse_severity(sev);
     }
-    if let Some(sev) = linting
-        .get("indentationSeverity")
-        .and_then(|v| v.as_str())
-    {
+    if let Some(sev) = linting.get("indentationSeverity").and_then(|v| v.as_str()) {
         config.indentation_severity = parse_severity(sev);
     }
 
@@ -4156,7 +4140,9 @@ impl LanguageServer for Backend {
                 let Ok(p) = c.uri.to_file_path() else {
                     return false;
                 };
-                let Some(name) = p.file_name() else { return false };
+                let Some(name) = p.file_name() else {
+                    return false;
+                };
                 name == std::ffi::OsStr::new("raven.toml") || name == std::ffi::OsStr::new(".lintr")
             })
             .cloned()
@@ -5462,10 +5448,7 @@ impl Backend {
     /// Returns the open URIs the caller should republish. Empty when only
     /// `packagesWatch*` flipped — nothing about diagnostic content moved,
     /// so the workspace-wide republish is a waste.
-    async fn reconcile_after_config_recompute(
-        &self,
-        prev: ConfigChangeSnapshot,
-    ) -> Vec<Url> {
+    async fn reconcile_after_config_recompute(&self, prev: ConfigChangeSnapshot) -> Vec<Url> {
         // Brief write lock: change detection, package_mode translate,
         // hier_support restore, force-republish marking. NO blocking I/O
         // happens inside this scope.
@@ -5477,8 +5460,9 @@ impl Backend {
             // set from client capabilities at initialize() time.
             state.symbol_config.hierarchical_document_symbol_support = prev.prev_hier_support;
 
-            let scope_changed =
-                prev.prev_cross_file.scope_settings_changed(&state.cross_file_config);
+            let scope_changed = prev
+                .prev_cross_file
+                .scope_settings_changed(&state.cross_file_config);
 
             let old_diagnostics_enabled = prev.prev_cross_file.diagnostics_enabled;
             let new_diagnostics_enabled = state.cross_file_config.diagnostics_enabled;
@@ -5488,8 +5472,7 @@ impl Backend {
             // subprocess call (~100ms). Keep this narrow.
             let package_settings_changed = state.cross_file_config.packages_enabled
                 != prev.prev_cross_file.packages_enabled
-                || state.cross_file_config.packages_r_path
-                    != prev.prev_cross_file.packages_r_path
+                || state.cross_file_config.packages_r_path != prev.prev_cross_file.packages_r_path
                 || state.cross_file_config.packages_additional_library_paths
                     != prev.prev_cross_file.packages_additional_library_paths;
 
@@ -5514,16 +5497,13 @@ impl Backend {
             // extend the chain when adding another such struct.
             let lint_config_changed = state.lint_config != prev.prev_lint;
 
-            let only_watch_changed = watch_settings_changed
-                && !lint_config_changed
-                && {
-                    let mut probe = state.cross_file_config.clone();
-                    probe.packages_watch_library_paths =
-                        prev.prev_cross_file.packages_watch_library_paths;
-                    probe.packages_watch_debounce_ms =
-                        prev.prev_cross_file.packages_watch_debounce_ms;
-                    probe == prev.prev_cross_file
-                };
+            let only_watch_changed = watch_settings_changed && !lint_config_changed && {
+                let mut probe = state.cross_file_config.clone();
+                probe.packages_watch_library_paths =
+                    prev.prev_cross_file.packages_watch_library_paths;
+                probe.packages_watch_debounce_ms = prev.prev_cross_file.packages_watch_debounce_ms;
+                probe == prev.prev_cross_file
+            };
 
             let packages_enabled = state.cross_file_config.packages_enabled;
 
@@ -5536,9 +5516,8 @@ impl Backend {
             let pkg_mode_io_needed: Option<std::path::PathBuf> = if package_mode_changed {
                 use crate::cross_file::config::PackageMode;
                 let mode = state.cross_file_config.package_mode;
-                let event = crate::package_state::event::HandlerEvent::SettingChanged {
-                    new_mode: mode,
-                };
+                let event =
+                    crate::package_state::event::HandlerEvent::SettingChanged { new_mode: mode };
                 if let Some(delta) =
                     crate::package_state::event::translate(&mut state.package_inputs, event)
                 {
@@ -6362,10 +6341,7 @@ impl Backend {
     ///
     /// Replaces the per-document indent unit map wholesale and triggers a
     /// force-republish for every document whose effective indent unit changed.
-    async fn handle_document_indent_units_changed(
-        &self,
-        params: DocumentIndentUnitsChangedParams,
-    ) {
+    async fn handle_document_indent_units_changed(&self, params: DocumentIndentUnitsChangedParams) {
         log::trace!(
             "Received documentIndentUnitsChanged: {} entries",
             params.units.len()
@@ -6411,12 +6387,8 @@ impl Backend {
         };
 
         for uri in affected_uris {
-            Backend::publish_diagnostics_via_arc(
-                self.state.clone(),
-                self.client.clone(),
-                &uri,
-            )
-            .await;
+            Backend::publish_diagnostics_via_arc(self.state.clone(), self.client.clone(), &uri)
+                .await;
         }
     }
 }
@@ -6531,12 +6503,8 @@ pub(crate) async fn publish_diagnostics_inner(
             if snap.file_type == crate::file_type::FileType::R
                 && snap.chunk_kind != crate::chunks::ChunkKind::Rmd =>
         {
-            handlers::diagnostics_from_snapshot(
-                &snap,
-                uri,
-                &handlers::DiagCancelToken::never(),
-            )
-            .unwrap_or_default()
+            handlers::diagnostics_from_snapshot(&snap, uri, &handlers::DiagCancelToken::never())
+                .unwrap_or_default()
         }
         _ => Vec::new(),
     };
@@ -6731,40 +6699,17 @@ pub(crate) async fn rebuild_package_library(
         )
     };
 
-    if !packages_enabled {
-        return (
-            Arc::new(crate::package_library::PackageLibrary::new_empty()),
-            false,
-        );
+    let outcome = crate::package_library::build_package_library(
+        packages_r_path,
+        &additional_paths,
+        workspace_root,
+        packages_enabled,
+    )
+    .await;
+    if let crate::package_library::PackageLibraryStatus::InitFailed(e) = &outcome.status {
+        log::warn!("rebuild_package_library: initialize failed: {e}");
     }
-
-    // R discovery does synchronous IO (which/where/R --version); run it off
-    // the async runtime.
-    let r_subprocess = tokio::task::spawn_blocking(move || {
-        let subprocess = crate::r_subprocess::RSubprocess::new(packages_r_path);
-        match (subprocess, workspace_root) {
-            (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
-            (sub, _) => sub,
-        }
-    })
-    .await
-    .unwrap_or(None);
-
-    let mut lib = crate::package_library::PackageLibrary::with_subprocess(r_subprocess);
-    let initialized = match lib.initialize().await {
-        Ok(()) => true,
-        Err(e) => {
-            log::warn!("rebuild_package_library: initialize failed: {e}");
-            false
-        }
-    };
-    lib.add_library_paths(&additional_paths);
-    // Readiness requires both a successful initialize() and non-empty
-    // lib_paths(): otherwise downstream code would treat a half-initialized
-    // library (e.g. R subprocess unavailable) as ready and emit false-positive
-    // missing-package diagnostics.
-    let ready = initialized && !lib.lib_paths().is_empty();
-    (Arc::new(lib), ready)
+    (outcome.library, outcome.status.is_ready())
 }
 
 /// Tear down any running libpath watcher and, if watching is enabled and the
@@ -8379,15 +8324,27 @@ mod tests {
         fn parse_lint_config_string_on_off() {
             let on = json!({ "linting": { "enabled": "on" } });
             let off = json!({ "linting": { "enabled": "off" } });
-            assert!(crate::backend::parse_lint_config(&on, false).unwrap().enabled);
-            assert!(!crate::backend::parse_lint_config(&off, true).unwrap().enabled);
+            assert!(
+                crate::backend::parse_lint_config(&on, false)
+                    .unwrap()
+                    .enabled
+            );
+            assert!(
+                !crate::backend::parse_lint_config(&off, true)
+                    .unwrap()
+                    .enabled
+            );
         }
 
         #[test]
         fn parse_lint_config_string_true_false_backcompat() {
             let t = json!({ "linting": { "enabled": "true" } });
             let f = json!({ "linting": { "enabled": "false" } });
-            assert!(crate::backend::parse_lint_config(&t, false).unwrap().enabled);
+            assert!(
+                crate::backend::parse_lint_config(&t, false)
+                    .unwrap()
+                    .enabled
+            );
             assert!(!crate::backend::parse_lint_config(&f, true).unwrap().enabled);
         }
 
@@ -8395,7 +8352,11 @@ mod tests {
         fn parse_lint_config_bool_backcompat() {
             let t = json!({ "linting": { "enabled": true } });
             let f = json!({ "linting": { "enabled": false } });
-            assert!(crate::backend::parse_lint_config(&t, false).unwrap().enabled);
+            assert!(
+                crate::backend::parse_lint_config(&t, false)
+                    .unwrap()
+                    .enabled
+            );
             assert!(!crate::backend::parse_lint_config(&f, true).unwrap().enabled);
         }
 
@@ -8416,10 +8377,7 @@ mod tests {
                 let settings = json!({ "linting": { "enabled": bad } });
                 // Auto with no lintr_discovered → off.
                 let cfg = crate::backend::parse_lint_config(&settings, false).unwrap();
-                assert!(
-                    !cfg.enabled,
-                    "expected off for invalid enabled value {bad}"
-                );
+                assert!(!cfg.enabled, "expected off for invalid enabled value {bad}");
             }
         }
 
@@ -10374,11 +10332,17 @@ mod project_config_initialize_tests {
             .await
             .unwrap();
         // Sanity: project file initially enables packages.
-        assert!(backend.state.read().await.cross_file_config.packages_enabled);
+        assert!(
+            backend
+                .state
+                .read()
+                .await
+                .cross_file_config
+                .packages_enabled
+        );
         // Capture the package_library Arc identity so we can prove the
         // reload's rebuild path replaced the instance.
-        let library_before =
-            std::sync::Arc::as_ptr(&backend.state.read().await.package_library);
+        let library_before = std::sync::Arc::as_ptr(&backend.state.read().await.package_library);
 
         // Edit raven.toml to disable packages on disk.
         fs::write(

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2430,6 +2430,23 @@ impl LanguageServer for Backend {
     ) -> tower_lsp::jsonrpc::Result<Option<serde_json::Value>> {
         match params.command.as_str() {
             "raven.refreshPackages" => {
+                // refreshPackages is meaningless when package awareness is
+                // disabled, and must leave the library the user built before
+                // disabling completely untouched — not just its `Arc`, but its
+                // cache, readiness flag, libpath watcher, and prefetch state.
+                // Bail out before any of that work runs. (This is also why the
+                // command does NOT route through the self-gating
+                // `rebuild_package_library`: that would swap in `new_empty()`
+                // and clobber the existing library.)
+                let packages_enabled =
+                    { self.state.read().await.cross_file_config.packages_enabled };
+                if !packages_enabled {
+                    log::info!(
+                        "raven.refreshPackages ignored: package function awareness is disabled"
+                    );
+                    return Ok(Some(serde_json::json!({ "cleared": 0 })));
+                }
+
                 // Collect open URIs for force-republish (needed before rebuild).
                 let open_uris: Vec<tower_lsp::lsp_types::Url> = {
                     let state = self.state.read().await;
@@ -2438,11 +2455,9 @@ impl LanguageServer for Backend {
 
                 // Capture the cache size of the *current* library before any
                 // rebuild/refresh so the user-visible "cleared N entries"
-                // count is meaningful even when `packages_enabled` triggers a
-                // full library rebuild. After a rebuild, `pkg_lib` points at a
-                // fresh empty library whose `cached_count()` starts at 0.
-                // We compute the user-visible delta against the pre-rebuild
-                // count instead.
+                // count is meaningful even when the rebuild swaps in a fresh
+                // empty library whose `cached_count()` starts at 0. We compute
+                // the user-visible delta against the pre-rebuild count instead.
                 let before_count = self.state.read().await.package_library.cached_count().await;
 
                 // Rebuild the PackageLibrary first — this re-runs `.libPaths()`
@@ -2451,17 +2466,8 @@ impl LanguageServer for Backend {
                 // up. `clear_cache` alone would leave the stale libpath
                 // snapshot in place and the refresh would re-populate with the
                 // same wrong paths.
-                let packages_enabled =
-                    { self.state.read().await.cross_file_config.packages_enabled };
-                // Load-bearing gate (do not collapse into `rebuild_package_library`
-                // the way the settings-reload site does): here the swap into
-                // `state` happens *inside* this `if`. Routing through the helper
-                // unconditionally would swap in `new_empty()` when packages are
-                // disabled, clobbering the library the user built before
-                // disabling — a `refreshPackages` issued while disabled must
-                // leave the existing library untouched.
-                if packages_enabled {
-                    let (new_lib, ready) = rebuild_package_library(&self.state).await;
+                let (new_lib, ready) = rebuild_package_library(&self.state).await;
+                {
                     let mut state = self.state.write().await;
                     state.package_library = new_lib;
                     state.package_library_ready = ready;
@@ -10077,13 +10083,22 @@ mod refresh_packages_tests {
             );
         }
 
-        /// refreshPackages site (load-bearing gate kept): a refresh issued while
-        /// packages are disabled must NOT clobber an already-populated library.
-        /// The gate skips the swap entirely, so the same library Arc survives.
+        /// refreshPackages site: a refresh issued while packages are disabled
+        /// must NOT touch the library the user built before disabling. The
+        /// command early-returns, so the same `Arc` survives *and* its cache is
+        /// left intact — the rest of the command (`clear_cache`, prefetch,
+        /// libpath-watcher restart, republish) is skipped entirely.
         #[tokio::test]
         async fn refresh_packages_disabled_keeps_existing_library() {
             let backend = make_backend();
             let original = ready_library(std::path::PathBuf::from("/tmp/libs"));
+            // Seed a cache entry so a stray `clear_cache()` would be observable.
+            original
+                .insert_package(crate::package_library::PackageInfo::new(
+                    "dplyr".to_string(),
+                    std::collections::HashSet::new(),
+                ))
+                .await;
             {
                 let mut state = backend.state.write().await;
                 state.cross_file_config.packages_enabled = false;
@@ -10108,6 +10123,10 @@ mod refresh_packages_tests {
             assert!(
                 !state.package_library.lib_paths().is_empty() && state.package_library_ready,
                 "refresh while disabled must leave lib_paths and readiness intact"
+            );
+            assert!(
+                state.package_library.is_cached("dplyr").await,
+                "refresh while disabled must not clear the existing library's cache"
             );
         }
     }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -5609,20 +5609,23 @@ impl Backend {
             .await
             .unwrap_or((None, None, Default::default()));
 
-            // Re-acquire write lock to apply results.
+            // Re-acquire write lock to apply results. Route through the same
+            // seeding helper the startup paths use, so config-reload and startup
+            // share one implementation: it sets workspace_root, package_mode,
+            // description, and namespace, hydrates R files from disk + index +
+            // open buffers, then applies the `Initial` delta. Seeding from disk
+            // matters here so a packageMode switch still sees closed R files when
+            // the background workspace index has not populated yet. (Re-setting
+            // package_mode is a no-op: `translate(SettingChanged)` above already
+            // set it to this same mode.)
             let mut state = self.state.write().await;
-            state.package_inputs.workspace_root = Some(root.clone());
-            state.package_inputs.description =
-                desc_text.map(|text| crate::package_state::DescriptionInput { text });
-            state.package_inputs.namespace =
-                ns_text.map(|text| crate::package_state::NamespaceInput { text });
-            // Seed from disk so packageMode switches still see closed R
-            // files when the background workspace index has not populated
-            // yet; then overlay index entries and open buffers through the
-            // shared helper.
-            let new_r_files = hydrate_package_r_files_from_state(&state, &root, disk_r_files);
-            state.package_inputs.r_files = new_r_files;
-            state.apply_package_event(&crate::package_state::PackageInputDelta::Initial);
+            initialize_package_inputs_from_state(
+                &mut state,
+                root,
+                desc_text,
+                ns_text,
+                disk_r_files,
+            );
             log::info!("Rebuilt package state after packageMode change (event-driven)");
         }
 

--- a/crates/raven/src/cli/analysis_stats.rs
+++ b/crates/raven/src/cli/analysis_stats.rs
@@ -360,7 +360,6 @@ fn format_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::should_skip_directory;
 
     #[test]
     fn test_parse_args_basic() {
@@ -450,17 +449,6 @@ mod tests {
             assert!(result.is_ok(), "Phase '{}' should be valid", phase);
             assert_eq!(result.unwrap().only.as_deref(), Some(*phase));
         }
-    }
-
-    #[test]
-    fn test_should_skip_directory() {
-        assert!(should_skip_directory(".git"));
-        assert!(should_skip_directory("node_modules"));
-        assert!(should_skip_directory("renv"));
-        assert!(should_skip_directory("target"));
-        assert!(!should_skip_directory("R"));
-        assert!(!should_skip_directory("src"));
-        assert!(!should_skip_directory("data"));
     }
 
     #[test]

--- a/crates/raven/src/cli/analysis_stats.rs
+++ b/crates/raven/src/cli/analysis_stats.rs
@@ -21,7 +21,6 @@ use url::Url;
 use crate::cross_file;
 use crate::parser_pool;
 use crate::perf::TimingGuard;
-use crate::state::should_skip_directory;
 
 /// Parsed arguments for the `analysis-stats` subcommand.
 #[derive(Debug)]
@@ -327,9 +326,17 @@ pub fn print_results_csv(results: &[PhaseResult]) {
 }
 
 /// Recursively discover all `.R` files under `root` and read their contents.
+///
+/// Path discovery is shared with `raven check` via
+/// [`crate::cli::shared::collect_r_file_paths`]; this reads the contents in a
+/// second pass. Unreadable files are skipped.
 fn discover_r_files(root: &Path) -> Vec<(PathBuf, String)> {
-    let mut files = Vec::new();
-    collect_r_files(root, &mut files);
+    let mut paths = Vec::new();
+    crate::cli::shared::collect_r_file_paths(root, &mut paths);
+    let mut files: Vec<(PathBuf, String)> = paths
+        .into_iter()
+        .filter_map(|p| std::fs::read_to_string(&p).ok().map(|content| (p, content)))
+        .collect();
     // Sort for deterministic ordering
     files.sort_by(|a, b| a.0.cmp(&b.0));
     files
@@ -350,33 +357,11 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-fn collect_r_files(dir: &Path, out: &mut Vec<(PathBuf, String)>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            // Skip common non-R directories (mirrors state.rs logic)
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if should_skip_directory(name) {
-                    continue;
-                }
-            }
-            collect_r_files(&path, out);
-        } else if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-            if ext.eq_ignore_ascii_case("r") {
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    out.push((path, content));
-                }
-            }
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::should_skip_directory;
 
     #[test]
     fn test_parse_args_basic() {

--- a/crates/raven/src/cli/analysis_stats.rs
+++ b/crates/raven/src/cli/analysis_stats.rs
@@ -357,7 +357,6 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -20,8 +20,9 @@ use std::path::{Path, PathBuf};
 use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
-    collect_r_file_paths, is_chunk_file, is_r_file, parse_output_format, parse_severity_level,
-    render, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    absolute_path, collect_r_file_paths, is_chunk_file, is_r_file, parse_output_format,
+    parse_severity_level, render, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK,
+    EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -467,11 +468,7 @@ fn collect_report_targets(
         collect_r_file_paths(root, &mut out);
     } else {
         for p in paths {
-            let abs = if p.is_absolute() {
-                p.clone()
-            } else {
-                root.join(p)
-            };
+            let abs = absolute_path(root, p);
             let abs = std::fs::canonicalize(&abs).unwrap_or(abs);
             if abs.is_dir() {
                 collect_r_file_paths(&abs, &mut out);

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -1,0 +1,662 @@
+//! `raven check` subcommand: index a workspace, then report the full diagnostic
+//! set (syntax, semantic, style lints, cross-file, package, and
+//! undefined-variable) for the requested files — the same diagnostics the
+//! editor publishes, run headlessly for CI.
+//!
+//! Unlike `raven lint` (style rules only; no `WorldState`, no cross-file), this
+//! builds a real `WorldState`, runs the same workspace scan the LSP server runs
+//! on startup, auto-detects R to populate the package library, then drives the
+//! shared diagnostic pipeline per reported file:
+//! `DiagnosticsSnapshot::build` → `handlers::diagnostics_from_snapshot` →
+//! `handlers::diagnostics_async_standalone` (the same three steps as the LSP
+//! publish path — notably NOT the `handlers::diagnostics()` convenience
+//! wrapper, which skips the async on-disk missing-file checks).
+//!
+//! The whole workspace is always indexed so cross-file resolution is accurate;
+//! `PATHS` only filter which files have their diagnostics *reported*.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::{Diagnostic, Url};
+
+use crate::cli::shared::{
+    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, print_json, print_sarif,
+    print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CheckArgs {
+    /// Files / directories to report on. Empty means "every R file in the
+    /// workspace". These filter only what is *reported*; the whole workspace is
+    /// always indexed regardless.
+    pub paths: Vec<PathBuf>,
+    /// Workspace root to index. Defaults to the current directory.
+    pub workspace: Option<PathBuf>,
+    pub config_path: Option<PathBuf>,
+    pub no_config: bool,
+    pub format: OutputFormat,
+    pub max_severity: SeverityLevel,
+    pub quiet: bool,
+    /// Accepted for forward compatibility; `text` output is currently uncolored,
+    /// so this has no visible effect yet (parity with `raven lint`).
+    pub no_color: bool,
+}
+
+pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<CheckArgs, String> {
+    let mut paths = Vec::new();
+    let mut workspace = None;
+    let mut config_path = None;
+    let mut no_config = false;
+    let mut format = OutputFormat::Text;
+    let mut max_severity = SeverityLevel::Info;
+    let mut quiet = false;
+    let mut no_color = false;
+
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--workspace" => {
+                workspace = Some(PathBuf::from(
+                    argv.next().ok_or("--workspace needs a path")?,
+                ));
+            }
+            "--config" => {
+                config_path = Some(PathBuf::from(argv.next().ok_or("--config needs a path")?));
+            }
+            "--no-config" => no_config = true,
+            "--format" => {
+                let v = argv.next().ok_or("--format needs a value")?;
+                format = parse_output_format(&v)?;
+            }
+            "--max-severity" => {
+                let v = argv.next().ok_or("--max-severity needs a value")?;
+                max_severity = parse_severity_level(&v)?;
+            }
+            "--quiet" => quiet = true,
+            "--no-color" => no_color = true,
+            "--help" => return Err("HELP".into()),
+            s if s.starts_with("--") => return Err(format!("unknown flag: {s}")),
+            p => paths.push(PathBuf::from(p)),
+        }
+    }
+    Ok(CheckArgs {
+        paths,
+        workspace,
+        config_path,
+        no_config,
+        format,
+        max_severity,
+        quiet,
+        no_color,
+    })
+}
+
+pub fn print_help() {
+    println!(
+        "raven check {} — full R diagnostics for CI
+
+Usage: raven check [OPTIONS] [PATHS...]
+
+Indexes the workspace, then reports the full diagnostic set for the requested
+files (or every R file in the workspace when no PATHS are given): syntax errors,
+semantic checks, style lints, cross-file diagnostics (missing source files,
+circular dependencies, out-of-scope usage), missing-package warnings, and
+undefined-variable diagnostics. Honors raven.toml / .lintr.
+
+Options:
+  --workspace DIR             Workspace root to index (default: current directory)
+  --config PATH               Path to raven.toml (default: search upward from --workspace)
+  --no-config                 Use built-in defaults; ignore raven.toml/.lintr
+  --format text|json|sarif    Output format (default: text)
+  --max-severity LEVEL        Highest severity that does NOT fail the build
+                              (off, hint, info, warning, error; default: info)
+  --quiet                     Suppress summary line in text output
+  --no-color                  Disable ANSI colors
+
+R / packages:
+  raven check auto-detects R on PATH to resolve installed-package exports and
+  base R symbols. If R is not found, package and base-symbol diagnostics are
+  limited and a note is printed to stderr; all other diagnostics still run.
+
+Exit codes:
+  0   No diagnostic exceeded --max-severity
+  1   A diagnostic exceeded --max-severity, or a usage error (unknown flag / bad option value)
+  2   Operator error while running (config parse failure, unreadable path)
+",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+pub async fn run(args: CheckArgs) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("raven check: cannot read current directory: {e}");
+            return EXIT_OPERATOR_ERROR;
+        }
+    };
+
+    // Workspace root: --workspace (resolved against CWD if relative), else CWD.
+    // Canonicalize so `Url::from_file_path` gets an absolute path and the
+    // relative paths in output are stable.
+    let abs_workspace = match args.workspace {
+        Some(ref p) if p.is_absolute() => p.clone(),
+        Some(ref p) => cwd.join(p),
+        None => cwd.clone(),
+    };
+    let root = std::fs::canonicalize(&abs_workspace).unwrap_or(abs_workspace);
+
+    let Ok(workspace_url) = Url::from_file_path(&root) else {
+        eprintln!("raven check: invalid workspace path: {}", root.display());
+        return EXIT_OPERATOR_ERROR;
+    };
+
+    // Build the indexed WorldState (config + workspace scan + package-mode).
+    let mut state = match build_indexed_state(
+        &root,
+        &workspace_url,
+        args.no_config,
+        args.config_path.as_deref(),
+    ) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+
+    // Auto-detect R for installed-package / base-symbol awareness. Any failure
+    // (R absent, init error, no library paths) degrades gracefully and prints
+    // its own one-line note to stderr.
+    maybe_init_r(&mut state, &root).await;
+
+    // Resolve which files to report diagnostics for. A named path that does not
+    // exist is an operator error (exit 2), matching `raven lint`.
+    let mut operator_error = false;
+    let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
+
+    let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
+
+    for path in &targets {
+        if is_chunk_file(path) {
+            // Chunk extraction isn't supported on the command line; mirror lint.
+            eprintln!(
+                "raven check: skipping {} (chunk-bearing file; diagnostics are R-only — see docs/cli.md)",
+                path.display()
+            );
+            continue;
+        }
+        let text = match std::fs::read_to_string(path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("raven check: cannot read {}: {e}", path.display());
+                operator_error = true;
+                continue;
+            }
+        };
+        let Ok(uri) = Url::from_file_path(path) else {
+            eprintln!("raven check: cannot convert path to URL: {}", path.display());
+            operator_error = true;
+            continue;
+        };
+        // The diagnostic snapshot reads the target from `state.documents`, which
+        // the workspace scan does NOT populate — so each reported file must be
+        // opened explicitly. Close it afterwards to bound memory across a large
+        // report set.
+        state.open_document_with_language_id(uri.clone(), &text, Some(1), Some("r"));
+        let diags = compute_file_diagnostics(&state, &uri).await;
+        state.close_document(&uri);
+        for d in diags {
+            all_diags.push((path.clone(), d));
+        }
+    }
+
+    // Deterministic output regardless of the scan's parallel HashMap order.
+    all_diags.sort_by(|(pa, da), (pb, db)| {
+        pa.cmp(pb)
+            .then(da.range.start.line.cmp(&db.range.start.line))
+            .then(da.range.start.character.cmp(&db.range.start.character))
+    });
+
+    let any_above_threshold = all_diags
+        .iter()
+        .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
+
+    match args.format {
+        OutputFormat::Text => print_text(&all_diags, &root, args.quiet),
+        OutputFormat::Json => print_json(&all_diags, &root),
+        OutputFormat::Sarif => print_sarif(&all_diags, &root),
+    }
+
+    // Operator error takes priority over a threshold breach: a half-read run
+    // shouldn't masquerade as a clean (or merely failing) lint result.
+    if operator_error {
+        EXIT_OPERATOR_ERROR
+    } else if any_above_threshold {
+        EXIT_LINT_FAILED
+    } else {
+        EXIT_OK
+    }
+}
+
+/// Build a fully-indexed `WorldState`: load project config, scan the workspace,
+/// and derive package-mode scope. The R package library is initialized
+/// separately (see [`maybe_init_r`]) since it depends on an external process.
+fn build_indexed_state(
+    root: &Path,
+    workspace_url: &Url,
+    no_config: bool,
+    config_path: Option<&Path>,
+) -> Result<crate::state::WorldState, i32> {
+    let (project_settings, project_config_path) =
+        resolve_project_config(no_config, config_path, root)?;
+
+    let mut state = crate::state::WorldState::new(crate::r_env::find_library_paths());
+    state.workspace_folders = vec![workspace_url.clone()];
+    state.raw_project_settings = project_settings;
+    state.project_config_path = project_config_path;
+    // `recompute_parsed_configs` is the only writer of the parsed config fields.
+    // It reads `project_config_path` to detect a discovered `.lintr` and gate
+    // its auto-enable (which, for the CLI's empty client layer, defaults on).
+    crate::config_file::recompute_parsed_configs(&mut state);
+
+    // Index the workspace exactly as the LSP server does on startup. This is
+    // rayon-parallel internally; there's no lock contention here since the CLI
+    // owns `state` exclusively.
+    let max_chain_depth = state.cross_file_config.max_chain_depth;
+    let (index, cross_file_entries, new_index_entries) =
+        crate::state::scan_workspace(std::slice::from_ref(workspace_url), max_chain_depth);
+    state.apply_workspace_index(index, cross_file_entries, new_index_entries);
+
+    // Derive package-mode scope (so `R/*.R` files in an R package see each
+    // other's top-level definitions without explicit `source()`). This is
+    // independent of the R subprocess — it's derived from the workspace files,
+    // DESCRIPTION, and NAMESPACE — but MUST run after `apply_workspace_index`,
+    // which resets package state.
+    let desc_text: Option<std::sync::Arc<str>> =
+        std::fs::read_to_string(root.join("DESCRIPTION")).ok().map(|t| t.into());
+    let ns_text: Option<std::sync::Arc<str>> =
+        std::fs::read_to_string(root.join("NAMESPACE")).ok().map(|t| t.into());
+    let disk_r_files = crate::backend::collect_package_r_file_inputs_from_disk(root);
+    crate::backend::initialize_package_inputs_from_state(
+        &mut state,
+        root.to_path_buf(),
+        desc_text,
+        ns_text,
+        disk_r_files,
+    );
+
+    Ok(state)
+}
+
+/// Discover and load the project config at or above `search_start` (the search
+/// itself is done by `find_config`). Returns `(settings, config_path)` to wire
+/// into the `WorldState`. Prints warnings to stderr; returns
+/// `Err(EXIT_OPERATOR_ERROR)` when a config that exists cannot be loaded.
+fn resolve_project_config(
+    no_config: bool,
+    config_path: Option<&Path>,
+    search_start: &Path,
+) -> Result<(Option<serde_json::Value>, Option<PathBuf>), i32> {
+    if no_config {
+        return Ok((None, None));
+    }
+    if let Some(explicit) = config_path {
+        return match crate::config_file::load_toml(explicit) {
+            Some(l) => {
+                for w in l.warnings {
+                    eprintln!("{w}");
+                }
+                Ok((Some(l.settings), Some(explicit.to_path_buf())))
+            }
+            None => {
+                eprintln!("raven check: failed to load --config {}", explicit.display());
+                Err(EXIT_OPERATOR_ERROR)
+            }
+        };
+    }
+    match crate::config_file::find_config(search_start) {
+        crate::config_file::DiscoveredConfig::RavenToml(p) => {
+            match crate::config_file::load_toml(&p) {
+                Some(l) => {
+                    for w in l.warnings {
+                        eprintln!("{w}");
+                    }
+                    Ok((Some(l.settings), Some(p)))
+                }
+                None => {
+                    eprintln!("raven check: failed to load {}", p.display());
+                    Err(EXIT_OPERATOR_ERROR)
+                }
+            }
+        }
+        crate::config_file::DiscoveredConfig::Lintr(p) => match std::fs::read_to_string(&p) {
+            Ok(text) => {
+                let l = crate::config_file::load_lintr_str(&text);
+                for w in l.warnings {
+                    eprintln!("{w}");
+                }
+                Ok((Some(l.settings), Some(p)))
+            }
+            Err(e) => {
+                eprintln!("raven check: cannot read {}: {e}", p.display());
+                Err(EXIT_OPERATOR_ERROR)
+            }
+        },
+        crate::config_file::DiscoveredConfig::None => Ok((None, None)),
+    }
+}
+
+/// Auto-detect R on PATH and initialize the package library so installed-package
+/// exports and base R symbols are available. On success the library and
+/// `package_library_ready = true` are stored on `state`. Every degradation path
+/// (R absent, init error, no library paths) leaves the default empty library in
+/// place and prints a specific one-line note to stderr so the message reflects
+/// what actually happened.
+async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
+    let root_owned = root.to_path_buf();
+    // R discovery performs synchronous IO (which/where, R --version); run it off
+    // the async executor, mirroring the LSP startup path in backend.rs.
+    let subprocess = tokio::task::spawn_blocking(move || {
+        crate::r_subprocess::RSubprocess::new(None).map(|s| s.with_working_dir(root_owned))
+    })
+    .await
+    .unwrap_or(None);
+
+    let Some(subprocess) = subprocess else {
+        eprintln!(
+            "raven check: R not found on PATH; package and base-symbol diagnostics will be limited"
+        );
+        return;
+    };
+
+    let mut lib = crate::package_library::PackageLibrary::with_subprocess(Some(subprocess));
+    match lib.initialize().await {
+        Ok(()) if !lib.lib_paths().is_empty() => {
+            state.package_library = std::sync::Arc::new(lib);
+            state.package_library_ready = true;
+        }
+        Ok(()) => {
+            eprintln!(
+                "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"
+            );
+        }
+    }
+}
+
+/// Run the full diagnostic pipeline for one already-opened document. Returns an
+/// empty vec when the snapshot can't be built (parse failure or document not
+/// open). A malformed file is not an operator error here — its reportable
+/// syntax errors are surfaced like any other diagnostic when the tree still
+/// builds.
+async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -> Vec<Diagnostic> {
+    let Some(snapshot) = crate::handlers::DiagnosticsSnapshot::build(state, uri) else {
+        return Vec::new();
+    };
+    let cancel = crate::handlers::DiagCancelToken::never();
+    let Some(sync_diags) = crate::handlers::diagnostics_from_snapshot(&snapshot, uri, &cancel)
+    else {
+        return Vec::new();
+    };
+    // Replace the snapshot's cache-based missing-file checks with real on-disk
+    // existence checks — exactly what the LSP publish path does.
+    let missing_file_severity = snapshot.cross_file_config.missing_file_severity;
+    crate::handlers::diagnostics_async_standalone(
+        uri,
+        sync_diags,
+        &snapshot.directive_meta,
+        state.workspace_folders.first(),
+        missing_file_severity,
+    )
+    .await
+}
+
+/// Resolve which files to report diagnostics for. Empty `paths` means every R
+/// file under the workspace root. Explicit paths are taken as-is (files) or
+/// walked (directories). The result is sorted and de-duplicated for stable
+/// output. An explicitly-named chunk file (`.Rmd`/`.qmd`) is included so the
+/// caller can emit the one-line skip note; chunk files found while walking a
+/// directory are not collected (they aren't R sources for diagnostics).
+///
+/// Every resolved path is canonicalized so its file URI matches the canonical
+/// `root` used to build the dependency graph. Without this, on platforms where
+/// the workspace root resolves through a symlink (e.g. macOS `/var` →
+/// `/private/var`), an explicitly-passed `/var/...` path would neither match
+/// the graph's `/private/var/...` keys (silently breaking cross-file
+/// resolution) nor pass the workspace-boundary check.
+///
+/// A named path that does not exist sets `*operator_error`, so the caller can
+/// return exit code 2 — matching `raven lint`.
+fn collect_report_targets(paths: &[PathBuf], root: &Path, operator_error: &mut bool) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if paths.is_empty() {
+        collect_r_files_recursively(root, &mut out);
+    } else {
+        for p in paths {
+            let abs = if p.is_absolute() { p.clone() } else { root.join(p) };
+            let abs = std::fs::canonicalize(&abs).unwrap_or(abs);
+            if abs.is_dir() {
+                collect_r_files_recursively(&abs, &mut out);
+            } else if abs.is_file() {
+                if is_r_file(&abs) || is_chunk_file(&abs) {
+                    out.push(abs);
+                }
+                // Other file types: silently ignored, matching lint's walk.
+            } else {
+                eprintln!("raven check: path does not exist: {}", p.display());
+                *operator_error = true;
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn collect_r_files_recursively(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_symlink() {
+            continue;
+        }
+        if p.is_dir() {
+            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                if crate::state::should_skip_directory(name) {
+                    continue;
+                }
+            }
+            collect_r_files_recursively(&p, out);
+        } else if is_r_file(&p) {
+            out.push(p);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn run_blocking(args: CheckArgs) -> i32 {
+        tokio::runtime::Runtime::new().unwrap().block_on(run(args))
+    }
+
+    fn base_args(workspace: &Path) -> CheckArgs {
+        CheckArgs {
+            paths: Vec::new(),
+            workspace: Some(workspace.to_path_buf()),
+            config_path: None,
+            no_config: true,
+            format: OutputFormat::Json,
+            max_severity: SeverityLevel::Info,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    #[test]
+    fn parse_defaults() {
+        let args = parse_args(Vec::<String>::new().into_iter()).unwrap();
+        assert!(args.paths.is_empty());
+        assert_eq!(args.workspace, None);
+        assert_eq!(args.format, OutputFormat::Text);
+        assert_eq!(args.max_severity, SeverityLevel::Info);
+        assert!(!args.no_config);
+    }
+
+    #[test]
+    fn parse_workspace_and_paths() {
+        let args = parse_args(
+            ["--workspace", "/tmp/ws", "R/foo.R", "R/bar.R"]
+                .iter()
+                .map(|s| s.to_string()),
+        )
+        .unwrap();
+        assert_eq!(args.workspace, Some(PathBuf::from("/tmp/ws")));
+        assert_eq!(
+            args.paths,
+            vec![PathBuf::from("R/foo.R"), PathBuf::from("R/bar.R")]
+        );
+    }
+
+    #[test]
+    fn parse_format_and_severity() {
+        let args = parse_args(
+            ["--format", "sarif", "--max-severity", "error"]
+                .iter()
+                .map(|s| s.to_string()),
+        )
+        .unwrap();
+        assert_eq!(args.format, OutputFormat::Sarif);
+        assert_eq!(args.max_severity, SeverityLevel::Error);
+    }
+
+    #[test]
+    fn parse_help_and_unknown_flag() {
+        assert_eq!(
+            parse_args(["--help"].iter().map(|s| s.to_string())).unwrap_err(),
+            "HELP"
+        );
+        assert!(parse_args(["--bogus"].iter().map(|s| s.to_string())).is_err());
+    }
+
+    #[test]
+    fn collect_targets_empty_walks_workspace() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
+        fs::create_dir(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/b.r"), "y <- 2\n").unwrap();
+        fs::write(tmp.path().join("notes.Rmd"), "prose\n").unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/c.R"), "z <- 3\n").unwrap();
+
+        let mut operator_error = false;
+        let targets = collect_report_targets(&[], tmp.path(), &mut operator_error);
+        // Two .R/.r files; .Rmd not collected during the walk; .git skipped.
+        assert_eq!(targets.len(), 2);
+        assert!(targets.iter().all(|p| is_r_file(p)));
+        assert!(!operator_error);
+    }
+
+    #[test]
+    fn collect_targets_explicit_chunk_file_included() {
+        let tmp = TempDir::new().unwrap();
+        let rmd = tmp.path().join("report.Rmd");
+        fs::write(&rmd, "prose\n").unwrap();
+        let mut operator_error = false;
+        let targets = collect_report_targets(&[rmd.clone()], tmp.path(), &mut operator_error);
+        // Targets are canonicalized so they match the canonical workspace root.
+        assert_eq!(targets, vec![std::fs::canonicalize(&rmd).unwrap()]);
+        assert!(!operator_error);
+    }
+
+    #[test]
+    fn collect_targets_nonexistent_flags_operator_error() {
+        let tmp = TempDir::new().unwrap();
+        let mut operator_error = false;
+        let targets = collect_report_targets(
+            &[PathBuf::from("no_such_file.R")],
+            tmp.path(),
+            &mut operator_error,
+        );
+        assert!(targets.is_empty());
+        assert!(operator_error);
+    }
+
+    #[test]
+    fn nonexistent_path_exits_operator_error() {
+        let tmp = TempDir::new().unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![tmp.path().join("missing.R")];
+        assert_eq!(run_blocking(args), EXIT_OPERATOR_ERROR);
+    }
+
+    #[test]
+    fn explicit_file_resolves_cross_file_scope() {
+        // Regression: an explicitly-passed file must canonicalize so its URI
+        // matches the canonical dependency-graph keys. Otherwise `add_one`
+        // (defined in a sourced sibling) would be flagged undefined and the
+        // sourced path would read as "outside workspace".
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/helpers.R"), "add_one <- function(x) x + 1\n").unwrap();
+        fs::write(
+            tmp.path().join("R/main.R"),
+            "source(\"helpers.R\")\nresult <- add_one(41)\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![tmp.path().join("R/main.R")];
+        // A clean cross-file reference must not trip any diagnostic.
+        assert_eq!(run_blocking(args), EXIT_OK);
+    }
+
+    #[test]
+    fn clean_file_exits_ok() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("clean.R"), "x <- 1\ny <- x + 1\n").unwrap();
+        assert_eq!(run_blocking(base_args(tmp.path())), EXIT_OK);
+    }
+
+    #[test]
+    fn syntax_error_exits_failed() {
+        let tmp = TempDir::new().unwrap();
+        // Unbalanced paren — a hard syntax error, always reported at ERROR.
+        fs::write(tmp.path().join("broken.R"), "f <- function( {\n").unwrap();
+        assert_eq!(run_blocking(base_args(tmp.path())), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn missing_source_file_exits_failed() {
+        // Demonstrates a cross-file diagnostic that `raven lint` cannot produce:
+        // a `source()` of a file that does not exist (missing-file = WARNING by
+        // default, which exceeds the default --max-severity of `info`).
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("main.R"),
+            "source(\"does_not_exist.R\")\n",
+        )
+        .unwrap();
+        assert_eq!(run_blocking(base_args(tmp.path())), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn missing_source_passes_when_threshold_raised() {
+        // With --max-severity warning, a WARNING-level missing-file diagnostic
+        // no longer fails the build.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("main.R"),
+            "source(\"does_not_exist.R\")\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.max_severity = SeverityLevel::Warning;
+        assert_eq!(run_blocking(args), EXIT_OK);
+    }
+}

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -191,7 +191,10 @@ pub async fn run(args: CheckArgs) -> i32 {
             }
         };
         let Ok(uri) = Url::from_file_path(path) else {
-            eprintln!("raven check: cannot convert path to URL: {}", path.display());
+            eprintln!(
+                "raven check: cannot convert path to URL: {}",
+                path.display()
+            );
             operator_error = true;
             continue;
         };
@@ -271,10 +274,12 @@ fn build_indexed_state(
     // them from disk here would only be overwritten. This mirrors the LSP's
     // with-scan startup path, which seeds package inputs from disk only on the
     // no-scan branch (see `backend.rs`).
-    let desc_text: Option<std::sync::Arc<str>> =
-        std::fs::read_to_string(root.join("DESCRIPTION")).ok().map(|t| t.into());
-    let ns_text: Option<std::sync::Arc<str>> =
-        std::fs::read_to_string(root.join("NAMESPACE")).ok().map(|t| t.into());
+    let desc_text: Option<std::sync::Arc<str>> = std::fs::read_to_string(root.join("DESCRIPTION"))
+        .ok()
+        .map(|t| t.into());
+    let ns_text: Option<std::sync::Arc<str>> = std::fs::read_to_string(root.join("NAMESPACE"))
+        .ok()
+        .map(|t| t.into());
     crate::backend::initialize_package_inputs_from_state(
         &mut state,
         root.to_path_buf(),
@@ -310,7 +315,10 @@ fn resolve_project_config(
         return match crate::config_file::load_toml(explicit) {
             Some(l) => loaded(l.warnings, l.settings, explicit.to_path_buf()),
             None => {
-                eprintln!("raven check: failed to load --config {}", explicit.display());
+                eprintln!(
+                    "raven check: failed to load --config {}",
+                    explicit.display()
+                );
                 Err(EXIT_OPERATOR_ERROR)
             }
         };
@@ -340,76 +348,69 @@ fn resolve_project_config(
 }
 
 /// Auto-detect R and initialize the package library so installed-package
-/// exports and base R symbols are available. Honors the same `raven.toml`
-/// package settings the editor does, applying them exactly as
-/// [`crate::backend::rebuild_package_library`] does so the two init paths can't
-/// drift:
-/// - `packages.enabled` (`cross_file_config.packages_enabled`) gates the whole
-///   thing — when `false`, this returns immediately (before any R discovery),
-///   leaving the default empty library and `package_library_ready = false`, so
-///   a user who disabled package awareness in their editor doesn't get package
-///   diagnostics in CI.
-/// - `packages.rPath` (`cross_file_config.packages_r_path`) selects the R binary.
-/// - `packages.additionalLibraryPaths`
-///   (`cross_file_config.packages_additional_library_paths`) augments the
-///   discovered search paths.
+/// exports and base R symbols are available. Routes through the shared
+/// [`crate::package_library::build_package_library`] helper, which is the
+/// single source of the readiness predicate and degradation classification, so
+/// this CLI path and the editor's startup paths can't drift. It honors the
+/// same `raven.toml` package settings the editor does:
+/// - `packages.enabled` gates the whole thing — when `false`, the helper
+///   returns `Disabled` *before* any R discovery, so this leaves the default
+///   empty library and `package_library_ready = false` and a user who disabled
+///   package awareness in their editor doesn't get package diagnostics in CI.
+/// - `packages.rPath` selects the R binary.
+/// - `packages.additionalLibraryPaths` augments the discovered search paths
+///   (applied after R discovery, so configured paths never suppress R-reported
+///   ones and count toward readiness).
 ///
-/// On success the library and `package_library_ready = true` are stored on
-/// `state`. Every degradation path (packages disabled, R absent, init error, no
-/// library paths) leaves the default empty library in place; the R-related ones
-/// print a specific one-line note to stderr so the message reflects what
-/// actually happened.
+/// On `Ready` the library and `package_library_ready = true` are stored on
+/// `state`. Every other status leaves the default empty library in place. There
+/// are **three** R-related degradation notes printed to stderr (R absent, init
+/// error, no library paths) so the message reflects what actually happened;
+/// `Disabled` is a degradation path that prints **nothing**.
 async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
-    // Gate on `packages.enabled` *before* any R discovery, exactly as
-    // `rebuild_package_library` does. A user who disabled package awareness in
-    // their editor must not get package / base-symbol diagnostics in CI; the
-    // default empty library stays in place and `package_library_ready` stays
-    // false.
-    if !state.cross_file_config.packages_enabled {
-        return;
-    }
-
+    // Snapshot config into locals before the call so the later `state`
+    // mutation doesn't conflict with the borrow.
     let r_path = state.cross_file_config.packages_r_path.clone();
-    let additional_paths = state
+    let additional = state
         .cross_file_config
         .packages_additional_library_paths
         .clone();
-    let root_owned = root.to_path_buf();
-    // R discovery performs synchronous IO (which/where, R --version); run it off
-    // the async executor, mirroring the LSP startup path in backend.rs.
-    let subprocess = tokio::task::spawn_blocking(move || {
-        crate::r_subprocess::RSubprocess::new(r_path).map(|s| s.with_working_dir(root_owned))
-    })
-    .await
-    .unwrap_or(None);
+    let enabled = state.cross_file_config.packages_enabled;
 
-    // Build the library even when R is absent, mirroring `rebuild_package_library`:
-    // `initialize()` does static, offline base-symbol loading, and the configured
-    // additional paths must still be honored. `r_found` only selects the right
-    // degradation message below.
-    let r_found = subprocess.is_some();
-    let mut lib = crate::package_library::PackageLibrary::with_subprocess(subprocess);
-    let init_result = lib.initialize().await;
-    // Apply user-configured additional library paths *after* R discovery so they
-    // augment (never suppress) the paths R reported — same ordering as
-    // `rebuild_package_library`.
-    lib.add_library_paths(&additional_paths);
+    let outcome = crate::package_library::build_package_library(
+        r_path,
+        &additional,
+        Some(root.to_path_buf()),
+        enabled,
+    )
+    .await;
 
-    if init_result.is_ok() && !lib.lib_paths().is_empty() {
-        state.package_library = std::sync::Arc::new(lib);
-        state.package_library_ready = true;
-    } else if !r_found {
-        eprintln!(
+    // The shared helper gates on `packages.enabled` *before* any R discovery
+    // (returning `Disabled`), applies `additionalLibraryPaths` after discovery,
+    // and computes readiness from non-empty `lib_paths()` — exactly as the
+    // editor's `backend::rebuild_package_library` does, so the two init paths
+    // can't drift. Each status surfaces its own way; only the R-related
+    // degradations print a note, and `Disabled` is silent.
+    use crate::package_library::PackageLibraryStatus::*;
+    match outcome.status {
+        Ready => {
+            state.package_library = outcome.library;
+            state.package_library_ready = true;
+        }
+        // Packages disabled in `raven.toml`: keep the default empty library and
+        // `package_library_ready = false`, silently — a user who disabled
+        // package awareness in their editor doesn't get package diagnostics in
+        // CI.
+        Disabled => {}
+        RNotFound => eprintln!(
             "raven check: R not found on PATH; package and base-symbol diagnostics will be limited"
-        );
-    } else if let Err(e) = init_result {
-        eprintln!(
+        ),
+        InitFailed(e) => eprintln!(
             "raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"
-        );
-    } else {
-        eprintln!(
+        ),
+        NoLibraryPaths => eprintln!(
             "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
-        );
+        ),
     }
 }
 
@@ -456,13 +457,21 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
 ///
 /// A named path that does not exist sets `*operator_error`, so the caller can
 /// return exit code 2 — matching `raven lint`.
-fn collect_report_targets(paths: &[PathBuf], root: &Path, operator_error: &mut bool) -> Vec<PathBuf> {
+fn collect_report_targets(
+    paths: &[PathBuf],
+    root: &Path,
+    operator_error: &mut bool,
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if paths.is_empty() {
         collect_r_file_paths(root, &mut out);
     } else {
         for p in paths {
-            let abs = if p.is_absolute() { p.clone() } else { root.join(p) };
+            let abs = if p.is_absolute() {
+                p.clone()
+            } else {
+                root.join(p)
+            };
             let abs = std::fs::canonicalize(&abs).unwrap_or(abs);
             if abs.is_dir() {
                 collect_r_file_paths(&abs, &mut out);
@@ -610,7 +619,11 @@ mod tests {
         // sourced path would read as "outside workspace".
         let tmp = TempDir::new().unwrap();
         fs::create_dir(tmp.path().join("R")).unwrap();
-        fs::write(tmp.path().join("R/helpers.R"), "add_one <- function(x) x + 1\n").unwrap();
+        fs::write(
+            tmp.path().join("R/helpers.R"),
+            "add_one <- function(x) x + 1\n",
+        )
+        .unwrap();
         fs::write(
             tmp.path().join("R/main.R"),
             "source(\"helpers.R\")\nresult <- add_one(41)\n",
@@ -643,11 +656,7 @@ mod tests {
         // a `source()` of a file that does not exist (missing-file = WARNING by
         // default, which exceeds the default --max-severity of `info`).
         let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("main.R"),
-            "source(\"does_not_exist.R\")\n",
-        )
-        .unwrap();
+        fs::write(tmp.path().join("main.R"), "source(\"does_not_exist.R\")\n").unwrap();
         assert_eq!(run_blocking(base_args(tmp.path())), EXIT_LINT_FAILED);
     }
 
@@ -656,11 +665,7 @@ mod tests {
         // With --max-severity warning, a WARNING-level missing-file diagnostic
         // no longer fails the build.
         let tmp = TempDir::new().unwrap();
-        fs::write(
-            tmp.path().join("main.R"),
-            "source(\"does_not_exist.R\")\n",
-        )
-        .unwrap();
+        fs::write(tmp.path().join("main.R"), "source(\"does_not_exist.R\")\n").unwrap();
         let mut args = base_args(tmp.path());
         args.max_severity = SeverityLevel::Warning;
         assert_eq!(run_blocking(args), EXIT_OK);

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -268,13 +268,19 @@ pub async fn run(args: CheckArgs) -> i32 {
 /// single offending byte to name.
 fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
     use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Range};
-    let detail = if byte == 0 {
+    // Compose the whole message per branch rather than gluing a fixed
+    // "not valid UTF-8" prefix onto the detail: the `byte == 0` case can be a
+    // malformed UTF-16 file (which carried a BOM), so a "not valid UTF-8" prefix
+    // would contradict its own tail.
+    let message = if byte == 0 {
         // No single offending byte to name: a truncated multibyte sequence at
-        // EOF, or malformed/odd-length UTF-16 (which carried a BOM). Keep this
-        // encoding-agnostic so it doesn't misattribute either case.
-        "could not be decoded as UTF-8 or UTF-16".to_string()
+        // EOF, or malformed/odd-length UTF-16.
+        "File could not be decoded as UTF-8 or UTF-16. Re-save the file as UTF-8.".to_string()
     } else {
-        format!("first invalid byte {byte:#04x} at offset {offset} (looks like Latin-1/Windows-1252)")
+        format!(
+            "File is not valid UTF-8: first invalid byte {byte:#04x} at offset {offset} \
+             (looks like Latin-1/Windows-1252). Re-save the file as UTF-8."
+        )
     };
     Diagnostic {
         range: Range {
@@ -282,7 +288,7 @@ fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
             end: Position { line: 0, character: 0 },
         },
         severity: Some(DiagnosticSeverity::ERROR),
-        message: format!("File is not valid UTF-8: {detail}. Re-save the file as UTF-8."),
+        message,
         ..Default::default()
     }
 }
@@ -796,6 +802,22 @@ mod tests {
         let mut args = base_args(workspace.path());
         args.paths = vec![broken];
         assert_eq!(run_blocking(args), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn encoding_diagnostic_message_matches_the_failure_kind() {
+        // Latin-1 (a concrete offending byte): names UTF-8 and the byte/offset.
+        let latin1 = encoding_diagnostic(930, 0xA0);
+        assert!(
+            latin1.message.contains("not valid UTF-8") && latin1.message.contains("0xa0"),
+            "{}",
+            latin1.message
+        );
+        // Malformed/odd-length UTF-16 (byte == 0): the file carried a BOM, so the
+        // message must NOT claim "not valid UTF-8" and must mention UTF-16.
+        let utf16 = encoding_diagnostic(0, 0);
+        assert!(!utf16.message.contains("not valid UTF-8"), "{}", utf16.message);
+        assert!(utf16.message.contains("UTF-16"), "{}", utf16.message);
     }
 
     #[test]

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -269,7 +269,10 @@ pub async fn run(args: CheckArgs) -> i32 {
 fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
     use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Range};
     let detail = if byte == 0 {
-        "no UTF-16 byte-order mark and not valid UTF-8".to_string()
+        // No single offending byte to name: a truncated multibyte sequence at
+        // EOF, or malformed/odd-length UTF-16 (which carried a BOM). Keep this
+        // encoding-agnostic so it doesn't misattribute either case.
+        "could not be decoded as UTF-8 or UTF-16".to_string()
     } else {
         format!("first invalid byte {byte:#04x} at offset {offset} (looks like Latin-1/Windows-1252)")
     };

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -460,9 +460,8 @@ async fn prefetch_reported_packages(state: &crate::state::WorldState, targets: &
         .into_iter()
         .filter(|p| crate::r_subprocess::is_valid_package_name(p))
         .collect();
-    if !packages.is_empty() {
-        state.package_library.prefetch_packages(&packages).await;
-    }
+    // `prefetch_packages` is a no-op on an empty slice, so no length guard here.
+    state.package_library.prefetch_packages(&packages).await;
 }
 
 /// Run the full diagnostic pipeline for one already-opened document. Returns an

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -20,8 +20,9 @@ use std::path::{Path, PathBuf};
 use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
-    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, print_json, print_sarif,
-    print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    collect_r_file_paths, is_chunk_file, is_r_file, parse_output_format, parse_severity_level,
+    print_json, print_sarif, print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK,
+    EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -431,13 +432,13 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
 fn collect_report_targets(paths: &[PathBuf], root: &Path, operator_error: &mut bool) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if paths.is_empty() {
-        collect_r_files_recursively(root, &mut out);
+        collect_r_file_paths(root, &mut out);
     } else {
         for p in paths {
             let abs = if p.is_absolute() { p.clone() } else { root.join(p) };
             let abs = std::fs::canonicalize(&abs).unwrap_or(abs);
             if abs.is_dir() {
-                collect_r_files_recursively(&abs, &mut out);
+                collect_r_file_paths(&abs, &mut out);
             } else if abs.is_file() {
                 if is_r_file(&abs) || is_chunk_file(&abs) {
                     out.push(abs);
@@ -452,28 +453,6 @@ fn collect_report_targets(paths: &[PathBuf], root: &Path, operator_error: &mut b
     out.sort();
     out.dedup();
     out
-}
-
-fn collect_r_files_recursively(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let p = entry.path();
-        if p.is_symlink() {
-            continue;
-        }
-        if p.is_dir() {
-            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
-                if crate::state::should_skip_directory(name) {
-                    continue;
-                }
-            }
-            collect_r_files_recursively(&p, out);
-        } else if is_r_file(&p) {
-            out.push(p);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -21,8 +21,7 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
     collect_r_file_paths, is_chunk_file, is_r_file, parse_output_format, parse_severity_level,
-    print_json, print_sarif, print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK,
-    EXIT_OPERATOR_ERROR,
+    render, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -219,11 +218,7 @@ pub async fn run(args: CheckArgs) -> i32 {
         .iter()
         .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
 
-    match args.format {
-        OutputFormat::Text => print_text(&all_diags, &root, args.quiet),
-        OutputFormat::Json => print_json(&all_diags, &root),
-        OutputFormat::Sarif => print_sarif(&all_diags, &root),
-    }
+    render(args.format, &all_diags, &root, args.quiet);
 
     // Operator error takes priority over a threshold breach: a half-read run
     // shouldn't masquerade as a clean (or merely failing) lint result.
@@ -270,17 +265,22 @@ fn build_indexed_state(
     // independent of the R subprocess — it's derived from the workspace files,
     // DESCRIPTION, and NAMESPACE — but MUST run after `apply_workspace_index`,
     // which resets package state.
+    //
+    // The disk seed is empty: `initialize_package_inputs_from_state` hydrates
+    // every package R file from the workspace index we just applied, so reading
+    // them from disk here would only be overwritten. This mirrors the LSP's
+    // with-scan startup path, which seeds package inputs from disk only on the
+    // no-scan branch (see `backend.rs`).
     let desc_text: Option<std::sync::Arc<str>> =
         std::fs::read_to_string(root.join("DESCRIPTION")).ok().map(|t| t.into());
     let ns_text: Option<std::sync::Arc<str>> =
         std::fs::read_to_string(root.join("NAMESPACE")).ok().map(|t| t.into());
-    let disk_r_files = crate::backend::collect_package_r_file_inputs_from_disk(root);
     crate::backend::initialize_package_inputs_from_state(
         &mut state,
         root.to_path_buf(),
         desc_text,
         ns_text,
-        disk_r_files,
+        Default::default(),
     );
 
     Ok(state)
@@ -298,14 +298,17 @@ fn resolve_project_config(
     if no_config {
         return Ok((None, None));
     }
+    // Every loader yields `settings` + `warnings`; emit the warnings and tag the
+    // settings with the config path they came from.
+    let loaded = |warnings: Vec<String>, settings: serde_json::Value, path: PathBuf| {
+        for w in warnings {
+            eprintln!("{w}");
+        }
+        Ok((Some(settings), Some(path)))
+    };
     if let Some(explicit) = config_path {
         return match crate::config_file::load_toml(explicit) {
-            Some(l) => {
-                for w in l.warnings {
-                    eprintln!("{w}");
-                }
-                Ok((Some(l.settings), Some(explicit.to_path_buf())))
-            }
+            Some(l) => loaded(l.warnings, l.settings, explicit.to_path_buf()),
             None => {
                 eprintln!("raven check: failed to load --config {}", explicit.display());
                 Err(EXIT_OPERATOR_ERROR)
@@ -315,12 +318,7 @@ fn resolve_project_config(
     match crate::config_file::find_config(search_start) {
         crate::config_file::DiscoveredConfig::RavenToml(p) => {
             match crate::config_file::load_toml(&p) {
-                Some(l) => {
-                    for w in l.warnings {
-                        eprintln!("{w}");
-                    }
-                    Ok((Some(l.settings), Some(p)))
-                }
+                Some(l) => loaded(l.warnings, l.settings, p),
                 None => {
                     eprintln!("raven check: failed to load {}", p.display());
                     Err(EXIT_OPERATOR_ERROR)
@@ -330,10 +328,7 @@ fn resolve_project_config(
         crate::config_file::DiscoveredConfig::Lintr(p) => match std::fs::read_to_string(&p) {
             Ok(text) => {
                 let l = crate::config_file::load_lintr_str(&text);
-                for w in l.warnings {
-                    eprintln!("{w}");
-                }
-                Ok((Some(l.settings), Some(p)))
+                loaded(l.warnings, l.settings, p)
             }
             Err(e) => {
                 eprintln!("raven check: cannot read {}: {e}", p.display());
@@ -344,45 +339,60 @@ fn resolve_project_config(
     }
 }
 
-/// Auto-detect R on PATH and initialize the package library so installed-package
-/// exports and base R symbols are available. On success the library and
-/// `package_library_ready = true` are stored on `state`. Every degradation path
-/// (R absent, init error, no library paths) leaves the default empty library in
-/// place and prints a specific one-line note to stderr so the message reflects
-/// what actually happened.
+/// Auto-detect R and initialize the package library so installed-package
+/// exports and base R symbols are available. Honors the same `raven.toml`
+/// package settings the editor does — `packages.rPath`
+/// (`cross_file_config.packages_r_path`) selects the R binary, and
+/// `packages.additionalLibraryPaths`
+/// (`cross_file_config.packages_additional_library_paths`) augments the
+/// discovered search paths — applying them exactly as
+/// [`crate::backend::rebuild_package_library`] does so the two init paths can't
+/// drift. On success the library and `package_library_ready = true` are stored
+/// on `state`. Every degradation path (R absent, init error, no library paths)
+/// leaves the default empty library in place and prints a specific one-line note
+/// to stderr so the message reflects what actually happened.
 async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
+    let r_path = state.cross_file_config.packages_r_path.clone();
+    let additional_paths = state
+        .cross_file_config
+        .packages_additional_library_paths
+        .clone();
     let root_owned = root.to_path_buf();
     // R discovery performs synchronous IO (which/where, R --version); run it off
     // the async executor, mirroring the LSP startup path in backend.rs.
     let subprocess = tokio::task::spawn_blocking(move || {
-        crate::r_subprocess::RSubprocess::new(None).map(|s| s.with_working_dir(root_owned))
+        crate::r_subprocess::RSubprocess::new(r_path).map(|s| s.with_working_dir(root_owned))
     })
     .await
     .unwrap_or(None);
 
-    let Some(subprocess) = subprocess else {
+    // Build the library even when R is absent, mirroring `rebuild_package_library`:
+    // `initialize()` does static, offline base-symbol loading, and the configured
+    // additional paths must still be honored. `r_found` only selects the right
+    // degradation message below.
+    let r_found = subprocess.is_some();
+    let mut lib = crate::package_library::PackageLibrary::with_subprocess(subprocess);
+    let init_result = lib.initialize().await;
+    // Apply user-configured additional library paths *after* R discovery so they
+    // augment (never suppress) the paths R reported — same ordering as
+    // `rebuild_package_library`.
+    lib.add_library_paths(&additional_paths);
+
+    if init_result.is_ok() && !lib.lib_paths().is_empty() {
+        state.package_library = std::sync::Arc::new(lib);
+        state.package_library_ready = true;
+    } else if !r_found {
         eprintln!(
             "raven check: R not found on PATH; package and base-symbol diagnostics will be limited"
         );
-        return;
-    };
-
-    let mut lib = crate::package_library::PackageLibrary::with_subprocess(Some(subprocess));
-    match lib.initialize().await {
-        Ok(()) if !lib.lib_paths().is_empty() => {
-            state.package_library = std::sync::Arc::new(lib);
-            state.package_library_ready = true;
-        }
-        Ok(()) => {
-            eprintln!(
-                "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
-            );
-        }
-        Err(e) => {
-            eprintln!(
-                "raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"
-            );
-        }
+    } else if let Err(e) = init_result {
+        eprintln!(
+            "raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"
+        );
+    } else {
+        eprintln!(
+            "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
+        );
     }
 }
 
@@ -637,5 +647,32 @@ mod tests {
         let mut args = base_args(tmp.path());
         args.max_severity = SeverityLevel::Warning;
         assert_eq!(run_blocking(args), EXIT_OK);
+    }
+
+    /// Regression: `raven check` must honor `packages.additionalLibraryPaths`
+    /// from `raven.toml`, exactly as the language server does via
+    /// `backend::rebuild_package_library`. The configured path must end up in
+    /// the resulting `PackageLibrary`'s search paths. R-independent: the
+    /// additional paths are applied after R discovery, so the assertion holds
+    /// whether or not R is installed.
+    #[tokio::test]
+    async fn maybe_init_r_honors_additional_library_paths() {
+        let workspace = TempDir::new().unwrap();
+        let extra_lib = TempDir::new().unwrap();
+        let mut state = crate::state::WorldState::new(vec![]);
+        state.cross_file_config.packages_additional_library_paths =
+            vec![extra_lib.path().to_path_buf()];
+
+        maybe_init_r(&mut state, workspace.path()).await;
+
+        assert!(
+            state
+                .package_library
+                .lib_paths()
+                .iter()
+                .any(|p| p == extra_lib.path()),
+            "check must honor packages.additionalLibraryPaths; got {:?}",
+            state.package_library.lib_paths()
+        );
     }
 }

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -209,11 +209,19 @@ pub async fn run(args: CheckArgs) -> i32 {
         if let Some(doc) = state.workspace_index.get(&uri).cloned() {
             state.documents.insert(uri.clone(), doc);
         } else {
-            let text = match std::fs::read_to_string(path) {
+            let text = match crate::state::read_source(path) {
                 Ok(t) => t,
-                Err(e) => {
+                Err(crate::state::SourceReadError::Io(e)) => {
                     eprintln!("raven check: cannot read {}: {e}", path.display());
                     operator_error = true;
+                    continue;
+                }
+                // A mis-encoded file is a property of the code, like a syntax
+                // error — not an operator error. Report it as a finding (see
+                // `encoding_diagnostic`) and keep going, so the exit code
+                // reflects findings rather than a half-read abort.
+                Err(crate::state::SourceReadError::InvalidEncoding { offset, byte }) => {
+                    all_diags.push((path.clone(), encoding_diagnostic(offset, byte)));
                     continue;
                 }
             };
@@ -247,6 +255,32 @@ pub async fn run(args: CheckArgs) -> i32 {
         EXIT_LINT_FAILED
     } else {
         EXIT_OK
+    }
+}
+
+/// Build the reported finding for a target that isn't valid UTF-8. A
+/// mis-encoded source file (typically Latin-1 / Windows-1252 saved without a
+/// BOM) can't be parsed, but it's a property of the user's code — so it's an
+/// error-severity diagnostic (exit 1, like a syntax error) rather than an
+/// operator error (exit 2). The range is `0:0` because the file can't be
+/// decoded into lines; the byte offset in the message is the actionable
+/// pointer. `byte == 0` marks the rare malformed-UTF-16 case, where there's no
+/// single offending byte to name.
+fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
+    use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Range};
+    let detail = if byte == 0 {
+        "no UTF-16 byte-order mark and not valid UTF-8".to_string()
+    } else {
+        format!("first invalid byte {byte:#04x} at offset {offset} (looks like Latin-1/Windows-1252)")
+    };
+    Diagnostic {
+        range: Range {
+            start: Position { line: 0, character: 0 },
+            end: Position { line: 0, character: 0 },
+        },
+        severity: Some(DiagnosticSeverity::ERROR),
+        message: format!("File is not valid UTF-8: {detail}. Re-save the file as UTF-8."),
+        ..Default::default()
     }
 }
 
@@ -759,6 +793,22 @@ mod tests {
         let mut args = base_args(workspace.path());
         args.paths = vec![broken];
         assert_eq!(run_blocking(args), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn non_utf8_file_is_reported_not_operator_error() {
+        // A Latin-1 / Windows-1252 source file (here a bare 0xA0 non-breaking
+        // space) is a property of the user's code, like a syntax error — not an
+        // operator error. raven check reports it as a finding (exit 1) instead
+        // of aborting the whole run (exit 2). The scan silently skips the
+        // undecodable file; the report loop's disk fallback turns the encoding
+        // failure into the diagnostic.
+        let workspace = TempDir::new().unwrap();
+        let mut bytes = b"x <- 1\n".to_vec();
+        bytes.push(0xA0); // invalid UTF-8 start byte
+        bytes.push(b'\n');
+        fs::write(workspace.path().join("latin1.R"), bytes).unwrap();
+        assert_eq!(run_blocking(base_args(workspace.path())), EXIT_LINT_FAILED);
     }
 
     #[cfg(unix)]

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -172,6 +172,10 @@ pub async fn run(args: CheckArgs) -> i32 {
     let mut operator_error = false;
     let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
 
+    // Warm the package-export cache before computing diagnostics, matching the
+    // editor's post-scan prefetch (see [`prefetch_reported_packages`]).
+    prefetch_reported_packages(&state, &targets).await;
+
     let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
 
     for path in &targets {
@@ -183,14 +187,6 @@ pub async fn run(args: CheckArgs) -> i32 {
             );
             continue;
         }
-        let text = match std::fs::read_to_string(path) {
-            Ok(t) => t,
-            Err(e) => {
-                eprintln!("raven check: cannot read {}: {e}", path.display());
-                operator_error = true;
-                continue;
-            }
-        };
         let Ok(uri) = Url::from_file_path(path) else {
             eprintln!(
                 "raven check: cannot convert path to URL: {}",
@@ -199,11 +195,30 @@ pub async fn run(args: CheckArgs) -> i32 {
             operator_error = true;
             continue;
         };
-        // The diagnostic snapshot reads the target from `state.documents`, which
-        // the workspace scan does NOT populate — so each reported file must be
-        // opened explicitly. Close it afterwards to bound memory across a large
-        // report set.
-        state.open_document_with_language_id(uri.clone(), &text, Some(1), Some("r"));
+        // `DiagnosticsSnapshot::build` reads the target from `state.documents`,
+        // which the workspace scan does NOT populate — it stores parsed
+        // `Document`s (tree included) in `state.workspace_index`. Reuse that
+        // already-parsed `Document` instead of re-reading the file from disk
+        // and re-parsing it: in the common "report the whole workspace" run
+        // that halves the tree-sitter work (parse once during the scan, not
+        // again here). Fall back to reading from disk only for a target the
+        // scan didn't index (e.g. a path the report walk reached through a
+        // different symlink alias). Either way the document is removed
+        // afterwards to bound memory across a large report set; the clone keeps
+        // the index entry intact for other files' cross-file resolution.
+        if let Some(doc) = state.workspace_index.get(&uri).cloned() {
+            state.documents.insert(uri.clone(), doc);
+        } else {
+            let text = match std::fs::read_to_string(path) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("raven check: cannot read {}: {e}", path.display());
+                    operator_error = true;
+                    continue;
+                }
+            };
+            state.open_document_with_language_id(uri.clone(), &text, Some(1), Some("r"));
+        }
         let diags = compute_file_diagnostics(&state, &uri).await;
         state.close_document(&uri);
         for d in diags {
@@ -238,6 +253,17 @@ pub async fn run(args: CheckArgs) -> i32 {
 /// Build a fully-indexed `WorldState`: load project config, scan the workspace,
 /// and derive package-mode scope. The R package library is initialized
 /// separately (see [`maybe_init_r`]) since it depends on an external process.
+///
+/// This is the synchronous, single-owner counterpart to the LSP server's
+/// startup (`backend::initialized`, "Task B"). The two intentionally differ
+/// only in *wiring* — the server is async, takes write locks, and records perf;
+/// the CLI owns `state` exclusively — while every piece of *logic* that could
+/// drift is single-sourced through shared seams: config discovery+load
+/// ([`crate::config_file::discover_and_load`]), the workspace scan
+/// ([`crate::state::scan_workspace`] + [`WorldState::apply_workspace_index`]),
+/// package-input seeding ([`crate::backend::initialize_package_inputs_from_state`]),
+/// and the R package library ([`crate::package_library::build_package_library`]).
+/// Keep new startup logic in those seams, not duplicated here.
 fn build_indexed_state(
     root: &Path,
     workspace_url: &Url,
@@ -324,50 +350,39 @@ fn resolve_project_config(
             }
         };
     }
-    match crate::config_file::find_config(search_start) {
-        crate::config_file::DiscoveredConfig::RavenToml(p) => {
-            match crate::config_file::load_toml(&p) {
-                Some(l) => loaded(l.warnings, l.settings, p),
-                None => {
-                    eprintln!("raven check: failed to load {}", p.display());
-                    Err(EXIT_OPERATOR_ERROR)
-                }
-            }
+    // Discovery (raven.toml beats .lintr) and loading are shared with the LSP
+    // server via `config_file::discover_and_load`, so the CLI and editor can't
+    // drift on discovery precedence or which loader reads `.lintr`.
+    match crate::config_file::discover_and_load(search_start) {
+        crate::config_file::DiscoveredLoad::Loaded {
+            path,
+            settings,
+            warnings,
+        } => loaded(warnings, settings, path),
+        crate::config_file::DiscoveredLoad::LoadFailed { path } => {
+            eprintln!("raven check: failed to load {}", path.display());
+            Err(EXIT_OPERATOR_ERROR)
         }
-        crate::config_file::DiscoveredConfig::Lintr(p) => match std::fs::read_to_string(&p) {
-            Ok(text) => {
-                let l = crate::config_file::load_lintr_str(&text);
-                loaded(l.warnings, l.settings, p)
-            }
-            Err(e) => {
-                eprintln!("raven check: cannot read {}: {e}", p.display());
-                Err(EXIT_OPERATOR_ERROR)
-            }
-        },
-        crate::config_file::DiscoveredConfig::None => Ok((None, None)),
+        crate::config_file::DiscoveredLoad::None => Ok((None, None)),
     }
 }
 
-/// Auto-detect R and initialize the package library so installed-package
-/// exports and base R symbols are available. Routes through the shared
-/// [`crate::package_library::build_package_library`] helper, which is the
-/// single source of the readiness predicate and degradation classification, so
-/// this CLI path and the editor's startup paths can't drift. It honors the
-/// same `raven.toml` package settings the editor does:
-/// - `packages.enabled` gates the whole thing — when `false`, the helper
-///   returns `Disabled` *before* any R discovery, so this leaves the default
-///   empty library and `package_library_ready = false` and a user who disabled
-///   package awareness in their editor doesn't get package diagnostics in CI.
-/// - `packages.rPath` selects the R binary.
-/// - `packages.additionalLibraryPaths` augments the discovered search paths
-///   (applied after R discovery, so configured paths never suppress R-reported
-///   ones and count toward readiness).
+/// Auto-detect R and store the resulting package library on `state`, so
+/// installed-package exports and base R symbols are available.
 ///
-/// On `Ready` the library and `package_library_ready = true` are stored on
-/// `state`. Every other status leaves the default empty library in place. There
-/// are **three** R-related degradation notes printed to stderr (R absent, init
-/// error, no library paths) so the message reflects what actually happened;
-/// `Disabled` is a degradation path that prints **nothing**.
+/// The shared construction and classification rules — the `packages.enabled`
+/// gate *before* any R discovery, `packages.rPath` selection, applying
+/// `packages.additionalLibraryPaths` *after* discovery, and the readiness
+/// predicate — all live in [`crate::package_library::build_package_library`];
+/// see its doc comment for that contract. Routing through it is what keeps this
+/// CLI path and the editor's startup paths from drifting.
+///
+/// This function owns only the *caller policy*: on `Ready` it installs the
+/// library and sets `package_library_ready = true`; every other status leaves
+/// the default empty library in place (`ready` stays false). The three
+/// R-related degradations each print a one-line note to stderr so CI shows what
+/// was missing; `Disabled` (the user turned package awareness off in
+/// `raven.toml`) is silent, matching the editor.
 async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
     // Snapshot config into locals before the call so the later `state`
     // mutation doesn't conflict with the borrow.
@@ -386,12 +401,9 @@ async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
     )
     .await;
 
-    // The shared helper gates on `packages.enabled` *before* any R discovery
-    // (returning `Disabled`), applies `additionalLibraryPaths` after discovery,
-    // and computes readiness from non-empty `lib_paths()` — exactly as the
-    // editor's `backend::rebuild_package_library` does, so the two init paths
-    // can't drift. Each status surfaces its own way; only the R-related
-    // degradations print a note, and `Disabled` is silent.
+    // Caller policy (see the doc comment): install only on `Ready`; otherwise
+    // keep the default empty library, printing a note for the R-related
+    // degradations and staying silent on `Disabled`.
     use crate::package_library::PackageLibraryStatus::*;
     match outcome.status {
         Ready => {
@@ -412,6 +424,44 @@ async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
         NoLibraryPaths => eprintln!(
             "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
         ),
+    }
+}
+
+/// Warm the package-export cache for the packages the reported files attach,
+/// matching the editor's post-scan prefetch
+/// ([`crate::backend::prefetch_packages_for_open_documents`]).
+///
+/// The undefined-variable check is synchronous and treats an installed-but-
+/// uncached package as "pending", suppressing bare calls that could resolve to
+/// it (`handlers.rs`). Without this warm-up `raven check` would under-report
+/// undefined symbols from attached packages relative to the editor whenever R
+/// (or a configured library path) makes the package installed-but-uncached.
+///
+/// Covers the directly-attached packages (`library()` / `require()`) of each
+/// reported file, read from the already-parsed workspace index. Cross-file
+/// *inherited* packages (attached in a `source()`d file) and packages of
+/// targets the scan did not index are not prefetched here, so calls relying on
+/// those stay conservatively suppressed — a narrower gap than before, noted in
+/// `docs/cli.md`. No-op when the library isn't ready (e.g. R absent with no
+/// configured library paths).
+async fn prefetch_reported_packages(state: &crate::state::WorldState, targets: &[PathBuf]) {
+    if !state.package_library_ready {
+        return;
+    }
+    let mut packages: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for path in targets {
+        if let Ok(uri) = Url::from_file_path(path) {
+            if let Some(doc) = state.workspace_index.get(&uri) {
+                packages.extend(doc.loaded_packages.iter().cloned());
+            }
+        }
+    }
+    let packages: Vec<String> = packages
+        .into_iter()
+        .filter(|p| crate::r_subprocess::is_valid_package_name(p))
+        .collect();
+    if !packages.is_empty() {
+        state.package_library.prefetch_packages(&packages).await;
     }
 }
 
@@ -645,6 +695,89 @@ mod tests {
         // Unbalanced paren — a hard syntax error, always reported at ERROR.
         fs::write(tmp.path().join("broken.R"), "f <- function( {\n").unwrap();
         assert_eq!(run_blocking(base_args(tmp.path())), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn reports_undefined_symbol_from_attached_package() {
+        // Regression (#8): editor/CI parity. When an installed package is
+        // attached (`library(pkg)`), the editor prefetches its exports so a
+        // bare call that ISN'T an export is flagged undefined. `raven check`
+        // must do the same; without warming the cache the package reads as
+        // "pending" and the call is suppressed, so the build would silently
+        // pass over a real undefined symbol the editor flags.
+        //
+        // R-free: a fake installed package (a NAMESPACE with no exportPattern)
+        // is parsed statically, and `additionalLibraryPaths` makes the library
+        // `Ready` without R.
+        let workspace = TempDir::new().unwrap();
+        let libdir = TempDir::new().unwrap();
+        let pkgdir = libdir.path().join("fakepkg");
+        fs::create_dir_all(&pkgdir).unwrap();
+        fs::write(
+            pkgdir.join("DESCRIPTION"),
+            "Package: fakepkg\nVersion: 1.0\n",
+        )
+        .unwrap();
+        // Exports exactly one symbol; `fakepkg_missing` is deliberately absent.
+        fs::write(pkgdir.join("NAMESPACE"), "export(real_export)\n").unwrap();
+        fs::write(
+            workspace.path().join("raven.toml"),
+            format!(
+                "[packages]\nadditionalLibraryPaths = [\"{}\"]\n",
+                libdir.path().display()
+            ),
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("main.R"),
+            "library(fakepkg)\nfakepkg_missing()\n",
+        )
+        .unwrap();
+
+        let args = CheckArgs {
+            paths: Vec::new(),
+            workspace: Some(workspace.path().to_path_buf()),
+            config_path: None,
+            no_config: false,
+            format: OutputFormat::Json,
+            max_severity: SeverityLevel::Info,
+            quiet: true,
+            no_color: true,
+        };
+        assert_eq!(run_blocking(args), EXIT_LINT_FAILED);
+    }
+
+    #[test]
+    fn nonindexed_explicit_file_uses_disk_fallback() {
+        // Regression (#3): the report loop reuses the workspace index's parsed
+        // Document when present, but a target the scan didn't index — here an
+        // explicit file outside the (empty) workspace root — must still be read
+        // from disk and reported. A syntax error proves the fallback branch ran.
+        let workspace = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let broken = outside.path().join("broken.R");
+        fs::write(&broken, "g <- function( {\n").unwrap();
+        let mut args = base_args(workspace.path());
+        args.paths = vec![broken];
+        assert_eq!(run_blocking(args), EXIT_LINT_FAILED);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_dir_file_is_reported() {
+        // Regression (#1): a .R file reachable only through a symlinked
+        // directory must have its diagnostics reported, not silently skipped.
+        // Before the fix, the report walk skipped the symlink while the
+        // indexer followed it, so `raven check` exited clean over a real
+        // syntax error the editor would flag.
+        let workspace = TempDir::new().unwrap();
+        let external = TempDir::new().unwrap();
+        // A hard syntax error lives in a directory OUTSIDE the workspace root,
+        // reachable only via a symlink inside the workspace.
+        fs::write(external.path().join("broken.R"), "f <- function( {\n").unwrap();
+        std::os::unix::fs::symlink(external.path(), workspace.path().join("linked")).unwrap();
+
+        assert_eq!(run_blocking(base_args(workspace.path())), EXIT_LINT_FAILED);
     }
 
     #[test]

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -341,17 +341,34 @@ fn resolve_project_config(
 
 /// Auto-detect R and initialize the package library so installed-package
 /// exports and base R symbols are available. Honors the same `raven.toml`
-/// package settings the editor does — `packages.rPath`
-/// (`cross_file_config.packages_r_path`) selects the R binary, and
-/// `packages.additionalLibraryPaths`
-/// (`cross_file_config.packages_additional_library_paths`) augments the
-/// discovered search paths — applying them exactly as
+/// package settings the editor does, applying them exactly as
 /// [`crate::backend::rebuild_package_library`] does so the two init paths can't
-/// drift. On success the library and `package_library_ready = true` are stored
-/// on `state`. Every degradation path (R absent, init error, no library paths)
-/// leaves the default empty library in place and prints a specific one-line note
-/// to stderr so the message reflects what actually happened.
+/// drift:
+/// - `packages.enabled` (`cross_file_config.packages_enabled`) gates the whole
+///   thing — when `false`, this returns immediately (before any R discovery),
+///   leaving the default empty library and `package_library_ready = false`, so
+///   a user who disabled package awareness in their editor doesn't get package
+///   diagnostics in CI.
+/// - `packages.rPath` (`cross_file_config.packages_r_path`) selects the R binary.
+/// - `packages.additionalLibraryPaths`
+///   (`cross_file_config.packages_additional_library_paths`) augments the
+///   discovered search paths.
+///
+/// On success the library and `package_library_ready = true` are stored on
+/// `state`. Every degradation path (packages disabled, R absent, init error, no
+/// library paths) leaves the default empty library in place; the R-related ones
+/// print a specific one-line note to stderr so the message reflects what
+/// actually happened.
 async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
+    // Gate on `packages.enabled` *before* any R discovery, exactly as
+    // `rebuild_package_library` does. A user who disabled package awareness in
+    // their editor must not get package / base-symbol diagnostics in CI; the
+    // default empty library stays in place and `package_library_ready` stays
+    // false.
+    if !state.cross_file_config.packages_enabled {
+        return;
+    }
+
     let r_path = state.cross_file_config.packages_r_path.clone();
     let additional_paths = state
         .cross_file_config
@@ -672,6 +689,35 @@ mod tests {
                 .iter()
                 .any(|p| p == extra_lib.path()),
             "check must honor packages.additionalLibraryPaths; got {:?}",
+            state.package_library.lib_paths()
+        );
+    }
+
+    /// Regression: `raven check` must honor `packages.enabled = false`,
+    /// matching the language server's `backend::rebuild_package_library`, which
+    /// returns an empty library without spawning R when packages are disabled.
+    /// With the gate, even a configured additional library path is left
+    /// unapplied and the library stays not-ready — so a user who disabled
+    /// package awareness in their editor doesn't get package diagnostics in CI.
+    /// R-independent: the gate short-circuits before R discovery.
+    #[tokio::test]
+    async fn maybe_init_r_skips_when_packages_disabled() {
+        let workspace = TempDir::new().unwrap();
+        let extra_lib = TempDir::new().unwrap();
+        let mut state = crate::state::WorldState::new(vec![]);
+        state.cross_file_config.packages_enabled = false;
+        state.cross_file_config.packages_additional_library_paths =
+            vec![extra_lib.path().to_path_buf()];
+
+        maybe_init_r(&mut state, workspace.path()).await;
+
+        assert!(
+            !state.package_library_ready,
+            "packages.enabled = false must leave the library not-ready"
+        );
+        assert!(
+            state.package_library.lib_paths().is_empty(),
+            "packages.enabled = false must not populate library paths; got {:?}",
             state.package_library.lib_paths()
         );
     }

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -3,14 +3,12 @@
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
+use tower_lsp::lsp_types::Diagnostic;
 
-/// Exit codes are returned as plain `i32` so `main()` can pass them directly
-/// to `std::process::exit`. Avoids the `ExitCode` cast trap (`ExitCode` is not
-/// a primitive and cannot be cast with `as`).
-pub const EXIT_OK: i32 = 0;
-pub const EXIT_LINT_FAILED: i32 = 1;
-pub const EXIT_OPERATOR_ERROR: i32 = 2;
+use crate::cli::shared::{
+    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, print_json, print_sarif,
+    print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct LintArgs {
@@ -21,34 +19,6 @@ pub struct LintArgs {
     pub max_severity: SeverityLevel,
     pub quiet: bool,
     pub no_color: bool,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum OutputFormat {
-    Text,
-    Json,
-    Sarif,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Eq, Ord)]
-pub enum SeverityLevel {
-    Off,
-    Hint,
-    Info,
-    Warning,
-    Error,
-}
-
-impl SeverityLevel {
-    fn from_diag(d: &Diagnostic) -> Self {
-        match d.severity {
-            Some(DiagnosticSeverity::ERROR) => SeverityLevel::Error,
-            Some(DiagnosticSeverity::WARNING) => SeverityLevel::Warning,
-            Some(DiagnosticSeverity::INFORMATION) => SeverityLevel::Info,
-            Some(DiagnosticSeverity::HINT) => SeverityLevel::Hint,
-            _ => SeverityLevel::Off,
-        }
-    }
 }
 
 pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, String> {
@@ -68,23 +38,11 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, St
             "--no-config" => no_config = true,
             "--format" => {
                 let v = argv.next().ok_or("--format needs a value")?;
-                format = match v.as_str() {
-                    "text" => OutputFormat::Text,
-                    "json" => OutputFormat::Json,
-                    "sarif" => OutputFormat::Sarif,
-                    other => return Err(format!("unknown --format value: {other}")),
-                };
+                format = parse_output_format(&v)?;
             }
             "--max-severity" => {
                 let v = argv.next().ok_or("--max-severity needs a value")?;
-                max_severity = match v.as_str() {
-                    "off" => SeverityLevel::Off,
-                    "hint" => SeverityLevel::Hint,
-                    "info" => SeverityLevel::Info,
-                    "warning" => SeverityLevel::Warning,
-                    "error" => SeverityLevel::Error,
-                    other => return Err(format!("unknown --max-severity value: {other}")),
-                };
+                max_severity = parse_severity_level(&v)?;
             }
             "--quiet" => quiet = true,
             "--no-color" => no_color = true,
@@ -240,7 +198,7 @@ pub fn run(args: LintArgs) -> i32 {
         .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
 
     match args.format {
-        OutputFormat::Text => print_text(&diagnostics, &args, &root),
+        OutputFormat::Text => print_text(&diagnostics, &root, args.quiet),
         OutputFormat::Json => print_json(&diagnostics, &root),
         OutputFormat::Sarif => print_sarif(&diagnostics, &root),
     }
@@ -348,151 +306,6 @@ fn walk(
         eprintln!("raven lint: path does not exist: {}", path.display());
         *operator_error = true;
     }
-}
-
-fn is_r_file(p: &Path) -> bool {
-    matches!(p.extension().and_then(|s| s.to_str()), Some("R") | Some("r"))
-}
-
-fn is_chunk_file(p: &Path) -> bool {
-    matches!(
-        p.extension().and_then(|s| s.to_str()),
-        Some("Rmd") | Some("rmd") | Some("RMD") | Some("qmd") | Some("Qmd") | Some("QMD")
-    )
-}
-
-fn print_text(diags: &[(PathBuf, Diagnostic)], args: &LintArgs, root: &Path) {
-    let mut errors = 0;
-    let mut warnings = 0;
-    let mut infos = 0;
-    let mut hints = 0;
-    let mut notes = 0;
-    for (path, d) in diags {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let level = match d.severity {
-            Some(DiagnosticSeverity::ERROR) => {
-                errors += 1;
-                "error"
-            }
-            Some(DiagnosticSeverity::WARNING) => {
-                warnings += 1;
-                "warning"
-            }
-            Some(DiagnosticSeverity::INFORMATION) => {
-                infos += 1;
-                "info"
-            }
-            Some(DiagnosticSeverity::HINT) => {
-                hints += 1;
-                "hint"
-            }
-            _ => {
-                notes += 1;
-                "note"
-            }
-        };
-        let line = d.range.start.line + 1;
-        let col = d.range.start.character + 1;
-        let rule = match &d.code {
-            Some(NumberOrString::String(s)) => s.as_str(),
-            _ => "",
-        };
-        println!(
-            "{}:{}:{} {}: {} [{}]",
-            rel.display(),
-            line,
-            col,
-            level,
-            d.message,
-            rule
-        );
-    }
-    if !args.quiet {
-        // Buckets sum to diags.len(): errors + warnings + infos + hints
-        // + notes (severity-less / unrecognized). Per-bucket reporting
-        // keeps INFORMATION distinct from WARNING in summaries — SARIF
-        // collapses them onto "note" by spec, but the human-readable
-        // CLI output should reflect the original LSP severity.
-        println!(
-            "{} issues ({} errors, {} warnings, {} infos, {} hints, {} notes)",
-            diags.len(),
-            errors,
-            warnings,
-            infos,
-            hints,
-            notes
-        );
-    }
-}
-
-fn print_json(diags: &[(PathBuf, Diagnostic)], root: &Path) {
-    let arr: Vec<_> = diags
-        .iter()
-        .map(|(p, d)| {
-            let rel = p.strip_prefix(root).unwrap_or(p);
-            json!({ "path": rel.display().to_string(), "diagnostic": d })
-        })
-        .collect();
-    println!("{}", serde_json::to_string_pretty(&json!(arr)).unwrap());
-}
-
-fn print_sarif(diags: &[(PathBuf, Diagnostic)], root: &Path) {
-    use std::collections::BTreeSet;
-    let rule_ids: BTreeSet<String> = diags
-        .iter()
-        .filter_map(|(_, d)| match &d.code {
-            Some(NumberOrString::String(s)) => Some(s.clone()),
-            _ => None,
-        })
-        .collect();
-    let rules: Vec<_> = rule_ids
-        .iter()
-        .map(|id| {
-            json!({
-                "id": id, "name": id, "shortDescription": { "text": id }
-            })
-        })
-        .collect();
-    let results: Vec<_> = diags
-        .iter()
-        .map(|(p, d)| {
-            let rel = p.strip_prefix(root).unwrap_or(p);
-            let level = match d.severity {
-                Some(DiagnosticSeverity::ERROR) => "error",
-                Some(DiagnosticSeverity::WARNING) => "warning",
-                _ => "note",
-            };
-            let rule_id = match &d.code {
-                Some(NumberOrString::String(s)) => s.clone(),
-                _ => String::new(),
-            };
-            json!({
-                "ruleId": rule_id,
-                "level": level,
-                "message": { "text": d.message },
-                "locations": [{
-                    "physicalLocation": {
-                        "artifactLocation": { "uri": rel.display().to_string() },
-                        "region": {
-                            "startLine": d.range.start.line + 1,
-                            "startColumn": d.range.start.character + 1,
-                            "endLine": d.range.end.line + 1,
-                            "endColumn": d.range.end.character + 1,
-                        }
-                    }
-                }]
-            })
-        })
-        .collect();
-    let sarif = json!({
-        "version": "2.1.0",
-        "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json",
-        "runs": [{
-            "tool": { "driver": { "name": "raven", "rules": rules } },
-            "results": results
-        }]
-    });
-    println!("{}", serde_json::to_string_pretty(&sarif).unwrap());
 }
 
 #[cfg(test)]

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -137,11 +137,18 @@ fn resolve_lint_config(
                 // every per-file `[[linting.overrides]]` patch (same failure
                 // mode as commit 81978f0 fixed for the non-explicit root).
                 let parent = explicit.parent().unwrap_or(cwd).to_path_buf();
-                let root = if parent.is_absolute() {
+                let absolute = if parent.is_absolute() {
                     parent
                 } else {
                     cwd.join(&parent)
                 };
+                // Then normalize away `.`/`..`: `strip_prefix(root)` is purely
+                // lexical, so a `..` left in `root` (e.g. `--config
+                // ../pkg/raven.toml`) wouldn't prefix-match a file given by its
+                // absolute path under that config root, again silently dropping
+                // its overrides. Normalize lexically (not via `canonicalize`) so
+                // a non-existent root still resolves predictably.
+                let root = crate::cross_file::normalize_path_public(&absolute).unwrap_or(absolute);
                 Ok((root, Some(l.settings), false))
             }
             None => {
@@ -431,6 +438,36 @@ mod tests {
             resolve_lint_config(tmp.path(), &discovery_args()),
             Err(EXIT_OPERATOR_ERROR)
         );
+    }
+
+    #[test]
+    fn resolve_lint_config_normalizes_explicit_config_root() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::create_dir(tmp.path().join("pkg")).unwrap();
+        fs::write(tmp.path().join("pkg/raven.toml"), "[linting]\nenabled = true\n").unwrap();
+
+        // An absolute --config that routes through `sub/..`: the `..` must not
+        // survive into `root`, or the purely lexical `strip_prefix(root)` in
+        // `resolve_lint_for_document` would drop every override for a file given
+        // by its (normalized) absolute path under the pkg root.
+        let dotted = tmp.path().join("sub").join("..").join("pkg").join("raven.toml");
+        let mut args = discovery_args();
+        args.config_path = Some(dotted);
+
+        let (root, _settings, lintr_discovered) =
+            resolve_lint_config(tmp.path(), &args).unwrap();
+        assert!(!lintr_discovered);
+        assert!(
+            !root.components().any(|c| matches!(
+                c,
+                std::path::Component::ParentDir | std::path::Component::CurDir
+            )),
+            "root still carries . / .. components: {root:?}"
+        );
+        assert!(root.ends_with("pkg"), "expected the pkg dir as root, got {root:?}");
     }
 
     #[test]

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -92,6 +92,86 @@ Exit codes:
     );
 }
 
+/// Resolve the project root, project settings, and lintr-discovered signal for
+/// `raven lint`. Factored out of [`run`] and parameterized on `cwd` so the
+/// discover-and-load branch is unit-testable without mutating the
+/// process-global current directory.
+///
+/// Precedence matches the editor: `--no-config` wins, then an explicit
+/// `--config` (raven.toml only — see the tri-state-enabled design spec,
+/// section 7), then auto-discovery via the shared
+/// [`crate::config_file::discover_and_load`] seam. Routing `raven lint` through
+/// that seam — the same one the LSP startup path, the watched-files reload, and
+/// `raven check` use — keeps the four from drifting on discovery precedence or
+/// which loader reads `.lintr`.
+///
+/// `lintr_discovered` is the input to `Auto` resolution in
+/// [`crate::backend::parse_lint_config`]: true only when a `.lintr` (not a
+/// `raven.toml`) is the discovered config. [`crate::config_file::find_config`]
+/// names the discovered file `.lintr` or `raven.toml`, so its file name is a
+/// reliable toml-vs-lintr discriminator — the same derivation
+/// `build_project_config_loaded_payload` uses for its notification payload.
+///
+/// Warnings go to stderr. Returns `Err(EXIT_OPERATOR_ERROR)` for an
+/// unreadable/unparseable config (the explicit `--config` and discovery paths
+/// print a one-line note first); `Ok((root, project_settings, lintr_discovered))`
+/// otherwise.
+fn resolve_lint_config(
+    cwd: &Path,
+    args: &LintArgs,
+) -> Result<(PathBuf, Option<serde_json::Value>, bool), i32> {
+    if args.no_config {
+        return Ok((cwd.to_path_buf(), None, false));
+    }
+
+    if let Some(explicit) = args.config_path.as_ref() {
+        return match crate::config_file::load_toml(explicit) {
+            Some(l) => {
+                for w in l.warnings {
+                    eprintln!("{w}");
+                }
+                // Resolve the parent so `root` is absolute even when `--config`
+                // points at a relative path. Without this,
+                // `resolve_lint_for_document`'s `strip_prefix(root)` check fails
+                // for the absolute URIs produced by `walk` — silently dropping
+                // every per-file `[[linting.overrides]]` patch (same failure
+                // mode as commit 81978f0 fixed for the non-explicit root).
+                let parent = explicit.parent().unwrap_or(cwd).to_path_buf();
+                let root = if parent.is_absolute() {
+                    parent
+                } else {
+                    cwd.join(&parent)
+                };
+                Ok((root, Some(l.settings), false))
+            }
+            None => {
+                eprintln!("raven lint: failed to load --config {}", explicit.display());
+                Err(EXIT_OPERATOR_ERROR)
+            }
+        };
+    }
+
+    match crate::config_file::discover_and_load(cwd) {
+        crate::config_file::DiscoveredLoad::Loaded {
+            path,
+            settings,
+            warnings,
+        } => {
+            for w in warnings {
+                eprintln!("{w}");
+            }
+            let lintr_discovered = path.file_name() == Some(std::ffi::OsStr::new(".lintr"));
+            let root = path.parent().unwrap_or(cwd).to_path_buf();
+            Ok((root, Some(settings), lintr_discovered))
+        }
+        crate::config_file::DiscoveredLoad::LoadFailed { path } => {
+            eprintln!("raven lint: failed to load {}", path.display());
+            Err(EXIT_OPERATOR_ERROR)
+        }
+        crate::config_file::DiscoveredLoad::None => Ok((cwd.to_path_buf(), None, false)),
+    }
+}
+
 pub fn run(args: LintArgs) -> i32 {
     let cwd = match std::env::current_dir() {
         Ok(p) => p,
@@ -102,68 +182,9 @@ pub fn run(args: LintArgs) -> i32 {
     };
 
     // Resolve project root + project settings + lintr-discovered signal.
-    // `lintr_discovered` is the input to `Auto` resolution in
-    // `parse_lint_config`. `--config` is currently raven.toml-only — see
-    // the design spec for tri-state enabled, section 7.
-    let (root, project_settings, lintr_discovered) = if args.no_config {
-        (cwd.clone(), None, false)
-    } else if let Some(explicit) = args.config_path.as_ref() {
-        match crate::config_file::load_toml(explicit) {
-            Some(l) => {
-                for w in l.warnings {
-                    eprintln!("{w}");
-                }
-                // Canonicalize the parent so `root` is absolute even when
-                // `--config` points at a relative path. Without this,
-                // `resolve_lint_for_document`'s `strip_prefix(root)`
-                // check fails for the absolute URIs produced by `walk`
-                // — silently dropping every per-file
-                // `[[linting.overrides]]` patch (same failure mode as
-                // commit 81978f0 fixed for the non-explicit root).
-                let parent = explicit.parent().unwrap_or(&cwd).to_path_buf();
-                let root = if parent.is_absolute() {
-                    parent
-                } else {
-                    cwd.join(&parent)
-                };
-                (root, Some(l.settings), false)
-            }
-            None => {
-                eprintln!(
-                    "raven lint: failed to load --config {}",
-                    explicit.display()
-                );
-                return EXIT_OPERATOR_ERROR;
-            }
-        }
-    } else {
-        match crate::config_file::find_config(&cwd) {
-            crate::config_file::DiscoveredConfig::RavenToml(p) => {
-                let l = match crate::config_file::load_toml(&p) {
-                    Some(v) => v,
-                    None => return EXIT_OPERATOR_ERROR,
-                };
-                for w in l.warnings {
-                    eprintln!("{w}");
-                }
-                (p.parent().unwrap_or(&cwd).to_path_buf(), Some(l.settings), false)
-            }
-            crate::config_file::DiscoveredConfig::Lintr(p) => {
-                let text = match std::fs::read_to_string(&p) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        eprintln!("raven lint: cannot read {}: {e}", p.display());
-                        return EXIT_OPERATOR_ERROR;
-                    }
-                };
-                let l = crate::config_file::load_lintr_str(&text);
-                for w in l.warnings {
-                    eprintln!("{w}");
-                }
-                (p.parent().unwrap_or(&cwd).to_path_buf(), Some(l.settings), true)
-            }
-            crate::config_file::DiscoveredConfig::None => (cwd.clone(), None, false),
-        }
+    let (root, project_settings, lintr_discovered) = match resolve_lint_config(&cwd, &args) {
+        Ok(v) => v,
+        Err(code) => return code,
     };
 
     // Parse the base lint config from the (project-only) settings, since the
@@ -337,6 +358,79 @@ mod tests {
     #[test]
     fn unknown_flag_errors() {
         assert!(parse_args(["--bogus"].iter().map(|s| s.to_string())).is_err());
+    }
+
+    /// Args that route `resolve_lint_config` through the discover-and-load
+    /// branch (no `--no-config`, no explicit `--config`).
+    fn discovery_args() -> LintArgs {
+        LintArgs {
+            paths: vec![PathBuf::from(".")],
+            config_path: None,
+            no_config: false,
+            format: OutputFormat::Text,
+            max_severity: SeverityLevel::Info,
+            quiet: true,
+            no_color: true,
+        }
+    }
+
+    #[test]
+    fn resolve_lint_config_honors_discovered_lintr() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".lintr"),
+            "linters: linters_with_defaults()\n",
+        )
+        .unwrap();
+        let (root, settings, lintr_discovered) =
+            resolve_lint_config(tmp.path(), &discovery_args()).unwrap();
+        assert_eq!(root, tmp.path().to_path_buf());
+        assert!(settings.is_some(), "a discovered .lintr yields project settings");
+        assert!(
+            lintr_discovered,
+            "a discovered .lintr must set lintr_discovered so Auto resolution opts in"
+        );
+    }
+
+    #[test]
+    fn resolve_lint_config_honors_discovered_raven_toml() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("raven.toml"), "[linting]\nenabled = true\n").unwrap();
+        let (root, settings, lintr_discovered) =
+            resolve_lint_config(tmp.path(), &discovery_args()).unwrap();
+        assert_eq!(root, tmp.path().to_path_buf());
+        assert!(settings.is_some(), "a discovered raven.toml yields project settings");
+        assert!(
+            !lintr_discovered,
+            "raven.toml is not a .lintr, so lintr_discovered must stay false"
+        );
+    }
+
+    #[test]
+    fn resolve_lint_config_none_when_no_config_present() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let (root, settings, lintr_discovered) =
+            resolve_lint_config(tmp.path(), &discovery_args()).unwrap();
+        assert_eq!(root, tmp.path().to_path_buf());
+        assert!(settings.is_none());
+        assert!(!lintr_discovered);
+    }
+
+    #[test]
+    fn resolve_lint_config_errors_on_malformed_raven_toml() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("raven.toml"), "not valid = = toml [[[\n").unwrap();
+        assert_eq!(
+            resolve_lint_config(tmp.path(), &discovery_args()),
+            Err(EXIT_OPERATOR_ERROR)
+        );
     }
 
     #[test]

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -6,8 +6,8 @@ use serde_json::json;
 use tower_lsp::lsp_types::Diagnostic;
 
 use crate::cli::shared::{
-    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, print_json, print_sarif,
-    print_text, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, render, OutputFormat,
+    SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -197,11 +197,7 @@ pub fn run(args: LintArgs) -> i32 {
         .iter()
         .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
 
-    match args.format {
-        OutputFormat::Text => print_text(&diagnostics, &root, args.quiet),
-        OutputFormat::Json => print_json(&diagnostics, &root),
-        OutputFormat::Sarif => print_sarif(&diagnostics, &root),
-    }
+    render(args.format, &diagnostics, &root, args.quiet);
 
     if any_above_threshold {
         EXIT_LINT_FAILED

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -6,8 +6,8 @@ use serde_json::json;
 use tower_lsp::lsp_types::Diagnostic;
 
 use crate::cli::shared::{
-    is_chunk_file, is_r_file, parse_output_format, parse_severity_level, render, OutputFormat,
-    SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    absolute_path, is_chunk_file, is_r_file, parse_output_format, parse_severity_level, render,
+    OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -239,11 +239,7 @@ fn walk(
         // `resolve_lint_for_document`'s `strip_prefix(root)` check
         // silently drops every per-file `[[linting.overrides]]` patch.
         // Canonicalize against `root` to preserve file identity.
-        let abs_path = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            root.join(path)
-        };
+        let abs_path = absolute_path(root, path);
         let uri = tower_lsp::lsp_types::Url::from_file_path(&abs_path)
             .unwrap_or_else(|_| tower_lsp::lsp_types::Url::parse("file:///").unwrap());
         let effective = crate::config_file::resolve_lint_for_document(

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -471,6 +471,70 @@ mod tests {
     }
 
     #[test]
+    fn walk_resolves_overrides_for_dotdot_paths_like_clean_paths() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("R")).unwrap();
+        // A line well over 20 chars, so the base config flags it...
+        fs::write(
+            root.join("R").join("foo.R"),
+            "x <- 'this line is intentionally way more than twenty characters wide'\n",
+        )
+        .unwrap();
+        // ...but an `enabled = false` override for `R/*.R` skips the file
+        // entirely. This exercises the `is_skipped_by_overrides` path, which
+        // (unlike `resolve_lint_for_document`) does NOT round-trip through a URL
+        // — so it sees the raw path and is the one that breaks on `..`.
+        let settings = serde_json::json!({
+            "linting": {
+                "enabled": true,
+                "lineLength": 20,
+                "lineLengthSeverity": "warning",
+                "overrides": [ { "files": ["R/*.R"], "enabled": false } ]
+            }
+        });
+        let base_lint = crate::backend::parse_lint_config(&settings, false).unwrap();
+        let base_section = settings.get("linting").cloned().unwrap();
+        let overrides = crate::config_file::compile_lint_overrides(&settings, root);
+
+        let run = |p: &Path| {
+            let mut diags = Vec::new();
+            let mut operator_error = false;
+            walk(
+                p,
+                root,
+                &base_section,
+                &base_lint,
+                &overrides,
+                &mut diags,
+                &mut operator_error,
+            );
+            assert!(!operator_error, "unexpected operator error for {p:?}");
+            diags.len()
+        };
+
+        // Characterization guard: a file referenced via a `..`-laden absolute
+        // path must resolve `[[linting.overrides]]` exactly as the clean path
+        // does. This already holds because `Url::from_file_path` performs
+        // RFC-3986 dot-segment removal, so `resolve_lint_for_document` (the
+        // authoritative override application) sees a normalized path and the
+        // `R/*.R` glob still matches. (`is_skipped_by_overrides` does see the
+        // raw `R/../R/foo.R` and miss, but that's only a pre-parse skip
+        // optimization — `run_lints` returns nothing for the disabled override
+        // either way, so the diagnostics are identical.) Locks the behavior in
+        // so a future change to the URI construction can't silently regress it.
+        let clean = root.join("R").join("foo.R");
+        let dotted = root.join("R").join("..").join("R").join("foo.R");
+        assert_eq!(
+            run(&dotted),
+            run(&clean),
+            "a `..`-laden path must resolve overrides the same as the clean path"
+        );
+    }
+
+    #[test]
     fn end_to_end_finds_line_length_violation() {
         use std::fs;
         use tempfile::TempDir;

--- a/crates/raven/src/cli/mod.rs
+++ b/crates/raven/src/cli/mod.rs
@@ -1,6 +1,10 @@
 // cli/mod.rs — CLI subcommands for Raven
 //
-// This module contains non-LSP CLI commands like `analysis-stats`.
+// This module contains non-LSP CLI commands like `analysis-stats`, `lint`, and
+// `check`. `shared` holds the output formatting + severity gating both `lint`
+// and `check` render with.
 
 pub mod analysis_stats;
+pub mod check;
 pub mod lint;
+pub mod shared;

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -80,6 +80,16 @@ pub fn is_chunk_file(p: &Path) -> bool {
     )
 }
 
+/// Return `path` unchanged when already absolute; otherwise resolve it against
+/// `base`.
+pub fn absolute_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
 /// Recursively collect `.R` / `.r` file paths under `dir`. Symlinks (files and
 /// directories) are skipped to avoid cycles and double-counting, and the
 /// non-source directories listed in [`crate::state::should_skip_directory`]
@@ -100,10 +110,11 @@ pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
             continue;
         }
         if p.is_dir() {
-            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
-                if crate::state::should_skip_directory(name) {
-                    continue;
-                }
+            if p.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(crate::state::should_skip_directory)
+            {
+                continue;
             }
             collect_r_file_paths(&p, out);
         } else if is_r_file(&p) {

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -80,6 +80,38 @@ pub fn is_chunk_file(p: &Path) -> bool {
     )
 }
 
+/// Recursively collect `.R` / `.r` file paths under `dir`. Symlinks (files and
+/// directories) are skipped to avoid cycles and double-counting, and the
+/// non-source directories listed in [`crate::state::should_skip_directory`]
+/// (`.git`, `node_modules`, `renv`, `target`, …) are pruned. Results are
+/// unsorted; callers that need deterministic order sort afterwards.
+///
+/// Shared by `raven check` (which reports diagnostics for the collected files)
+/// and `analysis-stats` (which reads their contents in a second pass). `.r` and
+/// `.R` are the only matched extensions — equivalent to a case-insensitive
+/// match on the single-character extension.
+pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_symlink() {
+            continue;
+        }
+        if p.is_dir() {
+            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                if crate::state::should_skip_directory(name) {
+                    continue;
+                }
+            }
+            collect_r_file_paths(&p, out);
+        } else if is_r_file(&p) {
+            out.push(p);
+        }
+    }
+}
+
 pub fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
     let mut errors = 0;
     let mut warnings = 0;
@@ -281,5 +313,41 @@ mod tests {
         assert!(is_chunk_file(Path::new("a.Rmd")));
         assert!(is_chunk_file(Path::new("a.qmd")));
         assert!(!is_chunk_file(Path::new("a.R")));
+    }
+
+    #[test]
+    fn collect_r_file_paths_walks_and_prunes() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.R"), "1\n").unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::write(tmp.path().join("sub/b.r"), "2\n").unwrap();
+        fs::write(tmp.path().join("c.Rmd"), "prose\n").unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/d.R"), "3\n").unwrap();
+
+        let mut out = Vec::new();
+        collect_r_file_paths(tmp.path(), &mut out);
+        // a.R + sub/b.r; .Rmd is not an R source; .git is pruned.
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|p| is_r_file(p)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_r_file_paths_skips_symlinks() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join("real.R"), "1\n").unwrap();
+        std::os::unix::fs::symlink(tmp.path().join("real.R"), tmp.path().join("link.R")).unwrap();
+        // A symlinked directory must not be followed (cycle / double-count guard).
+        fs::create_dir(tmp.path().join("d")).unwrap();
+        fs::write(tmp.path().join("d/inner.R"), "2\n").unwrap();
+        std::os::unix::fs::symlink(tmp.path().join("d"), tmp.path().join("dlink")).unwrap();
+
+        let mut out = Vec::new();
+        collect_r_file_paths(tmp.path(), &mut out);
+        // real.R and d/inner.R only; the symlinked file and directory are skipped.
+        assert_eq!(out.len(), 2);
     }
 }

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -90,25 +90,49 @@ pub fn absolute_path(base: &Path, path: &Path) -> PathBuf {
     }
 }
 
-/// Recursively collect `.R` / `.r` file paths under `dir`. Symlinks (files and
-/// directories) are skipped to avoid cycles and double-counting, and the
-/// non-source directories listed in [`crate::state::should_skip_directory`]
-/// (`.git`, `node_modules`, `renv`, `target`, …) are pruned. Results are
-/// unsorted; callers that need deterministic order sort afterwards.
+/// Recursively collect `.R` / `.r` file paths under `dir`. Symlinked
+/// directories ARE followed, with canonical-path cycle detection to terminate
+/// on loops and avoid double-counting; the non-source directories listed in
+/// [`crate::state::should_skip_directory`] (`.git`, `node_modules`, `renv`,
+/// `target`, …) are pruned. Results are unsorted; callers that need
+/// deterministic order sort afterwards.
+///
+/// This deliberately mirrors the workspace indexer's walk
+/// (`state.rs::collect_file_paths_inner`): both follow symlinked directories
+/// with a `visited` set of canonical paths and include symlinked files. Keeping
+/// the two walks consistent is what makes `raven check`'s *reported* file set
+/// equal its *indexed* file set — otherwise a `.R` file reachable only through a
+/// symlink (e.g. a monorepo `src -> ../shared` layout) would be indexed for
+/// cross-file resolution yet never have its own diagnostics reported, and CI
+/// would pass over a file the editor flags.
 ///
 /// Shared by `raven check` (which reports diagnostics for the collected files)
 /// and `analysis-stats` (which reads their contents in a second pass). `.r` and
 /// `.R` are the only matched extensions — equivalent to a case-insensitive
 /// match on the single-character extension.
 pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+    let mut visited = std::collections::HashSet::new();
+    // Seed with the canonical root so a symlink pointing back at the root (or
+    // any already-visited directory) is detected as a cycle and skipped.
+    if let Ok(canonical) = std::fs::canonicalize(dir) {
+        visited.insert(canonical);
+    }
+    collect_r_file_paths_inner(dir, out, &mut visited);
+}
+
+fn collect_r_file_paths_inner(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    visited: &mut std::collections::HashSet<PathBuf>,
+) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
         let p = entry.path();
-        if p.is_symlink() {
-            continue;
-        }
+        // `is_dir()` follows symlinks, so a symlink to a directory is walked
+        // (after the cycle check) and a symlink to a file falls through to the
+        // `is_r_file` branch — matching the indexer.
         if p.is_dir() {
             if p.file_name()
                 .and_then(|name| name.to_str())
@@ -116,7 +140,18 @@ pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
             {
                 continue;
             }
-            collect_r_file_paths(&p, out);
+            match std::fs::canonicalize(&p) {
+                Ok(canonical) => {
+                    if !visited.insert(canonical) {
+                        // Already visited (symlink cycle or alias) — skip.
+                        continue;
+                    }
+                }
+                // An unresolvable directory (e.g. broken symlink) can't be
+                // walked; skip it rather than error.
+                Err(_) => continue,
+            }
+            collect_r_file_paths_inner(&p, out, visited);
         } else if is_r_file(&p) {
             out.push(p);
         }
@@ -357,19 +392,35 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn collect_r_file_paths_skips_symlinks() {
+    fn collect_r_file_paths_follows_symlinks_with_cycle_detection() {
         use std::fs;
         let tmp = tempfile::TempDir::new().unwrap();
         fs::write(tmp.path().join("real.R"), "1\n").unwrap();
+        // A symlinked .R file is collected — the workspace indexer
+        // (state.rs collect_file_paths_inner) includes it, so the report set
+        // must too or `raven check` exits clean over a file the editor flags.
         std::os::unix::fs::symlink(tmp.path().join("real.R"), tmp.path().join("link.R")).unwrap();
-        // A symlinked directory must not be followed (cycle / double-count guard).
+        // Files reached only via a symlinked directory MUST be collected — the
+        // monorepo `src -> ../shared` layout this guards against.
         fs::create_dir(tmp.path().join("d")).unwrap();
         fs::write(tmp.path().join("d/inner.R"), "2\n").unwrap();
         std::os::unix::fs::symlink(tmp.path().join("d"), tmp.path().join("dlink")).unwrap();
+        // A self-referential symlink must terminate (cycle guard), not recurse
+        // forever.
+        std::os::unix::fs::symlink(tmp.path(), tmp.path().join("selfloop")).unwrap();
 
         let mut out = Vec::new();
         collect_r_file_paths(tmp.path(), &mut out);
-        // real.R and d/inner.R only; the symlinked file and directory are skipped.
-        assert_eq!(out.len(), 2);
+
+        // real.R + link.R + inner.R: `inner.R` is reached exactly once (the
+        // canonical-path cycle guard prevents visiting both `d` and `dlink`),
+        // and `selfloop` is skipped. Termination itself proves the guard works.
+        assert_eq!(out.len(), 3, "got {out:?}");
+        let canon_inner = fs::canonicalize(tmp.path().join("d/inner.R")).unwrap();
+        assert!(
+            out.iter()
+                .any(|p| fs::canonicalize(p).unwrap() == canon_inner),
+            "the file under the symlinked directory must be collected; got {out:?}"
+        );
     }
 }

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -112,7 +112,18 @@ pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-pub fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
+/// Render diagnostics in the requested format. The single dispatch point both
+/// `lint` and `check` call after collecting their `(path, diagnostic)` pairs,
+/// so the format → renderer mapping lives in one place next to the renderers.
+pub fn render(format: OutputFormat, diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
+    match format {
+        OutputFormat::Text => print_text(diags, root, quiet),
+        OutputFormat::Json => print_json(diags, root),
+        OutputFormat::Sarif => print_sarif(diags, root),
+    }
+}
+
+fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
     let mut errors = 0;
     let mut warnings = 0;
     let mut infos = 0;
@@ -176,7 +187,7 @@ pub fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
     }
 }
 
-pub fn print_json(diags: &[(PathBuf, Diagnostic)], root: &Path) {
+fn print_json(diags: &[(PathBuf, Diagnostic)], root: &Path) {
     let arr: Vec<_> = diags
         .iter()
         .map(|(p, d)| {
@@ -187,7 +198,7 @@ pub fn print_json(diags: &[(PathBuf, Diagnostic)], root: &Path) {
     println!("{}", serde_json::to_string_pretty(&json!(arr)).unwrap());
 }
 
-pub fn print_sarif(diags: &[(PathBuf, Diagnostic)], root: &Path) {
+fn print_sarif(diags: &[(PathBuf, Diagnostic)], root: &Path) {
     use std::collections::BTreeSet;
     let rule_ids: BTreeSet<String> = diags
         .iter()

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -1,0 +1,285 @@
+//! Output formatting, severity gating, and file-type helpers shared by the
+//! `lint` and `check` subcommands.
+//!
+//! Both subcommands accumulate `(PathBuf, Diagnostic)` pairs and render them
+//! identically (`text` / `json` / `sarif`), gate the process exit code on a
+//! `--max-severity` threshold, and agree on which files are R sources versus
+//! chunk-bearing documents. That common surface lives here so the two commands
+//! share one implementation without depending on each other's internals.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
+
+/// Exit codes are returned as plain `i32` so `main()` can pass them directly
+/// to `std::process::exit`. Avoids the `ExitCode` cast trap (`ExitCode` is not
+/// a primitive and cannot be cast with `as`).
+pub const EXIT_OK: i32 = 0;
+pub const EXIT_LINT_FAILED: i32 = 1;
+pub const EXIT_OPERATOR_ERROR: i32 = 2;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum OutputFormat {
+    Text,
+    Json,
+    Sarif,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Eq, Ord)]
+pub enum SeverityLevel {
+    Off,
+    Hint,
+    Info,
+    Warning,
+    Error,
+}
+
+impl SeverityLevel {
+    pub fn from_diag(d: &Diagnostic) -> Self {
+        match d.severity {
+            Some(DiagnosticSeverity::ERROR) => SeverityLevel::Error,
+            Some(DiagnosticSeverity::WARNING) => SeverityLevel::Warning,
+            Some(DiagnosticSeverity::INFORMATION) => SeverityLevel::Info,
+            Some(DiagnosticSeverity::HINT) => SeverityLevel::Hint,
+            _ => SeverityLevel::Off,
+        }
+    }
+}
+
+/// Parse a `--format` value into an [`OutputFormat`].
+pub fn parse_output_format(v: &str) -> Result<OutputFormat, String> {
+    match v {
+        "text" => Ok(OutputFormat::Text),
+        "json" => Ok(OutputFormat::Json),
+        "sarif" => Ok(OutputFormat::Sarif),
+        other => Err(format!("unknown --format value: {other}")),
+    }
+}
+
+/// Parse a `--max-severity` value into a [`SeverityLevel`].
+pub fn parse_severity_level(v: &str) -> Result<SeverityLevel, String> {
+    match v {
+        "off" => Ok(SeverityLevel::Off),
+        "hint" => Ok(SeverityLevel::Hint),
+        "info" => Ok(SeverityLevel::Info),
+        "warning" => Ok(SeverityLevel::Warning),
+        "error" => Ok(SeverityLevel::Error),
+        other => Err(format!("unknown --max-severity value: {other}")),
+    }
+}
+
+pub fn is_r_file(p: &Path) -> bool {
+    matches!(p.extension().and_then(|s| s.to_str()), Some("R") | Some("r"))
+}
+
+pub fn is_chunk_file(p: &Path) -> bool {
+    matches!(
+        p.extension().and_then(|s| s.to_str()),
+        Some("Rmd") | Some("rmd") | Some("RMD") | Some("qmd") | Some("Qmd") | Some("QMD")
+    )
+}
+
+pub fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
+    let mut errors = 0;
+    let mut warnings = 0;
+    let mut infos = 0;
+    let mut hints = 0;
+    let mut notes = 0;
+    for (path, d) in diags {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let level = match d.severity {
+            Some(DiagnosticSeverity::ERROR) => {
+                errors += 1;
+                "error"
+            }
+            Some(DiagnosticSeverity::WARNING) => {
+                warnings += 1;
+                "warning"
+            }
+            Some(DiagnosticSeverity::INFORMATION) => {
+                infos += 1;
+                "info"
+            }
+            Some(DiagnosticSeverity::HINT) => {
+                hints += 1;
+                "hint"
+            }
+            _ => {
+                notes += 1;
+                "note"
+            }
+        };
+        let line = d.range.start.line + 1;
+        let col = d.range.start.character + 1;
+        let rule = match &d.code {
+            Some(NumberOrString::String(s)) => s.as_str(),
+            _ => "",
+        };
+        println!(
+            "{}:{}:{} {}: {} [{}]",
+            rel.display(),
+            line,
+            col,
+            level,
+            d.message,
+            rule
+        );
+    }
+    if !quiet {
+        // Buckets sum to diags.len(): errors + warnings + infos + hints
+        // + notes (severity-less / unrecognized). Per-bucket reporting
+        // keeps INFORMATION distinct from WARNING in summaries — SARIF
+        // collapses them onto "note" by spec, but the human-readable
+        // CLI output should reflect the original LSP severity.
+        println!(
+            "{} issues ({} errors, {} warnings, {} infos, {} hints, {} notes)",
+            diags.len(),
+            errors,
+            warnings,
+            infos,
+            hints,
+            notes
+        );
+    }
+}
+
+pub fn print_json(diags: &[(PathBuf, Diagnostic)], root: &Path) {
+    let arr: Vec<_> = diags
+        .iter()
+        .map(|(p, d)| {
+            let rel = p.strip_prefix(root).unwrap_or(p);
+            json!({ "path": rel.display().to_string(), "diagnostic": d })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&json!(arr)).unwrap());
+}
+
+pub fn print_sarif(diags: &[(PathBuf, Diagnostic)], root: &Path) {
+    use std::collections::BTreeSet;
+    let rule_ids: BTreeSet<String> = diags
+        .iter()
+        .filter_map(|(_, d)| match &d.code {
+            Some(NumberOrString::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    let rules: Vec<_> = rule_ids
+        .iter()
+        .map(|id| {
+            json!({
+                "id": id, "name": id, "shortDescription": { "text": id }
+            })
+        })
+        .collect();
+    let results: Vec<_> = diags
+        .iter()
+        .map(|(p, d)| {
+            let rel = p.strip_prefix(root).unwrap_or(p);
+            let level = match d.severity {
+                Some(DiagnosticSeverity::ERROR) => "error",
+                Some(DiagnosticSeverity::WARNING) => "warning",
+                _ => "note",
+            };
+            let rule_id = match &d.code {
+                Some(NumberOrString::String(s)) => s.clone(),
+                _ => String::new(),
+            };
+            json!({
+                "ruleId": rule_id,
+                "level": level,
+                "message": { "text": d.message },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": { "uri": rel.display().to_string() },
+                        "region": {
+                            "startLine": d.range.start.line + 1,
+                            "startColumn": d.range.start.character + 1,
+                            "endLine": d.range.end.line + 1,
+                            "endColumn": d.range.end.character + 1,
+                        }
+                    }
+                }]
+            })
+        })
+        .collect();
+    let sarif = json!({
+        "version": "2.1.0",
+        "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json",
+        "runs": [{
+            "tool": { "driver": { "name": "raven", "rules": rules } },
+            "results": results
+        }]
+    });
+    println!("{}", serde_json::to_string_pretty(&sarif).unwrap());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::{Position, Range};
+
+    fn diag(severity: DiagnosticSeverity) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 1),
+            },
+            severity: Some(severity),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn severity_ordering() {
+        assert!(SeverityLevel::Error > SeverityLevel::Warning);
+        assert!(SeverityLevel::Warning > SeverityLevel::Info);
+        assert!(SeverityLevel::Info > SeverityLevel::Hint);
+        assert!(SeverityLevel::Hint > SeverityLevel::Off);
+    }
+
+    #[test]
+    fn severity_from_diag() {
+        assert_eq!(
+            SeverityLevel::from_diag(&diag(DiagnosticSeverity::ERROR)),
+            SeverityLevel::Error
+        );
+        assert_eq!(
+            SeverityLevel::from_diag(&diag(DiagnosticSeverity::WARNING)),
+            SeverityLevel::Warning
+        );
+        assert_eq!(
+            SeverityLevel::from_diag(&diag(DiagnosticSeverity::INFORMATION)),
+            SeverityLevel::Info
+        );
+        assert_eq!(
+            SeverityLevel::from_diag(&diag(DiagnosticSeverity::HINT)),
+            SeverityLevel::Hint
+        );
+    }
+
+    #[test]
+    fn format_parsing() {
+        assert_eq!(parse_output_format("text").unwrap(), OutputFormat::Text);
+        assert_eq!(parse_output_format("json").unwrap(), OutputFormat::Json);
+        assert_eq!(parse_output_format("sarif").unwrap(), OutputFormat::Sarif);
+        assert!(parse_output_format("toml").is_err());
+    }
+
+    #[test]
+    fn severity_parsing() {
+        assert_eq!(parse_severity_level("off").unwrap(), SeverityLevel::Off);
+        assert_eq!(parse_severity_level("error").unwrap(), SeverityLevel::Error);
+        assert!(parse_severity_level("fatal").is_err());
+    }
+
+    #[test]
+    fn file_type_predicates() {
+        assert!(is_r_file(Path::new("a.R")));
+        assert!(is_r_file(Path::new("a.r")));
+        assert!(!is_r_file(Path::new("a.Rmd")));
+        assert!(is_chunk_file(Path::new("a.Rmd")));
+        assert!(is_chunk_file(Path::new("a.qmd")));
+        assert!(!is_chunk_file(Path::new("a.R")));
+    }
+}

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -90,72 +90,21 @@ pub fn absolute_path(base: &Path, path: &Path) -> PathBuf {
     }
 }
 
-/// Recursively collect `.R` / `.r` file paths under `dir`. Symlinked
-/// directories ARE followed, with canonical-path cycle detection to terminate
-/// on loops and avoid double-counting; the non-source directories listed in
-/// [`crate::state::should_skip_directory`] (`.git`, `node_modules`, `renv`,
-/// `target`, …) are pruned. Results are unsorted; callers that need
-/// deterministic order sort afterwards.
-///
-/// This deliberately mirrors the workspace indexer's walk
-/// (`state.rs::collect_file_paths_inner`): both follow symlinked directories
-/// with a `visited` set of canonical paths and include symlinked files. Keeping
-/// the two walks consistent is what makes `raven check`'s *reported* file set
-/// equal its *indexed* file set — otherwise a `.R` file reachable only through a
-/// symlink (e.g. a monorepo `src -> ../shared` layout) would be indexed for
-/// cross-file resolution yet never have its own diagnostics reported, and CI
-/// would pass over a file the editor flags.
+/// Recursively collect `.R` / `.r` file paths under `dir`. A thin R-only
+/// wrapper over the shared directory walk [`crate::state::collect_files_matching`]:
+/// symlinked directories are followed with canonical-path cycle detection and
+/// non-source directories are pruned. Reusing the indexer's walk is what keeps
+/// `raven check`'s *reported* file set equal to its *indexed* set — a `.R` file
+/// reachable only through a symlink (e.g. a monorepo `src -> ../shared` layout)
+/// is both indexed and reported, not one or the other. Results are unsorted;
+/// callers that need deterministic order sort afterwards.
 ///
 /// Shared by `raven check` (which reports diagnostics for the collected files)
 /// and `analysis-stats` (which reads their contents in a second pass). `.r` and
 /// `.R` are the only matched extensions — equivalent to a case-insensitive
 /// match on the single-character extension.
 pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
-    let mut visited = std::collections::HashSet::new();
-    // Seed with the canonical root so a symlink pointing back at the root (or
-    // any already-visited directory) is detected as a cycle and skipped.
-    if let Ok(canonical) = std::fs::canonicalize(dir) {
-        visited.insert(canonical);
-    }
-    collect_r_file_paths_inner(dir, out, &mut visited);
-}
-
-fn collect_r_file_paths_inner(
-    dir: &Path,
-    out: &mut Vec<PathBuf>,
-    visited: &mut std::collections::HashSet<PathBuf>,
-) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let p = entry.path();
-        // `is_dir()` follows symlinks, so a symlink to a directory is walked
-        // (after the cycle check) and a symlink to a file falls through to the
-        // `is_r_file` branch — matching the indexer.
-        if p.is_dir() {
-            if p.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(crate::state::should_skip_directory)
-            {
-                continue;
-            }
-            match std::fs::canonicalize(&p) {
-                Ok(canonical) => {
-                    if !visited.insert(canonical) {
-                        // Already visited (symlink cycle or alias) — skip.
-                        continue;
-                    }
-                }
-                // An unresolvable directory (e.g. broken symlink) can't be
-                // walked; skip it rather than error.
-                Err(_) => continue,
-            }
-            collect_r_file_paths_inner(&p, out, visited);
-        } else if is_r_file(&p) {
-            out.push(p);
-        }
-    }
+    crate::state::collect_files_matching(dir, out, is_r_file);
 }
 
 /// Render diagnostics in the requested format. The single dispatch point both

--- a/crates/raven/src/config_file/discovery_load.rs
+++ b/crates/raven/src/config_file/discovery_load.rs
@@ -1,10 +1,11 @@
 //! Shared "discover the nearest project config, then load it" seam.
 //!
-//! The LSP startup path, the watched-files reload, and `raven check` all need
-//! the same sequence: run [`find_config`] from the workspace root, then load
-//! whichever file it discovered (`raven.toml` beats `.lintr`). Hand-reproducing
-//! that match in each site let them drift — notably on which loader reads
-//! `.lintr`. [`discover_and_load`] is the single implementation they share.
+//! The LSP startup path, the watched-files reload, `raven check`, and
+//! `raven lint` all need the same sequence: run [`find_config`] from the
+//! workspace root, then load whichever file it discovered (`raven.toml` beats
+//! `.lintr`). Hand-reproducing that match in each site let them drift — notably
+//! on which loader reads `.lintr`. [`discover_and_load`] is the single
+//! implementation they share.
 
 use std::path::{Path, PathBuf};
 
@@ -36,8 +37,8 @@ pub enum DiscoveredLoad {
 
 /// Discover the nearest project config (`raven.toml` beats `.lintr`) at or above
 /// `search_start` and load it. The single discovery+load seam shared by the LSP
-/// startup path, the watched-files reload, and `raven check`, so the three can't
-/// drift on discovery precedence or which loader reads each file.
+/// startup path, the watched-files reload, `raven check`, and `raven lint`, so
+/// they can't drift on discovery precedence or which loader reads each file.
 pub fn discover_and_load(search_start: &Path) -> DiscoveredLoad {
     match find_config(search_start) {
         DiscoveredConfig::RavenToml(path) => match load_toml(&path) {

--- a/crates/raven/src/config_file/discovery_load.rs
+++ b/crates/raven/src/config_file/discovery_load.rs
@@ -1,0 +1,113 @@
+//! Shared "discover the nearest project config, then load it" seam.
+//!
+//! The LSP startup path, the watched-files reload, and `raven check` all need
+//! the same sequence: run [`find_config`] from the workspace root, then load
+//! whichever file it discovered (`raven.toml` beats `.lintr`). Hand-reproducing
+//! that match in each site let them drift — notably on which loader reads
+//! `.lintr`. [`discover_and_load`] is the single implementation they share.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::{find_config, load_lintr, load_toml, DiscoveredConfig};
+
+/// Outcome of discovering and loading a project config from a directory.
+///
+/// Warnings are *returned*, not emitted, because each caller has its own sink
+/// (`log::warn!` in the server, `eprintln!` in the CLI). A discovered-but-
+/// unloadable file is [`LoadFailed`](DiscoveredLoad::LoadFailed), distinct from
+/// [`None`](DiscoveredLoad::None), so a caller that treats a broken config as an
+/// operator error (the CLI) can, while the server collapses both to "no project
+/// layer".
+#[derive(Debug)]
+pub enum DiscoveredLoad {
+    /// Neither `raven.toml` nor `.lintr` was found at or above the directory.
+    None,
+    /// A config file was discovered and parsed.
+    Loaded {
+        path: PathBuf,
+        settings: Value,
+        warnings: Vec<String>,
+    },
+    /// A config file was discovered but could not be read or parsed.
+    LoadFailed { path: PathBuf },
+}
+
+/// Discover the nearest project config (`raven.toml` beats `.lintr`) at or above
+/// `search_start` and load it. The single discovery+load seam shared by the LSP
+/// startup path, the watched-files reload, and `raven check`, so the three can't
+/// drift on discovery precedence or which loader reads each file.
+pub fn discover_and_load(search_start: &Path) -> DiscoveredLoad {
+    match find_config(search_start) {
+        DiscoveredConfig::RavenToml(path) => match load_toml(&path) {
+            Some(l) => DiscoveredLoad::Loaded {
+                path,
+                settings: l.settings,
+                warnings: l.warnings,
+            },
+            None => DiscoveredLoad::LoadFailed { path },
+        },
+        DiscoveredConfig::Lintr(path) => match load_lintr(&path) {
+            Some(l) => DiscoveredLoad::Loaded {
+                path,
+                settings: l.settings,
+                warnings: l.warnings,
+            },
+            None => DiscoveredLoad::LoadFailed { path },
+        },
+        DiscoveredConfig::None => DiscoveredLoad::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn none_when_no_config() {
+        let tmp = TempDir::new().unwrap();
+        assert!(matches!(discover_and_load(tmp.path()), DiscoveredLoad::None));
+    }
+
+    #[test]
+    fn loaded_for_raven_toml() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("raven.toml"), "[linting]\nenabled = true\n").unwrap();
+        match discover_and_load(tmp.path()) {
+            DiscoveredLoad::Loaded { path, settings, .. } => {
+                assert_eq!(path, tmp.path().join("raven.toml"));
+                assert!(settings.get("linting").is_some());
+            }
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loaded_for_lintr() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".lintr"),
+            "linters: linters_with_defaults()\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            discover_and_load(tmp.path()),
+            DiscoveredLoad::Loaded { .. }
+        ));
+    }
+
+    #[test]
+    fn load_failed_for_malformed_raven_toml() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("raven.toml"), "not valid = = toml [[[\n").unwrap();
+        match discover_and_load(tmp.path()) {
+            DiscoveredLoad::LoadFailed { path } => {
+                assert_eq!(path, tmp.path().join("raven.toml"))
+            }
+            other => panic!("expected LoadFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -9,7 +9,7 @@ pub mod toml_loader;
 
 pub use discovery::{find_config, DiscoveredConfig};
 pub use discovery_load::{discover_and_load, DiscoveredLoad};
-pub use lintr_loader::{load as load_lintr, load_str as load_lintr_str};
+pub use lintr_loader::load as load_lintr;
 pub use merge::merge as merge_settings;
 pub use overrides::{
     compile_lint_overrides, is_skipped_by_overrides, resolve_lint_for_document,

--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -1,12 +1,14 @@
 //! Project-level configuration loader (raven.toml, .lintr).
 
 pub mod discovery;
+pub mod discovery_load;
 pub mod lintr_loader;
 pub mod merge;
 pub mod overrides;
 pub mod toml_loader;
 
 pub use discovery::{find_config, DiscoveredConfig};
+pub use discovery_load::{discover_and_load, DiscoveredLoad};
 pub use lintr_loader::{load as load_lintr, load_str as load_lintr_str};
 pub use merge::merge as merge_settings;
 pub use overrides::{

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -54,6 +54,7 @@ fn print_usage() {
     print!(
         r#"
 Usage: raven [OPTIONS]
+       raven check [PATHS...] [--workspace DIR]
        raven lint [PATHS...]
        raven analysis-stats <path> [--csv] [--only <phase>]
 
@@ -65,6 +66,9 @@ Available options:
 
 Subcommands:
 
+check [PATHS...]             Index the workspace and report full diagnostics
+                             (syntax, semantic, cross-file, package, lints)
+  --workspace DIR            Workspace root to index (default: current directory)
 lint [PATHS...]              Run the native style linter on files / directories
 analysis-stats <path>        Profile workspace analysis phases
   --csv                      Output results in CSV format
@@ -119,6 +123,26 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(msg) => {
                     return Err(anyhow::anyhow!("raven lint: {}", msg));
+                }
+            }
+        }
+
+        if first == "check" {
+            env_logger::init();
+            let rest = args.into_iter().skip(1);
+            match cli::check::parse_args(rest) {
+                Ok(check_args) => {
+                    // `main` is already `#[tokio::main]`, so await directly —
+                    // no nested runtime.
+                    let code = cli::check::run(check_args).await;
+                    std::process::exit(code);
+                }
+                Err(msg) if msg == "HELP" => {
+                    cli::check::print_help();
+                    return Ok(());
+                }
+                Err(msg) => {
+                    return Err(anyhow::anyhow!("raven check: {}", msg));
                 }
             }
         }

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -89,8 +89,8 @@ async fn main() -> anyhow::Result<()> {
     // Collect args to peek at the first one for subcommand detection
     let args: Vec<String> = argv.collect();
 
-    if let Some(first) = args.first() {
-        if first == "analysis-stats" {
+    match args.first().map(String::as_str) {
+        Some("analysis-stats") => {
             env_logger::init();
             let mut rest = args.into_iter().skip(1);
             match cli::analysis_stats::parse_args(&mut rest) {
@@ -108,8 +108,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-
-        if first == "lint" {
+        Some("lint") => {
             env_logger::init();
             let rest = args.into_iter().skip(1);
             match cli::lint::parse_args(rest) {
@@ -126,8 +125,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-
-        if first == "check" {
+        Some("check") => {
             env_logger::init();
             let rest = args.into_iter().skip(1);
             match cli::check::parse_args(rest) {
@@ -146,6 +144,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
+        _ => {}
     }
 
     for arg in &args {

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -1513,9 +1513,195 @@ impl PackageLibrary {
     }
 }
 
+/// Outcome of [`build_package_library`]: the constructed library plus a single
+/// status that is the sole source of truth for readiness and the degradation
+/// reason. Encoding state as one enum (not a `(lib, bool)` pair + a separate
+/// reason) makes the illegal "ready, but with a degradation reason" state
+/// unrepresentable — the drift this helper exists to prevent.
+pub struct PackageLibraryOutcome {
+    /// Always present. `new_empty()` for `Disabled`. A non-`Ready` library may
+    /// still carry useful offline data (base symbols, configured additional
+    /// paths), so "install it anyway" vs "discard it" is a *caller policy*, not
+    /// implied by the status.
+    pub library: Arc<PackageLibrary>,
+    pub status: PackageLibraryStatus,
+}
+
+/// The single source of truth for package-library readiness and the reason a
+/// build degraded. Sites #1 (`backend::rebuild_package_library`) and #2
+/// (`cli::check::maybe_init_r`) route through [`build_package_library`]; the
+/// two startup sites (`backend::ensure_package_library_initialized` and the
+/// Task B post-scan init) follow in phase 2. Routing them all through one
+/// builder is what stops the editor and `raven check` from drifting, and this
+/// enum's [`classify`](PackageLibraryStatus::classify) is where the readiness
+/// predicate and degradation precedence live — not duplicated per site.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PackageLibraryStatus {
+    /// `packages.enabled == false`; no R discovery attempted.
+    Disabled,
+    /// Initialized with >= 1 library path — the only ready state.
+    Ready,
+    /// No R subprocess located (incl. `spawn_blocking` join failure).
+    RNotFound,
+    /// `initialize()` errored — currently unreachable end-to-end (it has a
+    /// single `Ok(())` return and swallows R failures), kept for the CLI's
+    /// degradation-note contract and `initialize()`'s fallible signature.
+    InitFailed(String),
+    /// R found, init ok, but zero lib paths discovered/configured.
+    NoLibraryPaths,
+}
+
+impl PackageLibraryStatus {
+    /// Only `Ready` is ready.
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+
+    /// Classify an *enabled* build. `init_error == None` means `initialize()`
+    /// succeeded. Precedence is `Ready -> RNotFound -> InitFailed ->
+    /// NoLibraryPaths`, mirroring the CLI's pre-refactor order exactly so the
+    /// extraction is behavior-identical. `Disabled` is set by the gate in
+    /// [`build_package_library`] before this is called.
+    fn classify(init_error: Option<String>, r_found: bool, has_lib_paths: bool) -> Self {
+        if init_error.is_none() && has_lib_paths {
+            Self::Ready
+        } else if !r_found {
+            Self::RNotFound
+        } else if let Some(err) = init_error {
+            Self::InitFailed(err)
+        } else {
+            Self::NoLibraryPaths
+        }
+    }
+}
+
+/// Build a `PackageLibrary` from current configuration — the shared constructor
+/// package-library init sites route through (sites #1 `rebuild_package_library`
+/// and #2 `maybe_init_r` today; the two startup sites follow in phase 2), so
+/// editor and CI can't drift.
+///
+/// Lock-free by design: takes owned/cloned inputs and no `WorldState`, so it
+/// adds no logging/perf/state dependency to this module. R discovery does
+/// synchronous IO, so it runs in `spawn_blocking`; a join failure collapses to
+/// "R not found" (matching the existing builders' `.unwrap_or(None)`), never
+/// `InitFailed`. The helper never logs or prints — each caller surfaces
+/// `status` its own way. Configured `additional_paths` are applied *after* R
+/// discovery so they augment (never suppress) R-reported paths and count toward
+/// readiness.
+pub async fn build_package_library(
+    r_path: Option<PathBuf>,
+    additional_paths: &[PathBuf],
+    workspace_root: Option<PathBuf>,
+    packages_enabled: bool,
+) -> PackageLibraryOutcome {
+    if !packages_enabled {
+        return PackageLibraryOutcome {
+            library: Arc::new(PackageLibrary::new_empty()),
+            status: PackageLibraryStatus::Disabled,
+        };
+    }
+
+    let subprocess =
+        tokio::task::spawn_blocking(move || match (RSubprocess::new(r_path), workspace_root) {
+            (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
+            (sub, _) => sub,
+        })
+        .await
+        .unwrap_or(None);
+
+    let r_found = subprocess.is_some();
+    let mut lib = PackageLibrary::with_subprocess(subprocess);
+    let init_error = lib.initialize().await.err().map(|e| e.to_string());
+    lib.add_library_paths(additional_paths);
+    let has_lib_paths = !lib.lib_paths().is_empty();
+
+    let status = PackageLibraryStatus::classify(init_error, r_found, has_lib_paths);
+    PackageLibraryOutcome {
+        library: Arc::new(lib),
+        status,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the readiness predicate and degradation precedence
+    /// platform-independently. The `Some(_)` rows exercise classification
+    /// *logic* only — `initialize()` never returns `Err` end-to-end, so those
+    /// statuses are unreachable via the real pipeline.
+    #[test]
+    fn classify_truth_table() {
+        use PackageLibraryStatus::*;
+        let none: Option<String> = None;
+        let err = || Some("boom".to_string());
+        // (init_error, r_found, has_lib_paths) -> status
+        assert_eq!(
+            PackageLibraryStatus::classify(none.clone(), true, true),
+            Ready
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(none.clone(), true, false),
+            NoLibraryPaths
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(none.clone(), false, true),
+            Ready
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(none, false, false),
+            RNotFound
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(err(), true, true),
+            InitFailed("boom".to_string())
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(err(), true, false),
+            InitFailed("boom".to_string())
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(err(), false, true),
+            RNotFound
+        );
+        assert_eq!(
+            PackageLibraryStatus::classify(err(), false, false),
+            RNotFound
+        );
+    }
+
+    #[test]
+    fn is_ready_only_for_ready() {
+        use PackageLibraryStatus::*;
+        assert!(Ready.is_ready());
+        for s in [Disabled, RNotFound, InitFailed("x".into()), NoLibraryPaths] {
+            assert!(!s.is_ready(), "{s:?} must not be ready");
+        }
+    }
+
+    #[tokio::test]
+    async fn build_package_library_disabled_is_empty_and_not_ready() {
+        let outcome = build_package_library(None, &[], None, false).await;
+        assert_eq!(outcome.status, PackageLibraryStatus::Disabled);
+        assert!(!outcome.status.is_ready());
+        assert!(outcome.library.lib_paths().is_empty());
+    }
+
+    /// A real temp dir is used because `add_library_paths` appends without an
+    /// existence check, so this reflects the "valid additional path" intent.
+    /// R-independent: additional paths are applied after R discovery.
+    #[tokio::test]
+    async fn build_package_library_honors_additional_paths() {
+        let extra = tempfile::TempDir::new().unwrap();
+        let extra_path = extra.path().to_path_buf();
+        let outcome =
+            build_package_library(None, std::slice::from_ref(&extra_path), None, true).await;
+        assert!(
+            outcome.library.lib_paths().iter().any(|p| p == &extra_path),
+            "additional path must appear in lib_paths; got {:?}",
+            outcome.library.lib_paths()
+        );
+    }
 
     #[test]
     fn test_package_info_new() {

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -69,6 +69,21 @@ fn meta_attached_packages(name: &str) -> &'static [&'static str] {
     }
 }
 
+fn is_meta_package_name(name: &str) -> bool {
+    matches!(name, "tidyverse" | "tidymodels")
+}
+
+fn meta_attached_package_names(name: &str) -> Vec<String> {
+    meta_attached_packages(name)
+        .iter()
+        .map(|package| (*package).to_string())
+        .collect()
+}
+
+fn is_readable_file(path: &Path) -> bool {
+    path.is_file() && std::fs::File::open(path).is_ok()
+}
+
 /// Cached package information
 ///
 /// Stores all relevant information about an R package including its exports,
@@ -92,14 +107,8 @@ pub struct PackageInfo {
 impl PackageInfo {
     /// Create a new PackageInfo with the given name and exports
     pub fn new(name: String, exports: HashSet<String>) -> Self {
-        let is_meta_package = name == "tidyverse" || name == "tidymodels";
-        let attached_packages = if name == "tidyverse" {
-            TIDYVERSE_PACKAGES.iter().map(|s| s.to_string()).collect()
-        } else if name == "tidymodels" {
-            TIDYMODELS_PACKAGES.iter().map(|s| s.to_string()).collect()
-        } else {
-            Vec::new()
-        };
+        let is_meta_package = is_meta_package_name(&name);
+        let attached_packages = meta_attached_package_names(&name);
 
         Self {
             name,
@@ -118,14 +127,8 @@ impl PackageInfo {
         depends: Vec<String>,
         lazy_data: Vec<String>,
     ) -> Self {
-        let is_meta_package = name == "tidyverse" || name == "tidymodels";
-        let attached_packages = if name == "tidyverse" {
-            TIDYVERSE_PACKAGES.iter().map(|s| s.to_string()).collect()
-        } else if name == "tidymodels" {
-            TIDYMODELS_PACKAGES.iter().map(|s| s.to_string()).collect()
-        } else {
-            Vec::new()
-        };
+        let is_meta_package = is_meta_package_name(&name);
+        let attached_packages = meta_attached_package_names(&name);
 
         Self {
             name,
@@ -1342,7 +1345,9 @@ impl PackageLibrary {
             let package_dir = lib_path.join(name);
             // Check for NAMESPACE or DESCRIPTION file to ensure it's a valid R package
             // Note: `base` package doesn't have NAMESPACE, only DESCRIPTION
-            if package_dir.join("NAMESPACE").exists() || package_dir.join("DESCRIPTION").exists() {
+            if is_readable_file(&package_dir.join("NAMESPACE"))
+                || is_readable_file(&package_dir.join("DESCRIPTION"))
+            {
                 return Some(package_dir);
             }
         }
@@ -2248,6 +2253,47 @@ mod tests {
                 lib.base_exports().len(),
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_initialize_skips_unusable_package_dir_for_later_valid_dir() {
+        let unusable_root = tempfile::tempdir().unwrap();
+        let valid_root = tempfile::tempdir().unwrap();
+
+        let unusable_datasets = unusable_root.path().join("datasets");
+        std::fs::create_dir_all(unusable_datasets.join("NAMESPACE")).unwrap();
+
+        let valid_datasets = valid_root.path().join("datasets");
+        let valid_data = valid_datasets.join("data");
+        std::fs::create_dir_all(&valid_data).unwrap();
+        std::fs::write(
+            valid_datasets.join("DESCRIPTION"),
+            "Package: datasets\nVersion: 4.6.0\nPriority: base\n",
+        )
+        .unwrap();
+        std::fs::write(
+            valid_datasets.join("NAMESPACE"),
+            "# This package exports nothing (it uses lazydata)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            valid_datasets.join("INDEX"),
+            "mtcars                  Motor Trend Car Road Tests\n",
+        )
+        .unwrap();
+        std::fs::write(valid_data.join("Rdata.rdx"), b"").unwrap();
+
+        let mut lib = PackageLibrary::with_subprocess(None);
+        lib.set_lib_paths(vec![
+            unusable_root.path().to_path_buf(),
+            valid_root.path().to_path_buf(),
+        ]);
+        lib.initialize().await.expect("initialize() succeeds");
+
+        assert!(
+            lib.is_base_export("mtcars"),
+            "initialize() should keep searching after an unusable package directory"
+        );
     }
 
     #[tokio::test]

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -69,10 +69,6 @@ fn meta_attached_packages(name: &str) -> &'static [&'static str] {
     }
 }
 
-fn is_meta_package_name(name: &str) -> bool {
-    matches!(name, "tidyverse" | "tidymodels")
-}
-
 fn meta_attached_package_names(name: &str) -> Vec<String> {
     meta_attached_packages(name)
         .iter()
@@ -107,8 +103,10 @@ pub struct PackageInfo {
 impl PackageInfo {
     /// Create a new PackageInfo with the given name and exports
     pub fn new(name: String, exports: HashSet<String>) -> Self {
-        let is_meta_package = is_meta_package_name(&name);
         let attached_packages = meta_attached_package_names(&name);
+        // A package is a meta-package exactly when it attaches children, so
+        // `meta_attached_packages` is the single source of truth for the set.
+        let is_meta_package = !attached_packages.is_empty();
 
         Self {
             name,
@@ -127,8 +125,10 @@ impl PackageInfo {
         depends: Vec<String>,
         lazy_data: Vec<String>,
     ) -> Self {
-        let is_meta_package = is_meta_package_name(&name);
         let attached_packages = meta_attached_package_names(&name);
+        // A package is a meta-package exactly when it attaches children, so
+        // `meta_attached_packages` is the single source of truth for the set.
+        let is_meta_package = !attached_packages.is_empty();
 
         Self {
             name,
@@ -1533,10 +1533,10 @@ pub struct PackageLibraryOutcome {
 }
 
 /// The single source of truth for package-library readiness and the reason a
-/// build degraded. Sites #1 (`backend::rebuild_package_library`) and #2
-/// (`cli::check::maybe_init_r`) route through [`build_package_library`]; the
-/// two startup sites (`backend::ensure_package_library_initialized` and the
-/// Task B post-scan init) follow in phase 2. Routing them all through one
+/// build degraded. All four package-library init sites route through
+/// [`build_package_library`]: `backend::rebuild_package_library`,
+/// `cli::check::maybe_init_r`, `backend::ensure_package_library_initialized`,
+/// and the Task B post-scan startup init. Routing them all through one
 /// builder is what stops the editor and `raven check` from drifting, and this
 /// enum's [`classify`](PackageLibraryStatus::classify) is where the readiness
 /// predicate and degradation precedence live — not duplicated per site.
@@ -1581,9 +1581,9 @@ impl PackageLibraryStatus {
 }
 
 /// Build a `PackageLibrary` from current configuration — the shared constructor
-/// package-library init sites route through (sites #1 `rebuild_package_library`
-/// and #2 `maybe_init_r` today; the two startup sites follow in phase 2), so
-/// editor and CI can't drift.
+/// all four package-library init sites route through (`rebuild_package_library`,
+/// `maybe_init_r`, `ensure_package_library_initialized`, and the Task B
+/// post-scan startup init), so editor and CI can't drift.
 ///
 /// Lock-free by design: takes owned/cloned inputs and no `WorldState`, so it
 /// adds no logging/perf/state dependency to this module. R discovery does

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -76,6 +76,28 @@ fn meta_attached_package_names(name: &str) -> Vec<String> {
         .collect()
 }
 
+/// Meta-package fields for a package name: `(is_meta_package, attached_packages)`.
+/// A package is a meta-package exactly when it attaches children, so
+/// `meta_attached_packages` is the single source of truth — and deriving both
+/// fields here keeps the two `PackageInfo` constructors from drifting apart.
+fn meta_package_fields(name: &str) -> (bool, Vec<String>) {
+    let attached_packages = meta_attached_package_names(name);
+    (!attached_packages.is_empty(), attached_packages)
+}
+
+/// True when `path` is a regular file whose contents can actually be opened
+/// for reading.
+///
+/// Validates a candidate package directory's `NAMESPACE` / `DESCRIPTION` in
+/// [`PackageLibrary::find_package_directory`]. `is_file()` alone already rejects
+/// the case where a directory is *named* `NAMESPACE`; the extra `File::open`
+/// also skips a metadata file that exists but cannot be read (wrong
+/// permissions, a dangling symlink target), so discovery moves on to the next
+/// library path instead of treating an unusable directory as the package — the
+/// "skip unreadable package directories" behavior. Opening is the only reliable
+/// readability probe (a permissions stat is racy and platform-dependent); the
+/// cost is one `open`/`close` per *resolved* package, paid once and then cached,
+/// so it is negligible on the init / package-resolution path.
 fn is_readable_file(path: &Path) -> bool {
     path.is_file() && std::fs::File::open(path).is_ok()
 }
@@ -103,10 +125,7 @@ pub struct PackageInfo {
 impl PackageInfo {
     /// Create a new PackageInfo with the given name and exports
     pub fn new(name: String, exports: HashSet<String>) -> Self {
-        let attached_packages = meta_attached_package_names(&name);
-        // A package is a meta-package exactly when it attaches children, so
-        // `meta_attached_packages` is the single source of truth for the set.
-        let is_meta_package = !attached_packages.is_empty();
+        let (is_meta_package, attached_packages) = meta_package_fields(&name);
 
         Self {
             name,
@@ -125,10 +144,7 @@ impl PackageInfo {
         depends: Vec<String>,
         lazy_data: Vec<String>,
     ) -> Self {
-        let attached_packages = meta_attached_package_names(&name);
-        // A package is a meta-package exactly when it attaches children, so
-        // `meta_attached_packages` is the single source of truth for the set.
-        let is_meta_package = !attached_packages.is_empty();
+        let (is_meta_package, attached_packages) = meta_package_fields(&name);
 
         Self {
             name,
@@ -1766,6 +1782,21 @@ mod tests {
         assert_eq!(info.depends, depends);
         assert_eq!(info.lazy_data, lazy_data);
         assert!(!info.is_meta_package);
+    }
+
+    #[test]
+    fn test_package_info_with_details_meta_matches_new() {
+        // Pins that `with_details` derives the meta-package fields identically
+        // to `new` — the invariant the two constructors must share. Guards the
+        // single derivation helper against the two constructors drifting apart.
+        let via_details =
+            PackageInfo::with_details("tidyverse".to_string(), HashSet::new(), vec![], vec![]);
+        let via_new = PackageInfo::new("tidyverse".to_string(), HashSet::new());
+
+        assert!(via_details.is_meta_package);
+        assert_eq!(via_details.is_meta_package, via_new.is_meta_package);
+        assert_eq!(via_details.attached_packages, via_new.attached_packages);
+        assert!(via_details.attached_packages.contains(&"dplyr".to_string()));
     }
 
     #[tokio::test]

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1445,6 +1445,17 @@ mod tests {
     include!("state_tests.rs");
 
     #[test]
+    fn test_should_skip_directory() {
+        assert!(should_skip_directory(".git"));
+        assert!(should_skip_directory("node_modules"));
+        assert!(should_skip_directory("renv"));
+        assert!(should_skip_directory("target"));
+        assert!(!should_skip_directory("R"));
+        assert!(!should_skip_directory("src"));
+        assert!(!should_skip_directory("data"));
+    }
+
+    #[test]
     fn test_document_apply_change_ascii() {
         let mut doc = Document::new("hello world", None);
 

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1222,10 +1222,90 @@ fn collect_files_matching_inner(
     }
 }
 
+/// Why a source file could not be read as text by [`read_source`].
+#[derive(Debug)]
+pub(crate) enum SourceReadError {
+    /// The file could not be read from disk at all (missing, permissions, …).
+    Io(std::io::Error),
+    /// The bytes are not valid UTF-8 and carry no UTF-16 byte-order mark —
+    /// almost always a legacy single-byte encoding (Latin-1 / Windows-1252).
+    /// `offset` is the byte index of the first undecodable byte and `byte` its
+    /// value, for an actionable diagnostic. `byte` is `0` only in the rare
+    /// malformed-UTF-16 case, where no single offending byte is meaningful.
+    InvalidEncoding { offset: usize, byte: u8 },
+}
+
+/// Read a source file as UTF-8 text, transparently handling byte-order marks:
+/// a UTF-8 BOM is stripped, and BOM-marked UTF-16 LE/BE is decoded to UTF-8.
+/// Any other input must already be valid UTF-8.
+///
+/// This is the single disk-read seam shared by the workspace scan
+/// ([`process_workspace_file`]) and `raven check`'s report loop, so the two
+/// decode files identically. It deliberately does NOT guess legacy encodings: a
+/// non-UTF-8 file with no UTF-16 BOM is reported as
+/// [`SourceReadError::InvalidEncoding`] rather than silently mis-decoded —
+/// guessing would hide bugs (e.g. a non-breaking space sitting inside a string
+/// comparison reads as a normal space). The scan discards the error (an
+/// undecodable file is simply left unindexed); `raven check` turns it into a
+/// reported finding. This governs only files raven reads from disk — open
+/// documents arrive already-decoded from the editor over LSP.
+pub(crate) fn read_source(path: &Path) -> Result<String, SourceReadError> {
+    decode_source(fs::read(path).map_err(SourceReadError::Io)?)
+}
+
+/// Decode raw file bytes per the [`read_source`] rules. Split out so the
+/// BOM/UTF-8 logic is unit-testable without touching the filesystem. Takes an
+/// owned `Vec` so the common no-BOM UTF-8 path moves the buffer straight into
+/// the `String` without copying.
+fn decode_source(bytes: Vec<u8>) -> Result<String, SourceReadError> {
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        // UTF-8 BOM: strip it; an error's file offset is then `3 + valid_up_to`.
+        return decode_utf8_slice(&bytes[3..], 3);
+    }
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        return decode_utf16(&bytes[2..], true);
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        return decode_utf16(&bytes[2..], false);
+    }
+    String::from_utf8(bytes).map_err(|e| {
+        let offset = e.utf8_error().valid_up_to();
+        SourceReadError::InvalidEncoding {
+            offset,
+            byte: e.as_bytes().get(offset).copied().unwrap_or(0),
+        }
+    })
+}
+
+fn decode_utf8_slice(bytes: &[u8], base_offset: usize) -> Result<String, SourceReadError> {
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|e| SourceReadError::InvalidEncoding {
+            offset: base_offset + e.valid_up_to(),
+            byte: bytes.get(e.valid_up_to()).copied().unwrap_or(0),
+        })
+}
+
+fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String, SourceReadError> {
+    // A trailing odd byte can't form a code unit; `chunks_exact` drops it. UTF-16
+    // source is vanishingly rare, so we don't pinpoint a byte offset here.
+    let units = bytes.chunks_exact(2).map(|c| {
+        let pair = [c[0], c[1]];
+        if little_endian {
+            u16::from_le_bytes(pair)
+        } else {
+            u16::from_be_bytes(pair)
+        }
+    });
+    char::decode_utf16(units)
+        .collect::<Result<String, _>>()
+        .map_err(|_| SourceReadError::InvalidEncoding { offset: 0, byte: 0 })
+}
+
 /// Process a single file: read, parse, compute metadata and artifacts.
 /// Returns `None` if the file can't be read or converted to a URI.
 fn process_workspace_file(path: &Path) -> Option<ProcessedFile> {
-    let text = fs::read_to_string(path).ok()?;
+    let text = read_source(path).ok()?;
     let uri = Url::from_file_path(path).ok()?;
     let metadata_result = fs::metadata(path).ok()?;
 
@@ -1471,6 +1551,49 @@ fn is_stat_model_extension(path: &Path) -> bool {
 mod tests {
     use super::*;
     use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+
+    #[test]
+    fn decode_source_plain_utf8() {
+        assert_eq!(decode_source(b"x <- 1\n".to_vec()).unwrap(), "x <- 1\n");
+    }
+
+    #[test]
+    fn decode_source_strips_utf8_bom() {
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"x <- 1\n");
+        // The BOM must not survive into the parsed content (a leading U+FEFF
+        // would otherwise corrupt the first token).
+        assert_eq!(decode_source(bytes).unwrap(), "x <- 1\n");
+    }
+
+    #[test]
+    fn decode_source_decodes_utf16le_bom() {
+        // "ab\n" as UTF-16 little-endian, BOM-prefixed.
+        let bytes = vec![0xFF, 0xFE, b'a', 0x00, b'b', 0x00, b'\n', 0x00];
+        assert_eq!(decode_source(bytes).unwrap(), "ab\n");
+    }
+
+    #[test]
+    fn decode_source_decodes_utf16be_bom() {
+        let bytes = vec![0xFE, 0xFF, 0x00, b'a', 0x00, b'b', 0x00, b'\n'];
+        assert_eq!(decode_source(bytes).unwrap(), "ab\n");
+    }
+
+    #[test]
+    fn decode_source_reports_first_bad_byte_for_latin1() {
+        // The real-world case: a non-breaking space (0xA0) after valid ASCII,
+        // no BOM. We must point at the offending byte, not silently mangle it.
+        let mut bytes = b"x <- 1".to_vec(); // 6 valid bytes
+        bytes.push(0xA0); // offset 6: invalid UTF-8 start byte
+        bytes.extend_from_slice(b"\n");
+        match decode_source(bytes) {
+            Err(SourceReadError::InvalidEncoding { offset, byte }) => {
+                assert_eq!(offset, 6);
+                assert_eq!(byte, 0xA0);
+            }
+            other => panic!("expected InvalidEncoding, got {other:?}"),
+        }
+    }
 
     // Include workspace scanning tests
     include!("state_tests.rs");

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -146,6 +146,7 @@ use crate::parameter_resolver::SignatureCache;
 use crate::workspace_index::WorkspaceIndex;
 
 /// A parsed document
+#[derive(Clone)]
 pub struct Document {
     pub contents: Rope,
     pub tree: Option<Tree>,

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1149,16 +1149,43 @@ struct ProcessedFile {
     new_index_entry: crate::workspace_index::IndexEntry,
 }
 
-/// Recursively collect file paths from a directory (serial walk, fast).
-fn collect_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+/// Recursively collect file paths under `dir` whose leaf matches `accept`
+/// (serial walk, fast). Symlinked directories ARE followed, with canonical-path
+/// cycle detection to terminate on loops and avoid double-counting; the
+/// non-source directories in [`should_skip_directory`] (`.git`, `node_modules`,
+/// `renv`, `target`, …) are pruned. Results are unsorted; callers that need
+/// deterministic order sort afterwards.
+///
+/// This is the single directory walk shared by the workspace indexer (which
+/// passes [`is_stat_model_extension`] to collect `.r`/`.jags`/`.bugs`/`.stan`)
+/// and the CLI's [`crate::cli::shared::collect_r_file_paths`] (R-only). Sharing
+/// one walk is what keeps `raven check`'s *reported* file set equal to its
+/// *indexed* set: a `.R` file reachable only through a symlinked directory
+/// (e.g. a monorepo `src -> ../shared` layout) is both indexed for cross-file
+/// resolution and reported, instead of one walk following the symlink while the
+/// other skips it. Only the leaf predicate differs between callers; the
+/// symlink/cycle/skip logic — the part that would otherwise drift — lives here
+/// once.
+pub(crate) fn collect_files_matching(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    accept: fn(&Path) -> bool,
+) {
     let mut visited = HashSet::new();
+    // Seed with the canonical root so a symlink pointing back at the root (or
+    // any already-visited directory) is detected as a cycle and skipped.
     if let Ok(canonical) = fs::canonicalize(dir) {
         visited.insert(canonical);
     }
-    collect_file_paths_inner(dir, out, &mut visited);
+    collect_files_matching_inner(dir, out, &mut visited, accept);
 }
 
-fn collect_file_paths_inner(dir: &Path, out: &mut Vec<PathBuf>, visited: &mut HashSet<PathBuf>) {
+fn collect_files_matching_inner(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+    accept: fn(&Path) -> bool,
+) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -1166,6 +1193,9 @@ fn collect_file_paths_inner(dir: &Path, out: &mut Vec<PathBuf>, visited: &mut Ha
     for entry in entries.flatten() {
         let path = entry.path();
 
+        // `is_dir()` follows symlinks, so a symlink to a directory is walked
+        // (after the cycle check) and a symlink to a file falls through to the
+        // `accept` branch.
         if path.is_dir() {
             if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
                 if should_skip_directory(dir_name) {
@@ -1185,8 +1215,8 @@ fn collect_file_paths_inner(dir: &Path, out: &mut Vec<PathBuf>, visited: &mut Ha
                     continue;
                 }
             }
-            collect_file_paths_inner(&path, out, visited);
-        } else if is_stat_model_extension(&path) {
+            collect_files_matching_inner(&path, out, visited, accept);
+        } else if accept(&path) {
             out.push(path);
         }
     }
@@ -1255,7 +1285,7 @@ pub fn scan_workspace(folders: &[Url], max_chain_depth: usize) -> WorkspaceScanR
     for folder in folders {
         log::info!("Scanning folder: {}", folder);
         if let Ok(path) = folder.to_file_path() {
-            collect_file_paths(&path, &mut file_paths);
+            collect_files_matching(&path, &mut file_paths, is_stat_model_extension);
         }
     }
 
@@ -1434,7 +1464,7 @@ fn is_stat_model_extension(path: &Path) -> bool {
         })
 }
 
-// `scan_directory` was replaced by `collect_file_paths` + `process_workspace_file`
+// `scan_directory` was replaced by `collect_files_matching` + `process_workspace_file`
 // for parallel scanning via rayon. See `scan_workspace`.
 
 #[cfg(test)]

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1197,23 +1197,41 @@ fn collect_files_matching_inner(
         // (after the cycle check) and a symlink to a file falls through to the
         // `accept` branch.
         if path.is_dir() {
-            if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
-                if should_skip_directory(dir_name) {
-                    log::trace!("Skipping directory: {}", path.display());
-                    continue;
-                }
+            // Cheap first pass: prune by the entry name (a real `node_modules`,
+            // `.git`, … — no canonicalize needed for the common case).
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(should_skip_directory)
+            {
+                log::trace!("Skipping directory: {}", path.display());
+                continue;
             }
-            match fs::canonicalize(&path) {
-                Ok(canonical) => {
-                    if !visited.insert(canonical) {
-                        log::trace!("Skipping symlink cycle: {}", path.display());
-                        continue;
-                    }
-                }
+            let canonical = match fs::canonicalize(&path) {
+                Ok(c) => c,
                 Err(e) => {
                     log::trace!("Skipping unresolvable dir {}: {}", path.display(), e);
                     continue;
                 }
+            };
+            // A symlink whose own name isn't skip-listed but whose TARGET is
+            // (e.g. `deps -> node_modules`) must be pruned too, or it pulls the
+            // whole vendored tree back into the scan.
+            if canonical
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(should_skip_directory)
+            {
+                log::trace!(
+                    "Skipping symlinked directory {} -> {}",
+                    path.display(),
+                    canonical.display()
+                );
+                continue;
+            }
+            if !visited.insert(canonical) {
+                log::trace!("Skipping symlink cycle: {}", path.display());
+                continue;
             }
             collect_files_matching_inner(&path, out, visited, accept);
         } else if accept(&path) {
@@ -1287,8 +1305,14 @@ fn decode_utf8_slice(bytes: &[u8], base_offset: usize) -> Result<String, SourceR
 }
 
 fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String, SourceReadError> {
-    // A trailing odd byte can't form a code unit; `chunks_exact` drops it. UTF-16
-    // source is vanishingly rare, so we don't pinpoint a byte offset here.
+    // An odd byte count means the final code unit is truncated; surface that
+    // rather than letting `chunks_exact` silently drop the dangling byte and
+    // accept corrupted input. UTF-16 source is vanishingly rare, so we don't
+    // pinpoint a byte offset here (`byte == 0` selects the encoding-agnostic
+    // diagnostic message in `encoding_diagnostic`).
+    if bytes.len() % 2 != 0 {
+        return Err(SourceReadError::InvalidEncoding { offset: 0, byte: 0 });
+    }
     let units = bytes.chunks_exact(2).map(|c| {
         let pair = [c[0], c[1]];
         if little_endian {
@@ -1580,6 +1604,21 @@ mod tests {
     }
 
     #[test]
+    fn decode_source_rejects_truncated_utf16() {
+        // UTF-16 LE BOM followed by an odd number of bytes: the final code unit
+        // is truncated. We must surface this rather than silently dropping the
+        // dangling byte and accepting corrupted input.
+        let bytes = vec![0xFF, 0xFE, b'a', 0x00, b'b']; // 'a', then a lone 0x62
+        match decode_source(bytes) {
+            Err(SourceReadError::InvalidEncoding { byte, .. }) => {
+                // byte == 0 selects the encoding-agnostic message (it had a BOM).
+                assert_eq!(byte, 0);
+            }
+            other => panic!("expected InvalidEncoding for truncated UTF-16, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn decode_source_reports_first_bad_byte_for_latin1() {
         // The real-world case: a non-breaking space (0xA0) after valid ASCII,
         // no BOM. We must point at the offending byte, not silently mangle it.
@@ -1593,6 +1632,30 @@ mod tests {
             }
             other => panic!("expected InvalidEncoding, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_files_matching_skips_symlink_to_skiplisted_dir() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join("real.R"), "1\n").unwrap();
+        // A skip-listed directory with a source file inside (pruned by name).
+        fs::create_dir(tmp.path().join("node_modules")).unwrap();
+        fs::write(tmp.path().join("node_modules").join("inner.R"), "1\n").unwrap();
+        // A symlink whose own name is NOT skip-listed but whose target IS
+        // (`deps -> node_modules`) must also be pruned, or it pulls the whole
+        // vendored tree back into the scan via the symlink alias.
+        std::os::unix::fs::symlink(tmp.path().join("node_modules"), tmp.path().join("deps"))
+            .unwrap();
+
+        let mut out = Vec::new();
+        collect_files_matching(tmp.path(), &mut out, is_stat_model_extension);
+
+        // Only real.R: inner.R is unreachable both directly (node_modules entry
+        // name) and via the symlink (deps' canonical target name).
+        assert_eq!(out.len(), 1, "got {out:?}");
+        assert!(out[0].ends_with("real.R"), "got {out:?}");
     }
 
     // Include workspace scanning tests

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ Raven ships a single binary that serves the LSP via stdio *and* exposes subcomma
 - `raven lint` — run the native **style** linter only.
 - `raven analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
 
-The difference between `check` and `lint`: `lint` parses each file in isolation and runs only the style rules, so it is fast and needs no R installation, but it cannot see relationships between files. `check` builds the same workspace index the language server builds, so it additionally reports cross-file, undefined-variable, and package diagnostics. Reach for `lint` when you only want style gating; reach for `check` when you want the editor's full analysis in CI.
+The difference between `check` and `lint` is **scope**: `lint` parses each file in isolation and runs only the style rules, so it needs no R installation and no workspace index — but it can't see relationships between files. `check` builds the same workspace index the language server builds (and, unless packages are disabled, runs R to resolve installed-package exports and base R symbols), so it additionally reports cross-file, undefined-variable, and package diagnostics. `lint` is therefore the cheaper, R-free option for pure style gating; `check` does more work per run in exchange for the editor's full analysis in CI.
 
 ## `raven check`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,11 +47,15 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 
 Before reporting, `raven check` warms the export cache for the packages each reported file attaches with `library()` / `require()`, so a bare call into an attached package that isn't one of its exports is flagged the same way the editor flags it. One narrow gap remains: a package attached only *indirectly* — in a `source()`d file rather than in the reported file itself — is not pre-warmed, so calls that could resolve to such a package are left unflagged rather than risk a false positive. Attach the package directly in the file (or rely on the editor) if you need those calls checked.
 
+### File encoding
+
+Source files must be UTF-8. A UTF-8 byte-order mark is stripped and BOM-marked UTF-16 (LE/BE) is decoded, but anything else must already be valid UTF-8 — Raven does not guess legacy single-byte encodings (Latin-1 / Windows-1252). Guessing would silently mis-decode: a non-breaking space (`0xA0`) inside a string comparison, for instance, would read as an ordinary space and quietly change what your code matches. A *reported* file that isn't valid UTF-8 is therefore flagged as an **error diagnostic** (`File is not valid UTF-8: first invalid byte 0x… at offset …`) that fails the build like any other error finding — it is **not** an operator error. Re-save the file as UTF-8 to fix it. A file that is only *indexed* for cross-file resolution (not itself reported) and can't be decoded is silently skipped, matching the editor.
+
 ### Exit codes
 
 - `0` — no diagnostic exceeded `--max-severity`.
-- `1` — at least one diagnostic exceeded `--max-severity`. An unknown flag is a usage error and also exits `1`.
-- `2` — operator error detected while running (config parse failure, unreadable path, invalid workspace).
+- `1` — at least one diagnostic exceeded `--max-severity`. An unknown flag is a usage error and also exits `1`. A reported file that isn't valid UTF-8 is an error diagnostic, so it also exits `1`.
+- `2` — operator error detected while running (config parse failure, an I/O failure reading a path, invalid workspace). A *readable* but mis-encoded file is a finding (exit `1`), not an operator error.
 
 ### GitHub Actions example
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 
 ### R and packages
 
-`raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
+`raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.enabled = false` disables R detection entirely (no R subprocess, no package or base-symbol diagnostics — matching the editor), `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
 
 ### Exit codes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 
 ### R and packages
 
-`raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
+`raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
 
 ### Exit codes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,73 @@
 # CLI
 
-Raven ships a single binary that serves the LSP via stdio *and* exposes a `lint` subcommand for use outside an editor. This page documents `lint`. The binary also has an `analysis-stats <path> [--csv] [--only <phase>]` subcommand for profiling workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help` for the current invocation.
+Raven ships a single binary that serves the LSP via stdio *and* exposes subcommands for use outside an editor:
+
+- `raven check` — index a workspace and report the **full** diagnostic set (the same diagnostics the editor publishes), for CI gating.
+- `raven lint` — run the native **style** linter only.
+- `analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
+
+The difference between `check` and `lint`: `lint` parses each file in isolation and runs only the style rules, so it is fast and needs no R installation, but it cannot see relationships between files. `check` builds the same workspace index the language server builds, so it additionally reports cross-file, undefined-variable, and package diagnostics. Reach for `lint` when you only want style gating; reach for `check` when you want the editor's full analysis in CI.
+
+## `raven check`
+
+Index the workspace, then report the full diagnostic set for the requested files and exit with a code suitable for CI gating.
+
+```text
+raven check [OPTIONS] [PATHS...]
+```
+
+Diagnostics reported (subject to configured severities — see [diagnostics.md](diagnostics.md)):
+
+- Syntax errors and semantic checks (e.g. assignment-in-condition, mixed logical operators).
+- The native style lints (when enabled via `raven.toml` / `.lintr`).
+- Cross-file diagnostics: missing sourced files, circular dependencies, exceeded max source-chain depth, redundant directives, and out-of-scope usage.
+- Missing-package warnings (`library(notInstalled)`).
+- Undefined-variable diagnostics, accounting for cross-file and package scope.
+
+### Workspace and paths
+
+The whole workspace is always indexed so cross-file resolution is accurate. The workspace root is `--workspace DIR`, defaulting to the current directory. `PATHS` only filter **which files have their diagnostics reported**:
+
+- With no `PATHS`, every R file in the workspace is reported.
+- With `PATHS`, only those files are reported (directories are walked recursively for R files). Indexing still covers the whole workspace, so a reported file's `source()` targets resolve even when they aren't named.
+
+### Options
+
+- `--workspace DIR` — workspace root to index (default: current directory).
+- `--config PATH` — explicit path to a `raven.toml` (default: walk upward from the workspace root, discovering a `raven.toml` or `.lintr`).
+- `--no-config` — ignore `raven.toml` and `.lintr`; use Raven's built-in defaults.
+- `--format text|json|sarif` — default `text`.
+- `--max-severity off|hint|info|warning|error` — highest severity that does **not** fail the build (default `info`). With the built-in defaults, undefined-variable and missing-file diagnostics are `warning` and circular dependencies are `error`, so they fail the build at the default threshold.
+- `--quiet` — suppress the trailing summary line.
+- `--no-color` — accepted for forward compatibility. `text` output is currently uncolored regardless, so this flag has no visible effect yet.
+
+### R and packages
+
+`raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
+
+### Exit codes
+
+- `0` — no diagnostic exceeded `--max-severity`.
+- `1` — at least one diagnostic exceeded `--max-severity`. An unknown flag is a usage error and also exits `1`.
+- `2` — operator error detected while running (config parse failure, unreadable path, invalid workspace).
+
+### GitHub Actions example
+
+```yaml
+- name: Check R sources
+  run: |
+    cargo install --git https://github.com/jbearak/raven raven
+    raven check --format sarif > raven.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: raven.sarif
+```
+
+To get installed-package and base-symbol awareness in CI, install R (e.g. `r-lib/actions/setup-r`) before running `raven check`. Without R, the command still runs and reports everything else.
+
+### Scope
+
+Only plain R files (`.R` / `.r`) are reported. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped — chunk extraction isn't supported on the command line — with a one-line note on stderr when one is named explicitly. Other file types (JAGS / Stan) are indexed for cross-file purposes where applicable but are not diagnosed.
 
 ## `raven lint`
 
@@ -22,14 +89,8 @@ raven lint [OPTIONS] [PATHS...]
 ### Exit codes
 
 - `0` — no diagnostic exceeded `--max-severity`.
-- `1` — at least one diagnostic exceeded `--max-severity`.
-- `2` — operator error detected while running (config parse failure, unreadable or missing path). An unknown flag is a usage error and exits `1`.
-
-### Output formats
-
-- `text` — `path:line:col level: message [rule]`, one per line.
-- `json` — array of `{ path, diagnostic }` objects (`diagnostic` is a verbatim LSP `Diagnostic`).
-- `sarif` — SARIF 2.1.0 envelope. Tool name `raven`; `ruleId` from `Diagnostic.code`.
+- `1` — at least one diagnostic exceeded `--max-severity`. An unknown flag is a usage error and exits `1`.
+- `2` — operator error detected while running (config parse failure, unreadable or missing path).
 
 ### GitHub Actions example
 
@@ -45,6 +106,14 @@ raven lint [OPTIONS] [PATHS...]
 
 ### Scope
 
-`raven lint` runs the native style linter only. Cross-file, undefined-variable, and package diagnostics need a workspace scan and are LSP-only.
+`raven lint` runs the native style linter only. Cross-file, undefined-variable, and package diagnostics need a workspace scan; use [`raven check`](#raven-check) for those.
 
 Only plain R files (`.R` / `.r`) are linted. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped with a one-line note on stderr — chunk extraction isn't supported on the command line — and other file types are ignored silently. Passing a directory walks it recursively for R files.
+
+## Output formats
+
+Both `check` and `lint` share the same renderers:
+
+- `text` — `path:line:col level: message [rule]`, one per line.
+- `json` — array of `{ path, diagnostic }` objects (`diagnostic` is a verbatim LSP `Diagnostic`).
+- `sarif` — SARIF 2.1.0 envelope. Tool name `raven`; `ruleId` from `Diagnostic.code`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,7 +4,7 @@ Raven ships a single binary that serves the LSP via stdio *and* exposes subcomma
 
 - `raven check` — index a workspace and report the **full** diagnostic set (the same diagnostics the editor publishes), for CI gating.
 - `raven lint` — run the native **style** linter only.
-- `analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
+- `raven analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
 
 The difference between `check` and `lint`: `lint` parses each file in isolation and runs only the style rules, so it is fast and needs no R installation, but it cannot see relationships between files. `check` builds the same workspace index the language server builds, so it additionally reports cross-file, undefined-variable, and package diagnostics. Reach for `lint` when you only want style gating; reach for `check` when you want the editor's full analysis in CI.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,8 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 
 `raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.enabled = false` disables R detection entirely (no R subprocess, no package or base-symbol diagnostics — matching the editor), `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
 
+Before reporting, `raven check` warms the export cache for the packages each reported file attaches with `library()` / `require()`, so a bare call into an attached package that isn't one of its exports is flagged the same way the editor flags it. One narrow gap remains: a package attached only *indirectly* — in a `source()`d file rather than in the reported file itself — is not pre-warmed, so calls that could resolve to such a package are left unflagged rather than risk a false positive. Attach the package directly in the file (or rely on the editor) if you need those calls checked.
+
 ### Exit codes
 
 - `0` — no diagnostic exceeded `--max-severity`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,7 +67,7 @@ To get installed-package and base-symbol awareness in CI, install R (e.g. `r-lib
 
 ### Scope
 
-Only plain R files (`.R` / `.r`) are reported. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped — chunk extraction isn't supported on the command line — with a one-line note on stderr when one is named explicitly. Other file types (JAGS / Stan) are indexed for cross-file purposes where applicable but are not diagnosed.
+Only plain R files (`.R` / `.r`) are reported. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped — chunk extraction isn't supported on the command line — with a one-line note on stderr when one is named explicitly.
 
 ## `raven lint`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ Most settings are exposed as VS Code settings — search for "raven" in Settings
 
 ## Project config: `raven.toml`
 
-The recommended way to configure Raven is a `raven.toml` file at the project root. Every editor and the `raven lint` CLI read this file, so a single committed config governs both interactive editing and CI.
+The recommended way to configure Raven is a `raven.toml` file at the project root. Every editor and the `raven check` / `raven lint` CLIs read this file, so a single committed config governs both interactive editing and CI.
 
 ### Discovery
 

--- a/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
@@ -1,0 +1,262 @@
+# Extract a shared `build_package_library` helper (kill editor/CI drift)
+
+**Date:** 2026-05-29
+**Status:** Design proposed (incorporates a Codex review); pending user review before implementation plan
+**Files:** `crates/raven/src/package_library.rs`, `crates/raven/src/backend.rs`, `crates/raven/src/cli/check.rs`, `docs/cli.md`
+
+## Problem
+
+The "build a `PackageLibrary` from current configuration" sequence is hand-reproduced in **four** places. They were written separately and have already drifted:
+
+| # | Site | Lock model | Readiness vs `add_library_paths` | R discovery | Surfacing |
+|---|---|---|---|---|---|
+| 1 | `backend.rs::rebuild_package_library` (~6715) | `&Arc<RwLock<WorldState>>`, snapshot-then-drop | **after** | `spawn_blocking` | `log::warn!` |
+| 2 | `cli/check.rs::maybe_init_r` (~362) | `&mut WorldState` (owned) | **after** | `spawn_blocking` | 3 `eprintln!` notes |
+| 3 | `backend.rs::ensure_package_library_initialized` (~1159) | snapshot + write-lock race re-check | **before** ⚠️ | direct on async executor ⚠️ | `log::warn!` |
+| 4 | `backend.rs` Task B post-scan init (~2324) | snapshot, write-lock apply | **before** ⚠️ | `spawn_blocking` | `log::info!` counts + perf |
+
+The two startup paths (#3, #4) compute `package_library_ready` from `lib_paths()` **before** `add_library_paths` runs, while the canonical builder (#1) and the CLI (#2) compute it **after**. In the case "R yields no paths, but `additionalLibraryPaths` is valid," #1/#2 mark the library *ready* while #3/#4 mark it *not-ready*. This divergence is not test-pinned. It is the same class of bug `raven check` was created to prevent (CI diagnostics must match the editor's), which itself already drifted once when `maybe_init_r` shipped without the `packages.enabled` gate (fixed in the prior session; see the working-tree diff to `check.rs`).
+
+This is a **refactor, not a bug fix**: present per-site behavior is what it is, and the convergence is designed to be observably behavior-neutral on supported platforms (see "Phase 2" and "Two findings" below). The goal is to remove the structural cause of this drift class.
+
+### Two findings that shape the design
+
+1. **`PackageLibrary::initialize()` never returns `Err`.** It has a single `Ok(())` return (`package_library.rs:1074`) and swallows every R failure with `log::trace!` + a fallback. So the `InitFailed` branch is dead in all four sites today. We keep the variant for the CLI's three-note contract and because `initialize()`'s signature is fallible, but we do not write tests or caller logic implying it is reachable via the real pipeline.
+
+2. **`get_fallback_lib_paths()` is unconditionally non-empty on macOS/Linux/Windows** (hardcoded framework/system/Homebrew pushes, `r_subprocess.rs:1189-1248`). `initialize()` falls back to it whenever R reports nothing (`package_library.rs:943-945`, `1095-1098`). Consequence: post-`initialize()`, `lib_paths()` is **always non-empty** on supported platforms. Therefore `RNotFound` / `NoLibraryPaths`, the CLI's R-degradation `eprintln!` notes, **and the phase-2 before/after readiness difference are all unreachable end-to-end** on dev/CI machines (they require an exotic target where the cfg fallback is empty). This is why the readiness predicate is pinned by a pure, platform-independent classifier rather than by end-to-end tests, and why phase 2 is a no-op on supported platforms.
+
+## Decisions
+
+Three open decisions from the handoff, resolved.
+
+### 1. Scope — full structure, two-phase
+
+Route all four sites through one helper, split into:
+
+- **Phase 1 (pure refactor):** converge sites #1 and #2 (already matching). Zero behavior change.
+- **Phase 2 (explicit, separately reviewable change):** migrate sites #3 and #4. Standardizes readiness on the canonical "after `add_library_paths`" timing and moves #3's R discovery into `spawn_blocking`. On supported platforms this is observably a no-op (finding #2); the convergence is what closes the drift.
+
+### 2. Outcome type — struct `{ library, status }` with a status enum
+
+```rust
+/// Outcome of [`build_package_library`]: the constructed library plus a single
+/// status that is the sole source of truth for readiness and the degradation
+/// reason. Encoding state as one enum (not a `(lib, bool)` pair + a separate
+/// reason) makes the illegal "ready, but with a degradation reason" state
+/// unrepresentable — the drift this helper exists to prevent.
+pub struct PackageLibraryOutcome {
+    /// Always present. `new_empty()` for `Disabled`. NOTE: a non-`Ready`
+    /// library may still carry useful offline data (base symbols, configured
+    /// additional paths), so "install it anyway" vs "discard it" is a *caller
+    /// policy*, not implied by the status — see the caller table below.
+    pub library: Arc<PackageLibrary>,
+    pub status: PackageLibraryStatus,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PackageLibraryStatus {
+    Disabled,            // packages.enabled == false; no R discovery attempted
+    Ready,               // initialized with >= 1 library path — the only ready state
+    RNotFound,           // no R subprocess located (incl. spawn_blocking join failure)
+    InitFailed(String),  // initialize() errored — currently unreachable (finding #1)
+    NoLibraryPaths,      // R found, init ok, but zero lib paths discovered/configured
+}
+```
+
+Rationale (researched): the `(lib, bool)` + separate-reason option is the desyncable "boolean flags are bugs in disguise" anti-pattern; a single enum makes illegal states unrepresentable (Minsky's principle). A struct wrapping a *common* `library` field + a status enum is preferred over a fat enum that repeats `Arc<PackageLibrary>` in every variant, because the library is genuinely common to every outcome and the LSP callers consume it uniformly — repeating it per-variant would only add destructuring boilerplate. The *state* is still one enum, satisfying the principle. Sources: [rafaelfernandez.dev](https://blog.rafaelfernandez.dev/posts/making-invalid-states-unrepresentable-1-boolean-flags/), [corrode — enums](https://corrode.dev/blog/enums/), [corrode — illegal state](https://corrode.dev/blog/illegal-state/).
+
+### 3. Helper home — `package_library.rs`
+
+Idiomatic Rust co-locates construction logic with the type it builds ([Rustonomicon — constructors](https://doc.rust-lang.org/nomicon/constructors.html)). The helper takes owned/cloned inputs and no `WorldState`, so it stays lock-free and adds no `WorldState`/`Client`/logging/perf dependency to the module — keeping the model type from becoming a backend module, and stopping the CLI reaching deeper into `backend`.
+
+## Architecture
+
+### The helper (`package_library.rs`)
+
+```rust
+pub async fn build_package_library(
+    r_path: Option<PathBuf>,
+    additional_paths: &[PathBuf],
+    workspace_root: Option<PathBuf>,
+    packages_enabled: bool,
+) -> PackageLibraryOutcome {
+    if !packages_enabled {
+        return PackageLibraryOutcome {
+            library: Arc::new(PackageLibrary::new_empty()),
+            status: PackageLibraryStatus::Disabled,
+        };
+    }
+
+    // R discovery does synchronous IO (which/where, R --version); keep it off
+    // the async runtime. A spawn_blocking join failure collapses to `None`,
+    // i.e. "R not found" — matching the existing builders' `.unwrap_or(None)`
+    // (backend.rs:6749, 2335). It is NOT mapped to InitFailed.
+    let subprocess = tokio::task::spawn_blocking(move || {
+        match (RSubprocess::new(r_path), workspace_root) {
+            (Some(sub), Some(root)) => Some(sub.with_working_dir(root)),
+            (sub, _) => sub,
+        }
+    })
+    .await
+    .unwrap_or(None);
+
+    let r_found = subprocess.is_some();
+    let mut lib = PackageLibrary::with_subprocess(subprocess);
+    let init_error = lib.initialize().await.err().map(|e| e.to_string());
+    // Augment, never clobber: additional paths apply AFTER discovery so the
+    // readiness check below counts them too.
+    lib.add_library_paths(additional_paths);
+    let has_lib_paths = !lib.lib_paths().is_empty();
+
+    let status = PackageLibraryStatus::classify(init_error, r_found, has_lib_paths);
+    PackageLibraryOutcome { library: Arc::new(lib), status }
+}
+```
+
+The helper **never logs or prints**; each caller surfaces the status its own way.
+
+### The pure classifier (single source of truth for the predicate)
+
+The readiness predicate + degradation precedence are extracted into a pure function so they can be table-tested deterministically and platform-independently (finding #2 makes end-to-end testing of the interesting branches impossible). The error payload lives *outside* the boolean truth table by passing `Option<String>` (resolving the "InitFailed payload vs exhaustive table fight"):
+
+```rust
+impl PackageLibraryStatus {
+    /// Only `Ready` is ready.
+    pub fn is_ready(&self) -> bool { matches!(self, Self::Ready) }
+
+    /// Classify an *enabled* build. `init_error == None` means initialize()
+    /// succeeded. Precedence mirrors the CLI's current order exactly
+    /// (Ready -> RNotFound -> InitFailed -> NoLibraryPaths), so phase 1 is
+    /// behavior-identical. `Disabled` is set by the gate before this is called.
+    fn classify(
+        init_error: Option<String>,
+        r_found: bool,
+        has_lib_paths: bool,
+    ) -> Self {
+        if init_error.is_none() && has_lib_paths {
+            Self::Ready
+        } else if !r_found {
+            Self::RNotFound
+        } else if let Some(err) = init_error {
+            Self::InitFailed(err)
+        } else {
+            Self::NoLibraryPaths
+        }
+    }
+}
+```
+
+Full truth table (8 rows), which the test pins exactly:
+
+| `init_error` | `r_found` | `has_lib_paths` | → status |
+|---|---|---|---|
+| None | T | T | Ready |
+| None | T | F | NoLibraryPaths |
+| None | F | T | Ready *(R absent but fallback/additional paths present — matches CLI)* |
+| None | F | F | RNotFound |
+| Some | T | T | InitFailed *(dead today; logic only)* |
+| Some | T | F | InitFailed *(dead today; logic only)* |
+| Some | F | T | RNotFound *(R-absent precedes init error — matches CLI)* |
+| Some | F | F | RNotFound |
+
+### Caller policy table
+
+The `library` field is common to all outcomes, but callers differ on whether to install a non-`Ready` library. This divergence is intentional and must be preserved exactly:
+
+| Caller | On `Disabled` | On other non-`Ready` | On `Ready` | Surfacing |
+|---|---|---|---|---|
+| #1 `rebuild_package_library` | returns `(library, false)` | returns `(library, false)` — **installs the built library** | `(library, true)` | `log::warn!` iff `InitFailed` |
+| #2 `maybe_init_r` (CLI) | keep pre-existing default; silent | **keep default**; `ready` stays false; print the matching R-degradation note | swap `library` in; `ready = true` | 3 `eprintln!` notes (R-degradation only) |
+| #3 `ensure_package_library_initialized` | (unreached: gated by early `!enabled` return) | install `library` under race-rechecked write lock; `ready = is_ready()` | same | `log::trace!` "on demand"; `log::warn!` iff `InitFailed` |
+| #4 Task B startup | install `new_empty`; `ready=false`; `log::info!` "disabled" | install `library` (race-rechecked); `ready = is_ready()` | same | `log::info!` counts; perf; `log::warn!` iff `InitFailed` |
+
+## Migration
+
+### Phase 1 — pure refactor (no behavior change)
+
+**#1 `rebuild_package_library`** keeps its snapshot-under-read-lock-then-drop block (locking discipline), then:
+
+```rust
+let outcome = crate::package_library::build_package_library(
+    packages_r_path, &additional_paths, workspace_root, packages_enabled,
+).await;
+if let PackageLibraryStatus::InitFailed(e) = &outcome.status {
+    log::warn!("rebuild_package_library: initialize failed: {e}");
+}
+(outcome.library, outcome.status.is_ready())
+```
+
+**#2 `maybe_init_r`** snapshots its inputs from `&mut state` into locals *before* the call (avoids the borrow conflict with the later `state` mutation), then matches:
+
+```rust
+let r_path = state.cross_file_config.packages_r_path.clone();
+let additional = state.cross_file_config.packages_additional_library_paths.clone();
+let enabled = state.cross_file_config.packages_enabled;
+let outcome = crate::package_library::build_package_library(
+    r_path, &additional, Some(root.to_path_buf()), enabled,
+).await;
+use crate::package_library::PackageLibraryStatus::*;
+match outcome.status {
+    Ready => { state.package_library = outcome.library; state.package_library_ready = true; }
+    Disabled => {}                       // keep default, silent — matches current early return
+    RNotFound => eprintln!("raven check: R not found on PATH; package and base-symbol diagnostics will be limited"),
+    InitFailed(e) => eprintln!("raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"),
+    NoLibraryPaths => eprintln!("raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"),
+}
+```
+
+This preserves: the disabled-gate-before-R-discovery, the three notes verbatim, "keep default on non-Ready," and the readiness predicate.
+
+### Phase 2 — explicit, separately reviewable change
+
+**#3 `ensure_package_library_initialized`**: keep the `!enabled` early-return and the `already_ready` short-circuit (the helper doesn't know about either), keep the `log::trace!`, then call `build_package_library(..., packages_enabled = true)`. **Keep the write-lock race re-check** (`backend.rs:1205-1212`) that avoids overwriting a library a competing path already installed — the helper must not absorb this stateful policy. Re-emit `log::warn!` on `InitFailed`.
+
+**#4 Task B post-scan init**: replace the inline `if packages_enabled { build } else { new_empty }` block (`backend.rs:2320-2369`) with the helper. **Keep perf metrics** (`record_package_init`, `backend.rs:2321/2351/2353`), the count `log::info!`, and the "disabled" `log::info!` (matched off `Disabled`) **outside** the helper. Keep the "apply only if not already ready" race re-check (`backend.rs:2376-2386`).
+
+Two intended changes fall out, both behavior-neutral on supported platforms (finding #2):
+
+1. Readiness now computed **after** `add_library_paths` in both (was before). Observable only where the platform fallback is empty *and* `additionalLibraryPaths` is set: there, the library flips `not-ready → ready`, matching the canonical builder, and the libpath watcher (`restart_libpath_watcher`, gated on `package_library_ready`) may then watch those configured paths.
+2. #3's R discovery moves into `spawn_blocking` (was a direct synchronous `RSubprocess::new` on the async executor in the `did_open` path, `backend.rs:1191`) — a latent fix aligning it with #1/#4.
+
+## Test plan
+
+The interesting predicate branches are unreachable end-to-end on supported platforms (finding #2), so the predicate is pinned by the pure classifier, and the anti-drift guarantee is "all four sites route through one helper" (verified by code, not by four parallel end-to-end tests).
+
+### Stay green (regression net)
+- `cli/check.rs::maybe_init_r_honors_additional_library_paths`
+- `cli/check.rs::maybe_init_r_skips_when_packages_disabled`
+- `backend.rs` `rebuild_package_library` disabled-path test (`backend.rs:9283`)
+
+### New — `package_library.rs` `mod tests`
+- **`classify` truth table:** all 8 rows above, asserted exactly. This is the deterministic, platform-independent pin for the readiness predicate and precedence. The `Some(_)` rows test classification *logic* only (finding #1 — not reachable via `initialize()`).
+- **`build_package_library` disabled:** `packages_enabled = false` → `status == Disabled`, `library.lib_paths()` empty, `!is_ready()`. R-independent.
+- **`build_package_library` honors additional paths:** with `packages_enabled = true` and a **real temp dir** in `additional_paths`, that path appears in `outcome.library.lib_paths()`. Uses a temp dir (not a bogus path) because `add_library_paths` appends without existence checks (`package_library.rs:721`), so the test reflects the "valid additional path" intent.
+
+### Adjacent disabled-gates — verify, don't refactor
+These are *callers* of `rebuild_package_library`, not builders, so they are out of refactor scope; but they hold `packages_enabled` semantics in a second place and could drift. Confirm (add a small assertion if not already covered) that each yields `Disabled + empty + not-ready`:
+- Settings reload, `backend.rs:5719` — `if packages_enabled { rebuild } else { new_empty }`. The outer gate is now redundant with the helper's gate; leave a one-line comment noting the helper self-gates, or drop the redundant branch (a judgment call for the plan).
+- `raven.refreshPackages`, `backend.rs:2476` — checks `packages_enabled` before rebuild.
+
+### Verification commands (run from the worktree, NOT the main checkout)
+```
+cargo test -p raven --lib package_library::   # helper + classify tests
+cargo test -p raven --lib cli::               # CLI module
+cargo test -p raven --lib maybe_init_r        # gate/additional-paths tests
+cargo test -p raven --lib rebuild_package     # backend builder tests
+```
+
+## Documentation updates
+- `cli/check.rs:342-361` doc comment: point at the shared `build_package_library` / status rules, not at `backend::rebuild_package_library`, so maintainers don't reintroduce backend↔CLI coupling by hand. Tighten the "degradation paths" wording: there are **three R-related** `eprintln!` notes; `Disabled` is a degradation path that prints **nothing**.
+- A doc comment on `build_package_library` / `PackageLibraryStatus` stating it is the single source of the readiness predicate and that all four sites route through it.
+- `docs/cli.md` "R and packages": no functional change, but verify wording still matches after the doc-comment tightening.
+
+## Invariants preserved (CLAUDE.md)
+- **Locking discipline.** The helper is lock-free (owned/cloned inputs, no `WorldState`). Phase-1 wrappers snapshot all config and drop the read guard before the `spawn_blocking` + `initialize().await`; phase-2 sites keep their existing snapshot-then-build structure. No lock is held across R discovery / `await` / cross-file work.
+- **Readiness predicate.** `Ready` still requires non-empty `lib_paths()`, so a half-initialized library never reads as ready and never emits false-positive missing-package diagnostics. Centralized in `classify`.
+- **`add_library_paths` ordering.** Runs *after* R discovery in the helper, so configured paths augment (never suppress) R-reported paths — now uniform across all four sites.
+
+## Out of scope
+- Removing the now-provably-dead `InitFailed` path (and collapsing the CLI from three R-notes to two).
+- Reworking the `did_open` race re-check in `ensure_package_library_initialized`.
+- Any change to `initialize()`'s fallback behavior or to `get_fallback_lib_paths()` (incl. the quirk that R-absent still yields fallback paths on supported platforms).
+- Refactoring the adjacent disabled-gates at `backend.rs:5719` / `2476` beyond an optional redundancy comment.

--- a/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
@@ -247,7 +247,7 @@ The interesting predicate branches are unreachable end-to-end on supported platf
 - **`backend.rs:2476` (kept):** verify (assert if not already covered) that `refreshPackages` while disabled does **not** clear an already-populated library — the behavior the load-bearing gate protects.
 
 ### Verification commands (run from the worktree, NOT the main checkout)
-```
+```bash
 cargo test -p raven --lib package_library::   # helper + classify tests
 cargo test -p raven --lib cli::               # CLI module
 cargo test -p raven --lib maybe_init_r        # gate/additional-paths tests

--- a/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
@@ -23,7 +23,7 @@ This is a **refactor, not a bug fix**: present per-site behavior is what it is, 
 
 1. **`PackageLibrary::initialize()` never returns `Err`.** It has a single `Ok(())` return (`package_library.rs:1074`) and swallows every R failure with `log::trace!` + a fallback. So the `InitFailed` branch is dead in all four sites today. We keep the variant for the CLI's three-note contract and because `initialize()`'s signature is fallible, but we do not write tests or caller logic implying it is reachable via the real pipeline.
 
-2. **`get_fallback_lib_paths()` is unconditionally non-empty on macOS/Linux/Windows** (hardcoded framework/system/Homebrew pushes, `r_subprocess.rs:1189-1248`). `initialize()` falls back to it whenever R reports nothing (`package_library.rs:943-945`, `1095-1098`). Consequence: post-`initialize()`, `lib_paths()` is **always non-empty** on supported platforms. Therefore `RNotFound` / `NoLibraryPaths`, the CLI's R-degradation `eprintln!` notes, **and the phase-2 before/after readiness difference are all unreachable end-to-end** on dev/CI machines (they require an exotic target where the cfg fallback is empty). This is why the readiness predicate is pinned by a pure, platform-independent classifier rather than by end-to-end tests, and why phase 2 is a no-op on supported platforms.
+2. **`get_fallback_lib_paths()` is non-empty only when R is actually installed.** It pushes hardcoded framework/system/Homebrew locations (`r_subprocess.rs:1189-1248`) **but then filters to only paths that exist** (`r_subprocess.rs:1262`, `.filter(|p| p.exists())`). `initialize()` falls back to it whenever R reports nothing (`package_library.rs:943-945`, `1095-1098`). Consequence on a dev machine with R installed: `lib_paths()` is non-empty even when R discovery itself fails, so `RNotFound` / `NoLibraryPaths` are not reached *there*. **But on a headless CI runner with no R installed — `raven check`'s explicit primary use case — none of those directories exist, the filtered fallback is empty, and `classify` returns `RNotFound` (or `NoLibraryPaths` if only `additionalLibraryPaths` is set).** So `RNotFound`, `NoLibraryPaths`, and their CLI degradation notes are **load-bearing in the no-R-in-CI case, not dead** — and the phase-2 readiness-timing difference is observable there whenever `additionalLibraryPaths` is configured. Only **`InitFailed` is genuinely unreachable** (finding #1: `initialize()` never returns `Err`). The readiness predicate is still pinned by a pure, platform-independent classifier because the *combination* of inputs (R-absent × fallback-empty × additional-paths) is awkward to stage end-to-end, not because the branches can't occur.
 
 ## Decisions
 
@@ -230,7 +230,7 @@ Two intended changes fall out, both behavior-neutral on supported platforms (fin
 
 ## Test plan
 
-The interesting predicate branches are unreachable end-to-end on supported platforms (finding #2), so the predicate is pinned by the pure classifier, and the anti-drift guarantee is "all four sites route through one helper" (verified by code, not by four parallel end-to-end tests).
+The interesting predicate branches are awkward to stage end-to-end (they need R-absent × empty-fallback × specific `additionalLibraryPaths` combinations — finding #2), though `RNotFound`/`NoLibraryPaths` do occur in real no-R CI runs. So the predicate is pinned by the pure classifier, and the anti-drift guarantee is "all four sites route through one helper" (verified by code, not by four parallel end-to-end tests).
 
 ### Stay green (regression net)
 - `cli/check.rs::maybe_init_r_honors_additional_library_paths`
@@ -278,5 +278,5 @@ TDD applies within each commit (helper `classify` tests are RED before the helpe
 ## Out of scope
 - Removing the now-provably-dead `InitFailed` path (and collapsing the CLI from three R-notes to two).
 - Reworking the `did_open` race re-check in `ensure_package_library_initialized`.
-- Any change to `initialize()`'s fallback behavior or to `get_fallback_lib_paths()` (incl. the quirk that R-absent still yields fallback paths on supported platforms).
+- Any change to `initialize()`'s fallback behavior or to `get_fallback_lib_paths()` (which yields fallback paths only when the standard R install directories actually exist — so on a machine *with* R it can mask R-discovery failure, but on a no-R CI runner it is empty and `RNotFound`/`NoLibraryPaths` are reached; see finding #2).
 - Changing `backend.rs:2476`'s behavior (its `packages_enabled` gate is load-bearing — see Decision 4 — so it stays; only a clarifying comment is added). The `backend.rs:5719` redundant branch **is** removed, but as its own isolated commit, not folded into the extraction.

--- a/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-package-library-helper-design.md
@@ -69,6 +69,16 @@ Rationale (researched): the `(lib, bool)` + separate-reason option is the desync
 
 Idiomatic Rust co-locates construction logic with the type it builds ([Rustonomicon — constructors](https://doc.rust-lang.org/nomicon/constructors.html)). The helper takes owned/cloned inputs and no `WorldState`, so it stays lock-free and adds no `WorldState`/`Client`/logging/perf dependency to the module — keeping the model type from becoming a backend module, and stopping the CLI reaching deeper into `backend`.
 
+### 4. Adjacent disabled-gates — remove the redundant one, keep the load-bearing one
+
+Two *callers* of `rebuild_package_library` hold `packages_enabled` semantics in a second place. They look alike but need opposite treatment:
+
+- **`backend.rs:5719` (settings reload) — remove the redundant branch.** It is `if packages_enabled { rebuild } else { (new_empty, false) }`, and it *always* swaps the result into `state`. Since `rebuild_package_library` already self-gates (`backend.rs:6734`) and returns exactly `(new_empty, false)` when disabled, the `else` branch is pure duplication of the disabled→empty decision — the very drift surface this refactor targets. DRY / single-source-of-truth says collapse it to an unconditional `let (lib, ready) = rebuild_package_library(&self.state).await;`. Behavior-neutral (when disabled, the helper returns `new_empty`/`false` either way; the only difference is one extra brief read-lock acquisition and no R discovery, exactly as before). `packages_enabled` stays captured for the later prefetch guard at `backend.rs:5754`.
+
+- **`backend.rs:2476` (`raven.refreshPackages`) — keep it; it is load-bearing.** When disabled, the swap is *inside* the `if`, so the existing library is left in place. Removing the gate would route through the helper and swap in `new_empty`, **clobbering** the user's current library on a refresh issued while packages are disabled. Leave it unchanged and add a one-line comment explaining the gate guards against that clobber, so it isn't "tidied" away later.
+
+Best-practice basis: DRY for the redundant gate ([replace-nested-conditional-with-guard-clauses](https://refactoring.guru/replace-nested-conditional-with-guard-clauses)); isolate the cleanup in its own commit to keep the extraction reviewable ([focused / "campsite" PRs](https://blog.thepete.net/blog/2019/05/10/6-practices-for-effective-pull-requests/)).
+
 ## Architecture
 
 ### The helper (`package_library.rs`)
@@ -232,10 +242,9 @@ The interesting predicate branches are unreachable end-to-end on supported platf
 - **`build_package_library` disabled:** `packages_enabled = false` → `status == Disabled`, `library.lib_paths()` empty, `!is_ready()`. R-independent.
 - **`build_package_library` honors additional paths:** with `packages_enabled = true` and a **real temp dir** in `additional_paths`, that path appears in `outcome.library.lib_paths()`. Uses a temp dir (not a bogus path) because `add_library_paths` appends without existence checks (`package_library.rs:721`), so the test reflects the "valid additional path" intent.
 
-### Adjacent disabled-gates — verify, don't refactor
-These are *callers* of `rebuild_package_library`, not builders, so they are out of refactor scope; but they hold `packages_enabled` semantics in a second place and could drift. Confirm (add a small assertion if not already covered) that each yields `Disabled + empty + not-ready`:
-- Settings reload, `backend.rs:5719` — `if packages_enabled { rebuild } else { new_empty }`. The outer gate is now redundant with the helper's gate; leave a one-line comment noting the helper self-gates, or drop the redundant branch (a judgment call for the plan).
-- `raven.refreshPackages`, `backend.rs:2476` — checks `packages_enabled` before rebuild.
+### Adjacent disabled-gate cleanup (its own commit — see Decision 4)
+- **`backend.rs:5719` removal:** add a regression test that a settings reload with `packages_enabled == false` yields `package_library` empty and `package_library_ready == false` (locking in that the now-unconditional `rebuild_package_library` call preserves the disabled outcome). Confirm the existing settings-reload tests stay green.
+- **`backend.rs:2476` (kept):** verify (assert if not already covered) that `refreshPackages` while disabled does **not** clear an already-populated library — the behavior the load-bearing gate protects.
 
 ### Verification commands (run from the worktree, NOT the main checkout)
 ```
@@ -244,6 +253,17 @@ cargo test -p raven --lib cli::               # CLI module
 cargo test -p raven --lib maybe_init_r        # gate/additional-paths tests
 cargo test -p raven --lib rebuild_package     # backend builder tests
 ```
+
+## Commit / PR strategy
+
+Separate commits, **one PR**. Ordered so each commit builds and tests green on its own:
+
+1. **Precondition.** Commit the prior session's existing working-tree changes (the `packages.enabled` gate in `maybe_init_r`, the `should_skip_directory` test relocation, the `docs/cli.md` wording) — the refactor edits the same code, so preserve them first (per the handoff).
+2. **Phase 1 — extract + converge the two matching sites.** Add `build_package_library`, `PackageLibraryOutcome`, `PackageLibraryStatus`, `is_ready`, `classify`, and the helper/`classify` tests in `package_library.rs`; route `rebuild_package_library` (#1) and `maybe_init_r` (#2) through it; update the CLI doc comment + `docs/cli.md` wording. Pure refactor.
+3. **Phase 2 — converge the two startup sites.** Route `ensure_package_library_initialized` (#3) and Task B (#4) through the helper, preserving each site's surrounding context; add the phase-2 notes. Explicit (no-op on supported platforms) behavior change.
+4. **Cleanup — adjacent gate (Decision 4).** Remove the redundant `packages_enabled` branch at `backend.rs:5719` + regression test; add the load-bearing comment at `backend.rs:2476`.
+
+TDD applies within each commit (helper `classify` tests are RED before the helper exists, etc.).
 
 ## Documentation updates
 - `cli/check.rs:342-361` doc comment: point at the shared `build_package_library` / status rules, not at `backend::rebuild_package_library`, so maintainers don't reintroduce backend↔CLI coupling by hand. Tighten the "degradation paths" wording: there are **three R-related** `eprintln!` notes; `Disabled` is a degradation path that prints **nothing**.
@@ -259,4 +279,4 @@ cargo test -p raven --lib rebuild_package     # backend builder tests
 - Removing the now-provably-dead `InitFailed` path (and collapsing the CLI from three R-notes to two).
 - Reworking the `did_open` race re-check in `ensure_package_library_initialized`.
 - Any change to `initialize()`'s fallback behavior or to `get_fallback_lib_paths()` (incl. the quirk that R-absent still yields fallback paths on supported platforms).
-- Refactoring the adjacent disabled-gates at `backend.rs:5719` / `2476` beyond an optional redundancy comment.
+- Changing `backend.rs:2476`'s behavior (its `packages_enabled` gate is load-bearing — see Decision 4 — so it stays; only a clarifying comment is added). The `backend.rs:5719` redundant branch **is** removed, but as its own isolated commit, not folded into the extraction.


### PR DESCRIPTION
## What

Adds a new `raven check` CLI subcommand and refactors the package-library initialization path to remove editor/CI drift.

### `raven check` — full diagnostics for CI
- New subcommand that indexes the workspace and reports the **full** diagnostic set (syntax, semantic, style lints, cross-file, package, and undefined-variable) — the same diagnostics the editor publishes, run headlessly. This is the CI counterpart to `raven lint`, which only runs style rules in isolation.
- Auto-detects R (honoring `packages.enabled` / `packages.rPath` / `packages.additionalLibraryPaths`) to resolve installed-package exports and base symbols; degrades gracefully with a one-line stderr note when R is absent.
- Exit codes match `raven lint` (`0` ok, `1` threshold breach / usage error, `2` operator error).
- Docs: new `docs/cli.md#raven-check` section, README/configuration updates, GitHub Actions + SARIF example.

### Shared CLI code (`cli/shared.rs`)
- Extracts `OutputFormat`, `SeverityLevel`, the `text`/`json`/`sarif` renderers, severity gating, file-type predicates, and the recursive R-file walker out of `cli/lint.rs` so `check`, `lint`, and `analysis-stats` share one implementation instead of each other's internals.

### Shared `build_package_library` helper (kills editor/CI drift)
- The "build a `PackageLibrary` from config" sequence was hand-reproduced in **four** places that had already drifted (readiness computed before vs after `add_library_paths`, inconsistent `spawn_blocking` use). All four now route through one `build_package_library` helper in `package_library.rs`.
- Readiness + degradation precedence live in a single pure `classify` function with a table-tested truth table, making the illegal "ready, but degraded" state unrepresentable via a `{ library, status }` outcome + `PackageLibraryStatus` enum.
- Adjacent `packages_enabled` gates cleaned up: the redundant settings-reload gate is collapsed (the helper self-gates); the load-bearing `refreshPackages` gate is kept with a comment + regression test (it must not clobber an existing library when packages are disabled).
- `find_package_directory` now requires NAMESPACE/DESCRIPTION to be a readable **file**, not just an existing path — fixes acceptance of a directory named `NAMESPACE`.

## Why

`raven lint` parses files in isolation, so CI couldn't gate on cross-file, undefined-variable, or package diagnostics. `raven check` closes that gap. The shared helper exists because CI diagnostics must match the editor's, and the four parallel init sites were the structural cause of drift (one already shipped without the `packages.enabled` gate).

## Reviewer notes

- The design rationale (four sites, the readiness predicate, the dead-but-kept `InitFailed` variant, why `get_fallback_lib_paths` makes some branches unreachable end-to-end) is documented in `docs/superpowers/specs/2026-05-29-package-library-helper-design.md`.
- `cli/check.rs` re-sequences shared building blocks (`recompute_parsed_configs` → `scan_workspace` → `apply_workspace_index` → `initialize_package_inputs_from_state` → `build_package_library`) rather than calling a single LSP orchestrator, because the LSP startup is bound to locks/client/background tasks and isn't extractable. The drift-prone part (package-library construction) is the part that *was* centralized.
- The interesting `classify` branches are unreachable on supported platforms (the cfg fallback is always non-empty), so they're pinned by the pure classifier's truth table rather than end-to-end tests.

## Tests
- `cargo test -p raven --lib package_library::` — 79 passed.
- New tests: `classify` truth table, `build_package_library` disabled/additional-paths, the two adjacent-gate regressions (settings-reload-disabled, refresh-while-disabled), `raven check` parse/collect/exit-code coverage, symlink-skipping walker, and the unusable-package-dir skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless "raven check" subcommand for full workspace diagnostics; shares text/json/sarif renderers with lint and honors severity thresholds.

* **Bug Fixes / Reliability**
  * More robust package-awareness and initialization (preserves existing library when packages disabled), safer workspace scanning, and consistent handling of unreadable or non-UTF encodings.

* **Documentation**
  * README and CLI docs clarified differences between `raven check` (full diagnostics) and `raven lint` (style-only) and documented usage/exit codes.

* **Tests**
  * Added/expanded tests covering CLI args, package gates, file decoding, and config discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->