### PR TITLE
feat: implement CLI color output (`--color` tri-state + `--no-color` alias + NO_COLOR env)

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -21,8 +21,8 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
     absolute_path, collect_r_file_paths, encoding_diagnostic, is_chunk_file, is_r_file,
-    parse_output_format, parse_severity_level, render, OutputFormat, SeverityLevel,
-    EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    parse_color_choice, parse_output_format, parse_severity_level, render, resolve_color_from_env,
+    ColorChoice, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -38,9 +38,11 @@ pub struct CheckArgs {
     pub format: OutputFormat,
     pub max_severity: SeverityLevel,
     pub quiet: bool,
-    /// Accepted for forward compatibility; `text` output is currently uncolored,
-    /// so this has no visible effect yet (parity with `raven lint`).
-    pub no_color: bool,
+    /// Color control for `text` output. `--no-color` parses to
+    /// [`ColorChoice::Never`]; `--color auto|always|never` sets it directly.
+    /// Resolved to on/off by [`resolve_color_from_env`] (TTY +
+    /// `NO_COLOR`/`FORCE_COLOR`).
+    pub color: ColorChoice,
 }
 
 pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<CheckArgs, String> {
@@ -51,7 +53,9 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<CheckArgs, S
     let mut format = OutputFormat::Text;
     let mut max_severity = SeverityLevel::Info;
     let mut quiet = false;
-    let mut no_color = false;
+    // `--color` and `--no-color` write the same field; last-one-wins on conflict
+    // (`--no-color --color always` ⇒ always), matching cargo/ripgrep.
+    let mut color = ColorChoice::Auto;
 
     while let Some(arg) = argv.next() {
         match arg.as_str() {
@@ -73,7 +77,11 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<CheckArgs, S
                 max_severity = parse_severity_level(&v)?;
             }
             "--quiet" => quiet = true,
-            "--no-color" => no_color = true,
+            "--color" => {
+                let v = argv.next().ok_or("--color needs a value")?;
+                color = parse_color_choice(&v)?;
+            }
+            "--no-color" => color = ColorChoice::Never,
             "--help" => return Err("HELP".into()),
             s if s.starts_with("--") => return Err(format!("unknown flag: {s}")),
             p => paths.push(PathBuf::from(p)),
@@ -87,7 +95,7 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<CheckArgs, S
         format,
         max_severity,
         quiet,
-        no_color,
+        color,
     })
 }
 
@@ -111,7 +119,11 @@ Options:
   --max-severity LEVEL        Highest severity that does NOT fail the build
                               (off, hint, info, warning, error; default: info)
   --quiet                     Suppress summary line in text output
-  --no-color                  Disable ANSI colors
+  --color auto|always|never   When to colorize text output (default: auto —
+                              color when stdout is a terminal). Honors NO_COLOR
+                              and FORCE_COLOR under auto; json/sarif are never
+                              colorized.
+  --no-color                  Alias for --color never
 
 R / packages:
   raven check auto-detects R on PATH to resolve installed-package exports and
@@ -245,7 +257,8 @@ pub async fn run(args: CheckArgs) -> i32 {
         .iter()
         .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
 
-    render(args.format, &all_diags, &root, args.quiet);
+    let use_color = resolve_color_from_env(args.color);
+    render(args.format, &all_diags, &root, args.quiet, use_color);
 
     // Operator error takes priority over a threshold breach: a half-read run
     // shouldn't masquerade as a clean (or merely failing) lint result.
@@ -564,7 +577,7 @@ mod tests {
             format: OutputFormat::Json,
             max_severity: SeverityLevel::Info,
             quiet: true,
-            no_color: true,
+            color: ColorChoice::Never,
         }
     }
 
@@ -576,6 +589,25 @@ mod tests {
         assert_eq!(args.format, OutputFormat::Text);
         assert_eq!(args.max_severity, SeverityLevel::Info);
         assert!(!args.no_config);
+        assert_eq!(args.color, ColorChoice::Auto);
+    }
+
+    #[test]
+    fn parse_color_and_no_color_alias() {
+        let always = parse_args(["--color", "always"].iter().map(|s| s.to_string())).unwrap();
+        assert_eq!(always.color, ColorChoice::Always);
+        let never = parse_args(["--no-color"].iter().map(|s| s.to_string())).unwrap();
+        assert_eq!(never.color, ColorChoice::Never);
+        // Last-one-wins on conflict: `--no-color --color always` ⇒ always.
+        let conflict = parse_args(
+            ["--no-color", "--color", "always"]
+                .iter()
+                .map(|s| s.to_string()),
+        )
+        .unwrap();
+        assert_eq!(conflict.color, ColorChoice::Always);
+        // A bad --color value is a usage error.
+        assert!(parse_args(["--color", "sometimes"].iter().map(|s| s.to_string())).is_err());
     }
 
     #[test]
