### PR TITLE
Add clippy CI gate and fix all clippy warnings

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,6 +41,54 @@ jobs:
       - name: Check formatting
         run: cargo +1.95.0 fmt --all --check
 
+  # ── Clippy lint gate (required check) ──────────────────────────────────
+  # Denies ALL clippy/rustc warnings (`-D warnings`) across every target so
+  # lint noise can't re-accumulate during development. Pinned to an explicit
+  # toolchain (not `@stable`) for the same reason as the fmt gate: new clippy
+  # releases add new lints, and an unpinned gate would start failing on
+  # unrelated PRs as the lint set shifts. `--all-targets --features
+  # test-support` matches the surface a developer sees in their editor
+  # (lib, tests, benches, examples). Unlike fmt, clippy DOES invoke rustc, so
+  # this job sets up sccache + mold like the other compiling jobs.
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install pinned clippy
+        run: rustup toolchain install 1.95.0 --profile minimal --component clippy
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.9
+
+      - name: Cache cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ runner.os }}-
+
+      - name: Cache sccache storage (clippy)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/sccache
+          key: sccache-clippy-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            sccache-clippy-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-
+            sccache-clippy-${{ runner.os }}-
+
+      - name: Install mold linker
+        run: sudo apt-get install -y --no-install-recommends mold
+
+      - name: Run clippy (deny warnings)
+        run: cargo +1.95.0 clippy --workspace --all-targets --features test-support -- -D warnings
+
+
   # Build only the release artifacts that genuinely need optimization: the LSP
   # binary (consumed by the vscode-mocha and binary-size jobs) and the
   # performance_budgets test binary (gated on `not(debug_assertions)`, asserts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 This file is intentionally short: a map to the docs and a list of invariants that span multiple systems. Invariants tied to one function or module belong as a doc comment on that function or module, not here.
 
+## CI gates (keep green before committing)
+
+Rust changes must pass two gates in `.github/workflows/integration.yml`, both pinned to toolchain `1.95.0` so results are reproducible:
+
+- **Formatting** — `cargo +1.95.0 fmt --all --check`. Always run `cargo fmt --all` before committing; never hand-format around it.
+- **Clippy** — `cargo +1.95.0 clippy --workspace --all-targets --features test-support -- -D warnings`. Zero warnings: every clippy/rustc warning is an error, across lib, tests, benches, and examples.
+
+Both block merge. Fix the underlying issue rather than suppressing it; when a lint is a genuine, deliberate exception, use a narrowly-scoped `#[allow(...)]` with a one-line reason. Project-wide exceptions live in `crates/raven/Cargo.toml` `[lints]` (currently only `field_reassign_with_default`).
+
 ## What to read
 
 User-facing:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.7.1"
 authors = ["Jonathan Marc Bearak <jbearak@gmail.com>"]
 edition = "2021"
 license = "GPL-3.0"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [workspace.dependencies]
 tower-lsp = "0.20"

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -8,6 +8,14 @@ license.workspace = true
 rust-version.workspace = true
 repository = "https://github.com/jbearak/Raven"
 
+# clippy is gated in CI with `-D warnings` (see .github/workflows/integration.yml).
+# `field_reassign_with_default` is the one lint allowed: the
+# `let mut x = T::default(); x.field = ..;` idiom is used pervasively and
+# deliberately in test/builder setup, where it reads more clearly than a
+# struct-literal with `..Default::default()`.
+[lints.clippy]
+field_reassign_with_default = "allow"
+
 [[bin]]
 name = "raven"
 path = "src/main.rs"

--- a/crates/raven/benches/cross_file.rs
+++ b/crates/raven/benches/cross_file.rs
@@ -171,6 +171,7 @@ fn bench_scope_resolution(c: &mut Criterion) {
                     true,
                     raven::cross_file::config::BackwardDependencyMode::Explicit,
                     &|| false,
+                    None,
                 ))
             })
         });
@@ -233,6 +234,7 @@ fn bench_scope_hotspots(c: &mut Criterion) {
                         true,
                         raven::cross_file::config::BackwardDependencyMode::Explicit,
                         &|| false,
+                        None,
                     ))
                 })
             },

