### PR TITLE
chore: upgrade to Rust 1.96 and edition 2024

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,9 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Install pinned rustfmt
-        run: rustup toolchain install 1.95.0 --profile minimal --component rustfmt
+        run: rustup toolchain install 1.96.0 --profile minimal --component rustfmt
       - name: Check formatting
-        run: cargo +1.95.0 fmt --all --check
+        run: cargo +1.96.0 fmt --all --check
 
   # ── Clippy lint gate (required check) ──────────────────────────────────
   # Denies ALL clippy/rustc warnings (`-D warnings`) across every target so
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install pinned clippy
-        run: rustup toolchain install 1.95.0 --profile minimal --component clippy
+        run: rustup toolchain install 1.96.0 --profile minimal --component clippy
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.9
@@ -86,7 +86,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends mold
 
       - name: Run clippy (deny warnings)
-        run: cargo +1.95.0 clippy --workspace --all-targets --features test-support -- -D warnings
+        run: cargo +1.96.0 clippy --workspace --all-targets --features test-support -- -D warnings
 
 
   # Build only the release artifacts that genuinely need optimization: the LSP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@ This file is intentionally short: a map to the docs and a list of invariants tha
 
 ## CI gates (keep green before committing)
 
-Rust changes must pass two gates in `.github/workflows/integration.yml`, both pinned to toolchain `1.95.0` so results are reproducible:
+Rust changes must pass two gates in `.github/workflows/integration.yml`, both pinned to toolchain `1.96.0` so results are reproducible:
 
-- **Formatting** — `cargo +1.95.0 fmt --all --check`. Always run `cargo fmt --all` before committing; never hand-format around it.
-- **Clippy** — `cargo +1.95.0 clippy --workspace --all-targets --features test-support -- -D warnings`. Zero warnings: every clippy/rustc warning is an error, across lib, tests, benches, and examples.
+- **Formatting** — `cargo +1.96.0 fmt --all --check`. Always run `cargo fmt --all` before committing; never hand-format around it.
+- **Clippy** — `cargo +1.96.0 clippy --workspace --all-targets --features test-support -- -D warnings`. Zero warnings: every clippy/rustc warning is an error, across lib, tests, benches, and examples.
 
 Both block merge. Fix the underlying issue rather than suppressing it; when a lint is a genuine, deliberate exception, use a narrowly-scoped `#[allow(...)]` with a one-line reason. Project-wide exceptions live in `crates/raven/Cargo.toml` `[lints]` (currently only `field_reassign_with_default`).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["crates/raven"]
 
 [workspace.package]
 version = "0.7.1"
 authors = ["Jonathan Marc Bearak <jbearak@gmail.com>"]
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0"
-rust-version = "1.80"
+rust-version = "1.96"
 
 [workspace.dependencies]
 tower-lsp = "0.20"

--- a/crates/raven/benches/cross_file.rs
+++ b/crates/raven/benches/cross_file.rs
@@ -7,17 +7,17 @@
 //
 // Requirements: 1.4, 1.3
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use url::Url;
 
 use raven::cross_file::types::CrossFileMetadata;
 use raven::cross_file::{
-    compute_artifacts, extract_metadata, scope_at_position, DependencyGraph, FunctionScopeTree,
-    Position, ScopeArtifacts,
+    DependencyGraph, FunctionScopeTree, Position, ScopeArtifacts, compute_artifacts,
+    extract_metadata, scope_at_position,
 };
-use raven::test_utils::fixture_workspace::{create_fixture_workspace, FixtureConfig};
+use raven::test_utils::fixture_workspace::{FixtureConfig, create_fixture_workspace};
 
 /// Pre-compute scope artifacts and metadata for all files in a workspace.
 ///

--- a/crates/raven/benches/edit_to_publish.rs
+++ b/crates/raven/benches/edit_to_publish.rs
@@ -19,12 +19,12 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use tempfile::TempDir;
 use url::Url;
 
-use raven::handlers::{diagnostics_via_snapshot, DiagCancelToken};
-use raven::state::{scan_workspace, Document, WorldState};
+use raven::handlers::{DiagCancelToken, diagnostics_via_snapshot};
+use raven::state::{Document, WorldState, scan_workspace};
 
 // ---------------------------------------------------------------------------
 // Topology generators

--- a/crates/raven/benches/libpath_capture.rs
+++ b/crates/raven/benches/libpath_capture.rs
@@ -3,7 +3,7 @@
 // Run with: cargo bench --bench libpath_capture --features test-support
 // Real libpath: RAVEN_BENCH_LIBPATH=/usr/local/lib/R/site-library cargo bench --bench libpath_capture --features test-support
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use raven::libpath_watcher::LibpathSnapshot;
 use std::path::PathBuf;
 use tempfile::TempDir;

--- a/crates/raven/benches/lsp_operations.rs
+++ b/crates/raven/benches/lsp_operations.rs
@@ -7,13 +7,13 @@
 //
 // Requirements: 1.2, 1.3, 1.5
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use tower_lsp::lsp_types::Position;
 use url::Url;
 
-use raven::state::{scan_workspace, Document, WorldState};
+use raven::state::{Document, WorldState, scan_workspace};
 use raven::test_utils::fixture_workspace::{
-    create_fanout_fixture_workspace, create_fixture_workspace, fanout_parent_uris, FixtureConfig,
+    FixtureConfig, create_fanout_fixture_workspace, create_fixture_workspace, fanout_parent_uris,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/raven/benches/startup.rs
+++ b/crates/raven/benches/startup.rs
@@ -5,13 +5,13 @@
 //
 // Allocation tracking: set RAVEN_BENCH_ALLOC=1 to report allocation counts.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tree_sitter::Parser;
 use url::Url;
 
-use raven::test_utils::fixture_workspace::{create_fixture_workspace, FixtureConfig};
+use raven::test_utils::fixture_workspace::{FixtureConfig, create_fixture_workspace};
 
 // Optional allocation counting (active when RAVEN_BENCH_ALLOC=1).
 #[path = "../src/test_utils/alloc_counter.rs"]

--- a/crates/raven/examples/profile_diagnostics.rs
+++ b/crates/raven/examples/profile_diagnostics.rs
@@ -7,8 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
-use raven::handlers::{diagnostics_via_snapshot_profile, DiagCancelToken};
-use raven::state::{scan_workspace, Document, WorldState};
+use raven::handlers::{DiagCancelToken, diagnostics_via_snapshot_profile};
+use raven::state::{Document, WorldState, scan_workspace};
 use tempfile::TempDir;
 use url::Url;
 

--- a/crates/raven/examples/profile_real_workspace.rs
+++ b/crates/raven/examples/profile_real_workspace.rs
@@ -14,8 +14,8 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
-use raven::handlers::{diagnostics_via_snapshot_profile, DiagCancelToken};
-use raven::state::{scan_workspace, Document, WorldState};
+use raven::handlers::{DiagCancelToken, diagnostics_via_snapshot_profile};
+use raven::state::{Document, WorldState, scan_workspace};
 use url::Url;
 
 fn main() {
@@ -148,23 +148,21 @@ fn main() {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
-                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        if name.starts_with('.')
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                        && (name.starts_with('.')
                             || name == "node_modules"
                             || name == "output"
                             || name == "abortion_data"
-                            || name == "fertility_surveys"
-                        {
-                            continue;
-                        }
+                            || name == "fertility_surveys")
+                    {
+                        continue;
                     }
                     walk(&path, out);
-                } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                    if matches!(ext, "r" | "R") {
-                        if let Ok(meta) = std::fs::metadata(&path) {
-                            out.push((path, meta.len() as usize));
-                        }
-                    }
+                } else if let Some(ext) = path.extension().and_then(|e| e.to_str())
+                    && matches!(ext, "r" | "R")
+                    && let Ok(meta) = std::fs::metadata(&path)
+                {
+                    out.push((path, meta.len() as usize));
                 }
             }
         }

--- a/crates/raven/examples/profile_worldwide.rs
+++ b/crates/raven/examples/profile_worldwide.rs
@@ -29,11 +29,11 @@ use std::time::{Duration, Instant};
 use url::Url;
 
 use raven::cross_file::file_cache::FileSnapshot;
-use raven::cross_file::{extract_metadata, extract_metadata_with_tree, scope, CrossFileMetadata};
-use raven::handlers::{diagnostics_via_snapshot_profile, DiagCancelToken};
+use raven::cross_file::{CrossFileMetadata, extract_metadata, extract_metadata_with_tree, scope};
+use raven::handlers::{DiagCancelToken, diagnostics_via_snapshot_profile};
 use raven::package_library::PackageLibrary;
 use raven::r_subprocess::RSubprocess;