@@ -749,7 +781,7 @@ mod tests {
             format: OutputFormat::Json,
             max_severity: SeverityLevel::Info,
             quiet: true,
-            no_color: true,
+            color: ColorChoice::Never,
         };
         assert_eq!(run_blocking(args), EXIT_LINT_FAILED);
     }

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -6,9 +6,9 @@ use serde_json::json;
 use tower_lsp::lsp_types::Diagnostic;
 
 use crate::cli::shared::{
-    absolute_path, encoding_diagnostic, is_chunk_file, is_r_file, parse_output_format,
-    parse_severity_level, render, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK,
-    EXIT_OPERATOR_ERROR,
+    absolute_path, encoding_diagnostic, is_chunk_file, is_r_file, parse_color_choice,
+    parse_output_format, parse_severity_level, render, resolve_color_from_env, ColorChoice,
+    OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -19,7 +19,11 @@ pub struct LintArgs {
     pub format: OutputFormat,
     pub max_severity: SeverityLevel,
     pub quiet: bool,
-    pub no_color: bool,
+    /// Color control for `text` output. `--no-color` parses to
+    /// [`ColorChoice::Never`]; `--color auto|always|never` sets it directly.
+    /// Resolved to on/off by [`resolve_color_from_env`] (TTY +
+    /// `NO_COLOR`/`FORCE_COLOR`).
+    pub color: ColorChoice,
 }
 
 pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, String> {
@@ -29,7 +33,9 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, St
     let mut format = OutputFormat::Text;
     let mut max_severity = SeverityLevel::Info;
     let mut quiet = false;
-    let mut no_color = false;
+    // `--color` and `--no-color` write the same field; last-one-wins on conflict
+    // (`--no-color --color always` ⇒ always), matching cargo/ripgrep.
+    let mut color = ColorChoice::Auto;
 
     while let Some(arg) = argv.next() {
         match arg.as_str() {
@@ -46,7 +52,11 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, St
                 max_severity = parse_severity_level(&v)?;
             }
             "--quiet" => quiet = true,
-            "--no-color" => no_color = true,
+            "--color" => {
+                let v = argv.next().ok_or("--color needs a value")?;
+                color = parse_color_choice(&v)?;
+            }
+            "--no-color" => color = ColorChoice::Never,
             "--help" => return Err("HELP".into()),
             s if s.starts_with("--") => return Err(format!("unknown flag: {s}")),
             p => paths.push(PathBuf::from(p)),
@@ -62,7 +72,7 @@ pub fn parse_args(mut argv: impl Iterator<Item = String>) -> Result<LintArgs, St
         format,
         max_severity,
         quiet,
-        no_color,
+        color,
     })
 }
 
@@ -82,7 +92,11 @@ Options:
   --max-severity LEVEL        Highest severity that does NOT fail the build
                               (off, hint, info, warning, error; default: info)
   --quiet                     Suppress summary line in text output
-  --no-color                  Disable ANSI colors
+  --color auto|always|never   When to colorize text output (default: auto —
+                              color when stdout is a terminal). Honors NO_COLOR
+                              and FORCE_COLOR under auto; json/sarif are never
+                              colorized.
+  --no-color                  Alias for --color never
 
 Exit codes:
   0   No diagnostic exceeded --max-severity
