### PR TITLE
raven packages fetch

### DIFF
--- a/crates/raven/src/cli/mod.rs
+++ b/crates/raven/src/cli/mod.rs
@@ -9,3 +9,45 @@ pub mod check;
 pub mod lint;
 pub mod packages;
 pub mod shared;
+
+/// Map a top-level CLI token to the `packages` subcommand it aliases, if any.
+/// `raven freeze ARGS` ≡ `raven packages freeze ARGS`; `raven fetch ARGS` ≡
+/// `raven packages fetch ARGS`. Only these two are aliased (§6); `update` /
+/// `build-shipped-db` stay nested. Returns the token unchanged (it is already
+/// the subcommand `packages::run` expects as its first arg) so the caller can
+/// delegate the full arg vector with no rewriting.
+pub fn packages_top_level_alias(token: &str) -> Option<&'static str> {
+    match token {
+        "freeze" => Some("freeze"),
+        "fetch" => Some("fetch"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packages_top_level_alias_recognizes_freeze_and_fetch() {
+        assert_eq!(packages_top_level_alias("freeze"), Some("freeze"));
+        assert_eq!(packages_top_level_alias("fetch"), Some("fetch"));
+        assert_eq!(packages_top_level_alias("update"), None);
+        assert_eq!(packages_top_level_alias("build-shipped-db"), None);
+        assert_eq!(packages_top_level_alias("check"), None);
+        assert_eq!(packages_top_level_alias("lint"), None);
+        assert_eq!(packages_top_level_alias(""), None);
+    }
+
+    #[tokio::test]
+    async fn packages_run_help_via_alias_argv_matches_nested() {
+        // The alias `raven fetch --help` passes ["fetch", "--help"] to packages::run.
+        // The nested `raven packages fetch --help` also passes ["fetch", "--help"] after skip(1).
+        // Both must return Err("HELP").
+        let result = packages::run(["fetch", "--help"].into_iter().map(String::from)).await;
+        assert_eq!(result, Err("HELP".to_string()));
+
+        let result = packages::run(["freeze", "--help"].into_iter().map(String::from)).await;
+        assert_eq!(result, Err("HELP".to_string()));
+    }
+}

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -285,12 +285,8 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
     // Step 4: tier1 lib for --missing-only
     let lib_outcome = if args.missing_only {
         Some(
-            crate::package_library::build_package_library_tier1_only(
-                None,
-                &[],
-                Some(root.clone()),
-            )
-            .await,
+            crate::package_library::build_package_library_tier1_only(None, &[], Some(root.clone()))
+                .await,
         )
     } else {
         None
@@ -389,9 +385,7 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
     // Step 11: resolved-nowhere warnings
     let resolved_nowhere: Vec<String> = used_nonbase
         .iter()
-        .filter(|n| {
-            !existing_names.contains(*n) && !is_installed(n) && !found_names.contains(*n)
-        })
+        .filter(|n| !existing_names.contains(*n) && !is_installed(n) && !found_names.contains(*n))
         .cloned()
         .collect();
     for p in &resolved_nowhere {
@@ -416,13 +410,12 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
-        let r_version = if args.missing_only
-            && lib_outcome.as_ref().is_some_and(|o| o.status.is_ready())
-        {
-            "present (--missing-only)".to_string()
-        } else {
-            "none (fetched)".to_string()
-        };
+        let r_version =
+            if args.missing_only && lib_outcome.as_ref().is_some_and(|o| o.status.is_ready()) {
+                "present (--missing-only)".to_string()
+            } else {
+                "none (fetched)".to_string()
+            };
         let db = RepoDb {
             schema_version: REPO_DB_SCHEMA_VERSION,
             provenance: RepoDbProvenance {
@@ -568,9 +561,7 @@ fn collect_used_package_names(root: &std::path::Path) -> Result<Vec<String>, Str
     let mut names = Vec::new();
     names.extend(scan_workspace_referenced_packages(root));
     names.extend(read_description_depends_imports(&root.join("DESCRIPTION")));
-    names.extend(
-        read_renv_lock_package_names(&root.join("renv.lock")).map_err(|e| e.to_string())?,
-    );
+    names.extend(read_renv_lock_package_names(&root.join("renv.lock")).map_err(|e| e.to_string())?);
     Ok(names)
 }
 
@@ -937,8 +928,7 @@ fn fetch_one_package_blocking(pkg: &str, base_urls: &[String]) -> PackageFetchOu
         PackageFetchOutcome::NotFound
     } else {
         PackageFetchOutcome::Transport(
-            last_error
-                .unwrap_or_else(|| format!("could not reach any r-universe base for {pkg}")),
+            last_error.unwrap_or_else(|| format!("could not reach any r-universe base for {pkg}")),
         )
     }
 }
@@ -967,10 +957,9 @@ async fn fetch_packages_wave(
         set.spawn(async move {
             let _permit = sem.acquire().await.unwrap();
             let n = name.clone();
-            let result =
-                tokio::task::spawn_blocking(move || fetch_one_package_blocking(&n, &urls))
-                    .await
-                    .unwrap();
+            let result = tokio::task::spawn_blocking(move || fetch_one_package_blocking(&n, &urls))
+                .await
+                .unwrap();
             (name, result)
         });
     }
@@ -1232,7 +1221,9 @@ pub async fn run(mut argv: impl Iterator<Item = String>) -> Result<(), String> {
             run_build_shipped_db(args).await
         }
         Some(other) => Err(format!("unknown packages subcommand: {other}")),
-        None => Err("usage: raven packages <fetch|freeze|update|build-shipped-db> [OPTIONS]".into()),
+        None => {
+            Err("usage: raven packages <fetch|freeze|update|build-shipped-db> [OPTIONS]".into())
+        }
     }
 }
 
@@ -1620,7 +1611,10 @@ mod tests {
         let args = super::parse_fetch_args(std::iter::empty()).unwrap();
         assert!(!args.missing_only);
         assert!(!args.fail_on_missing);
-        assert_eq!(args.output, std::path::PathBuf::from(".raven/packages.json"));
+        assert_eq!(
+            args.output,
+            std::path::PathBuf::from(".raven/packages.json")
+        );
         assert_eq!(args.workspace, None);
         assert_eq!(
             args.base_urls,
@@ -1666,8 +1660,7 @@ mod tests {
 
     #[test]
     fn parse_fetch_args_unknown_flag() {
-        let err =
-            super::parse_fetch_args(["--bogus"].iter().map(|s| s.to_string())).unwrap_err();
+        let err = super::parse_fetch_args(["--bogus"].iter().map(|s| s.to_string())).unwrap_err();
         assert!(err.contains("unknown flag"), "got {err}");
         assert!(err.contains("--bogus"), "got {err}");
     }
@@ -1676,10 +1669,8 @@ mod tests {
     fn parse_fetch_args_rejects_empty_base_urls() {
         // `--base-urls ''` (or only commas/whitespace) parses to no URLs; reject
         // it with a clear message rather than later misreporting a network outage.
-        let err = super::parse_fetch_args(
-            ["--base-urls", " , "].iter().map(|s| s.to_string()),
-        )
-        .unwrap_err();
+        let err = super::parse_fetch_args(["--base-urls", " , "].iter().map(|s| s.to_string()))
+            .unwrap_err();
         assert!(err.contains("--base-urls"), "got {err}");
     }
 
@@ -1803,9 +1794,21 @@ mod tests {
             super::PackageFetchOutcome::Found(rec) => {
                 assert_eq!(rec.name, "dplyr");
                 assert_eq!(rec.version, "1.1.4");
-                assert!(rec.exports.contains(&"mutate".to_string()), "{:?}", rec.exports);
-                assert!(rec.exports.contains(&"filter".to_string()), "{:?}", rec.exports);
-                assert!(rec.exports.contains(&"select".to_string()), "{:?}", rec.exports);
+                assert!(
+                    rec.exports.contains(&"mutate".to_string()),
+                    "{:?}",
+                    rec.exports
+                );
+                assert!(
+                    rec.exports.contains(&"filter".to_string()),
+                    "{:?}",
+                    rec.exports
+                );
+                assert!(
+                    rec.exports.contains(&"select".to_string()),
+                    "{:?}",
+                    rec.exports
+                );
             }
             other => panic!("expected Found, got {other:?}"),
         }
@@ -1868,7 +1871,9 @@ mod tests {
             "curl: (22) The requested URL returned error: 503 Service Unavailable"
         ));
         // Unparseable stderr conservatively returns false (treated as Transport).
-        assert!(!super::curl_http_error_is_not_found("curl: (22) something odd"));
+        assert!(!super::curl_http_error_is_not_found(
+            "curl: (22) something odd"
+        ));
     }
 
     #[test]
@@ -1915,8 +1920,13 @@ mod tests {
             results.iter().map(|(n, o)| (n.as_str(), o)).collect();
 
         assert!(matches!(map["dplyr"], super::PackageFetchOutcome::Found(r) if r.name == "dplyr"));
-        assert!(matches!(map["ggplot2"], super::PackageFetchOutcome::Found(r) if r.name == "ggplot2"));
-        assert!(matches!(map["bogus_nonexistent"], super::PackageFetchOutcome::NotFound));
+        assert!(
+            matches!(map["ggplot2"], super::PackageFetchOutcome::Found(r) if r.name == "ggplot2")
+        );
+        assert!(matches!(
+            map["bogus_nonexistent"],
+            super::PackageFetchOutcome::NotFound
+        ));
     }
 
     // --- Task 3: run_fetch tests ---
@@ -2062,7 +2072,10 @@ mod tests {
         assert!(result.is_ok(), "run_fetch failed: {:?}", result);
 
         let bytes_after = std::fs::read(&out).unwrap();
-        assert_eq!(bytes_before, bytes_after, "file should be unchanged (no-op)");
+        assert_eq!(
+            bytes_before, bytes_after,
+            "file should be unchanged (no-op)"
+        );
     }
 
     #[tokio::test]
@@ -2081,7 +2094,11 @@ mod tests {
             base_urls: vec![server.base_url()],
         };
         let result = super::run_fetch(args).await;
-        assert!(result.is_ok(), "expected Ok without --fail-on-missing, got: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "expected Ok without --fail-on-missing, got: {:?}",
+            result
+        );
 
         // With --fail-on-missing => Err
         // Remove the output so it starts fresh
@@ -2155,7 +2172,10 @@ mod tests {
             base_urls: vec![format!("http://127.0.0.1:{}", addr.port())],
         };
         let result = super::run_fetch(args).await;
-        assert!(result.is_err(), "expected hard error on total transport failure");
+        assert!(
+            result.is_err(),
+            "expected hard error on total transport failure"
+        );
         let err = result.unwrap_err();
         assert!(err.contains("could not reach"), "got: {err}");
 

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -327,7 +327,6 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
     let mut found_names: HashSet<String> = HashSet::new();
     let mut fetched_records: Vec<PackageRecord> = Vec::new();
     let mut found_count: usize = 0;
-    let mut notfound_count: usize = 0;
     let mut transport_count: usize = 0;
     let mut sample_transport: Option<String> = None;
     let mut queue = to_fetch;
@@ -352,9 +351,7 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
                     }
                     fetched_records.push(rec);
                 }
