### PR TITLE
chore: pin Rust toolchain via rust-toolchain.toml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,6 +103,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       # No explicit toolchain step: rust-toolchain.toml pins the version and
       # rustup auto-installs it on the first `cargo` call below.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,11 @@ env:
   # SCCACHE_GHA_ENABLED) so sccache never does a hard startup probe against
   # the GHA cache API — actions/cache below handles persistence gracefully.
   RUSTC_WRAPPER: sccache
+  # sccache can't cache incremental compilation units (and CI never reuses a
+  # target/ dir anyway), so disable incremental. dtolnay/rust-toolchain used to
+  # set this implicitly; now that the toolchain comes from rust-toolchain.toml,
+  # set it here.
+  CARGO_INCREMENTAL: 0
   # mold is a fast linker that significantly reduces link time on Linux.
   RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
@@ -24,41 +29,37 @@ concurrency:
 
 jobs:
   # ── Formatting gate ────────────────────────────────────────────────────
-  # Cheap, dependency-free check that the tree is `cargo fmt`-clean. Pinned to
-  # an explicit toolchain (not `@stable`) so the gate is reproducible: the
-  # whole point is to stop formatting drift from re-accumulating PR after PR,
-  # which it did because nothing enforced `cargo fmt` and "stable" rustfmt
-  # shifts over time. `cargo fmt` does not invoke rustc, so the sccache/mold
-  # env above is inert here.
+  # Cheap, dependency-free check that the tree is `cargo fmt`-clean. The
+  # toolchain — and its rustfmt component — is pinned by rust-toolchain.toml and
+  # auto-installed by rustup, so `cargo fmt` here is the exact rustfmt every
+  # contributor runs locally. The whole point is to stop formatting drift from
+  # re-accumulating PR after PR as "stable" rustfmt shifts over time. `cargo
+  # fmt` does not invoke rustc, so the sccache/mold env above is inert here.
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Install pinned rustfmt
-        run: rustup toolchain install 1.96.0 --profile minimal --component rustfmt
       - name: Check formatting
-        run: cargo +1.96.0 fmt --all --check
+        run: cargo fmt --all --check
 
   # ── Clippy lint gate (required check) ──────────────────────────────────
   # Denies ALL clippy/rustc warnings (`-D warnings`) across every target so
-  # lint noise can't re-accumulate during development. Pinned to an explicit
-  # toolchain (not `@stable`) for the same reason as the fmt gate: new clippy
-  # releases add new lints, and an unpinned gate would start failing on
-  # unrelated PRs as the lint set shifts. `--all-targets --features
-  # test-support` matches the surface a developer sees in their editor
-  # (lib, tests, benches, examples). Unlike fmt, clippy DOES invoke rustc, so
-  # this job sets up sccache + mold like the other compiling jobs.
+  # lint noise can't re-accumulate during development. The toolchain — and its
+  # clippy component — is pinned by rust-toolchain.toml (auto-installed by
+  # rustup), for the same reason as the fmt gate: new clippy releases add new
+  # lints, and an unpinned gate would start failing on unrelated PRs as the lint
+  # set shifts. `--all-targets --features test-support` matches the surface a
+  # developer sees in their editor (lib, tests, benches, examples). Unlike fmt,
+  # clippy DOES invoke rustc, so this job sets up sccache + mold like the other
+  # compiling jobs.
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-
-      - name: Install pinned clippy
-        run: rustup toolchain install 1.96.0 --profile minimal --component clippy
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.9
@@ -86,7 +87,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends mold
 
       - name: Run clippy (deny warnings)
-        run: cargo +1.96.0 clippy --workspace --all-targets --features test-support -- -D warnings
+        run: cargo clippy --workspace --all-targets --features test-support -- -D warnings
 
 
   # Build only the release artifacts that genuinely need optimization: the LSP
@@ -103,11 +104,8 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
-        with:
-          toolchain: stable
-
+      # No explicit toolchain step: rust-toolchain.toml pins the version and
+      # rustup auto-installs it on the first `cargo` call below.
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.9
 
@@ -191,11 +189,9 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
-        with:
-          toolchain: stable
-
+      # No explicit toolchain step: rust-toolchain.toml pins the version and
+      # rustup auto-installs it on the first `cargo` call below.
+      #
       # sccache + mold are referenced by the workflow-level RUSTC_WRAPPER /
       # RUSTFLAGS env, so every Rust-compiling job must set them up or rustc
       # fails. The debug dep cache is keyed separately from the release one

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: sccache
+  # sccache can't cache incremental units; disable (no benefit in CI). Was set
+  # implicitly by dtolnay/rust-toolchain, dropped in favor of rust-toolchain.toml.
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
 permissions:
@@ -29,11 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
-        with:
-          toolchain: stable
-
+      # rust-toolchain.toml pins the version (rustup auto-installs on first
+      # `cargo` use). Pinning also keeps PR-vs-main benchmark baselines
+      # comparable on the same compiler instead of drifting with floating stable.
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.9
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -31,6 +31,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       # rust-toolchain.toml pins the version (rustup auto-installs on first
       # `cargo` use). Pinning also keeps PR-vs-main benchmark baselines

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,10 +84,15 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+      # Pin to rust-toolchain.toml's channel so release binaries are built with
+      # the same compiler as CI/dev (reproducible). dtolnay can't read that file
+      # AND must install the per-matrix target's std for this toolchain — which
+      # the file's auto-install would not do — so the version is repeated here.
+      # Keep it in sync with rust-toolchain.toml.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
-          toolchain: stable
+          toolchain: "1.96.0"
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry & build artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@ This file is intentionally short: a map to the docs and a list of invariants tha
 
 ## CI gates (keep green before committing)
 
