### PR TITLE
Harden release supply chain: artifact provenance + pinned npm deps

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -48,6 +48,10 @@ jobs:
   build-lsp:
     needs: validate-names-db
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     defaults:
       run:
         shell: bash
@@ -130,6 +134,11 @@ jobs:
             cd dist && zip -r ../raven-${{ matrix.platform }}.zip .
           fi
 
+      - name: Attest build provenance (LSP archive)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: raven-${{ matrix.platform }}.zip
+
       - name: Upload LSP artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -140,6 +149,10 @@ jobs:
   build-vscode:
     needs: build-lsp
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         target: [darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64, win32-arm64]
@@ -176,7 +189,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd editors/vscode
-          npm install
+          npm ci
 
       - name: Compile extension
         run: |
@@ -201,6 +214,11 @@ jobs:
         run: |
           cd editors/vscode
           vsce package --target ${{ matrix.target }}
+
+      - name: Attest build provenance (VSIX)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: editors/vscode/*.vsix
 
       - name: Upload extension artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,7 @@ This updates `Cargo.toml` (workspace version) and `editors/vscode/package.json`,
 Pushing the tag triggers `release-build.yml`, which:
 1. Cross-compiles the `raven` binary for 6 platforms (linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64, windows-arm64)
 2. Packages a platform-specific `.vsix` for each target (the binary is embedded in `bin/`)
+3. Generates a Sigstore-backed build-provenance attestation (`actions/attest-build-provenance`) for each `raven-<platform>.zip` and `.vsix`, so a published artifact can be verified with `gh attestation verify <file> --repo jbearak/raven`
 
 ### Publishing
 


### PR DESCRIPTION
## Summary

Two focused supply-chain hardening changes to `release-build.yml` (the tag-triggered build pipeline):

1. **Build-provenance attestations.** Added `actions/attest-build-provenance` (SHA-pinned to `a2bbfa2` / v4.1.0) to both artifact-producing jobs:
   - `build-lsp` attests each `raven-<platform>.zip`
   - `build-vscode` attests each `.vsix`

   This gives each shipped artifact a Sigstore-backed, verifiable provenance record proving it was built by this repo's workflow — authenticity on top of the SHA-256 checksums you already publish (integrity). Consumers can verify with `gh attestation verify <file> --repo jbearak/raven`. Both jobs gain the minimal `id-token: write` + `attestations: write` permissions (plus `contents: read` for checkout); the repo-wide default stays `contents: read`.

2. **`npm install` → `npm ci`** for the VS Code extension dependency install. `npm ci` installs strictly from the committed `package-lock.json`, so a transitive dependency can't float to a newer (possibly malicious) version at release time. `integration.yml` already uses `npm ci`, so the lockfile is known to be in sync.

Docs: added the attestation step to the release-pipeline description in `docs/development.md`.

## Scope notes

- `release-publish.yml` was left untouched — its only npm usage is version-pinned global tool installs (`vsce`/`ovsx`), no project-level `npm install`.
- All actions remain SHA-pinned (the new action included), consistent with the repo convention.

## Testing

- `ruby` YAML parse check passes for `release-build.yml`.
- `package-lock.json` confirmed present under `editors/vscode/`, so `npm ci` is valid.
- Full validation happens on the next `v*` tag (attestation requires the real release run); the change is additive and gated behind the existing `release`/`marketplace` environment approvals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build artifact security with provenance attestations for release binaries and extensions.
  * Improved build reproducibility through deterministic dependency installation.
  * Updated CI/build process documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->