### PR TITLE
refactor: single source of truth for @lsp directive keyword vocabulary

### DIFF
--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -57,6 +57,25 @@ fn capture_symbol_name(caps: &regex::Captures, base_group: usize) -> Option<Stri
     Some(name)
 }
 
+/// Keyword alternation for forward source directives: `@lsp-source`, `@lsp-run`,
+/// `@lsp-include`. This is the inner body of the `@lsp-(?:…)` group only — the
+/// surrounding regex (anchoring, separator, capture groups) is supplied by each
+/// call site.
+///
+/// Single source of truth: the directive vocabulary is recognized by two
+/// independent regex sets — the full parser in [`patterns`] (capture groups,
+/// BOM-stripped input) and the column-aligned, BOM-tolerant prefix matchers in
+/// `file_path_intellisense::directive_path_patterns`. Those sets differ
+/// deliberately in everything *except* the keyword vocabulary, so only the
+/// alternation bodies are shared here to keep the recognized keywords from
+/// drifting between them.
+pub(crate) const FORWARD_DIRECTIVE_KEYWORDS: &str = "source|run|include";
+
+/// Keyword alternation for backward provenance directives: `@lsp-sourced-by`,
+/// `@lsp-run-by`, `@lsp-included-by`. See [`FORWARD_DIRECTIVE_KEYWORDS`] for why
+/// this is factored out.
+pub(crate) const BACKWARD_DIRECTIVE_KEYWORDS: &str = "sourced-by|run-by|included-by";
+
 fn patterns() -> &'static DirectivePatterns {
     static PATTERNS: OnceLock<DirectivePatterns> = OnceLock::new();
     PATTERNS.get_or_init(|| {
@@ -64,13 +83,28 @@ fn patterns() -> &'static DirectivePatterns {
         // Groups: 1=double-quoted, 2=single-quoted, 3=unquoted
         // All directive regexes are anchored to start of line (^\s*) except
         // @lsp-ignore, which can appear as a trailing comment (e.g., x <- foo # @lsp-ignore).
+        // The forward/backward keyword alternations are shared with
+        // file_path_intellisense via {FORWARD,BACKWARD}_DIRECTIVE_KEYWORDS,
+        // plugged into the middle of each pattern by concatenation.
         DirectivePatterns {
             backward: Regex::new(
-                r#"^\s*#\s*@lsp-(?:sourced-by|run-by|included-by)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+|eof|end))?(?:\s+match\s*=\s*["']([^"']+)["'])?"#
-            ).unwrap(),
+                &[
+                    r#"^\s*#\s*@lsp-(?:"#,
+                    BACKWARD_DIRECTIVE_KEYWORDS,
+                    r#")\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+|eof|end))?(?:\s+match\s*=\s*["']([^"']+)["'])?"#,
+                ]
+                .concat(),
+            )
+            .unwrap(),
             forward: Regex::new(
-                r#"^\s*#\s*@lsp-(?:source|run|include)(?:\s+:?\s*|:\s*)(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+|eof|end))?"#
-            ).unwrap(),
+                &[
+                    r#"^\s*#\s*@lsp-(?:"#,
+                    FORWARD_DIRECTIVE_KEYWORDS,
+                    r#")(?:\s+:?\s*|:\s*)(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+line\s*=\s*(\d+|eof|end))?"#,
+                ]
+                .concat(),
+            )
+            .unwrap(),
             working_dir: Regex::new(
                 r#"^\s*#\s*@lsp-(?:working-directory|working-dir|current-directory|current-dir|cd|wd)\s*:?\s*(?:"([^"]+)"|'([^']+)'|(\S+))"#
             ).unwrap(),

--- a/crates/raven/src/file_path_intellisense.rs
+++ b/crates/raven/src/file_path_intellisense.rs
@@ -16,6 +16,7 @@ use std::sync::OnceLock;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Location, Position, Url};
 use tree_sitter::{Node, Tree};
 
+use crate::cross_file::directive::{BACKWARD_DIRECTIVE_KEYWORDS, FORWARD_DIRECTIVE_KEYWORDS};
 use crate::cross_file::path_resolve::PathContext;
 use crate::cross_file::types::{byte_offset_to_utf16_column, CrossFileMetadata};
 use crate::utf16::utf16_column_to_byte_offset;
