### PR TITLE
docs: CI package-exports database (planned) — user + architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ User-facing:
 - `README.md`
 - `docs/cross-file.md`
 - `docs/r-package-dev.md`
+- `docs/package-database.md`
 - `docs/directives.md`
 - `docs/diagnostics.md`
 - `docs/linting.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,6 +5,7 @@ Raven ships a single binary that serves the LSP via stdio *and* exposes subcomma
 - `raven check` — index a workspace and report the **full** diagnostic set (the same diagnostics the editor publishes), for CI gating.
 - `raven lint` — run the native **style** linter only.
 - `raven analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
+- `raven packages freeze` — generate a committed `.raven/packages.json` export database so `raven check` can resolve package symbols in CI when no R or packages are installed (see [`raven packages`](#raven-packages) and [Package database](package-database.md)). The maintainer-only `raven packages build-shipped-db` builds Raven's bundled `names.db`.
 
 The difference between `check` and `lint` is **scope**: `lint` parses each file in isolation and runs only the style rules, so it needs no R installation and no workspace index — but it can't see relationships between files. `check` builds the same workspace index the language server builds (and, unless packages are disabled, runs R to resolve installed-package exports and base R symbols), so it additionally reports cross-file, undefined-variable, and package diagnostics. `lint` is therefore the cheaper, R-free option for pure style gating; `check` does more work per run in exchange for the editor's full analysis in CI.
 
@@ -21,7 +22,7 @@ Diagnostics reported (subject to configured severities — see [diagnostics.md](
 - Syntax errors and semantic checks (e.g. assignment-in-condition, mixed logical operators).
 - The native style lints (when enabled via `raven.toml` / `.lintr`).
 - Cross-file diagnostics: missing sourced files, circular dependencies, exceeded max source-chain depth, redundant directives, and out-of-scope usage.
-- Missing-package warnings (`library(notInstalled)`).
+- Missing-package warnings (`library(notInstalled)`) — see [Missing-package reporting in CI](#missing-package-reporting-in-ci) for the planned change to suppress these by default.
 - Undefined-variable diagnostics, accounting for cross-file and package scope.
 
 ### Workspace and paths
@@ -38,6 +39,7 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 - `--no-config` — ignore `raven.toml` and `.lintr`; use Raven's built-in defaults.
 - `--format text|json|sarif` — default `text`.
 - `--max-severity off|hint|info|warning|error` — highest severity that does **not** fail the build (default `info`). With the built-in defaults, undefined-variable and missing-file diagnostics are `warning` and circular dependencies are `error`, so they fail the build at the default threshold.
+- `--report-uninstalled` — re-enable missing-package warnings, which `raven check` otherwise suppresses by default. See [Missing-package reporting in CI](#missing-package-reporting-in-ci).
 - `--quiet` — suppress the trailing summary line.
 - `--color auto|always|never` — when to colorize `text` output (default `auto`). See [Color output](#color-output).
 - `--no-color` — alias for `--color never`.
@@ -47,6 +49,16 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 `raven check` auto-detects R on `PATH` to resolve installed-package exports and base R symbols (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.enabled = false` disables R detection entirely (no R subprocess, no package or base-symbol diagnostics — matching the editor), `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, package and base-symbol diagnostics are limited — `library()` calls aren't checked against installed packages, and undefined-variable detection falls back to a built-in symbol list — and a one-line note is printed to stderr. All other diagnostics still run.
 
 Before reporting, `raven check` warms the export cache for the packages each reported file attaches with `library()` / `require()`, so a bare call into an attached package that isn't one of its exports is flagged the same way the editor flags it. One narrow gap remains: a package attached only *indirectly* — in a `source()`d file rather than in the reported file itself — is not pre-warmed, so calls that could resolve to such a package are left unflagged rather than risk a false positive. Attach the package directly in the file (or rely on the editor) if you need those calls checked.
+
+### Missing-package reporting in CI
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+`raven check` resolves package **export names** through an ordered three-tier fallback — installed packages, then a committed `.raven/packages.json`, then Raven's bundled `names.db` — so symbols from attached packages resolve even when no R is installed. This stops the undefined-variable storm that otherwise makes Raven unusable in CI. See [Package database](package-database.md).
+
+Knowing a package's exports is **separate** from knowing whether it is installed. The **missing-package** diagnostic answers a different question — *"will `library(X)` succeed at runtime?"*, i.e. is `X` installed? — so it stays **Tier-1-only**: it is driven solely by what is present in the local library paths, never by the export database. Because CI deliberately omits package installation, `raven check` **suppresses missing-package warnings by default**.
+
+`--report-uninstalled` re-enables them. It is useful when a pipeline *does* install packages (e.g. `renv::restore()`) and wants to fail if any didn't install. It reports `library()` calls **not present in the local library paths** — **not** relative to the Tier 2/Tier 3 export metadata. One consequence: with the default off, a genuine typo such as `library(dpylr)` is silent (no tier knows it, but `raven check` isn't checking install status); it is reported only with `--report-uninstalled`. The language server is unchanged — it still fires missing-package whenever install state is known. See [Diagnostics](diagnostics.md#package-names-vs-install-status) for the full model.
 
 ### File encoding
 
@@ -121,6 +133,39 @@ raven lint [OPTIONS] [PATHS...]
 `raven lint` runs the native style linter only. Cross-file, undefined-variable, and package diagnostics need a workspace scan; use [`raven check`](#raven-check) for those.
 
 Only plain R files (`.R` / `.r`) are linted. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped with a one-line note on stderr — chunk extraction isn't supported on the command line — and other file types are ignored silently. Passing a directory walks it recursively for R files.
+
+## `raven packages`
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+A command group for the export databases Raven uses to resolve package symbols without installing packages. See [Package database](package-database.md) for the full three-tier model; the two subcommands below build the user-generated (Tier 2) and Raven-bundled (Tier 3) databases respectively.
+
+### `raven packages freeze`
+
+Generate a committed, repo-specific `.raven/packages.json` — a "frozen Tier 1" snapshot of your installed packages' export names, `Depends`, and datasets — so `raven check` and the editor can resolve those symbols in CI, where no R or packages are present. Run it on a machine that has R and the project's packages installed, then commit the result; it is generated, never hand-edited.
+
+```text
+raven packages freeze [OPTIONS]
+```
+
+#### Options
+
+- `--used` (default) — capture only the packages the repo uses. The set is deliberately **maximally inclusive**: packages referenced via `library`/`require`/`loadNamespace`/`requireNamespace` ∪ the left-hand side of `::`/`:::` ∪ everything in `renv.lock` ∪ the repo's own `DESCRIPTION` `Depends`/`Imports` ∪ their transitive `Depends`. (`LinkingTo` is excluded — it is C-level and has no R exports.) Over-inclusion is free: the capture skips anything not actually installed.
+- `--installed` / `--all` — capture every package across the renv and system libraries, not just the used set.
+- `--output PATH` — where to write the file (default: `.raven/packages.json` at the workspace root).
+- `--workspace DIR` — workspace root to scan for usage and config (default: current directory).
+
+#### Library order and renv
+
+Generation resolves each package from a **renv-first** library order: the renv project library first, system-wide libraries only for packages renv doesn't cover (renv wins, system fills the gaps). A `renv.lock` acts purely as a **set selector** — it decides *which* packages to include (a locked package is included even if no script ever calls it), **not** which version to read; the exports always come from the package actually installed locally. A locked package that isn't installed simply can't be captured and falls through to Tier 3 in CI. Best coverage therefore comes from running `freeze` after `renv::restore()`, but nothing breaks otherwise.
+
+#### No-op when content is unchanged
+
+If a `.raven/packages.json` already exists, `freeze` compares **package content only** (ignoring provenance such as the generation timestamp). When the content is identical it leaves the file untouched and prints "no changes" — so a regeneration that found nothing new produces a zero-line diff, and the provenance timestamp moves only when the captured exports actually changed.
+
+### `raven packages build-shipped-db`
+
+**Maintainer / CI-only — most users never run this.** Builds Raven's bundled Tier 3 `names.db` (and its companion base-exports file). The shipped binary is **network-free**: this command transforms r-universe JSON that the build workflow has already downloaded with `curl`, merging it **append-only** over an authoritative reference-R capture of the build machine's installed library. The result is published to the `names-db` GitHub Release and bundled next to the binary and into the VSIX. See [Package database](package-database.md#tier-3--bundled-namesdb) and [development.md](development.md#tier-3-build-pipeline) for the build pipeline.
 
 ## Output formats
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -64,6 +64,18 @@ Raven's analysis is static: it parses your code and your installed packages' `NA
 
 Run **Raven: Refresh package cache** after changing `.libPaths()` or running `renv::activate()` to re-run these queries.
 
+### Resolving exports without R
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+When a package isn't installed locally — or R can't launch, typically in CI — Raven still resolves its **export names** through an ordered three-tier fallback, consulted per package:
+
+1. **Tier 1 — installed.** The authoritative path above: parse the installed `NAMESPACE`, expanding `exportPattern` via R when needed. Version-exact to the install.
+2. **Tier 2 — repo database.** A committed, repo-specific `.raven/packages.json` you generate with [`raven packages freeze`](cli.md#raven-packages-freeze). It is "frozen Tier 1": full structure (exports, `Depends`, datasets) captured through the authoritative path, version-exact to when it was generated.
+3. **Tier 3 — shipped database.** Raven's bundled `names.db`, built from latest CRAN/Bioc. Export names only.
+
+Tier 2 outranks Tier 3 because it is project-specific and built through the authoritative path; a repo that never generates a Tier 2 file still works in CI via Tier 3 alone. Tiers 2 and 3 carry **export names, `Depends`, and datasets only** — no `:::` internal objects and no function signatures, which still require a local install (Tier 1). This fallback feeds **export resolution** only; it never changes a package's install status (see [Diagnostics](diagnostics.md#package-names-vs-install-status)). The full model, fidelity caveats, and how to generate the repo database are in [Package database](package-database.md).
+
 ### Base Packages
 
 Base R packages are always available without explicit `library()` calls: **base**, **methods**, **utils**, **grDevices**, **graphics**, **stats**, **datasets**. Raven uses this fixed list directly — it does not query R to discover the base packages. The R subprocess is queried for *installed user packages* (via the library paths), not to determine which base packages exist — though base-package *exports* are still expanded via R, since they use `exportPattern` (see [When Raven calls R](#when-raven-calls-r)).

--- a/docs/development.md
+++ b/docs/development.md
@@ -274,6 +274,161 @@ All R subprocess calls must:
 
 See `crates/raven/src/package_library.rs` and `crates/raven/src/r_subprocess.rs`.
 
+## Package-export databases (CI / R-free resolution)
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+This subsystem lets Raven resolve package **export names** without an installed
+package or a running R — the case that makes `raven check` usable in CI. It is an
+**ordered fallback over three tiers**: Tier 1 (installed, authoritative — the
+existing path above) → Tier 2 (a committed, repo-specific `.raven/packages.json`)
+→ Tier 3 (a Raven-bundled `names.db`). The user-facing contract lives in
+[`docs/package-database.md`](package-database.md); this section is the internals.
+
+**Critical invariant — names ≠ install status.** The databases feed *export
+resolution* only (they suppress the undefined-variable storm when R is absent).
+They **never** make a package count as installed. The missing-package diagnostic
+is Tier-1-only and is suppressed by default in `raven check` (re-enabled with
+`--report-uninstalled`). `package_exists()` is never wired to consult providers.
+See `docs/diagnostics.md` and `crates/raven/src/handlers.rs`.
+
+### The `package_db` module
+
+A new top-level module (`crates/raven/src/package_db/`) — declared in **both**
+`lib.rs` and `main.rs` per the module-declaration invariant — owns all
+encoding/decoding. `package_library.rs` is not moved or rewritten; it only gains
+the seam.
+
+- **One serializable record:** `model::PackageRecord` is the on-disk projection
+  of `PackageInfo` — `{ name, exports, depends, lazy_data }`, all vectors kept
+  **sorted and de-duplicated** so the Tier 2 JSON is deterministic and
+  diff-friendly. `is_meta_package` / `attached_packages` are a pure function of
+  the package name, so they are **re-derived on read** (via
+  `PackageInfo::with_details`), never stored.
+- **Two encodings, one reader each:**
+  - **Tier 2 — `json_db.rs`** (`RepoDb`): deterministic, sorted, pretty JSON,
+    committed as `.raven/packages.json`. Carries minimal provenance (Raven
+    version, R version, generation epoch) and a `schema_version`
+    (`REPO_DB_SCHEMA_VERSION`).
+  - **Tier 3 — `binary_db.rs`** (`ShippedDb`): a compact, memory-mapped,
+    lazily-decoded container. Layout: `MAGIC(8) | version(u32) | header_len(u32)
+    | header(postcard) | payload`. The header (provenance + a `blake3` hex of the
+    payload region + an index of `{name, offset, len}`) is decoded **once at
+    open**; per-package `PackageRecord`s in the mmap'd payload are postcard-decoded
+    **lazily** on lookup. Versioned by `FORMAT_VERSION`. Dependencies: `memmap2`,
+    `postcard` (added in Milestone 1); `blake3` was already a dep.
+- **Typed reader errors, explained not dropped (decision #9):** each reader
+  returns `Absent` (normal, silent) vs `UnsupportedSchema { found, supported }` /
+  `UnsupportedFormat` vs `Corrupt`. A present-but-unusable file (e.g. a
+  `.raven/packages.json` written by a newer Raven) is **explained and the surface
+  continues**: `raven check` prints a specific stderr note, the language server
+  raises `window/showMessage`, then resolution degrades to the next tier. A
+  missing or unreadable database never hard-fails the LSP or the build.
+
+### The `PackageMetadataProvider` seam
+
+Tier 1 stays a bespoke first step inside `get_package` — its subprocess/INDEX
+logic is intertwined with `lib_paths` and the caches, and wrapping it would risk
+regressing the authoritative path. The new tiers are pure pre-built reads, so the
+seam is a small **synchronous** trait:
+
+```rust
+pub trait PackageMetadataProvider: Send + Sync {
+    fn lookup(&self, name: &str) -> Option<PackageInfo>;
+}
+```
+
+`PackageLibrary` gains an ordered `providers: Vec<Box<dyn PackageMetadataProvider>>`
+(Tier 2 repo DB at index 0, Tier 3 shipped DB next), empty by default. The **one**
+hook is in `get_package`: when `find_package_directory` misses (Tier 1 has no
+directory), it consults the providers in order; the first hit is cached like any
+other `PackageInfo`. A package no provider knows is left **uncached**, so
+`package_exists()` still reports it missing.
+
+`prefetch_packages` is **unchanged** (decision #12): its Step 3 already funnels
+every loaded package — and transitive `Depends` and meta-package
+`attached_packages` — through `get_all_exports → collect_exports_recursive →
+get_package`, which carries the hook. So `library(tidyverse)` and `Depends`
+chains resolve in CI for free.
+
+**Construction split (decision #6):** `freeze` (and the Tier 3 reference-R seed)
+must capture a *provider-less* library so a "frozen Tier 1" file can't be
+contaminated by Tier 2/3 guesses. Construction is split into
+`build_library_inner` (no providers) feeding both
+`build_package_library_tier1_only` (capture) and `build_package_library`
+(runtime: inner + provider wiring). Existing 4-arg callers of
+`build_package_library` are unchanged.
+
+### Performance discipline (§12)
+
+The LSP hot path (diagnostic collection) reads the in-memory cache `try_read`-only
+and must not take a disk/page-fault stall. So:
+
+- the Tier 3 index is **preloaded at open**; per-package payloads decode lazily
+  from the mmap on first lookup;
+- the `blake3` payload checksum is verified **at open, in `spawn_blocking`**
+  (decision #13) — ~10–20 ms once during library init, off the async runtime —
+  catching truncation/corruption/tampering;
+- provider results feed the existing per-package cache, so steady-state lookups
+  are lock-free reads with no provider call.
+
+### Tier 3 build pipeline
+
+The shipped `names.db` is built **append-only** from an authoritative reference-R
+capture of the build machine's **entire installed library**
+(`enumerate_installed_packages` across all lib paths, via the Tier 1 path:
+`NAMESPACE` + subprocess `exportPattern` expansion + `data/` datasets) **∪** CRAN
++ Bioc r-universe (`cran.r-universe.dev` and `bioc.r-universe.dev` per-package
+`_exports`/`_dependencies`/`_datasets`). Precedence: **reference-R > r-universe >
+retained-from-prior**; a rebuild never drops a package (decision #8). The full
+installed library is the point — hard-to-install / GitHub-only / internal
+packages enter the floor only this way, and append-only keeps them. The
+maintainer **bootstraps** the floor once from a richly-provisioned machine; teams
+can build a private `names.db` from their own library for richer in-house
+coverage.
+
+- **Entry point:** `raven packages build-shipped-db` (maintainer/CI-only — the
+  shipped binary itself is **network-free**; the workflow uses `curl` to fetch
+  r-universe JSON into a directory that the command then transforms). Code:
+  `cli/packages.rs`, `package_db/{merge,runiverse}.rs`.
+- **Companion base-exports file (decision #7):** base/recommended records (also
+  from the reference R) ship in a separate file, loaded in `initialize()` to
+  populate `base_exports` when the base packages aren't on disk (CI). Base
+  **datasets** (`mtcars`/`iris`) are merged exactly as the disk path does, so base
+  datasets resolve in CI in v1, independent of #350. A real R install still wins.
+- **Delivery (decision #14):** `names.db` + the base-exports file + checksums live
+  on a **GitHub Release** (moving `names-db` tag) — durable across runs, unlike a
+  per-run CI artifact. A weekly + `workflow_dispatch` + on-release job
+  (`.github/workflows/build-names-db.yml`) downloads the current asset (the seed),
+  rebuilds, and re-uploads. `release-build.yml` / `bundle-binary.js` download the
+  same asset to place `names.db` exe-relative next to the binary and into the
+  VSIX. Located via `locate_shipped_db()` — `RAVEN_NAMES_DB` override, else
+  exe-relative. **Not** `include_bytes!` (avoids binary bloat), **not** committed
+  to git (except tiny back-compat fixtures).
+
+### Dependency on #350 (package-dataset resolution)
+
+`PackageRecord` captures `lazy_data`. [raven#350](https://github.com/jbearak/raven/issues/350)
+(landed) wired dataset resolution into `collect_exports_recursive`, so a Tier 2/3
+record's `lazy_data` is folded into the resolvable set automatically — *non-base*
+package datasets resolve in CI with no extra work in this subsystem. (Base
+datasets come via the base-exports file, above.)
+
+### Testing approach
+
+- **Runtime tempdir fixtures** for round-trip tests (write → open → lookup) of
+  both encodings, plus bad-magic / version-skew / payload-tamper rejection.
+- **Committed back-compat fixtures** (decision #15): tiny `names.db` +
+  `.raven/packages.json` under `crates/raven/tests/fixtures/package_db/` guard
+  format back-compat ("old fixtures still load").
+- **No-R consumer integration test** (`tests/package_db_consumer.rs`): empty
+  libpaths, `library(dplyr); mutate(...)` yields no undefined-variable;
+  `library(dpylr)` behaves per the names-vs-install-status split.
+- **Build-side differential** (deferred to the `build-names-db` job, where R + a
+  sample corpus are available): diff `names.db` against `getNamespaceExports()`.
+- **Generation round-trip** (on a machine with R): generate `.raven/packages.json`,
+  read it back, assert parity with the live Tier 1 result.
+
 ## Other subsystems
 
 Brief orientation for modules outside the cross-file and package-library subsystems.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -59,6 +59,28 @@ If the symbol is defined later in the same file at top level, the message also r
 |---|---|---|
 | Missing package | warning | `library()` references a package not installed on the system |
 
+### Package names vs. install status
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+Raven can resolve a package's **export names** from one of three tiers — installed packages, a committed `.raven/packages.json`, or Raven's bundled `names.db` — so symbols from `library(pkg)` resolve even when the package isn't installed (for example in CI with no R). See [Package database](package-database.md). Crucially, knowing a package's exports is kept **separate** from knowing whether it is installed:
+
+- **Export resolution** (suppresses undefined-variable noise) uses all three tiers, in every mode.
+- **Install status** (drives the *missing-package* diagnostic) is **Tier 1 only** — it reflects what is actually present in the local library paths, and never the export database. A database that knows `dplyr`'s exports does **not** make `dplyr` count as installed.
+
+#### Per-mode behavior
+
+| | Export resolution | Missing-package ("not installed") |
+|---|---|---|
+| **Language server (interactive)** | tiers 1→2→3 (no undefined-variable storm even when R is absent) | Fires when install state is known and the package is absent — regardless of the database. Unchanged from today; the database stops the symbol storm but never masks the "install this dependency" nudge. |
+| **`raven check` (CI)** | tiers 1→2→3 | **Suppressed by default** (CI deliberately omits installation). Re-enable with [`--report-uninstalled`](cli.md#missing-package-reporting-in-ci). |
+
+When enabled, `--report-uninstalled` reports `library()` calls **not present in the local library paths** — *not* relative to the Tier 2/Tier 3 export metadata.
+
+#### Accepted gap
+
+With missing-package off by default in `raven check`, a genuine typo such as `library(dpylr)` — unknown to every tier — is **silent** unless `--report-uninstalled` is passed. This is documented behavior: the default avoids nagging about known-but-uninstalled dependencies in CI. Pass the flag (e.g. in a pipeline that runs `renv::restore()`) to catch packages that failed to install. The language server still flags such a call interactively whenever install state is known.
+
 ### Cross-File Diagnostics
 
 | Diagnostic | Default Severity | Trigger |

--- a/docs/package-database.md
+++ b/docs/package-database.md
@@ -35,7 +35,7 @@ A repo-specific snapshot, generated on a machine that has R and the project's pa
 raven packages freeze
 ```
 
-See [`raven packages freeze`](cli.md#raven-packages-freeze) for all options. Generation resolves each package from a **renv-first** library order (the renv project library first, system libraries only for what renv doesn't cover), so "renv wins, system fills the gaps" happens automatically.
+In VS Code, the same generation runs from the command palette as **Raven: Generate Package Database for CI** — one implementation, two entry points. See [`raven packages freeze`](cli.md#raven-packages-freeze) for all options. Generation resolves each package from a **renv-first** library order (the renv project library first, system libraries only for what renv doesn't cover), so "renv wins, system fills the gaps" happens automatically.
 
 The default `--used` scope is **maximally inclusive** — over-inclusion is free, because the capture simply skips anything not actually installed. The "used" set is:
 

--- a/docs/package-database.md
+++ b/docs/package-database.md
@@ -1,0 +1,101 @@
+# Package database
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+Raven resolves the symbols a package exports so it can offer completions, hover, and — most importantly — avoid flagging every package function as an undefined variable. Normally it reads that information from the package as installed on your machine. But in CI there is often **no R and no installed packages**: `.libPaths()` is empty, so every `library(pkg)` would fire a missing-package warning and every symbol from a package would show as undefined. That makes Raven effectively unusable in CI.
+
+The package database fixes this by giving Raven a pre-built source of export **names** that needs neither R nor installed packages at analysis time. Resolution becomes an **ordered fallback over three tiers**, consulted per package only when the package isn't already resolved.
+
+## The three tiers
+
+| Tier | When it applies | Source | Fidelity |
+|---|---|---|---|
+| **1 — Installed** | Package installed locally (and R reachable for `exportPattern`) | The existing on-disk path: static `NAMESPACE` parse + an R subprocess to expand `exportPattern` | Authoritative, version-exact to the install |
+| **2 — Repo DB** | Not installed, or R can't launch | A repo-specific, committed `.raven/packages.json` you generate locally | "Frozen Tier 1": full structure, version-exact to when it was generated |
+| **3 — Shipped DB** | Otherwise | A Raven-bundled `names.db` built from a reference-R capture ∪ latest CRAN + Bioconductor | Latest CRAN/Bioc; export names only |
+
+**Tier 2 outranks Tier 3** because it is project-specific and built through the authoritative path. A repo that never generates a Tier 2 file still works in CI via Tier 3 alone (latest-only). The two databases share one in-memory model, one reader, and one writer.
+
+The tiers are a **floor, never a replacement**: whenever a package resolves from a real local install (Tier 1), that path stays in charge and is version-exact. Nothing here regresses behavior when packages *are* installed.
+
+> **Export names, not install status.** The database suppresses undefined-variable noise; it never makes a package count as *installed*. The missing-package diagnostic stays Tier-1-only and is **off by default in `raven check`**. See [Names vs. install status](#names-vs-install-status) below.
+
+## Tier 2 — the committed `.raven/packages.json`
+
+A repo-specific snapshot, generated on a machine that has R and the project's packages installed, and **committed to the repo**. Because it is produced through Raven's authoritative path, it is effectively *frozen Tier 1*: it captures the full structure — exports (with `exportPattern` correctly expanded), `Depends`, datasets, and meta-package attaches.
+
+- **Opt-in.** It exists only if you run the generation command; Raven never auto-creates it.
+- **Location.** `.raven/packages.json` at the repo root, auto-discovered like `raven.toml` / `.lintr`.
+- **Format.** Sorted, deterministic, diff-friendly JSON — generated, **not hand-edited**, and meant to be reviewed in PRs, so a `git diff` reads as "package Y gained export X."
+- **Provenance.** Records the generator Raven version, the R version, and the generation date — for debuggability only. There is **no drift-detection machinery**: no lockfile-hash comparison and no "snapshot is stale" diagnostic. Export names are stable; regeneration is a manual command you run when you choose.
+
+### Generating it
+
+```bash
+raven packages freeze
+```
+
+See [`raven packages freeze`](cli.md#raven-packages-freeze) for all options. Generation resolves each package from a **renv-first** library order (the renv project library first, system libraries only for what renv doesn't cover), so "renv wins, system fills the gaps" happens automatically.
+
+The default `--used` scope is **maximally inclusive** — over-inclusion is free, because the capture simply skips anything not actually installed. The "used" set is:
+
+- packages referenced via `library`/`require`/`loadNamespace`/`requireNamespace`, **∪**
+- the left-hand side of `::` / `:::` references, **∪**
+- everything listed in `renv.lock`, **∪**
+- the repo's own `DESCRIPTION` `Depends` / `Imports`, **∪**
+- their transitive `Depends`.
+
+(`LinkingTo` is excluded — it is C-level and has no R exports. For a `:::` reference, the *package's exports* are still frozen; only the internal-object names are out of scope.) Use `--installed` / `--all` to capture every package across the renv + system libraries instead.
+
+`renv.lock` is a **set selector** — it decides *which* packages to include (a locked package is included even if no script calls it), **not** which version to read; exports always come from whatever is installed locally. A locked package that isn't installed can't be captured and falls through to Tier 3 in CI. Best coverage therefore comes from generating after `renv::restore()`, but nothing breaks otherwise.
+
+### Regeneration is a no-op when unchanged
+
+If a `.raven/packages.json` already exists, `freeze` compares **package content only** (ignoring provenance such as the timestamp). When the content is identical it leaves the file untouched and prints "no changes" — so a regeneration that found nothing new produces a **zero-line diff**, and the provenance timestamp moves only when the captured exports actually changed.
+
+### Version skew is explained, not silently dropped
+
+If a committed `.raven/packages.json` was written by a **newer** Raven than the one reading it (an incompatible schema), Raven does not silently ignore it. It **explains and continues**: `raven check` prints a specific note to stderr, the language server raises a notification, and resolution degrades to the bundled database (Tier 3). The message tells you to upgrade Raven here or regenerate the file with `raven packages freeze`. An unreadable or corrupt file is reported the same way. A missing file is normal and silent.
+
+## Tier 3 — bundled `names.db`
+
+A Raven-bundled, latest-CRAN/Bioc export database — the R-free floor that works with no setup at all.
+
+- **Source.** An authoritative **reference-R capture of the build machine's entire installed library** (via Raven's Tier-1 path) **∪** **CRAN + Bioconductor** from [r-universe](https://r-universe.dev) (`cran.r-universe.dev` and `bioc.r-universe.dev`). r-universe's `_exports` is the *true post-load namespace export set* — `exportPattern()` already expanded — for the whole ecosystem. The two sources are merged **append-only**: each rebuild starts from the previous database, overlays the reference-R capture, appends r-universe packages not already present, and **never drops** a package. Precedence: reference-R > r-universe > retained-from-prior.
+- **Why the full installed library.** Hard-to-install, GitHub-only, internal, or fallback-built packages are absent from CRAN/Bioc and only ever enter the floor through the reference-R capture; append-only guarantees they're never lost on later rebuilds. The maintainer **bootstraps** the floor once from a richly-provisioned machine, after which automated runs seed from it and append. Teams can likewise build a private `names.db` from their own library for richer in-house coverage (point Raven at it with `RAVEN_NAMES_DB`).
+- **Contents.** Export names + `Depends` + dataset names. **Export-only** — no internal (`:::`) objects, no signatures.
+- **Delivery.** A sidecar file shipped with both the standalone binary and the VS Code extension, located next to the executable (override with the `RAVEN_NAMES_DB` environment variable). It is **not** compiled into the binary (which would bloat it) and **not** committed to git. It lives on a **GitHub Release** (a moving `names-db` tag) — a durable URL, unlike a per-run CI artifact — alongside the base-exports file and their checksums.
+- **Integrity & provenance.** The build records its source, snapshot date, package count, and Raven version in the database header, plus a [`blake3`](https://github.com/BLAKE3-team/BLAKE3) checksum of the payload that is verified when the file is opened. Bundling third-party data carries supply-chain responsibility, so provenance and a tamper check are part of the pipeline.
+- **Freshness.** Equals Raven's release/refresh cadence — a **weekly** rebuild plus a rebuild on each release. Acceptable because the database is latest-only by design and export names are stable; append-only means coverage only ever grows.
+
+A stale or corrupt `names.db` (for example a custom `RAVEN_NAMES_DB` from an incompatible Raven) is **explained and skipped**, exactly like a version-skewed Tier 2 file — Raven never hard-fails over it.
+
+## Base packages and datasets
+
+Base and recommended packages (**base**, **methods**, **utils**, **stats**, **datasets**, …) are normally read from your R installation. In CI without R they aren't on disk, so Raven ships a separate **base-exports file** (built from the same reference R) that populates base symbols when the base packages are absent. Base **datasets** — `mtcars`, `iris`, and the like — are merged in exactly as the on-disk path does, so they resolve in CI too. A real R install still wins: the file is only consulted when the base packages aren't found locally.
+
+**Non-base package datasets** (e.g. `flights` from **nycflights13**, `diamonds` from **ggplot2**) are captured as `lazy_data` in every tier's records. Resolving them as symbols is handled by [raven#350](https://github.com/jbearak/raven/issues/350) (the package-dataset / lazy-data resolution mechanism, already landed): once a record carries its datasets, that path folds them into the resolvable set automatically — so package datasets resolve in CI with no extra work here.
+
+## Names vs. install status
+
+Knowing a package's exports is deliberately **separate** from knowing whether it is installed:
+
+- **Export resolution** (suppresses undefined-variable noise) uses all three tiers, in every mode.
+- **Install status** (drives the *missing-package* diagnostic) is **Tier 1 only** — it reflects what is present in the local library paths, never the database.
+
+In CI, `raven check` **suppresses missing-package warnings by default** (CI deliberately omits installation); re-enable them with [`--report-uninstalled`](cli.md#missing-package-reporting-in-ci), which reports `library()` calls not present in the local library paths — *not* relative to the database. The full per-mode behavior and the accepted typo gap are documented in [Diagnostics](diagnostics.md#package-names-vs-install-status).
+
+## Fidelity caveats
+
+- **`exportPattern` → solved.** r-universe `_exports` is the post-load truth, so the minority of packages whose exports require a built-and-loaded namespace are correct, including the `.onLoad` ∩ pattern corner. Tier 2, generated via `asNamespace()`, is equally correct.
+- **Tier 3 latest-only drift.** A just-removed export may linger, or a brand-new export may not yet be in the latest rebuild — rare and soft. A project that needs exactness can pin it via Tier 2.
+- **Exports + `Depends` + datasets only.** Tiers 2 and 3 carry no `:::` internal objects and no function signatures (`formals`); those still come only from a local install (Tier 1/2 from a machine with the package). Signatures stay R-subprocess-only.
+- **Bioconductor cadence** differs from CRAN, so the shipped latest snapshot may not match a project's Bioc release train. Tier 2 covers projects that need exactness.
+
+## See also
+
+- [`raven packages`](cli.md#raven-packages) — the `freeze` and `build-shipped-db` commands.
+- [Diagnostics](diagnostics.md#package-names-vs-install-status) — names vs. install status, and the `raven check` default.
+- [Cross-File & Package Awareness](cross-file.md#resolving-exports-without-r) — where the three-tier fallback sits in package resolution.
+- [R Package Development](r-package-dev.md#generating-a-package-database-for-ci) — generating the repo database for a package project.
+- [Development notes](development.md#package-export-databases-ci--r-free-resolution) — the internal architecture.

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -249,6 +249,22 @@ imports remain visible if some `R/*.R` files don't carry roxygen tags.
 
 Raven watches for changes to `DESCRIPTION` and `NAMESPACE` files. After running `devtools::document()` or editing these files directly, diagnostics update automatically without restarting the editor.
 
+## Generating a package database for CI
+
+> **Status: planned.** Describes the CI package-exports database, in active development; not yet in a released build. Tracking: the package-database work (and prerequisite [raven#350](https://github.com/jbearak/raven/issues/350)).
+
+To gate diagnostics on your package in CI without installing R packages there, generate a committed export database and check it in:
+
+```bash
+raven packages freeze
+```
+
+This writes `.raven/packages.json` — a "frozen Tier 1" snapshot of your installed packages' export names, `Depends`, and datasets — which `raven check` then uses to resolve package symbols when no R is present, so symbols from `library()`/`@importFrom` dependencies don't show as undefined variables in CI. Run it on a machine that has R and the project's dependencies installed; the file is generated, not hand-edited, and is meant to be reviewed in PRs (a `git diff` shows "package X gained export Y").
+
+Generation uses a **renv-first** library order: the renv project library first, system libraries only for packages renv doesn't cover. If your project uses [`renv`](https://rstudio.github.io/renv/), run `freeze` after `renv::restore()` for the best coverage — `renv.lock` acts as a *set selector* (which packages to include), while the exports are read from whatever is actually installed locally. Regeneration is a no-op when nothing changed, so re-running it produces no diff unless your dependencies' exports actually moved.
+
+See [Package database](package-database.md) and [`raven packages freeze`](cli.md#raven-packages-freeze) for the full options and the three-tier resolution model.
+
 ## Configuration
 
 | Setting | Default | Description |


### PR DESCRIPTION
## Stage 1 of the CI package-exports database — documentation-first

This is the **docs-only Stage 1** of the CI package-exports DB feature, shipped as its own PR *before any feature code* (per the plan's "Execution order — documentation-first"). It is the **agreed UX/behavior contract**: reviewers approve the intended command names, flags, file locations, the names-vs-install-status split, and the three tiers here, and the implementation (Stages 2–6) builds to match in later sessions.

**No feature code** is touched — only `docs/` and the `CLAUDE.md` doc-map (its real file, `AGENTS.md`, which `CLAUDE.md` symlinks to). Every new/changed user-facing doc/section carries a `> **Status: planned.**` banner; the final code milestone (Task 6.5) removes those banners once the feature ships.

### Authoritative artifacts
- **Plan:** `docs/superpowers/plans/2026-05-30-ci-package-exports-db.md` (Milestone 6, Tasks 6.0–6.4 + 6.4b)
- **Design spec:** `docs/superpowers/specs/2026-05-30-ci-package-exports-db-design.md`
- **Prerequisite (landed):** raven#350 — package-dataset (lazy-data) resolution

### What's in this PR (Tasks 6.0–6.4)
- `docs/development.md` — architecture/internals: the `package_db` module, the `PackageMetadataProvider` seam (Tier 1 bespoke + first; Tier 2/3 on a `get_package` miss; `package_exists()` stays Tier-1-only; why `prefetch_packages` is unchanged), performance discipline (index preload, lazy mmap decode, `blake3` verify in `spawn_blocking`), the Tier 3 build pipeline (reference-R full library ∪ CRAN+Bioc r-universe, append-only, `names-db` GitHub Release, base-exports companion), the #350 dependency, and the testing approach.
- `docs/cli.md` — `raven packages freeze` (`--used` default / `--installed`/`--all`, `--output`, `--workspace`; renv-first order; renv.lock as a set selector; no-op when unchanged), the maintainer-only `raven packages build-shipped-db`, and `raven check --report-uninstalled` (missing-package off by default in CI; the flag reports `library()` calls absent from the local lib paths — *not* relative to Tier 2/3).
- `docs/diagnostics.md` — names ≠ install status (§10): missing-package is Tier-1-only and independent of the export DB; per-mode behavior table; the accepted typo gap.
- `docs/cross-file.md` — the three-tier export resolution; Tiers 2/3 are export-names-only (no `:::`, no signatures).
- `docs/r-package-dev.md` — generating `.raven/packages.json` for CI and the renv-first library order.
- `docs/package-database.md` (new) — the full user page: three tiers + fidelity table, the committed Tier 2 file (generated/reviewable, no-op-when-unchanged, version-skew explained), the maximally-inclusive `--used` set, the bundled `names.db` (append-only reference-R ∪ CRAN+Bioc, GitHub Release, `blake3`, weekly+release cadence), the base-exports file, package datasets via #350, and the fidelity caveats. Linked from the `CLAUDE.md` doc-map.

### Verification
- `git diff --name-only main...HEAD` → only `AGENTS.md` + `docs/*` (no `crates/`, no `editors/vscode/src`, no workflows, no `package.json` config).
- No new LSP setting → settings-reference generator deliberately **not** run.
- Status banner present in every new/changed doc; all cross-reference anchors verified against existing headings.