### PR TITLE
docs: clarify when and why Raven spawns R subprocesses

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ Each accepts: `"error"`, `"warning"`, `"information"`, `"hint"`, or `"off"`.
 
 ### Refresh Command
 
-**Raven: Refresh package cache** (`raven.refreshPackages`) — re-runs `.libPaths()`, rebuilds the package library, restarts the filesystem watcher, clears the cache, and republishes diagnostics. Use after `renv::activate()`, `.libPaths()` changes, or if the watcher misses an event.
+**Raven: Refresh package cache** (`raven.refreshPackages`) — re-runs `.libPaths()`, rebuilds the package library, restarts the filesystem watcher, clears the cache, and republishes diagnostics. Use after `renv::activate()`, `.libPaths()` changes, or if the watcher misses an event. See [When Raven calls R](cross-file.md#when-raven-calls-r) for what these R queries do.
 
 ## Scaffold Commands
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -50,13 +50,25 @@ Raven recognizes `library()`, `require()`, and `loadNamespace()` calls and makes
 
 When you write `library(dplyr)`, Raven:
 1. Detects the call and extracts the package name
-2. Queries R (via subprocess) for the package's exported symbols
+2. Resolves the package's exported symbols — usually by reading its installed `NAMESPACE` file directly, with no R involved (see [When Raven calls R](#when-raven-calls-r) for the cases that need a subprocess)
 3. Makes those symbols available with `{dplyr}` attribution in completions
 4. Suppresses "undefined variable" warnings for package exports
 
+### When Raven calls R
+
+Raven's analysis is static: it parses your code and your installed packages' `NAMESPACE` files without a running R session. It does, however, launch a short-lived, non-interactive R subprocess — the `R` on your `PATH`, or [`raven.packages.rPath`](configuration.md#package-settings) — in two situations. These are Raven's own processes; they never touch your interactive R session, and when no R is found Raven falls back gracefully.
+
+**1. To find where your packages are installed.** Raven runs `.libPaths()` to discover your library directories. Where packages live depends on your R installation, version, and project setup — including [`renv`](https://rstudio.github.io/renv/) project-local libraries, which Raven activates before reading the paths — so there's no reliable way to determine it statically. Without R, Raven falls back to the standard platform install locations plus any [`raven.packages.additionalLibraryPaths`](configuration.md#package-settings), which may miss user- or project-local libraries.
+
+**2. To expand exports that can't be read from `NAMESPACE` text.** Most packages list their exports with explicit `export(name)` directives, which Raven reads straight from the installed `NAMESPACE` file — no R required. But a package can instead (or additionally) declare `exportPattern("<regex>")`: "export every object in my namespace whose name matches this regex." Raven can't expand that from the file alone — it would need to know every object the namespace actually defines once loaded — so for these packages it asks R via `getNamespaceExports()`. Several base R packages use `exportPattern`, as do a minority of installed CRAN packages. When R isn't available, Raven approximates their exports from the package's `INDEX` file plus any explicit `export()` entries; this covers documented functions but may miss pattern-only or dynamically generated symbols.
+
+Run **Raven: Refresh package cache** after changing `.libPaths()` or running `renv::activate()` to re-run these queries.
+
 ### Base Packages
 
-Base R packages are always available without explicit `library()` calls: **base**, **methods**, **utils**, **grDevices**, **graphics**, **stats**, **datasets**. Raven uses this fixed list directly — it does not query R to discover the base packages. The R subprocess is queried for *installed user packages* (via the library paths), not to determine which base packages exist.
+Base R packages are always available without explicit `library()` calls: **base**, **methods**, **utils**, **grDevices**, **graphics**, **stats**, **datasets**. Raven uses this fixed list directly — it does not query R to discover the base packages. The R subprocess is queried for *installed user packages* (via the library paths), not to determine which base packages exist — though base-package *exports* are still expanded via R, since they use `exportPattern` (see [When Raven calls R](#when-raven-calls-r)).
+
+Lazy-loaded datasets are a related special case that does *not* require R. Base packages like `datasets` expose objects such as `mtcars` and `iris` that are auto-attached at startup but appear in neither `NAMESPACE` `export()` lines nor `getNamespaceExports()`. Raven discovers these statically, by walking the package's `data/` directory and `INDEX` file — so, unlike `exportPattern` exports, they're available with no subprocess.
 
 ### Position-Aware Loading
 


### PR DESCRIPTION
## Summary

The cross-file docs implied R was *always* queried for package exports. In reality Raven reads exports straight from the installed `NAMESPACE` for the typical package, and only shells out to a short-lived R subprocess in two cases. This clarifies the actual behavior.

## Changes

- **`docs/cross-file.md`**
  - Corrected the misleading How-It-Works step ("Queries R (via subprocess) for the package's exported symbols") — exports are *usually* read from `NAMESPACE` with no R.
  - Added a **When Raven calls R** section documenting the two reasons:
    1. `.libPaths()` to discover where packages are installed — renv-aware, with platform fallbacks when R is absent.
    2. `getNamespaceExports()` only for packages using `exportPattern()`, whose exports can't be expanded from `NAMESPACE` text alone (base R packages + a minority of CRAN packages).
  - Noted under **Base Packages** that lazy-loaded datasets (`mtcars`/`iris`) are discovered statically by walking `data/` + `INDEX` and need *no* R — the counterpoint to the `exportPattern` case.
- **`docs/configuration.md`** — cross-linked the Refresh Command entry to the new section.

## Notes

Docs-only; no code or settings-schema changes, so the settings-reference drift test is unaffected. Wording was verified against the source (`r_subprocess.rs` `.libPaths()` / `getNamespaceExports()`, `package_library.rs` static-vs-pattern split, the `data/`+`INDEX` walk for `datasets`).