@@ -1532,19 +1533,35 @@ struct DirectivePathPatterns {
 fn directive_path_patterns() -> &'static DirectivePathPatterns {
     static PATTERNS: OnceLock<DirectivePathPatterns> = OnceLock::new();
     PATTERNS.get_or_init(|| {
-        // Patterns match the directive keyword and trailing whitespace/colon
-        // Consistent with cross_file/directive.rs patterns
+        // Patterns match the directive keyword and trailing whitespace/colon.
+        // The keyword alternations are shared verbatim with
+        // cross_file/directive.rs via {FORWARD,BACKWARD}_DIRECTIVE_KEYWORDS so
+        // the recognized keyword set cannot drift between the two regex sets;
+        // they are plugged into the middle of each pattern by concatenation.
         // The @ is required, colon is optional, leading whitespace is allowed.
         // `\u{feff}` in the leading class tolerates a raw BOM on a first-line
         // directive (in-memory text keeps it verbatim); matching against the
         // BOM-bearing line keeps the reported path column client-aligned. #346.
+        // The leading class deliberately differs from directive.rs, which strips
+        // the BOM up-front and uses `^\s*`. Concatenation (rather than `format!`)
+        // keeps `\u{feff}` written verbatim — no brace-escaping to get wrong.
         DirectivePathPatterns {
             backward: Regex::new(
-                r#"^[\s\u{feff}]*#\s*@lsp-(?:sourced-by|run-by|included-by)(?:\s+:?\s*|:\s*)"#,
+                &[
+                    r#"^[\s\u{feff}]*#\s*@lsp-(?:"#,
+                    BACKWARD_DIRECTIVE_KEYWORDS,
+                    r#")(?:\s+:?\s*|:\s*)"#,
+                ]
+                .concat(),
             )
             .unwrap(),
             forward: Regex::new(
-                r#"^[\s\u{feff}]*#\s*@lsp-(?:source|run|include)(?:\s+:?\s*|:\s*)"#,
+                &[
+                    r#"^[\s\u{feff}]*#\s*@lsp-(?:"#,
+                    FORWARD_DIRECTIVE_KEYWORDS,
+                    r#")(?:\s+:?\s*|:\s*)"#,
+                ]
+                .concat(),
             )
             .unwrap(),
         }
@@ -2178,6 +2195,58 @@ mod tests {
         assert_eq!(directive_type, DirectiveType::Source);
         assert_eq!(partial, "utils");
         assert_eq!(path_start.character, 17);
+    }
+
+    /// Every keyword in the shared `FORWARD_DIRECTIVE_KEYWORDS` /
+    /// `BACKWARD_DIRECTIVE_KEYWORDS` source of truth must round-trip through BOTH
+    /// directive regex sets: the full parser in `cross_file::directive` and the
+    /// column-aligned path-context matcher here. Each side wraps the shared
+    /// alternation in its own (deliberately different) surrounding regex; this
+    /// test pins that the vocabulary stays mutually recognized after composition,
+    /// so the two seams cannot drift apart.
+    #[test]
+    fn test_shared_directive_keywords_recognized_by_both_regex_sets() {
+        use crate::cross_file::directive::parse_directives;
+
+        for kw in FORWARD_DIRECTIVE_KEYWORDS.split('|') {
+            let content = format!("# @lsp-{kw} utils.R");
+            let eol = Position::new(0, content.chars().count() as u32);
+
+            // file_path_intellisense seam (column-aligned, BOM-tolerant).
+            assert!(
+                matches!(
+                    is_directive_path_context(&content, eol),
+                    Some((DirectiveType::Source, _, _))
+                ),
+                "path-context matcher did not recognize forward keyword `{kw}`",
+            );
+
+            // cross_file::directive seam (full parser, capture groups).
+            assert_eq!(
+                parse_directives(&content).sources.len(),
+                1,
+                "directive parser did not recognize forward keyword `{kw}`",
+            );
+        }
+
+        for kw in BACKWARD_DIRECTIVE_KEYWORDS.split('|') {
+            let content = format!("# @lsp-{kw} ../main.R");
+            let eol = Position::new(0, content.chars().count() as u32);
+
+            assert!(
+                matches!(
+                    is_directive_path_context(&content, eol),
+                    Some((DirectiveType::SourcedBy, _, _))
+                ),
+                "path-context matcher did not recognize backward keyword `{kw}`",
+            );
+
+            assert_eq!(
+                parse_directives(&content).sourced_by.len(),
+                1,
+                "directive parser did not recognize backward keyword `{kw}`",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

The `@lsp-(?:source|run|include)` / `@lsp-(?:sourced-by|run-by|included-by)` keyword alternations were duplicated literally across two independent regex sets that had begun to drift (the leading char class diverged in #346):

1. `cross_file/directive.rs` `patterns()` — full patterns with path/line/match capture groups, anchored `^\s*#`, matching BOM-stripped text.
2. `file_path_intellisense.rs` `directive_path_patterns()` — prefix-only matchers (positional path-column math, no captures), BOM-tolerant `^[\s\u{feff}]*#`.

This factors the two keyword alternation **bodies** into shared `pub(crate)` consts — `FORWARD_DIRECTIVE_KEYWORDS` and `BACKWARD_DIRECTIVE_KEYWORDS` — in `directive.rs` (the canonical parser, which `file_path_intellisense` already depends on), and composes all four regexes from them.

## How / invariants preserved

- **Byte-for-byte identical** compiled patterns — only the shared alternation body is hoisted; the deliberately-different surroundings (anchoring, separators, capture groups, BOM handling) stay inlined per call site.
- Composition uses **`.concat()` of raw-string fragments rather than `format!`**, so the regex `\u{feff}` unicode escape stays written verbatim — no `format!` brace-escaping (`\u{{feff}}`) to get wrong on the BOM-bearing patterns.
- Same `.concat()` technique in both files for parallel structure, making the "plug the shared const into the middle" relationship visually obvious.
- Doc comments on the consts and at each call site document the single-source-of-truth invariant and *why* the surrounding regexes deliberately differ.

## Tests

- New `test_shared_directive_keywords_recognized_by_both_regex_sets` iterates the shared consts and asserts every keyword round-trips through **both** regex seams (`parse_directives` and `is_directive_path_context`) — guarding against future drift.
- Full crate suite green: `cargo test -p raven` → 4116 + 4116 (lib/bin) + integration suites, **0 failures**.
- No new clippy warnings on the touched code.

Pure reuse/maintainability refactor — no user-visible behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of directive keyword handling across the codebase by consolidating shared keyword definitions.

* **Tests**
  * Added comprehensive tests to verify directive keyword recognition consistency across components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/raven/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->