@@ -226,7 +240,8 @@ pub fn run(args: LintArgs) -> i32 {
         .iter()
         .any(|(_, d)| SeverityLevel::from_diag(d) > args.max_severity);
 
-    render(args.format, &diagnostics, &root, args.quiet);
+    let use_color = resolve_color_from_env(args.color);
+    render(args.format, &diagnostics, &root, args.quiet, use_color);
 
     if any_above_threshold {
         EXIT_LINT_FAILED
@@ -352,6 +367,24 @@ mod tests {
         assert_eq!(args.paths, vec![PathBuf::from(".")]);
         assert_eq!(args.format, OutputFormat::Text);
         assert_eq!(args.max_severity, SeverityLevel::Info);
+        assert_eq!(args.color, ColorChoice::Auto);
+    }
+
+    #[test]
+    fn parse_color_and_no_color_alias() {
+        let never = parse_args(["--color", "never"].iter().map(|s| s.to_string())).unwrap();
+        assert_eq!(never.color, ColorChoice::Never);
+        let alias = parse_args(["--no-color"].iter().map(|s| s.to_string())).unwrap();
+        assert_eq!(alias.color, ColorChoice::Never);
+        // Last-one-wins on conflict: `--no-color --color always` ⇒ always.
+        let conflict = parse_args(
+            ["--no-color", "--color", "always"]
+                .iter()
+                .map(|s| s.to_string()),
+        )
+        .unwrap();
+        assert_eq!(conflict.color, ColorChoice::Always);
+        assert!(parse_args(["--color", "bogus"].iter().map(|s| s.to_string())).is_err());
     }
 
     #[test]
@@ -391,7 +424,7 @@ mod tests {
             format: OutputFormat::Text,
             max_severity: SeverityLevel::Info,
             quiet: true,
-            no_color: true,
+            color: ColorChoice::Never,
         }
     }
 
@@ -574,7 +607,7 @@ mod tests {
             format: OutputFormat::Json,
             max_severity: SeverityLevel::Info,
             quiet: true,
-            no_color: true,
+            color: ColorChoice::Never,
         };
         // Redirect stdout to a buffer is non-trivial; instead just call run() and
         // assert the exit code. Stdout assertions live in the integration test
@@ -681,7 +714,7 @@ mod tests {
             format: OutputFormat::Json,
             max_severity: SeverityLevel::Info,
             quiet: true,
-            no_color: true,
+            color: ColorChoice::Never,
         };
         // Before this migration a non-UTF-8 file set operator_error → exit 2.
         // Now it is an ERROR finding (parity with `raven check`) → exit 1.

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -7,6 +7,7 @@
 //! chunk-bearing documents. That common surface lives here so the two commands
 //! share one implementation without depending on each other's internals.
 
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
@@ -24,6 +25,18 @@ pub enum OutputFormat {
     Text,
     Json,
     Sarif,
+}
+
+/// Tri-state color control for the `text` renderer, mirroring `cargo`/`ripgrep`.
+/// `--no-color` is kept as an alias for `Never`. The choice is resolved to a
+/// concrete on/off by [`resolve_color`]; the CLI entrypoints reach it through
+/// [`resolve_color_from_env`], which reads `NO_COLOR` / `FORCE_COLOR` and TTY
+/// state and applies them under `Auto`.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ColorChoice {
+    Auto,
+    Always,
+    Never,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, PartialOrd, Eq, Ord)]
@@ -67,6 +80,63 @@ pub fn parse_severity_level(v: &str) -> Result<SeverityLevel, String> {
         "error" => Ok(SeverityLevel::Error),
         other => Err(format!("unknown --max-severity value: {other}")),
     }
+}
+
+/// Parse a `--color` value into a [`ColorChoice`].
+pub fn parse_color_choice(v: &str) -> Result<ColorChoice, String> {
+    match v {
+        "auto" => Ok(ColorChoice::Auto),
+        "always" => Ok(ColorChoice::Always),
+        "never" => Ok(ColorChoice::Never),
+        other => Err(format!("unknown --color value: {other}")),
+    }
+}
+
+/// Resolve a [`ColorChoice`] to a concrete on/off, applying the precedence from
+/// no-color.org: an explicit `Always`/`Never` (including the `--no-color` alias)
+/// always wins, overriding the environment. Only under `Auto` do `NO_COLOR` and
+/// `FORCE_COLOR` apply — `NO_COLOR` (set and non-empty) forces off, then
+/// `FORCE_COLOR` (set and non-empty) forces on, otherwise color follows whether
+/// stdout is a terminal.
+///
+/// The environment values are passed in as already-read `Option<&str>` rather
+/// than read here so the resolver stays pure and unit-testable: cargo runs
+/// tests in parallel, and mutating process-global env vars from a test would
+/// race every other test. Callers pass `std::env::var("NO_COLOR").ok()` etc.
+/// An env var counts as set only when non-empty, per the standard.
+pub fn resolve_color(
+    choice: ColorChoice,
+    no_color: Option<&str>,
+    force_color: Option<&str>,
+    stdout_is_tty: bool,
+) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            if no_color.is_some_and(|v| !v.is_empty()) {
+                false
+            } else if force_color.is_some_and(|v| !v.is_empty()) {
+                true
+            } else {
+                stdout_is_tty
+            }
+        }
+    }
+}
+
+/// Resolve a [`ColorChoice`] against the live process environment — the impure
+/// counterpart to [`resolve_color`], which it delegates to after reading
+/// `NO_COLOR`/`FORCE_COLOR` and probing stdout for a TTY. Both `check` and
+/// `lint` call this once in their `run()` epilogue so the env+TTY gathering
+/// lives in one place; the pure `resolve_color` stays separate for unit tests.
+pub fn resolve_color_from_env(choice: ColorChoice) -> bool {
+    resolve_color(
+        choice,
+        std::env::var("NO_COLOR").ok().as_deref(),
+        std::env::var("FORCE_COLOR").ok().as_deref(),
+        std::io::stdout().is_terminal(),
+    )
 }
 
 pub fn is_r_file(p: &Path) -> bool {
@@ -146,18 +216,49 @@ pub fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
     }
 }
 