-                PackageFetchOutcome::NotFound => {
-                    notfound_count += 1;
-                }
+                PackageFetchOutcome::NotFound => {}
                 PackageFetchOutcome::Transport(msg) => {
                     transport_count += 1;
                     if sample_transport.is_none() {
@@ -366,8 +363,8 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
         queue = next_queue;
     }
 
-    // Step 9: hard error on total infrastructure failure
-    if found_count == 0 && notfound_count == 0 && transport_count > 0 {
+    // Step 9: hard error when infrastructure failure prevented any successful fetch.
+    if found_count == 0 && transport_count > 0 {
         let sample = sample_transport.unwrap_or_default();
         return Err(format!(
             "could not reach any r-universe host (network down or curl missing): {sample}. \
@@ -383,11 +380,12 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
     }
 
     // Step 11: resolved-nowhere warnings
-    let resolved_nowhere: Vec<String> = used_nonbase
+    let mut resolved_nowhere: Vec<String> = seen
         .iter()
         .filter(|n| !existing_names.contains(*n) && !is_installed(n) && !found_names.contains(*n))
         .cloned()
         .collect();
+    resolved_nowhere.sort();
     for p in &resolved_nowhere {
         eprintln!(
             "warning: package '{p}' could not be resolved from r-universe; it may be \
@@ -1702,6 +1700,10 @@ mod tests {
         /// Always 500 (used to prove a 5xx outage is a hard Transport error,
         /// not a soft NotFound that silently drops a package).
         ServerError,
+        /// Return 500 for dplyr, but 404 for every other package.
+        DplyrServerErrorOtherwiseNotFound,
+        /// Serve a package whose Depends includes cli; every other package is 404.
+        RootDependsCli,
     }
 
     impl TestServer {
@@ -1759,6 +1761,39 @@ mod tests {
                         stream,
                         "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
                     );
+                    return;
+                }
+                ServerMode::DplyrServerErrorOtherwiseNotFound => {
+                    if path == "/api/packages/dplyr" {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        );
+                    } else {
+                        let _ = write!(stream, "{not_found}");
+                    }
+                    return;
+                }
+                ServerMode::RootDependsCli => {
+                    if path == "/api/packages/rootpkg" {
+                        let body = r#"{
+  "Package": "rootpkg",
+  "Version": "1.0.0",
+  "_exports": ["root_fn"],
+  "_dependencies": [
+    { "package": "cli", "version": "*", "role": "Depends" }
+  ],
+  "_datasets": []
+}"#;
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                    } else {
+                        let _ = write!(stream, "{not_found}");
+                    }
                     return;
                 }
                 ServerMode::Fixtures => {}
@@ -2118,6 +2153,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_fetch_fail_on_missing_includes_transitive_depends() {
+        let server = TestServer::start_mode(ServerMode::RootDependsCli);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(rootpkg)\n").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: true,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(
+            result.is_err(),
+            "expected --fail-on-missing to fail when rootpkg's cli dependency is unresolved"
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("could not be resolved"), "got: {err}");
+        assert!(err.contains("--fail-on-missing"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn run_fetch_missing_only_degrades_without_r() {
         // When --missing-only is set and R is NOT available, the tier1 lib
         // degrades (package_exists returns false for everything), so the fetch
@@ -2181,6 +2240,37 @@ mod tests {
 
         // No output file created
         assert!(!root.join(".raven/packages.json").exists());
+    }
+
+    #[tokio::test]
+    async fn run_fetch_mixed_notfound_and_transport_with_no_records_is_hard_error() {
+        let server = TestServer::start_mode(ServerMode::DplyrServerErrorOtherwiseNotFound);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("script.R"),
+            "library(boguspkgxyz)\nlibrary(dplyr)\n",
+        )
+        .unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(
+            result.is_err(),
+            "expected hard error when no records were fetched and any request hit transport failure"
+        );
+        let err = result.unwrap_err();
+        assert!(err.contains("could not reach"), "got: {err}");
+        assert!(
+            !root.join(".raven/packages.json").exists(),
+            "no file should be written when zero records were fetched during a mixed outage"
+        );
     }
 
     #[tokio::test]

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -1,6 +1,8 @@
-//! `raven packages {freeze,update,build-shipped-db}` — package-database commands.
+//! `raven packages {fetch,freeze,update,build-shipped-db}` — package-database commands.
 //!
-//! `freeze` (Task 5.3) generates a repo's Tier 2 `.raven/packages.json`.
+//! `fetch` (this work) and `freeze` (Task 5.3) are the two producers of a repo's
+//! Tier 2 `.raven/packages.json`: `freeze` captures it from a local R install,
+//! `fetch` from CRAN/Bioc r-universe (R-free, additive merge — existing rows win).
 //! `build-shipped-db` is the maintainer-only Tier 3 builder. It merges, **append-only
 //! and version-monotonic**, three sources into `names.db`: the prior DB (the seed),
 //! an authoritative reference-R capture of the build machine's installed library,
@@ -160,6 +162,298 @@ pub fn parse_freeze_args(mut argv: impl Iterator<Item = String>) -> Result<Freez
     })
 }
 
+#[derive(Debug)]
+pub struct FetchArgs {
+    pub missing_only: bool,
+    pub fail_on_missing: bool,
+    pub output: PathBuf,
+    pub workspace: Option<PathBuf>,
+    pub base_urls: Vec<String>,
+}
+
+pub fn parse_fetch_args(mut argv: impl Iterator<Item = String>) -> Result<FetchArgs, String> {
+    let mut missing_only = false;
+    let mut fail_on_missing = false;
+    let mut output = PathBuf::from(".raven/packages.json");
+    let mut workspace = None;
+    let mut base_urls: Option<Vec<String>> = None;
+    while let Some(arg) = argv.next() {
+        match arg.as_str() {
+            "--missing-only" => missing_only = true,
+            "--fail-on-missing" => fail_on_missing = true,
+            "--output" => output = PathBuf::from(argv.next().ok_or("--output needs a path")?),
+            "--workspace" => {
+                workspace = Some(PathBuf::from(
+                    argv.next().ok_or("--workspace needs a path")?,
+                ))
+            }
+            "--base-urls" => {
+                let raw = argv.next().ok_or("--base-urls needs a value")?;
+                let parsed: Vec<String> = raw
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if parsed.is_empty() {
+                    return Err("--base-urls needs at least one non-empty URL".into());
+                }
+                base_urls = Some(parsed);
+            }
+            "--help" => return Err("HELP".into()),
+            s => return Err(format!("unknown flag: {s}")),
+        }
+    }
+    Ok(FetchArgs {
+        missing_only,
+        fail_on_missing,
+        output,
+        workspace,
+        base_urls: base_urls.unwrap_or_else(|| {
+            vec![
+                "https://cran.r-universe.dev".into(),
+                "https://bioc.r-universe.dev".into(),
+            ]
+        }),
+    })
+}
+
+/// One warning line per fetched record whose version differs from the renv.lock pin.
+fn renv_skew_warnings(
+    fetched: &[PackageRecord],
+    pinned: &std::collections::HashMap<String, String>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for rec in fetched {
+        if let Some(want) = pinned.get(&rec.name) {
+            if !want.is_empty() && want != &rec.version {
+                out.push(format!(
+                    "{}: fetched {} (latest); renv.lock pins {}. Export names usually match \
+                     across versions; install it and use `freeze` / `--missing-only` for a \
+                     version-exact capture.",
+                    rec.name, rec.version, want
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn write_repo_db_file_atomic(path: &std::path::Path, db: &RepoDb) -> Result<(), String> {
+    use crate::package_db::json_db::write_repo_db_string;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("packages.json");
+    let mut text = write_repo_db_string(db);
+    text.push('\n');
+    let tmp = write_unique_temp(dir, file_name, text.into_bytes())?;
+    if let Err(e) = replace_with_tmp(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Fetch package metadata from r-universe, following transitive dependencies.
+pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
+    use crate::package_db::renv_lock::read_renv_lock_package_versions;
+    use std::collections::HashSet;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let root = match &args.workspace {
+        Some(p) => absolute_path(&cwd, p),
+        None => cwd,
+    };
+    let out = absolute_path(&root, &args.output);
+
+    // Step 2: read existing
+    let existing_records = match read_repo_db_file(&out) {
+        Ok(db) => db.packages,
+        Err(crate::package_db::json_db::RepoDbError::Absent) => Vec::new(),
+        Err(e) => return Err(e.to_string()),
+    };
+    let existing_names: HashSet<String> = existing_records.iter().map(|r| r.name.clone()).collect();
+
+    // Step 3: base packages
+    let base = embedded_base_packages();
+
+    // Step 4: tier1 lib for --missing-only
+    let lib_outcome = if args.missing_only {
+        Some(
+            crate::package_library::build_package_library_tier1_only(
+                None,
+                &[],
+                Some(root.clone()),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
+    let is_installed = |name: &str| -> bool {
+        args.missing_only
+            && lib_outcome
+                .as_ref()
+                .is_some_and(|o| o.library.package_exists(name))
+    };
+
+    // Step 5: used packages (non-base, deduped)
+    let used = collect_used_package_names(&root)?;
+    let used_nonbase: Vec<String> = {
+        let mut set = HashSet::new();
+        let mut v = Vec::new();
+        for name in &used {
+            if !base.contains(name) && set.insert(name.clone()) {
+                v.push(name.clone());
+            }
+        }
+        v.sort();
+        v
+    };
+
+    // Step 6: initial fetch set
+    let to_fetch: Vec<String> = used_nonbase
+        .iter()
+        .filter(|n| !existing_names.contains(*n) && !is_installed(n))
+        .cloned()
+        .collect();
+
+    // Step 7: inform
+    if !to_fetch.is_empty() {
+        eprintln!(
+            "Fetching {} package(s) from r-universe: {}",
+            to_fetch.len(),
+            to_fetch.join(", ")
+        );
+    }
+
+    // Step 8: BFS waves
+    let mut seen: HashSet<String> = to_fetch.iter().cloned().collect();
+    let mut found_names: HashSet<String> = HashSet::new();
+    let mut fetched_records: Vec<PackageRecord> = Vec::new();
+    let mut found_count: usize = 0;
+    let mut notfound_count: usize = 0;
+    let mut transport_count: usize = 0;
+    let mut sample_transport: Option<String> = None;
+    let mut queue = to_fetch;
+
+    while !queue.is_empty() {
+        let results = fetch_packages_wave(std::mem::take(&mut queue), &args.base_urls).await;
+        let mut next_queue: Vec<String> = Vec::new();
+        for (name, outcome) in results {
+            match outcome {
+                PackageFetchOutcome::Found(rec) => {
+                    found_count += 1;
+                    found_names.insert(name);
+                    for dep in &rec.depends {
+                        if dep != "R"
+                            && !base.contains(dep)
+                            && !existing_names.contains(dep)
+                            && !is_installed(dep)
+                            && seen.insert(dep.clone())
+                        {
+                            next_queue.push(dep.clone());
+                        }
+                    }
+                    fetched_records.push(rec);
+                }
+                PackageFetchOutcome::NotFound => {
+                    notfound_count += 1;
+                }
+                PackageFetchOutcome::Transport(msg) => {
+                    transport_count += 1;
+                    if sample_transport.is_none() {
+                        sample_transport = Some(msg);
+                    }
+                }
+            }
+        }
+        queue = next_queue;
+    }
+
+    // Step 9: hard error on total infrastructure failure
+    if found_count == 0 && notfound_count == 0 && transport_count > 0 {
+        let sample = sample_transport.unwrap_or_default();
+        return Err(format!(
+            "could not reach any r-universe host (network down or curl missing): {sample}. \
+             Install the packages and use `raven packages freeze` for an offline, version-exact \
+             capture, or check connectivity."
+        ));
+    }
+
+    // Step 10: renv version-skew warnings
+    let pinned = read_renv_lock_package_versions(&root.join("renv.lock")).unwrap_or_default();
+    for w in renv_skew_warnings(&fetched_records, &pinned) {
+        eprintln!("{w}");
+    }
+
+    // Step 11: resolved-nowhere warnings
+    let resolved_nowhere: Vec<String> = used_nonbase
+        .iter()
+        .filter(|n| {
+            !existing_names.contains(*n) && !is_installed(n) && !found_names.contains(*n)
+        })
+        .cloned()
+        .collect();
+    for p in &resolved_nowhere {
+        eprintln!(
+            "warning: package '{p}' could not be resolved from r-universe; it may be \
+             GitHub-only, internal, not yet on r-universe, a typo, or the host was unreachable"
+        );
+    }
+
+    // Step 12: merge + write
+    let mut merged = existing_records.clone();
+    merged.extend(fetched_records);
+    merged.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut existing_sorted = existing_records;
+    existing_sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if merged == existing_sorted {
+        eprintln!("no changes; left {} untouched", out.display());
+    } else {
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let r_version = if args.missing_only
+            && lib_outcome.as_ref().is_some_and(|o| o.status.is_ready())
+        {
+            "present (--missing-only)".to_string()
+        } else {
+            "none (fetched)".to_string()
+        };
+        let db = RepoDb {
+            schema_version: REPO_DB_SCHEMA_VERSION,
+            provenance: RepoDbProvenance {
+                raven_version: env!("CARGO_PKG_VERSION").to_string(),
+                r_version,
+                generated_unix: now_unix,
+            },
+            packages: merged,
+        };
+        write_repo_db_file_atomic(&out, &db)?;
+        eprintln!("Wrote {} packages to {}", db.packages.len(), out.display());
+    }
+
+    // Step 13: fail-on-missing exit
+    if args.fail_on_missing && !resolved_nowhere.is_empty() {
+        return Err(format!(
+            "{} package(s) could not be resolved from r-universe; failing because \
+             --fail-on-missing was set",
+            resolved_nowhere.len()
+        ));
+    }
+
+    Ok(())
+}
+
 /// Generate a repo's Tier 2 `.raven/packages.json` from installed packages.
 ///
 /// **Provider-less (decision #6):** built with
@@ -212,11 +506,7 @@ pub async fn run_freeze(args: FreezeArgs) -> Result<(), String> {
     match args.scope {
         FreezeScope::All => queue.extend(lib.enumerate_installed_packages()),
         FreezeScope::Used => {
-            queue.extend(scan_workspace_referenced_packages(&root));
-            queue.extend(read_description_depends_imports(&root.join("DESCRIPTION")));
-            queue.extend(
-                read_renv_lock_package_names(&root.join("renv.lock")).map_err(|e| e.to_string())?,
-            );
+            queue.extend(collect_used_package_names(&root)?);
         }
     }
 
@@ -275,6 +565,25 @@ pub async fn run_freeze(args: FreezeArgs) -> Result<(), String> {
     write_repo_db_file(&out, &db).map_err(|e| e.to_string())?;
     eprintln!("Wrote {} packages to {}", db.packages.len(), out.display());
     Ok(())
+}
+
+/// Compute the union of package names referenced in the workspace: scan R files
+/// for `library()`/`require()`/`loadNamespace()`/`requireNamespace()` calls and
+/// `::` / `:::` LHS, plus DESCRIPTION Depends+Imports, plus renv.lock names.
+fn collect_used_package_names(root: &std::path::Path) -> Result<Vec<String>, String> {
+    let mut names = Vec::new();
+    names.extend(scan_workspace_referenced_packages(root));
+    names.extend(read_description_depends_imports(&root.join("DESCRIPTION")));
+    names.extend(
+        read_renv_lock_package_names(&root.join("renv.lock")).map_err(|e| e.to_string())?,
+    );
+    Ok(names)
+}
+
+/// Return the set of base/recommended package names from the embedded database,
+/// without requiring an R subprocess.
+fn embedded_base_packages() -> std::collections::HashSet<String> {
+    crate::package_db::embedded_base::load().1
 }
 
 /// Scan every R file under `root` for the maximally-inclusive referenced set
@@ -500,15 +809,10 @@ async fn download_asset(base_url: &str, name: &str) -> Result<Vec<u8>, String> {
         .map_err(|e| format!("download task failed for {name}: {e}"))?
 }
 
-fn download_asset_blocking(url: &str) -> Result<Vec<u8>, String> {
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        return Err(format!(
-            "refusing to download {url}: only http:// and https:// URLs are supported. {}",
-            manual_sidecar_guidance()
-        ));
-    }
-
-    let output = Command::new("curl")
+/// Run curl with the shared arg list. Both `download_asset_blocking` and
+/// `fetch_one_package_blocking` use this to avoid arg-list drift.
+fn run_curl(url: &str) -> std::io::Result<std::process::Output> {
+    Command::new("curl")
         .args([
             "--fail",
             "--location",
@@ -527,13 +831,23 @@ fn download_asset_blocking(url: &str) -> Result<Vec<u8>, String> {
             url,
         ])
         .output()
-        .map_err(|e| {
-            format!(
-                "failed to run curl for {url}: {e}. `raven packages update` requires curl; \
-                 {}",
-                manual_sidecar_guidance()
-            )
-        })?;
+}
+
+fn download_asset_blocking(url: &str) -> Result<Vec<u8>, String> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err(format!(
+            "refusing to download {url}: only http:// and https:// URLs are supported. {}",
+            manual_sidecar_guidance()
+        ));
+    }
+
+    let output = run_curl(url).map_err(|e| {
+        format!(
+            "failed to run curl for {url}: {e}. `raven packages update` requires curl; \
+             {}",
+            manual_sidecar_guidance()
+        )
+    })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(curl_failure_error(
@@ -543,6 +857,135 @@ fn download_asset_blocking(url: &str) -> Result<Vec<u8>, String> {
         ));
     }
     Ok(output.stdout)
+}
+
+/// Outcome of fetching one package across the ordered base-url list.
+///
+/// The distinction between `NotFound` and `Transport` is critical for Task 3's
+/// error policy: a lone typo (NotFound) must never hard-error the command; only
+/// genuine infrastructure failures (Transport) can escalate to a hard error when
+/// nothing was fetched at all.
+#[derive(Debug)]
+enum PackageFetchOutcome {
+    /// Fetched and parsed from one of the bases.
+    Found(PackageRecord),
+    /// Every base served a genuine HTTP not-found (404/410): the package is
+    /// off-ecosystem or a typo. SOFT — becomes a resolved-nowhere warning in
+    /// Task 3. Only a true not-found qualifies; a 5xx is a transient outage and
+    /// is treated as `Transport` so it can't silently drop a real package.
+    NotFound,
+    /// curl could not run, could not reach any base (spawn failure / DNS /
+    /// connection refused / timeout), or every base returned a *server* error
+    /// (5xx) — i.e. an infrastructure failure, surfaced so the command can
+    /// report it rather than silently dropping the package. Carries a message.
+    Transport(String),
+}
+
+/// Whether a curl `--fail` HTTP error (exit 22) is a genuine "not found".
+///
+/// curl with `--show-error` emits `curl: (22) The requested URL returned error:
+/// NNN ...` on stderr. A 404/410 means the package is not served by this host
+/// (soft `NotFound`); any other status — notably a 5xx during an r-universe
+/// outage — must escalate to `Transport` so a transient failure can't silently
+/// write a database that drops a real package. When the status can't be parsed
+/// we conservatively return `false` (treat as `Transport`, the loud direction).
+fn curl_http_error_is_not_found(stderr: &str) -> bool {
+    stderr
+        .split("returned error:")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|code| code.parse::<u16>().ok())
+        .is_some_and(|code| code == 404 || code == 410)
+}
+
+/// Fetch one package's r-universe JSON, trying each `{base}/api/packages/{pkg}`
+/// in order (CRAN then Bioc). Returns Found on the first base that serves a
+/// parseable record; NotFound when every base returned a genuine HTTP not-found
+/// (404/410); Transport when curl could not reach any base, or a base failed
+/// with a non-not-found error (5xx, parse failure, spawn failure).
+fn fetch_one_package_blocking(pkg: &str, base_urls: &[String]) -> PackageFetchOutcome {
+    use crate::package_db::runiverse::parse_runiverse_json;
+
+    let mut saw_http_not_found = false;
+    let mut last_error: Option<String> = None;
+
+    for base in base_urls {
+        let url = format!("{}/api/packages/{}", base.trim_end_matches('/'), pkg);
+        match run_curl(&url) {
+            Err(e) => {
+                last_error = Some(format!("failed to run curl for {url}: {e}"));
+            }
+            Ok(output) if output.status.success() => {
+                let text = String::from_utf8_lossy(&output.stdout);
+                match parse_runiverse_json(&text) {
+                    Ok(rec) => return PackageFetchOutcome::Found(rec),
+                    Err(e) => {
+                        last_error = Some(format!("parse error for {url}: {e}"));
+                    }
+                }
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if output.status.code() == Some(22) && curl_http_error_is_not_found(&stderr) {
+                    saw_http_not_found = true;
+                } else {
+                    last_error = Some(stderr.trim().to_string());
+                }
+            }
+        }
+    }
+
+    // Only a clean not-found across the bases is soft: if ANY base failed for a
+    // non-not-found reason (5xx outage, parse error, unreachable), that evidence
+    // wins, so a 404 on one host can't mask a transient outage on another and
+    // silently drop a package that the outaged host might actually serve.
+    if saw_http_not_found && last_error.is_none() {
+        PackageFetchOutcome::NotFound
+    } else {
+        PackageFetchOutcome::Transport(
+            last_error
+                .unwrap_or_else(|| format!("could not reach any r-universe base for {pkg}")),
+        )
+    }
+}
+
+const MAX_CONCURRENT_FETCHES: usize = 8;
+
+/// Fetch a batch (one BFS wave) of packages concurrently, bounded to
+/// MAX_CONCURRENT_FETCHES. curl is blocking, so each fetch runs on a blocking
+/// task; a semaphore caps in-flight work. Returns each name paired with its
+/// outcome (order not guaranteed).
+async fn fetch_packages_wave(
+    names: Vec<String>,
+    base_urls: &[String],
+) -> Vec<(String, PackageFetchOutcome)> {
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+    use tokio::task::JoinSet;
+
+    let sem = Arc::new(Semaphore::new(MAX_CONCURRENT_FETCHES));
+    let urls: Arc<Vec<String>> = Arc::new(base_urls.to_vec());
+    let mut set = JoinSet::new();
+
+    for name in names {
+        let sem = Arc::clone(&sem);
+        let urls = Arc::clone(&urls);
+        set.spawn(async move {
+            let _permit = sem.acquire().await.unwrap();
+            let n = name.clone();
+            let result =
+                tokio::task::spawn_blocking(move || fetch_one_package_blocking(&n, &urls))
+                    .await
+                    .unwrap();
+            (name, result)
+        });
+    }
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res.unwrap());
+    }
+    results
 }
 
 fn curl_failure_error(url: &str, status: &str, stderr: &str) -> String {
@@ -786,12 +1229,16 @@ pub async fn run(mut argv: impl Iterator<Item = String>) -> Result<(), String> {
             let args = parse_freeze_args(argv)?;
             run_freeze(args).await
         }
+        Some("fetch") => {
+            let args = parse_fetch_args(argv)?;
+            run_fetch(args).await
+        }
         Some("build-shipped-db") => {
             let args = parse_build_shipped_db_args(argv)?;
             run_build_shipped_db(args).await
         }
         Some(other) => Err(format!("unknown packages subcommand: {other}")),
-        None => Err("usage: raven packages <freeze|update|build-shipped-db> [OPTIONS]".into()),
+        None => Err("usage: raven packages <fetch|freeze|update|build-shipped-db> [OPTIONS]".into()),
     }
 }
 
@@ -799,6 +1246,8 @@ pub fn print_help() {
     println!(
         "raven packages — package-database commands\n\n\
          Usage:\n  \
+         raven packages fetch [--missing-only] [--fail-on-missing] [--output PATH] \
+[--workspace DIR] [--base-urls URL[,URL]]\n  \
          raven packages freeze [--used|--installed|--all] [--output PATH] [--workspace DIR]\n  \
          raven packages update [--base-url URL] [--dest-dir DIR]\n  \
          raven packages build-shipped-db [--reference-lib DIR] [--runiverse-cran DIR] \
@@ -1140,5 +1589,635 @@ mod tests {
 
         assert!(err.contains("replace"), "got {err}");
         assert_eq!(std::fs::read(&final_path).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn collect_used_package_names_unions_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // R file referencing ggplot2 and dplyr
+        std::fs::write(
+            root.join("script.R"),
+            "library(ggplot2)\ndplyr::mutate(x)\n",
+        )
+        .unwrap();
+
+        // DESCRIPTION with Imports: cli
+        std::fs::write(root.join("DESCRIPTION"), "Package: mypkg\nImports: cli\n").unwrap();
+
+        // renv.lock pinning tibble
+        std::fs::write(
+            root.join("renv.lock"),
+            r#"{"Packages":{"tibble":{"Package":"tibble","Version":"3.2.1"}}}"#,
+        )
+        .unwrap();
+
+        let names = super::collect_used_package_names(root).unwrap();
+        let set: std::collections::HashSet<&str> = names.iter().map(|s| s.as_str()).collect();
+        assert!(set.contains("ggplot2"), "missing ggplot2, got {set:?}");
+        assert!(set.contains("dplyr"), "missing dplyr, got {set:?}");
+        assert!(set.contains("cli"), "missing cli, got {set:?}");
+        assert!(set.contains("tibble"), "missing tibble, got {set:?}");
+    }
+
+    #[test]
+    fn parse_fetch_args_defaults() {
+        let args = super::parse_fetch_args(std::iter::empty()).unwrap();
+        assert!(!args.missing_only);
+        assert!(!args.fail_on_missing);
+        assert_eq!(args.output, std::path::PathBuf::from(".raven/packages.json"));
+        assert_eq!(args.workspace, None);
+        assert_eq!(
+            args.base_urls,
+            vec![
+                "https://cran.r-universe.dev".to_string(),
+                "https://bioc.r-universe.dev".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_fetch_args_all_flags() {
+        let args = super::parse_fetch_args(
+            [
+                "--missing-only",
+                "--fail-on-missing",
+                "--output",
+                "x.json",
+                "--workspace",
+                "w",
+                "--base-urls",
+                "http://a,http://b",
+            ]
+            .iter()
+            .map(|s| s.to_string()),
+        )
+        .unwrap();
+        assert!(args.missing_only);
+        assert!(args.fail_on_missing);
+        assert_eq!(args.output, std::path::PathBuf::from("x.json"));
+        assert_eq!(args.workspace, Some(std::path::PathBuf::from("w")));
+        assert_eq!(
+            args.base_urls,
+            vec!["http://a".to_string(), "http://b".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_fetch_args_help() {
+        let err = super::parse_fetch_args(["--help"].iter().map(|s| s.to_string())).unwrap_err();
+        assert_eq!(err, "HELP");
+    }
+
+    #[test]
+    fn parse_fetch_args_unknown_flag() {
+        let err =
+            super::parse_fetch_args(["--bogus"].iter().map(|s| s.to_string())).unwrap_err();
+        assert!(err.contains("unknown flag"), "got {err}");
+        assert!(err.contains("--bogus"), "got {err}");
+    }
+
+    #[test]
+    fn parse_fetch_args_rejects_empty_base_urls() {
+        // `--base-urls ''` (or only commas/whitespace) parses to no URLs; reject
+        // it with a clear message rather than later misreporting a network outage.
+        let err = super::parse_fetch_args(
+            ["--base-urls", " , "].iter().map(|s| s.to_string()),
+        )
+        .unwrap_err();
+        assert!(err.contains("--base-urls"), "got {err}");
+    }
+
+    #[test]
+    fn embedded_base_packages_contains_expected() {
+        let set = super::embedded_base_packages();
+        for pkg in ["base", "stats", "utils", "methods", "datasets"] {
+            assert!(set.contains(pkg), "expected {pkg} in base set");
+        }
+        assert!(!set.contains("dplyr"), "dplyr must not be in base set");
+    }
+
+    // --- Test server for fetch tests ---
+
+    /// Minimal blocking HTTP server for fetch tests. Serves fixture JSON for
+    /// known packages, 404 for unknown ones.
+    struct TestServer {
+        addr: std::net::SocketAddr,
+        _handle: std::thread::JoinHandle<()>,
+    }
+
+    /// How the test server responds to every request.
+    #[derive(Clone, Copy)]
+    enum ServerMode {
+        /// Serve the fixture for known packages, 404 for unknown ones.
+        Fixtures,
+        /// Always 404 (used to exercise the CRAN→Bioc fallback).
+        NotFound,
+        /// Always 500 (used to prove a 5xx outage is a hard Transport error,
+        /// not a soft NotFound that silently drops a package).
+        ServerError,
+    }
+
+    impl TestServer {
+        /// Start a test server. If `always_404` is true, every request gets 404.
+        fn start(always_404: bool) -> Self {
+            Self::start_mode(if always_404 {
+                ServerMode::NotFound
+            } else {
+                ServerMode::Fixtures
+            })
+        }
+
+        fn start_mode(mode: ServerMode) -> Self {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let handle = std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(stream) = stream else { break };
+                    std::thread::spawn(move || Self::handle_conn(stream, mode));
+                }
+            });
+            TestServer {
+                addr,
+                _handle: handle,
+            }
+        }
+
+        fn base_url(&self) -> String {
+            format!("http://127.0.0.1:{}", self.addr.port())
+        }
+
+        fn handle_conn(mut stream: std::net::TcpStream, mode: ServerMode) {
+            use std::io::{BufRead, BufReader, Write};
+            let reader = BufReader::new(&stream);
+            let request_line = match reader.lines().next() {
+                Some(Ok(line)) => line,
+                _ => return,
+            };
+            // Parse: "GET /api/packages/dplyr HTTP/1.1"
+            let parts: Vec<&str> = request_line.split_whitespace().collect();
+            if parts.len() < 2 {
+                return;
+            }
+            let path = parts[1];
+
+            let not_found =
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            match mode {
+                ServerMode::NotFound => {
+                    let _ = write!(stream, "{not_found}");
+                    return;
+                }
+                ServerMode::ServerError => {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                    return;
+                }
+                ServerMode::Fixtures => {}
+            }
+
+            let prefix = "/api/packages/";
+            if let Some(pkg) = path.strip_prefix(prefix) {
+                let fixture_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests/fixtures/package_db/runiverse");
+                let fixture_path = fixture_dir.join(format!("{pkg}.json"));
+                if let Ok(body) = std::fs::read(&fixture_path) {
+                    let _ = write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(&body);
+                } else {
+                    let _ = write!(stream, "{not_found}");
+                }
+            } else {
+                let _ = write!(stream, "{not_found}");
+            }
+        }
+    }
+
+    #[test]
+    fn fetch_one_package_found() {
+        let server = TestServer::start(false);
+        let bases = vec![server.base_url()];
+        let result = super::fetch_one_package_blocking("dplyr", &bases);
+        match result {
+            super::PackageFetchOutcome::Found(rec) => {
+                assert_eq!(rec.name, "dplyr");
+                assert_eq!(rec.version, "1.1.4");
+                assert!(rec.exports.contains(&"mutate".to_string()), "{:?}", rec.exports);
+                assert!(rec.exports.contains(&"filter".to_string()), "{:?}", rec.exports);
+                assert!(rec.exports.contains(&"select".to_string()), "{:?}", rec.exports);
+            }
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fetch_one_package_cran_miss_bioc_fallback() {
+        let server_404 = TestServer::start(true);
+        let server_ok = TestServer::start(false);
+        let bases = vec![server_404.base_url(), server_ok.base_url()];
+        let result = super::fetch_one_package_blocking("dplyr", &bases);
+        match result {
+            super::PackageFetchOutcome::Found(rec) => {
+                assert_eq!(rec.name, "dplyr");
+                assert_eq!(rec.version, "1.1.4");
+            }
+            other => panic!("expected Found from second base, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fetch_one_package_not_found_on_all_bases() {
+        let server = TestServer::start(false);
+        let bases = vec![server.base_url()];
+        let result = super::fetch_one_package_blocking("nonexistent_pkg_xyz", &bases);
+        assert!(
+            matches!(result, super::PackageFetchOutcome::NotFound),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_one_package_transport_when_unreachable() {
+        // Bind to get a free port, then drop the listener so nothing is listening.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let bases = vec![format!("http://127.0.0.1:{}", addr.port())];
+        let result = super::fetch_one_package_blocking("dplyr", &bases);
+        assert!(
+            matches!(result, super::PackageFetchOutcome::Transport(_)),
+            "expected Transport, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn curl_http_error_distinguishes_not_found_from_server_error() {
+        // curl --fail emits "curl: (22) The requested URL returned error: NNN".
+        // Only 404/410 are a genuine not-found (soft); a 5xx outage must NOT be.
+        assert!(super::curl_http_error_is_not_found(
+            "curl: (22) The requested URL returned error: 404"
+        ));
+        assert!(super::curl_http_error_is_not_found(
+            "curl: (22) The requested URL returned error: 410 Gone"
+        ));
+        assert!(!super::curl_http_error_is_not_found(
+            "curl: (22) The requested URL returned error: 500"
+        ));
+        assert!(!super::curl_http_error_is_not_found(
+            "curl: (22) The requested URL returned error: 503 Service Unavailable"
+        ));
+        // Unparseable stderr conservatively returns false (treated as Transport).
+        assert!(!super::curl_http_error_is_not_found("curl: (22) something odd"));
+    }
+
+    #[test]
+    fn fetch_one_package_server_error_is_transport_not_not_found() {
+        // A 5xx from every base is a transient outage, not a missing package:
+        // it must be Transport (hard) so run_fetch can refuse rather than write
+        // a database that silently drops the package.
+        let server = TestServer::start_mode(ServerMode::ServerError);
+        let bases = vec![server.base_url()];
+        let result = super::fetch_one_package_blocking("dplyr", &bases);
+        assert!(
+            matches!(result, super::PackageFetchOutcome::Transport(_)),
+            "expected Transport for a 5xx, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_one_package_5xx_on_one_base_not_masked_by_404_on_another() {
+        // A 5xx outage on the first base must NOT be masked by a genuine 404 on
+        // the second: the package might exist on the outaged host, so the result
+        // is Transport (hard), not NotFound (soft) — otherwise a partial outage
+        // could silently drop a real package.
+        let outage = TestServer::start_mode(ServerMode::ServerError);
+        let not_found = TestServer::start_mode(ServerMode::NotFound);
+        let bases = vec![outage.base_url(), not_found.base_url()];
+        let result = super::fetch_one_package_blocking("dplyr", &bases);
+        assert!(
+            matches!(result, super::PackageFetchOutcome::Transport(_)),
+            "expected Transport when one base 5xx'd, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_packages_wave_fetches_all() {
+        let server = TestServer::start(false);
+        let bases = vec![server.base_url()];
+        let names = vec![
+            "dplyr".to_string(),
+            "ggplot2".to_string(),
+            "bogus_nonexistent".to_string(),
+        ];
+        let results = super::fetch_packages_wave(names, &bases).await;
+        let map: std::collections::HashMap<&str, &super::PackageFetchOutcome> =
+            results.iter().map(|(n, o)| (n.as_str(), o)).collect();
+
+        assert!(matches!(map["dplyr"], super::PackageFetchOutcome::Found(r) if r.name == "dplyr"));
+        assert!(matches!(map["ggplot2"], super::PackageFetchOutcome::Found(r) if r.name == "ggplot2"));
+        assert!(matches!(map["bogus_nonexistent"], super::PackageFetchOutcome::NotFound));
+    }
+
+    // --- Task 3: run_fetch tests ---
+
+    #[test]
+    fn renv_skew_warnings_flags_only_mismatches() {
+        let fetched = vec![
+            PackageRecord {
+                name: "dplyr".into(),
+                version: "1.1.4".into(),
+                exports: vec![],
+                depends: vec![],
+                lazy_data: vec![],
+            },
+            PackageRecord {
+                name: "ggplot2".into(),
+                version: "3.5.0".into(),
+                exports: vec![],
+                depends: vec![],
+                lazy_data: vec![],
+            },
+        ];
+        let mut pinned = std::collections::HashMap::new();
+        pinned.insert("dplyr".to_string(), "1.1.2".to_string());
+        pinned.insert("ggplot2".to_string(), "3.5.0".to_string());
+
+        let warnings = super::renv_skew_warnings(&fetched, &pinned);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("dplyr"), "got: {}", warnings[0]);
+        assert!(warnings[0].contains("1.1.4"), "got: {}", warnings[0]);
+        assert!(warnings[0].contains("1.1.2"), "got: {}", warnings[0]);
+
+        // Empty pinned => no warnings
+        let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let warnings2 = super::renv_skew_warnings(&fetched, &empty);
+        assert!(warnings2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_fetch_writes_used_packages() {
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_ok(), "run_fetch failed: {:?}", result);
+
+        let out = root.join(".raven/packages.json");
+        let db = read_repo_db_file(&out).unwrap();
+        let dplyr = db.packages.iter().find(|r| r.name == "dplyr").unwrap();
+        assert!(dplyr.exports.contains(&"mutate".to_string()));
+        assert!(dplyr.exports.contains(&"filter".to_string()));
+        assert!(dplyr.exports.contains(&"select".to_string()));
+        assert_eq!(db.provenance.r_version, "none (fetched)");
+    }
+
+    #[tokio::test]
+    async fn run_fetch_merge_existing_wins() {
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\nlibrary(ggplot2)\n").unwrap();
+
+        // Pre-create with a sentinel dplyr record
+        let out = root.join(".raven/packages.json");
+        let sentinel_db = RepoDb {
+            schema_version: REPO_DB_SCHEMA_VERSION,
+            provenance: RepoDbProvenance {
+                raven_version: "0.0.0".into(),
+                r_version: "test".into(),
+                generated_unix: 0,
+            },
+            packages: vec![PackageRecord {
+                name: "dplyr".into(),
+                version: "0.0.0".into(),
+                exports: vec!["OLD_SENTINEL".into()],
+                depends: vec![],
+                lazy_data: vec![],
+            }],
+        };
+        write_repo_db_file(&out, &sentinel_db).unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_ok(), "run_fetch failed: {:?}", result);
+
+        let db = read_repo_db_file(&out).unwrap();
+        let dplyr = db.packages.iter().find(|r| r.name == "dplyr").unwrap();
+        assert_eq!(dplyr.version, "0.0.0");
+        assert_eq!(dplyr.exports, vec!["OLD_SENTINEL".to_string()]);
+        let ggplot2 = db.packages.iter().find(|r| r.name == "ggplot2").unwrap();
+        assert_eq!(ggplot2.version, "3.5.0");
+    }
+
+    #[tokio::test]
+    async fn run_fetch_noop_when_fully_covered() {
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let out = root.join(".raven/packages.json");
+        let existing_db = RepoDb {
+            schema_version: REPO_DB_SCHEMA_VERSION,
+            provenance: RepoDbProvenance {
+                raven_version: "0.0.0".into(),
+                r_version: "test".into(),
+                generated_unix: 0,
+            },
+            packages: vec![PackageRecord {
+                name: "dplyr".into(),
+                version: "1.1.4".into(),
+                exports: vec!["filter".into(), "mutate".into(), "select".into()],
+                depends: vec!["R".into(), "cli".into()],
+                lazy_data: vec![],
+            }],
+        };
+        write_repo_db_file(&out, &existing_db).unwrap();
+        let bytes_before = std::fs::read(&out).unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_ok(), "run_fetch failed: {:?}", result);
+
+        let bytes_after = std::fs::read(&out).unwrap();
+        assert_eq!(bytes_before, bytes_after, "file should be unchanged (no-op)");
+    }
+
+    #[tokio::test]
+    async fn run_fetch_resolved_nowhere_exit_codes() {
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(boguspkgxyz)\n").unwrap();
+
+        // Without --fail-on-missing => Ok
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_ok(), "expected Ok without --fail-on-missing, got: {:?}", result);
+
+        // With --fail-on-missing => Err
+        // Remove the output so it starts fresh
+        let _ = std::fs::remove_file(root.join(".raven/packages.json"));
+        let args2 = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: true,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result2 = super::run_fetch(args2).await;
+        assert!(result2.is_err(), "expected Err with --fail-on-missing");
+        let err = result2.unwrap_err();
+        assert!(err.contains("could not be resolved"), "got: {err}");
+        assert!(err.contains("--fail-on-missing"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_fetch_missing_only_degrades_without_r() {
+        // When --missing-only is set and R is NOT available, the tier1 lib
+        // degrades (package_exists returns false for everything), so the fetch
+        // proceeds as if --missing-only were not set. On machines WITH R where
+        // dplyr IS installed, the package is correctly subtracted. Either way
+        // run_fetch must succeed.
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: true,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_ok(), "run_fetch failed: {:?}", result);
+
+        let out = root.join(".raven/packages.json");
+        // If R is available and dplyr is installed, it's subtracted (no file written).
+        // If R is unavailable, dplyr is fetched (file written with dplyr).
+        // Both are correct behavior.
+        if out.exists() {
+            let db = read_repo_db_file(&out).unwrap();
+            assert!(
+                db.packages.iter().any(|r| r.name == "dplyr"),
+                "if file written, dplyr should be present"
+            );
+        }
+        // The key assertion: no error regardless of R availability.
+    }
+
+    #[tokio::test]
+    async fn run_fetch_all_transport_is_hard_error() {
+        // Bind to get a free port, then drop so nothing listens
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![format!("http://127.0.0.1:{}", addr.port())],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_err(), "expected hard error on total transport failure");
+        let err = result.unwrap_err();
+        assert!(err.contains("could not reach"), "got: {err}");
+
+        // No output file created
+        assert!(!root.join(".raven/packages.json").exists());
+    }
+
+    #[tokio::test]
+    async fn run_fetch_server_outage_5xx_is_hard_error_not_silent_write() {
+        // A 5xx from every host (transient r-universe outage) must hard-error
+        // and write nothing — NOT silently write a database that drops the
+        // package as if it were "resolved nowhere".
+        let server = TestServer::start_mode(ServerMode::ServerError);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_err(), "expected hard error on a 5xx outage");
+        assert!(
+            !root.join(".raven/packages.json").exists(),
+            "no file should be written during a 5xx outage"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_fetch_refuses_corrupt_existing() {
+        let server = TestServer::start(false);
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("script.R"), "library(dplyr)\n").unwrap();
+
+        let out = root.join(".raven/packages.json");
+        std::fs::create_dir_all(out.parent().unwrap()).unwrap();
+        std::fs::write(&out, "{ not valid json").unwrap();
+
+        let args = super::FetchArgs {
+            missing_only: false,
+            fail_on_missing: false,
+            output: std::path::PathBuf::from(".raven/packages.json"),
+            workspace: Some(root.to_path_buf()),
+            base_urls: vec![server.base_url()],
+        };
+        let result = super::run_fetch(args).await;
+        assert!(result.is_err(), "expected error on corrupt existing file");
+        let err = result.unwrap_err();
+        assert!(err.contains("unreadable"), "got: {err}");
+
+        // Corrupt file left intact
+        assert_eq!(std::fs::read_to_string(&out).unwrap(), "{ not valid json");
     }
 }

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -303,18 +303,12 @@ pub async fn run_fetch(args: FetchArgs) -> Result<(), String> {
     };
 
     // Step 5: used packages (non-base, deduped)
-    let used = collect_used_package_names(&root)?;
-    let used_nonbase: Vec<String> = {
-        let mut set = HashSet::new();
-        let mut v = Vec::new();
-        for name in &used {
-            if !base.contains(name) && set.insert(name.clone()) {
-                v.push(name.clone());
-            }
-        }
-        v.sort();
-        v
-    };
+    let mut used_nonbase: Vec<String> = collect_used_package_names(&root)?
+        .into_iter()
+        .filter(|name| !base.contains(name))
+        .collect();
+    used_nonbase.sort();
+    used_nonbase.dedup();
 
     // Step 6: initial fetch set
     let to_fetch: Vec<String> = used_nonbase

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -23,7 +23,9 @@ Usage: raven [OPTIONS]
        raven check [PATHS...] [--workspace DIR]
        raven lint [PATHS...]
        raven analysis-stats <path> [--csv] [--only <phase>]
-       raven packages <freeze|update|build-shipped-db> [OPTIONS]
+       raven packages <fetch|freeze|update|build-shipped-db> [OPTIONS]
+       raven freeze [ARGS]          (alias for: raven packages freeze)
+       raven fetch  [ARGS]          (alias for: raven packages fetch)
 
 Available options:
 
@@ -42,9 +44,11 @@ analysis-stats <path>        Profile workspace analysis phases
   --only <phase>             Run only the specified phase
                              (scan, parse, metadata, scope, packages)
 packages <subcommand>        Generate / maintain package databases
+  fetch                      Fetch a repo's Tier 2 .raven/packages.json from r-universe (R-free)
   freeze                     Write a repo's Tier 2 .raven/packages.json
   update                     Download names.db and base-exports.json sidecars
   build-shipped-db           Maintainer-only Tier 3 names.db builder
+freeze, fetch                Top-level aliases for raven packages freeze/fetch
 
 "#
     );
@@ -126,6 +130,21 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(msg) => {
                     return Err(anyhow::anyhow!("raven packages: {}", msg));
+                }
+            }
+        }
+        Some(tok) if cli::packages_top_level_alias(tok).is_some() => {
+            env_logger::init();
+            let alias = args[0].clone();
+            let rest = args.into_iter();
+            match cli::packages::run(rest).await {
+                Ok(()) => return Ok(()),
+                Err(msg) if msg == "HELP" => {
+                    cli::packages::print_help();
+                    return Ok(());
+                }
+                Err(msg) => {
+                    return Err(anyhow::anyhow!("raven {}: {}", alias, msg));
                 }
             }
         }

--- a/crates/raven/src/package_db/renv_lock.rs
+++ b/crates/raven/src/package_db/renv_lock.rs
@@ -9,9 +9,21 @@ use std::path::Path;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+struct RenvLockEntry {
+    #[serde(rename = "Version", default)]
+    version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct RenvLock {
     #[serde(rename = "Packages", default)]
     packages: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RenvLockVersioned {
+    #[serde(rename = "Packages", default)]
+    packages: HashMap<String, RenvLockEntry>,
 }
 
 /// Return the sorted, de-duplicated set of package names listed in `renv.lock`.
@@ -26,6 +38,22 @@ pub fn read_renv_lock_package_names(path: &Path) -> anyhow::Result<Vec<String>> 
     names.sort_unstable();
     names.dedup();
     Ok(names)
+}
+
+/// Return a map of package name → pinned version from `renv.lock`.
+/// A missing file yields an empty map (not an error), mirroring the names reader.
+/// Entries missing a `Version` field are omitted.
+pub fn read_renv_lock_package_versions(path: &Path) -> anyhow::Result<HashMap<String, String>> {
+    if !path.is_file() {
+        return Ok(HashMap::new());
+    }
+    let text = std::fs::read_to_string(path)?;
+    let lock: RenvLockVersioned = serde_json::from_str(&text)?;
+    Ok(lock
+        .packages
+        .into_iter()
+        .filter_map(|(name, entry)| entry.version.filter(|v| !v.is_empty()).map(|v| (name, v)))
+        .collect())
 }
 
 #[cfg(test)]
@@ -46,5 +74,22 @@ mod tests {
         let names =
             read_renv_lock_package_names(std::path::Path::new("/nonexistent/renv.lock")).unwrap();
         assert!(names.is_empty());
+    }
+
+    #[test]
+    fn reads_locked_package_versions() {
+        let path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/package_db/renv.lock");
+        let versions = read_renv_lock_package_versions(&path).unwrap();
+        assert_eq!(versions.get("dplyr").unwrap(), "1.1.4");
+        assert_eq!(versions.get("ggplot2").unwrap(), "3.5.0");
+    }
+
+    #[test]
+    fn missing_file_versions_is_empty_not_error() {
+        let versions =
+            read_renv_lock_package_versions(std::path::Path::new("/nonexistent/renv.lock"))
+                .unwrap();
+        assert!(versions.is_empty());
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,15 +1,21 @@
 # CLI
 
-Raven ships a single binary that serves the LSP via stdio *and* exposes subcommands for use outside an editor:
+Raven ships a single binary that serves the LSP via stdio *and* exposes subcommands for use outside an editor. The user-facing commands fall into two groups:
+
+**Check code**
 
 - `raven check` — index a workspace and report the **full** diagnostic set (the same diagnostics the editor publishes), for CI gating.
 - `raven lint` — run the native **style** linter only.
-- `raven analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
+
+The difference between `check` and `lint` is **scope**: `lint` parses each file in isolation and runs only the style rules, so it never needs R or a workspace index — but it can't see relationships between files. `check` builds the same workspace index the language server builds, so it additionally reports cross-file, undefined-variable, and package diagnostics. It can run without R, using embedded base/recommended coverage plus any package metadata files you provide; when R is available, it also reads the local R libraries for exact installed-package exports and base R symbols. `lint` is therefore the cheaper option for pure style gating; `check` does more work per run in exchange for the editor's full analysis in CI.
+
+**Manage package metadata**
+
+These commands make `raven check` easier to run in CI systems such as GitHub Actions or Bitbucket Pipelines when the job does not install R, or when R is present but some project packages are missing. They provide package export metadata outside the local R library, so automated pull-request checks can still recognize symbols from attached packages without paying the full package-install cost on every run.
+
 - `raven packages freeze` — generate a committed `.raven/packages.json` export database. This is the reproducible, project-specific path for CI: it captures the exports your installed project dependencies expose and should be committed when you need version-pinned package metadata. Choose its scope with `--used` (default — only the packages the repo uses) or `--installed`/`--all` (every installed package). See [`raven packages freeze`](#raven-packages-freeze) and [Package database](package-database.md).
 - `raven packages fetch` — produce the same `.raven/packages.json` from CRAN/Bioconductor r-universe instead of a local R install. Needs no R, no installed packages, and no dependency on the `names-db` Release. See [`raven packages fetch`](#raven-packages-fetch) and [Package database](package-database.md).
-- `raven packages update` — download Raven's mutable Tier 3 sidecars for source/Cargo installs. See [`raven packages update`](#raven-packages-update).
-
-The difference between `check` and `lint` is **scope**: `lint` parses each file in isolation and runs only the style rules, so it needs no R installation and no workspace index — but it can't see relationships between files. `check` builds the same workspace index the language server builds (and, unless packages are disabled, runs R to resolve installed-package exports and base R symbols), so it additionally reports cross-file, undefined-variable, and package diagnostics. `lint` is therefore the cheaper, R-free option for pure style gating; `check` does more work per run in exchange for the editor's full analysis in CI.
+- `raven packages update` — download the CRAN/Bioconductor metadata Raven uses to recognize symbols from packages that are not installed. Useful after `cargo install --git` or a local source build, which install only the executable. See [`raven packages update`](#raven-packages-update).
 
 ## `raven check`
 
@@ -48,13 +54,13 @@ The whole workspace is always indexed so cross-file resolution is accurate. The 
 
 ### R and packages
 
-`raven check` auto-detects R on `PATH` to resolve installed-package exports and exact local metadata (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.enabled = false` disables R detection entirely (no R subprocess and no installed/local package diagnostics — matching the editor), `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, `library()` calls aren't checked against installed packages, but base/recommended R platform symbols still have embedded fallback coverage. Broad CRAN/Bioconductor Tier 3 coverage without R comes from sidecars: release archives, VSIX installs, and package-manager builds ship them; source/Cargo installs need `raven packages update` or manually installed sidecars. A one-line note is printed to stderr when R is absent. All other diagnostics still run.
+`raven check` auto-detects R on `PATH` to resolve installed-package exports and exact local metadata (it runs `.libPaths()` and parses package `NAMESPACE` files, the same as the language server). It honors the same `raven.toml` package settings the editor does: `packages.enabled = false` disables R detection entirely (no R subprocess and no installed/local package diagnostics — matching the editor), `packages.rPath` selects the R binary instead of `PATH` auto-detection, and `packages.additionalLibraryPaths` adds extra library directories to the search path. If R is not found, `library()` calls aren't checked against installed packages, but base/recommended R platform symbols still have embedded fallback coverage. Broad CRAN/Bioconductor coverage without R comes from Raven's package metadata files (`names.db` and `base-exports.json`): release archives, VSIX installs, and package-manager builds ship them; installs that produce only the `raven` executable, such as `cargo install --git` or local source builds, need `raven packages update` or manually installed metadata files. A one-line note is printed to stderr when R is absent. All other diagnostics still run.
 
 Before reporting, `raven check` warms the export cache for the packages each reported file attaches with `library()` / `require()`, so a bare call into an attached package that isn't one of its exports is flagged the same way the editor flags it. One narrow gap remains: a package attached only *indirectly* — in a `source()`d file rather than in the reported file itself — is not pre-warmed, so calls that could resolve to such a package are left unflagged rather than risk a false positive. Attach the package directly in the file (or rely on the editor) if you need those calls checked.
 
 ### Missing-package reporting in CI
 
-`raven check` resolves package **export names** through an ordered three-tier fallback — installed packages, then a committed `.raven/packages.json`, then Raven's Tier 3 sidecars when available — so symbols from attached packages can resolve even when no R is installed. Release archives, VSIX installs, and package-manager builds ship those sidecars next to the Raven executable. Source/Cargo installs need an explicit `raven packages update` step for broad CRAN/Bioconductor Tier 3 coverage, though they still include embedded base/recommended R platform coverage. This stops the undefined-variable storm that otherwise makes Raven unusable in CI. See [Package database](package-database.md).
+`raven check` resolves package **export names** through an ordered three-tier fallback — installed packages, then a committed `.raven/packages.json`, then Raven's broad CRAN/Bioconductor metadata when available — so symbols from attached packages can resolve even when no R is installed. Release archives, VSIX installs, and package-manager builds ship that metadata next to the Raven executable. Installs that produce only the `raven` executable, such as `cargo install --git` or local source builds, need an explicit `raven packages update` step for broad CRAN/Bioconductor coverage, though they still include embedded base/recommended R platform coverage. This stops the undefined-variable storm that otherwise makes Raven unusable in CI. See [Package database](package-database.md).
 
 Knowing a package's exports is **separate** from knowing whether it is installed. The **missing-package** diagnostic answers a different question — *"will `library(X)` succeed at runtime?"*, i.e. is `X` installed? — so it stays **Tier-1-only**: it is driven solely by what is present in the local library paths, never by the export database. Because CI deliberately omits package installation, `raven check` **suppresses missing-package warnings by default**.
 
@@ -65,7 +71,7 @@ Knowing a package's exports is **separate** from knowing whether it is installed
 There are four strategies for giving `raven check` package-export coverage in CI. Each trades off differently on R requirements, network use, coverage breadth, and version fidelity:
 
 1. **R + packages installed** — install R and the project's packages in CI (e.g. `renv::restore()`). Exact, full coverage; version-exact; no dependency on external databases.
-2. **`raven packages update`** before `raven check` — downloads the whole-ecosystem Tier 3 sidecars from the `names-db` GitHub Release. No R needed; broad coverage; but depends on a maintainer-owned Release and tracks latest (not pinned).
+2. **`raven packages update`** before `raven check` — downloads broad CRAN/Bioconductor metadata from the `names-db` GitHub Release. No R needed; broad coverage; but depends on a maintainer-owned Release and tracks latest (not pinned).
 3. **`raven packages fetch [--missing-only]`** before `raven check` — fetches only the project's used packages from r-universe. No R needed; no dependency on the `names-db` Release; latest exports (installed rows are version-exact under `--missing-only`). If R is unavailable in CI, `--missing-only` is a no-op and this equals plain `raven packages fetch`.
 4. **`raven packages freeze`** locally + commit `.raven/packages.json` — run on a machine with R and packages installed, commit the result. No R or network needed in CI; version-exact; project-pinned.
 
@@ -82,7 +88,7 @@ See [`raven packages fetch`](#raven-packages-fetch), [`raven packages freeze`](#
 
 ### File encoding
 
-Source files must be UTF-8. A UTF-8 byte-order mark is stripped and BOM-marked UTF-16 (LE/BE) is decoded, but anything else must already be valid UTF-8 — Raven does not guess legacy single-byte encodings (Latin-1 / Windows-1252). Guessing would silently mis-decode: a non-breaking space (`0xA0`) inside a string comparison, for instance, would read as an ordinary space and quietly change what your code matches. A *reported* file that isn't valid UTF-8 is therefore flagged as an **error diagnostic** (`File is not valid UTF-8: first invalid byte 0x… at offset …`) that fails the build like any other error finding — it is **not** an operator error. Re-save the file as UTF-8 to fix it. A file that is only *indexed* for cross-file resolution (not itself reported) and can't be decoded is silently skipped, matching the editor. `raven lint` and `analysis-stats` read through the same decoder, so encoding handling is uniform across the CLI.
+Source files must be UTF-8. A UTF-8 byte-order mark is stripped and BOM-marked UTF-16 (LE/BE) is decoded, but anything else must already be valid UTF-8 — Raven does not guess legacy single-byte encodings (Latin-1 / Windows-1252). Guessing would silently mis-decode: a non-breaking space (`0xA0`) inside a string comparison, for instance, would read as an ordinary space and quietly change what your code matches. A *reported* file that isn't valid UTF-8 is therefore flagged as an **error diagnostic** (`File is not valid UTF-8: first invalid byte 0x… at offset …`) that fails the build like any other error finding — it is **not** an operator error. Re-save the file as UTF-8 to fix it. A file that is only *indexed* for cross-file resolution (not itself reported) and can't be decoded is silently skipped, matching the editor. `raven lint` reads through the same decoder, so encoding handling is uniform across the user-facing CLI.
 
 ### Exit codes
 
@@ -105,7 +111,7 @@ Source files must be UTF-8. A UTF-8 byte-order mark is stripped and BOM-marked U
 
 For reproducible CI, commit `.raven/packages.json` generated by `raven packages freeze`. `raven packages update` restores broad CRAN/Bioconductor coverage for zero-adoption scans, but it follows the moving `names-db` Release and is not version-pinned by the project.
 
-To get installed/local package awareness and exact local package metadata in CI, install R (e.g. `r-lib/actions/setup-r`) before running `raven check`. Base/recommended R platform symbols have embedded fallback coverage even without R. Broad CRAN/Bioconductor Tier 3 coverage for source/Cargo installs requires `raven packages update` or sidecars shipped/placed next to the executable; run that update during CI image setup or cache warmup so normal `raven check`, LSP startup, completion, hover, and package lookup stay network-free.
+To get installed/local package awareness and exact local package metadata in CI, install R (e.g. `r-lib/actions/setup-r`) before running `raven check`. Base/recommended R platform symbols have embedded fallback coverage even without R. Broad CRAN/Bioconductor coverage requires Raven's package metadata files (`names.db` and `base-exports.json`), either shipped next to the executable or installed by `raven packages update`. If you installed Raven with `cargo install --git` or from a local source build, run that update during CI image setup or cache warmup so normal `raven check`, LSP startup, completion, hover, and package lookup stay network-free.
 
 ### Scope
 
@@ -159,7 +165,7 @@ Only plain R files (`.R` / `.r`) are linted. R Markdown / Quarto files (`.Rmd` /
 
 ## `raven packages`
 
-A command group for the export databases Raven uses to resolve package symbols without installing packages. See [Package database](package-database.md) for the full three-tier model. Both `freeze` and `fetch` are **producers** of the Tier 2 `.raven/packages.json` — `freeze` captures exports from a local R install (version-exact, committed), while `fetch` sources them from CRAN/Bioconductor r-universe (latest, ephemeral). `update` downloads the mutable Tier 3 sidecars for source/Cargo installs, and `build-shipped-db` is the maintainer-only command that produces Tier 3 release assets.
+A command group for the export databases Raven uses to resolve package symbols without installing packages. See [Package database](package-database.md) for the full three-tier model. Both `freeze` and `fetch` are **producers** of the Tier 2 `.raven/packages.json` — `freeze` captures exports from a local R install (version-exact, committed), while `fetch` sources them from CRAN/Bioconductor r-universe (latest, ephemeral). `update` downloads broad CRAN/Bioconductor metadata for installs that did not bundle it, and `build-shipped-db` is the maintainer-only command that produces the bundled metadata.
 
 **Top-level aliases.** `raven freeze [ARGS]` is exactly equivalent to `raven packages freeze [ARGS]`, and `raven fetch [ARGS]` to `raven packages fetch [ARGS]`. They are thin routing aliases — same parsing, same handler, same help. Only `freeze` and `fetch` are aliased; `update` and `build-shipped-db` stay nested.
 
@@ -218,7 +224,7 @@ Two honest limits:
 
 ### `raven packages freeze`
 
-Generate a committed, repo-specific `.raven/packages.json` — a "frozen Tier 1" snapshot of your installed packages' export names, `Depends`, and datasets. This is Raven's reproducible CI path: run it on a machine that has R and the project's packages installed, then commit the result so CI uses project-pinned package metadata. Tier 3 sidecars provide broad ecosystem coverage when available, but this committed snapshot **improves accuracy** for packages Tier 3 doesn't cover (GitHub-only or internal packages) and for symbols newer than the Tier 3 snapshot. The file is generated, never hand-edited.
+Generate a committed, repo-specific `.raven/packages.json` — a "frozen Tier 1" snapshot of your installed packages' export names, `Depends`, and datasets. This is Raven's reproducible CI path: run it on a machine that has R and the project's packages installed, then commit the result so CI uses project-pinned package metadata. Raven's bundled or updated CRAN/Bioconductor metadata provides broad ecosystem coverage when available, but this committed snapshot **improves accuracy** for packages the broad metadata doesn't cover (GitHub-only or internal packages) and for symbols newer than the metadata snapshot. The file is generated, never hand-edited.
 
 ```text
 raven packages freeze [OPTIONS]
@@ -241,7 +247,7 @@ If a `.raven/packages.json` already exists, `freeze` compares **package content 
 
 ### `raven packages update`
 
-Downloads Raven's mutable Tier 3 sidecars (`names.db` and `base-exports.json`) from the `names-db` GitHub Release into Raven's user data directory. This is the explicit network boundary for source/Cargo installs; `raven check`, LSP startup, completion, hover, and normal package lookup do not fetch package metadata.
+Downloads the CRAN/Bioconductor metadata files Raven uses to recognize package symbols when the packages are not installed (`names.db` and `base-exports.json`) from the `names-db` GitHub Release into Raven's user data directory. Use this when your install only provided the `raven` executable, such as `cargo install --git` or a local source build. Release archives, VSIX installs, and package-manager builds normally ship these files next to the executable. This command is the explicit network boundary for package metadata: `raven check`, LSP startup, completion, hover, and normal package lookup do not fetch it.
 
 Use it during CI image setup or cache warmup when installing Raven from source:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,7 @@ Raven ships a single binary that serves the LSP via stdio *and* exposes subcomma
 - `raven lint` — run the native **style** linter only.
 - `raven analysis-stats <path> [--csv] [--only <phase>]` — profile workspace analysis phases (`scan`, `parse`, `metadata`, `scope`, `packages`); see `raven --help`.
 - `raven packages freeze` — generate a committed `.raven/packages.json` export database. This is the reproducible, project-specific path for CI: it captures the exports your installed project dependencies expose and should be committed when you need version-pinned package metadata. Choose its scope with `--used` (default — only the packages the repo uses) or `--installed`/`--all` (every installed package). See [`raven packages freeze`](#raven-packages-freeze) and [Package database](package-database.md).
+- `raven packages fetch` — produce the same `.raven/packages.json` from CRAN/Bioconductor r-universe instead of a local R install. Needs no R, no installed packages, and no dependency on the `names-db` Release. See [`raven packages fetch`](#raven-packages-fetch) and [Package database](package-database.md).
 - `raven packages update` — download Raven's mutable Tier 3 sidecars for source/Cargo installs. See [`raven packages update`](#raven-packages-update).
 
 The difference between `check` and `lint` is **scope**: `lint` parses each file in isolation and runs only the style rules, so it needs no R installation and no workspace index — but it can't see relationships between files. `check` builds the same workspace index the language server builds (and, unless packages are disabled, runs R to resolve installed-package exports and base R symbols), so it additionally reports cross-file, undefined-variable, and package diagnostics. `lint` is therefore the cheaper, R-free option for pure style gating; `check` does more work per run in exchange for the editor's full analysis in CI.
@@ -58,6 +59,26 @@ Before reporting, `raven check` warms the export cache for the packages each rep
 Knowing a package's exports is **separate** from knowing whether it is installed. The **missing-package** diagnostic answers a different question — *"will `library(X)` succeed at runtime?"*, i.e. is `X` installed? — so it stays **Tier-1-only**: it is driven solely by what is present in the local library paths, never by the export database. Because CI deliberately omits package installation, `raven check` **suppresses missing-package warnings by default**.
 
 `--report-uninstalled` re-enables them. Reach for it whenever a `library(X)` call must really succeed at runtime: a pipeline that *does* install packages (e.g. `renv::restore()`) and wants to fail if any didn't, **or** any CI that **actually runs your R scripts** after `raven check` (e.g. R-package CI), where an uninstalled package is a genuine failure rather than CI noise. Gate-only CI that never executes the scripts wants the default (suppressed). It reports `library()` calls **not present in the local library paths** — **not** relative to the Tier 2/Tier 3 export metadata. One consequence: with the default off, a genuine typo such as `library(dpylr)` is silent (no tier knows it, but `raven check` isn't checking install status); it is reported only with `--report-uninstalled`. The language server is unchanged — it still fires missing-package whenever install state is known. See [Diagnostics](diagnostics.md#package-names-vs-install-status) for the full model.
+
+### Four ways to run `raven check` in CI
+
+There are four strategies for giving `raven check` package-export coverage in CI. Each trades off differently on R requirements, network use, coverage breadth, and version fidelity:
+
+1. **R + packages installed** — install R and the project's packages in CI (e.g. `renv::restore()`). Exact, full coverage; version-exact; no dependency on external databases.
+2. **`raven packages update`** before `raven check` — downloads the whole-ecosystem Tier 3 sidecars from the `names-db` GitHub Release. No R needed; broad coverage; but depends on a maintainer-owned Release and tracks latest (not pinned).
+3. **`raven packages fetch [--missing-only]`** before `raven check` — fetches only the project's used packages from r-universe. No R needed; no dependency on the `names-db` Release; latest exports (installed rows are version-exact under `--missing-only`). If R is unavailable in CI, `--missing-only` is a no-op and this equals plain `raven packages fetch`.
+4. **`raven packages freeze`** locally + commit `.raven/packages.json` — run on a machine with R and packages installed, commit the result. No R or network needed in CI; version-exact; project-pinned.
+
+| Strategy | Needs R in CI | Network in CI | Coverage | Version fidelity | Committed | Depends on `names-db` Release |
+|---|---|---|---|---|---|---|
+| 1. R + packages installed | yes | (install) | exact, full | version-exact | no | no |
+| 2. `packages update` | no | yes (2 files) | whole ecosystem | latest snapshot | no | **yes** |
+| 3. `packages fetch [--missing-only]` | no | yes (per-pkg) | project's used set | latest (installed rows exact under `--missing-only`) | no (ephemeral) | no |
+| 4. `freeze` + commit | no (in CI) | no | project's used set | version-exact | yes | no |
+
+Strategies 3 and 4 can be combined: commit a `freeze` file for version-exact coverage of installed packages, then run `fetch` in CI to top up whatever `freeze` missed — `fetch`'s additive merge preserves every `freeze` row untouched.
+
+See [`raven packages fetch`](#raven-packages-fetch), [`raven packages freeze`](#raven-packages-freeze), and [Package database](package-database.md) for details.
 
 ### File encoding
 
@@ -138,7 +159,62 @@ Only plain R files (`.R` / `.r`) are linted. R Markdown / Quarto files (`.Rmd` /
 
 ## `raven packages`
 
-A command group for the export databases Raven uses to resolve package symbols without installing packages. See [Package database](package-database.md) for the full three-tier model. `freeze` builds the user-generated Tier 2 database, `update` downloads the mutable Tier 3 sidecars for source/Cargo installs, and `build-shipped-db` is the maintainer-only command that produces Tier 3 release assets.
+A command group for the export databases Raven uses to resolve package symbols without installing packages. See [Package database](package-database.md) for the full three-tier model. Both `freeze` and `fetch` are **producers** of the Tier 2 `.raven/packages.json` — `freeze` captures exports from a local R install (version-exact, committed), while `fetch` sources them from CRAN/Bioconductor r-universe (latest, ephemeral). `update` downloads the mutable Tier 3 sidecars for source/Cargo installs, and `build-shipped-db` is the maintainer-only command that produces Tier 3 release assets.
+
+**Top-level aliases.** `raven freeze [ARGS]` is exactly equivalent to `raven packages freeze [ARGS]`, and `raven fetch [ARGS]` to `raven packages fetch [ARGS]`. They are thin routing aliases — same parsing, same handler, same help. Only `freeze` and `fetch` are aliased; `update` and `build-shipped-db` stay nested.
+
+### `raven packages fetch`
+
+Produce a `.raven/packages.json` from CRAN/Bioconductor r-universe — the same Tier 2 artifact `freeze` produces, but sourced from community infrastructure instead of a local R install. It needs no R, no installed packages, and no dependency on the `names-db` GitHub Release. The file is an **ephemeral CI artifact** meant to be regenerated each run; gitignore it rather than committing it (contrast with `freeze`'s committed, version-pinned file).
+
+```text
+raven packages fetch [OPTIONS]
+```
+
+**Two modes:**
+
+- **Plain `raven packages fetch`** — computes the used set (R-free: tree-sitter scan ∪ `DESCRIPTION` `Depends`/`Imports` ∪ `renv.lock` names ∪ transitive `Depends` from r-universe), skips base/recommended packages (known offline via the embedded base set), and fetches the rest from r-universe. No R required.
+- **`raven packages fetch --missing-only`** — a pure optimization. When R is present with a populated library, it subtracts already-installed packages from the fetch set (they will resolve via Tier 1 in the same CI run). When R is absent or `.libPaths()` is empty, nothing is subtracted and `--missing-only` degrades to a full fetch. It is **never an error** to pass `--missing-only` without R.
+
+#### Options
+
+- `--missing-only` — subtract already-installed packages from the fetch set. No-op without R (degrades to a full fetch).
+- `--fail-on-missing` — exit non-zero if any used package resolved nowhere (after writing the file). By default, unresolvable packages produce warnings and a success exit.
+- `--output PATH` — where to write/merge (default: `.raven/packages.json` at the workspace root).
+- `--workspace DIR` — workspace root to scan for usage and config (default: current directory).
+- `--base-urls URL[,URL]` — override the ordered r-universe host list (for testing); each URL must include the scheme. Default: `https://cran.r-universe.dev,https://bioc.r-universe.dev`.
+- `--help` — usage.
+
+#### Additive merge — existing records always win
+
+`fetch` reads any existing `.raven/packages.json` at the target path and **preserves every record in it untouched**, adding records only for used packages not already present. It does not even refetch a package the existing file already covers. Run after `freeze`, it tops up coverage for whatever `freeze` missed (e.g. uninstalled packages) without disturbing a single `freeze` row. When the merge produces content identical to the existing file, `fetch` leaves the file untouched and prints "no changes."
+
+A corrupt or unsupported-schema existing file is surfaced as an error and the command refuses — it won't silently discard a file you may need. Delete it or point `--output` elsewhere.
+
+#### Output and warnings
+
+- An **inform** line names the packages about to be downloaded.
+- Per-package **warnings** for packages that resolve nowhere on r-universe (GitHub-only, internal, not-yet-indexed, or typos like `library(dpylr)`).
+- A **renv.lock version-skew warning** when the fetched record's version differs from the version `renv.lock` pins. r-universe serves latest only — it does not archive old versions — so `fetch` cannot pull the exact pinned version. The warning names both versions and points at `freeze` / `--missing-only` for a version-exact capture. Export names are usually stable across versions, so this is a soft heads-up, never an error, and never gated by `--fail-on-missing`.
+
+#### `--fail-on-missing`
+
+By default, packages that resolve nowhere produce warnings and a success exit. With `--fail-on-missing`, a non-empty resolved-nowhere set makes the command exit non-zero **after** writing the file (so partial results are still available). Suppression of expected-missing private/internal packages is a planned fast-follow; v1 warns them every run.
+
+#### Gitignore guidance
+
+The fetched file is an ephemeral CI artifact — regenerated each run from the latest r-universe exports. **Gitignore it** (add `.raven/packages.json` to `.gitignore`) rather than committing it. A user *may* commit it, but that is not the design target: for a committed, version-pinned artifact, use `freeze` instead.
+
+#### Network and atomicity
+
+Fetches via curl with bounded concurrency, trying CRAN then Bioconductor per package. Writes atomically (temp-then-rename) so a mid-fetch failure cannot feed a half-written file to `raven check`. If every fetch fails at the transport level (network down / curl missing), the command reports the failure and writes nothing — any existing file is left intact. A partial failure writes what it got and warns about the rest.
+
+#### Scope limits
+
+Two honest limits:
+
+1. `fetch` does **not** replace Tier 3's zero-adoption, whole-ecosystem floor — it covers only packages the project references (the "used set").
+2. `fetch` is **not** fully self-contained — base/recommended packages are not on r-universe and still come from local R or the embedded fallback at analysis time.
 
 ### `raven packages freeze`
 

--- a/docs/package-database.md
+++ b/docs/package-database.md
@@ -53,6 +53,21 @@ The default `--used` scope is **maximally inclusive** — over-inclusion is free
 
 If a `.raven/packages.json` already exists, `freeze` compares **package content only** (ignoring provenance such as the timestamp). When the content is identical it leaves the file untouched and prints "no changes" — so a regeneration that found nothing new produces a **zero-line diff**, and the provenance timestamp moves only when the captured exports actually changed.
 
+### Two producers, one artifact
+
+The Tier 2 `.raven/packages.json` has two producers — the three resolution tiers are unchanged:
+
+- **`raven packages freeze`** — sources exports from a local R install. Version-exact, deterministic, meant to be committed and reviewed in PRs. The reproducible, project-pinned path.
+- **`raven packages fetch`** — sources exports from CRAN/Bioconductor r-universe (`cran.r-universe.dev`, `bioc.r-universe.dev`). Needs no R, no installed packages, and no dependency on the `names-db` Release. Fetches **latest** exports only (r-universe does not archive old versions), so it is not version-pinned. The file is an ephemeral CI artifact meant to be regenerated each run and gitignored rather than committed.
+
+Both write the same schema (v1) and are consumed through the same reader — `raven check` and the language server cannot distinguish them. `fetch` is strictly **additive**: it reads any existing file at the target, preserves every record untouched, and adds records only for used packages not already present. Run after `freeze`, it tops up coverage for whatever `freeze` missed (e.g. uninstalled packages) without disturbing a single `freeze` row.
+
+**renv.lock version-skew heads-up.** Because r-universe is latest-only, `fetch` cannot pull the exact version `renv.lock` pins. When the fetched version differs from the locked version, `fetch` prints a warning naming both. Export names are usually stable across versions, so this is informational — never an error.
+
+**Scope limits.** `fetch` covers only the project's used set — it does not replace Tier 3's zero-adoption, whole-ecosystem floor. And base/recommended packages are not on r-universe; they still come from local R or the embedded fallback at analysis time.
+
+See [`raven packages fetch`](cli.md#raven-packages-fetch) and [Four ways to run `raven check` in CI](cli.md#four-ways-to-run-raven-check-in-ci) for usage and the full strategy comparison.
+
 ### Version skew is explained, not silently dropped
 
 If a committed `.raven/packages.json` was written by a **newer** Raven than the one reading it (an incompatible schema), Raven does not silently ignore it. It **explains and continues**: `raven check` prints a specific note to stderr, the language server raises a notification, and resolution degrades to Tier 3 when a usable sidecar is available. The message tells you to upgrade Raven here or regenerate the file with `raven packages freeze`. An unreadable or corrupt file is reported the same way. A missing file is normal and silent.
@@ -95,7 +110,7 @@ In CI, `raven check` **suppresses missing-package warnings by default** (CI deli
 
 ## See also
 
-- [`raven packages`](cli.md#raven-packages) — the `freeze`, `update`, and `build-shipped-db` commands.
+- [`raven packages`](cli.md#raven-packages) — the `freeze`, `fetch`, `update`, and `build-shipped-db` commands.
 - [Diagnostics](diagnostics.md#package-names-vs-install-status) — names vs. install status, and the `raven check` default.
 - [Cross-File & Package Awareness](cross-file.md#resolving-exports-without-r) — where the three-tier fallback sits in package resolution.
 - [R Package Development](r-package-dev.md#generating-a-package-database-for-ci) — generating the repo database for a package project.

--- a/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
+++ b/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
@@ -1,0 +1,224 @@
+# Design: `raven packages fetch` — R-free CI producer of the Tier 2 export database
+
+**Date:** 2026-05-31
+**Status:** Approved design — pending written-spec review.
+**Builds on:** [`2026-05-30-ci-package-exports-db-design.md`](2026-05-30-ci-package-exports-db-design.md), which established the three-tier export-resolution model (Tier 1 installed → Tier 2 committed `.raven/packages.json` → Tier 3 shipped `names.db`). That spec is authoritative for the tier model; this one adds a **second producer** of the Tier 2 artifact and does not change the resolution seam.
+
+---
+
+## 1. Goal & motivation
+
+Add `raven packages fetch` — a command that produces the same `.raven/packages.json` Tier 2 artifact `raven packages freeze` produces, but sources export metadata **from CRAN/Bioconductor r-universe** (`cran.r-universe.dev`, `bioc.r-universe.dev`) instead of from a local R install.
+
+It exists to give CI a way to get project-scoped package-export coverage that:
+
+- **does not require R or installed packages** (plain `fetch`), and
+- **does not depend on the `jbearak/raven` `names-db` GitHub Release** that Tier 3 (`raven packages update`) pulls from.
+
+Today a CI pipeline without R has exactly one zero-install option: `raven packages update`, which downloads the whole-ecosystem Tier 3 sidecars from a single maintainer-owned Release. `fetch` is the alternative: it fetches only the packages the project actually references, straight from community infrastructure, and writes them into the Tier 2 file that `raven check` already reads.
+
+**This is a new producer, not a new tier.** The output is byte-compatible with `freeze`'s output and is consumed through the existing `read_repo_db_file` / `RepoDbProvider` path with **no new consumption code**. What differs from `freeze` is the *source* of records (r-universe vs. local install) and the *lifecycle* (ephemeral CI artifact, regenerated per run, gitignored — vs. committed and reviewed).
+
+---
+
+## 2. Boundary & non-goals
+
+`fetch` is scoped to **producing the Tier 2 file from r-universe**. It is explicitly **not**:
+
+- **A change to `freeze`.** `freeze` keeps its contract intact: offline, deterministic, version-exact "frozen Tier 1," refuses without R. No flag is added to it here.
+- **A change to the resolution seam or tier precedence.** `raven check` / the language server read `.raven/packages.json` exactly as before. `fetch` only writes that file.
+- **A whole-ecosystem floor.** Unlike Tier 3, `fetch` captures only packages the project references (the "used set"). It does not give zero-adoption coverage for packages the code hasn't mentioned yet.
+- **A committed, version-pinned artifact.** The fetched records carry **latest** CRAN/Bioc exports, not the versions the project pins. The file is meant to be regenerated each CI run, not reviewed in a PR. (A user *may* commit it, but that is not the design target and the docs steer away from it.)
+- **A base/recommended-package source.** Base packages (`base`, `stats`, `utils`, `methods`, …) are not on r-universe; they are part of R itself. They are resolved at analysis time from local R (Tier 1) or the binary's embedded base fallback, exactly as today. `fetch` never tries to fetch them.
+
+---
+
+## 3. Locked decisions
+
+Settled during design Q&A (the dialogue that produced this spec):
+
+1. **Surface = a flag, not a third subcommand.** `raven packages fetch` and `raven packages fetch --missing-only`. The only behavioral delta between the two is "consult the local install and subtract what's already there," which is a modifier on one command, not a separate concept.
+2. **Plain `fetch` requires no R.** It computes the used set (R-free, via tree-sitter + file reads), skips base packages (known offline via the embedded base set), and fetches the rest from r-universe.
+3. **`--missing-only` also requires no R — it is a pure optimization.** When R is present with a populated library, it subtracts already-installed packages from the fetch set (they will resolve via Tier 1 in the same CI run). When R is absent or `.libPaths()` is empty, the "installed?" filter matches nothing, so **every** used package is treated as missing and `--missing-only` degrades to a full `fetch`. It is therefore never an error to pass `--missing-only` without R; it simply has nothing to subtract.
+4. **Provenance gains an optional `source` field** on `RepoDbProvenance`, added with `#[serde(default)]` so the Tier 2 **schema version stays at 1** (older Raven ignores the field; newer Raven defaults it for files that lack it). Fetched files stamp it (e.g. `"r-universe (cran+bioc) @ 2026-05-31"`); `freeze` leaves it empty/default.
+5. **`--fail-on-missing` is opt-in.** By default, packages that resolve nowhere produce warnings and a success exit. `--fail-on-missing` turns the warning set into a non-zero exit so a pipeline can gate on unresolvable references.
+6. **Clobber guard.** Checked **up front (step 0), before any fetching.** If the file at the target path already exists, parses as a valid Tier 2 file, and was written by `freeze` (its provenance `source` is empty/install-sourced), and the user did not pass `--output`, `fetch` **refuses** rather than overwrite a committed, version-exact file with latest-from-network records. An absent, corrupt, or fetch-written (non-empty `source`) target does not trip the guard. `--output PATH` overrides the guard and the default location.
+
+---
+
+## 4. Architecture overview
+
+`fetch` is a new async entry point `run_fetch` in `crates/raven/src/cli/packages.rs`, dispatched from the existing `packages` subcommand router alongside `freeze` / `update` / `build-shipped-db`. Its pipeline:
+
+```
+0. Clobber guard               (refuse early if target is a freeze file & no --output)
+1. Compute the used set        (shared with freeze; R-free)
+2. Drop base packages          (embedded base set; R-free)
+3. [--missing-only] subtract installed packages   (Tier-1 package_exists; no-op without R)
+4. Inform: print the packages about to be downloaded
+5. Fetch each from r-universe  (curl, CRAN then Bioc fallback, bounded concurrency)
+6. Parse responses             (existing parse_runiverse_json → PackageRecord)
+7. Collect "resolved nowhere"  (used − fetched − [installed if --missing-only])
+8. Warn per unresolved package; honor --fail-on-missing
+9. Write .raven/packages.json atomically (temp-then-rename), with source provenance
+```
+
+The clobber guard is **step 0** — checked up front so the command fails fast without doing network work it would only discard. Steps 1, 2, 6, and 9's writer already exist; the net-new logic is steps 0, 3–8 and the per-package fetch helper.
+
+---
+
+## 5. Components
+
+### 5.1 Shared used-set computation (extracted)
+
+`run_freeze` currently inlines the used-set computation: `scan_workspace_referenced_packages` ∪ `read_description_depends_imports(DESCRIPTION)` ∪ `read_renv_lock_package_names(renv.lock)`, plus transitive `Depends` expanded during the capture loop. `fetch` needs the identical set.
+
+**Extract a shared helper** (e.g. `collect_used_package_names(root) -> Vec<String>`) that returns the seed used set (pre-transitive), and have both `freeze` and `fetch` call it. The transitive-`Depends` expansion differs slightly between the two (freeze reads `Depends` from installed `PackageInfo`; fetch reads `_dependencies` role=`Depends` from r-universe JSON), so transitive expansion stays in each command's capture loop, but the seed computation is shared. This avoids two copies of the maximally-inclusive scan rule drifting apart.
+
+The R-free scanner `collect_referenced_packages` (tree-sitter; handles `library`/`require`/`loadNamespace`/`requireNamespace` + `::`/`:::` LHS) is reused unchanged.
+
+### 5.2 Base-package filter without R
+
+`fetch` must skip base/recommended packages without an R subprocess. It uses the embedded base set — `embedded_base::load()` returns `(exports, packages)` where `packages` is derived from `r_subprocess::get_fallback_base_packages()`. `fetch` checks membership in that set rather than calling `PackageLibrary::is_base_package` (which is fine to use when a library is built for `--missing-only`, but plain `fetch` builds no library). A single helper that answers "is this name base?" from the embedded set keeps both paths consistent.
+
+### 5.3 Installed-package filter (`--missing-only`)
+
+When `--missing-only` is set, build a Tier-1-only library via `build_package_library_tier1_only(None, &[], Some(root))` (the same call `freeze` uses) and filter the fetch set with `package_exists`, which is **Tier-1-only by contract** (guarded by the test `package_exists_never_consults_providers`). If the library is not ready (no R / no libpaths), `package_exists` returns false for everything, so nothing is subtracted — the documented degrade-to-full-fetch behavior. **No `is_ready()` refusal** is inherited from `freeze`; `fetch` must not refuse on missing R.
+
+### 5.4 Per-package r-universe fetch
+
+There is **no Rust HTTP client** in the codebase; networking shells out to `curl` (`download_asset_blocking` in `cli/packages.rs`, with `--fail --location --silent --show-error --proto =http,https --connect-timeout 20 --max-time 300 --max-filesize …`). `fetch` reuses that exact helper pattern, parameterized per package URL:
+
+- Try `https://cran.r-universe.dev/api/packages/<pkg>` first; on failure (curl non-success / 404) fall back to `https://bioc.r-universe.dev/api/packages/<pkg>`.
+- A package that fails on both is "resolved nowhere" (§5.5).
+- Parse each success with the existing `parse_runiverse_json` → `PackageRecord`.
+- **Bounded concurrency:** the transitive `Depends` closure can be dozens–hundreds of packages; serial curl (what the maintainer build workflow does) would be slow and rate-limit-prone interactively. Spawn fetches through `tokio::task::spawn_blocking` with a bounded concurrency limit (a small fixed cap, e.g. 8). The host list is overridable for testing (`--base-urls`, §6) so the CRAN→Bioc fallback can be exercised against a local server.
+
+The two hosts are tried **in order**, so they are modeled as an ordered list of base URLs (default `[cran.r-universe.dev, bioc.r-universe.dev]`), not a single base. This is what lets a test point the first host at a 404-ing fixture and the second at a serving one to exercise the fallback (§8).
+
+Transitive expansion: after fetching a package, enqueue its r-universe `Depends` (role-filtered, excluding `R`) that aren't already seen/base — mirroring `freeze`'s transitive loop but sourced from the fetched JSON.
+
+### 5.5 "Resolved nowhere" detection, warnings, and `--fail-on-missing`
+
+After fetching, compute the set of used packages (non-base) that produced **no** record — neither fetched from r-universe nor (under `--missing-only`) found installed. This set is exactly: GitHub-only / internal / private packages, packages not yet on r-universe, **and typos** (`library(dpylr)`). For each, emit a `stderr` warning naming the package. If `--fail-on-missing` is set and the set is non-empty, exit non-zero after writing the file.
+
+> **Note — suppression is deferred.** Legitimately off-ecosystem packages (private/internal) will warn every run. A suppression mechanism (an allowlist in `raven.toml`, or a directive) is **out of scope for v1** and noted as a fast-follow. v1 behavior: they warn; `--fail-on-missing` users who have such packages either don't use the flag or accept the failure until suppression lands.
+
+### 5.6 Provenance `source` field
+
+Add to `RepoDbProvenance`:
+
+```rust
+#[serde(default)]
+pub source: String,
+```
+
+`#[serde(default)]` is load-bearing: it keeps `REPO_DB_SCHEMA_VERSION` at `1` (an absent key deserializes to `""`, so files written by today's `freeze` still parse, and today's reader — which doesn't know the field — still parses tomorrow's files). `fetch` sets it to a human string like `"r-universe (cran+bioc) @ <date>"`. `freeze` continues to leave it empty. `r_version` for plain `fetch` is set to a sentinel such as `"none (fetched)"`; for `--missing-only` it reflects the R used for the install filter if any, else the same sentinel.
+
+The clobber guard (§3.6) reads this field on the existing target file **before fetching**: a target that parses as a valid Tier 2 file with an empty `source` ⇒ treat as freeze-written ⇒ refuse without `--output`. An absent or corrupt target does not trip the guard (nothing committed to protect).
+
+### 5.7 Atomic write
+
+Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sidecars` so a mid-fetch failure or partial network read can never feed a half-written `.raven/packages.json` to `raven check` in the same job. Write to a unique temp in the destination directory, then atomically rename over the target.
+
+---
+
+## 6. Arg parsing
+
+`parse_fetch_args` mirrors the existing `parse_freeze_args` shape:
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `--missing-only` | Subtract already-installed packages from the fetch set (no-op without R) | off |
+| `--fail-on-missing` | Exit non-zero if any used package resolved nowhere | off |
+| `--output PATH` | Where to write; overrides default and the clobber guard | `.raven/packages.json` |
+| `--workspace DIR` | Workspace root to scan for usage/config | current dir |
+| `--base-urls URL[,URL]` | Override the ordered r-universe host list (testing); tried in order | `cran.r-universe.dev,bioc.r-universe.dev` |
+| `--help` | Usage | — |
+
+`run` (the subcommand router) gains a `Some("fetch") => run_fetch(parse_fetch_args(argv)?)` arm; `print_help` gains the `fetch` usage line.
+
+---
+
+## 7. Error handling
+
+- **No R, plain `fetch`:** normal. No refusal; base via embedded set; everything else fetched.
+- **No R, `--missing-only`:** degrades to full `fetch` (nothing to subtract). No refusal.
+- **Single package fails on both r-universe hosts:** not fatal — recorded as "resolved nowhere," warned, and (only with `--fail-on-missing`) gates the exit.
+- **`curl` missing / network down for all:** the fetch helper surfaces curl's error; if *every* fetch fails the command reports the failure (and, like `update`, points at the manual/alternative path). A partial failure writes the records it got and warns about the rest.
+- **Clobber guard tripped:** refuse with a message naming the freeze-written target and pointing to `--output`.
+- **Write failure:** atomic-replace leaves any existing file intact (temp discarded).
+
+---
+
+## 8. Testing strategy
+
+- **Arg parsing:** `--missing-only`, `--fail-on-missing`, `--output`, `--workspace`, `--base-urls`; defaults; unknown-flag error. (Mirrors `parse_freeze_args_defaults_to_used`.)
+- **Used-set extraction is R-free:** already proven by `collect_referenced_packages_finds_namespace_and_calls`; add a test that the shared `collect_used_package_names` unions DESCRIPTION + renv.lock + scanned refs.
+- **Base filter:** a used set containing `stats`/`utils` fetches neither (membership in the embedded base set), with no R.
+- **`--missing-only` subtraction:** with a stub Tier-1 library reporting `dplyr` installed, `dplyr` is excluded from the fetch set; without a ready library, nothing is excluded (degrade-to-full).
+- **Fetch + parse against a local server:** point `--base-urls` at a local fixture server returning the existing `tests/fixtures/package_db/runiverse/*.json`; assert the written file's records match. CRAN-miss → Bioc-fallback path covered by pointing the first host at a 404-ing fixture and the second at a serving one.
+- **Resolved-nowhere + exit codes:** a used package absent from the fixture server warns; `--fail-on-missing` makes it exit non-zero while still writing the partial file; without the flag it exits zero.
+- **Provenance round-trip:** a fetched file carries a non-empty `source`; a `freeze`-written file (empty `source`) round-trips unchanged; an old file lacking the key deserializes with `source == ""` (schema-v1 back-compat).
+- **Clobber guard:** writing over a freeze file (empty `source`) without `--output` refuses; with `--output` it writes; over a fetch file (non-empty `source`) it overwrites.
+- **Atomic write:** a simulated mid-write failure leaves a pre-existing target intact (reuse `update`'s rollback test shape).
+- **No consumption regression:** `read_repo_db_file` / `RepoDbProvider` load a fetched file identically to a frozen one (same schema), so the `raven check` path needs no new test beyond confirming a fetched file resolves a package's exports with empty libpaths.
+
+---
+
+## 9. Documentation updates
+
+This work includes a **docs cleanup of the `raven packages` material**, which is currently implementation-heavy and at times confusing. Concretely:
+
+### 9.1 New: "Four ways to run `raven check` in CI"
+
+Add a section (in `docs/cli.md` and/or `docs/package-database.md`) presenting the four strategies plainly, with a pros/cons table:
+
+1. **R + all packages installed** on the CI system or image.
+2. **`raven packages update`** in the workflow before `raven check` (or baked into the image).
+3. **`raven packages fetch --missing-only`** in the workflow before `raven check`. *(If R is unavailable in CI, `--missing-only` is a no-op and this is equivalent to `raven packages fetch`, since all packages are then missing.)*
+4. **`raven packages freeze`** locally (with all packages installed) and commit `.raven/packages.json`.
+
+Each row should briefly say what it does and its trade-offs. Indicative axes for the table:
+
+| Strategy | Needs R in CI | Network in CI | Coverage | Version fidelity | Committed | Depends on `names-db` Release |
+|---|---|---|---|---|---|---|
+| 1. R + packages installed | yes | (install) | exact, full | version-exact | no | no |
+| 2. `packages update` | no | yes (2 files) | whole ecosystem | latest snapshot | no | **yes** |
+| 3. `packages fetch [--missing-only]` | no | yes (per-pkg) | project's used set | latest (installed rows exact under `--missing-only`) | no (ephemeral) | no |
+| 4. `freeze` + commit | no (in CI) | no | project's used set | version-exact | yes | no |
+
+### 9.2 New: document `raven packages fetch`
+
+A `cli.md` subsection paralleling `raven packages freeze` / `raven packages update`: synopsis, the two modes, the no-R behavior, the inform/warn output, `--fail-on-missing`, the gitignore guidance, the clobber guard, and the honest scope limits (no whole-ecosystem floor; base still from R/embedded).
+
+### 9.3 Cleanup pass on `docs/package-database.md` and the `raven packages` CLI docs
+
+Reduce implementation detail that confuses users, clarify the producer/consumer split (three **resolution tiers** vs. the **producers** of the Tier 2 file — `freeze` and now `fetch`), and make the "names vs. install status" and fidelity-caveat material easier to follow. Keep maintainer-only detail (e.g. `build-shipped-db` internals) clearly marked as such. This is a focused readability/accuracy pass tied to introducing `fetch` — not an unrelated rewrite.
+
+### 9.4 Honest framing
+
+Docs must state two limits plainly so `fetch` is not oversold:
+
+- It does **not** replace Tier 3's zero-adoption, whole-ecosystem floor — it only covers referenced packages.
+- It is **not** fully self-contained — base/recommended packages still come from local R or the embedded fallback at analysis time, because they are not on r-universe.
+
+---
+
+## 10. Code touchpoints
+
+- **New:** `run_fetch`, `parse_fetch_args`, `FetchArgs`, the per-package r-universe fetch helper, the "is base (embedded)" helper, the shared `collect_used_package_names` — all in `crates/raven/src/cli/packages.rs` (fetch helper may share a small module with `download_asset_blocking`).
+- **Modified:** `RepoDbProvenance` gains `#[serde(default)] source: String` (`package_db/json_db.rs`); `run_freeze` switches to the shared used-set helper (behavior-preserving); the `packages` `run` router + `print_help` gain the `fetch` arm.
+- **Reused unchanged:** `parse_runiverse_json` (`package_db/runiverse.rs`), `collect_referenced_packages` / `read_description_depends_imports` / `read_renv_lock_package_names`, `build_package_library_tier1_only` + `package_exists` (Tier-1), `embedded_base::load`, `write_repo_db_file` + the atomic-replace pattern from `update`.
+
+---
+
+## 11. Scope (v1) and explicit deferrals
+
+**In v1:** `raven packages fetch [--missing-only] [--fail-on-missing] [--output] [--workspace] [--base-urls]`; the optional `source` provenance field; the clobber guard; the inform/warn output; bounded-concurrency curl fetch with CRAN→Bioc fallback; atomic write; the docs (four-ways section, `fetch` reference, cleanup pass).
+
+**Deferred (noted, not built):**
+
+- **Suppression of expected-missing packages** (allowlist in `raven.toml` or a directive) so private/internal packages don't warn every run. v1 warns them.
+- **A `freeze --fetch-missing` gap-fill flag** (one-shot "install-wins, network-fills" producing a single committed file). This is a separate, additive decision with mixed-fidelity provenance implications; not needed to ship `fetch`.
+- **Caching fetched records** across runs (beyond what CI-level HTTP/dependency caching already offers).

--- a/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
+++ b/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
@@ -44,6 +44,7 @@ Settled during design Q&A (the dialogue that produced this spec):
 5. **`--fail-on-missing` is opt-in.** By default, packages that resolve nowhere produce warnings and a success exit. `--fail-on-missing` turns the warning set into a non-zero exit so a pipeline can gate on unresolvable references.
 6. **Merge, never clobber — existing records always win.** `fetch` reads any existing file at the target path and **preserves every record in it untouched**, adding records only for used packages **not already present**. It does not even fetch a package that the existing file already covers. This makes `fetch` purely additive: run after `freeze`, it tops up coverage for whatever `freeze` missed (e.g. packages that weren't installed) without disturbing a single `freeze` row. When the merge produces content identical to the existing file, `fetch` leaves the file untouched and prints "no changes" (reusing `freeze`'s content-comparison no-op), so it never creates a spurious diff.
 7. **Version-skew warning (the achievable half of the renv.lock idea).** r-universe serves **latest only** — it does not archive old versions (it tracks the upstream git URL/commit for `renv` to restore, but exposes no per-version export JSON). So `fetch` cannot pull the exact version `renv.lock` pins. Instead, when `renv.lock` pins version *X* for a package and the fetched record is latest *Y* ≠ *X*, `fetch` prints a one-line warning naming both versions and pointing at `freeze` / `--missing-only` for a version-exact capture. Export names are usually stable across versions, so this is a soft heads-up, not an error.
+8. **Top-level aliases `raven freeze` / `raven fetch`.** As a convenience, `raven freeze [ARGS]` is exactly equivalent to `raven packages freeze [ARGS]`, and `raven fetch [ARGS]` to `raven packages fetch [ARGS]`. They are thin routing aliases in the top-level dispatcher — same parsing, same handler, same help/error text — not separate implementations. Only these two get aliases; `update` and `build-shipped-db` stay nested under `packages` (they're rarer / maintainer-only). The nested `raven packages freeze` / `raven packages fetch` forms keep working unchanged.
 
 ---
 
@@ -148,6 +149,8 @@ Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sideca
 
 `run` (the subcommand router) gains a `Some("fetch") => run_fetch(parse_fetch_args(argv)?)` arm; `print_help` gains the `fetch` usage line.
 
+**Top-level aliases.** The flat dispatcher in `crates/raven/src/main.rs` (which routes `analysis-stats` / `lint` / `check` / `packages`) gains two arms: `Some("freeze")` and `Some("fetch")`. Each delegates to `cli::packages::run` with the subcommand token **prepended** to the remaining args — i.e. `raven freeze <rest>` calls `packages::run(["freeze", <rest>…])`, reusing the existing `HELP`/error handling exactly as the `packages` arm does. No collision risk: `freeze` / `fetch` are not existing top-level verbs. The top-level `--help` usage text adds the two aliases.
+
 ---
 
 ## 7. Error handling
@@ -174,6 +177,7 @@ Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sideca
 - **No-op when unchanged:** a `fetch` whose used set is fully covered by the existing file leaves the file untouched and prints "no changes."
 - **Version-skew warning:** a `renv.lock` pinning `dplyr 1.1.2` with a fixture serving `1.1.4` emits the skew warning naming both versions; identical versions emit none; the warning never changes the exit code.
 - **Atomic write:** a simulated mid-write failure leaves a pre-existing target intact (reuse `update`'s rollback test shape).
+- **Top-level aliases:** `raven freeze <args>` routes to the same handler as `raven packages freeze <args>`, and `raven fetch <args>` to `raven packages fetch <args>` (assert the prepend-and-delegate produces identical parsed args / behavior, including `--help`).
 - **No consumption regression:** `read_repo_db_file` / `RepoDbProvider` load a fetched file identically to a frozen one (same schema, no new field), so the `raven check` path needs no new test beyond confirming a fetched file resolves a package's exports with empty libpaths.
 
 ---
@@ -202,7 +206,7 @@ Each row should briefly say what it does and its trade-offs. Indicative axes for
 
 ### 9.2 New: document `raven packages fetch`
 
-A `cli.md` subsection paralleling `raven packages freeze` / `raven packages update`: synopsis, the two modes, the no-R behavior, the additive merge (existing records always win), the inform/warn output, the renv.lock version-skew warning, `--fail-on-missing`, the gitignore guidance, and the honest scope limits (no whole-ecosystem floor; base still from R/embedded).
+A `cli.md` subsection paralleling `raven packages freeze` / `raven packages update`: synopsis, the two modes, the no-R behavior, the additive merge (existing records always win), the inform/warn output, the renv.lock version-skew warning, `--fail-on-missing`, the gitignore guidance, and the honest scope limits (no whole-ecosystem floor; base still from R/embedded). Document the top-level aliases `raven freeze` / `raven fetch` alongside the nested forms.
 
 ### 9.3 Cleanup pass on `docs/package-database.md` and the `raven packages` CLI docs
 
@@ -220,14 +224,14 @@ Docs must state two limits plainly so `fetch` is not oversold:
 ## 10. Code touchpoints
 
 - **New:** `run_fetch`, `parse_fetch_args`, `FetchArgs`, the per-package r-universe fetch helper, the "is base (embedded)" helper, the shared `collect_used_package_names` — all in `crates/raven/src/cli/packages.rs` (fetch helper may share a small module with `download_asset_blocking`).
-- **Modified:** the `renv.lock` reader gains a name→version accessor for the skew warning (sibling to `read_renv_lock_package_names`); `run_freeze` switches to the shared used-set helper (behavior-preserving); the `packages` `run` router + `print_help` gain the `fetch` arm. **No change to `RepoDbProvenance` / the Tier 2 schema.**
+- **Modified:** the `renv.lock` reader gains a name→version accessor for the skew warning (sibling to `read_renv_lock_package_names`); `run_freeze` switches to the shared used-set helper (behavior-preserving); the `packages` `run` router + `print_help` gain the `fetch` arm; **`main.rs` gains top-level `freeze` / `fetch` alias arms** that delegate into `cli::packages::run` with the subcommand prepended, plus the usage text. **No change to `RepoDbProvenance` / the Tier 2 schema.**
 - **Reused unchanged:** `parse_runiverse_json` (`package_db/runiverse.rs`), `collect_referenced_packages` / `read_description_depends_imports` / `read_renv_lock_package_names`, `build_package_library_tier1_only` + `package_exists` (Tier-1), `embedded_base::load`, `read_repo_db_file` (merge seed) + `write_repo_db_file` + the atomic-replace pattern from `update`.
 
 ---
 
 ## 11. Scope (v1) and explicit deferrals
 
-**In v1:** `raven packages fetch [--missing-only] [--fail-on-missing] [--output] [--workspace] [--base-urls]`; additive merge with the existing file (existing records always win); the inform/warn output; the renv.lock version-skew warning; bounded-concurrency curl fetch with CRAN→Bioc fallback; atomic write + no-op-when-unchanged; the docs (four-ways section, `fetch` reference, cleanup pass). **No Tier 2 schema change.**
+**In v1:** `raven packages fetch [--missing-only] [--fail-on-missing] [--output] [--workspace] [--base-urls]`; additive merge with the existing file (existing records always win); the inform/warn output; the renv.lock version-skew warning; bounded-concurrency curl fetch with CRAN→Bioc fallback; atomic write + no-op-when-unchanged; the top-level aliases `raven freeze` / `raven fetch`; the docs (four-ways section, `fetch` reference, cleanup pass). **No Tier 2 schema change.**
 
 **Deferred (noted, not built):**
 

--- a/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
+++ b/docs/superpowers/specs/2026-05-31-packages-fetch-design.md
@@ -17,7 +17,7 @@ It exists to give CI a way to get project-scoped package-export coverage that:
 
 Today a CI pipeline without R has exactly one zero-install option: `raven packages update`, which downloads the whole-ecosystem Tier 3 sidecars from a single maintainer-owned Release. `fetch` is the alternative: it fetches only the packages the project actually references, straight from community infrastructure, and writes them into the Tier 2 file that `raven check` already reads.
 
-**This is a new producer, not a new tier.** The output is byte-compatible with `freeze`'s output and is consumed through the existing `read_repo_db_file` / `RepoDbProvider` path with **no new consumption code**. What differs from `freeze` is the *source* of records (r-universe vs. local install) and the *lifecycle* (ephemeral CI artifact, regenerated per run, gitignored — vs. committed and reviewed).
+**This is a new producer, not a new tier.** The output is byte-compatible with `freeze`'s output and is consumed through the existing `read_repo_db_file` / `RepoDbProvider` path with **no new consumption code**. What differs from `freeze` is the *source* of records (r-universe vs. local install) and the *lifecycle* (ephemeral CI artifact, regenerated per run, gitignored — vs. committed and reviewed). `fetch` is strictly **additive**: it never overwrites a record `freeze` produced — it merges into whatever Tier 2 file exists, keeping existing rows and adding only what's missing (§3.6).
 
 ---
 
@@ -25,7 +25,7 @@ Today a CI pipeline without R has exactly one zero-install option: `raven packag
 
 `fetch` is scoped to **producing the Tier 2 file from r-universe**. It is explicitly **not**:
 
-- **A change to `freeze`.** `freeze` keeps its contract intact: offline, deterministic, version-exact "frozen Tier 1," refuses without R. No flag is added to it here.
+- **A change to `freeze`.** `freeze` keeps its contract intact: offline, deterministic, version-exact "frozen Tier 1," refuses without R. No flag is added to it here. `fetch` never modifies or overwrites a record `freeze` wrote — it only adds records `freeze` didn't (§3.6).
 - **A change to the resolution seam or tier precedence.** `raven check` / the language server read `.raven/packages.json` exactly as before. `fetch` only writes that file.
 - **A whole-ecosystem floor.** Unlike Tier 3, `fetch` captures only packages the project references (the "used set"). It does not give zero-adoption coverage for packages the code hasn't mentioned yet.
 - **A committed, version-pinned artifact.** The fetched records carry **latest** CRAN/Bioc exports, not the versions the project pins. The file is meant to be regenerated each CI run, not reviewed in a PR. (A user *may* commit it, but that is not the design target and the docs steer away from it.)
@@ -40,9 +40,10 @@ Settled during design Q&A (the dialogue that produced this spec):
 1. **Surface = a flag, not a third subcommand.** `raven packages fetch` and `raven packages fetch --missing-only`. The only behavioral delta between the two is "consult the local install and subtract what's already there," which is a modifier on one command, not a separate concept.
 2. **Plain `fetch` requires no R.** It computes the used set (R-free, via tree-sitter + file reads), skips base packages (known offline via the embedded base set), and fetches the rest from r-universe.
 3. **`--missing-only` also requires no R — it is a pure optimization.** When R is present with a populated library, it subtracts already-installed packages from the fetch set (they will resolve via Tier 1 in the same CI run). When R is absent or `.libPaths()` is empty, the "installed?" filter matches nothing, so **every** used package is treated as missing and `--missing-only` degrades to a full `fetch`. It is therefore never an error to pass `--missing-only` without R; it simply has nothing to subtract.
-4. **Provenance gains an optional `source` field** on `RepoDbProvenance`, added with `#[serde(default)]` so the Tier 2 **schema version stays at 1** (older Raven ignores the field; newer Raven defaults it for files that lack it). Fetched files stamp it (e.g. `"r-universe (cran+bioc) @ 2026-05-31"`); `freeze` leaves it empty/default.
+4. **No schema change.** `fetch` writes the existing Tier 2 format unchanged (`REPO_DB_SCHEMA_VERSION` stays `1`). It does **not** add a provenance `source` field — merge semantics (#6) make distinguishing freeze-written from fetch-written files unnecessary. On write, `fetch` stamps the existing `RepoDbProvenance` fields: `raven_version` = current, `generated_unix` = now, `r_version` = `"none (fetched)"` (or the R version if `--missing-only` consulted a local library).
 5. **`--fail-on-missing` is opt-in.** By default, packages that resolve nowhere produce warnings and a success exit. `--fail-on-missing` turns the warning set into a non-zero exit so a pipeline can gate on unresolvable references.
-6. **Clobber guard.** Checked **up front (step 0), before any fetching.** If the file at the target path already exists, parses as a valid Tier 2 file, and was written by `freeze` (its provenance `source` is empty/install-sourced), and the user did not pass `--output`, `fetch` **refuses** rather than overwrite a committed, version-exact file with latest-from-network records. An absent, corrupt, or fetch-written (non-empty `source`) target does not trip the guard. `--output PATH` overrides the guard and the default location.
+6. **Merge, never clobber — existing records always win.** `fetch` reads any existing file at the target path and **preserves every record in it untouched**, adding records only for used packages **not already present**. It does not even fetch a package that the existing file already covers. This makes `fetch` purely additive: run after `freeze`, it tops up coverage for whatever `freeze` missed (e.g. packages that weren't installed) without disturbing a single `freeze` row. When the merge produces content identical to the existing file, `fetch` leaves the file untouched and prints "no changes" (reusing `freeze`'s content-comparison no-op), so it never creates a spurious diff.
+7. **Version-skew warning (the achievable half of the renv.lock idea).** r-universe serves **latest only** — it does not archive old versions (it tracks the upstream git URL/commit for `renv` to restore, but exposes no per-version export JSON). So `fetch` cannot pull the exact version `renv.lock` pins. Instead, when `renv.lock` pins version *X* for a package and the fetched record is latest *Y* ≠ *X*, `fetch` prints a one-line warning naming both versions and pointing at `freeze` / `--missing-only` for a version-exact capture. Export names are usually stable across versions, so this is a soft heads-up, not an error.
 
 ---
 
@@ -51,19 +52,21 @@ Settled during design Q&A (the dialogue that produced this spec):
 `fetch` is a new async entry point `run_fetch` in `crates/raven/src/cli/packages.rs`, dispatched from the existing `packages` subcommand router alongside `freeze` / `update` / `build-shipped-db`. Its pipeline:
 
 ```
-0. Clobber guard               (refuse early if target is a freeze file & no --output)
 1. Compute the used set        (shared with freeze; R-free)
 2. Drop base packages          (embedded base set; R-free)
-3. [--missing-only] subtract installed packages   (Tier-1 package_exists; no-op without R)
-4. Inform: print the packages about to be downloaded
-5. Fetch each from r-universe  (curl, CRAN then Bioc fallback, bounded concurrency)
-6. Parse responses             (existing parse_runiverse_json → PackageRecord)
-7. Collect "resolved nowhere"  (used − fetched − [installed if --missing-only])
-8. Warn per unresolved package; honor --fail-on-missing
-9. Write .raven/packages.json atomically (temp-then-rename), with source provenance
+3. Read existing target file    (merge seed; existing records always win)
+4. [--missing-only] subtract installed packages   (Tier-1 package_exists; no-op without R)
+5. Drop packages already in the existing file       (additive merge — don't refetch)
+6. Inform: print the packages about to be downloaded
+7. Fetch each from r-universe  (curl, CRAN then Bioc fallback, bounded concurrency)
+8. Parse responses             (existing parse_runiverse_json → PackageRecord)
+9. Warn on renv.lock version skew (fetched latest ≠ pinned version)
+10. Collect "resolved nowhere" (used − existing − fetched − [installed if --missing-only])
+11. Warn per unresolved package; honor --fail-on-missing
+12. Merge (existing ∪ fetched) and write atomically; no-op if content unchanged
 ```
 
-The clobber guard is **step 0** — checked up front so the command fails fast without doing network work it would only discard. Steps 1, 2, 6, and 9's writer already exist; the net-new logic is steps 0, 3–8 and the per-package fetch helper.
+Steps 1, 2, 8, and the writer already exist; the net-new logic is steps 3, 5, 7, 9–11 and the per-package fetch helper.
 
 ---
 
@@ -100,24 +103,31 @@ Transitive expansion: after fetching a package, enqueue its r-universe `Depends`
 
 ### 5.5 "Resolved nowhere" detection, warnings, and `--fail-on-missing`
 
-After fetching, compute the set of used packages (non-base) that produced **no** record — neither fetched from r-universe nor (under `--missing-only`) found installed. This set is exactly: GitHub-only / internal / private packages, packages not yet on r-universe, **and typos** (`library(dpylr)`). For each, emit a `stderr` warning naming the package. If `--fail-on-missing` is set and the set is non-empty, exit non-zero after writing the file.
+After fetching, compute the set of used packages (non-base) that produced **no** record — not already in the existing file, not fetched from r-universe, and not (under `--missing-only`) found installed. This set is exactly: GitHub-only / internal / private packages, packages not yet on r-universe, **and typos** (`library(dpylr)`). For each, emit a `stderr` warning naming the package. If `--fail-on-missing` is set and the set is non-empty, exit non-zero after writing the file.
 
 > **Note — suppression is deferred.** Legitimately off-ecosystem packages (private/internal) will warn every run. A suppression mechanism (an allowlist in `raven.toml`, or a directive) is **out of scope for v1** and noted as a fast-follow. v1 behavior: they warn; `--fail-on-missing` users who have such packages either don't use the flag or accept the failure until suppression lands.
 
-### 5.6 Provenance `source` field
+### 5.6 Merge with the existing file (existing records always win)
 
-Add to `RepoDbProvenance`:
+`fetch` is additive and never overwrites a record already present. Before fetching, it reads the target path with `read_repo_db_file`:
 
-```rust
-#[serde(default)]
-pub source: String,
-```
+- **Absent** (`RepoDbError::Absent`) — start from an empty record set; write a fresh file.
+- **Valid** — seed the record set with **every** existing record. These names are excluded from the fetch set (step 5), so an already-covered package is never refetched and never overwritten — whether it was written by `freeze` or a prior `fetch`.
+- **Corrupt / unsupported schema** — surface the typed error and refuse (don't silently discard a file the user may need); the user can delete it or point `--output` elsewhere.
 
-`#[serde(default)]` is load-bearing: it keeps `REPO_DB_SCHEMA_VERSION` at `1` (an absent key deserializes to `""`, so files written by today's `freeze` still parse, and today's reader — which doesn't know the field — still parses tomorrow's files). `fetch` sets it to a human string like `"r-universe (cran+bioc) @ <date>"`. `freeze` continues to leave it empty. `r_version` for plain `fetch` is set to a sentinel such as `"none (fetched)"`; for `--missing-only` it reflects the R used for the install filter if any, else the same sentinel.
+The written file is `existing ∪ fetched`, sorted by name (the writer already sorts). Because existing records win and base packages are excluded, there is no need to distinguish "freeze-written" from "fetch-written" files — so **no `source` provenance field is added** and the schema stays at v1. `fetch` stamps the standard `RepoDbProvenance` on write: `raven_version` current, `generated_unix` now, `r_version` = `"none (fetched)"` (or the consulted R version under `--missing-only`).
 
-The clobber guard (§3.6) reads this field on the existing target file **before fetching**: a target that parses as a valid Tier 2 file with an empty `source` ⇒ treat as freeze-written ⇒ refuse without `--output`. An absent or corrupt target does not trip the guard (nothing committed to protect).
+**No-op when unchanged:** reuse `freeze`'s content comparison — if `existing ∪ fetched` equals the existing file's records (e.g. everything was already covered), leave the file untouched and print "no changes."
 
-### 5.7 Atomic write
+### 5.7 Version-skew warning against renv.lock
+
+r-universe is latest-only (it does not archive old versions), so `fetch` cannot retrieve the exact version `renv.lock` pins. When a `renv.lock` is present, `fetch` reads its `Package → Version` map (the existing `renv.lock` reader already parses the file; it currently returns names — extend it, or add a sibling, to also expose the pinned version). For each fetched record whose `version` differs from the locked version, print:
+
+> `dplyr: fetched 1.1.4 (latest); renv.lock pins 1.1.2. Export names usually match across versions; install it and use `freeze` / `--missing-only` for a version-exact capture.`
+
+This is a warning only — never an error and never gated by `--fail-on-missing` (which is for *unresolvable* packages, not version skew).
+
+### 5.8 Atomic write
 
 Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sidecars` so a mid-fetch failure or partial network read can never feed a half-written `.raven/packages.json` to `raven check` in the same job. Write to a unique temp in the destination directory, then atomically rename over the target.
 
@@ -131,7 +141,7 @@ Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sideca
 |---|---|---|
 | `--missing-only` | Subtract already-installed packages from the fetch set (no-op without R) | off |
 | `--fail-on-missing` | Exit non-zero if any used package resolved nowhere | off |
-| `--output PATH` | Where to write; overrides default and the clobber guard | `.raven/packages.json` |
+| `--output PATH` | Where to write/merge | `.raven/packages.json` |
 | `--workspace DIR` | Workspace root to scan for usage/config | current dir |
 | `--base-urls URL[,URL]` | Override the ordered r-universe host list (testing); tried in order | `cran.r-universe.dev,bioc.r-universe.dev` |
 | `--help` | Usage | — |
@@ -146,7 +156,8 @@ Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sideca
 - **No R, `--missing-only`:** degrades to full `fetch` (nothing to subtract). No refusal.
 - **Single package fails on both r-universe hosts:** not fatal — recorded as "resolved nowhere," warned, and (only with `--fail-on-missing`) gates the exit.
 - **`curl` missing / network down for all:** the fetch helper surfaces curl's error; if *every* fetch fails the command reports the failure (and, like `update`, points at the manual/alternative path). A partial failure writes the records it got and warns about the rest.
-- **Clobber guard tripped:** refuse with a message naming the freeze-written target and pointing to `--output`.
+- **Existing file present:** its records are preserved and excluded from the fetch set (additive merge, §5.6). An already-covered package is never refetched or overwritten.
+- **Existing file corrupt / unsupported schema:** surface the typed `RepoDbError` and refuse, rather than silently discard a file the user may need. The user deletes it or points `--output` elsewhere.
 - **Write failure:** atomic-replace leaves any existing file intact (temp discarded).
 
 ---
@@ -158,11 +169,12 @@ Reuse the temp-then-rename discipline from `update`'s `install_downloaded_sideca
 - **Base filter:** a used set containing `stats`/`utils` fetches neither (membership in the embedded base set), with no R.
 - **`--missing-only` subtraction:** with a stub Tier-1 library reporting `dplyr` installed, `dplyr` is excluded from the fetch set; without a ready library, nothing is excluded (degrade-to-full).
 - **Fetch + parse against a local server:** point `--base-urls` at a local fixture server returning the existing `tests/fixtures/package_db/runiverse/*.json`; assert the written file's records match. CRAN-miss → Bioc-fallback path covered by pointing the first host at a 404-ing fixture and the second at a serving one.
-- **Resolved-nowhere + exit codes:** a used package absent from the fixture server warns; `--fail-on-missing` makes it exit non-zero while still writing the partial file; without the flag it exits zero.
-- **Provenance round-trip:** a fetched file carries a non-empty `source`; a `freeze`-written file (empty `source`) round-trips unchanged; an old file lacking the key deserializes with `source == ""` (schema-v1 back-compat).
-- **Clobber guard:** writing over a freeze file (empty `source`) without `--output` refuses; with `--output` it writes; over a fetch file (non-empty `source`) it overwrites.
+- **Resolved-nowhere + exit codes:** a used package absent from the fixture server warns; `--fail-on-missing` makes it exit non-zero while still writing the file; without the flag it exits zero.
+- **Merge — existing records always win:** seed the target with an existing file containing `dplyr` (any version/exports); a `fetch` whose used set includes `dplyr` and `cli` preserves the existing `dplyr` record byte-for-byte, does not refetch it, and adds only `cli`. An absent target writes a fresh file; a corrupt target surfaces the typed error and refuses.
+- **No-op when unchanged:** a `fetch` whose used set is fully covered by the existing file leaves the file untouched and prints "no changes."
+- **Version-skew warning:** a `renv.lock` pinning `dplyr 1.1.2` with a fixture serving `1.1.4` emits the skew warning naming both versions; identical versions emit none; the warning never changes the exit code.
 - **Atomic write:** a simulated mid-write failure leaves a pre-existing target intact (reuse `update`'s rollback test shape).
-- **No consumption regression:** `read_repo_db_file` / `RepoDbProvider` load a fetched file identically to a frozen one (same schema), so the `raven check` path needs no new test beyond confirming a fetched file resolves a package's exports with empty libpaths.
+- **No consumption regression:** `read_repo_db_file` / `RepoDbProvider` load a fetched file identically to a frozen one (same schema, no new field), so the `raven check` path needs no new test beyond confirming a fetched file resolves a package's exports with empty libpaths.
 
 ---
 
@@ -190,7 +202,7 @@ Each row should briefly say what it does and its trade-offs. Indicative axes for
 
 ### 9.2 New: document `raven packages fetch`
 
-A `cli.md` subsection paralleling `raven packages freeze` / `raven packages update`: synopsis, the two modes, the no-R behavior, the inform/warn output, `--fail-on-missing`, the gitignore guidance, the clobber guard, and the honest scope limits (no whole-ecosystem floor; base still from R/embedded).
+A `cli.md` subsection paralleling `raven packages freeze` / `raven packages update`: synopsis, the two modes, the no-R behavior, the additive merge (existing records always win), the inform/warn output, the renv.lock version-skew warning, `--fail-on-missing`, the gitignore guidance, and the honest scope limits (no whole-ecosystem floor; base still from R/embedded).
 
 ### 9.3 Cleanup pass on `docs/package-database.md` and the `raven packages` CLI docs
 
@@ -208,17 +220,17 @@ Docs must state two limits plainly so `fetch` is not oversold:
 ## 10. Code touchpoints
 
 - **New:** `run_fetch`, `parse_fetch_args`, `FetchArgs`, the per-package r-universe fetch helper, the "is base (embedded)" helper, the shared `collect_used_package_names` — all in `crates/raven/src/cli/packages.rs` (fetch helper may share a small module with `download_asset_blocking`).
-- **Modified:** `RepoDbProvenance` gains `#[serde(default)] source: String` (`package_db/json_db.rs`); `run_freeze` switches to the shared used-set helper (behavior-preserving); the `packages` `run` router + `print_help` gain the `fetch` arm.
-- **Reused unchanged:** `parse_runiverse_json` (`package_db/runiverse.rs`), `collect_referenced_packages` / `read_description_depends_imports` / `read_renv_lock_package_names`, `build_package_library_tier1_only` + `package_exists` (Tier-1), `embedded_base::load`, `write_repo_db_file` + the atomic-replace pattern from `update`.
+- **Modified:** the `renv.lock` reader gains a name→version accessor for the skew warning (sibling to `read_renv_lock_package_names`); `run_freeze` switches to the shared used-set helper (behavior-preserving); the `packages` `run` router + `print_help` gain the `fetch` arm. **No change to `RepoDbProvenance` / the Tier 2 schema.**
+- **Reused unchanged:** `parse_runiverse_json` (`package_db/runiverse.rs`), `collect_referenced_packages` / `read_description_depends_imports` / `read_renv_lock_package_names`, `build_package_library_tier1_only` + `package_exists` (Tier-1), `embedded_base::load`, `read_repo_db_file` (merge seed) + `write_repo_db_file` + the atomic-replace pattern from `update`.
 
 ---
 
 ## 11. Scope (v1) and explicit deferrals
 
-**In v1:** `raven packages fetch [--missing-only] [--fail-on-missing] [--output] [--workspace] [--base-urls]`; the optional `source` provenance field; the clobber guard; the inform/warn output; bounded-concurrency curl fetch with CRAN→Bioc fallback; atomic write; the docs (four-ways section, `fetch` reference, cleanup pass).
+**In v1:** `raven packages fetch [--missing-only] [--fail-on-missing] [--output] [--workspace] [--base-urls]`; additive merge with the existing file (existing records always win); the inform/warn output; the renv.lock version-skew warning; bounded-concurrency curl fetch with CRAN→Bioc fallback; atomic write + no-op-when-unchanged; the docs (four-ways section, `fetch` reference, cleanup pass). **No Tier 2 schema change.**
 
 **Deferred (noted, not built):**
 
 - **Suppression of expected-missing packages** (allowlist in `raven.toml` or a directive) so private/internal packages don't warn every run. v1 warns them.
-- **A `freeze --fetch-missing` gap-fill flag** (one-shot "install-wins, network-fills" producing a single committed file). This is a separate, additive decision with mixed-fidelity provenance implications; not needed to ship `fetch`.
+- **Version-exact fetch** for renv.lock-pinned versions. r-universe is latest-only, so this would require a different, heavier source (e.g. CRAN-Archive source tarballs parsed for `NAMESPACE`) at lower fidelity (no `exportPattern` expansion without building) and with no clean Bioconductor analog. v1 fetches latest and warns on skew instead.
 - **Caching fetched records** across runs (beyond what CI-level HTTP/dependency caching already offers).


### PR DESCRIPTION
- **docs: spec raven packages fetch (R-free CI Tier 2 producer)**
- **docs: revise fetch spec — additive merge (existing wins), drop source field, renv.lock version-skew warning**
- **docs: add top-level 'raven freeze' / 'raven fetch' aliases to fetch spec**
- **feat(packages): add `raven packages fetch` — R-free CI producer of the Tier 2 export DB from r-universe**
- **refactor(packages): simplify used_nonbase to sorted dedup in run_fetch**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `raven packages fetch` to top up package metadata from r-universe with transitive resolution, additive merges, and options: --missing-only, --fail-on-missing, --output, --workspace, --base-urls
  * Top-level aliases `raven fetch` and `raven freeze` now route to the packages workflow

* **Improvements**
  * Freeze now gathers used package names more robustly and skips embedded base packages without requiring R
  * Added renv.lock-aware version extraction

* **Documentation**
  * Expanded CLI and package-database docs and added a design spec for `packages fetch`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->