-use raven::state::{scan_workspace, Document, WorldState};
+use raven::state::{Document, WorldState, scan_workspace};
 use raven::workspace_index as new_workspace_index;
 
 const SKIP_DIRECTORIES: &[&str] = &[
@@ -71,10 +71,10 @@ fn discover(dir: &Path, out: &mut Vec<PathBuf>) {
     for e in entries.flatten() {
         let p = e.path();
         if p.is_dir() {
-            if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-                if should_skip(n) {
-                    continue;
-                }
+            if let Some(n) = p.file_name().and_then(|n| n.to_str())
+                && should_skip(n)
+            {
+                continue;
             }
             discover(&p, out);
         } else if is_r_file(&p) {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -15,20 +15,20 @@ use serde::Deserialize;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tower::Service;
+use tower_lsp::Client;
+use tower_lsp::LanguageServer;
+use tower_lsp::LspService;
+use tower_lsp::Server;
 use tower_lsp::jsonrpc::{
     Error as JsonRpcError, Id as JsonRpcId, Request as JsonRpcRequest, Response as JsonRpcResponse,
     Result,
 };
 use tower_lsp::lsp_types::*;
-use tower_lsp::Client;
-use tower_lsp::LanguageServer;
-use tower_lsp::LspService;
-use tower_lsp::Server;
 
 use crate::handlers;
 use crate::indentation;
 use crate::r_env;
-use crate::state::{scan_workspace, IndentationSettings, SymbolConfig, WorldState};
+use crate::state::{IndentationSettings, SymbolConfig, WorldState, scan_workspace};
 use crate::utf16::utf16_column_to_byte_offset;
 tokio::task_local! {
     static CURRENT_LSP_REQUEST_ID: JsonRpcId;
@@ -176,10 +176,10 @@ pub(crate) fn parse_cross_file_config(
         value: Option<&serde_json::Value>,
         name: &str,
     ) -> std::result::Result<(), String> {
-        if let Some(v) = value {
-            if !v.is_object() {
-                return Err(format!("{name} must be an object."));
-            }
+        if let Some(v) = value
+            && !v.is_object()
+        {
+            return Err(format!("{name} must be an object."));
         }
         Ok(())
     }
@@ -279,7 +279,9 @@ pub(crate) fn parse_cross_file_config(
                         crate::cross_file::BackwardDependencyMode::Explicit;
                 }
                 Some(other) => {
-                    log::warn!("Unrecognized crossFile.backwardDependencies value '{other}', defaulting to 'auto'.");
+                    log::warn!(
+                        "Unrecognized crossFile.backwardDependencies value '{other}', defaulting to 'auto'."
+                    );
                     config.backward_dependencies = crate::cross_file::BackwardDependencyMode::Auto;
                 }
                 None => {
@@ -366,10 +368,11 @@ pub(crate) fn parse_cross_file_config(
                 .map(std::path::PathBuf::from)
                 .collect();
         }
-        if let Some(v) = packages.get("rPath").and_then(|v| v.as_str()) {
-            if !v.is_empty() && !v.contains('\0') {
-                config.packages_r_path = Some(std::path::PathBuf::from(v));
-            }
+        if let Some(v) = packages.get("rPath").and_then(|v| v.as_str())
+            && !v.is_empty()
+            && !v.contains('\0')
+        {
+            config.packages_r_path = Some(std::path::PathBuf::from(v));
         }
         if let Some(sev) = packages
             .get("missingPackageSeverity")
@@ -1565,43 +1568,42 @@ fn hydrate_package_r_files_from_state(
         if open_uris.contains(&uri) {
             continue;
         }
-        if let Ok(path) = uri.to_file_path() {
-            if let Some(kind) = crate::package_state::is_r_source_path(&path, root) {
-                if let Some(entry) = state.workspace_index_new.get(&uri) {
-                    let text: std::sync::Arc<str> = entry.contents.to_string().into();
-                    let digest = crate::package_state::ContentDigest::of(&text);
-                    r_files.insert(
-                        path,
-                        crate::package_state::RFileInput {
-                            kind,
-                            text,
-                            content_digest: digest,
-                        },
-                    );
-                }
-            }
+        if let Ok(path) = uri.to_file_path()
+            && let Some(kind) = crate::package_state::is_r_source_path(&path, root)
+            && let Some(entry) = state.workspace_index_new.get(&uri)
+        {
+            let text: std::sync::Arc<str> = entry.contents.to_string().into();
+            let digest = crate::package_state::ContentDigest::of(&text);
+            r_files.insert(
+                path,
+                crate::package_state::RFileInput {
+                    kind,
+                    text,
+                    content_digest: digest,
+                },
+            );
         }
     }
 
     for uri in &open_uris {
-        if let Ok(path) = uri.to_file_path() {
-            if let Some(kind) = crate::package_state::is_r_source_path(&path, root) {
-                let text: std::sync::Arc<str> = state
-                    .documents
-                    .get(uri)
-                    .map(|d| d.text())
-                    .unwrap_or_default()
-                    .into();
-                let digest = crate::package_state::ContentDigest::of(&text);
-                r_files.insert(
-                    path,
-                    crate::package_state::RFileInput {
-                        kind,
-                        text,
-                        content_digest: digest,
-                    },
-                );
-            }
+        if let Ok(path) = uri.to_file_path()
+            && let Some(kind) = crate::package_state::is_r_source_path(&path, root)
+        {
+            let text: std::sync::Arc<str> = state
+                .documents
+                .get(uri)
+                .map(|d| d.text())
+                .unwrap_or_default()
+                .into();
+            let digest = crate::package_state::ContentDigest::of(&text);
+            r_files.insert(
+                path,
+                crate::package_state::RFileInput {
+                    kind,
+                    text,
+                    content_digest: digest,
+                },
+            );
         }
     }
 
@@ -1764,11 +1766,11 @@ async fn run_debounced_diagnostics(
             return;
         }
 
-        if let Some(ver) = current_version {
-            if !state.diagnostics_gate.can_publish(&affected_uri, ver) {
-                log::trace!("Skipping diagnostics for {}: monotonic gate", affected_uri);
-                return;
-            }
+        if let Some(ver) = current_version
+            && !state.diagnostics_gate.can_publish(&affected_uri, ver)
+        {
+            log::trace!("Skipping diagnostics for {}: monotonic gate", affected_uri);
+            return;
         }
 
         // Build the snapshot (captures all state needed for diagnostics)
@@ -2585,14 +2587,14 @@ impl LanguageServer for Backend {
                         "message": "topic failed validation",
                     })));
                 }
-                if let Some(p) = package {
-                    if !crate::r_subprocess::is_valid_package_name(p) {
-                        return Ok(Some(serde_json::json!({
-                            "ok": false,
-                            "reason": "invalid-topic",
-                            "message": "package failed validation",
-                        })));
-                    }
+                if let Some(p) = package
+                    && !crate::r_subprocess::is_valid_package_name(p)
+                {
+                    return Ok(Some(serde_json::json!({
+                        "ok": false,
+                        "reason": "invalid-topic",
+                        "message": "package failed validation",
+                    })));
                 }
 
                 let (cache, r_path) = {
@@ -2805,25 +2807,23 @@ impl LanguageServer for Backend {
                 );
 
                 for source in &meta.sources {
-                    if let Some(ctx) = path_ctx.as_ref() {
-                        if let Some(resolved) =
+                    if let Some(ctx) = path_ctx.as_ref()
+                        && let Some(resolved) =
                             crate::cross_file::path_resolve::resolve_path_with_workspace_fallback(
                                 &source.path,
                                 ctx,
                             )
+                        && let Ok(source_uri) = Url::from_file_path(resolved)
+                    {
+                        // Check if file needs indexing (not open, not in workspace index)
+                        if !state.documents.contains_key(&source_uri)
+                            && !state.cross_file_workspace_index.contains(&source_uri)
                         {
-                            if let Ok(source_uri) = Url::from_file_path(resolved) {
-                                // Check if file needs indexing (not open, not in workspace index)
-                                if !state.documents.contains_key(&source_uri)
-                                    && !state.cross_file_workspace_index.contains(&source_uri)
-                                {
-                                    log::trace!(
-                                        "Scheduling on-demand indexing for sourced file: {}",
-                                        source_uri
-                                    );
-                                    files_to_index.push((source_uri, IndexCategory::Sourced));
-                                }
-                            }
+                            log::trace!(
+                                "Scheduling on-demand indexing for sourced file: {}",
+                                source_uri
+                            );
+                            files_to_index.push((source_uri, IndexCategory::Sourced));
                         }
                     }
                 }
@@ -2835,23 +2835,18 @@ impl LanguageServer for Backend {
                 );
 
                 for directive in &meta.sourced_by {
-                    if let Some(ctx) = backward_ctx.as_ref() {
-                        if let Some(resolved) =
+                    if let Some(ctx) = backward_ctx.as_ref()
+                        && let Some(resolved) =
                             crate::cross_file::path_resolve::resolve_path(&directive.path, ctx)
-                        {
-                            if let Ok(parent_uri) = Url::from_file_path(resolved) {
-                                if !state.documents.contains_key(&parent_uri)
-                                    && !state.cross_file_workspace_index.contains(&parent_uri)
-                                {
-                                    log::trace!(
-                                        "Scheduling on-demand indexing for parent file: {}",
-                                        parent_uri
-                                    );
-                                    files_to_index
-                                        .push((parent_uri, IndexCategory::BackwardDirective));
-                                }
-                            }
-                        }
+                        && let Ok(parent_uri) = Url::from_file_path(resolved)
+                        && !state.documents.contains_key(&parent_uri)
+                        && !state.cross_file_workspace_index.contains(&parent_uri)
+                    {
+                        log::trace!(
+                            "Scheduling on-demand indexing for parent file: {}",
+                            parent_uri
+                        );
+                        files_to_index.push((parent_uri, IndexCategory::BackwardDirective));
                     }
                 }
             }
@@ -2946,20 +2941,17 @@ impl LanguageServer for Backend {
             // `append_package_contribution` injects package-internal symbols
             // into both kinds — so when an R/ interface changes, both kinds
             // of open files have potentially stale diagnostics.
-            if interface_changed || package_visibility_changed {
-                if let Some(pkg) = state.package_workspace() {
-                    if let Ok(fp) = uri.to_file_path() {
-                        let r_dir = pkg.root.join("R");
-                        if package_visibility_changed || fp.starts_with(&r_dir) {
-                            for open_uri in state.documents.keys() {
-                                if let Ok(p) = open_uri.to_file_path() {
-                                    if crate::package_state::is_r_source_path(&p, &pkg.root)
-                                        .is_some()
-                                    {
-                                        affected.insert(open_uri.clone());
-                                    }
-                                }
-                            }
+            if (interface_changed || package_visibility_changed)
+                && let Some(pkg) = state.package_workspace()
+                && let Ok(fp) = uri.to_file_path()
+            {
+                let r_dir = pkg.root.join("R");
+                if package_visibility_changed || fp.starts_with(&r_dir) {
+                    for open_uri in state.documents.keys() {
+                        if let Ok(p) = open_uri.to_file_path()
+                            && crate::package_state::is_r_source_path(&p, &pkg.root).is_some()
+                        {
+                            affected.insert(open_uri.clone());
                         }
                     }
                 }
@@ -3264,21 +3256,20 @@ impl LanguageServer for Backend {
                                 &source.path,
                                 &forward_ctx,
                             )
+                            && let Ok(child_uri) = Url::from_file_path(resolved)
                         {
-                            if let Ok(child_uri) = Url::from_file_path(resolved) {
-                                let needs_indexing = {
-                                    !state.documents.contains_key(&child_uri)
-                                        && !state.cross_file_workspace_index.contains(&child_uri)
-                                };
-                                if needs_indexing {
-                                    log::trace!(
-                                        "did_open re-enrich: indexing direct source {}",
-                                        child_uri
-                                    );
-                                    drop(state);
-                                    let _ = self.index_file_on_demand(&child_uri).await;
-                                    state = self.state.write().await;
-                                }
+                            let needs_indexing = {
+                                !state.documents.contains_key(&child_uri)
+                                    && !state.cross_file_workspace_index.contains(&child_uri)
+                            };
+                            if needs_indexing {
+                                log::trace!(
+                                    "did_open re-enrich: indexing direct source {}",
+                                    child_uri
+                                );
+                                drop(state);
+                                let _ = self.index_file_on_demand(&child_uri).await;
+                                state = self.state.write().await;
                             }
                         }
                     }
@@ -3752,14 +3743,12 @@ impl LanguageServer for Backend {
             // Both `R/` (two-way) and `tests/testthat/` (one-way) receive the
             // contribution via `append_package_contribution`, so both need
             // the affected-set.
-            if package_visibility_changed {
-                if let Some(pkg) = state.package_workspace() {
-                    for open_uri in state.documents.keys() {
-                        if let Ok(p) = open_uri.to_file_path() {
-                            if crate::package_state::is_r_source_path(&p, &pkg.root).is_some() {
-                                affected.insert(open_uri.clone());
-                            }
-                        }
+            if package_visibility_changed && let Some(pkg) = state.package_workspace() {
+                for open_uri in state.documents.keys() {
+                    if let Ok(p) = open_uri.to_file_path()
+                        && crate::package_state::is_r_source_path(&p, &pkg.root).is_some()
+                    {
+                        affected.insert(open_uri.clone());
                     }
                 }
             }
@@ -3769,20 +3758,18 @@ impl LanguageServer for Backend {
             // added/removed symbols propagate to undefined-variable
             // diagnostics. `tests/testthat/` sees R/ symbols (one-way), so
             // include test files in the affected set too.
-            if interface_changed && !package_visibility_changed {
-                if let Some(pkg) = state.package_workspace() {
-                    if let Ok(fp) = uri.to_file_path() {
-                        let r_dir = pkg.root.join("R");
-                        if fp.starts_with(&r_dir) {
-                            for open_uri in state.documents.keys() {
-                                if let Ok(p) = open_uri.to_file_path() {
-                                    if crate::package_state::is_r_source_path(&p, &pkg.root)
-                                        .is_some()
-                                    {
-                                        affected.insert(open_uri.clone());
-                                    }
-                                }
-                            }
+            if interface_changed
+                && !package_visibility_changed
+                && let Some(pkg) = state.package_workspace()
+                && let Ok(fp) = uri.to_file_path()
+            {
+                let r_dir = pkg.root.join("R");
+                if fp.starts_with(&r_dir) {
+                    for open_uri in state.documents.keys() {
+                        if let Ok(p) = open_uri.to_file_path()
+                            && crate::package_state::is_r_source_path(&p, &pkg.root).is_some()
+                        {
+                            affected.insert(open_uri.clone());
                         }
                     }
                 }
@@ -4089,14 +4076,13 @@ impl LanguageServer for Backend {
             }
 
             // Invalidate the workspace index entry so the next scan re-reads from disk.
-            if let Ok(p) = uri.to_file_path() {
-                if state
+            if let Ok(p) = uri.to_file_path()
+                && state
                     .package_workspace()
                     .is_some_and(|pkg| is_package_source_dir(&p, &pkg.root))
-                {
-                    state.cross_file_workspace_index.invalidate(uri);
-                    state.workspace_index_new.invalidate(uri);
-                }
+            {
+                state.cross_file_workspace_index.invalidate(uri);
+                state.workspace_index_new.invalidate(uri);
             }
 
             // Refresh the pin set now that the open set has shrunk; URIs reachable
@@ -4505,15 +4491,15 @@ impl LanguageServer for Backend {
                     let pkg_visibility_changed = state.package_state.namespace_model()
                         != old_ns_model.as_ref()
                         || state.package_state.scope_contribution() != &old_contribution;
-                    if pkg_visibility_changed {
-                        if let Some(root) = state.package_inputs.workspace_root.clone() {
-                            extend_with_open_package_docs(
-                                &mut affected,
-                                &mut affected_set,
-                                &state,
-                                &root,
-                            );
-                        }
+                    if pkg_visibility_changed
+                        && let Some(root) = state.package_inputs.workspace_root.clone()
+                    {
+                        extend_with_open_package_docs(
+                            &mut affected,
+                            &mut affected_set,
+                            &state,
+                            &root,
+                        );
                     }
                 }
 
@@ -4542,15 +4528,10 @@ impl LanguageServer for Backend {
                 let pkg_visibility_changed = state.package_state.namespace_model()
                     != old_ns_model.as_ref()
                     || state.package_state.scope_contribution() != &old_contribution;
-                if pkg_visibility_changed {
-                    if let Some(root) = state.package_inputs.workspace_root.clone() {
-                        extend_with_open_package_docs(
-                            &mut affected,
-                            &mut affected_set,
-                            &state,
-                            &root,
-                        );
-                    }
+                if pkg_visibility_changed
+                    && let Some(root) = state.package_inputs.workspace_root.clone()
+                {
+                    extend_with_open_package_docs(&mut affected, &mut affected_set, &state, &root);
                 }
             }
             // Watched-file deletions can drop edges that put a closed neighbor
@@ -4917,13 +4898,12 @@ impl LanguageServer for Backend {
                             // diagnostics are refreshed.
                             if let Some(ref root) = state.package_inputs.workspace_root.clone() {
                                 for open_uri in state.documents.keys() {
-                                    if let Ok(p) = open_uri.to_file_path() {
-                                        if crate::package_state::is_r_source_path(&p, root)
+                                    if let Ok(p) = open_uri.to_file_path()
+                                        && crate::package_state::is_r_source_path(&p, root)
                                             .is_some()
-                                            && affected_for_async_set.insert(open_uri.clone())
-                                        {
-                                            affected_for_async.push(open_uri.clone());
-                                        }
+                                        && affected_for_async_set.insert(open_uri.clone())
+                                    {
+                                        affected_for_async.push(open_uri.clone());
                                     }
                                 }
                             }
@@ -7123,8 +7103,8 @@ mod tests {
 
     mod request_cancellation {
         use super::super::{
-            Backend, CancellableRequestKind, RequestCancellationRegistry,
-            RequestCancellationService, CURRENT_LSP_REQUEST_ID,
+            Backend, CURRENT_LSP_REQUEST_ID, CancellableRequestKind, RequestCancellationRegistry,
+            RequestCancellationService,
         };
         use std::convert::Infallible;
         use std::future::Future;
@@ -7291,9 +7271,11 @@ mod tests {
             registry.register(id.clone(), CancellableRequestKind::GotoDefinition);
             registry.complete(&id);
 
-            assert!(registry
-                .token_for_id(&id, CancellableRequestKind::GotoDefinition)
-                .is_none());
+            assert!(
+                registry
+                    .token_for_id(&id, CancellableRequestKind::GotoDefinition)
+                    .is_none()
+            );
         }
 
         #[tokio::test]
@@ -7345,9 +7327,11 @@ mod tests {
             service.call(cancel).await.expect("cancel request handled");
 
             assert!(token.is_cancelled());
-            assert!(registry
-                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
-                .is_some_and(|token| token.is_cancelled()));
+            assert!(
+                registry
+                    .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                    .is_some_and(|token| token.is_cancelled())
+            );
 
             release_tx.send(()).expect("release observed request");
             let response = request_task
@@ -7356,9 +7340,11 @@ mod tests {
                 .expect("inner service succeeds")
                 .expect("request has a response");
             assert!(response.is_ok());
-            assert!(registry
-                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
-                .is_none());
+            assert!(
+                registry
+                    .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                    .is_none()
+            );
         }
 
         #[tokio::test]
@@ -7421,9 +7407,11 @@ mod tests {
                 response.error(),
                 Some(&tower_lsp::jsonrpc::Error::request_cancelled())
             );
-            assert!(registry
-                .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
-                .is_none());
+            assert!(
+                registry
+                    .token_for_id(&request_id, CancellableRequestKind::GotoDefinition)
+                    .is_none()
+            );
         }
     }
     /// Tests for saturating arithmetic used in priority scoring
@@ -9816,8 +9804,8 @@ mod refresh_packages_tests {
     // Unit tests for raven.getHelpHtml execute_command handler.
     // ============================================================================
     mod get_help_html_command {
-        use std::sync::mpsc;
         use std::sync::Arc;
+        use std::sync::mpsc;
         use tower_lsp::lsp_types::{ExecuteCommandParams, InitializeParams, InitializeResult};
         use tower_lsp::{LanguageServer, LspService};
 
@@ -10061,8 +10049,8 @@ mod refresh_packages_tests {
     // `rebuild_package_library` (design Decision 4).
     // ============================================================================
     mod package_enabled_gates {
-        use std::sync::mpsc;
         use std::sync::Arc;
+        use std::sync::mpsc;
         use tower_lsp::lsp_types::{
             DidChangeConfigurationParams, ExecuteCommandParams, InitializeParams, InitializeResult,
         };

--- a/crates/raven/src/cli/analysis_stats.rs
+++ b/crates/raven/src/cli/analysis_stats.rs
@@ -113,8 +113,7 @@ pub fn run_analysis_stats(args: &AnalysisStatsArgs) -> Vec<PhaseResult> {
     };
     let mut results = Vec::new();
 
-    let should_run =
-        |phase: &str| -> bool { args.only.as_ref().map_or(true, |only| only == phase) };
+    let should_run = |phase: &str| -> bool { args.only.as_ref().is_none_or(|only| only == phase) };
 
     // Phase 1: Scan — discover R files
     let mut r_files: Vec<(PathBuf, String)> = Vec::new();
@@ -261,10 +260,10 @@ pub fn run_analysis_stats(args: &AnalysisStatsArgs) -> Vec<PhaseResult> {
         let pkg_lib = crate::package_library::PackageLibrary::new_empty();
         let mut resolved = 0usize;
         for pkg_name in &unique_packages {
-            if let Some(pkg_dir) = pkg_lib.find_package_directory(pkg_name) {
-                if pkg_lib.parse_package_static(&pkg_dir).is_some() {
-                    resolved += 1;
-                }
+            if let Some(pkg_dir) = pkg_lib.find_package_directory(pkg_name)
+                && pkg_lib.parse_package_static(&pkg_dir).is_some()
+            {
+                resolved += 1;
             }
         }
 

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -20,9 +20,9 @@ use std::path::{Path, PathBuf};
 use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
+    ColorChoice, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR, OutputFormat, SeverityLevel,
     absolute_path, collect_r_file_paths, encoding_diagnostic, is_chunk_file, is_r_file,
     parse_color_choice, parse_output_format, parse_severity_level, render, resolve_color_from_env,
-    ColorChoice, OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -525,10 +525,10 @@ async fn prefetch_reported_packages(state: &crate::state::WorldState, targets: &
     }
     let mut packages: std::collections::HashSet<String> = std::collections::HashSet::new();
     for path in targets {
-        if let Ok(uri) = Url::from_file_path(path) {
-            if let Some(doc) = state.workspace_index.get(&uri) {
-                packages.extend(doc.loaded_packages.iter().cloned());
-            }
+        if let Ok(uri) = Url::from_file_path(path)
+            && let Some(doc) = state.workspace_index.get(&uri)
+        {
+            packages.extend(doc.loaded_packages.iter().cloned());
         }
     }
     let packages: Vec<String> = packages
@@ -1107,7 +1107,7 @@ mod tests {
     /// installed library.
     #[tokio::test]
     async fn maybe_init_r_keeps_provider_library_when_r_absent() {
-        use crate::package_db::binary_db::{write_shipped_db, ShippedDbProvenance};
+        use crate::package_db::binary_db::{ShippedDbProvenance, write_shipped_db};
         use crate::package_db::model::PackageRecord;
 
         let _env = crate::package_db::RAVEN_NAMES_DB_ENV_LOCK.lock().await;
@@ -1134,10 +1134,9 @@ mod tests {
         .unwrap();
 
         let workspace = TempDir::new().unwrap();
-        std::env::set_var("RAVEN_NAMES_DB", &db_path);
+        let _db_env = crate::package_db::NamesDbEnvGuard::set(&db_path);
         let mut state = crate::state::WorldState::new(vec![]);
         maybe_init_r(&mut state, workspace.path()).await;
-        std::env::remove_var("RAVEN_NAMES_DB");
 
         // The Tier 3 provider survived (library not dropped) and is marked ready,
         // so prefetch + resolution can run even though R is irrelevant here.

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -6,9 +6,9 @@ use serde_json::json;
 use tower_lsp::lsp_types::Diagnostic;
 
 use crate::cli::shared::{
+    ColorChoice, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR, OutputFormat, SeverityLevel,
     absolute_path, encoding_diagnostic, is_chunk_file, is_r_file, parse_color_choice,
-    parse_output_format, parse_severity_level, render, resolve_color_from_env, ColorChoice,
-    OutputFormat, SeverityLevel, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR,
+    parse_output_format, parse_severity_level, render, resolve_color_from_env,
 };
 
 #[derive(Debug, PartialEq, Clone)]

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -14,9 +14,9 @@ use std::process::Command;
 use std::{fs::OpenOptions, io::Write};
 
 use crate::cli::shared::absolute_path;
-use crate::package_db::binary_db::{write_shipped_db, ShippedDb, ShippedDbProvenance};
+use crate::package_db::binary_db::{ShippedDb, ShippedDbProvenance, write_shipped_db};
 use crate::package_db::json_db::{
-    read_repo_db_file, write_repo_db_file, RepoDb, RepoDbProvenance, REPO_DB_SCHEMA_VERSION,
+    REPO_DB_SCHEMA_VERSION, RepoDb, RepoDbProvenance, read_repo_db_file, write_repo_db_file,
 };
 use crate::package_db::merge::merge_append_only;
 use crate::package_db::model::PackageRecord;
@@ -89,7 +89,7 @@ pub fn parse_update_args(mut argv: impl Iterator<Item = String>) -> Result<Updat
             s if s.starts_with('-') => return Err(format!("unknown flag: {s}")),
             s if date.is_some() => return Err(format!("unexpected extra argument: {s}")),
             s if !is_yyyy_mm_dd(s) => {
-                return Err(format!("expected a release date as YYYY-MM-DD, got: {s}"))
+                return Err(format!("expected a release date as YYYY-MM-DD, got: {s}"));
             }
             s => date = Some(s.to_string()),
         }
@@ -99,7 +99,7 @@ pub fn parse_update_args(mut argv: impl Iterator<Item = String>) -> Result<Updat
     // suffix on the default GitHub base.
     let base_url = match (base_url, date) {
         (Some(_), Some(_)) => {
-            return Err("pass either a YYYY-MM-DD release date or --base-url, not both".into())
+            return Err("pass either a YYYY-MM-DD release date or --base-url, not both".into());
         }
         (Some(b), None) => b,
         (None, Some(d)) => format!("{DEFAULT_NAMES_DB_RELEASE_BASE}-{d}"),
@@ -285,15 +285,16 @@ fn renv_skew_warnings(
 ) -> Vec<String> {
     let mut out = Vec::new();
     for rec in fetched {
-        if let Some(want) = pinned.get(&rec.name) {
-            if !want.is_empty() && want != &rec.version {
-                out.push(format!(
-                    "{}: fetched {} (latest); renv.lock pins {}. Export names usually match \
+        if let Some(want) = pinned.get(&rec.name)
+            && !want.is_empty()
+            && want != &rec.version
+        {
+            out.push(format!(
+                "{}: fetched {} (latest); renv.lock pins {}. Export names usually match \
                      across versions; install it and use `freeze` / `--missing-only` for a \
                      version-exact capture.",
-                    rec.name, rec.version, want
-                ));
-            }
+                rec.name, rec.version, want
+            ));
         }
     }
     out
@@ -591,11 +592,11 @@ pub async fn run_freeze(args: FreezeArgs) -> Result<(), String> {
     let out = absolute_path(&root, &args.output);
     // `read_repo_db_file` maps a missing file to `Err(Absent)`, so no `exists()`
     // pre-check is needed — an absent/unreadable file simply isn't a no-op match.
-    if let Ok(existing) = read_repo_db_file(&out) {
-        if existing.packages == records {
-            eprintln!("no changes; left {} untouched", out.display());
-            return Ok(());
-        }
+    if let Ok(existing) = read_repo_db_file(&out)
+        && existing.packages == records
+    {
+        eprintln!("no changes; left {} untouched", out.display());
+        return Ok(());
     }
 
     let r_version = lib
@@ -690,21 +691,20 @@ fn collect_referenced_packages(
                     if matches!(
                         func_text,
                         "library" | "require" | "loadNamespace" | "requireNamespace"
-                    ) {
-                        if let Some(args) = node.child_by_field_name("arguments") {
-                            for i in 0..args.child_count() {
-                                let Some(arg) = args.child(i) else { continue };
-                                if arg.kind() != "argument" {
-                                    continue;
+                    ) && let Some(args) = node.child_by_field_name("arguments")
+                    {
+                        for i in 0..args.child_count() {
+                            let Some(arg) = args.child(i) else { continue };
+                            if arg.kind() != "argument" {
+                                continue;
+                            }
+                            if let Some(value) = arg.child_by_field_name("value") {
+                                let name = text[value.byte_range()]
+                                    .trim_matches(|c| c == '"' || c == '\'');
+                                if is_valid_package_name(name) {
+                                    out.insert(name.to_string());
                                 }
-                                if let Some(value) = arg.child_by_field_name("value") {
-                                    let name = text[value.byte_range()]
-                                        .trim_matches(|c| c == '"' || c == '\'');
-                                    if is_valid_package_name(name) {
-                                        out.insert(name.to_string());
-                                    }
-                                    break; // only the first arg names the package
-                                }
+                                break; // only the first arg names the package
                             }
                         }
                     }
@@ -773,7 +773,7 @@ pub async fn run_build_shipped_db(args: BuildShippedDbArgs) -> Result<(), String
                     "could not read seed DB {}: {e}; rerun with --fresh only if dropping \
                      prior history is intentional",
                     seed_path.display()
-                ))
+                ));
             }
         }
     };
@@ -1393,10 +1393,9 @@ pub async fn run_build_embedded_base(args: BuildEmbeddedBaseArgs) -> Result<(), 
                 if std::fs::symlink_metadata(pkg_dir.join("data"))
                     .map(|m| m.is_dir())
                     .unwrap_or(false)
+                    && let Ok(idx) = crate::namespace_parser::parse_index_exports(&pkg_dir).await
                 {
-                    if let Ok(idx) = crate::namespace_parser::parse_index_exports(&pkg_dir).await {
-                        dataset_set.extend(idx);
-                    }
+                    dataset_set.extend(idx);
                 }
             }
         }
@@ -1467,9 +1466,9 @@ pub fn print_help() {
 
 #[cfg(test)]
 mod tests {
-    use crate::package_db::binary_db::{write_shipped_db, ShippedDb, ShippedDbProvenance};
+    use crate::package_db::binary_db::{ShippedDb, ShippedDbProvenance, write_shipped_db};
     use crate::package_db::json_db::{
-        read_repo_db_file, write_repo_db_file, RepoDb, RepoDbProvenance, REPO_DB_SCHEMA_VERSION,
+        REPO_DB_SCHEMA_VERSION, RepoDb, RepoDbProvenance, read_repo_db_file, write_repo_db_file,
     };
     use crate::package_db::model::PackageRecord;
 

--- a/crates/raven/src/completion_context.rs
+++ b/crates/raven/src/completion_context.rs
@@ -188,30 +188,30 @@ fn find_enclosing_function_call(
                 let args_end = args_node.end_position();
 
                 // cursor must be after the opening `(` and before or at the closing `)`
-                if cursor_point > args_start && cursor_point <= args_end {
-                    if let Some(func_node) = current.child_by_field_name("function") {
-                        let ast_ctx = extract_call_info(func_node, text);
+                if cursor_point > args_start
+                    && cursor_point <= args_end
+                    && let Some(func_node) = current.child_by_field_name("function")
+                {
+                    let ast_ctx = extract_call_info(func_node, text);
 
-                        // When the argument subtree has parse errors,
-                        // tree-sitter's bracket recovery can mis-group `(`
-                        // with `)` (e.g. `a(if(b, c))` — the outer `)` is
-                        // grouped with the outer `(` at the AST level even
-                        // though textually it pairs with the inner `(`).
-                        // Cross-check against the bracket heuristic and
-                        // prefer it on disagreement — but keep the AST
-                        // result when the heuristic returns `None` or
-                        // agrees with it (the heuristic can't extract
-                        // backticked or non-ASCII function names that the
-                        // AST handles fine).
-                        if args_node.has_error() {
-                            if let Some(fallback) = detect_via_bracket_heuristic(text, position) {
-                                if ast_ctx.as_ref() != Some(&fallback) {
-                                    return Some(fallback);
-                                }
-                            }
-                        }
-                        return ast_ctx;
+                    // When the argument subtree has parse errors,
+                    // tree-sitter's bracket recovery can mis-group `(`
+                    // with `)` (e.g. `a(if(b, c))` — the outer `)` is
+                    // grouped with the outer `(` at the AST level even
+                    // though textually it pairs with the inner `(`).
+                    // Cross-check against the bracket heuristic and
+                    // prefer it on disagreement — but keep the AST
+                    // result when the heuristic returns `None` or
+                    // agrees with it (the heuristic can't extract
+                    // backticked or non-ASCII function names that the
+                    // AST handles fine).
+                    if args_node.has_error()
+                        && let Some(fallback) = detect_via_bracket_heuristic(text, position)
+                        && ast_ctx.as_ref() != Some(&fallback)
+                    {
+                        return Some(fallback);
                     }
+                    return ast_ctx;
                 }
             }
         }
@@ -502,12 +502,12 @@ fn detect_via_bracket_heuristic(text: &str, position: Position) -> Option<Functi
         // Check if the top of the stack is an unmatched `(` from this line.
         // We want the rightmost unmatched `(` from this line.
         // Find the last `(` in line_opens.
-        if let Some(&top) = bracket_stack.last() {
-            if top == '(' {
-                // Find the rightmost `(` in line_opens
-                if let Some(&(_ch, paren_pos)) = line_opens.iter().rev().find(|(c, _)| *c == '(') {
-                    return extract_function_name_before_paren(lines[line_idx], paren_pos);
-                }
+        if let Some(&top) = bracket_stack.last()
+            && top == '('
+        {
+            // Find the rightmost `(` in line_opens
+            if let Some(&(_ch, paren_pos)) = line_opens.iter().rev().find(|(c, _)| *c == '(') {
+                return extract_function_name_before_paren(lines[line_idx], paren_pos);
             }
         }
     }

--- a/crates/raven/src/config_file/discovery_load.rs
+++ b/crates/raven/src/config_file/discovery_load.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use super::{find_config, load_lintr, load_toml, DiscoveredConfig};
+use super::{DiscoveredConfig, find_config, load_lintr, load_toml};
 
 /// Outcome of discovering and loading a project config from a directory.
 ///

--- a/crates/raven/src/config_file/lintr_loader.rs
+++ b/crates/raven/src/config_file/lintr_loader.rs
@@ -12,7 +12,7 @@
 
 use std::path::Path;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 pub struct LoadedLintr {
     pub settings: Value,
@@ -153,10 +153,10 @@ fn apply_linters(
 
 fn strip_linters_with_defaults(body: &str) -> &str {
     let trimmed = body.trim();
-    if let Some(rest) = trimmed.strip_prefix("linters_with_defaults(") {
-        if let Some(inner) = rest.strip_suffix(')') {
-            return inner.trim();
-        }
+    if let Some(rest) = trimmed.strip_prefix("linters_with_defaults(")
+        && let Some(inner) = rest.strip_suffix(')')
+    {
+        return inner.trim();
     }
     trimmed
 }
@@ -190,12 +190,12 @@ fn apply_linter_call(
             }
         }
         "object_name_linter" => {
-            if let Some(styles) = parse_named_string_vec(args, "styles") {
-                if let Some(first) = styles.first() {
-                    linting.insert("objectNameStyleFunction".into(), json!(first));
-                    linting.insert("objectNameStyleVariable".into(), json!(first));
-                    linting.insert("objectNameStyleArgument".into(), json!(first));
-                }
+            if let Some(styles) = parse_named_string_vec(args, "styles")
+                && let Some(first) = styles.first()
+            {
+                linting.insert("objectNameStyleFunction".into(), json!(first));
+                linting.insert("objectNameStyleVariable".into(), json!(first));
+                linting.insert("objectNameStyleArgument".into(), json!(first));
             }
         }
         "trailing_whitespace_linter"
@@ -340,10 +340,10 @@ fn parse_named_int(args: &str, name: &str) -> Option<u64> {
         // earlier in the list (e.g. `indentation_linter(2, indent = 4)`)
         // doesn't short-circuit the whole search — mirrors the
         // `parse_named_string` / `parse_named_string_vec` shape.
-        if let Some((lhs, rhs)) = part.split_once('=') {
-            if lhs.trim() == name {
-                return rhs.trim().parse::<u64>().ok();
-            }
+        if let Some((lhs, rhs)) = part.split_once('=')
+            && lhs.trim() == name
+        {
+            return rhs.trim().parse::<u64>().ok();
         }
     }
     None
@@ -351,11 +351,11 @@ fn parse_named_int(args: &str, name: &str) -> Option<u64> {
 
 fn parse_named_string(args: &str, name: &str) -> Option<String> {
     for part in split_top_level_commas(args) {
-        if let Some((lhs, rhs)) = part.split_once('=') {
-            if lhs.trim() == name {
-                let v = rhs.trim().trim_matches(|c| c == '"' || c == '\'');
-                return Some(v.to_string());
-            }
+        if let Some((lhs, rhs)) = part.split_once('=')
+            && lhs.trim() == name
+        {
+            let v = rhs.trim().trim_matches(|c| c == '"' || c == '\'');
+            return Some(v.to_string());
         }
     }
     None
@@ -363,18 +363,18 @@ fn parse_named_string(args: &str, name: &str) -> Option<String> {
 
 fn parse_named_string_vec(args: &str, name: &str) -> Option<Vec<String>> {
     for part in split_top_level_commas(args) {
-        if let Some((lhs, rhs)) = part.split_once('=') {
-            if lhs.trim() == name {
-                let rhs = rhs.trim();
-                let inner = rhs.strip_prefix("c(").and_then(|r| r.strip_suffix(')'))?;
-                return Some(
-                    split_top_level_commas(inner)
-                        .into_iter()
-                        .map(|s| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect(),
-                );
-            }
+        if let Some((lhs, rhs)) = part.split_once('=')
+            && lhs.trim() == name
+        {
+            let rhs = rhs.trim();
+            let inner = rhs.strip_prefix("c(").and_then(|r| r.strip_suffix(')'))?;
+            return Some(
+                split_top_level_commas(inner)
+                    .into_iter()
+                    .map(|s| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            );
         }
     }
     None
@@ -428,9 +428,10 @@ mod tests {
     #[test]
     fn out_of_grammar_yields_batch_warning() {
         let out = load_str("linters: linters_with_defaults(linters_with_tags(\"default\"))\n");
-        assert!(out
-            .warnings
-            .iter()
-            .any(|w| w.contains("unrecognized construct")));
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("unrecognized construct"))
+        );
     }
 }

--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -7,13 +7,13 @@ pub mod merge;
 pub mod overrides;
 pub mod toml_loader;
 
-pub use discovery::{find_config, DiscoveredConfig};
-pub use discovery_load::{discover_and_load, DiscoveredLoad};
+pub use discovery::{DiscoveredConfig, find_config};
+pub use discovery_load::{DiscoveredLoad, discover_and_load};
 pub use lintr_loader::load as load_lintr;
 pub use merge::merge as merge_settings;
 pub use overrides::{
-    compile_lint_overrides, is_skipped_by_overrides, resolve_lint_for_document,
-    CompiledLintOverride,
+    CompiledLintOverride, compile_lint_overrides, is_skipped_by_overrides,
+    resolve_lint_for_document,
 };
 pub use toml_loader::load as load_toml;
 
@@ -43,10 +43,10 @@ pub use toml_loader::load as load_toml;
 /// "auto"`. See #281.
 fn strip_project_auto_enabled(project: Option<&serde_json::Value>) -> Option<serde_json::Value> {
     let mut cloned = project.cloned()?;
-    if let Some(linting) = cloned.get_mut("linting").and_then(|l| l.as_object_mut()) {
-        if linting.get("enabled") == Some(&serde_json::Value::String("auto".into())) {
-            linting.remove("enabled");
-        }
+    if let Some(linting) = cloned.get_mut("linting").and_then(|l| l.as_object_mut())
+        && linting.get("enabled") == Some(&serde_json::Value::String("auto".into()))
+    {
+        linting.remove("enabled");
     }
     Some(cloned)
 }

--- a/crates/raven/src/config_file/toml_loader.rs
+++ b/crates/raven/src/config_file/toml_loader.rs
@@ -141,14 +141,14 @@ fn validate_top_level_keys(
             ));
             continue;
         }
-        if key == "linting" {
-            if let Value::Object(linting_map) = value {
-                for nested in linting_map.keys() {
-                    if !KNOWN_LINTING_KEYS.contains(&nested.as_str()) {
-                        warnings.push(format!(
-                            "{source_label}: unknown key 'linting.{nested}'; ignoring"
-                        ));
-                    }
+        if key == "linting"
+            && let Value::Object(linting_map) = value
+        {
+            for nested in linting_map.keys() {
+                if !KNOWN_LINTING_KEYS.contains(&nested.as_str()) {
+                    warnings.push(format!(
+                        "{source_label}: unknown key 'linting.{nested}'; ignoring"
+                    ));
                 }
             }
         }

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -197,10 +197,10 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 2. Check legacy documents HashMap (for migration compatibility)
-        if let Some(legacy_docs) = self.legacy_documents {
-            if let Some(doc) = legacy_docs.get(uri) {
-                return Some(doc.text());
-            }
+        if let Some(legacy_docs) = self.legacy_documents
+            && let Some(doc) = legacy_docs.get(uri)
+        {
+            return Some(doc.text());
         }
 
         // 3. Check WorkspaceIndex
@@ -209,10 +209,10 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 4. Check legacy workspace_index (for migration compatibility)
-        if let Some(legacy_ws) = self.legacy_workspace_index {
-            if let Some(doc) = legacy_ws.get(uri) {
-                return Some(doc.text());
-            }
+        if let Some(legacy_ws) = self.legacy_workspace_index
+            && let Some(doc) = legacy_ws.get(uri)
+        {
+            return Some(doc.text());
         }
 
         // 5. Check file cache (no synchronous disk I/O)
@@ -236,11 +236,11 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 2. Check legacy documents HashMap (for migration compatibility)
-        if let Some(legacy_docs) = self.legacy_documents {
-            if let Some(doc) = legacy_docs.get(uri) {
-                let text = doc.text();
-                return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
-            }
+        if let Some(legacy_docs) = self.legacy_documents
+            && let Some(doc) = legacy_docs.get(uri)
+        {
+            let text = doc.text();
+            return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
         }
 
         // 3. Check WorkspaceIndex
@@ -249,18 +249,18 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 4. Check legacy cross_file_workspace_index (for migration compatibility)
-        if let Some(legacy_cf_ws) = self.legacy_cross_file_workspace_index {
-            if let Some(metadata) = legacy_cf_ws.get_metadata(uri) {
-                return Some(metadata);
-            }
+        if let Some(legacy_cf_ws) = self.legacy_cross_file_workspace_index
+            && let Some(metadata) = legacy_cf_ws.get_metadata(uri)
+        {
+            return Some(metadata);
         }
 
         // 5. Check legacy workspace_index (for migration compatibility)
-        if let Some(legacy_ws) = self.legacy_workspace_index {
-            if let Some(doc) = legacy_ws.get(uri) {
-                let text = doc.text();
-                return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
-            }
+        if let Some(legacy_ws) = self.legacy_workspace_index
+            && let Some(doc) = legacy_ws.get(uri)
+        {
+            let text = doc.text();
+            return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
         }
 
         None
@@ -283,21 +283,20 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 2. Check legacy documents HashMap (for migration compatibility)
-        if let Some(legacy_docs) = self.legacy_documents {
-            if let Some(doc) = legacy_docs.get(uri) {
-                if let Some(tree) = &doc.tree {
-                    let text = doc.text();
-                    // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
-                    // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-                    let metadata = crate::cross_file::extract_metadata(&text);
-                    return Some(Arc::new(scope::compute_artifacts_with_metadata(
-                        uri,
-                        tree,
-                        &text,
-                        Some(&metadata),
-                    )));
-                }
-            }
+        if let Some(legacy_docs) = self.legacy_documents
+            && let Some(doc) = legacy_docs.get(uri)
+            && let Some(tree) = &doc.tree
+        {
+            let text = doc.text();
+            // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
+            // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
+            let metadata = crate::cross_file::extract_metadata(&text);
+            return Some(Arc::new(scope::compute_artifacts_with_metadata(
+                uri,
+                tree,
+                &text,
+                Some(&metadata),
+            )));
         }
 
         // 3. Check WorkspaceIndex
@@ -306,28 +305,27 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
         }
 
         // 4. Check legacy cross_file_workspace_index (for migration compatibility)
-        if let Some(legacy_cf_ws) = self.legacy_cross_file_workspace_index {
-            if let Some(artifacts) = legacy_cf_ws.get_artifacts(uri) {
-                return Some(artifacts);
-            }
+        if let Some(legacy_cf_ws) = self.legacy_cross_file_workspace_index
+            && let Some(artifacts) = legacy_cf_ws.get_artifacts(uri)
+        {
+            return Some(artifacts);
         }
 
         // 5. Check legacy workspace_index (for migration compatibility)
-        if let Some(legacy_ws) = self.legacy_workspace_index {
-            if let Some(doc) = legacy_ws.get(uri) {
-                if let Some(tree) = &doc.tree {
-                    let text = doc.text();
-                    // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
-                    // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-                    let metadata = crate::cross_file::extract_metadata(&text);
-                    return Some(Arc::new(scope::compute_artifacts_with_metadata(
-                        uri,
-                        tree,
-                        &text,
-                        Some(&metadata),
-                    )));
-                }
-            }
+        if let Some(legacy_ws) = self.legacy_workspace_index
+            && let Some(doc) = legacy_ws.get(uri)
+            && let Some(tree) = &doc.tree
+        {
+            let text = doc.text();
+            // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
+            // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
+            let metadata = crate::cross_file::extract_metadata(&text);
+            return Some(Arc::new(scope::compute_artifacts_with_metadata(
+                uri,
+                tree,
+                &text,
+                Some(&metadata),
+            )));
         }
 
         None
@@ -1801,10 +1799,12 @@ mod integration_tests {
         // Verify we can get artifacts from utils.R via ContentProvider
         let utils_artifacts_from_provider = provider.get_artifacts(&utils_uri);
         assert!(utils_artifacts_from_provider.is_some());
-        assert!(utils_artifacts_from_provider
-            .unwrap()
-            .exported_interface
-            .contains_key("helper_func"));
+        assert!(
+            utils_artifacts_from_provider
+                .unwrap()
+                .exported_interface
+                .contains_key("helper_func")
+        );
     }
 
     /// Integration test for async diagnostics
@@ -2160,7 +2160,7 @@ mod integration_tests {
     async fn test_scope_resolution_uses_indexed_file_declarations() {
         use crate::cross_file::dependency::DependencyGraph;
         use crate::cross_file::scope::{
-            scope_at_position_with_graph, ScopeArtifacts, ScopeEvent, ScopedSymbol, SymbolKind,
+            ScopeArtifacts, ScopeEvent, ScopedSymbol, SymbolKind, scope_at_position_with_graph,
         };
         use crate::cross_file::types::{CrossFileMetadata, DeclaredSymbol, ForwardSource};
         use std::collections::HashSet;

--- a/crates/raven/src/cross_file/background_indexer.rs
+++ b/crates/raven/src/cross_file/background_indexer.rs
@@ -20,9 +20,9 @@ use tower_lsp::lsp_types::Url;
 
 use crate::cross_file::file_cache::FileSnapshot;
 use crate::cross_file::path_resolve::{
-    resolve_path, resolve_path_with_workspace_fallback, PathContext,
+    PathContext, resolve_path, resolve_path_with_workspace_fallback,
 };
-use crate::cross_file::{extract_metadata_with_tree, CrossFileMetadata};
+use crate::cross_file::{CrossFileMetadata, extract_metadata_with_tree};
 use crate::state::WorldState;
 
 /// Task for background indexing
@@ -412,51 +412,50 @@ impl BackgroundIndexer {
 
         // Uses workspace-root fallback for files without @lsp-cd directives
         for source in &metadata.sources {
-            if let Some(ctx) = path_ctx.as_ref() {
-                if let Some(resolved) = resolve_path_with_workspace_fallback(&source.path, ctx) {
-                    if let Ok(source_uri) = Url::from_file_path(resolved) {
-                        // Check if file needs indexing
-                        let needs_indexing = {
-                            let state_guard = state.read().await;
-                            !state_guard.documents.contains_key(&source_uri)
-                                && !state_guard.cross_file_workspace_index.contains(&source_uri)
-                        };
+            if let Some(ctx) = path_ctx.as_ref()
+                && let Some(resolved) = resolve_path_with_workspace_fallback(&source.path, ctx)
+                && let Ok(source_uri) = Url::from_file_path(resolved)
+            {
+                // Check if file needs indexing
+                let needs_indexing = {
+                    let state_guard = state.read().await;
+                    !state_guard.documents.contains_key(&source_uri)
+                        && !state_guard.cross_file_workspace_index.contains(&source_uri)
+                };
 
-                        if needs_indexing {
-                            // O(1) duplicate check via pending set
-                            let already_pending = pending.lock().unwrap().contains(&source_uri);
-                            if already_pending {
-                                continue;
-                            }
-
-                            let mut q = queue.lock().unwrap();
-
-                            // Check queue size limit
-                            if q.len() >= max_queue_size {
-                                log::warn!(
-                                    "Background indexing queue full, dropping transitive task for {} ({}/{})",
-                                    source_uri,
-                                    q.len(),
-                                    max_queue_size
-                                );
-                                continue;
-                            }
-
-                            // Use saturating_add to prevent integer overflow at max depth
-                            let next_depth = current_depth.saturating_add(1);
-                            q.push_back(IndexTask {
-                                uri: source_uri.clone(),
-                                depth: next_depth,
-                                submitted_at: Instant::now(),
-                            });
-                            pending.lock().unwrap().insert(source_uri.clone());
-                            log::trace!(
-                                "Queued transitive dependency: {} (depth {})",
-                                source_uri,
-                                next_depth
-                            );
-                        }
+                if needs_indexing {
+                    // O(1) duplicate check via pending set
+                    let already_pending = pending.lock().unwrap().contains(&source_uri);
+                    if already_pending {
+                        continue;
                     }
+
+                    let mut q = queue.lock().unwrap();
+
+                    // Check queue size limit
+                    if q.len() >= max_queue_size {
+                        log::warn!(
+                            "Background indexing queue full, dropping transitive task for {} ({}/{})",
+                            source_uri,
+                            q.len(),
+                            max_queue_size
+                        );
+                        continue;
+                    }
+
+                    // Use saturating_add to prevent integer overflow at max depth
+                    let next_depth = current_depth.saturating_add(1);
+                    q.push_back(IndexTask {
+                        uri: source_uri.clone(),
+                        depth: next_depth,
+                        submitted_at: Instant::now(),
+                    });
+                    pending.lock().unwrap().insert(source_uri.clone());
+                    log::trace!(
+                        "Queued transitive dependency: {} (depth {})",
+                        source_uri,
+                        next_depth
+                    );
                 }
             }
         }

--- a/crates/raven/src/cross_file/cache.rs
+++ b/crates/raven/src/cross_file/cache.rs
@@ -45,25 +45,25 @@ pub(crate) fn pin_aware_push<V>(
 ) {
     let already_present = guard.contains(&uri);
     let cap = guard.cap().get();
-    if !already_present && guard.len() >= cap {
-        if let Ok(p) = pinned.read() {
-            let lru_unpinned = guard
-                .iter()
-                .rev()
-                .find(|(k, _)| !p.contains(*k))
-                .map(|(k, _)| k.clone());
+    if !already_present
+        && guard.len() >= cap
+        && let Ok(p) = pinned.read()
+    {
+        let lru_unpinned = guard
+            .iter()
+            .rev()
+            .find(|(k, _)| !p.contains(*k))
+            .map(|(k, _)| k.clone());
 
-            if let Some(victim) = lru_unpinned {
-                guard.pop(&victim);
-            } else {
-                let new_cap =
-                    NonZeroUsize::new(guard.len() + 1).expect("len() + 1 is always non-zero");
-                guard.resize(new_cap);
-            }
+        if let Some(victim) = lru_unpinned {
+            guard.pop(&victim);
+        } else {
+            let new_cap = NonZeroUsize::new(guard.len() + 1).expect("len() + 1 is always non-zero");
+            guard.resize(new_cap);
         }
-        // pinned.read() poisoned: fall through to push() — may evict a
-        // pinned entry, but the lock is already in a bad state.
     }
+    // pinned.read() poisoned: fall through to push() — may evict a
+    // pinned entry, but the lock is already in a bad state.
     guard.push(uri, entry);
 }
 

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -9,7 +9,7 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use super::parent_resolve::{infer_call_site_from_parent, resolve_match_pattern};
 use super::path_resolve::{
-    path_to_uri, resolve_path, resolve_path_with_workspace_fallback, PathContext,
+    PathContext, path_to_uri, resolve_path, resolve_path_with_workspace_fallback,
 };
 use super::types::{CallSiteSpec, CrossFileMetadata};
 
@@ -438,49 +438,49 @@ where
     );
 
     // If multiple backward directives resolve to different working directories, log which one we used.
-    if meta.sourced_by.len() > 1 {
-        if let Some(ref first_wd) = inherited_wd {
-            let mut differing_parent: Option<(String, String)> = None;
-            let backward_ctx = PathContext::new(uri, workspace_root);
-            for directive in meta.sourced_by.iter().skip(1) {
-                let ctx = match backward_ctx.as_ref() {
-                    Some(ctx) => ctx,
-                    None => break,
-                };
-                let other_parent_path = match resolve_path(&directive.path, ctx) {
-                    Some(path) => path,
-                    None => continue,
-                };
-                let other_parent_uri = match path_to_uri(&other_parent_path) {
-                    Some(uri) => uri,
-                    None => continue,
-                };
-                let mut other_visited = HashSet::new();
-                let other_wd = resolve_parent_working_directory_with_visited(
-                    &other_parent_uri,
-                    get_metadata,
-                    workspace_root,
-                    max_depth,
-                    &mut other_visited,
-                );
-                if let Some(other_wd) = other_wd {
-                    if &other_wd != first_wd {
-                        differing_parent = Some((directive.path.clone(), other_wd));
-                        break;
-                    }
-                }
+    if meta.sourced_by.len() > 1
+        && let Some(ref first_wd) = inherited_wd
+    {
+        let mut differing_parent: Option<(String, String)> = None;
+        let backward_ctx = PathContext::new(uri, workspace_root);
+        for directive in meta.sourced_by.iter().skip(1) {
+            let ctx = match backward_ctx.as_ref() {
+                Some(ctx) => ctx,
+                None => break,
+            };
+            let other_parent_path = match resolve_path(&directive.path, ctx) {
+                Some(path) => path,
+                None => continue,
+            };
+            let other_parent_uri = match path_to_uri(&other_parent_path) {
+                Some(uri) => uri,
+                None => continue,
+            };
+            let mut other_visited = HashSet::new();
+            let other_wd = resolve_parent_working_directory_with_visited(
+                &other_parent_uri,
+                get_metadata,
+                workspace_root,
+                max_depth,
+                &mut other_visited,
+            );
+            if let Some(other_wd) = other_wd
+                && &other_wd != first_wd
+            {
+                differing_parent = Some((directive.path.clone(), other_wd));
+                break;
             }
+        }
 
-            if let Some((other_parent, other_wd)) = differing_parent {
-                log::trace!(
-                    "Multiple backward directives for {} resolve to different working directories; using first parent '{}' with WD '{}', ignoring '{}' (WD '{}')",
-                    uri,
-                    first_directive.path,
-                    first_wd,
-                    other_parent,
-                    other_wd
-                );
-            }
+        if let Some((other_parent, other_wd)) = differing_parent {
+            log::trace!(
+                "Multiple backward directives for {} resolve to different working directories; using first parent '{}' with WD '{}', ignoring '{}' (WD '{}')",
+                uri,
+                first_directive.path,
+                first_wd,
+                other_parent,
+                other_wd
+            );
         }
     }
 
@@ -950,101 +950,99 @@ impl DependencyGraph {
         // Requirements 4.1, 4.2, 4.3, 4.4, 4.5
         let mut ast_edges: Vec<DependencyEdge> = Vec::new();
         for source in &meta.sources {
-            if !source.is_directive {
-                if let Some(to_uri) = do_resolve(&source.path) {
-                    let edge = DependencyEdge {
-                        from: uri.clone(),
-                        to: to_uri.clone(),
-                        call_site_line: Some(source.line),
-                        call_site_column: Some(source.column),
-                        local: source.local,
-                        chdir: source.chdir,
-                        is_sys_source: source.is_sys_source,
-                        is_directive: false,
-                        is_backward_directive: false,
-                    };
-                    let pair = edge.as_from_to_pair();
+            if !source.is_directive
+                && let Some(to_uri) = do_resolve(&source.path)
+            {
+                let edge = DependencyEdge {
+                    from: uri.clone(),
+                    to: to_uri.clone(),
+                    call_site_line: Some(source.line),
+                    call_site_column: Some(source.column),
+                    local: source.local,
+                    chdir: source.chdir,
+                    is_sys_source: source.is_sys_source,
+                    is_directive: false,
+                    is_backward_directive: false,
+                };
+                let pair = edge.as_from_to_pair();
 
-                    // Check for directive-vs-AST conflict
-                    if directive_from_to.contains(&pair) {
-                        // Find the directive edge for this (from, to) pair
-                        let directive_edge =
-                            directive_edges.iter().find(|e| e.as_from_to_pair() == pair);
+                // Check for directive-vs-AST conflict
+                if directive_from_to.contains(&pair) {
+                    // Find the directive edge for this (from, to) pair
+                    let directive_edge =
+                        directive_edges.iter().find(|e| e.as_from_to_pair() == pair);
 
-                        if let Some(dir_edge) = directive_edge {
-                            // Check if directive has a known call site
-                            let directive_has_call_site = dir_edge.call_site_line.is_some()
-                                && dir_edge.call_site_line != Some(u32::MAX);
+                    if let Some(dir_edge) = directive_edge {
+                        // Check if directive has a known call site
+                        let directive_has_call_site = dir_edge.call_site_line.is_some()
+                            && dir_edge.call_site_line != Some(u32::MAX);
 
-                            if directive_has_call_site {
-                                // Directive has known call site: only override AST edge at same call site
+                        if directive_has_call_site {
+                            // Directive has known call site: only override AST edge at same call site
+                            // (Requirement 4.3)
+                            let call_sites_match = dir_edge.call_site_line == edge.call_site_line
+                                && dir_edge.call_site_column == edge.call_site_column;
+
+                            if call_sites_match {
+                                // Case 1: Same call site - directive wins, skip AST edge
                                 // (Requirement 4.3)
-                                let call_sites_match = dir_edge.call_site_line
-                                    == edge.call_site_line
-                                    && dir_edge.call_site_column == edge.call_site_column;
-
-                                if call_sites_match {
-                                    // Case 1: Same call site - directive wins, skip AST edge
-                                    // (Requirement 4.3)
-                                    continue;
-                                } else {
-                                    // Case 2: Different call sites - keep both edges
-                                    // (Requirement 4.4)
-                                    ast_edges.push(edge);
-                                    continue;
-                                }
+                                continue;
                             } else {
-                                // Directive has no explicit call site
-                                // (Requirement 4.5)
+                                // Case 2: Different call sites - keep both edges
+                                // (Requirement 4.4)
+                                ast_edges.push(edge);
+                                continue;
+                            }
+                        } else {
+                            // Directive has no explicit call site
+                            // (Requirement 4.5)
 
-                                // Get the directive's line (where it appears in the file)
-                                let directive_line = meta
-                                    .sources
-                                    .iter()
-                                    .find(|s| {
-                                        s.is_directive
-                                            && do_resolve(&s.path) == Some(to_uri.clone())
-                                    })
-                                    .map(|s| s.line);
+                            // Get the directive's line (where it appears in the file)
+                            let directive_line = meta
+                                .sources
+                                .iter()
+                                .find(|s| {
+                                    s.is_directive && do_resolve(&s.path) == Some(to_uri.clone())
+                                })
+                                .map(|s| s.line);
 
-                                // Check if AST edge is at an earlier line than the directive
-                                let ast_is_earlier = match directive_line {
-                                    Some(dir_line) => source.line < dir_line,
-                                    None => false, // If we can't determine directive line, don't treat AST as earlier
-                                };
+                            // Check if AST edge is at an earlier line than the directive
+                            let ast_is_earlier = match directive_line {
+                                Some(dir_line) => source.line < dir_line,
+                                None => false, // If we can't determine directive line, don't treat AST as earlier
+                            };
 
-                                if ast_is_earlier {
-                                    // Case 3: Directive without line=, AST at earlier line
-                                    // Keep AST edge (earliest call site wins), store redundancy info
-                                    // for optional diagnostic emission with configurable severity
-                                    // (Requirement 4.5, 6.2)
-                                    let diag_line = directive_line.unwrap_or(0);
-                                    let target_filename = to_uri
-                                        .path_segments()
-                                        .and_then(|mut s| s.next_back())
-                                        .unwrap_or("")
-                                        .to_string();
-                                    result.redundant_directives.push(RedundantDirective {
-                                        directive_line: diag_line,
-                                        target_filename,
-                                        source_call_line: source.line,
-                                    });
-                                    ast_edges.push(edge);
-                                    continue;
-                                } else {
-                                    // AST is at same or later line than directive
-                                    // Directive wins (it's earlier or at same position)
-                                    // Skip AST edge
-                                    continue;
-                                }
+                            if ast_is_earlier {
+                                // Case 3: Directive without line=, AST at earlier line
+                                // Keep AST edge (earliest call site wins), store redundancy info
+                                // for optional diagnostic emission with configurable severity
+                                // (Requirement 4.5, 6.2)
+                                let diag_line = directive_line.unwrap_or(0);
+                                let target_filename = to_uri
+                                    .path_segments()
+                                    .and_then(|mut s| s.next_back())
+                                    .unwrap_or("")
+                                    .to_string();
+                                result.redundant_directives.push(RedundantDirective {
+                                    directive_line: diag_line,
+                                    target_filename,
+                                    source_call_line: source.line,
+                                });
+                                ast_edges.push(edge);
+                                continue;
+                            } else {
+                                // AST is at same or later line than directive
+                                // Directive wins (it's earlier or at same position)
+                                // Skip AST edge
+                                continue;
                             }
                         }
-                        // No matching directive edge found (shouldn't happen), skip
-                        continue;
                     }
-
-                    ast_edges.push(edge);
+                    // No matching directive edge found (shouldn't happen), skip
+                    continue;
                 }
+
+                ast_edges.push(edge);
             }
         }
 
@@ -1637,13 +1635,12 @@ impl DependencyGraph {
 
         // Fast path: cache hit at the current edge revision. `peek` to keep
         // the read lock concurrent (no LRU promotion under shared access).
-        if let Ok(guard) = self.cycle_cache.read() {
-            if let Some((cached_rev, cached_result)) = guard.peek(uri) {
-                if *cached_rev == revision {
-                    self.cycle_cache_hits.fetch_add(1, Ordering::Relaxed);
-                    return cached_result.clone();
-                }
-            }
+        if let Ok(guard) = self.cycle_cache.read()
+            && let Some((cached_rev, cached_result)) = guard.peek(uri)
+            && *cached_rev == revision
+        {
+            self.cycle_cache_hits.fetch_add(1, Ordering::Relaxed);
+            return cached_result.clone();
         }
 
         let mut visited = HashSet::new();
@@ -1680,13 +1677,12 @@ impl DependencyGraph {
         use std::sync::atomic::Ordering;
         let revision = self.edge_revision.load(Ordering::Acquire);
 
-        if let Ok(guard) = self.subgraph_cache.read() {
-            if let Some((cached_rev, cached)) = guard.peek(&(uri.clone(), max_depth, max_visited)) {
-                if *cached_rev == revision {
-                    self.subgraph_cache_hits.fetch_add(1, Ordering::Relaxed);
-                    return std::sync::Arc::clone(cached);
-                }
-            }
+        if let Ok(guard) = self.subgraph_cache.read()
+            && let Some((cached_rev, cached)) = guard.peek(&(uri.clone(), max_depth, max_visited))
+            && *cached_rev == revision
+        {
+            self.subgraph_cache_hits.fetch_add(1, Ordering::Relaxed);
+            return std::sync::Arc::clone(cached);
         }
 
         let neighborhood = self.collect_neighborhood(uri, max_depth, max_visited);

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -25,22 +25,22 @@ struct DirectivePatterns {
 /// Extract path from capture groups (double-quoted, single-quoted, or unquoted)
 fn capture_path(caps: &regex::Captures, base_group: usize) -> Option<String> {
     // Try double-quoted (base_group)
-    if let Some(m) = caps.get(base_group) {
-        if !m.as_str().is_empty() {
-            return Some(m.as_str().to_string());
-        }
+    if let Some(m) = caps.get(base_group)
+        && !m.as_str().is_empty()
+    {
+        return Some(m.as_str().to_string());
     }
     // Try single-quoted (base_group + 1)
-    if let Some(m) = caps.get(base_group + 1) {
-        if !m.as_str().is_empty() {
-            return Some(m.as_str().to_string());
-        }
+    if let Some(m) = caps.get(base_group + 1)
+        && !m.as_str().is_empty()
+    {
+        return Some(m.as_str().to_string());
     }
     // Try unquoted (base_group + 2)
-    if let Some(m) = caps.get(base_group + 2) {
-        if !m.as_str().is_empty() {
-            return Some(m.as_str().to_string());
-        }
+    if let Some(m) = caps.get(base_group + 2)
+        && !m.as_str().is_empty()
+    {
+        return Some(m.as_str().to_string());
     }
     None
 }
@@ -174,51 +174,47 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
         }
 
         // Header-only: backward directives
-        if in_header {
-            if let Some(caps) = patterns.backward.captures(line) {
-                let path = capture_path(&caps, 1).unwrap_or_default();
-                let call_site = if let Some(line_match) = caps.get(4) {
-                    let line_str = line_match.as_str();
-                    if line_str == "eof" || line_str == "end" {
-                        // Use u32::MAX as EOF sentinel
-                        CallSiteSpec::Line(u32::MAX)
-                    } else {
-                        // Convert 1-based user input to 0-based internal
-                        let user_line: u32 = line_str.parse().unwrap_or(1);
-                        CallSiteSpec::Line(user_line.saturating_sub(1))
-                    }
-                } else if let Some(match_pattern) = caps.get(5) {
-                    CallSiteSpec::Match(match_pattern.as_str().to_string())
+        if in_header && let Some(caps) = patterns.backward.captures(line) {
+            let path = capture_path(&caps, 1).unwrap_or_default();
+            let call_site = if let Some(line_match) = caps.get(4) {
+                let line_str = line_match.as_str();
+                if line_str == "eof" || line_str == "end" {
+                    // Use u32::MAX as EOF sentinel
+                    CallSiteSpec::Line(u32::MAX)
                 } else {
-                    CallSiteSpec::Default
-                };
-                log::trace!(
-                    "  Parsed backward directive at line {}: path='{}' call_site={:?}",
-                    line_num,
-                    path,
-                    call_site
-                );
-                meta.sourced_by.push(BackwardDirective {
-                    path,
-                    call_site,
-                    directive_line: line_num,
-                });
-                continue;
-            }
+                    // Convert 1-based user input to 0-based internal
+                    let user_line: u32 = line_str.parse().unwrap_or(1);
+                    CallSiteSpec::Line(user_line.saturating_sub(1))
+                }
+            } else if let Some(match_pattern) = caps.get(5) {
+                CallSiteSpec::Match(match_pattern.as_str().to_string())
+            } else {
+                CallSiteSpec::Default
+            };
+            log::trace!(
+                "  Parsed backward directive at line {}: path='{}' call_site={:?}",
+                line_num,
+                path,
+                call_site
+            );
+            meta.sourced_by.push(BackwardDirective {
+                path,
+                call_site,
+                directive_line: line_num,
+            });
+            continue;
         }
 
         // Header-only: working directory directive
-        if in_header {
-            if let Some(caps) = patterns.working_dir.captures(line) {
-                let path = capture_path(&caps, 1).unwrap_or_default();
-                log::trace!(
-                    "  Parsed working directory directive at line {}: path='{}'",
-                    line_num,
-                    path
-                );
-                meta.working_directory = Some(path);
-                continue;
-            }
+        if in_header && let Some(caps) = patterns.working_dir.captures(line) {
+            let path = capture_path(&caps, 1).unwrap_or_default();
+            log::trace!(
+                "  Parsed working directory directive at line {}: path='{}'",
+                line_num,
+                path
+            );
+            meta.working_directory = Some(path);
+            continue;
         }
 
         // Full-file: forward directive

--- a/crates/raven/src/cross_file/integration_tests.rs
+++ b/crates/raven/src/cross_file/integration_tests.rs
@@ -1295,7 +1295,9 @@ result <- get_colnames(my_data)
         assert!(
             children.contains(&get_colnames_uri),
             "collate.r should have get_colnames.r as a dependency. Expected: {}, Found {} children: {:?}",
-            get_colnames_uri, children.len(), children
+            get_colnames_uri,
+            children.len(),
+            children
         );
 
         // Verify get_colnames.r has collate.r as a parent
@@ -1430,7 +1432,9 @@ my_function <- function() {
             children.contains(&child_uri),
             "oos.r should have subdir/child.r as a dependency (forward edge created by backward directive). \
              Expected: {}, Found {} children: {:?}",
-            child_uri, children.len(), children
+            child_uri,
+            children.len(),
+            children
         );
 
         // Verify child.r has oos.r as a parent
@@ -1887,7 +1891,9 @@ child_function <- function() {
             children.contains(&child_uri),
             "parent.r should have subdir/child.r as a dependency (forward edge created by backward directive). \
              Expected: {}, Found {} children: {:?}",
-            child_uri, children.len(), children
+            child_uri,
+            children.len(),
+            children
         );
         println!("  ✓ Forward edge exists: parent.r -> subdir/child.r");
 
@@ -2240,7 +2246,9 @@ child_function <- function() {
             "parent.r should have child.r as a dependency (forward edge created by backward directive). \
              Bug would cause this to fail because file_exists would not check filesystem. \
              Expected: {}, Found {} children: {:?}",
-            child_uri, children.len(), children
+            child_uri,
+            children.len(),
+            children
         );
         println!("  ✓ Forward edge exists: parent.r -> child.r");
 
@@ -4347,7 +4355,9 @@ wrong_func <- function() { "wrong" }
             resolved.display()
         );
         println!("\nRequirements Validated:");
-        println!("  - 2.1: Child with backward directive inherits parent's directory when parent has no @lsp-cd");
+        println!(
+            "  - 2.1: Child with backward directive inherits parent's directory when parent has no @lsp-cd"
+        );
         println!("  - 2.2: Path resolution correctly uses parent's directory path for inheritance");
     }
 
@@ -4674,8 +4684,8 @@ mod lsp_source_scope_tests {
     use super::*;
     use crate::cross_file::dependency::DependencyGraph;
     use crate::cross_file::scope::{
-        compute_artifacts, compute_artifacts_with_metadata, scope_at_position_with_graph,
-        ScopeArtifacts,
+        ScopeArtifacts, compute_artifacts, compute_artifacts_with_metadata,
+        scope_at_position_with_graph,
     };
     use crate::cross_file::types::CrossFileMetadata;
     use std::collections::HashSet;
@@ -5942,7 +5952,7 @@ mod cross_directory_hoisting_tests {
     use super::*;
     use crate::cross_file::dependency::DependencyGraph;
     use crate::cross_file::scope::{
-        compute_artifacts, scope_at_position_with_graph, ScopeArtifacts,
+        ScopeArtifacts, compute_artifacts, scope_at_position_with_graph,
     };
     use crate::cross_file::types::{
         BackwardDirective, CallSiteSpec, CrossFileMetadata, ForwardSource,

--- a/crates/raven/src/cross_file/parent_resolve.rs
+++ b/crates/raven/src/cross_file/parent_resolve.rs
@@ -14,7 +14,7 @@ use super::config::{CallSiteDefault, CrossFileConfig};
 use super::dependency::DependencyGraph;
 #[cfg(test)]
 use super::types::BackwardDirective;
-use super::types::{byte_offset_to_utf16_column, CallSiteSpec, CrossFileMetadata};
+use super::types::{CallSiteSpec, CrossFileMetadata, byte_offset_to_utf16_column};
 
 /// Resolve the effective call site when a file is sourced multiple times.
 /// Returns the earliest call site position using lexicographic ordering.
@@ -208,12 +208,12 @@ where
                 .unwrap_or_default();
 
             // Try to get parent directory name for relative path matching
-            if let Some(parent) = full_path.parent() {
-                if let Some(parent_name) = parent.file_name() {
-                    let parent_str = parent_name.to_string_lossy();
-                    // Return "parent/filename" format for better matching
-                    return format!("{}/{}", parent_str, filename);
-                }
+            if let Some(parent) = full_path.parent()
+                && let Some(parent_name) = parent.file_name()
+            {
+                let parent_str = parent_name.to_string_lossy();
+                // Return "parent/filename" format for better matching
+                return format!("{}/{}", parent_str, filename);
             }
             filename
         })

--- a/crates/raven/src/cross_file/path_resolve.rs
+++ b/crates/raven/src/cross_file/path_resolve.rs
@@ -95,20 +95,20 @@ impl PathContext {
         // Apply inherited working directory if no explicit one.
         // Inherited working directories are stored as absolute paths, so use directly
         // when absolute. Only resolve if relative (legacy/edge case).
-        if ctx.working_directory.is_none() {
-            if let Some(ref inherited_wd) = metadata.inherited_working_directory {
-                let inherited_path = PathBuf::from(inherited_wd);
-                if inherited_path.is_absolute() {
-                    ctx.inherited_working_directory = Some(inherited_path);
-                } else {
-                    // Relative inherited paths should not occur in normal operation
-                    log::trace!(
-                        "Inherited WD is relative '{}' for {}, resolving relative to file directory",
-                        inherited_wd,
-                        file_uri
-                    );
-                    ctx.inherited_working_directory = resolve_working_directory(inherited_wd, &ctx);
-                }
+        if ctx.working_directory.is_none()
+            && let Some(ref inherited_wd) = metadata.inherited_working_directory
+        {
+            let inherited_path = PathBuf::from(inherited_wd);
+            if inherited_path.is_absolute() {
+                ctx.inherited_working_directory = Some(inherited_path);
+            } else {
+                // Relative inherited paths should not occur in normal operation
+                log::trace!(
+                    "Inherited WD is relative '{}' for {}, resolving relative to file directory",
+                    inherited_wd,
+                    file_uri
+                );
+                ctx.inherited_working_directory = resolve_working_directory(inherited_wd, &ctx);
             }
         }
 
@@ -256,20 +256,22 @@ fn resolve_path_impl(
         let has_explicit_wd = context.working_directory.is_some();
         let has_inherited_wd = context.inherited_working_directory.is_some();
 
-        if try_workspace_fallback && !has_explicit_wd && !has_inherited_wd {
-            if let Some(ref workspace_root) = context.workspace_root {
-                let workspace_resolved = workspace_root.join(path);
-                if let Some(workspace_canonical) = normalize_path(&workspace_resolved) {
-                    if workspace_canonical.exists() {
-                        log::trace!(
-                            "Resolved path '{}' via workspace-root fallback: '{}' (file-relative '{}' did not exist)",
-                            path,
-                            workspace_canonical.display(),
-                            canonical.display()
-                        );
-                        return Some(workspace_canonical);
-                    }
-                }
+        if try_workspace_fallback
+            && !has_explicit_wd
+            && !has_inherited_wd
+            && let Some(ref workspace_root) = context.workspace_root
+        {
+            let workspace_resolved = workspace_root.join(path);
+            if let Some(workspace_canonical) = normalize_path(&workspace_resolved)
+                && workspace_canonical.exists()
+            {
+                log::trace!(
+                    "Resolved path '{}' via workspace-root fallback: '{}' (file-relative '{}' did not exist)",
+                    path,
+                    workspace_canonical.display(),
+                    canonical.display()
+                );
+                return Some(workspace_canonical);
             }
         }
 
@@ -363,10 +365,10 @@ fn normalize_path(path: &Path) -> Option<PathBuf> {
             std::path::Component::ParentDir => {
                 // Only pop if the last component is a Normal segment
                 // Preserve RootDir and Prefix components
-                if let Some(last) = components.last() {
-                    if matches!(last, std::path::Component::Normal(_)) {
-                        components.pop();
-                    }
+                if let Some(last) = components.last()
+                    && matches!(last, std::path::Component::Normal(_))
+                {
+                    components.pop();
                 }
             }
             std::path::Component::CurDir => {}

--- a/crates/raven/src/cross_file/property_tests.rs
+++ b/crates/raven/src/cross_file/property_tests.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::directive::parse_directives;
-use super::path_resolve::{resolve_working_directory, PathContext};
+use super::path_resolve::{PathContext, resolve_working_directory};
 use super::types::{CallSiteSpec, CrossFileMetadata};
 
 // ============================================================================
@@ -1556,7 +1556,7 @@ proptest! {
 // Validates: Requirements 5.4, 7.3, 8.3, 9.2, 9.3
 // ============================================================================
 
-use super::scope::{compute_artifacts, scope_at_position_with_deps, ScopeArtifacts};
+use super::scope::{ScopeArtifacts, compute_artifacts, scope_at_position_with_deps};
 
 fn parse_r_tree(code: &str) -> tree_sitter::Tree {
     let mut parser = Parser::new();
@@ -7604,7 +7604,7 @@ proptest! {
 // - The position ordering is correct
 // ============================================================================
 
-use super::scope::{event_effect_position, ScopeEvent};
+use super::scope::{ScopeEvent, event_effect_position};
 
 /// R reserved words that cannot be used as package names
 const R_RESERVED_PKG: &[&str] = &[
@@ -7750,16 +7750,10 @@ proptest! {
             prev_pos = pos;
         }
 
-        // 6. Verify position-aware property: PackageLoad should come AFTER definitions on earlier lines
-        //    and BEFORE definitions on later lines
-        for event in &artifacts.timeline {
-            if let ScopeEvent::Def { line, .. } = event {
-                if *line < library_line as u32 {
-                    // Definitions before library call should come before PackageLoad in timeline
-                    // (This is implicitly verified by the sorted check above)
-                }
-            }
-        }
+        // 6. Position-aware property: definitions before the library call come before
+        //    PackageLoad in the timeline, and definitions after it come after. This is
+        //    implicitly verified by the sorted-timeline check in step 5 above, so there
+        //    is no separate assertion here.
     }
 
     /// Property 3 extended: Multiple library calls should create multiple PackageLoad events in order

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -14,7 +14,7 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::{Node, Tree};
 
 use super::source_detect::{detect_library_calls, detect_rm_calls, detect_source_calls};
-use super::types::{byte_offset_to_utf16_column, ForwardSource};
+use super::types::{ForwardSource, byte_offset_to_utf16_column};
 
 // ============================================================================
 // Line Index for Fast Lookups
@@ -409,15 +409,15 @@ impl FunctionScopeTree {
 
         // Compute max_end as max of: node's end, left subtree max_end, right subtree max_end
         let mut max_end = interval.end;
-        if let Some(ref left_node) = left {
-            if left_node.max_end > max_end {
-                max_end = left_node.max_end;
-            }
+        if let Some(ref left_node) = left
+            && left_node.max_end > max_end
+        {
+            max_end = left_node.max_end;
         }
-        if let Some(ref right_node) = right {
-            if right_node.max_end > max_end {
-                max_end = right_node.max_end;
-            }
+        if let Some(ref right_node) = right
+            && right_node.max_end > max_end
+        {
+            max_end = right_node.max_end;
         }
 
         Some(Box::new(IntervalNode {
@@ -475,10 +475,10 @@ impl FunctionScopeTree {
         // Prune left subtree if its max_end < pos
         // If the maximum end position in the left subtree is less than the query position,
         // no interval in the left subtree can contain the position.
-        if let Some(ref left) = node.left {
-            if left.max_end >= pos {
-                Self::query_point_recursive(left, pos, results);
-            }
+        if let Some(ref left) = node.left
+            && left.max_end >= pos
+        {
+            Self::query_point_recursive(left, pos, results);
         }
 
         // Prune right subtree if node's start > pos
@@ -487,10 +487,11 @@ impl FunctionScopeTree {
         // so none of them can contain the position.
         // We also skip the right subtree when its max_end is before the query position,
         // since no interval in it can contain pos.
-        if let Some(ref right) = node.right {
-            if node.interval.start <= pos && right.max_end >= pos {
-                Self::query_point_recursive(right, pos, results);
-            }
+        if let Some(ref right) = node.right
+            && node.interval.start <= pos
+            && right.max_end >= pos
+        {
+            Self::query_point_recursive(right, pos, results);
         }
     }
 
@@ -531,31 +532,30 @@ impl FunctionScopeTree {
     ) -> Option<FunctionScopeInterval> {
         // If the current node starts after the position, only the left subtree might contain pos.
         if node.interval.start > pos {
-            if let Some(ref left) = node.left {
-                if left.max_end >= pos {
-                    return Self::query_innermost_recursive(left, pos);
-                }
+            if let Some(ref left) = node.left
+                && left.max_end >= pos
+            {
+                return Self::query_innermost_recursive(left, pos);
             }
             return None;
         }
 
         // Prefer right subtree first (larger start positions).
-        if let Some(ref right) = node.right {
-            if right.max_end >= pos {
-                if let Some(right_result) = Self::query_innermost_recursive(right, pos) {
-                    return Some(right_result);
-                }
-            }
+        if let Some(ref right) = node.right
+            && right.max_end >= pos
+            && let Some(right_result) = Self::query_innermost_recursive(right, pos)
+        {
+            return Some(right_result);
         }
 
         if node.interval.contains(pos) {
             return Some(node.interval);
         }
 
-        if let Some(ref left) = node.left {
-            if left.max_end >= pos {
-                return Self::query_innermost_recursive(left, pos);
-            }
+        if let Some(ref left) = node.left
+            && left.max_end >= pos
+        {
+            return Self::query_innermost_recursive(left, pos);
         }
 
         None
@@ -1934,10 +1934,10 @@ where
                     // Local definitions take precedence (don't overwrite)
 
                     // Skip function-local definitions not in our scope
-                    if let Some(def_scope) = function_scope {
-                        if !active_function_scopes.contains(def_scope) {
-                            continue;
-                        }
+                    if let Some(def_scope) = function_scope
+                        && !active_function_scopes.contains(def_scope)
+                    {
+                        continue;
                     }
                     scope.symbols.entry(symbol.name.clone()).or_insert_with(|| {
                         log::trace!(
@@ -1961,10 +1961,10 @@ where
             } => {
                 // Only include if source() call is before the position
                 if (*src_line, *src_col) < (line, column) {
-                    if let Some(src_scope) = function_scope {
-                        if !active_function_scopes.contains(src_scope) {
-                            continue;
-                        }
+                    if let Some(src_scope) = function_scope
+                        && !active_function_scopes.contains(src_scope)
+                    {
+                        continue;
                     }
                     // If this is a local-only source (or sys.source into a non-global env), only
                     // make its symbols available within the containing function scope.
@@ -2132,45 +2132,45 @@ fn collect_definitions(
     // The symbol's own `defined_line/defined_column` (used for hover and
     // go-to-definition) remains at the LHS identifier, so navigation is
     // unaffected.
-    if node.kind() == "binary_operator" {
-        if let Some(symbol) = try_extract_assignment(node, line_index, uri) {
-            let (visible_line, visible_column) =
-                assignment_visible_from_position(node, line_index, &symbol);
-            let event = ScopeEvent::Def {
-                line: symbol.defined_line,
-                column: symbol.defined_column,
-                visible_from_line: visible_line,
-                visible_from_column: visible_column,
-                symbol: symbol.clone(),
-                function_scope: None,
-            };
-            artifacts.timeline.push(event);
-            artifacts
-                .exported_interface
-                .insert(symbol.name.clone(), symbol);
-        }
+    if node.kind() == "binary_operator"
+        && let Some(symbol) = try_extract_assignment(node, line_index, uri)
+    {
+        let (visible_line, visible_column) =
+            assignment_visible_from_position(node, line_index, &symbol);
+        let event = ScopeEvent::Def {
+            line: symbol.defined_line,
+            column: symbol.defined_column,
+            visible_from_line: visible_line,
+            visible_from_column: visible_column,
+            symbol: symbol.clone(),
+            function_scope: None,
+        };
+        artifacts.timeline.push(event);
+        artifacts
+            .exported_interface
+            .insert(symbol.name.clone(), symbol);
     }
 
     // Check for assign() calls (Requirement 17.4). The value argument is always
     // an immediately-evaluated expression (R does not introspect strings here),
     // so the RHS-before-binding rule always applies — the new binding becomes
     // visible at the end of the call.
-    if node.kind() == "call" {
-        if let Some(symbol) = try_extract_assign_call(node, line_index, uri) {
-            let (visible_line, visible_column) = node_end_position_utf16(node, line_index);
-            let event = ScopeEvent::Def {
-                line: symbol.defined_line,
-                column: symbol.defined_column,
-                visible_from_line: visible_line,
-                visible_from_column: visible_column,
-                symbol: symbol.clone(),
-                function_scope: None,
-            };
-            artifacts.timeline.push(event);
-            artifacts
-                .exported_interface
-                .insert(symbol.name.clone(), symbol);
-        }
+    if node.kind() == "call"
+        && let Some(symbol) = try_extract_assign_call(node, line_index, uri)
+    {
+        let (visible_line, visible_column) = node_end_position_utf16(node, line_index);
+        let event = ScopeEvent::Def {
+            line: symbol.defined_line,
+            column: symbol.defined_column,
+            visible_from_line: visible_line,
+            visible_from_column: visible_column,
+            symbol: symbol.clone(),
+            function_scope: None,
+        };
+        artifacts.timeline.push(event);
+        artifacts
+            .exported_interface
+            .insert(symbol.name.clone(), symbol);
     }
 
     // Check for for loop iterators.
@@ -2182,28 +2182,28 @@ fn collect_definitions(
     // position. (Whether `for (i in expr_referencing_i)` should resolve to an
     // outer `i` is a separate question with the same answer R itself gives;
     // this fix targets `<-`/`=`/`<<-`/`assign()` only.)
-    if node.kind() == "for_statement" {
-        if let Some(symbol) = try_extract_for_loop_iterator(node, line_index, uri) {
-            let event = ScopeEvent::Def {
-                line: symbol.defined_line,
-                column: symbol.defined_column,
-                visible_from_line: symbol.defined_line,
-                visible_from_column: symbol.defined_column,
-                symbol: symbol.clone(),
-                function_scope: None,
-            };
-            artifacts.timeline.push(event);
-            artifacts
-                .exported_interface
-                .insert(symbol.name.clone(), symbol);
-        }
+    if node.kind() == "for_statement"
+        && let Some(symbol) = try_extract_for_loop_iterator(node, line_index, uri)
+    {
+        let event = ScopeEvent::Def {
+            line: symbol.defined_line,
+            column: symbol.defined_column,
+            visible_from_line: symbol.defined_line,
+            visible_from_column: symbol.defined_column,
+            symbol: symbol.clone(),
+            function_scope: None,
+        };
+        artifacts.timeline.push(event);
+        artifacts
+            .exported_interface
+            .insert(symbol.name.clone(), symbol);
     }
 
     // Check for function definitions to extract parameter scope
-    if node.kind() == "function_definition" {
-        if let Some(function_scope) = try_extract_function_scope(node, line_index, uri) {
-            artifacts.timeline.push(function_scope);
-        }
+    if node.kind() == "function_definition"
+        && let Some(function_scope) = try_extract_function_scope(node, line_index, uri)
+    {
+        artifacts.timeline.push(function_scope);
     }
 
     // Recurse into children
@@ -2226,7 +2226,8 @@ fn try_extract_function_scope(node: Node, line_index: &LineIndex, uri: &Url) -> 
         .child_by_field_name("body")
         .or_else(|| {
             // Most common body node for function definitions.
-            node.children(&mut node.walk())
+            let mut cursor = node.walk();
+            node.children(&mut cursor)
                 .find(|c| c.is_named() && c.kind() == "braced_expression")
         })
         .or_else(|| {
@@ -2243,10 +2244,9 @@ fn try_extract_function_scope(node: Node, line_index: &LineIndex, uri: &Url) -> 
         if matches!(
             child.kind(),
             "parameter" | "default_parameter" | "identifier" | "dots"
-        ) {
-            if let Some(param_symbol) = extract_parameter_symbol(child, line_index, uri) {
-                parameters.push(param_symbol);
-            }
+        ) && let Some(param_symbol) = extract_parameter_symbol(child, line_index, uri)
+        {
+            parameters.push(param_symbol);
         }
     }
 
@@ -3711,10 +3711,10 @@ where
             } => {
                 // Include source() if before position, or if hoisting and it's a global source()
                 let passes_position = (*src_line, *src_col) < (line, column);
-                if let Some(src_scope) = function_scope {
-                    if !active_function_scopes.contains(src_scope) {
-                        continue;
-                    }
+                if let Some(src_scope) = function_scope
+                    && !active_function_scopes.contains(src_scope)
+                {
+                    continue;
                 }
                 let is_global_source = query_inside_function && function_scope.is_none();
                 if passes_position || is_global_source {
@@ -4072,10 +4072,10 @@ where
     // NAMESPACE-imported symbols that were not already resolved by the
     // standard scope engine above. This ensures existing local definitions
     // always take precedence (additive-only).
-    if current_depth == 0 {
-        if let Some(contrib) = package_contribution {
-            append_package_contribution(&mut scope, uri, contrib);
-        }
+    if current_depth == 0
+        && let Some(contrib) = package_contribution
+    {
+        append_package_contribution(&mut scope, uri, contrib);
     }
 
     scope
@@ -7734,12 +7734,13 @@ outside_var <- 2"#;
         inside_function: bool,
     ) -> Option<tree_sitter::Node<'a>> {
         let now_inside_function = inside_function || node.kind() == "function_definition";
-        if now_inside_function && node.kind() == "call" {
-            if let Some(func_node) = node.child_by_field_name("function") {
-                if func_node.kind() == "identifier" && &content[func_node.byte_range()] == name {
-                    return Some(node);
-                }
-            }
+        if now_inside_function
+            && node.kind() == "call"
+            && let Some(func_node) = node.child_by_field_name("function")
+            && func_node.kind() == "identifier"
+            && &content[func_node.byte_range()] == name
+        {
+            return Some(node);
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
@@ -12806,9 +12807,7 @@ x <- 1"#;
 
         // Grandparent should have stringr (loaded in grandchild, propagated via loaded_packages)
         assert!(
-            grandparent_scope
-                .loaded_packages
-                .contains("stringr"),
+            grandparent_scope.loaded_packages.contains("stringr"),
             "Grandparent should have stringr from grandchild (package propagation via loaded_packages)"
         );
 
@@ -13343,7 +13342,7 @@ y <- filter(df)"#;
 
     mod reserved_word_property_tests {
         use super::*;
-        use crate::reserved_words::{is_reserved_word, RESERVED_WORDS};
+        use crate::reserved_words::{RESERVED_WORDS, is_reserved_word};
         use proptest::prelude::*;
 
         /// Strategy to generate a reserved word from the set.
@@ -13372,8 +13371,8 @@ y <- filter(df)"#;
 
         /// Generate R code with an assignment to a reserved word.
         /// Returns (code, reserved_word, operator).
-        fn reserved_word_assignment_strategy(
-        ) -> impl Strategy<Value = (String, &'static str, &'static str)> {
+        fn reserved_word_assignment_strategy()
+        -> impl Strategy<Value = (String, &'static str, &'static str)> {
             (
                 reserved_word_strategy(),
                 assignment_operator_strategy(),

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tree_sitter::{Node, Tree};
 
 use super::scope::FunctionScopeInterval;
-use super::types::{byte_offset_to_utf16_column, ForwardSource};
+use super::types::{ForwardSource, byte_offset_to_utf16_column};
 
 /// Detected rm()/remove() call with extracted symbol names
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,10 +88,10 @@ pub fn detect_source_calls(tree: &Tree, content: &str) -> Vec<ForwardSource> {
 }
 
 fn visit_node(node: Node, content: &str, sources: &mut Vec<ForwardSource>) {
-    if node.kind() == "call" {
-        if let Some(source) = try_parse_source_call(node, content) {
-            sources.push(source);
-        }
+    if node.kind() == "call"
+        && let Some(source) = try_parse_source_call(node, content)
+    {
+        sources.push(source);
     }
 
     for child in node.children(&mut node.walk()) {
@@ -161,16 +161,16 @@ fn has_function_definition_ancestor(node: Node) -> bool {
 fn find_envir_is_global(args_node: &Node, content: &str) -> bool {
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "envir" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        let value = node_text(value_node, content).trim();
-                        // Check for globalenv() or .GlobalEnv
-                        return value == "globalenv()" || value == ".GlobalEnv";
-                    }
-                }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "envir"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                let value = node_text(value_node, content).trim();
+                // Check for globalenv() or .GlobalEnv
+                return value == "globalenv()" || value == ".GlobalEnv";
             }
         }
     }
@@ -185,24 +185,25 @@ fn find_file_argument(args_node: &Node, content: &str) -> Option<String> {
 
     // Look for named "file" argument
     for child in &children {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "file" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        return extract_string_literal(value_node, content);
-                    }
-                }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "file"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                return extract_string_literal(value_node, content);
             }
         }
     }
 
     // Use first positional argument
     for child in &children {
-        if child.kind() == "argument" && child.child_by_field_name("name").is_none() {
-            if let Some(value_node) = child.child_by_field_name("value") {
-                return extract_string_literal(value_node, content);
-            }
+        if child.kind() == "argument"
+            && child.child_by_field_name("name").is_none()
+            && let Some(value_node) = child.child_by_field_name("value")
+        {
+            return extract_string_literal(value_node, content);
         }
     }
 
@@ -212,19 +213,19 @@ fn find_file_argument(args_node: &Node, content: &str) -> Option<String> {
 fn find_bool_argument(args_node: &Node, content: &str, param_name: &str) -> Option<bool> {
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == param_name {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        let value = node_text(value_node, content);
-                        return match value {
-                            "TRUE" | "T" => Some(true),
-                            "FALSE" | "F" => Some(false),
-                            _ => None,
-                        };
-                    }
-                }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == param_name
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                let value = node_text(value_node, content);
+                return match value {
+                    "TRUE" | "T" => Some(true),
+                    "FALSE" | "F" => Some(false),
+                    _ => None,
+                };
             }
         }
     }
@@ -274,12 +275,12 @@ fn visit_node_for_rm(node: Node, content: &str, rm_calls: &mut Vec<RmCall>) {
     if node.kind() == "identifier" {
         return;
     }
-    if node.kind() == "call" {
-        if let Some(rm_call) = try_parse_rm_call(node, content) {
-            // Only add if there are symbols to remove
-            if !rm_call.symbols.is_empty() {
-                rm_calls.push(rm_call);
-            }
+    if node.kind() == "call"
+        && let Some(rm_call) = try_parse_rm_call(node, content)
+    {
+        // Only add if there are symbols to remove
+        if !rm_call.symbols.is_empty() {
+            rm_calls.push(rm_call);
         }
     }
 
@@ -334,20 +335,20 @@ fn try_parse_rm_call(node: Node, content: &str) -> Option<RmCall> {
 fn has_non_default_envir_for_rm(args_node: &Node, content: &str) -> bool {
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "envir" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        let value = node_text(value_node, content).trim();
-                        // Default-equivalent values: globalenv() or .GlobalEnv
-                        if value == "globalenv()" || value == ".GlobalEnv" {
-                            return false;
-                        }
-                        // Any other value means non-default
-                        return true;
-                    }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "envir"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                let value = node_text(value_node, content).trim();
+                // Default-equivalent values: globalenv() or .GlobalEnv
+                if value == "globalenv()" || value == ".GlobalEnv" {
+                    return false;
                 }
+                // Any other value means non-default
+                return true;
             }
         }
     }
@@ -364,13 +365,13 @@ fn extract_bare_symbols(args_node: &Node, content: &str) -> Vec<String> {
     for child in args_node.children(&mut cursor) {
         if child.kind() == "argument" {
             // Only process positional arguments (no name)
-            if child.child_by_field_name("name").is_none() {
-                if let Some(value_node) = child.child_by_field_name("value") {
-                    // Only extract if it's an identifier (bare symbol)
-                    if value_node.kind() == "identifier" {
-                        let symbol_name = node_text(value_node, content).to_string();
-                        symbols.push(symbol_name);
-                    }
+            if child.child_by_field_name("name").is_none()
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                // Only extract if it's an identifier (bare symbol)
+                if value_node.kind() == "identifier" {
+                    let symbol_name = node_text(value_node, content).to_string();
+                    symbols.push(symbol_name);
                 }
             }
         }
@@ -394,10 +395,10 @@ fn extract_list_symbols(args_node: &Node, content: &str) -> Vec<String> {
             // Look for named argument with name "list"
             if let Some(name_node) = child.child_by_field_name("name") {
                 let name = node_text(name_node, content);
-                if name == "list" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        return extract_list_value_symbols(value_node, content);
-                    }
+                if name == "list"
+                    && let Some(value_node) = child.child_by_field_name("value")
+                {
+                    return extract_list_value_symbols(value_node, content);
                 }
             }
         }
@@ -464,14 +465,12 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
     if let Some(args_node) = node.child_by_field_name("arguments") {
         let mut cursor = args_node.walk();
         for child in args_node.children(&mut cursor) {
-            if child.kind() == "argument" {
-                if let Some(value_node) = child.child_by_field_name("value") {
-                    if value_node.kind() == "string" {
-                        if let Some(s) = extract_string_literal(value_node, content) {
-                            symbols.push(s);
-                        }
-                    }
-                }
+            if child.kind() == "argument"
+                && let Some(value_node) = child.child_by_field_name("value")
+                && value_node.kind() == "string"
+                && let Some(s) = extract_string_literal(value_node, content)
+            {
+                symbols.push(s);
             }
         }
     }
@@ -657,15 +656,15 @@ fn try_parse_library_call(node: Node, content: &str) -> Option<LibraryCall> {
 fn has_character_only_true(args_node: &Node, content: &str) -> bool {
     let mut cursor = args_node.walk();
     for child in args_node.children(&mut cursor) {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "character.only" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        let value = node_text(value_node, content);
-                        return value == "TRUE" || value == "T";
-                    }
-                }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "character.only"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                let value = node_text(value_node, content);
+                return value == "TRUE" || value == "T";
             }
         }
     }
@@ -701,24 +700,25 @@ fn extract_package_name(args_node: &Node, content: &str) -> Option<String> {
 
     // Look for named "package" argument first
     for child in &children {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "package" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        return extract_package_value(value_node, content);
-                    }
-                }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "package"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                return extract_package_value(value_node, content);
             }
         }
     }
 
     // Use first positional argument
     for child in &children {
-        if child.kind() == "argument" && child.child_by_field_name("name").is_none() {
-            if let Some(value_node) = child.child_by_field_name("value") {
-                return extract_package_value(value_node, content);
-            }
+        if child.kind() == "argument"
+            && child.child_by_field_name("name").is_none()
+            && let Some(value_node) = child.child_by_field_name("value")
+        {
+            return extract_package_value(value_node, content);
         }
     }
 
@@ -835,12 +835,11 @@ fn record_binary_assignment(node: Node, content: &str, map: &mut HashMap<String,
     let entry = map.entry(name).or_default();
     entry.assignment_count = entry.assignment_count.saturating_add(1);
 
-    if matches!(op.as_str(), "<-" | "=") {
-        if let Some(packages) = extract_c_strings_strict(value_node, content) {
-            if entry.static_packages.is_none() {
-                entry.static_packages = Some((packages, node.start_byte()));
-            }
-        }
+    if matches!(op.as_str(), "<-" | "=")
+        && let Some(packages) = extract_c_strings_strict(value_node, content)
+        && entry.static_packages.is_none()
+    {
+        entry.static_packages = Some((packages, node.start_byte()));
     }
 }
 
@@ -941,12 +940,11 @@ fn record_assign_call(node: Node, content: &str, map: &mut HashMap<String, VarBi
 
     let entry = map.entry(name).or_default();
     entry.assignment_count = entry.assignment_count.saturating_add(1);
-    if let Some(value_node) = value_node {
-        if let Some(packages) = extract_c_strings_strict(value_node, content) {
-            if entry.static_packages.is_none() {
-                entry.static_packages = Some((packages, node.start_byte()));
-            }
-        }
+    if let Some(value_node) = value_node
+        && let Some(packages) = extract_c_strings_strict(value_node, content)
+        && entry.static_packages.is_none()
+    {
+        entry.static_packages = Some((packages, node.start_byte()));
     }
 }
 
@@ -3252,8 +3250,8 @@ mod property_tests {
     /// assert!(!code.is_empty());
     /// assert!(!specs.is_empty());
     /// ```
-    fn r_code_with_dynamic_library_calls(
-    ) -> impl Strategy<Value = (String, Vec<DynamicLibraryCallSpec>)> {
+    fn r_code_with_dynamic_library_calls()
+    -> impl Strategy<Value = (String, Vec<DynamicLibraryCallSpec>)> {
         // Generate 1-5 dynamic library calls
         prop::collection::vec(dynamic_library_call_spec(), 1..=5)
             .prop_flat_map(|specs| {
@@ -3307,8 +3305,8 @@ mod property_tests {
     /// // `strat` is a `Strategy` that generates `(String, Vec<LibraryCallSpec>, Vec<DynamicLibraryCallSpec>)`.
     /// let _ = strat;
     /// ```
-    fn r_code_with_mixed_library_calls(
-    ) -> impl Strategy<Value = (String, Vec<LibraryCallSpec>, Vec<DynamicLibraryCallSpec>)> {
+    fn r_code_with_mixed_library_calls()
+    -> impl Strategy<Value = (String, Vec<LibraryCallSpec>, Vec<DynamicLibraryCallSpec>)> {
         (
             prop::collection::vec(library_call_spec(), 1..=3),
             prop::collection::vec(dynamic_library_call_spec(), 1..=3),

--- a/crates/raven/src/cross_file/workspace_index.rs
+++ b/crates/raven/src/cross_file/workspace_index.rs
@@ -118,10 +118,11 @@ impl CrossFileWorkspaceIndex {
         }
 
         let user_cap = self.user_cap.load(Ordering::Relaxed);
-        if let Some(user_cap_nz) = NonZeroUsize::new(user_cap) {
-            if guard.cap().get() > user_cap && guard.len() <= user_cap {
-                guard.resize(user_cap_nz);
-            }
+        if let Some(user_cap_nz) = NonZeroUsize::new(user_cap)
+            && guard.cap().get() > user_cap
+            && guard.len() <= user_cap
+        {
+            guard.resize(user_cap_nz);
         }
     }
 
@@ -267,11 +268,11 @@ impl CrossFileWorkspaceIndex {
             if exclude.contains(uri) {
                 continue;
             }
-            if let Ok(p) = uri.to_file_path() {
-                if p.starts_with(prefix) {
-                    for name in entry.artifacts.exported_interface.keys() {
-                        symbols.insert(name.to_string());
-                    }
+            if let Ok(p) = uri.to_file_path()
+                && p.starts_with(prefix)
+            {
+                for name in entry.artifacts.exported_interface.keys() {
+                    symbols.insert(name.to_string());
                 }
             }
         }

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -8,8 +8,8 @@
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use indexmap::IndexSet;
 use ropey::Rope;
@@ -828,33 +828,27 @@ impl DocumentStore {
     }
     /// Recursively visit nodes to find library/require calls
     fn visit_for_packages(node: tree_sitter::Node, text: &str, packages: &mut Vec<String>) {
-        if node.kind() == "call" {
-            if let Some(func_node) = node.child_by_field_name("function") {
-                let func_text = &text[func_node.byte_range()];
+        if node.kind() == "call"
+            && let Some(func_node) = node.child_by_field_name("function")
+        {
+            let func_text = &text[func_node.byte_range()];
 
-                if func_text == "library" || func_text == "require" || func_text == "loadNamespace"
-                {
-                    if let Some(args_node) = node.child_by_field_name("arguments") {
-                        for i in 0..args_node.child_count() {
-                            if let Some(child) = args_node.child(i) {
-                                if child.kind() == "argument" {
-                                    if let Some(value_node) = child.child_by_field_name("value") {
-                                        let value_text = &text[value_node.byte_range()];
-                                        let pkg_name = value_text
-                                            .trim_matches(|c: char| c == '"' || c == '\'');
-                                        if crate::r_subprocess::is_valid_package_name(pkg_name) {
-                                            packages.push(pkg_name.to_string());
-                                        } else {
-                                            log::warn!(
-                                                "Skipping suspicious package name: {}",
-                                                pkg_name
-                                            );
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
+            if (func_text == "library" || func_text == "require" || func_text == "loadNamespace")
+                && let Some(args_node) = node.child_by_field_name("arguments")
+            {
+                for i in 0..args_node.child_count() {
+                    if let Some(child) = args_node.child(i)
+                        && child.kind() == "argument"
+                        && let Some(value_node) = child.child_by_field_name("value")
+                    {
+                        let value_text = &text[value_node.byte_range()];
+                        let pkg_name = value_text.trim_matches(|c: char| c == '"' || c == '\'');
+                        if crate::r_subprocess::is_valid_package_name(pkg_name) {
+                            packages.push(pkg_name.to_string());
+                        } else {
+                            log::warn!("Skipping suspicious package name: {}", pkg_name);
                         }
+                        break;
                     }
                 }
             }
@@ -1967,8 +1961,8 @@ mod tests {
 
                 // The last accessed document should still be present (if any eviction occurred)
                 // because it was most recently used
-                if let Some(ref last_uri) = last_accessed {
-                    if store.metrics().evictions > 0 && store.len() > 1 {
+                if let Some(ref last_uri) = last_accessed
+                    && store.metrics().evictions > 0 && store.len() > 1 {
                         // If evictions happened and we have multiple docs,
                         // the most recently accessed should likely still be there
                         // (unless the large doc alone exceeds the limit)
@@ -1984,7 +1978,6 @@ mod tests {
                             let _ = last_uri; // Acknowledge we checked
                         }
                     }
-                }
 
                 // Memory should be within limits
                 let final_memory = store.estimate_memory_usage();

--- a/crates/raven/src/file_path_intellisense.rs
+++ b/crates/raven/src/file_path_intellisense.rs
@@ -18,7 +18,7 @@ use tree_sitter::{Node, Tree};
 
 use crate::cross_file::directive::{BACKWARD_DIRECTIVE_KEYWORDS, FORWARD_DIRECTIVE_KEYWORDS};
 use crate::cross_file::path_resolve::PathContext;
-use crate::cross_file::types::{byte_offset_to_utf16_column, CrossFileMetadata};
+use crate::cross_file::types::{CrossFileMetadata, byte_offset_to_utf16_column};
 use crate::utf16::utf16_column_to_byte_offset;
 
 // ============================================================================
@@ -295,16 +295,16 @@ fn is_file_argument(string_node: &Node, call_node: &Node, content: &str) -> bool
 
     // Check for named "file" argument
     for child in &children {
-        if child.kind() == "argument" {
-            if let Some(name_node) = child.child_by_field_name("name") {
-                let name = node_text(name_node, content);
-                if name == "file" {
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        // Check if this value node contains our string node
-                        if nodes_overlap(&value_node, string_node) {
-                            return true;
-                        }
-                    }
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            let name = node_text(name_node, content);
+            if name == "file"
+                && let Some(value_node) = child.child_by_field_name("value")
+            {
+                // Check if this value node contains our string node
+                if nodes_overlap(&value_node, string_node) {
+                    return true;
                 }
             }
         }
@@ -972,22 +972,22 @@ pub fn file_path_definition(
     }
 
     // 5. Check workspace boundary if workspace_root is provided
-    if let Some(workspace_url) = workspace_root {
-        if let Ok(workspace_path) = workspace_url.to_file_path() {
-            // Canonicalize both paths for accurate comparison
-            let canonical_resolved = resolved_path.canonicalize().ok();
-            let canonical_workspace = workspace_path.canonicalize().ok();
+    if let Some(workspace_url) = workspace_root
+        && let Ok(workspace_path) = workspace_url.to_file_path()
+    {
+        // Canonicalize both paths for accurate comparison
+        let canonical_resolved = resolved_path.canonicalize().ok();
+        let canonical_workspace = workspace_path.canonicalize().ok();
 
-            if let (Some(resolved), Some(workspace)) = (canonical_resolved, canonical_workspace) {
-                if !resolved.starts_with(&workspace) {
-                    log::trace!(
-                        "file_path_definition: Path '{}' is outside workspace '{}'",
-                        resolved_path.display(),
-                        workspace_path.display()
-                    );
-                    return None;
-                }
-            }
+        if let (Some(resolved), Some(workspace)) = (canonical_resolved, canonical_workspace)
+            && !resolved.starts_with(&workspace)
+        {
+            log::trace!(
+                "file_path_definition: Path '{}' is outside workspace '{}'",
+                resolved_path.display(),
+                workspace_path.display()
+            );
+            return None;
         }
     }
 
@@ -1372,10 +1372,11 @@ pub fn resolve_base_directory(
                 // use workspace-root fallback to match resolve_path_with_workspace_fallback behavior
                 let has_explicit_wd = path_context.working_directory.is_some();
                 let has_inherited_wd = path_context.inherited_working_directory.is_some();
-                if !has_explicit_wd && !has_inherited_wd {
-                    if let Some(ref workspace_root) = path_context.workspace_root {
-                        return Some(workspace_root.clone());
-                    }
+                if !has_explicit_wd
+                    && !has_inherited_wd
+                    && let Some(ref workspace_root) = path_context.workspace_root
+                {
+                    return Some(workspace_root.clone());
                 }
                 Some(path_context.effective_working_directory())
             } else {
@@ -1402,10 +1403,11 @@ pub fn resolve_base_directory(
                 if partial_dir.is_empty() {
                     let has_explicit_wd = path_context.working_directory.is_some();
                     let has_inherited_wd = path_context.inherited_working_directory.is_some();
-                    if !has_explicit_wd && !has_inherited_wd {
-                        if let Some(ref workspace_root) = path_context.workspace_root {
-                            return Some(workspace_root.clone());
-                        }
+                    if !has_explicit_wd
+                        && !has_inherited_wd
+                        && let Some(ref workspace_root) = path_context.workspace_root
+                    {
+                        return Some(workspace_root.clone());
                     }
                     Some(path_context.effective_working_directory())
                 } else {
@@ -1457,10 +1459,10 @@ fn normalize_path_for_completion(path: &Path) -> Option<PathBuf> {
             std::path::Component::ParentDir => {
                 // Only pop if the last component is a Normal segment
                 // Preserve RootDir and Prefix components
-                if let Some(last) = components.last() {
-                    if matches!(last, std::path::Component::Normal(_)) {
-                        components.pop();
-                    }
+                if let Some(last) = components.last()
+                    && matches!(last, std::path::Component::Normal(_))
+                {
+                    components.pop();
                 }
             }
             std::path::Component::CurDir => {
@@ -5372,8 +5374,8 @@ mod tests {
                     if let Ok(normalized) = escape_path.canonicalize() {
                         // If the normalized path is outside workspace, listing it
                         // with workspace boundary should exclude entries
-                        if let Ok(canonical_workspace) = workspace_path.canonicalize() {
-                            if !normalized.starts_with(&canonical_workspace) {
+                        if let Ok(canonical_workspace) = workspace_path.canonicalize()
+                            && !normalized.starts_with(&canonical_workspace) {
                                 // This path is outside workspace
                                 // list_directory_entries should either fail or return
                                 // entries filtered by workspace boundary
@@ -5392,7 +5394,6 @@ mod tests {
                                     }
                                 }
                             }
-                        }
                     }
                 }
             }
@@ -5444,8 +5445,8 @@ mod tests {
                             // canonicalize and check, it should be filtered
                             // if it points outside the workspace
                             for (name, path, _) in &entries {
-                                if let Ok(canonical_path) = path.canonicalize() {
-                                    if let Ok(canonical_workspace) = workspace.canonicalize() {
+                                if let Ok(canonical_path) = path.canonicalize()
+                                    && let Ok(canonical_workspace) = workspace.canonicalize() {
                                         // Entries should be within workspace
                                         // Note: The symlink entry itself is in workspace,
                                         // but its target is outside. The current implementation
@@ -5459,7 +5460,6 @@ mod tests {
                                             canonical_workspace
                                         );
                                     }
-                                }
                             }
                         }
                     }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -18,8 +18,8 @@ use tree_sitter::QueryCursor;
 
 use crate::content_provider::ContentProvider;
 use crate::cross_file::dependency::compute_inherited_working_directory;
-use crate::cross_file::{scope, ScopedSymbol};
-use crate::file_type::{file_type_from_uri, FileType};
+use crate::cross_file::{ScopedSymbol, scope};
+use crate::file_type::{FileType, file_type_from_uri};
 use crate::state::WorldState;
 use crate::utf16::utf16_column_to_byte_offset;
 
@@ -398,49 +398,47 @@ pub(crate) fn diagnostics_from_snapshot(
     ));
 
     // Cycle detection (uses pre-computed result from full graph, not trimmed subgraph)
-    if let Some(severity) = snapshot.cross_file_config.circular_dependency_severity {
-        if let Some(cycle) = &snapshot.cycle_detection {
-            let out = &cycle.outgoing_edge;
-            let close = &cycle.closing_edge;
-            let line = out.call_site_line.unwrap_or(0);
-            let col = out.call_site_column.unwrap_or(0);
-            let max_line = snapshot.text.lines().count().saturating_sub(1) as u32;
-            let line = line.min(max_line);
+    if let Some(severity) = snapshot.cross_file_config.circular_dependency_severity
+        && let Some(cycle) = &snapshot.cycle_detection
+    {
+        let out = &cycle.outgoing_edge;
+        let close = &cycle.closing_edge;
+        let line = out.call_site_line.unwrap_or(0);
+        let col = out.call_site_column.unwrap_or(0);
+        let max_line = snapshot.text.lines().count().saturating_sub(1) as u32;
+        let line = line.min(max_line);
 
-            let closing_file = close
-                .from
-                .path_segments()
-                .and_then(|mut s| s.next_back().map(|s| s.to_string()))
-                .unwrap_or_default();
-            let closing_line_1based = close.call_site_line.map(|l| l + 1);
+        let closing_file = close
+            .from
+            .path_segments()
+            .and_then(|mut s| s.next_back().map(|s| s.to_string()))
+            .unwrap_or_default();
+        let closing_line_1based = close.call_site_line.map(|l| l + 1);
 
-            let message = match (
-                closing_line_1based,
-                snapshot.cycle_closing_snippet.as_deref(),
-            ) {
-                (Some(cl), Some(code)) => {
-                    format!(
-                        "Circular dependency: {closing_file} line {cl} sources this file: `{code}`"
-                    )
-                }
-                (Some(cl), None) => {
-                    format!("Circular dependency: {closing_file} line {cl} sources this file")
-                }
-                _ => {
-                    format!("Circular dependency: {closing_file} sources this file")
-                }
-            };
+        let message = match (
+            closing_line_1based,
+            snapshot.cycle_closing_snippet.as_deref(),
+        ) {
+            (Some(cl), Some(code)) => {
+                format!("Circular dependency: {closing_file} line {cl} sources this file: `{code}`")
+            }
+            (Some(cl), None) => {
+                format!("Circular dependency: {closing_file} line {cl} sources this file")
+            }
+            _ => {
+                format!("Circular dependency: {closing_file} sources this file")
+            }
+        };
 
-            diagnostics.push(Diagnostic {
-                range: Range {
-                    start: Position::new(line, col),
-                    end: Position::new(line, col.saturating_add(1)),
-                },
-                severity: Some(severity),
-                message,
-                ..Default::default()
-            });
-        }
+        diagnostics.push(Diagnostic {
+            range: Range {
+                start: Position::new(line, col),
+                end: Position::new(line, col.saturating_add(1)),
+            },
+            severity: Some(severity),
+            message,
+            ..Default::default()
+        });
     }
 
     // Max depth diagnostics
@@ -828,8 +826,8 @@ fn value_is_function_definition(node: Node) -> bool {
     }
 
     let mut cursor = node.walk();
-    let contains_function_definition = node.children(&mut cursor).any(value_is_function_definition);
-    contains_function_definition
+
+    node.children(&mut cursor).any(value_is_function_definition)
 }
 fn push_function_token(node: Node, lines: &[&str], tokens: &mut Vec<AbsoluteSemanticToken>) {
     let start = node.start_position();
@@ -1703,15 +1701,15 @@ impl<'a> SymbolExtractor<'a> {
                 // The first child of a call node is the function identifier
                 let mut cursor = node.walk();
                 let children: Vec<_> = node.children(&mut cursor).collect();
-                if let Some(func_node) = children.first() {
-                    if func_node.kind() == "identifier" {
-                        let func_name = node_text(*func_node, self.text);
-                        return match func_name {
-                            "c" | "vector" | "matrix" | "array" => Some(DocumentSymbolKind::Array),
-                            "list" => Some(DocumentSymbolKind::List),
-                            _ => None,
-                        };
-                    }
+                if let Some(func_node) = children.first()
+                    && func_node.kind() == "identifier"
+                {
+                    let func_name = node_text(*func_node, self.text);
+                    return match func_name {
+                        "c" | "vector" | "matrix" | "array" => Some(DocumentSymbolKind::Array),
+                        "list" => Some(DocumentSymbolKind::List),
+                        _ => None,
+                    };
                 }
                 None
             }
@@ -2094,10 +2092,10 @@ impl<'a> SymbolExtractor<'a> {
                 // Only process positional arguments (no name field)
                 if child.child_by_field_name("name").is_none() {
                     // This is the first positional argument - it must be a string
-                    if let Some(value_node) = child.child_by_field_name("value") {
-                        if let Some(name) = self.extract_string_literal(value_node) {
-                            return Some((name, value_node));
-                        }
+                    if let Some(value_node) = child.child_by_field_name("value")
+                        && let Some(name) = self.extract_string_literal(value_node)
+                    {
+                        return Some((name, value_node));
                     }
                     // First positional argument is not a string, return None
                     return None;
@@ -4445,33 +4443,33 @@ async fn collect_missing_file_diagnostics_standalone(
             crate::cross_file::path_resolve::resolve_path_with_workspace_fallback(&source.path, ctx)
         });
         if let Some(path) = resolved {
-            if let Some(root) = &workspace_root {
-                if !path.starts_with(root) {
-                    let message = if source.is_directive {
-                        format!(
-                            "File '{}' referenced by @lsp-source directive is outside workspace",
-                            source.path
-                        )
-                    } else {
-                        format!("Path is outside workspace: '{}'", source.path)
-                    };
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position::new(source.line, source.column),
-                            end: Position::new(
-                                source.line,
-                                source
-                                    .column
-                                    .saturating_add(source.path.len() as u32)
-                                    .saturating_add(10),
-                            ),
-                        },
-                        severity: Some(missing_file_severity),
-                        message,
-                        ..Default::default()
-                    });
-                    continue;
-                }
+            if let Some(root) = &workspace_root
+                && !path.starts_with(root)
+            {
+                let message = if source.is_directive {
+                    format!(
+                        "File '{}' referenced by @lsp-source directive is outside workspace",
+                        source.path
+                    )
+                } else {
+                    format!("Path is outside workspace: '{}'", source.path)
+                };
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position::new(source.line, source.column),
+                        end: Position::new(
+                            source.line,
+                            source
+                                .column
+                                .saturating_add(source.path.len() as u32)
+                                .saturating_add(10),
+                        ),
+                    },
+                    severity: Some(missing_file_severity),
+                    message,
+                    ..Default::default()
+                });
+                continue;
             }
             paths_to_check.push((
                 path,
@@ -4513,19 +4511,19 @@ async fn collect_missing_file_diagnostics_standalone(
             .as_ref()
             .and_then(|ctx| crate::cross_file::path_resolve::resolve_path(&directive.path, ctx));
         if let Some(path) = resolved {
-            if let Some(root) = &workspace_root {
-                if !path.starts_with(root) {
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position::new(directive.directive_line, 0),
-                            end: Position::new(directive.directive_line, LSP_EOL_CHARACTER),
-                        },
-                        severity: Some(missing_file_severity),
-                        message: format!("Path is outside workspace: '{}'", directive.path),
-                        ..Default::default()
-                    });
-                    continue;
-                }
+            if let Some(root) = &workspace_root
+                && !path.starts_with(root)
+            {
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position::new(directive.directive_line, 0),
+                        end: Position::new(directive.directive_line, LSP_EOL_CHARACTER),
+                    },
+                    severity: Some(missing_file_severity),
+                    message: format!("Path is outside workspace: '{}'", directive.path),
+                    ..Default::default()
+                });
+                continue;
             }
             // Backward directives are always directives (is_directive=true for backward)
             paths_to_check.push((
@@ -4679,33 +4677,33 @@ pub async fn collect_missing_file_diagnostics_async(
         if let Some(path) = resolved_path {
             // Guard against paths outside workspace
             // Uses missing_file_severity since the file is effectively inaccessible
-            if let Some(root) = &workspace_root {
-                if !path.starts_with(root) {
-                    let message = if source.is_directive {
-                        format!(
-                            "File '{}' referenced by @lsp-source directive is outside workspace",
-                            source.path
-                        )
-                    } else {
-                        format!("Path is outside workspace: '{}'", source.path)
-                    };
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position::new(source.line, source.column),
-                            end: Position::new(
-                                source.line,
-                                source
-                                    .column
-                                    .saturating_add(source.path.len() as u32)
-                                    .saturating_add(10),
-                            ),
-                        },
-                        severity: Some(missing_file_severity),
-                        message,
-                        ..Default::default()
-                    });
-                    continue;
-                }
+            if let Some(root) = &workspace_root
+                && !path.starts_with(root)
+            {
+                let message = if source.is_directive {
+                    format!(
+                        "File '{}' referenced by @lsp-source directive is outside workspace",
+                        source.path
+                    )
+                } else {
+                    format!("Path is outside workspace: '{}'", source.path)
+                };
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position::new(source.line, source.column),
+                        end: Position::new(
+                            source.line,
+                            source
+                                .column
+                                .saturating_add(source.path.len() as u32)
+                                .saturating_add(10),
+                        ),
+                    },
+                    severity: Some(missing_file_severity),
+                    message,
+                    ..Default::default()
+                });
+                continue;
             }
             if let Some(target_uri) = crate::cross_file::path_resolve::path_to_uri(&path) {
                 uris_to_check.push((
@@ -5565,16 +5563,15 @@ fn collect_undefined_variables_from_snapshot(
         let usage_col_utf16 =
             byte_offset_to_utf16_column(usage_line_text, usage_node.start_position().column);
 
-        if hoist_globals {
-            if let Some((ref exports, ref fn_tree)) = local_opt {
-                if exports.contains(name.as_str()) {
-                    let inside_function = !fn_tree
-                        .query_point(scope::Position::new(usage_line, usage_col_utf16))
-                        .is_empty();
-                    if inside_function {
-                        continue;
-                    }
-                }
+        if hoist_globals
+            && let Some((ref exports, ref fn_tree)) = local_opt
+            && exports.contains(name.as_str())
+        {
+            let inside_function = !fn_tree
+                .query_point(scope::Position::new(usage_line, usage_col_utf16))
+                .is_empty();
+            if inside_function {
+                continue;
             }
         }
 
@@ -5592,10 +5589,10 @@ fn collect_undefined_variables_from_snapshot(
             // `symbol_for` walk is cheaper than materializing a full
             // ScopeAtPosition because it short-circuits on the first
             // matching frame.
-            if let Some(sym) = stream.symbol_for(&name) {
-                if !is_forward_reference_in_same_file(&sym, uri, usage_line, usage_col_utf16) {
-                    continue;
-                }
+            if let Some(sym) = stream.symbol_for(&name)
+                && !is_forward_reference_in_same_file(&sym, uri, usage_line, usage_col_utf16)
+            {
+                continue;
             }
             // Slow path: name is undefined or forward-referenced. We
             // need the full ScopeAtPosition for the package checks
@@ -5617,12 +5614,11 @@ fn collect_undefined_variables_from_snapshot(
         // For the no-stream fall-back path we still need to apply the
         // forward-reference check (the stream path applied it above
         // before the snapshot materialization).
-        if stream_opt.is_none() {
-            if let Some(sym) = scope.symbols.get(name.as_str()) {
-                if !is_forward_reference_in_same_file(sym, uri, usage_line, usage_col_utf16) {
-                    continue;
-                }
-            }
+        if stream_opt.is_none()
+            && let Some(sym) = scope.symbols.get(name.as_str())
+            && !is_forward_reference_in_same_file(sym, uri, usage_line, usage_col_utf16)
+        {
+            continue;
         }
 
         let defined_in_loaded_direct_source = direct_sources
@@ -5797,21 +5793,21 @@ fn is_structural_non_reference(node: Node, text: &str) -> bool {
                 return true;
             }
             // Right-assignment target: `1 -> x`, `1 ->> x`.
-            if let Some(third) = third {
-                if third.id() == node.id() && matches!(op_text, "->" | "->>") {
-                    return true;
-                }
+            if let Some(third) = third
+                && third.id() == node.id()
+                && matches!(op_text, "->" | "->>")
+            {
+                return true;
             }
         }
     }
 
     // Named argument: `n = 1` in `f(..., n = 1)`.
-    if parent.kind() == "argument" {
-        if let Some(name_node) = parent.child_by_field_name("name") {
-            if name_node.id() == node.id() {
-                return true;
-            }
-        }
+    if parent.kind() == "argument"
+        && let Some(name_node) = parent.child_by_field_name("name")
+        && name_node.id() == node.id()
+    {
+        return true;
     }
 
     // Parameter NAME only. Default expressions are intentionally treated as
@@ -5819,12 +5815,11 @@ fn is_structural_non_reference(node: Node, text: &str) -> bool {
     // source-order dependencies such as `function(a = b)` before a later
     // `source()` that defines `b`, because relying on that later side effect
     // is fragile.
-    if matches!(parent.kind(), "parameter" | "default_parameter") {
-        if let Some(name_node) = parent.child_by_field_name("name") {
-            if name_node.id() == node.id() {
-                return true;
-            }
-        }
+    if matches!(parent.kind(), "parameter" | "default_parameter")
+        && let Some(name_node) = parent.child_by_field_name("name")
+        && name_node.id() == node.id()
+    {
+        return true;
     }
 
     // Identifier directly inside a `parameters` list.
@@ -5899,13 +5894,13 @@ fn containing_default_parameter(node: Node) -> Option<Node> {
         if parent.kind() == "default_parameter" {
             return Some(parent);
         }
-        if parent.kind() == "parameter" {
-            if let Some(default_node) = parent.child_by_field_name("default") {
-                let node_range = node.byte_range();
-                let default_range = default_node.byte_range();
-                if default_range.start <= node_range.start && node_range.end <= default_range.end {
-                    return Some(parent);
-                }
+        if parent.kind() == "parameter"
+            && let Some(default_node) = parent.child_by_field_name("default")
+        {
+            let node_range = node.byte_range();
+            let default_range = default_node.byte_range();
+            if default_range.start <= node_range.start && node_range.end <= default_range.end {
+                return Some(parent);
             }
         }
         current = parent;
@@ -6576,36 +6571,36 @@ fn collect_syntax_errors_inner(
         // Bracket-kind MISSING routes through the opener-anchoring helper
         // unless the opener is already covered by a mismatched-bracket
         // diagnostic emitted earlier in this traversal.
-        if matches!(node.kind(), ")" | "}" | "]" | "]]") {
-            if let Some((opener, range)) = find_opener_for_missing(node, text) {
-                if !state.covered_openers.contains(&opener.id()) {
-                    let opener_text = text
-                        .get(opener.start_byte()..opener.end_byte())
-                        .unwrap_or("");
-                    if let Some(k) = DelimiterKind::from_opener(opener_text) {
-                        diagnostics.push(Diagnostic {
-                            range,
-                            severity: Some(DiagnosticSeverity::ERROR),
-                            message: format!(
-                                "Unclosed `{}`: missing matching `{}`",
-                                k.opener_str(),
-                                k.closer_str(),
-                            ),
-                            ..Default::default()
-                        });
-                    } else {
-                        debug_assert!(
-                            false,
-                            "find_opener_for_missing returned opener text {:?} that DelimiterKind::from_opener does not recognize; this is a precondition violation",
-                            opener_text
-                        );
-                    }
+        if matches!(node.kind(), ")" | "}" | "]" | "]]")
+            && let Some((opener, range)) = find_opener_for_missing(node, text)
+        {
+            if !state.covered_openers.contains(&opener.id()) {
+                let opener_text = text
+                    .get(opener.start_byte()..opener.end_byte())
+                    .unwrap_or("");
+                if let Some(k) = DelimiterKind::from_opener(opener_text) {
+                    diagnostics.push(Diagnostic {
+                        range,
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        message: format!(
+                            "Unclosed `{}`: missing matching `{}`",
+                            k.opener_str(),
+                            k.closer_str(),
+                        ),
+                        ..Default::default()
+                    });
+                } else {
+                    debug_assert!(
+                        false,
+                        "find_opener_for_missing returned opener text {:?} that DelimiterKind::from_opener does not recognize; this is a precondition violation",
+                        opener_text
+                    );
                 }
-                return;
             }
-            // Bracket-kind MISSING with no structural parent: fall through
-            // to the existing default branch.
+            return;
         }
+        // Bracket-kind MISSING with no structural parent: fall through
+        // to the existing default branch.
 
         // Existing default branch for non-bracket MISSING (e.g. identifier
         // missing after `x <-`). PRESERVE BYTE-FOR-BYTE from Task 3.
@@ -7015,10 +7010,10 @@ fn classify_via_delimiter_scan(
             if ch.start_byte() == target && ch.child_count() == 0 {
                 return Some(ch);
             }
-            if ch.is_error() {
-                if let Some(found) = find_node_by_byte(ch, target, depth + 1) {
-                    return Some(found);
-                }
+            if ch.is_error()
+                && let Some(found) = find_node_by_byte(ch, target, depth + 1)
+            {
+                return Some(found);
             }
         }
         None
@@ -7355,9 +7350,9 @@ fn detect_fat_arrow(node: Node, text: &str) -> Option<String> {
 #[cfg(test)]
 mod syntax_error_range_tests {
     use super::{
-        anchor_missing_position, classify_via_delimiter_scan, collect_syntax_errors,
-        delimiter_events, end_of_meaningful_content, find_first_content_line, find_innermost_error,
-        find_opener_for_missing, CollectState, DelimiterKind,
+        CollectState, DelimiterKind, anchor_missing_position, classify_via_delimiter_scan,
+        collect_syntax_errors, delimiter_events, end_of_meaningful_content,
+        find_first_content_line, find_innermost_error, find_opener_for_missing,
     };
     use tower_lsp::lsp_types::Diagnostic;
 
@@ -10356,7 +10351,7 @@ mod invalid_assignment_target_tests {
 /// behind `run_lints` would silently suppress them for any user with linting disabled.
 #[cfg(test)]
 mod semantic_warning_pipeline_tests {
-    use super::{diagnostics_from_snapshot, DiagCancelToken, DiagnosticsSnapshot};
+    use super::{DiagCancelToken, DiagnosticsSnapshot, diagnostics_from_snapshot};
     use crate::linting::LintConfig;
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::Url;
@@ -10432,38 +10427,39 @@ mod semantic_warning_pipeline_tests {
 /// else {z} }")` succeeds; the function body `function() { if (x) {y}\nelse
 /// {z} }` runs). Flagging it would be a false positive.
 fn collect_else_newline_errors(node: Node, text: &str, diagnostics: &mut Vec<Diagnostic>) {
-    if node.kind() == "identifier" && node_text(node, text) == "else" && !node.is_error() {
-        if let Some(parent) = node.parent() {
-            if !parent.is_error() {
-                let mut used_same_line_message = false;
-                let mut prev = node.prev_named_sibling();
-                while let Some(sibling) = prev {
-                    if sibling.kind() == "comment" {
-                        prev = sibling.prev_named_sibling();
-                        continue;
-                    }
-                    if sibling.kind() == "if_statement"
-                        && !if_statement_has_else(sibling)
-                        && !has_separator_between(sibling, node, text)
-                    {
-                        // Only use the brace-specific "same-line as `}`" hint
-                        // when the `if`'s body actually has a closing `}`.
-                        // For braceless bodies (`if (x) y\nelse z`), fall
-                        // through to the orphan message — saying "same line as
-                        // `}`" would lie about a brace that isn't there.
-                        if let Some(brace_line) = find_closing_brace_line(&sibling, text) {
-                            if node.start_position().row > brace_line {
-                                emit_else_newline_diagnostic(node, text, diagnostics);
-                                used_same_line_message = true;
-                            }
-                        }
-                    }
-                    break;
-                }
-                if !used_same_line_message {
-                    emit_orphan_else_diagnostic(node, text, diagnostics);
+    if node.kind() == "identifier"
+        && node_text(node, text) == "else"
+        && !node.is_error()
+        && let Some(parent) = node.parent()
+        && !parent.is_error()
+    {
+        let mut used_same_line_message = false;
+        let mut prev = node.prev_named_sibling();
+        while let Some(sibling) = prev {
+            if sibling.kind() == "comment" {
+                prev = sibling.prev_named_sibling();
+                continue;
+            }
+            if sibling.kind() == "if_statement"
+                && !if_statement_has_else(sibling)
+                && !has_separator_between(sibling, node, text)
+            {
+                // Only use the brace-specific "same-line as `}`" hint
+                // when the `if`'s body actually has a closing `}`.
+                // For braceless bodies (`if (x) y\nelse z`), fall
+                // through to the orphan message — saying "same line as
+                // `}`" would lie about a brace that isn't there.
+                if let Some(brace_line) = find_closing_brace_line(&sibling, text)
+                    && node.start_position().row > brace_line
+                {
+                    emit_else_newline_diagnostic(node, text, diagnostics);
+                    used_same_line_message = true;
                 }
             }
+            break;
+        }
+        if !used_same_line_message {
+            emit_orphan_else_diagnostic(node, text, diagnostics);
         }
     }
 
@@ -10487,10 +10483,10 @@ fn has_separator_between(prev: Node, next: Node, text: &str) -> bool {
             Some(n) if n.id() != next.id() => n.start_byte(),
             _ => next.start_byte(),
         };
-        if let Some(gap) = text.get(last_end..stop_at) {
-            if gap.contains(';') {
-                return true;
-            }
+        if let Some(gap) = text.get(last_end..stop_at)
+            && gap.contains(';')
+        {
+            return true;
         }
         match cur {
             Some(n) if n.id() != next.id() => {
@@ -10508,8 +10504,8 @@ fn has_separator_between(prev: Node, next: Node, text: &str) -> bool {
 /// statement is a fully orphan token, not a misplaced `else` for this `if`.
 fn if_statement_has_else(if_stmt: Node) -> bool {
     let mut cursor = if_stmt.walk();
-    let has_else = if_stmt.children(&mut cursor).any(|c| c.kind() == "else");
-    has_else
+
+    if_stmt.children(&mut cursor).any(|c| c.kind() == "else")
 }
 
 /// LSP `Position` for a tree-sitter node's start, converting byte column to
@@ -11073,12 +11069,12 @@ fn collect_usages_with_context<'a>(
         // containing a right-assignment operator (e.g., `-> x` or `->> x` where
         // the parser couldn't find a LHS value). This handles broken-tree
         // recovery that the structural predicate can't see.
-        if let Some(prev) = node.prev_sibling() {
-            if prev.is_error() {
-                let prev_text = &text[prev.start_byte()..prev.end_byte()];
-                if prev_text.trim() == "->" || prev_text.trim() == "->>" {
-                    return;
-                }
+        if let Some(prev) = node.prev_sibling()
+            && prev.is_error()
+        {
+            let prev_text = &text[prev.start_byte()..prev.end_byte()];
+            if prev_text.trim() == "->" || prev_text.trim() == "->>" {
+                return;
             }
         }
 
@@ -11388,28 +11384,28 @@ fn collect_stan_declaration_matches(text: &str) -> Vec<StanDocumentSymbolMatch> 
 
     for (line_idx, line) in text.lines().enumerate() {
         for (offset, candidate) in stan_line_candidates(line) {
-            if let Some(captures) = var_re.captures(candidate) {
-                if let Some(symbol) = stan_match_from_captures(
+            if let Some(captures) = var_re.captures(candidate)
+                && let Some(symbol) = stan_match_from_captures(
                     captures,
                     offset,
                     line_idx,
                     StanDocumentSymbolKind::Variable,
-                ) {
-                    matches.push(symbol);
-                    break;
-                }
+                )
+            {
+                matches.push(symbol);
+                break;
             }
 
-            if let Some(captures) = fn_re.captures(candidate) {
-                if let Some(symbol) = stan_match_from_captures(
+            if let Some(captures) = fn_re.captures(candidate)
+                && let Some(symbol) = stan_match_from_captures(
                     captures,
                     offset,
                     line_idx,
                     StanDocumentSymbolKind::Function,
-                ) {
-                    matches.push(symbol);
-                    break;
-                }
+                )
+            {
+                matches.push(symbol);
+                break;
             }
         }
     }
@@ -11506,19 +11502,16 @@ fn collect_stan_definition_candidates(text: &str) -> Vec<StanDefinitionCandidate
             if let Some(captures) = var_re
                 .captures(candidate)
                 .or_else(|| fn_re.captures(candidate))
+                && let Some(name) = captures.get(1)
             {
-                if let Some(name) = captures.get(1) {
-                    let start = offset + name.start();
-                    let end = offset + name.end();
-                    candidates.push(StanDefinitionCandidate {
-                        name: name.as_str().to_string(),
-                        line: line_idx as u32,
-                        start_col: crate::cross_file::types::byte_offset_to_utf16_column(
-                            line, start,
-                        ),
-                        end_col: crate::cross_file::types::byte_offset_to_utf16_column(line, end),
-                    });
-                }
+                let start = offset + name.start();
+                let end = offset + name.end();
+                candidates.push(StanDefinitionCandidate {
+                    name: name.as_str().to_string(),
+                    line: line_idx as u32,
+                    start_col: crate::cross_file::types::byte_offset_to_utf16_column(line, start),
+                    end_col: crate::cross_file::types::byte_offset_to_utf16_column(line, end),
+                });
             }
         }
 
@@ -11749,21 +11742,21 @@ fn collect_jags_document_completions(
     for (line_idx, line) in text.lines().enumerate() {
         let code = line.split('#').next().unwrap_or(line);
         for candidate in std::iter::once(code).chain(code.rsplit_once('{').map(|(_, tail)| tail)) {
-            if let Some(captures) = symbol_re.captures(candidate) {
-                if let Some(name) = captures.get(1) {
-                    if is_r_only_jags_completion_name(name.as_str()) {
-                        break;
-                    }
-                    push_local_symbol_completion(
-                        items,
-                        seen_names,
-                        uri,
-                        name.as_str(),
-                        line_idx as u32,
-                        CompletionItemKind::FIELD,
-                    );
+            if let Some(captures) = symbol_re.captures(candidate)
+                && let Some(name) = captures.get(1)
+            {
+                if is_r_only_jags_completion_name(name.as_str()) {
                     break;
                 }
+                push_local_symbol_completion(
+                    items,
+                    seen_names,
+                    uri,
+                    name.as_str(),
+                    line_idx as u32,
+                    CompletionItemKind::FIELD,
+                );
+                break;
             }
         }
     }
@@ -11849,22 +11842,20 @@ fn collect_jags_definition_candidates(text: &str) -> Vec<StanDefinitionCandidate
             code.match_indices('{')
                 .map(|(i, _)| (i + 1, &code[i + 1..])),
         ) {
-            if let Some(captures) = def_re.captures(candidate) {
-                if let Some(name) = captures.get(1) {
-                    let byte_start = offset + name.start();
-                    let byte_end = offset + name.end();
-                    candidates.push(StanDefinitionCandidate {
-                        name: name.as_str().to_string(),
-                        line: line_idx as u32,
-                        start_col: crate::cross_file::types::byte_offset_to_utf16_column(
-                            line, byte_start,
-                        ),
-                        end_col: crate::cross_file::types::byte_offset_to_utf16_column(
-                            line, byte_end,
-                        ),
-                    });
-                    break;
-                }
+            if let Some(captures) = def_re.captures(candidate)
+                && let Some(name) = captures.get(1)
+            {
+                let byte_start = offset + name.start();
+                let byte_end = offset + name.end();
+                candidates.push(StanDefinitionCandidate {
+                    name: name.as_str().to_string(),
+                    line: line_idx as u32,
+                    start_col: crate::cross_file::types::byte_offset_to_utf16_column(
+                        line, byte_start,
+                    ),
+                    end_col: crate::cross_file::types::byte_offset_to_utf16_column(line, byte_end),
+                });
+                break;
             }
         }
 
@@ -13125,7 +13116,7 @@ fn find_assignment_statement<'a>(
                 return Some(StatementMatch {
                     node,
                     header_only: false,
-                })
+                });
             }
             "parameter" => {
                 // For parameters, find enclosing function_definition
@@ -13159,13 +13150,13 @@ fn find_function_statement<'a>(
         match node.kind() {
             "function_definition" => {
                 // Check if parent is assignment
-                if let Some(parent) = node.parent() {
-                    if parent.kind() == "binary_operator" {
-                        return Some(StatementMatch {
-                            node: parent,
-                            header_only: false,
-                        });
-                    }
+                if let Some(parent) = node.parent()
+                    && parent.kind() == "binary_operator"
+                {
+                    return Some(StatementMatch {
+                        node: parent,
+                        header_only: false,
+                    });
                 }
                 return Some(StatementMatch {
                     node,
@@ -13212,10 +13203,10 @@ fn find_enclosing_function(mut node: tree_sitter::Node) -> Option<tree_sitter::N
     loop {
         if node.kind() == "function_definition" {
             // Check if parent is assignment
-            if let Some(parent) = node.parent() {
-                if parent.kind() == "binary_operator" {
-                    return Some(parent);
-                }
+            if let Some(parent) = node.parent()
+                && parent.kind() == "binary_operator"
+            {
+                return Some(parent);
             }
             return Some(node);
         }
@@ -13356,13 +13347,13 @@ fn extract_function_header(node: tree_sitter::Node, content: &str) -> String {
                     }
                 }
                 // Add partial last line if body starts mid-line
-                if body_start.column > 0 {
-                    if let Some(line) = lines.get(body_start.row) {
-                        if !result.is_empty() {
-                            result.push('\n');
-                        }
-                        result.push_str(line[..body_start.column.min(line.len())].trim_end());
+                if body_start.column > 0
+                    && let Some(line) = lines.get(body_start.row)
+                {
+                    if !result.is_empty() {
+                        result.push('\n');
                     }
+                    result.push_str(line[..body_start.column.min(line.len())].trim_end());
                 }
                 return result;
             }
@@ -14684,17 +14675,17 @@ pub fn goto_definition_with_cancel(
         if &file_uri == uri {
             continue;
         }
-        if let Some(artifacts) = content_provider.get_artifacts(&file_uri) {
-            if let Some(symbol) = artifacts.exported_interface.get(name) {
-                // Skip package exports (they have pseudo-URIs that can't be navigated to)
-                if symbol.source_uri.as_str().starts_with("package:") {
-                    continue;
-                }
-                return Some(GotoDefinitionResponse::Scalar(Location {
-                    uri: symbol.source_uri.clone(),
-                    range: scoped_symbol_range(symbol, name),
-                }));
+        if let Some(artifacts) = content_provider.get_artifacts(&file_uri)
+            && let Some(symbol) = artifacts.exported_interface.get(name)
+        {
+            // Skip package exports (they have pseudo-URIs that can't be navigated to)
+            if symbol.source_uri.as_str().starts_with("package:") {
+                continue;
             }
+            return Some(GotoDefinitionResponse::Scalar(Location {
+                uri: symbol.source_uri.clone(),
+                range: scoped_symbol_range(symbol, name),
+            }));
         }
     }
 
@@ -14706,17 +14697,17 @@ pub fn goto_definition_with_cancel(
         if &file_uri == uri {
             continue;
         }
-        if let Some(artifacts) = content_provider.get_artifacts(&file_uri) {
-            if let Some(symbol) = artifacts.exported_interface.get(name) {
-                // Skip package exports (they have pseudo-URIs that can't be navigated to)
-                if symbol.source_uri.as_str().starts_with("package:") {
-                    continue;
-                }
-                return Some(GotoDefinitionResponse::Scalar(Location {
-                    uri: symbol.source_uri.clone(),
-                    range: scoped_symbol_range(symbol, name),
-                }));
+        if let Some(artifacts) = content_provider.get_artifacts(&file_uri)
+            && let Some(symbol) = artifacts.exported_interface.get(name)
+        {
+            // Skip package exports (they have pseudo-URIs that can't be navigated to)
+            if symbol.source_uri.as_str().starts_with("package:") {
+                continue;
             }
+            return Some(GotoDefinitionResponse::Scalar(Location {
+                uri: symbol.source_uri.clone(),
+                range: scoped_symbol_range(symbol, name),
+            }));
         }
     }
 
@@ -14985,16 +14976,16 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
         }
         if let Some(content) = content_provider.get_content(&file_uri) {
             // Parse the content to search for references
-            if let Some(doc_state) = state.document_store.get_without_touch(&file_uri) {
-                if let Some(tree) = &doc_state.tree {
-                    find_references_in_tree(
-                        tree.root_node(),
-                        name,
-                        &content,
-                        &file_uri,
-                        &mut locations,
-                    );
-                }
+            if let Some(doc_state) = state.document_store.get_without_touch(&file_uri)
+                && let Some(tree) = &doc_state.tree
+            {
+                find_references_in_tree(
+                    tree.root_node(),
+                    name,
+                    &content,
+                    &file_uri,
+                    &mut locations,
+                );
             }
         }
     }
@@ -15235,12 +15226,12 @@ fn find_user_function_signature(
     name: &str,
 ) -> Option<String> {
     // 1. Search current document
-    if let Some(doc) = state.get_document(current_uri) {
-        if let Some(tree) = &doc.tree {
-            let text = doc.text();
-            if let Some(func_node) = find_function_definition_node(tree.root_node(), name, &text) {
-                return Some(extract_function_signature(func_node, name, &text));
-            }
+    if let Some(doc) = state.get_document(current_uri)
+        && let Some(tree) = &doc.tree
+    {
+        let text = doc.text();
+        if let Some(func_node) = find_function_definition_node(tree.root_node(), name, &text) {
+            return Some(extract_function_signature(func_node, name, &text));
         }
     }
 
@@ -34836,8 +34827,8 @@ setClass("{}", slots = c(value = "numeric"))
                 // in the items list (since they are prepended)
                 if let Some(last_param_idx) = items.iter().rposition(|item| {
                     item.sort_text.as_ref().is_some_and(|st| st.starts_with("0-"))
-                }) {
-                    if let Some(first_standard_idx) = items.iter().position(|item| {
+                })
+                    && let Some(first_standard_idx) = items.iter().position(|item| {
                         item.sort_text.as_ref().is_some_and(|st| {
                             st.starts_with("1-") || st.starts_with("4-") || st.starts_with("5-")
                         })
@@ -34851,7 +34842,6 @@ setClass("{}", slots = c(value = "numeric"))
                             code
                         );
                     }
-                }
 
                 // --- Check 4: Parameter completions are ADDITIVE (not replacing) ---
                 // The total number of items should be greater than just the parameter count
@@ -35013,8 +35003,8 @@ setClass("{}", slots = c(value = "numeric"))
                     // If the detail includes a default value (optional enhancement),
                     // verify it matches the actual default value.
                     // The design doc specifies the format: "parameter = <default>"
-                    if let Some(default_val) = default {
-                        if detail_str.contains('=') {
+                    if let Some(default_val) = default
+                        && detail_str.contains('=') {
                             // Detail includes a default — verify it contains the
                             // actual default value string
                             prop_assert!(
@@ -35030,7 +35020,6 @@ setClass("{}", slots = c(value = "numeric"))
                         // If detail is just "parameter" (no default shown), that's
                         // acceptable — defaults in detail are an optional enhancement
                         // per Requirements 2.3, 4.3, 5.2.
-                    }
                 }
             } else {
                 prop_assert!(false, "Expected CompletionResponse::Array");
@@ -37090,20 +37079,20 @@ process_data <- function(data, threshold = 0.5, ...) {
 
         for (position, symbol_name, expected_statement) in hover_tests {
             let hover_result = hover_blocking(&state, &uri, position);
-            if let Some(hover) = hover_result {
-                if let HoverContents::Markup(content) = hover.contents {
-                    assert!(
-                        content.value.contains(expected_statement),
-                        "Hover for '{}' should contain '{}', got: {}",
-                        symbol_name,
-                        expected_statement,
-                        content.value
-                    );
-                    assert!(
-                        content.value.contains("this file"),
-                        "Hover should show file location"
-                    );
-                }
+            if let Some(hover) = hover_result
+                && let HoverContents::Markup(content) = hover.contents
+            {
+                assert!(
+                    content.value.contains(expected_statement),
+                    "Hover for '{}' should contain '{}', got: {}",
+                    symbol_name,
+                    expected_statement,
+                    content.value
+                );
+                assert!(
+                    content.value.contains("this file"),
+                    "Hover should show file location"
+                );
             }
         }
     }
@@ -37275,13 +37264,13 @@ helper_transform <- function(data) {
         let multi_line_func_position = Position::new(13, 0); // analyze_data function name
         let hover_result = hover_blocking(&state, &main_uri, multi_line_func_position);
 
-        if let Some(hover) = hover_result {
-            if let HoverContents::Markup(content) = hover.contents {
-                assert!(content.value.contains("analyze_data <- function(dataset,"));
-                assert!(content.value.contains("this file"));
-                // Should handle markdown special characters properly
-                assert!(!content.value.contains("*asterisks*")); // Should be escaped
-            }
+        if let Some(hover) = hover_result
+            && let HoverContents::Markup(content) = hover.contents
+        {
+            assert!(content.value.contains("analyze_data <- function(dataset,"));
+            assert!(content.value.contains("this file"));
+            // Should handle markdown special characters properly
+            assert!(!content.value.contains("*asterisks*")); // Should be escaped
         }
 
         // Test no false positives for valid symbols
@@ -37396,14 +37385,14 @@ local_var <- 200"#;
         let hover_position = Position::new(5, 16); // "global_func" usage
         let hover_result = hover_blocking(&state, &main_uri, hover_position);
 
-        if let Some(hover) = hover_result {
-            if let HoverContents::Markup(content) = hover.contents {
-                assert!(content.value.contains("global_func"));
-                assert!(
-                    content.value.contains("global_source.R"),
-                    "Should show cross-file source"
-                );
-            }
+        if let Some(hover) = hover_result
+            && let HoverContents::Markup(content) = hover.contents
+        {
+            assert!(content.value.contains("global_func"));
+            assert!(
+                content.value.contains("global_source.R"),
+                "Should show cross-file source"
+            );
         }
     }
 
@@ -37450,15 +37439,17 @@ result <- helper_with_spaces(42)"#;
         let position = Position::new(1, 10); // "helper_with_spaces"
         let hover_result = hover_blocking(&state, &main_uri, position);
 
-        if let Some(hover) = hover_result {
-            if let HoverContents::Markup(content) = hover.contents {
-                // Should contain properly formatted hyperlink
-                assert!(content.value.contains("[utils/helpers with spaces.R]"));
-                assert!(content
+        if let Some(hover) = hover_result
+            && let HoverContents::Markup(content) = hover.contents
+        {
+            // Should contain properly formatted hyperlink
+            assert!(content.value.contains("[utils/helpers with spaces.R]"));
+            assert!(
+                content
                     .value
-                    .contains("file:///workspace/utils/helpers%20with%20spaces.R"));
-                assert!(content.value.contains("line 1"));
-            }
+                    .contains("file:///workspace/utils/helpers%20with%20spaces.R")
+            );
+            assert!(content.value.contains("line 1"));
         }
     }
 
@@ -37601,9 +37592,11 @@ result <- helper_with_spaces(42)"#;
             1,
             "Should emit one diagnostic for missing package"
         );
-        assert!(diagnostics[0]
-            .message
-            .contains("__nonexistent_package_xyz__"));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("__nonexistent_package_xyz__")
+        );
         assert!(diagnostics[0].message.contains("not installed"));
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
     }
@@ -39044,8 +39037,7 @@ result <- helper_with_spaces(42)"#;
             .documents
             .insert(utils_url.clone(), Document::new(utils_code, None));
 
-        let main_code =
-            "analyze <- function(method) { method }\nfor (j in 1:3) { print(j) }\nsource('utils.R')";
+        let main_code = "analyze <- function(method) { method }\nfor (j in 1:3) { print(j) }\nsource('utils.R')";
         state
             .documents
             .insert(main_url.clone(), Document::new(main_code, None));
@@ -40492,8 +40484,8 @@ y <- x"#;
 mod position_aware_tests {
     use crate::cross_file::directive::parse_directives;
     use crate::handlers::{
-        collect_undefined_variables_from_snapshot, diagnostics_from_snapshot, goto_definition,
-        DiagCancelToken, DiagnosticsSnapshot,
+        DiagCancelToken, DiagnosticsSnapshot, collect_undefined_variables_from_snapshot,
+        diagnostics_from_snapshot, goto_definition,
     };
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Url};
@@ -43179,7 +43171,7 @@ source(\"helpers.R\")
 #[cfg(test)]
 mod function_parameter_tests {
     use crate::handlers::{
-        collect_undefined_variables_from_snapshot, DiagCancelToken, DiagnosticsSnapshot,
+        DiagCancelToken, DiagnosticsSnapshot, collect_undefined_variables_from_snapshot,
     };
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
@@ -44422,7 +44414,7 @@ my_func <- function(a = default_value) {
 
 #[cfg(test)]
 mod diagnostics_master_switch_tests {
-    use crate::handlers::{diagnostics, DiagCancelToken};
+    use crate::handlers::{DiagCancelToken, diagnostics};
     use crate::state::{Document, WorldState};
     use proptest::prelude::*;
     use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
@@ -44941,9 +44933,11 @@ mod dollar_member_completion_tests {
         let items = completion_items("foo <- list(alpha = 1, beta = 2)\nfoo$|");
 
         assert_eq!(sorted_labels(&items), vec!["alpha", "beta"]);
-        assert!(items
-            .iter()
-            .all(|item| item.kind == Some(CompletionItemKind::FIELD)));
+        assert!(
+            items
+                .iter()
+                .all(|item| item.kind == Some(CompletionItemKind::FIELD))
+        );
     }
 
     #[test]
@@ -46509,9 +46503,11 @@ mod block_detector_integration_tests {
 
         assert_eq!(trend_section.range.end, outer_loop.range.end);
         let trend_children = trend_section.children.as_ref().unwrap();
-        assert!(trend_children
-            .iter()
-            .any(|s| s.name == "for (p_idx in 1:n_p1)"));
+        assert!(
+            trend_children
+                .iter()
+                .any(|s| s.name == "for (p_idx in 1:n_p1)")
+        );
     }
 
     #[test]

--- a/crates/raven/src/help/cache.rs
+++ b/crates/raven/src/help/cache.rs
@@ -114,11 +114,11 @@ impl HtmlHelpCache {
         result: Result_,
         expected_generation: u64,
     ) -> bool {
-        if let Ok(mut guard) = self.inner.write() {
-            if self.generation.load(Ordering::SeqCst) == expected_generation {
-                Self::insert_locked(&mut guard, topic, package, result);
-                return true;
-            }
+        if let Ok(mut guard) = self.inner.write()
+            && self.generation.load(Ordering::SeqCst) == expected_generation
+        {
+            Self::insert_locked(&mut guard, topic, package, result);
+            return true;
         }
         false
     }
@@ -213,10 +213,10 @@ impl HtmlHelpCache {
                 // single-flight guarantee until the new Owner finishes.
                 {
                     let mut map = self.in_flight.lock().expect("in_flight lock");
-                    if let Some(current) = map.get(&key) {
-                        if current.same_channel(&sender) {
-                            map.remove(&key);
-                        }
+                    if let Some(current) = map.get(&key)
+                        && current.same_channel(&sender)
+                    {
+                        map.remove(&key);
                     }
                 }
                 let shared = Arc::new(result.clone());

--- a/crates/raven/src/help/html.rs
+++ b/crates/raven/src/help/html.rs
@@ -74,12 +74,12 @@ fn get_help_html_inner(
             message: format!("invalid topic: {}", topic.escape_debug()),
         });
     }
-    if let Some(p) = package {
-        if !crate::r_subprocess::is_valid_package_name(p) {
-            return Err(HelpHtmlError::InvalidTopic {
-                message: format!("invalid package: {}", p.escape_debug()),
-            });
-        }
+    if let Some(p) = package
+        && !crate::r_subprocess::is_valid_package_name(p)
+    {
+        return Err(HelpHtmlError::InvalidTopic {
+            message: format!("invalid package: {}", p.escape_debug()),
+        });
     }
 
     let timeout = timeout_from_env();

--- a/crates/raven/src/help/rewrite.rs
+++ b/crates/raven/src/help/rewrite.rs
@@ -11,7 +11,7 @@
 //!
 //! See the help-viewer spec ("Cross-reference link rewriting") for full rules.
 
-use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use std::sync::OnceLock;
 
 /// Canonical basenames of R's bundled manuals that CRAN serves at
@@ -113,10 +113,10 @@ fn classify_href(href: &str) -> HrefKind {
     //
     // Unknown basenames (e.g. `rw-FAQ.html`, custom manuals) Drop rather
     // than synthesize a CRAN URL that would 404. See `R_MANUAL_BASENAMES`.
-    if let Some(rest) = href.strip_prefix("/doc/manual/") {
-        if let Some(url) = r_manual_cran_url(rest) {
-            return HrefKind::Replace(url);
-        }
+    if let Some(rest) = href.strip_prefix("/doc/manual/")
+        && let Some(url) = r_manual_cran_url(rest)
+    {
+        return HrefKind::Replace(url);
     }
     if let Some(rest) = href.strip_prefix("../../") {
         let mut parts = rest.splitn(3, '/');

--- a/crates/raven/src/help/text.rs
+++ b/crates/raven/src/help/text.rs
@@ -165,10 +165,10 @@ impl HelpCache {
 
         // Check argument cache under read lock (concurrent reads allowed)
         {
-            if let Ok(guard) = self.arguments.read() {
-                if let Some(cached) = guard.peek(&key) {
-                    return cached.clone();
-                }
+            if let Ok(guard) = self.arguments.read()
+                && let Some(cached) = guard.peek(&key)
+            {
+                return cached.clone();
             }
         }
 
@@ -177,11 +177,7 @@ impl HelpCache {
         let args = match help_text {
             Some(text) => {
                 let map = extract_arguments_from_help(&text);
-                if map.is_empty() {
-                    None
-                } else {
-                    Some(map)
-                }
+                if map.is_empty() { None } else { Some(map) }
             }
             // Transient R failure — don't cache so retries can succeed later
             None => return None,
@@ -309,11 +305,11 @@ fn get_help_inner(
         log::trace!("get_help: topic {:?} failed validation", topic);
         return None;
     }
-    if let Some(p) = package {
-        if !crate::r_subprocess::is_valid_package_name(p) {
-            log::trace!("get_help: package {:?} failed validation", p);
-            return None;
-        }
+    if let Some(p) = package
+        && !crate::r_subprocess::is_valid_package_name(p)
+    {
+        log::trace!("get_help: package {:?} failed validation", p);
+        return None;
     }
 
     let timeout = timeout_from_env();
@@ -360,19 +356,19 @@ fn get_help_inner(
 
     let stdout_thread = std::thread::spawn(move || -> Vec<u8> {
         let mut buf = Vec::new();
-        if let Some(mut pipe) = stdout_pipe {
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                log::trace!("get_help: failed to read stdout pipe: {}", e);
-            }
+        if let Some(mut pipe) = stdout_pipe
+            && let Err(e) = pipe.read_to_end(&mut buf)
+        {
+            log::trace!("get_help: failed to read stdout pipe: {}", e);
         }
         buf
     });
     let stderr_thread = std::thread::spawn(move || -> Vec<u8> {
         let mut buf = Vec::new();
-        if let Some(mut pipe) = stderr_pipe {
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                log::trace!("get_help: failed to read stderr pipe: {}", e);
-            }
+        if let Some(mut pipe) = stderr_pipe
+            && let Err(e) = pipe.read_to_end(&mut buf)
+        {
+            log::trace!("get_help: failed to read stderr pipe: {}", e);
         }
         buf
     });
@@ -870,12 +866,11 @@ fn is_r_param_name(s: &str) -> bool {
     if !(first.is_alphabetic() || first == '.') {
         return false;
     }
-    if first == '.' {
-        if let Some(&next) = s.as_bytes().get(1) {
-            if next.is_ascii_digit() {
-                return false;
-            }
-        }
+    if first == '.'
+        && let Some(&next) = s.as_bytes().get(1)
+        && next.is_ascii_digit()
+    {
+        return false;
     }
     chars.all(|c| c.is_alphanumeric() || c == '.' || c == '_')
 }

--- a/crates/raven/src/help/types.rs
+++ b/crates/raven/src/help/types.rs
@@ -92,20 +92,26 @@ mod tests {
     fn cacheable_classification() {
         assert!(HelpHtmlError::NotFound.is_cacheable());
         assert!(HelpHtmlError::PackageNotInstalled.is_cacheable());
-        assert!(HelpHtmlError::InvalidTopic {
-            message: "x".into()
-        }
-        .is_cacheable());
-        assert!(HelpHtmlError::RenderFailed {
-            message: "x".into()
-        }
-        .is_cacheable());
+        assert!(
+            HelpHtmlError::InvalidTopic {
+                message: "x".into()
+            }
+            .is_cacheable()
+        );
+        assert!(
+            HelpHtmlError::RenderFailed {
+                message: "x".into()
+            }
+            .is_cacheable()
+        );
         assert!(HelpHtmlError::TooLarge.is_cacheable());
         assert!(!HelpHtmlError::Timeout.is_cacheable());
-        assert!(!HelpHtmlError::RUnavailable {
-            message: "x".into()
-        }
-        .is_cacheable());
+        assert!(
+            !HelpHtmlError::RUnavailable {
+                message: "x".into()
+            }
+            .is_cacheable()
+        );
     }
 
     #[test]

--- a/crates/raven/src/indentation/context.rs
+++ b/crates/raven/src/indentation/context.rs
@@ -314,10 +314,10 @@ pub fn find_matching_opener<'a>(node: Node<'a>, delimiter: char) -> Option<Node<
             // For call nodes, return the arguments child if it exists
             if current.kind() == "call" {
                 for i in 0..current.child_count() {
-                    if let Some(child) = current.child(i) {
-                        if child.kind() == "arguments" {
-                            return Some(child);
-                        }
+                    if let Some(child) = current.child(i)
+                        && child.kind() == "arguments"
+                    {
+                        return Some(child);
                     }
                 }
             }
@@ -659,16 +659,16 @@ fn should_use_fallback(root: Node, source: &str, position: Position) -> bool {
             return true;
         }
 
-        if let Some(prev_line_text) = source.lines().nth(prev_row) {
-            if !prev_line_text.is_empty() {
-                let end_col = prev_line_text.len().saturating_sub(1);
-                let prev_end = tree_sitter::Point {
-                    row: prev_row,
-                    column: end_col,
-                };
-                if has_error_at(prev_end) {
-                    return true;
-                }
+        if let Some(prev_line_text) = source.lines().nth(prev_row)
+            && !prev_line_text.is_empty()
+        {
+            let end_col = prev_line_text.len().saturating_sub(1);
+            let prev_end = tree_sitter::Point {
+                row: prev_row,
+                column: end_col,
+            };
+            if has_error_at(prev_end) {
+                return true;
             }
         }
     }
@@ -694,61 +694,61 @@ fn fallback_detect_context(source: &str, position: Position, tab_size: u32) -> I
     // 1. Check if current line starts with closing delimiter
     if let Some(line_text) = source.lines().nth(position.line as usize) {
         let trimmed = line_text.trim_start();
-        if let Some(first_char) = trimmed.chars().next() {
-            if matches!(first_char, ')' | ']' | '}') {
-                // Find matching opener using simple bracket counting
-                if let Some((opener_line, opener_col)) =
-                    find_matching_opener_heuristic(source, position.line, first_char)
-                {
-                    return IndentContext::ClosingDelimiter {
-                        opener_line,
-                        opener_col,
-                        delimiter: first_char,
-                    };
-                }
-                // No matching opener found - use previous line indent
-                let prev_indent = if position.line > 0 {
-                    get_line_indent(source, position.line - 1, tab_size)
-                } else {
-                    0
-                };
-                return IndentContext::AfterCompleteExpression {
-                    enclosing_block_indent: prev_indent,
+        if let Some(first_char) = trimmed.chars().next()
+            && matches!(first_char, ')' | ']' | '}')
+        {
+            // Find matching opener using simple bracket counting
+            if let Some((opener_line, opener_col)) =
+                find_matching_opener_heuristic(source, position.line, first_char)
+            {
+                return IndentContext::ClosingDelimiter {
+                    opener_line,
+                    opener_col,
+                    delimiter: first_char,
                 };
             }
+            // No matching opener found - use previous line indent
+            let prev_indent = if position.line > 0 {
+                get_line_indent(source, position.line - 1, tab_size)
+            } else {
+                0
+            };
+            return IndentContext::AfterCompleteExpression {
+                enclosing_block_indent: prev_indent,
+            };
         }
     }
 
     // 2. Check if previous line ends with continuation operator
-    if position.line > 0 {
-        if let Some(prev_line) = source.lines().nth((position.line - 1) as usize) {
-            let trimmed = strip_trailing_comment(prev_line).trim_end();
+    if position.line > 0
+        && let Some(prev_line) = source.lines().nth((position.line - 1) as usize)
+    {
+        let trimmed = strip_trailing_comment(prev_line).trim_end();
 
-            // Check for continuation operators
-            let operator_type = if trimmed.ends_with("|>") {
-                Some(OperatorType::Pipe)
-            } else if trimmed.ends_with("%>%") {
-                Some(OperatorType::MagrittrPipe)
-            } else if trimmed.ends_with('+') {
-                Some(OperatorType::Plus)
-            } else if trimmed.ends_with('~') {
-                Some(OperatorType::Tilde)
-            } else if trimmed.ends_with('%') && is_custom_infix_ending(trimmed) {
-                Some(OperatorType::CustomInfix)
-            } else {
-                None
+        // Check for continuation operators
+        let operator_type = if trimmed.ends_with("|>") {
+            Some(OperatorType::Pipe)
+        } else if trimmed.ends_with("%>%") {
+            Some(OperatorType::MagrittrPipe)
+        } else if trimmed.ends_with('+') {
+            Some(OperatorType::Plus)
+        } else if trimmed.ends_with('~') {
+            Some(OperatorType::Tilde)
+        } else if trimmed.ends_with('%') && is_custom_infix_ending(trimmed) {
+            Some(OperatorType::CustomInfix)
+        } else {
+            None
+        };
+
+        if let Some(op_type) = operator_type {
+            // Find chain start using simple backward walk
+            let (chain_start_line, chain_start_col) =
+                find_chain_start_heuristic(source, position.line - 1, tab_size);
+            return IndentContext::AfterContinuationOperator {
+                chain_start_line,
+                chain_start_col,
+                operator_type: op_type,
             };
-
-            if let Some(op_type) = operator_type {
-                // Find chain start using simple backward walk
-                let (chain_start_line, chain_start_col) =
-                    find_chain_start_heuristic(source, position.line - 1, tab_size);
-                return IndentContext::AfterContinuationOperator {
-                    chain_start_line,
-                    chain_start_col,
-                    operator_type: op_type,
-                };
-            }
         }
     }
 
@@ -1112,12 +1112,11 @@ fn is_inside_pipe_chain(node: Node, source: &str) -> bool {
                 if kind == "|>" {
                     return true;
                 }
-                if kind == "special" {
-                    if let Ok(text) = child.utf8_text(source_bytes) {
-                        if text == "%>%" {
-                            return true;
-                        }
-                    }
+                if kind == "special"
+                    && let Ok(text) = child.utf8_text(source_bytes)
+                    && text == "%>%"
+                {
+                    return true;
                 }
             }
         }
@@ -1158,11 +1157,11 @@ fn find_opener_position(node: Node, delimiter: char, _source: &str) -> Option<(u
             if current.kind() == "call" {
                 // Find the arguments child
                 for i in 0..current.child_count() {
-                    if let Some(child) = current.child(i) {
-                        if child.kind() == "arguments" {
-                            let start = child.start_position();
-                            return Some((start.row as u32, start.column as u32));
-                        }
+                    if let Some(child) = current.child(i)
+                        && child.kind() == "arguments"
+                    {
+                        let start = child.start_position();
+                        return Some((start.row as u32, start.column as u32));
                     }
                 }
             }
@@ -2027,7 +2026,7 @@ mod tests {
     fn test_is_position_valid_multibyte() {
         // CJK character: 3 bytes, 1 UTF-16 code unit
         let source = "\u{4E16}\u{754C}"; // 世界 — 2 chars, 2 UTF-16 code units, 6 bytes
-                                         // character=2 (UTF-16 count) should be valid (end of line)
+        // character=2 (UTF-16 count) should be valid (end of line)
         assert!(is_position_valid(
             source,
             Position {
@@ -5628,7 +5627,10 @@ mod tests {
             IndentContext::InsideParens { .. } => {
                 // Also acceptable if cursor is considered inside
             }
-            _ => panic!("Expected AfterCompleteExpression or InsideParens for empty function call, got {:?}", ctx),
+            _ => panic!(
+                "Expected AfterCompleteExpression or InsideParens for empty function call, got {:?}",
+                ctx
+            ),
         }
     }
 
@@ -6382,7 +6384,7 @@ mod tests {
 mod auto_close_tests {
     use super::*;
     use crate::indentation::calculator::{
-        calculate_indentation, IndentationConfig, IndentationStyle,
+        IndentationConfig, IndentationStyle, calculate_indentation,
     };
     use tower_lsp::lsp_types::Position;
 

--- a/crates/raven/src/indentation/mod.rs
+++ b/crates/raven/src/indentation/mod.rs
@@ -17,9 +17,9 @@ mod calculator;
 mod context;
 mod formatter;
 
-pub use calculator::{calculate_indentation, IndentationConfig, IndentationStyle};
+pub use calculator::{IndentationConfig, IndentationStyle, calculate_indentation};
 #[allow(unused_imports)] // Used by integration tests
-pub use context::{detect_context, IndentContext, OperatorType};
+pub use context::{IndentContext, OperatorType, detect_context};
 pub use formatter::format_indentation;
 
 /// Returns the LSP capability options for on-type formatting.

--- a/crates/raven/src/linting/nolint.rs
+++ b/crates/raven/src/linting/nolint.rs
@@ -77,12 +77,10 @@ impl Suppressions {
 
         // Unterminated `nolint start` — treat as suppressing to EOF, matching
         // lintr's behavior so a missing `end` doesn't silently lose coverage.
-        if in_block {
-            if let Some(start) = block_start {
-                let total_lines = text.lines().count() as u32;
-                for l in start..total_lines {
-                    suppressed.insert(l);
-                }
+        if in_block && let Some(start) = block_start {
+            let total_lines = text.lines().count() as u32;
+            for l in start..total_lines {
+                suppressed.insert(l);
             }
         }
 

--- a/crates/raven/src/linting/rules/assignment_operator.rs
+++ b/crates/raven/src/linting/rules/assignment_operator.rs
@@ -11,10 +11,10 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::config::AssignmentOperatorStyle;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
@@ -36,45 +36,45 @@ fn visit(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    if node.kind() == "binary_operator" {
-        if let Some(op_node) = node.child_by_field_name("operator") {
-            let op_text = node_text(op_node, text);
-            // Skip `=` that is directly in an if/while condition —
-            // condition_assignment handles it with a more specific message.
-            let skip_for_condition = op_text == "=" && is_if_while_condition_directly(node);
-            if !skip_for_condition && !is_named_argument(node, op_text) {
-                let bad = match style {
-                    AssignmentOperatorStyle::LeftArrow => op_text == "=",
-                    AssignmentOperatorStyle::Equals => op_text == "<-",
-                };
-                if bad {
-                    let line_no = op_node.start_position().row as u32;
-                    if !suppressions.is_suppressed(line_no) {
-                        let line_text = text.lines().nth(line_no as usize).unwrap_or("");
-                        let start_col =
-                            byte_offset_to_utf16_column(line_text, op_node.start_position().column);
-                        let end_col =
-                            byte_offset_to_utf16_column(line_text, op_node.end_position().column);
-                        let preferred = match style {
-                            AssignmentOperatorStyle::LeftArrow => "<-",
-                            AssignmentOperatorStyle::Equals => "=",
-                        };
-                        out.push(Diagnostic {
-                            range: Range {
-                                start: Position::new(line_no, start_col),
-                                end: Position::new(op_node.end_position().row as u32, end_col),
-                            },
-                            severity: Some(severity),
-                            source: Some(LINT_SOURCE.to_string()),
-                            code: Some(NumberOrString::String(
-                                rule_ids::ASSIGNMENT_OPERATOR.to_string(),
-                            )),
-                            message: format!(
-                                "Use `{preferred}` for assignment instead of `{op_text}`."
-                            ),
-                            ..Default::default()
-                        });
-                    }
+    if node.kind() == "binary_operator"
+        && let Some(op_node) = node.child_by_field_name("operator")
+    {
+        let op_text = node_text(op_node, text);
+        // Skip `=` that is directly in an if/while condition —
+        // condition_assignment handles it with a more specific message.
+        let skip_for_condition = op_text == "=" && is_if_while_condition_directly(node);
+        if !skip_for_condition && !is_named_argument(node, op_text) {
+            let bad = match style {
+                AssignmentOperatorStyle::LeftArrow => op_text == "=",
+                AssignmentOperatorStyle::Equals => op_text == "<-",
+            };
+            if bad {
+                let line_no = op_node.start_position().row as u32;
+                if !suppressions.is_suppressed(line_no) {
+                    let line_text = text.lines().nth(line_no as usize).unwrap_or("");
+                    let start_col =
+                        byte_offset_to_utf16_column(line_text, op_node.start_position().column);
+                    let end_col =
+                        byte_offset_to_utf16_column(line_text, op_node.end_position().column);
+                    let preferred = match style {
+                        AssignmentOperatorStyle::LeftArrow => "<-",
+                        AssignmentOperatorStyle::Equals => "=",
+                    };
+                    out.push(Diagnostic {
+                        range: Range {
+                            start: Position::new(line_no, start_col),
+                            end: Position::new(op_node.end_position().row as u32, end_col),
+                        },
+                        severity: Some(severity),
+                        source: Some(LINT_SOURCE.to_string()),
+                        code: Some(NumberOrString::String(
+                            rule_ids::ASSIGNMENT_OPERATOR.to_string(),
+                        )),
+                        message: format!(
+                            "Use `{preferred}` for assignment instead of `{op_text}`."
+                        ),
+                        ..Default::default()
+                    });
                 }
             }
         }
@@ -106,12 +106,11 @@ fn is_named_argument(binop: Node<'_>, op_text: &str) -> bool {
 /// `if_statement` or `while_statement`. Used to avoid double-diagnosing
 /// `if (x = 1)` — `condition_assignment` handles that case specifically.
 fn is_if_while_condition_directly(binop: Node<'_>) -> bool {
-    if let Some(parent) = binop.parent() {
-        if matches!(parent.kind(), "if_statement" | "while_statement") {
-            if let Some(cond) = parent.child_by_field_name("condition") {
-                return cond.id() == binop.id();
-            }
-        }
+    if let Some(parent) = binop.parent()
+        && matches!(parent.kind(), "if_statement" | "while_statement")
+        && let Some(cond) = parent.child_by_field_name("condition")
+    {
+        return cond.id() == binop.id();
     }
     false
 }

--- a/crates/raven/src/linting/rules/commas.rs
+++ b/crates/raven/src/linting/rules/commas.rs
@@ -9,9 +9,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/commented_code.rs
+++ b/crates/raven/src/linting/rules/commented_code.rs
@@ -32,10 +32,10 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::parse_gate::looks_like_code;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::{byte_offset_to_utf16_column, strip_leading_bom_for_scan};
 
 /// Annotation prefixes (case-insensitive). `TODO`, `FIXME`, etc. — these are
@@ -269,10 +269,10 @@ fn is_annotation_comment(trimmed_line: &str) -> bool {
         if tail.is_empty() {
             return true;
         }
-        if let Some(c) = tail.chars().next() {
-            if c.is_whitespace() || c == ':' || c == '(' || c == '-' {
-                return true;
-            }
+        if let Some(c) = tail.chars().next()
+            && (c.is_whitespace() || c == ':' || c == '(' || c == '-')
+        {
+            return true;
         }
     }
     false

--- a/crates/raven/src/linting/rules/condition_assignment.rs
+++ b/crates/raven/src/linting/rules/condition_assignment.rs
@@ -22,9 +22,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
@@ -44,10 +44,10 @@ fn visit(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    if matches!(node.kind(), "if_statement" | "while_statement") {
-        if let Some(cond) = node.child_by_field_name("condition") {
-            scan_condition(cond, text, severity, suppressions, out);
-        }
+    if matches!(node.kind(), "if_statement" | "while_statement")
+        && let Some(cond) = node.child_by_field_name("condition")
+    {
+        scan_condition(cond, text, severity, suppressions, out);
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -73,12 +73,12 @@ fn scan_condition(
     ) {
         return;
     }
-    if node.kind() == "binary_operator" {
-        if let Some(op) = node.child_by_field_name("operator") {
-            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
-            if op_text == "=" {
-                emit(op, text, severity, suppressions, out);
-            }
+    if node.kind() == "binary_operator"
+        && let Some(op) = node.child_by_field_name("operator")
+    {
+        let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+        if op_text == "=" {
+            emit(op, text, severity, suppressions, out);
         }
     }
     let mut cursor = node.walk();

--- a/crates/raven/src/linting/rules/equals_na.rs
+++ b/crates/raven/src/linting/rules/equals_na.rs
@@ -9,9 +9,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/function_left_parentheses.rs
+++ b/crates/raven/src/linting/rules/function_left_parentheses.rs
@@ -9,9 +9,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -47,9 +47,9 @@ use std::collections::{HashMap, HashSet};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 
 pub(crate) fn collect(
     text: &str,

--- a/crates/raven/src/linting/rules/infix_spaces.rs
+++ b/crates/raven/src/linting/rules/infix_spaces.rs
@@ -25,9 +25,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/line_length.rs
+++ b/crates/raven/src/linting/rules/line_length.rs
@@ -5,9 +5,9 @@
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 
 pub(crate) fn collect(
     text: &str,

--- a/crates/raven/src/linting/rules/mixed_logical.rs
+++ b/crates/raven/src/linting/rules/mixed_logical.rs
@@ -19,9 +19,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
@@ -46,22 +46,22 @@ fn visit(
     if matches!(node.kind(), "call" | "subset" | "subset2") {
         return;
     }
-    if node.kind() == "binary_operator" {
-        if let Some(op) = node.child_by_field_name("operator") {
-            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
-            if matches!(op_text, "|" | "||") {
-                let lhs = node.child_by_field_name("lhs");
-                let rhs = node.child_by_field_name("rhs");
-                let lhs_bare = lhs.is_some_and(|n| is_bare_and(n, text));
-                let rhs_bare = rhs.is_some_and(|n| is_bare_and(n, text));
-                if lhs_bare || rhs_bare {
-                    let and_node = if lhs_bare { lhs.unwrap() } else { rhs.unwrap() };
-                    let and_op_text = and_node
-                        .child_by_field_name("operator")
-                        .and_then(|n| text.get(n.start_byte()..n.end_byte()))
-                        .unwrap_or("&");
-                    emit(op, op_text, and_op_text, text, severity, suppressions, out);
-                }
+    if node.kind() == "binary_operator"
+        && let Some(op) = node.child_by_field_name("operator")
+    {
+        let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+        if matches!(op_text, "|" | "||") {
+            let lhs = node.child_by_field_name("lhs");
+            let rhs = node.child_by_field_name("rhs");
+            let lhs_bare = lhs.is_some_and(|n| is_bare_and(n, text));
+            let rhs_bare = rhs.is_some_and(|n| is_bare_and(n, text));
+            if lhs_bare || rhs_bare {
+                let and_node = if lhs_bare { lhs.unwrap() } else { rhs.unwrap() };
+                let and_op_text = and_node
+                    .child_by_field_name("operator")
+                    .and_then(|n| text.get(n.start_byte()..n.end_byte()))
+                    .unwrap_or("&");
+                emit(op, op_text, and_op_text, text, severity, suppressions, out);
             }
         }
     }

--- a/crates/raven/src/linting/rules/no_tab.rs
+++ b/crates/raven/src/linting/rules/no_tab.rs
@@ -6,9 +6,9 @@
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/object_length.rs
+++ b/crates/raven/src/linting/rules/object_length.rs
@@ -15,9 +15,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/object_name.rs
+++ b/crates/raven/src/linting/rules/object_name.rs
@@ -34,10 +34,10 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::config::ObjectNameStyle;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 /// Per-kind style configuration for the rule.
@@ -168,7 +168,8 @@ fn check_parameters(
         return;
     }
     let params_node = node.child_by_field_name("parameters").or_else(|| {
-        node.children(&mut node.walk())
+        let mut cursor = node.walk();
+        node.children(&mut cursor)
             .find(|c| c.is_named() && c.kind() == "parameters")
     });
     let params_node = match params_node {

--- a/crates/raven/src/linting/rules/quotes.rs
+++ b/crates/raven/src/linting/rules/quotes.rs
@@ -8,10 +8,10 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::config::StringDelimiter;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/semicolon.rs
+++ b/crates/raven/src/linting/rules/semicolon.rs
@@ -12,9 +12,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/spaces_inside.rs
+++ b/crates/raven/src/linting/rules/spaces_inside.rs
@@ -15,9 +15,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -22,9 +22,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/trailing_blank_lines.rs
+++ b/crates/raven/src/linting/rules/trailing_blank_lines.rs
@@ -6,9 +6,9 @@
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 
 pub(crate) fn collect(
     text: &str,

--- a/crates/raven/src/linting/rules/trailing_whitespace.rs
+++ b/crates/raven/src/linting/rules/trailing_whitespace.rs
@@ -2,9 +2,9 @@
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(

--- a/crates/raven/src/linting/rules/vector_logic.rs
+++ b/crates/raven/src/linting/rules/vector_logic.rs
@@ -14,9 +14,9 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
 
+use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
 use crate::linting::rule_ids;
-use crate::linting::LINT_SOURCE;
 use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
@@ -36,10 +36,10 @@ fn visit(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    if matches!(node.kind(), "if_statement" | "while_statement") {
-        if let Some(cond) = node.child_by_field_name("condition") {
-            scan_condition(cond, text, severity, suppressions, out);
-        }
+    if matches!(node.kind(), "if_statement" | "while_statement")
+        && let Some(cond) = node.child_by_field_name("condition")
+    {
+        scan_condition(cond, text, severity, suppressions, out);
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -59,13 +59,13 @@ fn scan_condition(
     if matches!(node.kind(), "call" | "subset" | "subset2") {
         return;
     }
-    if node.kind() == "binary_operator" {
-        if let Some(op) = node.child_by_field_name("operator") {
-            let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
-            if op_text == "&" || op_text == "|" {
-                let preferred = if op_text == "&" { "&&" } else { "||" };
-                emit(op, op_text, preferred, text, severity, suppressions, out);
-            }
+    if node.kind() == "binary_operator"
+        && let Some(op) = node.child_by_field_name("operator")
+    {
+        let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+        if op_text == "&" || op_text == "|" {
+            let preferred = if op_text == "&" { "&&" } else { "||" };
+            emit(op, op_text, preferred, text, severity, suppressions, out);
         }
     }
     let mut cursor = node.walk();

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -11,7 +11,7 @@
 // integrated into PackageLibrary in task 3.3
 #![allow(dead_code)]
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use dashmap::DashMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -100,10 +100,10 @@ fn parse_namespace_content(content: &str) -> Vec<String> {
         // Handle S3method(generic, class) and S3method(generic, class, method)
         // Requirement 3.5: WHEN a NAMESPACE file contains `S3method(generic, class)`,
         // THE Package_Resolver SHALL include the S3 method in exports
-        else if let Some(args) = extract_directive_args(line, "S3method") {
-            if let Some(method_name) = parse_s3method_args(&args) {
-                exports.push(method_name);
-            }
+        else if let Some(args) = extract_directive_args(line, "S3method")
+            && let Some(method_name) = parse_s3method_args(&args)
+        {
+            exports.push(method_name);
         }
     }
 
@@ -546,26 +546,24 @@ pub async fn parse_data_symbols(pkg_dir: &Path) -> Vec<String> {
             let datalist_ok = fs::symlink_metadata(&datalist_path)
                 .map(|m| m.is_file())
                 .unwrap_or(false);
-            if datalist_ok {
-                if let Ok(content) = fs::read_to_string(&datalist_path) {
-                    for line in content.lines() {
-                        let line = line.trim();
-                        if line.is_empty() || line.starts_with('#') {
-                            continue;
+            if datalist_ok && let Ok(content) = fs::read_to_string(&datalist_path) {
+                for line in content.lines() {
+                    let line = line.trim();
+                    if line.is_empty() || line.starts_with('#') {
+                        continue;
+                    }
+                    if let Some((primary, rest)) = line.split_once(':') {
+                        let primary = primary.trim();
+                        if is_valid_r_identifier(primary) {
+                            found.push(primary.to_string());
                         }
-                        if let Some((primary, rest)) = line.split_once(':') {
-                            let primary = primary.trim();
-                            if is_valid_r_identifier(primary) {
-                                found.push(primary.to_string());
+                        for sub in rest.split_whitespace() {
+                            if is_valid_r_identifier(sub) {
+                                found.push(sub.to_string());
                             }
-                            for sub in rest.split_whitespace() {
-                                if is_valid_r_identifier(sub) {
-                                    found.push(sub.to_string());
-                                }
-                            }
-                        } else if is_valid_r_identifier(line) {
-                            found.push(line.to_string());
                         }
+                    } else if is_valid_r_identifier(line) {
+                        found.push(line.to_string());
                     }
                 }
             }
@@ -692,12 +690,11 @@ fn is_valid_r_identifier(s: &str) -> bool {
     }
 
     // If starts with dot, second char must be letter (not digit)
-    if first == '.' {
-        if let Some(second) = chars.next() {
-            if second.is_ascii_digit() {
-                return false;
-            }
-        }
+    if first == '.'
+        && let Some(second) = chars.next()
+        && second.is_ascii_digit()
+    {
+        return false;
     }
 
     // Rest must be alphanumeric, dot, or underscore
@@ -962,8 +959,7 @@ exportPattern("^helper_")
 
     #[test]
     fn test_parse_description_depends_with_version_constraints() {
-        let content =
-            "Package: mypackage\nDepends: R (>= 4.0), dplyr (>= 1.0.0), ggplot2 (>= 3.0)\nVersion: 1.0.0";
+        let content = "Package: mypackage\nDepends: R (>= 4.0), dplyr (>= 1.0.0), ggplot2 (>= 3.0)\nVersion: 1.0.0";
         let depends = parse_description_field(content, "Depends");
         assert_eq!(depends, vec!["dplyr", "ggplot2"]);
     }

--- a/crates/raven/src/package_db/binary_db.rs
+++ b/crates/raven/src/package_db/binary_db.rs
@@ -24,8 +24,8 @@ use std::path::Path;
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
 
-use crate::package_db::model::PackageRecord;
 use crate::package_db::PackageMetadataProvider;
+use crate::package_db::model::PackageRecord;
 use crate::package_library::PackageInfo;
 
 const MAGIC: &[u8; 8] = b"RAVNDB\0\0";
@@ -157,7 +157,7 @@ impl ShippedDb {
         let file = match std::fs::File::open(path) {
             Ok(f) => f,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(ShippedDbError::Absent)
+                return Err(ShippedDbError::Absent);
             }
             Err(e) => return Err(ShippedDbError::Corrupt(e.to_string())),
         };

--- a/crates/raven/src/package_db/json_db.rs
+++ b/crates/raven/src/package_db/json_db.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::package_db::model::PackageRecord;
 use crate::package_db::PackageMetadataProvider;
+use crate::package_db::model::PackageRecord;
 use crate::package_library::PackageInfo;
 
 /// Tier 2 schema version. Bump when the on-disk shape changes incompatibly.

--- a/crates/raven/src/package_db/merge.rs
+++ b/crates/raven/src/package_db/merge.rs
@@ -20,11 +20,7 @@ pub fn version_cmp(a: &str, b: &str) -> Ordering {
     // sentinel like -1) is what keeps `1.foo` from out-sorting `1`: a malformed
     // suffix must sink the *whole* string, not just append a low component.
     fn parts(v: &str) -> Option<Vec<u64>> {
-        // Clippy suggests the `['.', '-']` array pattern, but `Pattern for
-        // [char; N]` is stable only since Rust 1.80 and this crate's MSRV is
-        // 1.75 — so the closure form is required.
-        #[allow(clippy::manual_pattern_char_comparison)]
-        v.split(|c| c == '.' || c == '-')
+        v.split(['.', '-'])
             .filter(|s| !s.is_empty())
             .map(|s| s.parse::<u64>())
             .collect::<Result<Vec<_>, _>>()

--- a/crates/raven/src/package_db/mod.rs
+++ b/crates/raven/src/package_db/mod.rs
@@ -60,18 +60,18 @@ pub fn user_data_sidecar_path(file_name: &str) -> Option<PathBuf> {
 /// data sidecar, then executable-relative bundled sidecar.
 fn locate_sidecar_candidates(env_var: &str, file_name: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Ok(p) = std::env::var(env_var) {
-        if !p.is_empty() {
-            out.push(PathBuf::from(p));
-        }
+    if let Ok(p) = std::env::var(env_var)
+        && !p.is_empty()
+    {
+        out.push(PathBuf::from(p));
     }
     if let Some(p) = user_data_sidecar_path(file_name) {
         push_unique(&mut out, p);
     }
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            push_unique(&mut out, dir.join(file_name));
-        }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        push_unique(&mut out, dir.join(file_name));
     }
     out
 }
@@ -175,6 +175,43 @@ impl Drop for TestUserDataDirGuard {
 pub(crate) static RAVEN_NAMES_DB_ENV_LOCK: tokio::sync::Mutex<()> =
     tokio::sync::Mutex::const_new(());
 
+/// RAII guard for the process-global `RAVEN_NAMES_DB` var in tests: sets it on
+/// construction and restores the prior value (or unsets it) on drop, so a
+/// panicking assertion can't leak the var to a sibling test. Callers MUST hold
+/// [`RAVEN_NAMES_DB_ENV_LOCK`] for the guard's whole lifetime — that lock is
+/// what makes the `set_var`/`remove_var` sound, by serializing every test in
+/// this binary that reads or writes the var. This concentrates the one
+/// `unsafe` env mutation (edition 2024 made `set_var`/`remove_var` unsafe) in a
+/// single audited place instead of repeating it at each call site.
+#[cfg(test)]
+pub(crate) struct NamesDbEnvGuard {
+    previous: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl NamesDbEnvGuard {
+    pub(crate) fn set(value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os("RAVEN_NAMES_DB");
+        // SAFETY: the caller holds `RAVEN_NAMES_DB_ENV_LOCK` (see type doc), so
+        // no other thread reads or writes the environment concurrently.
+        unsafe { std::env::set_var("RAVEN_NAMES_DB", value) };
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for NamesDbEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: mirrors `set`; the lock is still held for the guard's lifetime.
+        unsafe {
+            match self.previous.take() {
+                Some(prev) => std::env::set_var("RAVEN_NAMES_DB", prev),
+                None => std::env::remove_var("RAVEN_NAMES_DB"),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,10 +223,9 @@ mod tests {
         let user_data = dir.path().join("data");
         let custom = dir.path().join("custom.db");
 
-        std::env::set_var("RAVEN_NAMES_DB", &custom);
+        let _db_env = NamesDbEnvGuard::set(&custom);
         let _user_data_guard = test_user_data_dir_guard(user_data.clone());
         let candidates = locate_shipped_db_candidates();
-        std::env::remove_var("RAVEN_NAMES_DB");
         let exe_relative = std::env::current_exe()
             .unwrap()
             .parent()
@@ -207,10 +243,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let user_data = dir.path().join("data");
 
-        std::env::set_var("RAVEN_NAMES_DB", "");
+        let _db_env = NamesDbEnvGuard::set("");
         let _user_data_guard = test_user_data_dir_guard(user_data.clone());
         let first = locate_shipped_db_candidates().remove(0);
-        std::env::remove_var("RAVEN_NAMES_DB");
 
         assert_eq!(first, user_data.join("names.db"));
     }

--- a/crates/raven/src/package_db/runiverse.rs
+++ b/crates/raven/src/package_db/runiverse.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::package_db::model::{sorted_unique, PackageRecord};
+use crate::package_db::model::{PackageRecord, sorted_unique};
 
 /// Deserialize a JSON array that may also be `null` into a `Vec`.
 ///

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -375,27 +375,27 @@ impl PackageLibrary {
         // Requirement 9.3: Show all packages that export the same symbol
         for pkg_name in loaded_packages {
             // Try combined_exports first
-            if let Some(ref cache) = combined_cache {
-                if let Some(exports) = cache.get(pkg_name) {
-                    for export in exports.iter() {
-                        result
-                            .entry(export.clone())
-                            .or_default()
-                            .push(pkg_name.clone());
-                    }
-                    continue; // Found in combined cache, skip per-package lookup
+            if let Some(ref cache) = combined_cache
+                && let Some(exports) = cache.get(pkg_name)
+            {
+                for export in exports.iter() {
+                    result
+                        .entry(export.clone())
+                        .or_default()
+                        .push(pkg_name.clone());
                 }
+                continue; // Found in combined cache, skip per-package lookup
             }
 
             // Fall back to per-package exports
-            if let Some(ref cache) = packages_cache {
-                if let Some(info) = cache.get(pkg_name) {
-                    for export in &info.exports {
-                        result
-                            .entry(export.clone())
-                            .or_default()
-                            .push(pkg_name.clone());
-                    }
+            if let Some(ref cache) = packages_cache
+                && let Some(info) = cache.get(pkg_name)
+            {
+                for export in &info.exports {
+                    result
+                        .entry(export.clone())
+                        .or_default()
+                        .push(pkg_name.clone());
                 }
             }
         }
@@ -431,10 +431,10 @@ impl PackageLibrary {
         // Try combined_exports cache first (includes Depends/attached packages)
         if let Ok(combined_cache) = self.combined_exports.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(exports) = combined_cache.get(pkg_name) {
-                    if exports.contains(symbol) {
-                        return true;
-                    }
+                if let Some(exports) = combined_cache.get(pkg_name)
+                    && exports.contains(symbol)
+                {
+                    return true;
                 }
             }
         }
@@ -453,10 +453,10 @@ impl PackageLibrary {
 
         // Check each loaded package
         for pkg_name in loaded_packages {
-            if let Some(info) = cache.get(pkg_name) {
-                if info.exports.contains(symbol) {
-                    return true;
-                }
+            if let Some(info) = cache.get(pkg_name)
+                && info.exports.contains(symbol)
+            {
+                return true;
             }
         }
 
@@ -490,10 +490,10 @@ impl PackageLibrary {
         if self.package_exists(package) || self.is_base_package(package) {
             return false;
         }
-        if let Some(cached) = self.get_cached_package(package).await {
-            if !cached.exports.is_empty() {
-                return false;
-            }
+        if let Some(cached) = self.get_cached_package(package).await
+            && !cached.exports.is_empty()
+        {
+            return false;
         }
         self.resolve_from_providers(package).is_none()
     }
@@ -646,18 +646,18 @@ impl PackageLibrary {
     /// otherwise do byte-identical per-package work.
     async fn prefetch_pattern_packages_via_index(&self, pattern_packages: &[String]) {
         for pkg_name in pattern_packages {
-            if let Some(pkg_dir) = self.find_package_directory(pkg_name) {
-                if let Some(parse_result) = self.parse_package_static(&pkg_dir) {
-                    let exports = self.load_with_index_fallback(&pkg_dir, &parse_result).await;
-                    let info = package_info_from_dir(
-                        pkg_name.clone(),
-                        &pkg_dir,
-                        exports,
-                        parse_result.depends,
-                    )
-                    .await;
-                    self.insert_package(info).await;
-                }
+            if let Some(pkg_dir) = self.find_package_directory(pkg_name)
+                && let Some(parse_result) = self.parse_package_static(&pkg_dir)
+            {
+                let exports = self.load_with_index_fallback(&pkg_dir, &parse_result).await;
+                let info = package_info_from_dir(
+                    pkg_name.clone(),
+                    &pkg_dir,
+                    exports,
+                    parse_result.depends,
+                )
+                .await;
+                self.insert_package(info).await;
             }
         }
     }
@@ -868,10 +868,10 @@ impl PackageLibrary {
         // Check combined_exports cache first
         if let Ok(cache) = self.combined_exports.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(exports) = cache.get(pkg_name) {
-                    if exports.contains(symbol) {
-                        return Some(pkg_name.clone());
-                    }
+                if let Some(exports) = cache.get(pkg_name)
+                    && exports.contains(symbol)
+                {
+                    return Some(pkg_name.clone());
                 }
             }
         }
@@ -879,10 +879,10 @@ impl PackageLibrary {
         // Fall back to per-package cache
         if let Ok(cache) = self.packages.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(info) = cache.get(pkg_name) {
-                    if info.exports.contains(symbol) {
-                        return Some(pkg_name.clone());
-                    }
+                if let Some(info) = cache.get(pkg_name)
+                    && info.exports.contains(symbol)
+                {
+                    return Some(pkg_name.clone());
                 }
             }
         }
@@ -1083,60 +1083,60 @@ impl PackageLibrary {
         let mut pattern_packages: Vec<String> = Vec::new();
 
         for package in &base_packages_list {
-            if let Some(pkg_dir) = self.find_package_directory(package) {
-                if let Some(parse_result) = self.parse_package_static(&pkg_dir) {
-                    let pkg_exports = per_package_exports.entry(package.clone()).or_default();
-                    // Preserve depends from DESCRIPTION for transitive dependency resolution
-                    if !parse_result.depends.is_empty() {
-                        per_package_depends.insert(package.clone(), parse_result.depends.clone());
-                    }
-                    // Add explicit exports
-                    for export in &parse_result.explicit_exports {
+            if let Some(pkg_dir) = self.find_package_directory(package)
+                && let Some(parse_result) = self.parse_package_static(&pkg_dir)
+            {
+                let pkg_exports = per_package_exports.entry(package.clone()).or_default();
+                // Preserve depends from DESCRIPTION for transitive dependency resolution
+                if !parse_result.depends.is_empty() {
+                    per_package_depends.insert(package.clone(), parse_result.depends.clone());
+                }
+                // Add explicit exports
+                for export in &parse_result.explicit_exports {
+                    all_base_exports.insert(export.clone());
+                    pkg_exports.insert(export.clone());
+                }
+
+                if parse_result.has_export_pattern {
+                    // Base packages use exportPattern - add INDEX exports and track for R fallback
+                    let index_exports =
+                        self.load_with_index_fallback(&pkg_dir, &parse_result).await;
+                    for export in &index_exports {
                         all_base_exports.insert(export.clone());
                         pkg_exports.insert(export.clone());
                     }
+                    pattern_packages.push(package.clone());
+                }
 
-                    if parse_result.has_export_pattern {
-                        // Base packages use exportPattern - add INDEX exports and track for R fallback
-                        let index_exports =
-                            self.load_with_index_fallback(&pkg_dir, &parse_result).await;
+                // Step 3b: Pick up data objects auto-attached at startup
+                // (issue #276). Lazy-loaded base packages like `datasets`
+                // expose `mtcars`/`iris`/... without listing them in
+                // NAMESPACE export() or `getNamespaceExports()`. Walk
+                // `data/` for individual files and fall back to INDEX
+                // topics when the data is bundled into `Rdata.r{db,dx,ds}`.
+                //
+                // Use `symlink_metadata` (not `is_dir`, which traverses
+                // symlinks) for consistency with `parse_data_symbols`'s
+                // own rejection of symlinked `data/` trees.
+                let has_real_data_dir = std::fs::symlink_metadata(pkg_dir.join("data"))
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false);
+                if has_real_data_dir {
+                    for sym in parse_data_symbols(&pkg_dir).await {
+                        all_base_exports.insert(sym.clone());
+                        pkg_exports.insert(sym);
+                    }
+                    // INDEX entries are documented topic names — for
+                    // lazy-loaded data packages these correspond to
+                    // top-level dataset names (mtcars, iris, ...). Only
+                    // applied here when has_export_pattern is false so we
+                    // don't double-merge with the existing fallback above.
+                    if !parse_result.has_export_pattern
+                        && let Ok(index_exports) = parse_index_exports(&pkg_dir).await
+                    {
                         for export in &index_exports {
                             all_base_exports.insert(export.clone());
                             pkg_exports.insert(export.clone());
-                        }
-                        pattern_packages.push(package.clone());
-                    }
-
-                    // Step 3b: Pick up data objects auto-attached at startup
-                    // (issue #276). Lazy-loaded base packages like `datasets`
-                    // expose `mtcars`/`iris`/... without listing them in
-                    // NAMESPACE export() or `getNamespaceExports()`. Walk
-                    // `data/` for individual files and fall back to INDEX
-                    // topics when the data is bundled into `Rdata.r{db,dx,ds}`.
-                    //
-                    // Use `symlink_metadata` (not `is_dir`, which traverses
-                    // symlinks) for consistency with `parse_data_symbols`'s
-                    // own rejection of symlinked `data/` trees.
-                    let has_real_data_dir = std::fs::symlink_metadata(pkg_dir.join("data"))
-                        .map(|m| m.is_dir())
-                        .unwrap_or(false);
-                    if has_real_data_dir {
-                        for sym in parse_data_symbols(&pkg_dir).await {
-                            all_base_exports.insert(sym.clone());
-                            pkg_exports.insert(sym);
-                        }
-                        // INDEX entries are documented topic names — for
-                        // lazy-loaded data packages these correspond to
-                        // top-level dataset names (mtcars, iris, ...). Only
-                        // applied here when has_export_pattern is false so we
-                        // don't double-merge with the existing fallback above.
-                        if !parse_result.has_export_pattern {
-                            if let Ok(index_exports) = parse_index_exports(&pkg_dir).await {
-                                for export in &index_exports {
-                                    all_base_exports.insert(export.clone());
-                                    pkg_exports.insert(export.clone());
-                                }
-                            }
                         }
                     }
                 }
@@ -1145,32 +1145,32 @@ impl PackageLibrary {
 
         // Step 4: If R subprocess is available and we have pattern packages,
         // try to get accurate exports for them
-        if !pattern_packages.is_empty() {
-            if let Some(ref r_subprocess) = self.r_subprocess {
-                log::trace!(
-                    "Querying R for {} base packages with exportPattern",
-                    pattern_packages.len()
-                );
-                match r_subprocess
-                    .get_multiple_package_exports(&pattern_packages)
-                    .await
-                {
-                    Ok(exports_map) => {
-                        for (pkg_name, exports) in exports_map {
-                            let pkg_exports = per_package_exports.entry(pkg_name).or_default();
-                            for export in exports {
-                                all_base_exports.insert(export.clone());
-                                pkg_exports.insert(export);
-                            }
+        if !pattern_packages.is_empty()
+            && let Some(ref r_subprocess) = self.r_subprocess
+        {
+            log::trace!(
+                "Querying R for {} base packages with exportPattern",
+                pattern_packages.len()
+            );
+            match r_subprocess
+                .get_multiple_package_exports(&pattern_packages)
+                .await
+            {
+                Ok(exports_map) => {
+                    for (pkg_name, exports) in exports_map {
+                        let pkg_exports = per_package_exports.entry(pkg_name).or_default();
+                        for export in exports {
+                            all_base_exports.insert(export.clone());
+                            pkg_exports.insert(export);
                         }
                     }
-                    Err(e) => {
-                        log::trace!(
-                            "R batch query for base packages failed: {}, using INDEX fallback",
-                            e
-                        );
-                        // Continue with INDEX-based exports
-                    }
+                }
+                Err(e) => {
+                    log::trace!(
+                        "R batch query for base packages failed: {}, using INDEX fallback",
+                        e
+                    );
+                    // Continue with INDEX-based exports
                 }
             }
         }
@@ -1525,10 +1525,11 @@ impl PackageLibrary {
             };
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_dir() && path.join("DESCRIPTION").is_file() {
-                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        names.insert(name.to_string());
-                    }
+                if path.is_dir()
+                    && path.join("DESCRIPTION").is_file()
+                    && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                {
+                    names.insert(name.to_string());
                 }
             }
         }
@@ -1926,13 +1927,14 @@ pub async fn build_package_library_tier1_only(
 mod tests {
     use super::*;
 
-    /// The shared `RAVEN_NAMES_DB` env-var serialization lock (defined in
-    /// `package_db` so every lib-test that touches the var shares one instance).
-    use crate::package_db::RAVEN_NAMES_DB_ENV_LOCK;
+    /// The shared `RAVEN_NAMES_DB` env-var serialization lock and its RAII guard
+    /// (defined in `package_db` so every lib-test that touches the var shares one
+    /// instance / one audited `unsafe` mutation site).
+    use crate::package_db::{NamesDbEnvGuard, RAVEN_NAMES_DB_ENV_LOCK};
 
     #[tokio::test]
     async fn build_library_wires_shipped_db_provider_from_env() {
-        use crate::package_db::binary_db::{write_shipped_db, ShippedDbProvenance};
+        use crate::package_db::binary_db::{ShippedDbProvenance, write_shipped_db};
         use crate::package_db::model::PackageRecord;
 
         // Use a synthetic name that cannot exist in any real R install, so the
@@ -1961,18 +1963,19 @@ mod tests {
         )
         .unwrap();
 
-        std::env::set_var("RAVEN_NAMES_DB", &db_path);
+        let _db_env = NamesDbEnvGuard::set(&db_path);
         let outcome = build_package_library(None, &[], None, true).await; // runtime path -> wires providers
         let outcome_t1 = build_package_library_tier1_only(None, &[], None).await; // capture path -> no providers
-        std::env::remove_var("RAVEN_NAMES_DB");
 
-        assert!(outcome
-            .library
-            .get_package(pkg)
-            .await
-            .expect("Tier 3 resolves synthetic pkg")
-            .exports
-            .contains("mutate"));
+        assert!(
+            outcome
+                .library
+                .get_package(pkg)
+                .await
+                .expect("Tier 3 resolves synthetic pkg")
+                .exports
+                .contains("mutate")
+        );
         // Provider-less capture must NOT resolve the synthetic pkg from Tier 3.
         assert!(outcome_t1.library.get_package(pkg).await.is_none());
     }
@@ -1985,9 +1988,8 @@ mod tests {
         // Too short / bad magic => ShippedDb::open returns Corrupt => a load note.
         std::fs::write(&bad, b"NOT A RAVEN DB").unwrap();
 
-        std::env::set_var("RAVEN_NAMES_DB", &bad);
+        let _db_env = NamesDbEnvGuard::set(&bad);
         let outcome = build_package_library(None, &[], None, true).await;
-        std::env::remove_var("RAVEN_NAMES_DB");
 
         // The build degrades (does not panic) AND explains the unreadable DB.
         assert!(
@@ -2003,7 +2005,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_library_falls_back_from_bad_user_db_to_lower_candidate() {
-        use crate::package_db::binary_db::{write_shipped_db, ShippedDbProvenance};
+        use crate::package_db::binary_db::{ShippedDbProvenance, write_shipped_db};
         use crate::package_db::model::PackageRecord;
 
         let _env_guard = RAVEN_NAMES_DB_ENV_LOCK.lock().await;
@@ -2034,18 +2036,19 @@ mod tests {
         .unwrap();
 
         let _user_data_guard = crate::package_db::test_user_data_dir_guard(user_data);
-        std::env::set_var("RAVEN_NAMES_DB", &bad_env_db);
+        let _db_env = NamesDbEnvGuard::set(&bad_env_db);
         let outcome = build_package_library(None, &[], None, true).await;
-        std::env::remove_var("RAVEN_NAMES_DB");
 
         assert!(outcome.load_notes.iter().any(|n| n.contains("bad.db")));
-        assert!(outcome
-            .library
-            .get_package(pkg)
-            .await
-            .expect("lower candidate provider resolves")
-            .exports
-            .contains("lower_export"));
+        assert!(
+            outcome
+                .library
+                .get_package(pkg)
+                .await
+                .expect("lower candidate provider resolves")
+                .exports
+                .contains("lower_export")
+        );
     }
 
     /// Pins the readiness predicate and degradation precedence

--- a/crates/raven/src/package_namespace.rs
+++ b/crates/raven/src/package_namespace.rs
@@ -113,10 +113,10 @@ fn detect_roxygen_usage(workspace_root: &Path) -> bool {
         } else {
             continue;
         }
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            if ROXYGEN_EXPORT_RE.is_match(&content) {
-                return true;
-            }
+        if let Ok(content) = std::fs::read_to_string(&path)
+            && ROXYGEN_EXPORT_RE.is_match(&content)
+        {
+            return true;
         }
     }
     false

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -482,10 +482,11 @@ mod tests {
             &inputs,
             &PackageInputDelta::Initial,
         );
-        assert!(!s
-            .scope_contribution
-            .r_internal_symbols
-            .contains("test_helper"));
+        assert!(
+            !s.scope_contribution
+                .r_internal_symbols
+                .contains("test_helper")
+        );
     }
 
     #[test]
@@ -836,20 +837,24 @@ foo <- function() 1
             &with_description(PackageMode::Auto, "Package: foo\nImports: testthat\n"),
             &PackageInputDelta::Initial,
         );
-        assert!(s_imp
-            .scope_contribution
-            .test_attached_packages
-            .contains("testthat"));
+        assert!(
+            s_imp
+                .scope_contribution
+                .test_attached_packages
+                .contains("testthat")
+        );
 
         let s_dep = derive_package_state(
             &PackageState::default(),
             &with_description(PackageMode::Auto, "Package: foo\nDepends: testthat\n"),
             &PackageInputDelta::Initial,
         );
-        assert!(s_dep
-            .scope_contribution
-            .test_attached_packages
-            .contains("testthat"));
+        assert!(
+            s_dep
+                .scope_contribution
+                .test_attached_packages
+                .contains("testthat")
+        );
     }
 
     /// Without testthat declared anywhere, do not implicitly attach it.
@@ -946,10 +951,11 @@ foo <- function() 1
         // Neither leaks into r_internal_symbols (R/ files remain isolated
         // from tests/testthat/ contributions).
         assert!(!s.scope_contribution.r_internal_symbols.contains("fixture"));
-        assert!(!s
-            .scope_contribution
-            .r_internal_symbols
-            .contains("test_local"));
+        assert!(
+            !s.scope_contribution
+                .r_internal_symbols
+                .contains("test_local")
+        );
     }
 
     /// Multiple helper files contribute their union — peer helpers see each
@@ -984,16 +990,18 @@ foo <- function() 1
             &inputs,
             &PackageInputDelta::Initial,
         );
-        assert!(s
-            .scope_contribution
-            .test_helper_symbols
-            .values()
-            .any(|syms| syms.contains("helper_a_fn")));
-        assert!(s
-            .scope_contribution
-            .test_helper_symbols
-            .values()
-            .any(|syms| syms.contains("helper_b_fn")));
+        assert!(
+            s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("helper_a_fn"))
+        );
+        assert!(
+            s.scope_contribution
+                .test_helper_symbols
+                .values()
+                .any(|syms| syms.contains("helper_b_fn"))
+        );
     }
 
     /// Codex follow-up: `tests/testthat/sub/helper-x.R` must NOT be

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -15,8 +15,8 @@ use lru::LruCache;
 use tree_sitter::Node;
 use url::Url;
 
-use crate::cross_file::scope::ScopeAtPosition;
 use crate::cross_file::SymbolKind;
+use crate::cross_file::scope::ScopeAtPosition;
 use crate::state::WorldState;
 
 // ---------------------------------------------------------------------------
@@ -964,31 +964,43 @@ mod tests {
         cache.insert_user(format!("{}#func_c", other_uri.as_str()), sig3);
 
         // Verify all are present
-        assert!(cache
-            .get_user(&format!("{}#func_a", uri.as_str()))
-            .is_some());
-        assert!(cache
-            .get_user(&format!("{}#func_b", uri.as_str()))
-            .is_some());
-        assert!(cache
-            .get_user(&format!("{}#func_c", other_uri.as_str()))
-            .is_some());
+        assert!(
+            cache
+                .get_user(&format!("{}#func_a", uri.as_str()))
+                .is_some()
+        );
+        assert!(
+            cache
+                .get_user(&format!("{}#func_b", uri.as_str()))
+                .is_some()
+        );
+        assert!(
+            cache
+                .get_user(&format!("{}#func_c", other_uri.as_str()))
+                .is_some()
+        );
 
         // Invalidate the first file
         cache.invalidate_file(&uri);
 
         // Signatures from the invalidated file should be gone
-        assert!(cache
-            .get_user(&format!("{}#func_a", uri.as_str()))
-            .is_none());
-        assert!(cache
-            .get_user(&format!("{}#func_b", uri.as_str()))
-            .is_none());
+        assert!(
+            cache
+                .get_user(&format!("{}#func_a", uri.as_str()))
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_user(&format!("{}#func_b", uri.as_str()))
+                .is_none()
+        );
 
         // Signature from the other file should still be present
-        assert!(cache
-            .get_user(&format!("{}#func_c", other_uri.as_str()))
-            .is_some());
+        assert!(
+            cache
+                .get_user(&format!("{}#func_c", other_uri.as_str()))
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/raven/src/perf.rs
+++ b/crates/raven/src/perf.rs
@@ -7,8 +7,8 @@
 //   RAVEN_PERF=1 raven --stdio      # Enable basic timing logs
 //   RAVEN_PERF=verbose raven --stdio # Enable detailed timing with thresholds
 
-use std::sync::atomic::Ordering;
 use std::sync::OnceLock;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 /// Global flag indicating whether performance timing is enabled
@@ -105,15 +105,16 @@ impl Drop for TimingGuard {
         let elapsed = self.start.elapsed();
         log::info!("[PERF] {} completed in {:?}", self.name, elapsed);
 
-        if let Some(threshold) = self.threshold_warn_ms {
-            if elapsed.as_millis() > threshold as u128 && is_verbose() {
-                log::warn!(
-                    "[PERF] {} exceeded threshold ({}ms > {}ms)",
-                    self.name,
-                    elapsed.as_millis(),
-                    threshold
-                );
-            }
+        if let Some(threshold) = self.threshold_warn_ms
+            && elapsed.as_millis() > threshold as u128
+            && is_verbose()
+        {
+            log::warn!(
+                "[PERF] {} exceeded threshold ({}ms > {}ms)",
+                self.name,
+                elapsed.as_millis(),
+                threshold
+            );
         }
     }
 }
@@ -211,10 +212,10 @@ pub fn record_first_diagnostic(duration: Duration) {
     if !is_enabled() {
         return;
     }
-    if let Ok(mut metrics) = startup_metrics().lock() {
-        if metrics.first_diagnostic_duration.is_none() {
-            metrics.first_diagnostic_duration = Some(duration);
-        }
+    if let Ok(mut metrics) = startup_metrics().lock()
+        && metrics.first_diagnostic_duration.is_none()
+    {
+        metrics.first_diagnostic_duration = Some(duration);
     }
 }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -201,12 +201,11 @@ fn first_direct_string_argument(args: Node) -> Option<Node> {
         if child.kind() == "string" {
             return Some(child);
         }
-        if child.kind() == "argument" {
-            if let Some(value) = child.child_by_field_name("value") {
-                if value.kind() == "string" {
-                    return Some(value);
-                }
-            }
+        if child.kind() == "argument"
+            && let Some(value) = child.child_by_field_name("value")
+            && value.kind() == "string"
+        {
+            return Some(value);
         }
     }
     None
@@ -1355,10 +1354,11 @@ fn ascend_to_assignment_for<'a>(start: Node<'a>, text: &str, lhs_name: &str) -> 
                 Some("->") | Some("->>") => current.child_by_field_name("rhs"),
                 _ => None,
             };
-            if let Some(t) = target {
-                if t.kind() == "identifier" && node_text(t, text) == lhs_name {
-                    return Some(current);
-                }
+            if let Some(t) = target
+                && t.kind() == "identifier"
+                && node_text(t, text) == lhs_name
+            {
+                return Some(current);
             }
         }
         current = current.parent()?;
@@ -1403,7 +1403,7 @@ fn nth_line(text: &str, n: usize) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use crate::handlers::{goto_definition, goto_definition_with_cancel, DiagCancelToken};
+    use crate::handlers::{DiagCancelToken, goto_definition, goto_definition_with_cancel};
     use crate::state::{Document, WorldState};
     use std::sync::Arc;
     use std::time::SystemTime;
@@ -2546,8 +2546,8 @@ df$gamma <- 3
     /// reference a different `df` and must not be offered as completions
     /// for the cursor's `df`.
     #[test]
-    fn dollar_member_completion_excludes_post_nested_source_rebinding_in_non_redefining_contributor(
-    ) {
+    fn dollar_member_completion_excludes_post_nested_source_rebinding_in_non_redefining_contributor()
+     {
         let mut state = fresh_state();
         let main_code = "\
 df <- list(alpha = 1)

--- a/crates/raven/src/r_env.rs
+++ b/crates/raven/src/r_env.rs
@@ -20,13 +20,13 @@ pub fn find_r_home() -> Option<PathBuf> {
     }
 
     // Try R CMD config
-    if let Ok(output) = Command::new("R").args(["CMD", "config", "R_HOME"]).output() {
-        if output.status.success() {
-            let r_home = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let path = PathBuf::from(&r_home);
-            if path.exists() {
-                return Some(path);
-            }
+    if let Ok(output) = Command::new("R").args(["CMD", "config", "R_HOME"]).output()
+        && output.status.success()
+    {
+        let r_home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = PathBuf::from(&r_home);
+        if path.exists() {
+            return Some(path);
         }
     }
 
@@ -98,14 +98,13 @@ pub fn find_library_paths() -> Vec<PathBuf> {
     if let Ok(output) = Command::new("R")
         .args(["--vanilla", "--slave", "-e", "cat(.libPaths(), sep='\\n')"])
         .output()
+        && output.status.success()
     {
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                let path = PathBuf::from(line.trim());
-                if path.exists() && !paths.contains(&path) {
-                    paths.push(path);
-                }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let path = PathBuf::from(line.trim());
+            if path.exists() && !paths.contains(&path) {
+                paths.push(path);
             }
         }
     }
@@ -120,10 +119,10 @@ pub fn find_library_paths() -> Vec<PathBuf> {
         }
 
         // User library
-        if let Some(user_lib) = user_library_path() {
-            if user_lib.exists() {
-                paths.push(user_lib);
-            }
+        if let Some(user_lib) = user_library_path()
+            && user_lib.exists()
+        {
+            paths.push(user_lib);
         }
     }
 

--- a/crates/raven/src/r_env.rs
+++ b/crates/raven/src/r_env.rs
@@ -161,14 +161,14 @@ fn user_library_path() -> Option<PathBuf> {
             #[cfg(target_os = "linux")]
             {
                 let r_lib = home.join("R");
-                if r_lib.exists() {
-                    if let Ok(entries) = std::fs::read_dir(&r_lib) {
-                        for entry in entries.flatten() {
-                            if let Ok(versions) = std::fs::read_dir(entry.path()) {
-                                for ver_entry in versions.flatten() {
-                                    if ver_entry.path().is_dir() {
-                                        return Some(ver_entry.path());
-                                    }
+                if r_lib.exists()
+                    && let Ok(entries) = std::fs::read_dir(&r_lib)
+                {
+                    for entry in entries.flatten() {
+                        if let Ok(versions) = std::fs::read_dir(entry.path()) {
+                            for ver_entry in versions.flatten() {
+                                if ver_entry.path().is_dir() {
+                                    return Some(ver_entry.path());
                                 }
                             }
                         }

--- a/crates/raven/src/r_subprocess.rs
+++ b/crates/raven/src/r_subprocess.rs
@@ -23,7 +23,7 @@
 // integrated into WorldState in task 7.1
 #![allow(dead_code)]
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::path::PathBuf;
 use tokio::process::Command;
 
@@ -661,13 +661,13 @@ cat("__RAVEN_END__\n")
         }
 
         // Validate package name if provided
-        if let Some(pkg) = package {
-            if !is_valid_package_name(pkg) {
-                return Err(anyhow!(
-                    "Invalid package name '{}': must contain only letters, numbers, dots, and underscores",
-                    pkg
-                ));
-            }
+        if let Some(pkg) = package
+            && !is_valid_package_name(pkg)
+        {
+            return Err(anyhow!(
+                "Invalid package name '{}': must contain only letters, numbers, dots, and underscores",
+                pkg
+            ));
         }
 
         // Build R code to resolve the function and extract formals.

--- a/crates/raven/src/roxygen.rs
+++ b/crates/raven/src/roxygen.rs
@@ -416,7 +416,9 @@ process <- function(data, verbose = FALSE) {}
         let block = extract_roxygen_block(code, 5).unwrap();
         assert_eq!(
             block.params.get("data").map(|s| s.as_str()),
-            Some("A data frame containing the input data. Must have columns 'x' and 'y'. Additional columns are ignored.")
+            Some(
+                "A data frame containing the input data. Must have columns 'x' and 'y'. Additional columns are ignored."
+            )
         );
         assert_eq!(
             block.params.get("verbose").map(|s| s.as_str()),
@@ -748,7 +750,9 @@ filter_and_summarize <- function(df, threshold = 0, cols = NULL, na.rm = TRUE, .
         assert_eq!(block.title.as_deref(), Some("Filter and summarize data"));
         assert_eq!(
             block.description.as_deref(),
-            Some("Takes a data frame and applies filtering based on the specified threshold, then computes summary statistics.")
+            Some(
+                "Takes a data frame and applies filtering based on the specified threshold, then computes summary statistics."
+            )
         );
         assert_eq!(block.params.len(), 5);
         assert_eq!(
@@ -921,20 +925,20 @@ mod prop_tests {
         lines.push("# preamble".to_string());
 
         // Add title line if present
-        if let Some(ref t) = title {
+        if let Some(t) = title {
             lines.push(format!("#' {}", t));
         }
 
         // Add description
         match desc_style {
             DescriptionStyle::Implicit => {
-                if let Some(ref d) = description {
+                if let Some(d) = description {
                     // Implicit description: lines after title, before first tag
                     lines.push(format!("#' {}", d));
                 }
             }
             DescriptionStyle::Explicit => {
-                if let Some(ref d) = description {
+                if let Some(d) = description {
                     // Explicit @description tag
                     lines.push(format!("#' @description {}", d));
                 }
@@ -1291,10 +1295,10 @@ pub fn extract_roxygen_namespace_tags(content: &str) -> RoxygenNamespace {
                         break;
                     }
                 }
-                if i < lines.len() {
-                    if let Some(name) = extract_definition_name(lines[i]) {
-                        ns.exports.push(name);
-                    }
+                if i < lines.len()
+                    && let Some(name) = extract_definition_name(lines[i])
+                {
+                    ns.exports.push(name);
                 }
             }
         }
@@ -1491,11 +1495,7 @@ fn extract_first_identifier(line: &str) -> Option<String> {
             break;
         }
     }
-    if name.is_empty() {
-        None
-    } else {
-        Some(name)
-    }
+    if name.is_empty() { None } else { Some(name) }
 }
 
 /// Extract top-level definition names from R source text.

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -132,7 +132,7 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::Parser;
 use tree_sitter::Tree;
 
-use crate::chunks::{classify_chunk_document, classify_chunk_document_for, ChunkKind};
+use crate::chunks::{ChunkKind, classify_chunk_document, classify_chunk_document_for};
 use crate::content_provider::DefaultContentProvider;
 use crate::cross_file::revalidation::CrossFileDiagnosticsGate;
 use crate::cross_file::{
@@ -140,7 +140,7 @@ use crate::cross_file::{
     CrossFileWorkspaceIndex, DependencyGraph, MetadataCache,
 };
 use crate::document_store::DocumentStore;
-use crate::file_type::{file_type_from_language_id_or_uri, file_type_from_uri, FileType};
+use crate::file_type::{FileType, file_type_from_language_id_or_uri, file_type_from_uri};
 use crate::package_library::PackageLibrary;
 use crate::parameter_resolver::SignatureCache;
 use crate::workspace_index::WorkspaceIndex;
@@ -302,16 +302,15 @@ fn extract_loaded_packages(tree: &Option<Tree>, text: &str) -> Vec<String> {
                     // Extract the first argument
                     if let Some(args_node) = node.child_by_field_name("arguments") {
                         for i in 0..args_node.child_count() {
-                            if let Some(child) = args_node.child(i) {
-                                if child.kind() == "argument" {
-                                    if let Some(value_node) = child.child_by_field_name("value") {
-                                        let value_text = &text[value_node.byte_range()];
-                                        let pkg_name = value_text
-                                            .trim_matches(|c: char| c == '"' || c == '\'');
-                                        packages.push(pkg_name.to_string());
-                                        break;
-                                    }
-                                }
+                            if let Some(child) = args_node.child(i)
+                                && child.kind() == "argument"
+                                && let Some(value_node) = child.child_by_field_name("value")
+                            {
+                                let value_text = &text[value_node.byte_range()];
+                                let pkg_name =
+                                    value_text.trim_matches(|c: char| c == '"' || c == '\'');
+                                packages.push(pkg_name.to_string());
+                                break;
                             }
                         }
                     }
@@ -437,16 +436,15 @@ fn parse_index(path: &PathBuf) -> Option<Vec<String>> {
 
     for line in text.lines() {
         // INDEX format: symbol_name<whitespace>description
-        if let Some(sym) = line.split_whitespace().next() {
-            if !sym.is_empty()
-                && sym
-                    .chars()
-                    .next()
-                    .map(|c| c.is_alphabetic())
-                    .unwrap_or(false)
-            {
-                symbols.push(sym.to_string());
-            }
+        if let Some(sym) = line.split_whitespace().next()
+            && !sym.is_empty()
+            && sym
+                .chars()
+                .next()
+                .map(|c| c.is_alphabetic())
+                .unwrap_or(false)
+        {
+            symbols.push(sym.to_string());
         }
     }
 
@@ -470,10 +468,10 @@ impl Library {
 
     #[allow(dead_code)]
     pub fn get(&self, name: &str) -> Option<Arc<Package>> {
-        if let Ok(packages) = self.packages.read() {
-            if let Some(pkg) = packages.get(name) {
-                return Some(pkg.clone());
-            }
+        if let Ok(packages) = self.packages.read()
+            && let Some(pkg) = packages.get(name)
+        {
+            return Some(pkg.clone());
         }
 
         // Try to load from library paths
@@ -499,12 +497,12 @@ impl Library {
         for lib_path in &self.paths {
             if let Ok(entries) = fs::read_dir(lib_path) {
                 for entry in entries.flatten() {
-                    if entry.path().join("DESCRIPTION").exists() {
-                        if let Some(name) = entry.file_name().to_str() {
-                            let s = name.to_string();
-                            if names_set.insert(s.clone()) {
-                                names.push(s);
-                            }
+                    if entry.path().join("DESCRIPTION").exists()
+                        && let Some(name) = entry.file_name().to_str()
+                    {
+                        let s = name.to_string();
+                        if names_set.insert(s.clone()) {
+                            names.push(s);
                         }
                     }
                 }
@@ -1041,7 +1039,9 @@ impl WorldState {
         // forward-created backward edges are available for auto-detect mode.
         self.build_dependency_graph_from_workspace();
         self.workspace_scan_complete = true;
-        log::info!("[Background] Dependency graph built from workspace entries, workspace_scan_complete = true");
+        log::info!(
+            "[Background] Dependency graph built from workspace entries, workspace_scan_complete = true"
+        );
 
         // Now that the graph reflects the workspace, refresh the document_store
         // pin set so any file opened before the scan completes picks up its
@@ -1104,21 +1104,21 @@ impl WorldState {
             let path = entry.path();
 
             if path.is_dir() {
-                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
-                    if should_skip_directory(dir_name) {
-                        continue;
-                    }
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str())
+                    && should_skip_directory(dir_name)
+                {
+                    continue;
                 }
                 self.index_directory(&path);
             } else if is_stat_model_extension(&path) {
                 // Route through the shared BOM-aware seam; an undecodable file
                 // is left unindexed. See `read_source` for the decode policy.
-                if let Ok(text) = read_source(&path) {
-                    if let Ok(uri) = Url::from_file_path(&path) {
-                        log::trace!("Indexing file: {}", uri);
-                        self.workspace_index
-                            .insert(uri.clone(), Document::new_with_uri(&text, None, &uri));
-                    }
+                if let Ok(text) = read_source(&path)
+                    && let Ok(uri) = Url::from_file_path(&path)
+                {
+                    log::trace!("Indexing file: {}", uri);
+                    self.workspace_index
+                        .insert(uri.clone(), Document::new_with_uri(&text, None, &uri));
                 }
             }
         }
@@ -1351,7 +1351,7 @@ fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String, SourceReadE
     // accept corrupted input. UTF-16 source is vanishingly rare, so we don't
     // pinpoint a byte offset here (`byte == 0` selects the encoding-agnostic
     // diagnostic message in `encoding_diagnostic`).
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return Err(SourceReadError::InvalidEncoding { offset: 0, byte: 0 });
     }
     let units = bytes.chunks_exact(2).map(|c| {

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -492,10 +492,10 @@ impl WorkspaceIndex {
         self.version.fetch_add(1, Ordering::SeqCst);
 
         // Update metrics
-        if count > 0 {
-            if let Ok(mut metrics) = self.metrics.write() {
-                metrics.invalidations += count as u64;
-            }
+        if count > 0
+            && let Ok(mut metrics) = self.metrics.write()
+        {
+            metrics.invalidations += count as u64;
         }
     }
 

--- a/crates/raven/tests/indentation_integration.rs
+++ b/crates/raven/tests/indentation_integration.rs
@@ -8,8 +8,8 @@
 //! **Validates: Requirements 3.2, 4.1, 6.1, 7.2, 7.3**
 
 use raven::indentation::{
-    calculate_indentation, detect_context, format_indentation, IndentContext, IndentationConfig,
-    IndentationStyle,
+    IndentContext, IndentationConfig, IndentationStyle, calculate_indentation, detect_context,
+    format_indentation,
 };
 use tower_lsp::lsp_types::Position;
 use tree_sitter::Parser;

--- a/crates/raven/tests/libpath_watching.rs
+++ b/crates/raven/tests/libpath_watching.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use raven::libpath_watcher::{spawn_watcher, LibpathEvent};
+use raven::libpath_watcher::{LibpathEvent, spawn_watcher};
 use raven::package_library::{PackageInfo, PackageLibrary};
 use tempfile::tempdir;
 use tokio::sync::mpsc;

--- a/crates/raven/tests/package_db_consumer.rs
+++ b/crates/raven/tests/package_db_consumer.rs
@@ -3,7 +3,7 @@
 //! (spec §14, §10). Uses a synthetic package name so the test proves Tier 3
 //! resolution regardless of what is installed on the build machine.
 
-use raven::package_db::binary_db::{write_shipped_db, ShippedDbProvenance};
+use raven::package_db::binary_db::{ShippedDbProvenance, write_shipped_db};
 use raven::package_db::model::PackageRecord;
 use raven::package_library::build_package_library;
 
@@ -23,16 +23,23 @@ struct NamesDbEnvGuard(Option<std::ffi::OsString>);
 impl NamesDbEnvGuard {
     fn set(path: &std::path::Path) -> Self {
         let prior = std::env::var_os("RAVEN_NAMES_DB");
-        std::env::set_var("RAVEN_NAMES_DB", path);
+        // SAFETY: test-only; callers hold `ENV_LOCK` for the whole test, which
+        // serializes every test in this binary that reads or writes the var, so
+        // no other thread touches the environment concurrently.
+        unsafe { std::env::set_var("RAVEN_NAMES_DB", path) };
         Self(prior)
     }
 }
 
 impl Drop for NamesDbEnvGuard {
     fn drop(&mut self) {
-        match self.0.take() {
-            Some(v) => std::env::set_var("RAVEN_NAMES_DB", v),
-            None => std::env::remove_var("RAVEN_NAMES_DB"),
+        // SAFETY: this guard is dropped before the test's `ENV_LOCK` guard, so
+        // the restore still runs serialized — see `set` above.
+        unsafe {
+            match self.0.take() {
+                Some(v) => std::env::set_var("RAVEN_NAMES_DB", v),
+                None => std::env::remove_var("RAVEN_NAMES_DB"),
+            }
         }
     }
 }
@@ -86,7 +93,7 @@ async fn tier3_resolves_export_with_no_r() {
 #[tokio::test]
 async fn freeze_round_trip_matches_tier1_when_r_present() {
     use raven::package_db::json_db::{
-        read_repo_db_str, write_repo_db_string, RepoDb, RepoDbProvenance, REPO_DB_SCHEMA_VERSION,
+        REPO_DB_SCHEMA_VERSION, RepoDb, RepoDbProvenance, read_repo_db_str, write_repo_db_string,
     };
     use raven::package_db::model::PackageRecord;
 
@@ -128,7 +135,7 @@ async fn freeze_round_trip_matches_tier1_when_r_present() {
 #[tokio::test]
 async fn tier2_repo_db_from_workspace_outranks_tier3() {
     use raven::package_db::json_db::{
-        write_repo_db_file, RepoDb, RepoDbProvenance, REPO_DB_SCHEMA_VERSION,
+        REPO_DB_SCHEMA_VERSION, RepoDb, RepoDbProvenance, write_repo_db_file,
     };
 
     let _guard = ENV_LOCK.lock().await;

--- a/crates/raven/tests/performance_budgets.rs
+++ b/crates/raven/tests/performance_budgets.rs
@@ -208,7 +208,7 @@ use std::fmt::Write;
 use tree_sitter::Parser;
 use url::Url;
 
-use raven::test_utils::fixture_workspace::{create_fixture_workspace, FixtureConfig};
+use raven::test_utils::fixture_workspace::{FixtureConfig, create_fixture_workspace};
 
 /// Create a tree-sitter parser configured for R.
 fn make_r_parser() -> Parser {
@@ -490,7 +490,7 @@ fn budget_scope_resolution_50_file_workspace_auto() {
 
 #[test]
 fn budget_single_file_completion() {
-    use raven::state::{scan_workspace, Document, WorldState};
+    use raven::state::{Document, WorldState, scan_workspace};
     use tower_lsp::lsp_types::Position;
 
     // Create a small fixture workspace for realistic completion context

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,7 @@ Key code entry points:
 ## Build from source
 
 Prerequisites:
-- Rust toolchain (MSRV: 1.80)
+- Rust toolchain (MSRV: 1.96; the workspace is on the 2024 edition)
 
 Clone and build:
 ```bash

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,4 @@
 # toolchain in the Integration "Formatting" job). Keep this file to stable-only
 # options so `cargo fmt` behaves identically for every contributor; the edition
 # is stated explicitly so running `rustfmt` directly matches `cargo fmt`.
-edition = "2021"
+edition = "2024"


### PR DESCRIPTION
## What

Moves the **whole workspace** — not just CI — onto **Rust 1.96**, migrates to **edition 2024**, and modernizes the codebase accordingly.

| | Before | After |
|---|---|---|
| Edition | 2021 | **2024** |
| MSRV (`rust-version`) | 1.80 | **1.96** |
| Resolver | 2 | **3** |
| CI fmt/clippy pins | 1.95.0 | **1.96.0** |

> Build-from-source now requires `rustc 1.96`.

## Changes

- **`Cargo.toml`**: edition `2024`, `rust-version = "1.96"`, `resolver = "3"`. No `Cargo.lock` churn from the resolver bump.
- **CI** (`.github/workflows/integration.yml`): the formatting and clippy gate jobs pin `1.96.0`. (The `build`/`cargo`/`perf` jobs stay on `dtolnay@stable`, which is ≥ 1.96 — unchanged by design.)
- **Docs**: `AGENTS.md` (and its `CLAUDE.md` symlink) and `docs/development.md` updated to the new toolchain/MSRV/edition. `rustfmt.toml` edition → `2024` so a direct `rustfmt` invocation matches `cargo fmt`.
- **`cargo fix --edition` migration**:
  - `std::env::set_var` / `remove_var` are now `unsafe` in 2024 — wrapped accordingly (test-only call sites).
  - Bound tree-sitter cursors to named locals (`scope.rs`, `object_name.rs`) where edition-2024's temporary-drop-order change applies.
- **clippy 1.96 / let-chain modernization**: collapsed nested `if`/`if let` into let-chains (stable in edition 2024) across the crate. Removed the now-obsolete `#[allow(clippy::manual_pattern_char_comparison)]` + stale MSRV comment in `merge.rs` in favor of `split(['.', '-'])`.
- **Cleanup (from two `/simplify` passes)**: consolidated the repeated per-test `RAVEN_NAMES_DB` env `set`/`remove` pairs into one audited, panic-safe `NamesDbEnvGuard` RAII guard — concentrating the edition-2024-required `unsafe` env mutation in a single place behind the existing serialization lock; removed a dead no-op block in `property_tests.rs`.

The bulk of the line count is mechanical, machine-applied `collapsible_if` → let-chain collapses; the hand-authored surface is the config/docs, the two cursor bindings, the `merge.rs` simplification, and the env-guard consolidation.

## Verification (toolchain `1.96.0`)

- ✅ `cargo +1.96.0 fmt --all --check`
- ✅ `cargo +1.96.0 clippy --workspace --all-targets --features test-support -- -D warnings` (zero warnings)
- ✅ `cargo +1.96.0 build --release -p raven --features test-support`
- ✅ `cargo +1.96.0 test -p raven --features test-support` — **4232 unit + 103 + 3 + 58 integration/doctests passed, 0 failed**
- ✅ Two consecutive clean `/simplify` review passes (reuse / simplification / efficiency / altitude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced package state hydration to use workspace index entries for more accurate content resolution.

* **Bug Fixes**
  * Improved diagnostics freshness gating with monotonic version checks before snapshot computation.
  * Refined package configuration validation for `packages.rPath` to require non-empty, non-null strings.
  * Tightened command validation for optional package arguments.

* **Refactor**
  * Updated Rust toolchain to version 1.96 and edition to 2024.
  * Improved code clarity through control-flow refactoring across multiple modules.
  * Reorganized imports throughout codebase for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->