+/// SGR reset; closes any color span opened by [`colorize_level`].
+const ANSI_RESET: &str = "\x1b[0m";
+
+/// Wrap a severity word in a minimal ANSI color span when `use_color` is set,
+/// returning it unchanged otherwise. Only the severity word is colorized (per
+/// the design); the path, location, message, and `[rule]` stay uncolored so the
+/// output remains easy to grep. `note` (severity-less / unrecognized) is left
+/// uncolored intentionally.
+fn colorize_level(level: &str, use_color: bool) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+    if !use_color {
+        return Cow::Borrowed(level);
+    }
+    let code = match level {
+        "error" => "\x1b[31m",   // red
+        "warning" => "\x1b[33m", // yellow
+        "info" => "\x1b[34m",    // blue
+        "hint" => "\x1b[36m",    // cyan
+        _ => return Cow::Borrowed(level),
+    };
+    Cow::Owned(format!("{code}{level}{ANSI_RESET}"))
+}
+
 /// Render diagnostics in the requested format. The single dispatch point both
 /// `lint` and `check` call after collecting their `(path, diagnostic)` pairs,
 /// so the format → renderer mapping lives in one place next to the renderers.
-pub fn render(format: OutputFormat, diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
+/// `use_color` colorizes only the `text` renderer's severity word; `json` /
+/// `sarif` are machine formats and never colorized regardless.
+pub fn render(
+    format: OutputFormat,
+    diags: &[(PathBuf, Diagnostic)],
+    root: &Path,
+    quiet: bool,
+    use_color: bool,
+) {
     match format {
-        OutputFormat::Text => print_text(diags, root, quiet),
+        OutputFormat::Text => print_text(diags, root, quiet, use_color),
         OutputFormat::Json => print_json(diags, root),
         OutputFormat::Sarif => print_sarif(diags, root),
     }
 }
 
-fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
+fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool, use_color: bool) {
     let mut errors = 0;
     let mut warnings = 0;
     let mut infos = 0;
@@ -198,7 +299,7 @@ fn print_text(diags: &[(PathBuf, Diagnostic)], root: &Path, quiet: bool) {
             rel.display(),
             line,
             col,
-            level,
+            colorize_level(level, use_color),
             d.message,
             rule
         );
@@ -364,6 +465,57 @@ mod tests {
         assert_eq!(parse_severity_level("off").unwrap(), SeverityLevel::Off);
         assert_eq!(parse_severity_level("error").unwrap(), SeverityLevel::Error);
         assert!(parse_severity_level("fatal").is_err());
+    }
+
+    #[test]
+    fn color_parsing() {
+        assert_eq!(parse_color_choice("auto").unwrap(), ColorChoice::Auto);
+        assert_eq!(parse_color_choice("always").unwrap(), ColorChoice::Always);
+        assert_eq!(parse_color_choice("never").unwrap(), ColorChoice::Never);
+        assert!(parse_color_choice("yes").is_err());
+    }
+
+    #[test]
+    fn resolve_color_explicit_overrides_win_over_env_and_tty() {
+        // `always` forces on even when piped (no TTY) and NO_COLOR is set.
+        assert!(resolve_color(ColorChoice::Always, Some("1"), None, false));
+        // `never` forces off even on a TTY with FORCE_COLOR set.
+        assert!(!resolve_color(ColorChoice::Never, None, Some("1"), true));
+    }
+
+    #[test]
+    fn resolve_color_auto_honors_no_color() {
+        // NO_COLOR set and non-empty disables color even on a TTY.
+        assert!(!resolve_color(ColorChoice::Auto, Some("1"), None, true));
+        // An empty NO_COLOR is treated as unset (per the standard), so color
+        // falls through to TTY detection.
+        assert!(resolve_color(ColorChoice::Auto, Some(""), None, true));
+        // NO_COLOR beats FORCE_COLOR when both are set.
+        assert!(!resolve_color(ColorChoice::Auto, Some("1"), Some("1"), true));
+    }
+
+    #[test]
+    fn resolve_color_auto_honors_force_color_then_tty() {
+        // FORCE_COLOR (non-empty) forces on even when piped.
+        assert!(resolve_color(ColorChoice::Auto, None, Some("1"), false));
+        // An empty FORCE_COLOR is treated as unset, so a non-TTY stays off.
+        assert!(!resolve_color(ColorChoice::Auto, None, Some(""), false));
+        // With no env overrides, color follows the TTY flag.
+        assert!(resolve_color(ColorChoice::Auto, None, None, true));
+        assert!(!resolve_color(ColorChoice::Auto, None, None, false));
+    }
+
+    #[test]
+    fn colorize_level_wraps_only_when_enabled() {
+        // Disabled: returned verbatim, no escapes.
+        assert_eq!(colorize_level("error", false), "error");
+        // Enabled: wrapped in an SGR span that resets at the end.
+        let colored = colorize_level("error", true);
+        assert!(colored.starts_with("\x1b["), "{colored}");
+        assert!(colored.ends_with(ANSI_RESET), "{colored}");
+        assert!(colored.contains("error"), "{colored}");
+        // `note` is intentionally left uncolored even when enabled.
+        assert_eq!(colorize_level("note", true), "note");
     }
 
     #[test]

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -7,6 +7,7 @@
 //! chunk-bearing documents. That common surface lives here so the two commands
 //! share one implementation without depending on each other's internals.
 
+use std::ffi::OsStr;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
@@ -92,31 +93,37 @@ pub fn parse_color_choice(v: &str) -> Result<ColorChoice, String> {
     }
 }
 