--- a/crates/raven/benches/edit_to_publish.rs
+++ b/crates/raven/benches/edit_to_publish.rs
@@ -79,7 +79,7 @@ fn write_fanout(dir: &Path, leaves: usize) {
     for i in 0..5 {
         hub.push_str(&format!("util_{i} <- function(x) x + {i}\n", i = i));
     }
-    hub.push_str("\n");
+    hub.push('\n');
     hub.push_str(&body_for(999));
     write(&dir.join("utility.R"), &hub);
 
@@ -160,7 +160,7 @@ fn build_state(workspace: &Path) -> (WorldState, Arc<Url>) {
             .insert(uri.clone(), Document::new_with_uri(&content, Some(1), &uri));
     }
 
-    let (index, cross_file_entries, new_index_entries) = scan_workspace(&[folder_url.clone()], 20);
+    let (index, cross_file_entries, new_index_entries) = scan_workspace(std::slice::from_ref(&folder_url), 20);
     state.apply_workspace_index(index, cross_file_entries, new_index_entries);
 
     (state, Arc::new(folder_url))

--- a/crates/raven/benches/edit_to_publish.rs
+++ b/crates/raven/benches/edit_to_publish.rs
@@ -160,7 +160,8 @@ fn build_state(workspace: &Path) -> (WorldState, Arc<Url>) {
             .insert(uri.clone(), Document::new_with_uri(&content, Some(1), &uri));
     }
 
-    let (index, cross_file_entries, new_index_entries) = scan_workspace(std::slice::from_ref(&folder_url), 20);
+    let (index, cross_file_entries, new_index_entries) =
+        scan_workspace(std::slice::from_ref(&folder_url), 20);
     state.apply_workspace_index(index, cross_file_entries, new_index_entries);
 
     (state, Arc::new(folder_url))

--- a/crates/raven/examples/profile_real_workspace.rs
+++ b/crates/raven/examples/profile_real_workspace.rs
@@ -47,7 +47,7 @@ fn main() {
     eprintln!("\n=== Phase 1: scan_workspace (cold) ===");
     let t0 = Instant::now();
     let (index, cross_file_entries, new_index_entries) =
-        scan_workspace(&[workspace_url.clone()], 20);
+        scan_workspace(std::slice::from_ref(&workspace_url), 20);
     let scan_time = t0.elapsed();
     eprintln!(
         "  {:?} ({} files, {} cross-file entries, {} new index)",
@@ -135,7 +135,7 @@ fn main() {
     // ── Phase 4: scan_workspace (warm filesystem) ──
     eprintln!("\n=== Phase 4: scan_workspace (warm) ===");
     let t4 = Instant::now();
-    let (index2, _, _) = scan_workspace(&[workspace_url.clone()], 20);
+    let (index2, _, _) = scan_workspace(std::slice::from_ref(&workspace_url), 20);
     let scan_warm_time = t4.elapsed();
     eprintln!("  {:?} ({} files)", scan_warm_time, index2.len());
 
@@ -170,7 +170,7 @@ fn main() {
         }
     }
     walk(&workspace, &mut file_sizes);
-    file_sizes.sort_by(|a, b| b.1.cmp(&a.1));
+    file_sizes.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (path, size) in file_sizes.iter().take(10) {
         let Ok(content) = std::fs::read_to_string(path) else {

--- a/crates/raven/examples/profile_worldwide.rs
+++ b/crates/raven/examples/profile_worldwide.rs
@@ -306,7 +306,7 @@ fn main() {
     let mut last: Option<(usize, usize, usize)> = None;
     for _ in 0..3 {
         let t = Instant::now();
-        let (index, cf, new_idx) = scan_workspace(&[folder.clone()], 20);
+        let (index, cf, new_idx) = scan_workspace(std::slice::from_ref(&folder), 20);
         let elapsed = t.elapsed();
         runs.push(elapsed);
         last = Some((index.len(), cf.len(), new_idx.len()));
@@ -333,7 +333,7 @@ fn main() {
     let mut apply_runs = Vec::new();
     for _ in 0..3 {
         // Fresh scan each time so the inputs aren't moved
-        let (index, cf, new_idx) = scan_workspace(&[folder.clone()], 20);
+        let (index, cf, new_idx) = scan_workspace(std::slice::from_ref(&folder), 20);
         let mut state = make_state(&workspace);
         let t = Instant::now();
         state.apply_workspace_index(index, cf, new_idx);
@@ -442,7 +442,7 @@ fn main() {
     // Phase 6: scripts/data.r diagnostics — POST-scan (workspace index applied)
     // ------------------------------------------------------------------
     println!("[6] scripts/data.r diagnostics — POST-scan (workspace_scan_complete=true):");
-    let (index, cf, new_idx) = scan_workspace(&[folder.clone()], 20);
+    let (index, cf, new_idx) = scan_workspace(std::slice::from_ref(&folder), 20);
     state.apply_workspace_index(index, cf, new_idx);
     // Warmup
     for _ in 0..3 {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -4701,7 +4701,7 @@ impl LanguageServer for Backend {
                     // Capture old metadata before recomputing (for WD change detection)
                     let old_meta = {
                         let state = state_arc.read().await;
-                        state.get_enriched_metadata(&uri)
+                        state.get_enriched_metadata(uri)
                     };
 
                     // Compute metadata and artifacts
@@ -4713,7 +4713,7 @@ impl LanguageServer for Backend {
                                 // Use compute_artifacts_with_metadata to include declared symbols from directives
                                 // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
                                 crate::cross_file::scope::compute_artifacts_with_metadata(
-                                    &uri,
+                                    uri,
                                     &tree,
                                     &content,
                                     Some(&cross_file_meta),
@@ -4743,7 +4743,7 @@ impl LanguageServer for Backend {
                         let open_docs: std::collections::HashSet<_> =
                             state.documents.keys().cloned().collect();
                         state.cross_file_workspace_index.update_from_disk(
-                            &uri,
+                            uri,
                             &open_docs,
                             snapshot,
                             cross_file_meta.clone(),
@@ -4784,7 +4784,7 @@ impl LanguageServer for Backend {
                                 .collect();
 
                         let graph_result = state.cross_file_graph.update_file(
-                            &uri,
+                            uri,
                             &cross_file_meta,
                             workspace_root.as_ref(),
                             |parent_uri| parent_content.get(parent_uri).cloned(),
@@ -4792,7 +4792,7 @@ impl LanguageServer for Backend {
 
                         // Invalidate children affected by working directory change (Requirement 8)
                         let wd_children = crate::cross_file::revalidation::invalidate_children_on_parent_wd_change(
-                            &uri,
+                            uri,
                             old_meta.as_deref(),
                             &cross_file_meta,
                             &state.cross_file_graph,
@@ -4823,7 +4823,7 @@ impl LanguageServer for Backend {
                         if graph_result.edges_changed {
                             let post_neighbors =
                                 crate::cross_file::revalidation::compute_affected_dependents_after_edit(
-                                    &uri,
+                                    uri,
                                     true,
                                     true,
                                     &state.cross_file_graph,

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -138,8 +138,8 @@ fn detect_rmd_chunks(lines: &[&str]) -> Vec<Chunk> {
         let fence_char = fence.chars().next().unwrap_or('`');
         let min_len = fence.len();
         let mut closing_line: Option<u32> = None;
-        for j in (i + 1)..lines.len() {
-            if let Some(close_caps) = close_re.captures(lines[j]) {
+        for (j, &line) in lines.iter().enumerate().skip(i + 1) {
+            if let Some(close_caps) = close_re.captures(line) {
                 let close = close_caps.get(1).map(|m| m.as_str()).unwrap_or("");
                 if close.starts_with(fence_char) && close.len() >= min_len {
                     closing_line = Some(j as u32);

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -856,7 +856,8 @@ mod tests {
         let rmd = tmp.path().join("report.Rmd");
         fs::write(&rmd, "prose\n").unwrap();
         let mut operator_error = false;
-        let targets = collect_report_targets(std::slice::from_ref(&rmd), tmp.path(), &mut operator_error);
+        let targets =
+            collect_report_targets(std::slice::from_ref(&rmd), tmp.path(), &mut operator_error);
         // Targets are canonicalized so they match the canonical workspace root.
         assert_eq!(targets, vec![std::fs::canonicalize(&rmd).unwrap()]);
         assert!(!operator_error);

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -856,7 +856,7 @@ mod tests {
         let rmd = tmp.path().join("report.Rmd");
         fs::write(&rmd, "prose\n").unwrap();
         let mut operator_error = false;
-        let targets = collect_report_targets(&[rmd.clone()], tmp.path(), &mut operator_error);
+        let targets = collect_report_targets(std::slice::from_ref(&rmd), tmp.path(), &mut operator_error);
         // Targets are canonicalized so they match the canonical workspace root.
         assert_eq!(targets, vec![std::fs::canonicalize(&rmd).unwrap()]);
         assert!(!operator_error);

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -1117,9 +1117,8 @@ pub fn install_downloaded_sidecars(
 
     // Backup existing, replace, restore on failure. Clean up the validated
     // temp on any failure after validation so a rare error can't leak it.
-    let backup = backup_existing_final(&names_final).map_err(|e| {
+    let backup = backup_existing_final(&names_final).inspect_err(|_e| {
         let _ = std::fs::remove_file(&names_tmp);
-        e
     })?;
     if let Err(e) = replace_with_tmp(&names_tmp, &names_final) {
         let _ = std::fs::remove_file(&names_tmp);

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1539,8 +1539,9 @@ impl DependencyGraph {
     ///   (use this for diagnostic positioning in the queried file)
     /// - `closing_edge`: the edge that points BACK to `uri` completing the cycle
     ///   (use this for the diagnostic message details)
-    ///   Collect all URIs reachable from `uri` within `max_depth` hops,
-    ///   following both forward and backward edges.
+    ///
+    /// Collect all URIs reachable from `uri` within `max_depth` hops,
+    /// following both forward and backward edges.
     ///
     /// `max_visited` caps the total number of nodes collected to prevent
     /// unbounded expansion in dense bidirectional graphs.

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1533,14 +1533,6 @@ impl DependencyGraph {
         }
     }
 
-    /// Detect cycles involving a URI.
-    ///
-    /// Returns a `CycleDetection` containing:
-    /// - `outgoing_edge`: the first edge FROM `uri` that leads into the cycle
-    ///   (use this for diagnostic positioning in the queried file)
-    /// - `closing_edge`: the edge that points BACK to `uri` completing the cycle
-    ///   (use this for the diagnostic message details)
-    ///
     /// Collect all URIs reachable from `uri` within `max_depth` hops,
     /// following both forward and backward edges.
     ///
@@ -1632,6 +1624,13 @@ impl DependencyGraph {
         visited
     }
 
+    /// Detect cycles involving a URI.
+    ///
+    /// Returns a `CycleDetection` containing:
+    /// - `outgoing_edge`: the first edge FROM `uri` that leads into the cycle
+    ///   (use this for diagnostic positioning in the queried file)
+    /// - `closing_edge`: the edge that points BACK to `uri` completing the cycle
+    ///   (use this for the diagnostic message details)
     pub fn detect_cycle(&self, uri: &Url) -> Option<CycleDetection> {
         use std::sync::atomic::Ordering;
         let revision = self.edge_revision.load(Ordering::Acquire);

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -634,6 +634,10 @@ pub struct NeighborhoodSubgraph {
 const CYCLE_CACHE_CAPACITY: usize = 4096;
 const SUBGRAPH_CACHE_CAPACITY: usize = 4096;
 
+/// LRU cache of extracted subgraphs keyed by `(root_uri, max_depth, max_visited)`.
+type SubgraphCache =
+    std::sync::RwLock<lru::LruCache<(Url, usize, usize), (u64, std::sync::Arc<NeighborhoodSubgraph>)>>;
+
 /// Dependency graph tracking source relationships between files
 pub struct DependencyGraph {
     /// Forward lookup: parent URI -> edges to children
@@ -655,9 +659,7 @@ pub struct DependencyGraph {
     /// in the snapshot path do refcount bumps rather than re-walking the
     /// graph and cloning edges. Bounded LRU for the same reason as
     /// `cycle_cache`.
-    subgraph_cache: std::sync::RwLock<
-        lru::LruCache<(Url, usize, usize), (u64, std::sync::Arc<NeighborhoodSubgraph>)>,
-    >,
+    subgraph_cache: SubgraphCache,
     /// Counter of subgraph cache hits — exposed for tests.
     subgraph_cache_hits: std::sync::atomic::AtomicU64,
 }

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1047,7 +1047,7 @@ impl DependencyGraph {
 
         // Deduplicate and add all edges
         let mut seen_keys = HashSet::new();
-        for edge in directive_edges.into_iter().chain(ast_edges.into_iter()) {
+        for edge in directive_edges.into_iter().chain(ast_edges) {
             let key = edge.key();
             if !seen_keys.contains(&key) {
                 seen_keys.insert(key);
@@ -1537,8 +1537,8 @@ impl DependencyGraph {
     ///   (use this for diagnostic positioning in the queried file)
     /// - `closing_edge`: the edge that points BACK to `uri` completing the cycle
     ///   (use this for the diagnostic message details)
-    /// Collect all URIs reachable from `uri` within `max_depth` hops,
-    /// following both forward and backward edges.
+    ///   Collect all URIs reachable from `uri` within `max_depth` hops,
+    ///   following both forward and backward edges.
     ///
     /// `max_visited` caps the total number of nodes collected to prevent
     /// unbounded expansion in dense bidirectional graphs.

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -635,8 +635,9 @@ const CYCLE_CACHE_CAPACITY: usize = 4096;
 const SUBGRAPH_CACHE_CAPACITY: usize = 4096;
 
 /// LRU cache of extracted subgraphs keyed by `(root_uri, max_depth, max_visited)`.
-type SubgraphCache =
-    std::sync::RwLock<lru::LruCache<(Url, usize, usize), (u64, std::sync::Arc<NeighborhoodSubgraph>)>>;
+type SubgraphCache = std::sync::RwLock<
+    lru::LruCache<(Url, usize, usize), (u64, std::sync::Arc<NeighborhoodSubgraph>)>,
+>;
 
 /// Dependency graph tracking source relationships between files
 pub struct DependencyGraph {

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -663,7 +663,7 @@ x <- undefined"#;
             let caps = patterns
                 .forward
                 .captures(&line)
-                .expect(&format!("Should match for {}", directive));
+                .unwrap_or_else(|| panic!("Should match for {}", directive));
 
             // Path should be in group 3 (unquoted)
             assert_eq!(

--- a/crates/raven/src/cross_file/integration_tests.rs
+++ b/crates/raven/src/cross_file/integration_tests.rs
@@ -3105,11 +3105,13 @@ mod activity_signal_tests {
         );
 
         // Simulate files needing revalidation
-        let mut files_to_revalidate = [other.clone(),
+        let mut files_to_revalidate = [
+            other.clone(),
             visible2.clone(),
             recent.clone(),
             active.clone(),
-            visible1.clone()];
+            visible1.clone(),
+        ];
 
         // Sort by priority (lower = higher priority)
         files_to_revalidate.sort_by_key(|uri| state.priority_score(uri));

--- a/crates/raven/src/cross_file/integration_tests.rs
+++ b/crates/raven/src/cross_file/integration_tests.rs
@@ -3105,13 +3105,11 @@ mod activity_signal_tests {
         );
 
         // Simulate files needing revalidation
-        let mut files_to_revalidate = vec![
-            other.clone(),
+        let mut files_to_revalidate = [other.clone(),
             visible2.clone(),
             recent.clone(),
             active.clone(),
-            visible1.clone(),
-        ];
+            visible1.clone()];
 
         // Sort by priority (lower = higher priority)
         files_to_revalidate.sort_by_key(|uri| state.priority_score(uri));
@@ -3132,7 +3130,7 @@ mod activity_signal_tests {
         println!("✓ Revalidation prioritization verified:");
         for (i, uri) in files_to_revalidate.iter().enumerate() {
             let priority = state.priority_score(uri);
-            let filename = uri.path().split('/').last().unwrap_or("unknown");
+            let filename = uri.path().split('/').next_back().unwrap_or("unknown");
             println!("  {}. {} (priority: {})", i + 1, filename, priority);
         }
     }

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -9054,6 +9054,7 @@ proptest! {
     /// For any two positions a, b: if a < b, then NOT (b < a).
     /// Also: if a <= b and b <= a, then a == b.
     #[test]
+    #[allow(clippy::nonminimal_bool)] // assert on the negated operator directly to exercise it
     fn prop_position_ordering_antisymmetry(
         line1 in 0..u32::MAX,
         col1 in 0..u32::MAX,
@@ -9065,7 +9066,7 @@ proptest! {
 
         // If pos1 < pos2, then NOT (pos2 < pos1)
         if pos1 < pos2 {
-            prop_assert!((pos2 >= pos1),
+            prop_assert!(!(pos2 < pos1),
                 "Antisymmetry violated: ({}, {}) < ({}, {}) but also ({}, {}) < ({}, {})",
                 line1, col1, line2, col2, line2, col2, line1, col1);
         }
@@ -9083,6 +9084,7 @@ proptest! {
     ///
     /// For any position a: a == a and a <= a and NOT (a < a).
     #[test]
+    #[allow(clippy::nonminimal_bool)] // assert on the negated operator directly to exercise it
     fn prop_position_ordering_reflexivity(
         line in 0..u32::MAX,
         col in 0..u32::MAX,
@@ -9100,7 +9102,7 @@ proptest! {
             line, col, line, col);
 
         // NOT (a < a)
-        prop_assert!((pos >= pos),
+        prop_assert!(!(pos < pos),
             "Irreflexivity violated: ({}, {}) < ({}, {})",
             line, col, line, col);
     }
@@ -9111,6 +9113,7 @@ proptest! {
     /// Specifically: (a == b) implies (a.cmp(&b) == Ordering::Equal)
     /// and (a < b) implies (a.cmp(&b) == Ordering::Less)
     #[test]
+    #[allow(clippy::nonminimal_bool)] // assert on the negated operator directly to exercise it
     fn prop_position_ordering_consistency(
         line1 in 0..u32::MAX,
         col1 in 0..u32::MAX,
@@ -9130,10 +9133,10 @@ proptest! {
                 prop_assert!(pos1 < pos2,
                     "Consistency violated: cmp returned Less but ({}, {}) not < ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 != pos2),
+                prop_assert!(!(pos1 == pos2),
                     "Consistency violated: cmp returned Less but ({}, {}) == ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 <= pos2),
+                prop_assert!(!(pos1 > pos2),
                     "Consistency violated: cmp returned Less but ({}, {}) > ({}, {})",
                     line1, col1, line2, col2);
             }
@@ -9141,10 +9144,10 @@ proptest! {
                 prop_assert!(pos1 == pos2,
                     "Consistency violated: cmp returned Equal but ({}, {}) != ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 >= pos2),
+                prop_assert!(!(pos1 < pos2),
                     "Consistency violated: cmp returned Equal but ({}, {}) < ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 <= pos2),
+                prop_assert!(!(pos1 > pos2),
                     "Consistency violated: cmp returned Equal but ({}, {}) > ({}, {})",
                     line1, col1, line2, col2);
             }
@@ -9152,10 +9155,10 @@ proptest! {
                 prop_assert!(pos1 > pos2,
                     "Consistency violated: cmp returned Greater but ({}, {}) not > ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 != pos2),
+                prop_assert!(!(pos1 == pos2),
                     "Consistency violated: cmp returned Greater but ({}, {}) == ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!((pos1 >= pos2),
+                prop_assert!(!(pos1 < pos2),
                     "Consistency violated: cmp returned Greater but ({}, {}) < ({}, {})",
                     line1, col1, line2, col2);
             }

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -8749,8 +8749,10 @@ proptest! {
     ) {
         // Create some nested intervals by shrinking existing ones
         let mut all_scopes = base_intervals.clone();
-        for i in 0..nested_count.min(base_intervals.len()) {
-            let (sl, sc, el, ec) = base_intervals[i];
+        for &(sl, sc, el, ec) in base_intervals
+            .iter()
+            .take(nested_count.min(base_intervals.len()))
+        {
             // Create a nested interval if possible
             if sl + 1 < el || (sl + 1 == el && sc + 1 < ec) {
                 let nested = (
@@ -11729,14 +11731,7 @@ proptest! {
         let artifacts = compute_artifacts(&uri, &tree, &code);
 
         // Create a package exports callback that returns EMPTY exports
-        let pkg_clone = package.clone();
-        let get_exports = move |p: &str| -> HashSet<String> {
-            if p == pkg_clone {
-                HashSet::new() // Empty exports!
-            } else {
-                HashSet::new()
-            }
-        };
+        let get_exports = move |_p: &str| -> HashSet<String> { HashSet::new() };
 
         let base_exports = HashSet::new();
 

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -3178,9 +3178,9 @@ proptest! {
         };
 
         // Resolve parent multiple times
-        let result1 = resolve_parent(&metadata, &graph, &child_uri, &config, &resolve_path);
-        let result2 = resolve_parent(&metadata, &graph, &child_uri, &config, &resolve_path);
-        let result3 = resolve_parent(&metadata, &graph, &child_uri, &config, &resolve_path);
+        let result1 = resolve_parent(&metadata, &graph, &child_uri, &config, resolve_path);
+        let result2 = resolve_parent(&metadata, &graph, &child_uri, &config, resolve_path);
+        let result3 = resolve_parent(&metadata, &graph, &child_uri, &config, resolve_path);
 
         // All results should be identical (deterministic)
         match (&result1, &result2, &result3) {
@@ -3244,8 +3244,8 @@ proptest! {
             }
         };
 
-        let result_with_line = resolve_parent(&metadata_with_line, &graph, &child_uri, &config, &resolve_path);
-        let result_with_default = resolve_parent(&metadata_with_default, &graph, &child_uri, &config, &resolve_path);
+        let result_with_line = resolve_parent(&metadata_with_line, &graph, &child_uri, &config, resolve_path);
+        let result_with_default = resolve_parent(&metadata_with_default, &graph, &child_uri, &config, resolve_path);
 
         // Both should resolve to the same parent
         match (&result_with_line, &result_with_default) {
@@ -3313,8 +3313,8 @@ proptest! {
             }
         };
 
-        let result1 = resolve_parent(&metadata, &graph, &child_uri, &config, &resolve_path);
-        let result2 = resolve_parent(&metadata, &graph, &child_uri, &config, &resolve_path);
+        let result1 = resolve_parent(&metadata, &graph, &child_uri, &config, resolve_path);
+        let result2 = resolve_parent(&metadata, &graph, &child_uri, &config, resolve_path);
 
         match (&result1, &result2) {
             (
@@ -5015,7 +5015,7 @@ proptest! {
     /// symbols are specified or whether they are currently defined in scope.
     #[test]
     fn prop_rm_bare_symbol_extraction_single(symbol in r_identifier()) {
-        let code = rm_bare_symbols(&[symbol.clone()]);
+        let code = rm_bare_symbols(std::slice::from_ref(&symbol));
         let tree = parse_r(&code);
         let rm_calls = detect_rm_calls(&tree, &code);
 
@@ -5066,7 +5066,7 @@ proptest! {
     /// Removal event SHALL contain exactly those symbol names.
     #[test]
     fn prop_remove_bare_symbol_extraction_single(symbol in r_identifier()) {
-        let code = remove_bare_symbols(&[symbol.clone()]);
+        let code = remove_bare_symbols(std::slice::from_ref(&symbol));
         let tree = parse_r(&code);
         let rm_calls = detect_rm_calls(&tree, &code);
 
@@ -5118,7 +5118,7 @@ proptest! {
     #[test]
     fn prop_rm_bare_symbol_extraction_undefined(symbol in r_identifier()) {
         // Symbol is not defined anywhere, just used in rm()
-        let code = rm_bare_symbols(&[symbol.clone()]);
+        let code = rm_bare_symbols(std::slice::from_ref(&symbol));
         let tree = parse_r(&code);
         let rm_calls = detect_rm_calls(&tree, &code);
 
@@ -5194,8 +5194,8 @@ proptest! {
     /// Test case: Single bare symbol
     #[test]
     fn prop_remove_equivalence_bare_single(symbol in r_identifier()) {
-        let rm_code = rm_bare_symbols(&[symbol.clone()]);
-        let remove_code = remove_bare_symbols(&[symbol.clone()]);
+        let rm_code = rm_bare_symbols(std::slice::from_ref(&symbol));
+        let remove_code = remove_bare_symbols(std::slice::from_ref(&symbol));
 
         let rm_tree = parse_r(&rm_code);
         let remove_tree = parse_r(&remove_code);
@@ -5378,8 +5378,8 @@ proptest! {
     /// Test case: Verify column positions are relative to the call (both start at column 0)
     #[test]
     fn prop_remove_equivalence_column_position(symbol in r_identifier()) {
-        let rm_code = rm_bare_symbols(&[symbol.clone()]);
-        let remove_code = remove_bare_symbols(&[symbol.clone()]);
+        let rm_code = rm_bare_symbols(std::slice::from_ref(&symbol));
+        let remove_code = remove_bare_symbols(std::slice::from_ref(&symbol));
 
         let rm_tree = parse_r(&rm_code);
         let remove_tree = parse_r(&remove_code);
@@ -7698,7 +7698,7 @@ proptest! {
         let package_load_events: Vec<_> = artifacts.timeline.iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { line, column, package: pkg, function_scope } = e {
-                    Some((*line, *column, pkg.clone(), function_scope.clone()))
+                    Some((*line, *column, pkg.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -7928,7 +7928,7 @@ proptest! {
         let package_load_events: Vec<_> = artifacts.timeline.iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { line, column, package: pkg, function_scope } = e {
-                    Some((*line, *column, pkg.clone(), function_scope.clone()))
+                    Some((*line, *column, pkg.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -8006,7 +8006,7 @@ proptest! {
         let package_load_events: Vec<_> = artifacts.timeline.iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { function_scope, package: pkg, .. } = e {
-                    Some((pkg.clone(), function_scope.clone()))
+                    Some((pkg.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -8050,7 +8050,7 @@ proptest! {
         let package_load_events: Vec<_> = artifacts.timeline.iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { line, function_scope, package: pkg, .. } = e {
-                    Some((*line, pkg.clone(), function_scope.clone()))
+                    Some((*line, pkg.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -8130,7 +8130,7 @@ proptest! {
         let package_load_events: Vec<_> = artifacts.timeline.iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { line, package, function_scope, .. } = e {
-                    Some((*line, package.clone(), function_scope.clone()))
+                    Some((*line, package.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -8335,7 +8335,7 @@ proptest! {
             // Query at start position
             let start_results = tree.query_point(interval.start);
             prop_assert!(
-                start_results.iter().any(|i| *i == interval),
+                start_results.contains(&interval),
                 "Interval ({}, {}) - ({}, {}) should contain its start position ({}, {})",
                 sl, sc, el, ec, sl, sc
             );
@@ -8343,7 +8343,7 @@ proptest! {
             // Query at end position
             let end_results = tree.query_point(interval.end);
             prop_assert!(
-                end_results.iter().any(|i| *i == interval),
+                end_results.contains(&interval),
                 "Interval ({}, {}) - ({}, {}) should contain its end position ({}, {})",
                 sl, sc, el, ec, el, ec
             );
@@ -8757,7 +8757,7 @@ proptest! {
                     sl + 1,
                     sc.saturating_add(1).min(99),
                     el.saturating_sub(1).max(sl + 1),
-                    ec.saturating_sub(1).max(0),
+                    ec.saturating_sub(1),
                 );
                 // Only add if valid
                 if (nested.0, nested.1) <= (nested.2, nested.3) {
@@ -9063,7 +9063,7 @@ proptest! {
 
         // If pos1 < pos2, then NOT (pos2 < pos1)
         if pos1 < pos2 {
-            prop_assert!(!(pos2 < pos1),
+            prop_assert!((pos2 >= pos1),
                 "Antisymmetry violated: ({}, {}) < ({}, {}) but also ({}, {}) < ({}, {})",
                 line1, col1, line2, col2, line2, col2, line1, col1);
         }
@@ -9098,7 +9098,7 @@ proptest! {
             line, col, line, col);
 
         // NOT (a < a)
-        prop_assert!(!(pos < pos),
+        prop_assert!((pos >= pos),
             "Irreflexivity violated: ({}, {}) < ({}, {})",
             line, col, line, col);
     }
@@ -9128,10 +9128,10 @@ proptest! {
                 prop_assert!(pos1 < pos2,
                     "Consistency violated: cmp returned Less but ({}, {}) not < ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 == pos2),
+                prop_assert!((pos1 != pos2),
                     "Consistency violated: cmp returned Less but ({}, {}) == ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 > pos2),
+                prop_assert!((pos1 <= pos2),
                     "Consistency violated: cmp returned Less but ({}, {}) > ({}, {})",
                     line1, col1, line2, col2);
             }
@@ -9139,10 +9139,10 @@ proptest! {
                 prop_assert!(pos1 == pos2,
                     "Consistency violated: cmp returned Equal but ({}, {}) != ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 < pos2),
+                prop_assert!((pos1 >= pos2),
                     "Consistency violated: cmp returned Equal but ({}, {}) < ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 > pos2),
+                prop_assert!((pos1 <= pos2),
                     "Consistency violated: cmp returned Equal but ({}, {}) > ({}, {})",
                     line1, col1, line2, col2);
             }
@@ -9150,10 +9150,10 @@ proptest! {
                 prop_assert!(pos1 > pos2,
                     "Consistency violated: cmp returned Greater but ({}, {}) not > ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 == pos2),
+                prop_assert!((pos1 != pos2),
                     "Consistency violated: cmp returned Greater but ({}, {}) == ({}, {})",
                     line1, col1, line2, col2);
-                prop_assert!(!(pos1 < pos2),
+                prop_assert!((pos1 >= pos2),
                     "Consistency violated: cmp returned Greater but ({}, {}) < ({}, {})",
                     line1, col1, line2, col2);
             }
@@ -15693,7 +15693,7 @@ proptest! {
 
         // Test with max_depth = 0: should return None (depth limit reached immediately)
         let result_depth_0 = compute_inherited_working_directory_with_depth(
-            &child_uri, &child_meta, Some(&workspace_uri), &get_metadata, 0,
+            &child_uri, &child_meta, Some(&workspace_uri), get_metadata, 0,
         );
         prop_assert!(
             result_depth_0.is_none(),
@@ -15702,7 +15702,7 @@ proptest! {
 
         // Test with max_depth = 1: should resolve parent's effective WD
         let result_depth_1 = compute_inherited_working_directory_with_depth(
-            &child_uri, &child_meta, Some(&workspace_uri), &get_metadata, 1,
+            &child_uri, &child_meta, Some(&workspace_uri), get_metadata, 1,
         );
         prop_assert!(
             result_depth_1.is_some(),
@@ -15718,7 +15718,7 @@ proptest! {
 
         // Test with sufficient depth (2+): should get parent's explicit WD
         let result_sufficient = compute_inherited_working_directory_with_depth(
-            &child_uri, &child_meta, Some(&workspace_uri), &get_metadata, 2,
+            &child_uri, &child_meta, Some(&workspace_uri), get_metadata, 2,
         );
         prop_assert!(
             result_sufficient.is_some(),
@@ -15845,7 +15845,7 @@ proptest! {
             &uris[last_idx],
             &metadatas[last_idx],
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
             0,
         );
         prop_assert!(
@@ -15858,7 +15858,7 @@ proptest! {
             &uris[last_idx],
             &metadatas[last_idx],
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
             1,
         );
         prop_assert!(
@@ -15886,7 +15886,7 @@ proptest! {
             &uris[last_idx],
             &metadatas[last_idx],
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
             100, // Large enough for any chain
         );
         prop_assert!(
@@ -15957,7 +15957,7 @@ proptest! {
 
         // With max_depth=0, should always return None
         let result = compute_inherited_working_directory_with_depth(
-            &child_uri, &child_meta, Some(&workspace_uri), &get_metadata, 0,
+            &child_uri, &child_meta, Some(&workspace_uri), get_metadata, 0,
         );
 
         prop_assert!(
@@ -16056,7 +16056,7 @@ proptest! {
             &uris[last_idx],
             &metadatas[last_idx],
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
         );
 
         // For chains shorter than DEFAULT_MAX_INHERITANCE_DEPTH, should succeed
@@ -16302,7 +16302,7 @@ proptest! {
             &a_uri,
             &meta_a,
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
         );
 
         // When cycle is detected, the system falls back to the file's directory
@@ -16320,7 +16320,7 @@ proptest! {
         // The result should be some directory in the workspace (either A's, B's, or C's directory
         // depending on where the cycle detection kicks in)
         prop_assert!(
-            a_inherited_path.starts_with(&format!("/{}", workspace)),
+            a_inherited_path.starts_with(format!("/{}", workspace)),
             "Cycle fallback should be within workspace"
         );
     }
@@ -16703,7 +16703,7 @@ proptest! {
             &a_uri,
             &meta_a,
             Some(&workspace_uri),
-            &get_metadata,
+            get_metadata,
         );
 
         // Should get some result (fallback to directory when cycle detected)
@@ -16715,7 +16715,7 @@ proptest! {
         // The result should be within the workspace
         let a_inherited_path = PathBuf::from(a_inherited_wd.as_ref().unwrap());
         prop_assert!(
-            a_inherited_path.starts_with(&format!("/{}", workspace)),
+            a_inherited_path.starts_with(format!("/{}", workspace)),
             "Fallback directory should be within workspace"
         );
     }
@@ -21854,13 +21854,13 @@ proptest! {
         let mut expected_vars = Vec::new();
         let mut expected_funcs = Vec::new();
 
-        for (_i, name) in var_names.iter().enumerate() {
+        for name in var_names.iter() {
             let line_num = lines.len() as u32;
             lines.push(format!("# @lsp-var {}", name));
             expected_vars.push((name.clone(), line_num));
         }
 
-        for (_i, name) in func_names.iter().enumerate() {
+        for name in func_names.iter() {
             let line_num = lines.len() as u32;
             lines.push(format!("# @lsp-func {}", name));
             expected_funcs.push((name.clone(), line_num));

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -11150,7 +11150,7 @@ outside_var <- 2"#;
         assert!(Position::new(1000000, 50000) < Position::new(1000001, 0));
 
         // Test ordering is consistent with Ord trait
-        let mut positions = vec![
+        let mut positions = [
             Position::new(10, 5),
             Position::new(5, 20),
             Position::new(5, 10),
@@ -13641,9 +13641,7 @@ y <- filter(df)"#;
         /// dependency edge derived from `main.R`'s `source()` call (if
         /// any). Returns the components needed for both `ScopeStream::new`
         /// and `scope_at_position_with_graph_cached`.
-        fn build_two_file_fixture(
-            main_code: &str,
-        ) -> (
+        type TwoFileFixture = (
             Url,
             Url,
             Url,
@@ -13652,7 +13650,8 @@ y <- filter(df)"#;
             std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
             std::sync::Arc<crate::cross_file::types::CrossFileMetadata>,
             crate::cross_file::dependency::DependencyGraph,
-        ) {
+        );
+        fn build_two_file_fixture(main_code: &str) -> TwoFileFixture {
             use crate::cross_file::dependency::DependencyGraph;
             use crate::cross_file::types::CrossFileMetadata;
 

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -11153,8 +11153,8 @@ outside_var <- 2"#;
 
         // Equal positions
         assert!(Position::new(5, 10) == Position::new(5, 10));
-        assert!((Position::new(5, 10) >= Position::new(5, 10)));
-        assert!((Position::new(5, 10) <= Position::new(5, 10)));
+        assert!(Position::new(5, 10) >= Position::new(5, 10));
+        assert!(Position::new(5, 10) <= Position::new(5, 10));
 
         // Test with large values
         assert!(Position::new(1000000, 50000) < Position::new(1000001, 0));

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -1967,12 +1967,11 @@ where
                     }
                     // If this is a local-only source (or sys.source into a non-global env), only
                     // make its symbols available within the containing function scope.
-                    if should_apply_local_scoping(source) {
-                        if function_scope.is_none() {
+                    if should_apply_local_scoping(source)
+                        && function_scope.is_none() {
                             // local=TRUE at top-level doesn't contribute to global scope
                             continue;
                         }
-                    }
 
                     // Resolve the path and get symbols from sourced file
                     if let Some(child_uri) = resolve_path(&source.path, uri) {
@@ -3214,7 +3213,7 @@ where
         }
         super::config::BackwardDependencyMode::Auto => {
             let file_has_backward_directives =
-                get_metadata(uri).map_or(false, |m| !m.sourced_by.is_empty());
+                get_metadata(uri).is_some_and(|m| !m.sourced_by.is_empty());
             if file_has_backward_directives {
                 parent_edges.retain(|e| e.is_backward_directive);
             }
@@ -3721,12 +3720,11 @@ where
                 if passes_position || is_global_source {
                     // If this is a local-only source (or sys.source into a non-global env), only
                     // make its symbols available within the containing function scope.
-                    if should_apply_local_scoping(source) {
-                        if function_scope.is_none() {
+                    if should_apply_local_scoping(source)
+                        && function_scope.is_none() {
                             // local=TRUE at top-level doesn't contribute to global scope
                             continue;
                         }
-                    }
 
                     // Resolve the child URI: prefer pre-computed dependency graph edges
                     // (which use workspace-root fallback) over re-resolving the path
@@ -5856,16 +5854,13 @@ mod tests {
         // Verify parent artifacts
         println!("Parent timeline:");
         for event in &parent_artifacts.timeline {
-            match event {
-                ScopeEvent::Def {
+            if let ScopeEvent::Def {
                     line,
                     column,
                     symbol,
                     ..
-                } => {
-                    println!("  Def: {} at ({}, {})", symbol.name, line, column);
-                }
-                _ => {}
+                } = event {
+                println!("  Def: {} at ({}, {})", symbol.name, line, column);
             }
         }
 
@@ -7291,7 +7286,7 @@ outside_var <- 2"#;
         // with function_scope (not just Removal events), otherwise function-local symbols
         // leak into global scope.
         let code = "my_func <- function() { local_var <- 42; local_var }\nglobal_var <- 100";
-        let tree = parse_r(&code);
+        let tree = parse_r(code);
         let metadata = CrossFileMetadata::default();
         let artifacts = compute_artifacts_with_metadata(&test_uri(), &tree, code, Some(&metadata));
 
@@ -7889,8 +7884,7 @@ outside_var <- 2"#;
     #[test]
     fn test_removal_event_sorting_by_position() {
         // Test that Removal events are correctly sorted by (line, column) position
-        let mut events = vec![
-            ScopeEvent::Removal {
+        let mut events = [ScopeEvent::Removal {
                 line: 5,
                 column: 10,
                 symbols: vec!["c".to_string()],
@@ -7913,8 +7907,7 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["d".to_string()],
                 function_scope: None,
-            },
-        ];
+            }];
 
         // Sort using the same key as compute_artifacts
         // Sort by each event's *effect* position so test ordering matches the
@@ -7937,8 +7930,7 @@ outside_var <- 2"#;
     #[test]
     fn test_removal_event_sorting_same_line_different_columns() {
         // Test that Removal events on the same line are sorted by column
-        let mut events = vec![
-            ScopeEvent::Removal {
+        let mut events = [ScopeEvent::Removal {
                 line: 3,
                 column: 20,
                 symbols: vec!["c".to_string()],
@@ -7955,8 +7947,7 @@ outside_var <- 2"#;
                 column: 10,
                 symbols: vec!["b".to_string()],
                 function_scope: None,
-            },
-        ];
+            }];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -7979,8 +7970,7 @@ outside_var <- 2"#;
     fn test_removal_event_mixed_with_def_events() {
         // Test that Removal events sort correctly when mixed with Def events
         let uri = test_uri();
-        let mut events = vec![
-            ScopeEvent::Removal {
+        let mut events = [ScopeEvent::Removal {
                 line: 3,
                 column: 0,
                 symbols: vec!["x".to_string()],
@@ -8017,8 +8007,7 @@ outside_var <- 2"#;
                     is_declared: false,
                 },
                 function_scope: None,
-            },
-        ];
+            }];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -8055,8 +8044,7 @@ outside_var <- 2"#;
         // Test that Removal events sort correctly when mixed with Source events
         use super::super::types::ForwardSource;
 
-        let mut events = vec![
-            ScopeEvent::Removal {
+        let mut events = [ScopeEvent::Removal {
                 line: 2,
                 column: 0,
                 symbols: vec!["x".to_string()],
@@ -8083,8 +8071,7 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["y".to_string()],
                 function_scope: None,
-            },
-        ];
+            }];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -8110,8 +8097,7 @@ outside_var <- 2"#;
         use super::super::types::ForwardSource;
 
         let uri = test_uri();
-        let mut events = vec![
-            ScopeEvent::Removal {
+        let mut events = [ScopeEvent::Removal {
                 line: 5,
                 column: 0,
                 symbols: vec!["z".to_string()],
@@ -8161,8 +8147,7 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["w".to_string()],
                 function_scope: None,
-            },
-        ];
+            }];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -11158,8 +11143,8 @@ outside_var <- 2"#;
 
         // Equal positions
         assert!(Position::new(5, 10) == Position::new(5, 10));
-        assert!(!(Position::new(5, 10) < Position::new(5, 10)));
-        assert!(!(Position::new(5, 10) > Position::new(5, 10)));
+        assert!((Position::new(5, 10) >= Position::new(5, 10)));
+        assert!((Position::new(5, 10) <= Position::new(5, 10)));
 
         // Test with large values
         assert!(Position::new(1000000, 50000) < Position::new(1000001, 0));
@@ -11278,7 +11263,7 @@ outside_var <- 2"#;
                     function_scope,
                 } = e
                 {
-                    Some((*line, *column, package.clone(), function_scope.clone()))
+                    Some((*line, *column, package.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -11450,7 +11435,7 @@ outside_var <- 2"#;
             .iter()
             .filter_map(|e| {
                 if let ScopeEvent::PackageLoad { function_scope, .. } = e {
-                    Some(function_scope.clone())
+                    Some(*function_scope)
                 } else {
                     None
                 }
@@ -11497,7 +11482,7 @@ outside_var <- 2"#;
                     ..
                 } = e
                 {
-                    Some((package.clone(), function_scope.clone()))
+                    Some((package.clone(), *function_scope))
                 } else {
                     None
                 }
@@ -12204,7 +12189,7 @@ x <- 1"#;
 
         // Child should have inherited dplyr from parent
         assert!(
-            scope.inherited_packages.contains(&"dplyr".to_string()),
+            scope.inherited_packages.contains("dplyr"),
             "Child should inherit dplyr package from parent"
         );
     }
@@ -12284,7 +12269,7 @@ x <- 1"#;
 
         // Child should NOT have dplyr (it was loaded after source() call)
         assert!(
-            !scope.inherited_packages.contains(&"dplyr".to_string()),
+            !scope.inherited_packages.contains("dplyr"),
             "Child should NOT inherit dplyr (loaded after source() call)"
         );
     }
@@ -12364,11 +12349,11 @@ x <- 1"#;
 
         // Child should have both packages
         assert!(
-            scope.inherited_packages.contains(&"dplyr".to_string()),
+            scope.inherited_packages.contains("dplyr"),
             "Child should inherit dplyr from parent"
         );
         assert!(
-            scope.inherited_packages.contains(&"ggplot2".to_string()),
+            scope.inherited_packages.contains("ggplot2"),
             "Child should inherit ggplot2 from parent"
         );
     }
@@ -12449,7 +12434,7 @@ x <- 1"#;
 
         // Child should NOT have dplyr (it's function-scoped in parent)
         assert!(
-            !scope.inherited_packages.contains(&"dplyr".to_string()),
+            !scope.inherited_packages.contains("dplyr"),
             "Child should NOT inherit function-scoped dplyr from parent"
         );
     }
@@ -12523,7 +12508,7 @@ x <- 1"#;
         );
 
         assert!(
-            scope.inherited_packages.contains(&"dplyr".to_string()),
+            scope.inherited_packages.contains("dplyr"),
             "Child should inherit dplyr when a nested local source() call runs inside an outer function that loaded it"
         );
     }
@@ -12610,7 +12595,7 @@ x <- 1"#;
         // Parent should have dplyr (loaded in child, available after source())
         // Packages from sourced files go into loaded_packages, not inherited_packages
         assert!(
-            scope.loaded_packages.contains(&"dplyr".to_string()),
+            scope.loaded_packages.contains("dplyr"),
             "Parent should have dplyr from child (package propagation via loaded_packages)"
         );
     }
@@ -12697,7 +12682,7 @@ x <- 1"#;
 
         // Packages from child should be in parent's loaded_packages (not inherited_packages)
         assert!(
-            scope.loaded_packages.contains(&"ggplot2".to_string()),
+            scope.loaded_packages.contains("ggplot2"),
             "Parent should have ggplot2 from child (package propagation via loaded_packages)"
         );
     }
@@ -12813,7 +12798,7 @@ x <- 1"#;
         assert!(
             grandparent_scope
                 .loaded_packages
-                .contains(&"stringr".to_string()),
+                .contains("stringr"),
             "Grandparent should have stringr from grandchild (package propagation via loaded_packages)"
         );
 
@@ -12838,7 +12823,7 @@ x <- 1"#;
         assert!(
             parent_scope
                 .loaded_packages
-                .contains(&"stringr".to_string()),
+                .contains("stringr"),
             "Parent should have stringr from child (package propagation via loaded_packages)"
         );
     }
@@ -12921,7 +12906,7 @@ x <- 1"#;
         assert!(
             child_scope
                 .inherited_packages
-                .contains(&"dplyr".to_string()),
+                .contains("dplyr"),
             "Child should inherit dplyr from parent (forward propagation works)"
         );
 
@@ -12946,7 +12931,7 @@ x <- 1"#;
         assert!(
             parent_scope
                 .loaded_packages
-                .contains(&"ggplot2".to_string()),
+                .contains("ggplot2"),
             "Parent should have ggplot2 from child (package propagation via loaded_packages)"
         );
     }
@@ -13104,7 +13089,7 @@ x <- 1"#;
         assert!(
             abortions_scope
                 .inherited_packages
-                .contains(&"plyr".to_string()),
+                .contains("plyr"),
             "abortions.r should inherit plyr from sibling functions.r via main.r chain. \
              inherited_packages: {:?}",
             abortions_scope.inherited_packages
@@ -13207,7 +13192,7 @@ x <- 1"#;
         );
 
         assert!(
-            b_scope.inherited_packages.contains(&"dplyr".to_string()),
+            b_scope.inherited_packages.contains("dplyr"),
             "b.r should inherit dplyr from sibling a.r via parent's forward path. \
              inherited_packages: {:?}",
             b_scope.inherited_packages
@@ -13231,7 +13216,7 @@ x <- 1"#;
         );
 
         assert!(
-            parent_scope.loaded_packages.contains(&"dplyr".to_string()),
+            parent_scope.loaded_packages.contains("dplyr"),
             "Parent should have dplyr in loaded_packages after processing source(\"a.r\"). \
              loaded_packages: {:?}",
             parent_scope.loaded_packages
@@ -13254,14 +13239,14 @@ x <- 1"#;
         // Query at line 0 (before library call) - should NOT have dplyr in loaded_packages
         let scope_before = scope_at_position(&artifacts, 0, 10, false);
         assert!(
-            !scope_before.loaded_packages.contains(&"dplyr".to_string()),
+            !scope_before.loaded_packages.contains("dplyr"),
             "dplyr should NOT be in loaded_packages before library() call"
         );
 
         // Query at line 2 (after library call) - should have dplyr in loaded_packages
         let scope_after = scope_at_position(&artifacts, 2, 10, false);
         assert!(
-            scope_after.loaded_packages.contains(&"dplyr".to_string()),
+            scope_after.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages after library() call"
         );
     }
@@ -13276,22 +13261,22 @@ x <- 1"#;
         // Query at line 0 (after first library, before second)
         let scope_mid = scope_at_position(&artifacts, 0, 20, false);
         assert!(
-            scope_mid.loaded_packages.contains(&"dplyr".to_string()),
+            scope_mid.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages after first library() call"
         );
         assert!(
-            !scope_mid.loaded_packages.contains(&"ggplot2".to_string()),
+            !scope_mid.loaded_packages.contains("ggplot2"),
             "ggplot2 should NOT be in loaded_packages before second library() call"
         );
 
         // Query at line 2 (after both library calls)
         let scope_end = scope_at_position(&artifacts, 2, 10, false);
         assert!(
-            scope_end.loaded_packages.contains(&"dplyr".to_string()),
+            scope_end.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages"
         );
         assert!(
-            scope_end.loaded_packages.contains(&"ggplot2".to_string()),
+            scope_end.loaded_packages.contains("ggplot2"),
             "ggplot2 should be in loaded_packages"
         );
     }
@@ -13310,14 +13295,14 @@ y <- filter(df)"#;
         // Query inside the function (line 2) - should have dplyr
         let scope_inside = scope_at_position(&artifacts, 2, 10, false);
         assert!(
-            scope_inside.loaded_packages.contains(&"dplyr".to_string()),
+            scope_inside.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages inside function"
         );
 
         // Query outside the function (line 4) - should NOT have dplyr
         let scope_outside = scope_at_position(&artifacts, 4, 10, false);
         assert!(
-            !scope_outside.loaded_packages.contains(&"dplyr".to_string()),
+            !scope_outside.loaded_packages.contains("dplyr"),
             "dplyr should NOT be in loaded_packages outside function (function-scoped)"
         );
     }
@@ -13331,7 +13316,7 @@ y <- filter(df)"#;
 
         let scope = scope_at_position(&artifacts, 1, 10, false);
         assert!(
-            scope.loaded_packages.contains(&"dplyr".to_string()),
+            scope.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages after require() call"
         );
     }
@@ -13345,7 +13330,7 @@ y <- filter(df)"#;
 
         let scope = scope_at_position(&artifacts, 1, 10, false);
         assert!(
-            scope.loaded_packages.contains(&"dplyr".to_string()),
+            scope.loaded_packages.contains("dplyr"),
             "dplyr should be in loaded_packages after loadNamespace() call"
         );
     }

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -1013,6 +1013,7 @@ fn annotate_event_function_scopes(artifacts: &mut ScopeArtifacts) {
                 // Non-local source() (the default) evaluates in .GlobalEnv,
                 // so its symbols should be globally visible regardless of
                 // where the call site is.
+                #[allow(clippy::collapsible_match)] // guard would break match exhaustiveness
                 if should_apply_local_scoping(source) {
                     *function_scope = find_containing_function_scope(
                         &artifacts.function_scope_tree,

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -1968,11 +1968,10 @@ where
                     }
                     // If this is a local-only source (or sys.source into a non-global env), only
                     // make its symbols available within the containing function scope.
-                    if should_apply_local_scoping(source)
-                        && function_scope.is_none() {
-                            // local=TRUE at top-level doesn't contribute to global scope
-                            continue;
-                        }
+                    if should_apply_local_scoping(source) && function_scope.is_none() {
+                        // local=TRUE at top-level doesn't contribute to global scope
+                        continue;
+                    }
 
                     // Resolve the path and get symbols from sourced file
                     if let Some(child_uri) = resolve_path(&source.path, uri) {
@@ -3721,11 +3720,10 @@ where
                 if passes_position || is_global_source {
                     // If this is a local-only source (or sys.source into a non-global env), only
                     // make its symbols available within the containing function scope.
-                    if should_apply_local_scoping(source)
-                        && function_scope.is_none() {
-                            // local=TRUE at top-level doesn't contribute to global scope
-                            continue;
-                        }
+                    if should_apply_local_scoping(source) && function_scope.is_none() {
+                        // local=TRUE at top-level doesn't contribute to global scope
+                        continue;
+                    }
 
                     // Resolve the child URI: prefer pre-computed dependency graph edges
                     // (which use workspace-root fallback) over re-resolving the path
@@ -5856,11 +5854,12 @@ mod tests {
         println!("Parent timeline:");
         for event in &parent_artifacts.timeline {
             if let ScopeEvent::Def {
-                    line,
-                    column,
-                    symbol,
-                    ..
-                } = event {
+                line,
+                column,
+                symbol,
+                ..
+            } = event
+            {
                 println!("  Def: {} at ({}, {})", symbol.name, line, column);
             }
         }
@@ -7885,7 +7884,8 @@ outside_var <- 2"#;
     #[test]
     fn test_removal_event_sorting_by_position() {
         // Test that Removal events are correctly sorted by (line, column) position
-        let mut events = [ScopeEvent::Removal {
+        let mut events = [
+            ScopeEvent::Removal {
                 line: 5,
                 column: 10,
                 symbols: vec!["c".to_string()],
@@ -7908,7 +7908,8 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["d".to_string()],
                 function_scope: None,
-            }];
+            },
+        ];
 
         // Sort using the same key as compute_artifacts
         // Sort by each event's *effect* position so test ordering matches the
@@ -7931,7 +7932,8 @@ outside_var <- 2"#;
     #[test]
     fn test_removal_event_sorting_same_line_different_columns() {
         // Test that Removal events on the same line are sorted by column
-        let mut events = [ScopeEvent::Removal {
+        let mut events = [
+            ScopeEvent::Removal {
                 line: 3,
                 column: 20,
                 symbols: vec!["c".to_string()],
@@ -7948,7 +7950,8 @@ outside_var <- 2"#;
                 column: 10,
                 symbols: vec!["b".to_string()],
                 function_scope: None,
-            }];
+            },
+        ];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -7971,7 +7974,8 @@ outside_var <- 2"#;
     fn test_removal_event_mixed_with_def_events() {
         // Test that Removal events sort correctly when mixed with Def events
         let uri = test_uri();
-        let mut events = [ScopeEvent::Removal {
+        let mut events = [
+            ScopeEvent::Removal {
                 line: 3,
                 column: 0,
                 symbols: vec!["x".to_string()],
@@ -8008,7 +8012,8 @@ outside_var <- 2"#;
                     is_declared: false,
                 },
                 function_scope: None,
-            }];
+            },
+        ];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -8045,7 +8050,8 @@ outside_var <- 2"#;
         // Test that Removal events sort correctly when mixed with Source events
         use super::super::types::ForwardSource;
 
-        let mut events = [ScopeEvent::Removal {
+        let mut events = [
+            ScopeEvent::Removal {
                 line: 2,
                 column: 0,
                 symbols: vec!["x".to_string()],
@@ -8072,7 +8078,8 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["y".to_string()],
                 function_scope: None,
-            }];
+            },
+        ];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -8098,7 +8105,8 @@ outside_var <- 2"#;
         use super::super::types::ForwardSource;
 
         let uri = test_uri();
-        let mut events = [ScopeEvent::Removal {
+        let mut events = [
+            ScopeEvent::Removal {
                 line: 5,
                 column: 0,
                 symbols: vec!["z".to_string()],
@@ -8148,7 +8156,8 @@ outside_var <- 2"#;
                 column: 0,
                 symbols: vec!["w".to_string()],
                 function_scope: None,
-            }];
+            },
+        ];
 
         // Sort by each event's *effect* position so test ordering matches the
         // production timeline sort (Def events use `visible_from_*`, all others
@@ -12822,9 +12831,7 @@ x <- 1"#;
 
         // Parent should also have stringr (loaded in child, propagated via loaded_packages)
         assert!(
-            parent_scope
-                .loaded_packages
-                .contains("stringr"),
+            parent_scope.loaded_packages.contains("stringr"),
             "Parent should have stringr from child (package propagation via loaded_packages)"
         );
     }
@@ -12905,9 +12912,7 @@ x <- 1"#;
 
         // Child SHOULD have dplyr (propagated from parent)
         assert!(
-            child_scope
-                .inherited_packages
-                .contains("dplyr"),
+            child_scope.inherited_packages.contains("dplyr"),
             "Child should inherit dplyr from parent (forward propagation works)"
         );
 
@@ -12930,9 +12935,7 @@ x <- 1"#;
 
         // Parent should have ggplot2 (loaded in child, propagated via loaded_packages)
         assert!(
-            parent_scope
-                .loaded_packages
-                .contains("ggplot2"),
+            parent_scope.loaded_packages.contains("ggplot2"),
             "Parent should have ggplot2 from child (package propagation via loaded_packages)"
         );
     }
@@ -13088,9 +13091,7 @@ x <- 1"#;
         );
 
         assert!(
-            abortions_scope
-                .inherited_packages
-                .contains("plyr"),
+            abortions_scope.inherited_packages.contains("plyr"),
             "abortions.r should inherit plyr from sibling functions.r via main.r chain. \
              inherited_packages: {:?}",
             abortions_scope.inherited_packages

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -2618,38 +2618,22 @@ mod property_tests {
         use_named_arg: bool,
     }
 
-    /// Generates an arbitrary `LibraryCallSpec` strategy for property-based tests.
-
-    ///
-
-    /// The strategy produces tuples describing a library-like call: the function name (`library`, `require`, or `loadNamespace`),
-
-    /// a package name, the string quote style to use (none, single, or double), and a boolean indicating whether the package
-
-    /// is supplied with a named `package=` argument.
-
-    ///
-
-    /// # Examples
-
-    ///
-
-    /// ```
-
-    /// use proptest::prelude::*;
-
-    ///
-
-    /// let mut runner = proptest::test_runner::TestRunner::default();
-
-    /// let tree = library_call_spec().new_tree(&mut runner).unwrap();
-
-    /// let spec = tree.current();
-
-    /// // `spec` contains generated fields: `func`, `package`, `quote_style`, and `use_named_arg`.
-
-    /// assert!(!spec.package.is_empty());
-
+    /// Generates an arbitrary `LibraryCallSpec` strategy for property-based tests.    ///
+    ///    ///
+    /// The strategy produces tuples describing a library-like call: the function name (`library`, `require`, or `loadNamespace`),    ///
+    /// a package name, the string quote style to use (none, single, or double), and a boolean indicating whether the package    ///
+    /// is supplied with a named `package=` argument.    ///
+    ///    ///
+    /// # Examples    ///
+    ///    ///
+    /// ```    ///
+    /// use proptest::prelude::*;    ///
+    ///    ///
+    /// let mut runner = proptest::test_runner::TestRunner::default();    ///
+    /// let tree = library_call_spec().new_tree(&mut runner).unwrap();    ///
+    /// let spec = tree.current();    ///
+    /// // `spec` contains generated fields: `func`, `package`, `quote_style`, and `use_named_arg`.    ///
+    /// assert!(!spec.package.is_empty());    ///
     /// ```
     fn library_call_spec() -> impl Strategy<Value = LibraryCallSpec> {
         (

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -2618,22 +2618,22 @@ mod property_tests {
         use_named_arg: bool,
     }
 
-    /// Generates an arbitrary `LibraryCallSpec` strategy for property-based tests.    ///
-    ///    ///
-    /// The strategy produces tuples describing a library-like call: the function name (`library`, `require`, or `loadNamespace`),    ///
-    /// a package name, the string quote style to use (none, single, or double), and a boolean indicating whether the package    ///
-    /// is supplied with a named `package=` argument.    ///
-    ///    ///
-    /// # Examples    ///
-    ///    ///
-    /// ```    ///
-    /// use proptest::prelude::*;    ///
-    ///    ///
-    /// let mut runner = proptest::test_runner::TestRunner::default();    ///
-    /// let tree = library_call_spec().new_tree(&mut runner).unwrap();    ///
-    /// let spec = tree.current();    ///
-    /// // `spec` contains generated fields: `func`, `package`, `quote_style`, and `use_named_arg`.    ///
-    /// assert!(!spec.package.is_empty());    ///
+    /// Generates an arbitrary `LibraryCallSpec` strategy for property-based tests.
+    ///
+    /// The strategy produces tuples describing a library-like call: the function name (`library`, `require`, or `loadNamespace`),
+    /// a package name, the string quote style to use (none, single, or double), and a boolean indicating whether the package
+    /// is supplied with a named `package=` argument.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use proptest::prelude::*;
+    ///
+    /// let mut runner = proptest::test_runner::TestRunner::default();
+    /// let tree = library_call_spec().new_tree(&mut runner).unwrap();
+    /// let spec = tree.current();
+    /// // `spec` contains generated fields: `func`, `package`, `quote_style`, and `use_named_arg`.
+    /// assert!(!spec.package.is_empty());
     /// ```
     fn library_call_spec() -> impl Strategy<Value = LibraryCallSpec> {
         (

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -1709,11 +1709,7 @@ mod tests {
                 }
 
                 // Calculate expected evictions
-                let expected_evictions = if num_unique_docs > max_documents {
-                    num_unique_docs - max_documents
-                } else {
-                    0
-                };
+                let expected_evictions = num_unique_docs.saturating_sub(max_documents);
 
                 assert_eq!(
                     store.metrics().evictions,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3534,8 +3534,8 @@ impl BlockDetector {
             } else {
                 // Scan forward from the line after the keyword for the opening brace
                 let mut found = None;
-                for scan_line in (keyword_line + 1)..total_lines {
-                    if let Some(col) = lines[scan_line].find('{') {
+                for (scan_line, &line) in lines.iter().enumerate().skip(keyword_line + 1) {
+                    if let Some(col) = line.find('{') {
                         found = Some((scan_line, col));
                         break;
                     }
@@ -10695,6 +10695,9 @@ fn classify_comment_for_ignore(
     let prefix = line_text.get(..start_col).unwrap_or("");
     let standalone = prefix.trim().is_empty();
 
+    // Collapsing these inner `if`s into match guards would force a wildcard
+    // arm and lose exhaustiveness over `LspIgnoreKind` variants.
+    #[allow(clippy::collapsible_match)]
     match classify_lsp_ignore_marker(body) {
         Some(LspIgnoreKind::SameLine) => {
             // Inline `# @lsp-ignore` suppresses *this* line — but only
@@ -27662,8 +27665,8 @@ mod proptests {
             let param_count = param_count.min(has_defaults.len());
             let mut params = Vec::new();
 
-            for i in 0..param_count {
-                if has_defaults[i] {
+            for (i, &has_default) in has_defaults.iter().enumerate().take(param_count) {
+                if has_default {
                     params.push(format!("p{} = {}", i, i + 1));
                 } else {
                     params.push(format!("p{}", i));
@@ -33944,8 +33947,7 @@ setClass("{}", slots = c(value = "numeric"))
             for i in 0..expected_sections.len() {
                 let (current_start, current_level) = expected_sections[i];
                 let mut end_line = line_count - 1; // default: EOF
-                for j in (i + 1)..expected_sections.len() {
-                    let (next_start, next_level) = expected_sections[j];
+                for &(next_start, next_level) in expected_sections.iter().skip(i + 1) {
                     if next_level <= current_level {
                         // Found sibling or ancestor
                         end_line = if next_start > 0 { next_start - 1 } else { 0 };
@@ -34133,8 +34135,7 @@ setClass("{}", slots = c(value = "numeric"))
             for i in 0..sections_info.len() {
                 let (start, level, ref name) = sections_info[i];
                 let mut end_line = line_count - 1; // default: EOF
-                for j in (i + 1)..sections_info.len() {
-                    let (next_start, next_level, _) = sections_info[j];
+                for &(next_start, next_level, _) in sections_info.iter().skip(i + 1) {
                     if next_level <= level {
                         end_line = if next_start > 0 { next_start - 1 } else { 0 };
                         break;
@@ -35103,15 +35104,16 @@ setClass("{}", slots = c(value = "numeric"))
     ///      The result.
     /// ```
     fn build_rd_help_text(params: &[(String, String)]) -> String {
-        let mut lines = Vec::new();
-        lines.push("Function Title".to_string());
-        lines.push(String::new());
-        lines.push("Description:".to_string());
-        lines.push(String::new());
-        lines.push("     Some description of the function.".to_string());
-        lines.push(String::new());
-        lines.push("Arguments:".to_string());
-        lines.push(String::new());
+        let mut lines = vec![
+            "Function Title".to_string(),
+            String::new(),
+            "Description:".to_string(),
+            String::new(),
+            "     Some description of the function.".to_string(),
+            String::new(),
+            "Arguments:".to_string(),
+            String::new(),
+        ];
 
         for (name, desc) in params {
             // Rd2txt format: indented name followed by ": " and description.

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5040,8 +5040,8 @@ fn collect_redundant_directive_diagnostics_from_snapshot(
         .collect();
 
     for edge in &deps {
-        if edge.is_directive && !edge.is_backward_directive {
-            if ast_targets.contains(&edge.to) {
+        if edge.is_directive && !edge.is_backward_directive
+            && ast_targets.contains(&edge.to) {
                 let line = edge.call_site_line.unwrap_or(0);
                 let target_name = edge
                     .to
@@ -5061,7 +5061,6 @@ fn collect_redundant_directive_diagnostics_from_snapshot(
                     ..Default::default()
                 });
             }
-        }
     }
 }
 
@@ -5463,10 +5462,10 @@ fn collect_undefined_variables_from_snapshot(
         .unwrap_or_default();
 
     let parent_symbol_names: HashSet<String> = {
-        if !scope_cache.contains_key(&(0, 0)) {
-            let computed = snapshot.get_scope(uri, 0, 0, cancel);
-            scope_cache.insert((0, 0), computed);
-        }
+        scope_cache.entry((0, 0)).or_insert_with(|| {
+            
+            snapshot.get_scope(uri, 0, 0, cancel)
+        });
         let scope_0_0 = scope_cache.get(&(0, 0)).unwrap();
         // Only include symbols from OTHER files. When a parent sources this file,
         // the file's own exports flow into the parent's scope and back here via
@@ -8827,7 +8826,7 @@ mod syntax_error_range_tests {
             // (b) a MISSING node exists inside the ERROR (Phase 1 took priority)
             for &(s_row, s_col, e_row, e_col) in &single_line_errors {
                 let error_node = find_error_at(root, s_row, s_col);
-                let has_missing = error_node.map_or(false, |n| has_missing_descendant(n));
+                let has_missing = error_node.is_some_and(|n| has_missing_descendant(n));
 
                 if has_missing {
                     // Phase 1 (MISSING priority) may override the range — that's OK
@@ -10523,7 +10522,7 @@ fn ts_start_to_lsp(node: Node, text: &str) -> Position {
     let line_text = text.lines().nth(row).unwrap_or("");
     Position::new(
         row as u32,
-        byte_offset_to_utf16_column(line_text, node.start_position().column) as u32,
+        byte_offset_to_utf16_column(line_text, node.start_position().column),
     )
 }
 
@@ -10535,7 +10534,7 @@ fn ts_end_to_lsp(node: Node, text: &str) -> Position {
     let line_text = text.lines().nth(row).unwrap_or("");
     Position::new(
         row as u32,
-        byte_offset_to_utf16_column(line_text, node.end_position().column) as u32,
+        byte_offset_to_utf16_column(line_text, node.end_position().column),
     )
 }
 
@@ -10862,7 +10861,7 @@ fn classify_target(node: Node, text: &str) -> Option<TargetClassification> {
             label,
         });
     }
-    if let Some(label) = suspicious_target_kind(node, text) {
+    if let Some(label) = suspicious_target_kind(node) {
         return Some(TargetClassification {
             severity: DiagnosticSeverity::WARNING,
             label,
@@ -10950,7 +10949,7 @@ fn unary_operator_text<'a>(node: Node<'_>, text: &'a str) -> Option<&'a str> {
 /// Classify an assignment-target node as suspicious (R accepts, but the
 /// binding is almost certainly unintended). Returns `Some(label)` for cases
 /// like `"foo" <- 1`, `... <- 1`, `..N <- 1`.
-fn suspicious_target_kind(node: Node, text: &str) -> Option<&'static str> {
+fn suspicious_target_kind(node: Node) -> Option<&'static str> {
     match node.kind() {
         "string" => Some("string literal"),
         "dots" => Some("dots"),
@@ -10959,7 +10958,7 @@ fn suspicious_target_kind(node: Node, text: &str) -> Option<&'static str> {
         // `("foo") <- 1` and `(... ) <- 1` keep getting the WARNING tier.
         "parenthesized_expression" => {
             let inner = node.child_by_field_name("body")?;
-            suspicious_target_kind(inner, text)
+            suspicious_target_kind(inner)
         }
         _ => None,
     }
@@ -11707,10 +11706,10 @@ fn collect_stan_identifier_occurrences(text: &str) -> Vec<StanIdentifierOccurren
     occurrences
 }
 
-fn stan_identifier_at_position<'a>(
-    occurrences: &'a [StanIdentifierOccurrence],
+fn stan_identifier_at_position(
+    occurrences: &[StanIdentifierOccurrence],
     position: Position,
-) -> Option<&'a StanIdentifierOccurrence> {
+) -> Option<&StanIdentifierOccurrence> {
     occurrences.iter().find(|occurrence| {
         occurrence.line == position.line
             && position.character >= occurrence.start_col
@@ -13020,11 +13019,7 @@ pub fn extract_definition_statement(
     // Get content provider for the symbol's source file
     let content = if let Some(doc) = state.documents.get(&symbol.source_uri) {
         doc.text()
-    } else if let Some(cached) = state.cross_file_file_cache.get(&symbol.source_uri) {
-        cached
-    } else {
-        return None;
-    };
+    } else { state.cross_file_file_cache.get(&symbol.source_uri)? };
 
     // Get tree for parsing
     let tree = if let Some(doc) = state.documents.get(&symbol.source_uri) {
@@ -16481,7 +16476,7 @@ result <- "#;
                     helper_item
                         .detail
                         .as_ref()
-                        .map_or(false, |d| d.contains("{testpkg}")),
+                        .is_some_and(|d| d.contains("{testpkg}")),
                     "helper_func should have package attribution {{testpkg}}"
                 );
             } else {
@@ -16614,7 +16609,7 @@ result <- "#;
                     filter_items[0]
                         .detail
                         .as_ref()
-                        .map_or(false, |d| d.contains("{dplyr}")),
+                        .is_some_and(|d| d.contains("{dplyr}")),
                     "'filter' should have package attribution {{dplyr}}"
                 );
 
@@ -16626,7 +16621,7 @@ result <- "#;
                     select_items[0]
                         .detail
                         .as_ref()
-                        .map_or(false, |d| d.contains("{dplyr}")),
+                        .is_some_and(|d| d.contains("{dplyr}")),
                     "'select' should have package attribution {{dplyr}}"
                 );
 
@@ -16702,10 +16697,10 @@ x <- "#;
                 // Both packages should be represented
                 let has_pkg1 = common_items
                     .iter()
-                    .any(|item| item.detail.as_ref().map_or(false, |d| d.contains("{pkg1}")));
+                    .any(|item| item.detail.as_ref().is_some_and(|d| d.contains("{pkg1}")));
                 let has_pkg2 = common_items
                     .iter()
-                    .any(|item| item.detail.as_ref().map_or(false, |d| d.contains("{pkg2}")));
+                    .any(|item| item.detail.as_ref().is_some_and(|d| d.contains("{pkg2}")));
                 assert!(has_pkg1, "'common_func' should have entry from pkg1");
                 assert!(has_pkg2, "'common_func' should have entry from pkg2");
 
@@ -16784,7 +16779,7 @@ x <- "#;
                     assert!(
                         item.sort_text
                             .as_ref()
-                            .map_or(false, |s| s.starts_with("0-")),
+                            .is_some_and(|s| s.starts_with("0-")),
                         "Parameter item '{}' should have sort_text starting with '0-', got {:?}",
                         item.label,
                         item.sort_text
@@ -16830,7 +16825,7 @@ x <- "#;
                     x_item
                         .insert_text
                         .as_ref()
-                        .map_or(false, |t| t.contains("= ")),
+                        .is_some_and(|t| t.contains("= ")),
                     "Parameter 'x' insert_text should contain '= ', got {:?}",
                     x_item.insert_text
                 );
@@ -27604,7 +27599,7 @@ mod proptests {
 
             prop_assert!(defined.contains(&var_name));
             prop_assert!(defined.contains(&func_name));
-            prop_assert!(is_builtin(&builtin));
+            prop_assert!(is_builtin(builtin));
         }
 
         #[test]
@@ -27908,12 +27903,12 @@ mod proptests {
             state.documents.insert(uri.clone(), Document::new(&code, None));
 
             // Should return user-defined signature, not built-in
-            let signature = find_user_function_signature(&state, &uri, &builtin);
+            let signature = find_user_function_signature(&state, &uri, builtin);
             prop_assert!(signature.is_some(), "Should find user-defined function");
 
             if let Some(sig) = signature {
                 prop_assert!(sig.contains("(x, y)"), "Should return user-defined signature: {}", sig);
-                prop_assert!(sig.contains(&builtin), "Should contain function name: {}", sig);
+                prop_assert!(sig.contains(builtin), "Should contain function name: {}", sig);
             }
         }
 
@@ -28254,7 +28249,7 @@ mod proptests {
             let info = def_info.unwrap();
             let statement = &info.statement;
             prop_assert_eq!(statement, &code, "Should include complete assignment statement");
-            prop_assert!(statement.contains(&op), "Should include assignment operator {}", op);
+            prop_assert!(statement.contains(op), "Should include assignment operator {}", op);
         }
 
         #[test]
@@ -32440,11 +32435,7 @@ setClass("{}", slots = c(value = "numeric"))
         ) {
             // Ensure the comment doesn't accidentally match the section pattern
             let clean_text = comment_text
-                .replace('-', " ")
-                .replace('#', " ")
-                .replace('=', " ")
-                .replace('*', " ")
-                .replace('+', " ");
+                .replace(['-', '#', '=', '*', '+'], " ");
             let code = format!("# {}\nx <- 1", clean_text.trim());
 
             let tree = parse_r_code(&code);
@@ -34340,7 +34331,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // Collect parameter completion items (those with sort_text starting with "0-")
                 let param_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -34521,7 +34512,7 @@ setClass("{}", slots = c(value = "numeric"))
             if let Some(CompletionResponse::Array(items)) = completions {
                 let param_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -34564,7 +34555,7 @@ setClass("{}", slots = c(value = "numeric"))
             if let Some(CompletionResponse::Array(items_nm)) = completions_nm {
                 let param_items_nm: Vec<&CompletionItem> = items_nm.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -34656,7 +34647,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // Parameter items are identified by sort_text starting with "0-".
                 let param_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -34674,7 +34665,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // (belt-and-suspenders check)
                 let param_detail_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.detail.as_ref().map_or(false, |d| d == "parameter")
+                        item.detail.as_ref().is_some_and(|d| d == "parameter")
                     })
                     .collect();
 
@@ -34775,7 +34766,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // --- Check 1: Parameter items are present (sort_text starts with "0-") ---
                 let param_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -34806,7 +34797,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // 2a: Keywords should be present (sort_text starts with "5-")
                 let keyword_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("5-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("5-"))
                             && item.kind == Some(CompletionItemKind::KEYWORD)
                     })
                     .collect();
@@ -34822,7 +34813,7 @@ setClass("{}", slots = c(value = "numeric"))
                 // 2b: Local variable definitions should be present (sort_text starts with "1-")
                 let scope_items: Vec<&CompletionItem> = items.iter()
                     .filter(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| st.starts_with("1-"))
+                        item.sort_text.as_ref().is_some_and(|st| st.starts_with("1-"))
                     })
                     .collect();
 
@@ -34843,10 +34834,10 @@ setClass("{}", slots = c(value = "numeric"))
                 // All "0-" prefixed items should appear before any "1-", "4-", or "5-" items
                 // in the items list (since they are prepended)
                 if let Some(last_param_idx) = items.iter().rposition(|item| {
-                    item.sort_text.as_ref().map_or(false, |st| st.starts_with("0-"))
+                    item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
                 }) {
                     if let Some(first_standard_idx) = items.iter().position(|item| {
-                        item.sort_text.as_ref().map_or(false, |st| {
+                        item.sort_text.as_ref().is_some_and(|st| {
                             st.starts_with("1-") || st.starts_with("4-") || st.starts_with("5-")
                         })
                     }) {
@@ -34965,7 +34956,7 @@ setClass("{}", slots = c(value = "numeric"))
                     .filter(|item| {
                         item.sort_text
                             .as_ref()
-                            .map_or(false, |st| st.starts_with("0-"))
+                            .is_some_and(|st| st.starts_with("0-"))
                     })
                     .collect();
 
@@ -42161,10 +42152,8 @@ source(\"helpers.R\")
                 );
             }
 
-            let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).expect(&format!(
-                "Should build snapshot for data.R (scan_complete={})",
-                workspace_scan_complete
-            ));
+            let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).unwrap_or_else(|| panic!("Should build snapshot for data.R (scan_complete={})",
+                workspace_scan_complete));
             let diagnostics =
                 diagnostics_from_snapshot(&snapshot, &data_uri, &DiagCancelToken::never())
                     .expect("Should produce diagnostics");

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5365,6 +5365,7 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_undefined_variables_from_snapshot(
     snapshot: &DiagnosticsSnapshot,
     uri: &Url,
@@ -5508,7 +5509,6 @@ fn collect_undefined_variables_from_snapshot(
     // monotonically. tree-sitter's `walk()` typically yields nodes in
     // document order already; the sort is a defensive guarantee for the
     // streaming `advance_to` invariant.
-    let mut used = used;
     used.sort_by_key(|(_, n)| (n.start_position().row, n.start_position().column));
 
     // Build a single ScopeStream for the queried URI. The closures
@@ -44774,7 +44774,7 @@ result <- undefined_var
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```ignore
     /// #[test]
     /// fn explore_parser_behavior() {
     ///     inspect_ast("x <- 42", Some("numeric assignment"));

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5040,27 +5040,26 @@ fn collect_redundant_directive_diagnostics_from_snapshot(
         .collect();
 
     for edge in &deps {
-        if edge.is_directive && !edge.is_backward_directive
-            && ast_targets.contains(&edge.to) {
-                let line = edge.call_site_line.unwrap_or(0);
-                let target_name = edge
-                    .to
-                    .path_segments()
-                    .and_then(|mut s| s.next_back().map(|s| s.to_string()))
-                    .unwrap_or_default();
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position::new(line, 0),
-                        end: Position::new(line, LSP_EOL_CHARACTER),
-                    },
-                    severity: Some(severity),
-                    message: format!(
-                        "Redundant @lsp-source directive: '{}' is already sourced by a source() call",
-                        target_name
-                    ),
-                    ..Default::default()
-                });
-            }
+        if edge.is_directive && !edge.is_backward_directive && ast_targets.contains(&edge.to) {
+            let line = edge.call_site_line.unwrap_or(0);
+            let target_name = edge
+                .to
+                .path_segments()
+                .and_then(|mut s| s.next_back().map(|s| s.to_string()))
+                .unwrap_or_default();
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position::new(line, 0),
+                    end: Position::new(line, LSP_EOL_CHARACTER),
+                },
+                severity: Some(severity),
+                message: format!(
+                    "Redundant @lsp-source directive: '{}' is already sourced by a source() call",
+                    target_name
+                ),
+                ..Default::default()
+            });
+        }
     }
 }
 
@@ -5463,10 +5462,9 @@ fn collect_undefined_variables_from_snapshot(
         .unwrap_or_default();
 
     let parent_symbol_names: HashSet<String> = {
-        scope_cache.entry((0, 0)).or_insert_with(|| {
-            
-            snapshot.get_scope(uri, 0, 0, cancel)
-        });
+        scope_cache
+            .entry((0, 0))
+            .or_insert_with(|| snapshot.get_scope(uri, 0, 0, cancel));
         let scope_0_0 = scope_cache.get(&(0, 0)).unwrap();
         // Only include symbols from OTHER files. When a parent sources this file,
         // the file's own exports flow into the parent's scope and back here via
@@ -13022,7 +13020,9 @@ pub fn extract_definition_statement(
     // Get content provider for the symbol's source file
     let content = if let Some(doc) = state.documents.get(&symbol.source_uri) {
         doc.text()
-    } else { state.cross_file_file_cache.get(&symbol.source_uri)? };
+    } else {
+        state.cross_file_file_cache.get(&symbol.source_uri)?
+    };
 
     // Get tree for parsing
     let tree = if let Some(doc) = state.documents.get(&symbol.source_uri) {
@@ -42154,8 +42154,12 @@ source(\"helpers.R\")
                 );
             }
 
-            let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).unwrap_or_else(|| panic!("Should build snapshot for data.R (scan_complete={})",
-                workspace_scan_complete));
+            let snapshot = DiagnosticsSnapshot::build(&state, &data_uri).unwrap_or_else(|| {
+                panic!(
+                    "Should build snapshot for data.R (scan_complete={})",
+                    workspace_scan_complete
+                )
+            });
             let diagnostics =
                 diagnostics_from_snapshot(&snapshot, &data_uri, &DiagCancelToken::never())
                     .expect("Should produce diagnostics");

--- a/crates/raven/src/help/cache.rs
+++ b/crates/raven/src/help/cache.rs
@@ -400,7 +400,7 @@ mod tests {
                 }
             })
             .await;
-        assert!(matches!(res2, Ok(_)));
+        assert!(res2.is_ok());
         assert_eq!(
             calls.load(StdOrdering::SeqCst),
             2,
@@ -517,7 +517,7 @@ mod tests {
                 }
             })
             .await;
-        assert!(matches!(res2, Ok(_)));
+        assert!(res2.is_ok());
         assert_eq!(
             calls.load(Ordering::SeqCst),
             2,

--- a/crates/raven/src/help/cache.rs
+++ b/crates/raven/src/help/cache.rs
@@ -411,6 +411,10 @@ mod tests {
         assert!(c.get("filter", Some("dplyr")).is_some());
     }
 
+    // Deliberately holds the LRU write guard while orchestrating the Owner
+    // task to reproduce the `drain()` ordering; the guard is explicitly dropped
+    // before the only `.await`, so this is safe despite the lint.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread")]
     async fn drain_generation_check_is_atomic_with_lru_insert() {
         // Regression: checking `generation` before acquiring the LRU write

--- a/crates/raven/src/indentation/context.rs
+++ b/crates/raven/src/indentation/context.rs
@@ -4575,7 +4575,19 @@ mod tests {
 
     /// Verify that the detected context matches the expected innermost context type.
     fn verify_innermost_context(ctx: &IndentContext, expected_type: &str) -> bool {
-        matches!((ctx, expected_type), (IndentContext::AfterContinuationOperator { .. }, "AfterContinuationOperator") | (IndentContext::InsideParens { .. }, "InsideParens") | (IndentContext::InsideBraces { .. }, "InsideBraces") | (IndentContext::ClosingDelimiter { .. }, "ClosingDelimiter") | (IndentContext::AfterCompleteExpression { .. }, "AfterCompleteExpression"))
+        matches!(
+            (ctx, expected_type),
+            (
+                IndentContext::AfterContinuationOperator { .. },
+                "AfterContinuationOperator"
+            ) | (IndentContext::InsideParens { .. }, "InsideParens")
+                | (IndentContext::InsideBraces { .. }, "InsideBraces")
+                | (IndentContext::ClosingDelimiter { .. }, "ClosingDelimiter")
+                | (
+                    IndentContext::AfterCompleteExpression { .. },
+                    "AfterCompleteExpression"
+                )
+        )
     }
 
     proptest! {

--- a/crates/raven/src/indentation/context.rs
+++ b/crates/raven/src/indentation/context.rs
@@ -2290,8 +2290,13 @@ mod tests {
         // Should not panic, should return a valid context
         let ctx = detect_context(&tree, code, position, 2);
 
-        // The fallback should detect this as a complete expression
-        if let IndentContext::AfterCompleteExpression { .. } = ctx {}
+        // The fallback should not panic; any resulting context is acceptable
+        // (malformed input does not guarantee a specific variant).
+        #[allow(clippy::single_match)]
+        match ctx {
+            IndentContext::AfterCompleteExpression { .. } => {}
+            _ => {}
+        }
     }
 
     // ========================================================================
@@ -6086,8 +6091,13 @@ mod tests {
         // Should not panic
         let ctx = detect_context(&tree, code, position, 2);
 
-        // Should handle gracefully
-        if let IndentContext::AfterCompleteExpression { .. } = ctx {}
+        // Should handle gracefully; any resulting context is acceptable as long
+        // as detect_context does not panic.
+        #[allow(clippy::single_match)]
+        match ctx {
+            IndentContext::AfterCompleteExpression { .. } => {}
+            _ => {}
+        }
     }
 
     #[test]

--- a/crates/raven/src/indentation/context.rs
+++ b/crates/raven/src/indentation/context.rs
@@ -2291,10 +2291,7 @@ mod tests {
         let ctx = detect_context(&tree, code, position, 2);
 
         // The fallback should detect this as a complete expression
-        match ctx {
-            IndentContext::AfterCompleteExpression { .. } => {}
-            _ => {} // Any context is fine, just shouldn't panic
-        }
+        if let IndentContext::AfterCompleteExpression { .. } = ctx {}
     }
 
     // ========================================================================
@@ -4578,14 +4575,7 @@ mod tests {
 
     /// Verify that the detected context matches the expected innermost context type.
     fn verify_innermost_context(ctx: &IndentContext, expected_type: &str) -> bool {
-        match (ctx, expected_type) {
-            (IndentContext::AfterContinuationOperator { .. }, "AfterContinuationOperator") => true,
-            (IndentContext::InsideParens { .. }, "InsideParens") => true,
-            (IndentContext::InsideBraces { .. }, "InsideBraces") => true,
-            (IndentContext::ClosingDelimiter { .. }, "ClosingDelimiter") => true,
-            (IndentContext::AfterCompleteExpression { .. }, "AfterCompleteExpression") => true,
-            _ => false,
-        }
+        matches!((ctx, expected_type), (IndentContext::AfterContinuationOperator { .. }, "AfterContinuationOperator") | (IndentContext::InsideParens { .. }, "InsideParens") | (IndentContext::InsideBraces { .. }, "InsideBraces") | (IndentContext::ClosingDelimiter { .. }, "ClosingDelimiter") | (IndentContext::AfterCompleteExpression { .. }, "AfterCompleteExpression"))
     }
 
     proptest! {
@@ -4650,7 +4640,7 @@ mod tests {
             // Should detect pipe context, not parens context
             match ctx {
                 IndentContext::AfterContinuationOperator { operator_type, .. } => {
-                    match &*pipe_op {
+                    match pipe_op {
                         "|>" => prop_assert_eq!(operator_type, OperatorType::Pipe),
                         "%>%" => prop_assert_eq!(operator_type, OperatorType::MagrittrPipe),
                         _ => prop_assert!(false, "Unexpected pipe operator"),
@@ -6085,10 +6075,7 @@ mod tests {
         let ctx = detect_context(&tree, code, position, 2);
 
         // Should handle gracefully
-        match ctx {
-            IndentContext::AfterCompleteExpression { .. } => {}
-            _ => {}
-        }
+        if let IndentContext::AfterCompleteExpression { .. } = ctx {}
     }
 
     #[test]

--- a/crates/raven/src/jags_builtins.rs
+++ b/crates/raven/src/jags_builtins.rs
@@ -1,8 +1,7 @@
-/// Built-in distributions, functions, and keywords for the JAGS language.
-///
-/// These lists are used by the completion handler to provide JAGS-specific
-/// suggestions when editing `.jags` and `.bugs` files.
-
+//! Built-in distributions, functions, and keywords for the JAGS language.
+//!
+//! These lists are used by the completion handler to provide JAGS-specific
+//! suggestions when editing `.jags` and `.bugs` files.
 pub static JAGS_DISTRIBUTIONS: &[&str] = &[
     "dnorm",
     "dbern",

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -2199,7 +2199,8 @@ mod code_field_tests {
     fn every_rule_emits_its_id() {
         use super::rule_ids::*;
 
-        let cases: Vec<(&str, Box<dyn Fn(&mut LintConfig)>, &str)> = vec![
+        type LintCase = (&'static str, Box<dyn Fn(&mut LintConfig)>, &'static str);
+        let cases: Vec<LintCase> = vec![
             (
                 LINE_LENGTH,
                 Box::new(|c| {

--- a/crates/raven/src/linting/nolint.rs
+++ b/crates/raven/src/linting/nolint.rs
@@ -41,6 +41,9 @@ impl Suppressions {
             let line_no = idx as u32;
             let marker = find_marker(line);
 
+            // Collapsing these inner `if`s into match guards would force a
+            // wildcard arm and lose exhaustiveness over `NolintMarker` variants.
+            #[allow(clippy::collapsible_match)]
             match marker {
                 Some(NolintMarker::Start) => {
                     if !in_block {

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -1451,7 +1451,7 @@ importFrom(magrittr, "%>%")
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use proptest::prelude::*;
     ///
     /// proptest! {

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -1525,38 +1525,22 @@ importFrom(magrittr, "%>%")
         })
     }
 
-    /// Generates a proptest strategy that produces a tuple containing:
-
-    /// - an `S3method(...)` directive string, and
-
-    /// - the corresponding expected export name `generic.class` as a single-item `Vec<String>`.
-
-    ///
-
-    /// # Examples
-
-    ///
-
-    /// ```
-
-    /// use proptest::test_runner::TestRunner;
-
-    ///
-
-    /// let mut runner = TestRunner::default();
-
-    /// let strategy = s3method_directive_strategy();
-
-    /// let tree = strategy.new_tree(&mut runner).unwrap();
-
-    /// let (directive, expected) = tree.current();
-
-    /// assert!(directive.starts_with("S3method("));
-
-    /// assert_eq!(expected.len(), 1);
-
-    /// assert!(expected[0].contains('.'));
-
+    /// Generates a proptest strategy that produces a tuple containing:    ///
+    /// - an `S3method(...)` directive string, and    ///
+    /// - the corresponding expected export name `generic.class` as a single-item `Vec<String>`.    ///
+    ///    ///
+    /// # Examples    ///
+    ///    ///
+    /// ```    ///
+    /// use proptest::test_runner::TestRunner;    ///
+    ///    ///
+    /// let mut runner = TestRunner::default();    ///
+    /// let strategy = s3method_directive_strategy();    ///
+    /// let tree = strategy.new_tree(&mut runner).unwrap();    ///
+    /// let (directive, expected) = tree.current();    ///
+    /// assert!(directive.starts_with("S3method("));    ///
+    /// assert_eq!(expected.len(), 1);    ///
+    /// assert!(expected[0].contains('.'));    ///
     /// ```
     fn s3method_directive_strategy() -> impl Strategy<Value = (String, Vec<String>)> {
         (r_identifier_strategy(), r_identifier_with_dots_strategy()).prop_map(|(generic, class)| {

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -1525,22 +1525,22 @@ importFrom(magrittr, "%>%")
         })
     }
 
-    /// Generates a proptest strategy that produces a tuple containing:    ///
-    /// - an `S3method(...)` directive string, and    ///
-    /// - the corresponding expected export name `generic.class` as a single-item `Vec<String>`.    ///
-    ///    ///
-    /// # Examples    ///
-    ///    ///
-    /// ```    ///
-    /// use proptest::test_runner::TestRunner;    ///
-    ///    ///
-    /// let mut runner = TestRunner::default();    ///
-    /// let strategy = s3method_directive_strategy();    ///
-    /// let tree = strategy.new_tree(&mut runner).unwrap();    ///
-    /// let (directive, expected) = tree.current();    ///
-    /// assert!(directive.starts_with("S3method("));    ///
-    /// assert_eq!(expected.len(), 1);    ///
-    /// assert!(expected[0].contains('.'));    ///
+    /// Generates a proptest strategy that produces a tuple containing:
+    /// - an `S3method(...)` directive string, and
+    /// - the corresponding expected export name `generic.class` as a single-item `Vec<String>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use proptest::test_runner::TestRunner;
+    ///
+    /// let mut runner = TestRunner::default();
+    /// let strategy = s3method_directive_strategy();
+    /// let tree = strategy.new_tree(&mut runner).unwrap();
+    /// let (directive, expected) = tree.current();
+    /// assert!(directive.starts_with("S3method("));
+    /// assert_eq!(expected.len(), 1);
+    /// assert!(expected[0].contains('.'));
     /// ```
     fn s3method_directive_strategy() -> impl Strategy<Value = (String, Vec<String>)> {
         (r_identifier_strategy(), r_identifier_with_dots_strategy()).prop_map(|(generic, class)| {

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -3967,7 +3967,7 @@ mod tests {
                 let mut packages: Vec<(String, HashSet<String>, Vec<String>)> = Vec::new();
 
                 // Create all packages first with empty dependencies
-                for (name, exp) in names.into_iter().zip(exports.into_iter()) {
+                for (name, exp) in names.into_iter().zip(exports) {
                     packages.push((name, exp, Vec::new()));
                 }
 
@@ -4568,7 +4568,7 @@ mod tests {
         );
         assert_eq!(result.get("mutate"), Some(&vec!["dplyr".to_string()]));
         assert!(
-            result.get("ggplot").is_none(),
+            !result.contains_key("ggplot"),
             "ggplot should not be in results"
         );
     }

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -47,7 +47,6 @@ pub fn derive_package_state(
         namespace_model,
         r_file_facts,
         scope_contribution,
-        ..PackageState::default()
     }
 }
 

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -196,7 +196,7 @@ fn merge_namespace_model(
     let mut seen_full: std::collections::HashSet<String> =
         model.full_imports.iter().cloned().collect();
 
-    for (_path, facts) in r_file_facts {
+    for facts in r_file_facts.values() {
         if facts.kind != RFileKind::Source {
             continue;
         }

--- a/crates/raven/src/package_state/event.rs
+++ b/crates/raven/src/package_state/event.rs
@@ -50,9 +50,7 @@ pub fn translate(inputs: &mut PackageInputs, event: HandlerEvent) -> Option<Pack
         return Some(PackageInputDelta::SettingChanged);
     }
 
-    let Some(root) = inputs.workspace_root.clone() else {
-        return None;
-    };
+    let root = inputs.workspace_root.clone()?;
     match event {
         HandlerEvent::DidOpen { uri, text } | HandlerEvent::DidChange { uri, text } => {
             let path = uri.to_file_path().ok()?;

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -315,6 +315,7 @@ pub fn resolve_qualified_member(
 /// `cancel` is polled cooperatively at scope-lookup and loop boundaries.
 /// Returns `None` on cancellation; passing [`DiagCancelToken::never`] yields
 /// the same behavior as [`resolve_qualified_member`].
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_qualified_member_with_cancel(
     state: &WorldState,
     uri: &Url,
@@ -452,6 +453,7 @@ pub fn complete_qualified_members_with_cancel(
     completions
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_qualified_member_candidates_with_cancel(
     state: &WorldState,
     uri: &Url,

--- a/crates/raven/src/r_subprocess.rs
+++ b/crates/raven/src/r_subprocess.rs
@@ -1288,8 +1288,7 @@ mod tests {
     fn test_new_with_none_discovers_r() {
         // This test will pass if R is installed, skip otherwise
         let subprocess = RSubprocess::new(None);
-        if subprocess.is_some() {
-            let subprocess = subprocess.unwrap();
+        if let Some(subprocess) = subprocess {
             assert!(subprocess.r_path().exists());
         }
     }

--- a/crates/raven/src/roxygen.rs
+++ b/crates/raven/src/roxygen.rs
@@ -1172,7 +1172,7 @@ fn process_roxygen_tag(
         && tag_line
             .as_bytes()
             .get(7)
-            .map_or(false, |b| b.is_ascii_whitespace())
+            .is_some_and(|b| b.is_ascii_whitespace())
     {
         *has_export = true;
         for name in tag_line[7..].split_whitespace() {
@@ -1184,7 +1184,7 @@ fn process_roxygen_tag(
         && tag_line
             .as_bytes()
             .get(11)
-            .map_or(false, |b| b.is_ascii_whitespace())
+            .is_some_and(|b| b.is_ascii_whitespace())
     {
         let mut parts = tag_line[11..].split_whitespace();
         if let Some(pkg) = parts.next() {
@@ -1199,7 +1199,7 @@ fn process_roxygen_tag(
         && tag_line
             .as_bytes()
             .get(7)
-            .map_or(false, |b| b.is_ascii_whitespace())
+            .is_some_and(|b| b.is_ascii_whitespace())
     {
         for pkg in tag_line[7..].split_whitespace() {
             if !pkg.is_empty() {
@@ -1478,7 +1478,7 @@ fn find_toplevel_equals(s: &str) -> Option<usize> {
 fn extract_first_identifier(line: &str) -> Option<String> {
     let mut chars = line.chars().peekable();
     // Skip whitespace
-    while chars.peek().map_or(false, |c| c.is_whitespace()) {
+    while chars.peek().is_some_and(|c| c.is_whitespace()) {
         chars.next();
     }
     // Collect identifier chars

--- a/crates/raven/src/stan_builtins.rs
+++ b/crates/raven/src/stan_builtins.rs
@@ -1,8 +1,7 @@
-/// Built-in types, block keywords, control flow, and functions for the Stan language.
-///
-/// These lists are used by the completion handler to provide Stan-specific
-/// suggestions when editing `.stan` files.
-
+//! Built-in types, block keywords, control flow, and functions for the Stan language.
+//!
+//! These lists are used by the completion handler to provide Stan-specific
+//! suggestions when editing `.stan` files.
 pub static STAN_TYPES: &[&str] = &[
     "int",
     "real",

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -919,11 +919,12 @@ impl WorldState {
     /// 3. Legacy cross_file_workspace_index
     /// 4. Legacy documents HashMap (re-extract metadata)
     /// 5. File cache (re-extract metadata)
-    ///    Find or parse `CrossFileMetadata` for `uri` for the working-directory
-    ///    inheritance closures used by snapshot builds and several diagnostic
-    ///    helpers. Walks the chain: open document → cross-file workspace index
-    ///    → file-cache contents. Returns an `Arc` so callers (closures bound to
-    ///    `compute_inherited_working_directory`) avoid deep clones.
+    ///
+    /// Find or parse `CrossFileMetadata` for `uri` for the working-directory
+    /// inheritance closures used by snapshot builds and several diagnostic
+    /// helpers. Walks the chain: open document → cross-file workspace index
+    /// → file-cache contents. Returns an `Arc` so callers (closures bound to
+    /// `compute_inherited_working_directory`) avoid deep clones.
     pub fn get_or_parse_metadata(
         &self,
         uri: &Url,

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -919,11 +919,11 @@ impl WorldState {
     /// 3. Legacy cross_file_workspace_index
     /// 4. Legacy documents HashMap (re-extract metadata)
     /// 5. File cache (re-extract metadata)
-    /// Find or parse `CrossFileMetadata` for `uri` for the working-directory
-    /// inheritance closures used by snapshot builds and several diagnostic
-    /// helpers. Walks the chain: open document → cross-file workspace index
-    /// → file-cache contents. Returns an `Arc` so callers (closures bound to
-    /// `compute_inherited_working_directory`) avoid deep clones.
+    ///    Find or parse `CrossFileMetadata` for `uri` for the working-directory
+    ///    inheritance closures used by snapshot builds and several diagnostic
+    ///    helpers. Walks the chain: open document → cross-file workspace index
+    ///    → file-cache contents. Returns an `Arc` so callers (closures bound to
+    ///    `compute_inherited_working_directory`) avoid deep clones.
     pub fn get_or_parse_metadata(
         &self,
         uri: &Url,

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,7 @@ Key code entry points:
 ## Build from source
 
 Prerequisites:
-- Rust toolchain (MSRV: 1.75)
+- Rust toolchain (MSRV: 1.80)
 
 Clone and build:
 ```bash


### PR DESCRIPTION
## Summary

Adds a **Clippy lint gate** to CI and drives the workspace to **zero clippy/rustc warnings** so lint noise stops accumulating during development.

### CI

- New `clippy` job in `.github/workflows/integration.yml` running
  `cargo clippy --workspace --all-targets --features test-support -- -D warnings`.
- Pinned to toolchain `1.95.0` with the `clippy` component — same anti-drift
  rationale as the existing `fmt` gate (new clippy releases add new lints, so an
  unpinned gate would fail on unrelated PRs). Sets up sccache + mold like the
  other compiling jobs, since clippy invokes rustc.

### Lint fixes (267 → 0 warnings)

- The bulk were applied mechanically (clippy's machine-applicable /
  maybe-incorrect suggestions), then verified by compile + full test suite.
- **MSRV**: bumped `rust-version` `1.75` → `1.80`. The crate already uses
  `std::sync::LazyLock` (1.80) and `Arc::unwrap_or_clone` (1.76), so `1.75` was
  already factually impossible to build — this just makes the declared MSRV honest.
- **`type_complexity`**: extracted type aliases (`SubgraphCache`, `TwoFileFixture`, `LintCase`).
- **`too_many_arguments`** (3 × 8/7): targeted `#[allow]` rather than churning signatures.
- **`collapsible_match`** (5): scoped `#[allow]` — collapsing the inner `if` into a
  match guard would force a wildcard arm and lose exhaustiveness over the enum
  variants (this is the `E0004` that clippy's own autofix produced).
- **`await_holding_lock`** (1): scoped `#[allow]` on a test that deliberately holds
  a guard to reproduce a `drain()` race, then drops it before the only await.
- **`field_reassign_with_default`**: allowed once in `crates/raven/Cargo.toml`
  `[lints]` — the `let mut x = T::default(); x.field = ..` idiom is used
  pervasively and deliberately in test/builder setup.
- **`needless_range_loop`** (6): converted to iterator/`enumerate` form.
- Misc: `manual_inspect`, `vec_init_then_push`, `useless_vec`, `unnecessary_unwrap`,
  `redundant_locals`, `needless_update`, `if_same_then_else`, doctest/`doc_*` cleanups.
- Fixed a pre-existing **stale benchmark** (`benches/cross_file.rs`) that no longer
  compiled against the current `scope_at_position_with_graph` signature.

### Testing

- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- `cargo test -p raven --features test-support` → 4232 + 103 + 3 + 58 pass, 0 failed

### Notes

An adversarial self-review caught that a bulk doc-comment auto-fix had corrupted
two doc blocks (`source_detect.rs`, `namespace_parser.rs`) with trailing `///`
artifacts, and that a lazy-continuation fix had buried two function descriptions
as list sub-items (`state.rs`, `dependency.rs`); all four were rewritten by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated Clippy lint checking as a required CI job to enforce code quality standards.

* **Chores**
  * Updated minimum Rust toolchain requirement from 1.75 to 1.80.
  * Enhanced test coverage and modernized assertion patterns across the codebase.
  * Refactored internal code patterns for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->