-Rust changes must pass two gates in `.github/workflows/integration.yml`, both pinned to toolchain `1.96.0` so results are reproducible:
+Rust changes must pass two gates in `.github/workflows/integration.yml`. Both run on the toolchain pinned in `rust-toolchain.toml` (currently `1.96.0`, the project MSRV) so results are reproducible — rustup auto-installs it, so a bare `cargo fmt` / `cargo clippy` uses it:
 
-- **Formatting** — `cargo +1.96.0 fmt --all --check`. Always run `cargo fmt --all` before committing; never hand-format around it.
-- **Clippy** — `cargo +1.96.0 clippy --workspace --all-targets --features test-support -- -D warnings`. Zero warnings: every clippy/rustc warning is an error, across lib, tests, benches, and examples.
+- **Formatting** — `cargo fmt --all --check`. Always run `cargo fmt --all` before committing; never hand-format around it.
+- **Clippy** — `cargo clippy --workspace --all-targets --features test-support -- -D warnings`. Zero warnings: every clippy/rustc warning is an error, across lib, tests, benches, and examples.
 
 Both block merge. Fix the underlying issue rather than suppressing it; when a lint is a genuine, deliberate exception, use a narrowly-scoped `#[allow(...)]` with a one-line reason. Project-wide exceptions live in `crates/raven/Cargo.toml` `[lints]` (currently only `field_reassign_with_default`).
 

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-repository = "https://github.com/jbearak/Raven"
+repository = "https://github.com/jbearak/raven"
 
 # clippy is gated in CI with `-D warnings` (see .github/workflows/integration.yml).
 # `field_reassign_with_default` is the one lint allowed: the

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,8 +43,8 @@ Prerequisites:
 
 Clone and build:
 ```bash
-git clone https://github.com/jbearak/Raven.git
-cd Raven
+git clone https://github.com/jbearak/raven.git
+cd raven
 cargo build --release -p raven
 # Binary will be at target/release/raven
 ```

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -16,7 +16,7 @@
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbearak/Raven"
+    "url": "https://github.com/jbearak/raven"
   },
   "engines": {
     "vscode": "^1.82.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Single source of truth for the Rust toolchain. Local `cargo build/test/fmt/
+# clippy` and the CI jobs in .github/workflows/{integration,perf}.yml all run on
+# this version — rustup auto-installs it on first use, so a bare `cargo fmt` /
+# `cargo clippy` is the same rustfmt/clippy every contributor and gate uses.
+# 1.96.0 is also the project MSRV (`rust-version` in Cargo.toml), so CI actually
+# exercises the minimum supported compiler.
+#
+# Pinning makes upgrades intentional: it stops fmt/clippy drift and unrelated PR
+# failures as the floating `stable` toolchain shifts under contributors. Bump in
+# a dedicated PR — and update the matching `toolchain:` in release-build.yml,
+# which needs an explicit version to install cross-compilation targets.
+#
+# `profile = minimal` + the rustfmt/clippy components are what the fmt and clippy
+# gates rely on.
+[toolchain]
+channel = "1.96.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
Adopt a pinned Rust toolchain as the single source of truth (option A) and tidy the CI workflows to consume it.

- **Add `rust-toolchain.toml`** pinning `1.96.0` (the project MSRV) with the `rustfmt`/`clippy` components. rustup auto-installs it, so local dev and every CI job run on the same compiler and upgrades become intentional — no more fmt/clippy drift failing unrelated PRs as floating `stable` shifts.
- **`integration.yml` / `perf.yml`** — drop the explicit `rustup toolchain install` steps and `dtolnay/rust-toolchain@stable`; run bare `cargo fmt` / `clippy` / `build` / `test` on the pinned toolchain (build + test now actually exercise the MSRV). Add `CARGO_INCREMENTAL: 0` to `env` (sccache can't cache incremental units; `dtolnay` set this implicitly before).
- **`release-build.yml`** — pin `build-lsp` to `1.96.0` (kept `targets:`) so each matrix target's std installs for the pinned toolchain. `dtolnay` can't read `rust-toolchain.toml`, so this is the one intentional repetition of the version (a comment flags the sync point).
- **`AGENTS.md`** — CI-gates section references `rust-toolchain.toml`; documented commands drop `+1.96.0`.
- **URL typo fix** — capital-R `github.com/jbearak/Raven` → lowercase in `Cargo.toml`, `editors/vscode/package.json`, `docs/development.md`.

No change: `build-names-db.yml` (builds a different branch, host-only), `release-publish.yml` / `claude.yml` (no cargo), `dependabot.yml` (unconfigured placeholder, left as-is).

## Tested
- All three changed workflows parse as valid YAML (`yaml.safe_load`).
- Confirmed bare `cargo fmt --all --check` resolves to the pinned `1.96.0` and the tree is clean.
- Grep confirms no stale `+1.96.0` / `rustup toolchain install` / `toolchain: stable` config remains; the only real `dtolnay` usage left is the intentional pinned one in `release-build.yml`.

## Note
Bumping the toolchain is now a two-file change: `rust-toolchain.toml` and the `toolchain:` in `release-build.yml` (comments in each point at the other).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build-from-source instructions to use the correct repository URL and directory naming conventions.

* **Chores**
  * Standardized repository URLs across project configuration files and metadata.
  * Configured Rust toolchain pinning for reproducible builds across all CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->