+/// Whether an environment variable counts as "set" for color control. Per
+/// no-color.org / force-color.org, that means present **and non-empty** —
+/// regardless of UTF-8 validity, which is why the value is an `OsStr` (a
+/// non-UTF-8 but non-empty `NO_COLOR` still counts; `std::env::var` would have
+/// dropped it). Reading the env stays at the call site (see
+/// [`resolve_color_from_env`]); this predicate is pure so the rule is
+/// unit-testable without racing process-global env across parallel tests.
+pub fn env_flag_is_set(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|v| !v.is_empty())
+}
+
 /// Resolve a [`ColorChoice`] to a concrete on/off, applying the precedence from
 /// no-color.org: an explicit `Always`/`Never` (including the `--no-color` alias)
-/// always wins, overriding the environment. Only under `Auto` do `NO_COLOR` and
-/// `FORCE_COLOR` apply — `NO_COLOR` (set and non-empty) forces off, then
-/// `FORCE_COLOR` (set and non-empty) forces on, otherwise color follows whether
-/// stdout is a terminal.
-///
-/// The environment values are passed in as already-read `Option<&str>` rather
-/// than read here so the resolver stays pure and unit-testable: cargo runs
-/// tests in parallel, and mutating process-global env vars from a test would
-/// race every other test. Callers pass `std::env::var("NO_COLOR").ok()` etc.
-/// An env var counts as set only when non-empty, per the standard.
+/// always wins, overriding the environment. Only under `Auto` do the env signals
+/// apply — `no_color` forces off, then `force_color` forces on, otherwise color
+/// follows whether stdout is a terminal. The two flags are "is the var set?"
+/// booleans (see [`env_flag_is_set`]), so this stays a pure precedence function
+/// over already-resolved inputs — unit-testable without touching the real env.
 pub fn resolve_color(
     choice: ColorChoice,
-    no_color: Option<&str>,
-    force_color: Option<&str>,
+    no_color: bool,
+    force_color: bool,
     stdout_is_tty: bool,
 ) -> bool {
     match choice {
         ColorChoice::Always => true,
         ColorChoice::Never => false,
         ColorChoice::Auto => {
-            if no_color.is_some_and(|v| !v.is_empty()) {
+            if no_color {
                 false
-            } else if force_color.is_some_and(|v| !v.is_empty()) {
+            } else if force_color {
                 true
             } else {
                 stdout_is_tty
@@ -133,8 +140,8 @@ pub fn resolve_color(
 pub fn resolve_color_from_env(choice: ColorChoice) -> bool {
     resolve_color(
         choice,
-        std::env::var("NO_COLOR").ok().as_deref(),
-        std::env::var("FORCE_COLOR").ok().as_deref(),
+        env_flag_is_set(std::env::var_os("NO_COLOR").as_deref()),
+        env_flag_is_set(std::env::var_os("FORCE_COLOR").as_deref()),
         std::io::stdout().is_terminal(),
     )
 }
@@ -216,27 +223,26 @@ pub fn encoding_diagnostic(offset: usize, byte: u8) -> Diagnostic {
     }
 }
 
-/// SGR reset; closes any color span opened by [`colorize_level`].
-const ANSI_RESET: &str = "\x1b[0m";
-
 /// Wrap a severity word in a minimal ANSI color span when `use_color` is set,
 /// returning it unchanged otherwise. Only the severity word is colorized (per
 /// the design); the path, location, message, and `[rule]` stay uncolored so the
 /// output remains easy to grep. `note` (severity-less / unrecognized) is left
 /// uncolored intentionally.
-fn colorize_level(level: &str, use_color: bool) -> std::borrow::Cow<'_, str> {
-    use std::borrow::Cow;
+///
+/// The colored forms are a closed set of `&'static str` literals (color code +
+/// word + `\x1b[0m` reset), so this allocates nothing and returns a borrow — the
+/// uncolored cases return the input `level` unchanged.
+fn colorize_level(level: &str, use_color: bool) -> &str {
     if !use_color {
-        return Cow::Borrowed(level);
+        return level;
     }
-    let code = match level {
-        "error" => "\x1b[31m",   // red
-        "warning" => "\x1b[33m", // yellow
-        "info" => "\x1b[34m",    // blue
-        "hint" => "\x1b[36m",    // cyan
-        _ => return Cow::Borrowed(level),
-    };
-    Cow::Owned(format!("{code}{level}{ANSI_RESET}"))
+    match level {
+        "error" => "\x1b[31merror\x1b[0m",     // red
+        "warning" => "\x1b[33mwarning\x1b[0m", // yellow
+        "info" => "\x1b[34minfo\x1b[0m",       // blue
+        "hint" => "\x1b[36mhint\x1b[0m",       // cyan
+        _ => level,
+    }
 }
 
 /// Render diagnostics in the requested format. The single dispatch point both
@@ -476,33 +482,48 @@ mod tests {
     }
 
     #[test]
+    fn env_flag_is_set_requires_present_and_non_empty() {
+        assert!(!env_flag_is_set(None), "unset ⇒ not set");
+        assert!(!env_flag_is_set(Some(OsStr::new(""))), "empty ⇒ not set");
+        assert!(env_flag_is_set(Some(OsStr::new("1"))), "non-empty ⇒ set");
+    }
+
+    /// A non-UTF-8 but non-empty value must still count as set (no-color.org
+    /// cares only about presence + non-emptiness). This is the case `var_os`
+    /// preserves and `var().ok()` would silently drop to "unset".
+    #[cfg(unix)]
+    #[test]
+    fn env_flag_is_set_treats_non_utf8_value_as_set() {
+        use std::os::unix::ffi::OsStrExt;
+        let invalid = OsStr::from_bytes(&[0xFF]); // not valid UTF-8, non-empty
+        assert!(env_flag_is_set(Some(invalid)));
+    }
+
+    #[test]
     fn resolve_color_explicit_overrides_win_over_env_and_tty() {
         // `always` forces on even when piped (no TTY) and NO_COLOR is set.
-        assert!(resolve_color(ColorChoice::Always, Some("1"), None, false));
+        assert!(resolve_color(ColorChoice::Always, true, false, false));
         // `never` forces off even on a TTY with FORCE_COLOR set.
-        assert!(!resolve_color(ColorChoice::Never, None, Some("1"), true));
+        assert!(!resolve_color(ColorChoice::Never, false, true, true));
     }
 
     #[test]
     fn resolve_color_auto_honors_no_color() {
-        // NO_COLOR set and non-empty disables color even on a TTY.
-        assert!(!resolve_color(ColorChoice::Auto, Some("1"), None, true));
-        // An empty NO_COLOR is treated as unset (per the standard), so color
-        // falls through to TTY detection.
-        assert!(resolve_color(ColorChoice::Auto, Some(""), None, true));
+        // NO_COLOR set disables color even on a TTY.
+        assert!(!resolve_color(ColorChoice::Auto, true, false, true));
+        // NO_COLOR unset falls through to TTY detection.
+        assert!(resolve_color(ColorChoice::Auto, false, false, true));
         // NO_COLOR beats FORCE_COLOR when both are set.
-        assert!(!resolve_color(ColorChoice::Auto, Some("1"), Some("1"), true));
+        assert!(!resolve_color(ColorChoice::Auto, true, true, true));
     }
 
     #[test]
     fn resolve_color_auto_honors_force_color_then_tty() {
-        // FORCE_COLOR (non-empty) forces on even when piped.
-        assert!(resolve_color(ColorChoice::Auto, None, Some("1"), false));
-        // An empty FORCE_COLOR is treated as unset, so a non-TTY stays off.
-        assert!(!resolve_color(ColorChoice::Auto, None, Some(""), false));
-        // With no env overrides, color follows the TTY flag.
-        assert!(resolve_color(ColorChoice::Auto, None, None, true));
-        assert!(!resolve_color(ColorChoice::Auto, None, None, false));
+        // FORCE_COLOR forces on even when piped.
+        assert!(resolve_color(ColorChoice::Auto, false, true, false));
+        // No env overrides: color follows the TTY flag.
+        assert!(resolve_color(ColorChoice::Auto, false, false, true));
+        assert!(!resolve_color(ColorChoice::Auto, false, false, false));
     }
 
     #[test]
@@ -512,7 +533,7 @@ mod tests {
         // Enabled: wrapped in an SGR span that resets at the end.
         let colored = colorize_level("error", true);
         assert!(colored.starts_with("\x1b["), "{colored}");
-        assert!(colored.ends_with(ANSI_RESET), "{colored}");
+        assert!(colored.ends_with("\x1b[0m"), "{colored}");
         assert!(colored.contains("error"), "{colored}");
         // `note` is intentionally left uncolored even when enabled.
         assert_eq!(colorize_level("note", true), "note");

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,8 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 - `--format text|json|sarif` — default `text`.
 - `--max-severity off|hint|info|warning|error` — highest severity that does **not** fail the build (default `info`). With the built-in defaults, undefined-variable and missing-file diagnostics are `warning` and circular dependencies are `error`, so they fail the build at the default threshold.
 - `--quiet` — suppress the trailing summary line.
-- `--no-color` — accepted for forward compatibility. `text` output is currently uncolored regardless, so this flag has no visible effect yet.
+- `--color auto|always|never` — when to colorize `text` output (default `auto`). See [Color output](#color-output).
+- `--no-color` — alias for `--color never`.
 
 ### R and packages
 
@@ -90,7 +91,8 @@ raven lint [OPTIONS] [PATHS...]
 - `--format text|json|sarif` — default `text`.
 - `--max-severity off|hint|info|warning|error` — highest severity that does **not** fail the build (default `info`). Linting is opt-in: with no `raven.toml` / `.lintr` discovered (or under `--no-config`) the linter is disabled and emits no diagnostics, so `raven lint .` exits 0. A discovered config enables rules; raising any to `warning` or `error` is what then gates CI.
 - `--quiet` — suppress the trailing summary line.
-- `--no-color` — accepted for forward compatibility. `text` output is currently uncolored regardless, so this flag has no visible effect yet.
+- `--color auto|always|never` — when to colorize `text` output (default `auto`). See [Color output](#color-output).
+- `--no-color` — alias for `--color never`.
 
 ### File encoding
 
@@ -127,3 +129,17 @@ Both `check` and `lint` share the same renderers:
 - `text` — `path:line:col level: message [rule]`, one per line.
 - `json` — array of `{ path, diagnostic }` objects (`diagnostic` is a verbatim LSP `Diagnostic`).
 - `sarif` — SARIF 2.1.0 envelope. Tool name `raven`; `ruleId` from `Diagnostic.code`.
+
+## Color output
+
+Both `check` and `lint` colorize the **severity word** (`error`, `warning`, `info`, `hint`) in `text` output — the rest of the line stays uncolored so it remains easy to grep. The `json` and `sarif` formats are machine-readable and are **never** colorized regardless of the flag or environment.
+
+`--color auto|always|never` controls it (default `auto`), and `--no-color` is a familiar alias for `--color never`. Resolution precedence, highest first:
+
+1. An explicit `--color always` / `--color never` (or `--no-color` ⇒ `never`) always wins, overriding the environment.
+2. Otherwise (`auto`):
+   - [`NO_COLOR`](https://no-color.org/) set and non-empty ⇒ **off**.
+   - else [`FORCE_COLOR`](https://force-color.org/) set and non-empty ⇒ **on**.
+   - else **on** when stdout is a terminal, **off** when piped or redirected.
+
+So `--color always` forces color even through a pipe (e.g. into `less -R` or a CI log viewer), `--color never` / `--no-color` / `NO_COLOR` suppress it, and the default tracks whether you're looking at a terminal. Conflicting explicit flags are last-one-wins (`--no-color --color always` ⇒ color on).


### PR DESCRIPTION
Closes #344.

## Summary

`--no-color` was parsed and stored on `CheckArgs`/`LintArgs` but never read, and the `text` renderer emitted no ANSI — so the flag had no observable effect. This implements real color support, shared by `raven check` and `raven lint` so they behave identically.

- **`--color auto|always|never`** on both subcommands, default `auto`.
- **`--no-color`** kept as an alias for `--color never` (last-one-wins on conflict, matching cargo/ripgrep).
- **`NO_COLOR`** (and optional **`FORCE_COLOR`**) honored under `auto`.

## Resolution precedence (highest first)

1. Explicit `--color always` / `--color never` (and `--no-color` ⇒ `never`) — always wins, overriding the environment.
2. Otherwise (`auto`): `NO_COLOR` set+non-empty ⇒ off; else `FORCE_COLOR` set+non-empty ⇒ on; else on iff `stdout().is_terminal()`.

## Implementation

- New `ColorChoice { Auto, Always, Never }` + `parse_color_choice` in `cli/shared.rs`, mirroring the existing `parse_output_format`/`parse_severity_level` pattern. The write-only `no_color: bool` field is replaced by `color: ColorChoice`.
- Pure `resolve_color(choice, no_color, force_color, stdout_is_tty)` applies the precedence above; env values are injected so the resolver is unit-testable without racing process-global env across parallel tests. The thin `resolve_color_from_env` wrapper reads env + TTY at each `run()` epilogue.
- `colorize_level` colorizes only the **severity word** in `text` output (`Cow`, zero-alloc when off); `json` / `sarif` are **never** colorized.
- `--help` and `docs/cli.md` document `--color`, the `--no-color` alias, and `NO_COLOR`/`FORCE_COLOR`.

## Acceptance criteria

- [x] `text` colorized when stdout is a TTY and not otherwise (default `auto`).
- [x] `NO_COLOR` disables under `auto`; `--no-color`/`--color never` disable explicitly; `--color always` forces color even when piped.
- [x] An explicit `--color`/`--no-color` overrides `NO_COLOR`.
- [x] `json` / `sarif` never colorized.
- [x] `check` and `lint` share one resolver + renderer, with shared unit tests for the resolver.
- [x] `--help` and `docs/cli.md` document the flags and `NO_COLOR`.

## Testing

- New unit tests in `cli/shared.rs` cover `parse_color_choice`, the full `resolve_color` precedence matrix (explicit-wins, NO_COLOR, empty-as-unset, FORCE_COLOR, TTY fallthrough), and `colorize_level`.
- New parse tests in `check.rs`/`lint.rs` for `--color`, the `--no-color` alias, last-one-wins, and bad-value errors.
- Full suite green: `cargo test -p raven --lib` → 4113 passed.
- Manually verified the precedence end-to-end against the built binary (piped `--color always` emits ANSI; `auto` piped does not; `NO_COLOR` overridden by `--color always`; `FORCE_COLOR` honored under `auto` and beaten by `NO_COLOR`).

## Out of scope (per issue)

- Colorizing the LSP/server path (N/A — diagnostics are structured JSON-RPC; the editor renders them).
- `CLICOLOR`/`CLICOLOR_FORCE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--color auto|always|never` flag to `raven check` and `raven lint` commands
  * `--no-color` now acts as an alias for `--color never`
  * Color output automatically adjusts based on TTY detection and `NO_COLOR`/`FORCE_COLOR` environment variables
  * Severity words in text output are now colorized when colors are enabled

* **Documentation**
  * Updated CLI documentation to detail new color control options and behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->