### PR TITLE
First-class R chunks in .Rmd/.qmd: diagnostics in raven check/lint + full language intel in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Raven also provides lightweight support for **JAGS** (`.jags`, `.bugs`) and **St
 ### R session integration
 
 - **[R console](docs/r-console.md)** — Interactive R console with statement detection and a temp-file fallback for large blocks; supports R, arf, and radian
-- **[Code chunks](docs/chunks.md)** — R Markdown / Quarto chunk detection with Run Chunk / Run Above / Run All commands, CodeLens buttons, navigation, and background highlighting; `# %%` cell support in `.R` files
+- **[Code chunks](docs/chunks.md)** — R Markdown / Quarto chunk detection with Run Chunk / Run Above / Run All commands, CodeLens buttons, navigation, and background highlighting; full R language intelligence (diagnostics, completion, hover, navigation) inside chunk bodies; `# %%` cell support in `.R` files
 - **[Knit Preview + Export](docs/knit.md)** — `Raven: Knit Preview` renders R Markdown to an HTML preview without requiring Pandoc; companion `Export to HTML / PDF / Word` commands save the result next to the `.Rmd` via Pandoc
 - **[Plot viewer](docs/plot-viewer.md)** — Plots render in a VS Code panel via [httpgd](https://nx10.dev/httpgd/), with history navigation, save (PNG/SVG/PDF), and theme-aware background
 - **[Data viewer](docs/data-viewer.md)** — `View(df)` opens a virtualized grid backed by Apache Arrow; viewport-based rendering keeps scrolling responsive on multi-million-row frames

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2864,9 +2864,8 @@ impl LanguageServer for Backend {
             // languageId-then-URI so untitled `.Rmd`/`.qmd` buffers (no file
             // extension) are masked too — and reuse the same `chunk_kind` for
             // the DocumentStore open below so its tree/artifacts agree.
-            let chunk_kind =
-                crate::chunks::classify_chunk_document_for(Some(language_id.as_str()), uri.path());
-            let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+            let (chunk_kind, analysis_text) =
+                crate::cross_file::classify_and_mask(Some(language_id.as_str()), &uri, &text);
             let mut meta = crate::cross_file::extract_metadata(&analysis_text);
             let uri_clone = uri.clone();
             let workspace_root = state.workspace_folders.first().cloned();
@@ -3265,11 +3264,8 @@ impl LanguageServer for Backend {
                 // Masked for Rmd/Quarto (chunk bodies only); raw otherwise.
                 // Classify by languageId-then-URI so untitled buffers mask, and
                 // extract metadata from that same masked view (#343).
-                let chunk_kind = crate::chunks::classify_chunk_document_for(
-                    Some(language_id.as_str()),
-                    uri.path(),
-                );
-                let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+                let (chunk_kind, analysis_text) =
+                    crate::cross_file::classify_and_mask(Some(language_id.as_str()), &uri, &text);
                 let mut meta = crate::cross_file::extract_metadata(&analysis_text);
                 log::trace!(
                     "did_open re-enrich: uri={}, sources={}, sourced_by={}",
@@ -3432,9 +3428,8 @@ impl LanguageServer for Backend {
             // languageId-then-URI classification masks untitled buffers (#343);
             // extract metadata from the same masked view so the graph and the
             // DocumentStore tree/artifacts agree (chunk bodies only for Rmd).
-            let chunk_kind =
-                crate::chunks::classify_chunk_document_for(Some(language_id.as_str()), uri.path());
-            let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+            let (chunk_kind, analysis_text) =
+                crate::cross_file::classify_and_mask(Some(language_id.as_str()), &uri, &text);
             let mut meta = crate::cross_file::extract_metadata(&analysis_text);
             crate::cross_file::enrich_metadata_with_inherited_wd(
                 &mut meta,
@@ -3699,84 +3694,100 @@ impl LanguageServer for Backend {
             let max_chain_depth = state.cross_file_config.max_chain_depth;
 
             // Extract and enrich metadata with inherited working directory
-            let (packages_to_prefetch, enriched_meta, wd_affected, edges_changed) =
-                if let Some(doc) = state.documents.get(&uri) {
-                    // Analysis text: masked for Rmd/Quarto (chunk bodies only),
-                    // raw otherwise. Feeds the graph + DocumentStore (#343).
-                    let text = doc.analysis_text();
-                    let mut meta = crate::cross_file::extract_metadata(&text);
-                    let uri_clone = uri.clone();
-                    let workspace_root = state.workspace_folders.first().cloned();
+            let (
+                packages_to_prefetch,
+                enriched_meta,
+                precomputed_masked,
+                wd_affected,
+                edges_changed,
+            ) = if let Some(doc) = state.documents.get(&uri) {
+                // Analysis text: masked for Rmd/Quarto (chunk bodies only),
+                // raw otherwise. Feeds the graph + DocumentStore (#343).
+                // `apply_change` above already masked this exact raw content
+                // for this doc's fixed chunk kind, so we hand the Rmd mask to
+                // `update_with_metadata` below to skip a second `mask_to_r`
+                // pass per keystroke. Only Rmd carries a mask; plain R's
+                // analysis text equals raw text, so pass `None` there.
+                let text = doc.analysis_text();
+                let precomputed_masked = doc.is_rmd_document().then(|| text.clone());
+                let mut meta = crate::cross_file::extract_metadata(&text);
+                let uri_clone = uri.clone();
+                let workspace_root = state.workspace_folders.first().cloned();
 
-                    // Enrich metadata with inherited working directory before any use
-                    // Use get_enriched_metadata to prefer already-enriched sources for transitive inheritance
-                    crate::cross_file::enrich_metadata_with_inherited_wd(
-                        &mut meta,
-                        &uri_clone,
-                        workspace_root.as_ref(),
-                        |parent_uri| state.get_enriched_metadata(parent_uri),
-                        max_chain_depth,
-                    );
+                // Enrich metadata with inherited working directory before any use
+                // Use get_enriched_metadata to prefer already-enriched sources for transitive inheritance
+                crate::cross_file::enrich_metadata_with_inherited_wd(
+                    &mut meta,
+                    &uri_clone,
+                    workspace_root.as_ref(),
+                    |parent_uri| state.get_enriched_metadata(parent_uri),
+                    max_chain_depth,
+                );
 
-                    // Collect package names for prefetch (validate names to
-                    // reject suspicious inputs before R subprocess calls)
-                    let pkgs: Vec<String> = if packages_enabled {
-                        extract_loaded_packages_from_library_calls(&meta.library_calls)
-                    } else {
-                        Vec::new()
-                    };
-
-                    // Pre-collect content for potential parent files to avoid borrow conflicts
-                    // IMPORTANT: Use PathContext WITHOUT @lsp-cd for backward directives
-                    // Backward directives should always be resolved relative to the file's directory
-                    let backward_path_ctx = crate::cross_file::path_resolve::PathContext::new(
-                        &uri_clone,
-                        workspace_root.as_ref(),
-                    );
-                    let parent_content: std::collections::HashMap<Url, String> = meta
-                        .sourced_by
-                        .iter()
-                        .filter_map(|d| {
-                            let ctx = backward_path_ctx.as_ref()?;
-                            let resolved =
-                                crate::cross_file::path_resolve::resolve_path(&d.path, ctx)?;
-                            let parent_uri = Url::from_file_path(resolved).ok()?;
-                            let content = state
-                                .documents
-                                .get(&parent_uri)
-                                .map(|doc| doc.text())
-                                .or_else(|| state.cross_file_file_cache.get(&parent_uri))?;
-                            Some((parent_uri, content))
-                        })
-                        .collect();
-
-                    let graph_result = state.cross_file_graph.update_file(
-                        &uri,
-                        &meta,
-                        workspace_root.as_ref(),
-                        |parent_uri| parent_content.get(parent_uri).cloned(),
-                    );
-
-                    // Invalidate children affected by working directory change (Requirement 8)
-                    let wd_children =
-                        crate::cross_file::revalidation::invalidate_children_on_parent_wd_change(
-                            &uri,
-                            old_meta.as_deref(),
-                            &meta,
-                            &state.cross_file_graph,
-                            &state.cross_file_meta,
-                        );
-
-                    (pkgs, Some(meta), wd_children, graph_result.edges_changed)
+                // Collect package names for prefetch (validate names to
+                // reject suspicious inputs before R subprocess calls)
+                let pkgs: Vec<String> = if packages_enabled {
+                    extract_loaded_packages_from_library_calls(&meta.library_calls)
                 } else {
-                    (Vec::new(), None, Vec::new(), false)
+                    Vec::new()
                 };
+
+                // Pre-collect content for potential parent files to avoid borrow conflicts
+                // IMPORTANT: Use PathContext WITHOUT @lsp-cd for backward directives
+                // Backward directives should always be resolved relative to the file's directory
+                let backward_path_ctx = crate::cross_file::path_resolve::PathContext::new(
+                    &uri_clone,
+                    workspace_root.as_ref(),
+                );
+                let parent_content: std::collections::HashMap<Url, String> = meta
+                    .sourced_by
+                    .iter()
+                    .filter_map(|d| {
+                        let ctx = backward_path_ctx.as_ref()?;
+                        let resolved = crate::cross_file::path_resolve::resolve_path(&d.path, ctx)?;
+                        let parent_uri = Url::from_file_path(resolved).ok()?;
+                        let content = state
+                            .documents
+                            .get(&parent_uri)
+                            .map(|doc| doc.text())
+                            .or_else(|| state.cross_file_file_cache.get(&parent_uri))?;
+                        Some((parent_uri, content))
+                    })
+                    .collect();
+
+                let graph_result = state.cross_file_graph.update_file(
+                    &uri,
+                    &meta,
+                    workspace_root.as_ref(),
+                    |parent_uri| parent_content.get(parent_uri).cloned(),
+                );
+
+                // Invalidate children affected by working directory change (Requirement 8)
+                let wd_children =
+                    crate::cross_file::revalidation::invalidate_children_on_parent_wd_change(
+                        &uri,
+                        old_meta.as_deref(),
+                        &meta,
+                        &state.cross_file_graph,
+                        &state.cross_file_meta,
+                    );
+
+                (
+                    pkgs,
+                    Some(meta),
+                    precomputed_masked,
+                    wd_children,
+                    graph_result.edges_changed,
+                )
+            } else {
+                (Vec::new(), None, None, Vec::new(), false)
+            };
 
             // Update new DocumentStore with enriched metadata (Requirement 1.4)
             if let Some(meta) = enriched_meta {
                 state
                     .document_store
-                    .update_with_metadata(&uri, changes, version, meta)
+                    .update_with_metadata(&uri, changes, version, meta, precomputed_masked)
                     .await;
             } else {
                 state.document_store.update(&uri, changes, version).await;

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -5405,10 +5405,21 @@ impl LanguageServer for Backend {
             }
         };
 
-        // Skip Rmd/Quarto: indentation rules designed for R syntax would
-        // produce surprising edits on prose, YAML, or non-R chunk content.
-        if doc.is_rmd_document() {
-            log::trace!("on_type_formatting: skipping Rmd/Quarto document {}", uri);
+        let position = params.text_document_position.position;
+
+        // Rmd/Quarto: indentation is first-class inside R chunk bodies, but a
+        // prose/YAML line maps to a blank masked line that the R indentation
+        // engine would treat as top-level R — applying R rules to markdown.
+        // Short-circuit unless the position is inside an R chunk body. The
+        // chunk-position check uses the RAW text (fences are blanked in the
+        // masked analysis text).
+        if doc.is_rmd_document()
+            && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
+        {
+            log::trace!(
+                "on_type_formatting: skipping prose position in Rmd/Quarto document {}",
+                uri
+            );
             return Ok(None);
         }
 
@@ -5421,8 +5432,10 @@ impl LanguageServer for Backend {
             }
         };
 
-        let source = doc.text();
-        let position = params.text_document_position.position;
+        // The tree is parsed from the analysis text (masked for Rmd); the
+        // indentation engine must receive the same text so its byte offsets
+        // and tree-sitter points line up. Behavior-neutral for plain R.
+        let source = doc.analysis_text();
 
         // Get indentation style from server configuration
         let style = state.indentation_config.style;
@@ -11212,6 +11225,117 @@ lineLength = 200
                 .iter()
                 .map(|d| (d.range.start.line, d.message.clone()))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Open an Rmd document through the real `did_open` path. Returns the owned
+    /// `LspService` (keep it alive for the test's duration), the backend's URI,
+    /// and the `TempDir` backing the file. Shared by the on-type-formatting
+    /// chunk/prose tests.
+    async fn open_rmd(content: &str) -> (tower_lsp::LspService<Backend>, Url, TempDir) {
+        use tower_lsp::lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
+
+        let tmp = TempDir::new().unwrap();
+        let rmd_path = tmp.path().join("report.Rmd");
+        fs::write(&rmd_path, content).unwrap();
+
+        let (svc, _socket) = tower_lsp::LspService::new(Backend::new);
+        let backend = svc.inner();
+        backend
+            .initialize(InitializeParams {
+                workspace_folders: Some(vec![WorkspaceFolder {
+                    uri: Url::from_file_path(tmp.path()).unwrap(),
+                    name: "t".into(),
+                }]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let uri = Url::from_file_path(&rmd_path).unwrap();
+        backend
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "rmd".into(),
+                    version: 1,
+                    text: content.into(),
+                },
+            })
+            .await;
+        (svc, uri, tmp)
+    }
+
+    fn on_type_params(
+        uri: &Url,
+        line: u32,
+        character: u32,
+    ) -> tower_lsp::lsp_types::DocumentOnTypeFormattingParams {
+        use tower_lsp::lsp_types::{
+            DocumentOnTypeFormattingParams, FormattingOptions, Position, TextDocumentPositionParams,
+        };
+        DocumentOnTypeFormattingParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: tower_lsp::lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position { line, character },
+            },
+            ch: "\n".into(),
+            options: FormattingOptions {
+                tab_size: 2,
+                insert_spaces: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Issue #343 Task 4: on-type-formatting indents inside an R chunk body.
+    /// The indentation engine receives the masked analysis text, so a newline
+    /// inside a function body produces a body-indent edit at document
+    /// coordinates exactly as a plain-R file would.
+    #[tokio::test]
+    async fn on_type_formatting_indents_inside_rmd_chunk() {
+        // Cursor lands on the blank line 3, inside the brace block opened on
+        // line 2; the engine should indent it under the block.
+        //   0  ```{r}
+        //   1  prose-free chunk
+        //   2  f <- function() {
+        //   3  (cursor here, empty)
+        //   4  }
+        //   5  ```
+        let content = "```{r}\nx <- 1\nf <- function() {\n\n}\n```\n";
+        let (svc, uri, _tmp) = open_rmd(content).await;
+
+        let edits = svc
+            .inner()
+            .on_type_formatting(on_type_params(&uri, 3, 0))
+            .await
+            .expect("on_type_formatting must not error");
+        let edits = edits.expect("on_type_formatting must return edits inside a chunk body");
+        assert!(
+            !edits.is_empty() && edits.iter().any(|e| e.new_text.contains(' ')),
+            "indentation edit must add leading spaces inside the chunk function body, got {:?}",
+            edits
+        );
+    }
+
+    /// The complement: a newline on a prose line must be inert. Without the
+    /// prose guard the engine would treat the blank masked line as top-level R
+    /// and apply R indentation rules to markdown.
+    #[tokio::test]
+    async fn on_type_formatting_inert_on_rmd_prose() {
+        // Line 2 is prose; an Enter there must yield no edits.
+        let content = "```{r}\nx <- 1\n```\n\nSome prose line.\n";
+        let (svc, uri, _tmp) = open_rmd(content).await;
+
+        let edits = svc
+            .inner()
+            .on_type_formatting(on_type_params(&uri, 4, 5))
+            .await
+            .expect("on_type_formatting must not error");
+        assert!(
+            edits.is_none() || edits.as_ref().is_some_and(|e| e.is_empty()),
+            "on_type_formatting must be inert on a prose line, got {:?}",
+            edits
         );
     }
 }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -11304,36 +11304,9 @@ lineLength = 200
     /// and the `TempDir` backing the file. Shared by the on-type-formatting
     /// chunk/prose tests.
     async fn open_rmd(content: &str) -> (tower_lsp::LspService<Backend>, Url, TempDir) {
-        use tower_lsp::lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
-
         let tmp = TempDir::new().unwrap();
-        let rmd_path = tmp.path().join("report.Rmd");
-        fs::write(&rmd_path, content).unwrap();
-
-        let (svc, _socket) = tower_lsp::LspService::new(Backend::new);
-        let backend = svc.inner();
-        backend
-            .initialize(InitializeParams {
-                workspace_folders: Some(vec![WorkspaceFolder {
-                    uri: Url::from_file_path(tmp.path()).unwrap(),
-                    name: "t".into(),
-                }]),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
-
-        let uri = Url::from_file_path(&rmd_path).unwrap();
-        backend
-            .did_open(DidOpenTextDocumentParams {
-                text_document: TextDocumentItem {
-                    uri: uri.clone(),
-                    language_id: "rmd".into(),
-                    version: 1,
-                    text: content.into(),
-                },
-            })
-            .await;
+        fs::write(tmp.path().join("report.Rmd"), content).unwrap();
+        let (svc, uri) = open_in_workspace(&tmp, "report.Rmd", "rmd", content).await;
         (svc, uri, tmp)
     }
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3709,8 +3709,10 @@ impl LanguageServer for Backend {
                 // pass per keystroke. Only Rmd carries a mask; plain R's
                 // analysis text equals raw text, so pass `None` there.
                 let text = doc.analysis_text();
-                let precomputed_masked = doc.is_rmd_document().then(|| text.clone());
                 let mut meta = crate::cross_file::extract_metadata(&text);
+                // Extract first, then move `text` into the mask slot — avoids
+                // cloning the masked String a second time per keystroke.
+                let precomputed_masked = doc.is_rmd_document().then_some(text);
                 let uri_clone = uri.clone();
                 let workspace_root = state.workspace_folders.first().cloned();
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2857,8 +2857,11 @@ impl LanguageServer for Backend {
                         .map(|a| a.interface_hash)
                 });
 
-            // Extract and enrich metadata with inherited working directory
-            let mut meta = crate::cross_file::extract_metadata(&text);
+            // Extract and enrich metadata with inherited working directory.
+            // For Rmd/Quarto docs this masks the prose first so the graph,
+            // DocumentStore, and on-demand indexing see only chunk-body
+            // source()/library() calls and directives (#343).
+            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
             let uri_clone = uri.clone();
             let workspace_root = state.workspace_folders.first().cloned();
             let max_chain_depth = state.cross_file_config.max_chain_depth;
@@ -3251,7 +3254,8 @@ impl LanguageServer for Backend {
                 let workspace_root = state.workspace_folders.first().cloned();
                 let max_chain_depth = state.cross_file_config.max_chain_depth;
 
-                let mut meta = crate::cross_file::extract_metadata(&text);
+                // Masked for Rmd/Quarto (chunk bodies only); raw otherwise (#343).
+                let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
                 log::trace!(
                     "did_open re-enrich: uri={}, sources={}, sourced_by={}",
                     uri,
@@ -3410,7 +3414,8 @@ impl LanguageServer for Backend {
             let workspace_root = state.workspace_folders.first().cloned();
             let max_chain_depth = state.cross_file_config.max_chain_depth;
 
-            let mut meta = crate::cross_file::extract_metadata(&text);
+            // Masked for Rmd/Quarto (chunk bodies only); raw otherwise (#343).
+            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
             crate::cross_file::enrich_metadata_with_inherited_wd(
                 &mut meta,
                 &uri,
@@ -3676,7 +3681,9 @@ impl LanguageServer for Backend {
             // Extract and enrich metadata with inherited working directory
             let (packages_to_prefetch, enriched_meta, wd_affected, edges_changed) =
                 if let Some(doc) = state.documents.get(&uri) {
-                    let text = doc.text();
+                    // Analysis text: masked for Rmd/Quarto (chunk bodies only),
+                    // raw otherwise. Feeds the graph + DocumentStore (#343).
+                    let text = doc.analysis_text();
                     let mut meta = crate::cross_file::extract_metadata(&text);
                     let uri_clone = uri.clone();
                     let workspace_root = state.workspace_folders.first().cloned();
@@ -6013,14 +6020,22 @@ impl Backend {
             }
         };
 
-        let tree = crate::parser_pool::with_parser(|parser| parser.parse(&content, None));
+        // Analysis text: masked for Rmd/Quarto (chunk bodies only), raw
+        // otherwise. The tree, metadata, and artifacts derive from this so a
+        // `.Rmd` reached via a backward directive contributes chunk-defined
+        // symbols and chunk library()/source() calls — not prose. The cached
+        // content and `IndexEntry.contents` below stay RAW (see those sites).
+        let analysis_text_cow =
+            crate::cross_file::analysis_text_for_path(file_uri.path(), &content);
+        let analysis_text: &str = &analysis_text_cow;
+        let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis_text, None));
         let mut cross_file_meta =
-            crate::cross_file::extract_metadata_with_tree(&content, tree.as_ref());
+            crate::cross_file::extract_metadata_with_tree(analysis_text, tree.as_ref());
         let artifacts = std::sync::Arc::new(match tree.as_ref() {
             Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
                 file_uri,
                 tree,
-                &content,
+                analysis_text,
                 Some(&cross_file_meta),
             ),
             None => crate::cross_file::scope::ScopeArtifacts::default(),
@@ -6084,6 +6099,10 @@ impl Backend {
         };
 
         let cross_file_meta = std::sync::Arc::new(cross_file_meta);
+        // Raw-content / masked-analysis split (#343): `contents` holds the
+        // verbatim RAW source (serves snippets / get_content), while `tree`,
+        // `metadata`, and `artifacts` were derived above from the masked
+        // analysis text (chunk bodies only for Rmd/Quarto).
         let index_entry = crate::workspace_index::IndexEntry {
             contents: ropey::Rope::from_str(&content),
             tree,
@@ -6096,6 +6115,7 @@ impl Backend {
 
         {
             let mut state = self.state.write().await;
+            // RAW content cache (serves snippets / get_content), not masked.
             state
                 .cross_file_file_cache
                 .insert(file_uri.clone(), snapshot.clone(), content.clone());
@@ -6338,9 +6358,14 @@ impl Backend {
             }
         };
 
-        let tree = crate::parser_pool::with_parser(|parser| parser.parse(&content, None));
+        // Analysis text: masked for Rmd/Quarto (chunk bodies only), raw
+        // otherwise (#343). Cached content / `IndexEntry.contents` stay RAW.
+        let analysis_text_cow =
+            crate::cross_file::analysis_text_for_path(file_uri.path(), &content);
+        let analysis_text: &str = &analysis_text_cow;
+        let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis_text, None));
         let mut cross_file_meta =
-            crate::cross_file::extract_metadata_with_tree(&content, tree.as_ref());
+            crate::cross_file::extract_metadata_with_tree(analysis_text, tree.as_ref());
         if cross_file_meta.working_directory.is_none()
             && cross_file_meta.inherited_working_directory.is_none()
         {
@@ -6351,7 +6376,7 @@ impl Backend {
             Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
                 file_uri,
                 tree,
-                &content,
+                analysis_text,
                 Some(&cross_file_meta),
             ),
             None => crate::cross_file::scope::ScopeArtifacts::default(),
@@ -6406,6 +6431,10 @@ impl Backend {
         };
 
         let cross_file_meta = std::sync::Arc::new(cross_file_meta);
+        // Raw-content / masked-analysis split (#343): `contents` holds the
+        // verbatim RAW source (serves snippets / get_content), while `tree`,
+        // `metadata`, and `artifacts` were derived above from the masked
+        // analysis text (chunk bodies only for Rmd/Quarto).
         let index_entry = crate::workspace_index::IndexEntry {
             contents: ropey::Rope::from_str(&content),
             tree,
@@ -6418,6 +6447,7 @@ impl Backend {
 
         {
             let mut state = self.state.write().await;
+            // RAW content cache (serves snippets / get_content), not masked.
             state
                 .cross_file_file_cache
                 .insert(file_uri.clone(), snapshot.clone(), content.clone());
@@ -6686,11 +6716,19 @@ pub(crate) async fn publish_diagnostics_inner(
             None
         };
 
-        // Extract metadata for async missing file checks
-        let directive_meta = state
-            .documents
-            .get(uri)
-            .map(|doc| crate::cross_file::directive::parse_directives(&doc.text()))
+        // Metadata for async missing-file checks. Reuse the snapshot's
+        // `directive_meta`, which is `extract_metadata` (not just directives):
+        // it carries AST-detected `source()` calls AND is masked-correct for
+        // Rmd/Quarto (chunk bodies only). The old `parse_directives(doc.text())`
+        // here was raw and directives-only, so an AST `source("missing.R")`
+        // inside a chunk was stripped by `diagnostics_async_standalone`'s
+        // retain() and never re-added — losing the missing-file diagnostic
+        // (#343). Mirrors the dependent-revalidation path, which already passes
+        // `snapshot.directive_meta`. When the snapshot is absent (diagnostics
+        // disabled) the async phase below is skipped, so the fallback is inert.
+        let directive_meta = snapshot
+            .as_ref()
+            .map(|s| s.directive_meta.clone())
             .unwrap_or_default();
 
         let workspace_folder = state.workspace_folders.first().cloned();
@@ -11150,12 +11188,12 @@ lineLength = 200
     /// Issue #343: an open Rmd document must flow through the publish-path
     /// dispatch (`publish_diagnostics_inner` Phase 1 build + Phase 2 match
     /// guard) and produce chunk diagnostics. The document is opened via the
-    /// real `did_open` path, so its DocumentStore entry holds raw-derived
-    /// metadata/tree; the snapshot must still be masked-correct (metadata and
-    /// `text`/`tree` re-derived from the masked analysis text in
-    /// `DiagnosticsSnapshot::build`). This mirrors the exact match arm in
-    /// `publish_diagnostics_inner`: build the snapshot, then run
-    /// `diagnostics_from_snapshot` iff `file_type == R`.
+    /// real `did_open` path, whose DocumentStore entry now stores
+    /// masked-derived metadata/tree (#343 Task 5), so the snapshot is
+    /// masked-correct: diagnostics fall only on R chunk-body lines, never
+    /// prose. This mirrors the exact match arm in `publish_diagnostics_inner`:
+    /// build the snapshot, then run `diagnostics_from_snapshot` iff
+    /// `file_type == R`.
     #[tokio::test]
     async fn rmd_document_flows_through_publish_path_and_flags_chunk_error() {
         use tower_lsp::lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
@@ -11336,6 +11374,404 @@ lineLength = 200
             edits.is_none() || edits.as_ref().is_some_and(|e| e.is_empty()),
             "on_type_formatting must be inert on a prose line, got {:?}",
             edits
+        );
+    }
+
+    // ====================================================================
+    // Issue #343 Task 5: outgoing-only chunk-aware cross-file metadata.
+    //
+    // These exercise the production did_open / publish / on-demand paths to
+    // prove that for an open `.Rmd`, cross-file metadata feeding the
+    // dependency graph, the DocumentStore, and the async missing-file phase
+    // is derived from the MASKED analysis text (chunk bodies only), never
+    // from prose, while raw content remains available to non-analysis
+    // consumers.
+    // ====================================================================
+
+    /// Open an arbitrary file (by path under a freshly-initialized workspace)
+    /// through the real `did_open` path. Returns the live `LspService`, the
+    /// document URI, and the backing `TempDir`. The `TempDir` must already
+    /// contain the workspace fixtures; `path` is relative to it.
+    async fn open_in_workspace(
+        tmp: &TempDir,
+        rel_path: &str,
+        language_id: &str,
+        content: &str,
+    ) -> (tower_lsp::LspService<Backend>, Url) {
+        use tower_lsp::lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
+
+        let (svc, _socket) = tower_lsp::LspService::new(Backend::new);
+        let backend = svc.inner();
+        backend
+            .initialize(InitializeParams {
+                workspace_folders: Some(vec![WorkspaceFolder {
+                    uri: Url::from_file_path(tmp.path()).unwrap(),
+                    name: "t".into(),
+                }]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let uri = Url::from_file_path(tmp.path().join(rel_path)).unwrap();
+        backend
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: language_id.into(),
+                    version: 1,
+                    text: content.into(),
+                },
+            })
+            .await;
+        (svc, uri)
+    }
+
+    fn snapshot_diagnostics(
+        state: &WorldState,
+        uri: &Url,
+    ) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+        let snapshot =
+            crate::handlers::DiagnosticsSnapshot::build(state, uri).expect("snapshot must build");
+        if snapshot.file_type == crate::file_type::FileType::R {
+            crate::handlers::diagnostics_from_snapshot(
+                &snapshot,
+                uri,
+                &crate::handlers::DiagCancelToken::never(),
+            )
+            .unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Flag #1: an open Rmd whose chunk `source()`s an existing helper must
+    /// produce an outgoing dependency-graph edge, and a symbol defined in the
+    /// helper used in a later chunk must NOT be flagged undefined.
+    #[tokio::test]
+    async fn rmd_chunk_source_produces_outgoing_edge_and_resolves_symbol() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("helpers.R"), "helper_fn <- function() 1\n").unwrap();
+        // Prose mentions `source(\"prose_decoy.R\")` which must be ignored; the
+        // real source() lives in an R chunk. A later chunk uses helper_fn().
+        let rmd = concat!(
+            "# Report\n",
+            "\n",
+            "Prose calls source(\"prose_decoy.R\") but that is not R.\n",
+            "\n",
+            "```{r}\n",
+            "source(\"helpers.R\")\n",
+            "```\n",
+            "\n",
+            "More prose.\n",
+            "\n",
+            "```{r}\n",
+            "y <- helper_fn()\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("analysis.Rmd"), rmd).unwrap();
+
+        let (svc, uri) = open_in_workspace(&tmp, "analysis.Rmd", "rmd", rmd).await;
+        let backend = svc.inner();
+        let state = backend.state.read().await;
+
+        // Outgoing edge analysis.Rmd -> helpers.R exists, and the decoy does not.
+        let helpers_uri = Url::from_file_path(tmp.path().join("helpers.R")).unwrap();
+        let decoy_uri = Url::from_file_path(tmp.path().join("prose_decoy.R")).unwrap();
+        let deps = state.cross_file_graph.get_dependencies(&uri);
+        let targets: Vec<&Url> = deps.iter().map(|e| &e.to).collect();
+        assert!(
+            targets.contains(&&helpers_uri),
+            "chunk source() must add an outgoing edge to helpers.R; edges: {:?}",
+            targets
+        );
+        assert!(
+            !targets.contains(&&decoy_uri),
+            "prose source() must NOT add an edge; edges: {:?}",
+            targets
+        );
+
+        // helper_fn used in a later chunk must resolve (no undefined-var diag).
+        let diags = snapshot_diagnostics(&state, &uri);
+        assert!(
+            !diags
+                .iter()
+                .any(|d| d.message.contains("Undefined variable: helper_fn")),
+            "helper_fn from the sourced helper must resolve; diagnostics: {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Flag #3: a chunk `source("nonexistent.R")` must yield a missing-file
+    /// diagnostic through the ASYNC publish path. The async path strips the
+    /// sync missing-file diagnostics and re-adds them from a separately-built
+    /// `directive_meta`. Pre-fix, `publish_diagnostics_inner` Phase 1 built
+    /// that meta from `parse_directives(doc.text())` — RAW and directives-only,
+    /// so it carried NO AST `source()` calls — and the chunk's missing-file
+    /// diagnostic was silently lost. The fix sources `directive_meta` from
+    /// `snapshot.directive_meta` (full `extract_metadata`, masked for Rmd).
+    #[tokio::test]
+    async fn rmd_chunk_missing_source_flagged_through_async_publish_path() {
+        let tmp = TempDir::new().unwrap();
+        let rmd = concat!(
+            "# Report\n",
+            "\n",
+            "```{r}\n",
+            "source(\"nonexistent.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("analysis.Rmd"), rmd).unwrap();
+        let (svc, uri) = open_in_workspace(&tmp, "analysis.Rmd", "rmd", rmd).await;
+        let backend = svc.inner();
+
+        // Reproduce publish_diagnostics_inner Phase 1-3 exactly (the production
+        // async path), then assert the missing-file diagnostic survives at the
+        // chunk's document line (line 3, 0-based).
+        let (snapshot, directive_meta, raw_text, workspace_folder, missing_file_severity) = {
+            let state = backend.state.read().await;
+            let snapshot = crate::handlers::DiagnosticsSnapshot::build(&state, &uri);
+            // Production Phase 1 sources directive_meta from the snapshot.
+            let directive_meta = snapshot
+                .as_ref()
+                .map(|s| s.directive_meta.clone())
+                .unwrap_or_default();
+            let raw_text = state.get_document(&uri).map(|d| d.text()).unwrap();
+            let wf = state.workspace_folders.first().cloned();
+            let sev = state.cross_file_config.missing_file_severity;
+            (snapshot, directive_meta, raw_text, wf, sev)
+        };
+        let snapshot = snapshot.expect("snapshot must build for Rmd");
+
+        // The production directive_meta carries the chunk's AST source() call...
+        assert!(
+            directive_meta
+                .sources
+                .iter()
+                .any(|s| s.path == "nonexistent.R"),
+            "snapshot.directive_meta (the production async-phase source) must carry the chunk source() call"
+        );
+        // ...whereas the PRE-FIX source (raw `parse_directives`) does not — this
+        // is exactly why the old code lost the diagnostic. Guarding it pins the
+        // fix at the seam: a regression to `parse_directives(doc.text())` would
+        // feed `diagnostics_async_standalone` a meta with no AST source() call.
+        let prefix_meta = crate::cross_file::directive::parse_directives(&raw_text);
+        assert!(
+            !prefix_meta
+                .sources
+                .iter()
+                .any(|s| s.path == "nonexistent.R"),
+            "the pre-fix raw parse_directives must NOT carry the chunk source() — it is directives-only and prose-blind"
+        );
+
+        let sync_diagnostics = crate::handlers::diagnostics_from_snapshot(
+            &snapshot,
+            &uri,
+            &crate::handlers::DiagCancelToken::never(),
+        )
+        .unwrap_or_default();
+        let diagnostics = crate::handlers::diagnostics_async_standalone(
+            &uri,
+            sync_diagnostics,
+            &directive_meta,
+            workspace_folder.as_ref(),
+            missing_file_severity,
+        )
+        .await;
+
+        assert!(
+            diagnostics.iter().any(|d| {
+                (d.message.starts_with("File not found:")
+                    || d.message.starts_with("Cannot resolve path:"))
+                    && d.range.start.line == 3
+            }),
+            "missing-file diagnostic for the chunk source() must survive the async path on line 3; got {:?}",
+            diagnostics
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A `# @lsp-cd` directive in Rmd PROSE must be ignored (prose is masked
+    /// away), while the same directive inside an R chunk is honored. Asserted
+    /// cheaply at the metadata-extraction seam via `extract_metadata_for_path`,
+    /// the shared helper every Rmd extraction site routes through.
+    #[test]
+    fn rmd_lsp_cd_directive_honored_in_chunk_ignored_in_prose() {
+        // Prose `# @lsp-cd` — masked away, so no working_directory.
+        let prose_cd = "# @lsp-cd /tmp/prose\n\n```{r}\nx <- 1\n```\n";
+        let meta = crate::cross_file::extract_metadata_for_path("a.Rmd", prose_cd);
+        assert!(
+            meta.working_directory.is_none(),
+            "a @lsp-cd in prose must not set working_directory; got {:?}",
+            meta.working_directory
+        );
+
+        // Chunk `# @lsp-cd` — a real directive inside R chunk body.
+        let chunk_cd = "# heading\n\n```{r}\n# @lsp-cd /tmp/chunk\nx <- 1\n```\n";
+        let meta = crate::cross_file::extract_metadata_for_path("a.Rmd", chunk_cd);
+        assert_eq!(
+            meta.working_directory.as_deref(),
+            Some("/tmp/chunk"),
+            "a @lsp-cd inside a chunk must set working_directory"
+        );
+    }
+
+    /// Flag #2: after did_open of an Rmd, the DocumentStore exposes
+    /// chunk-defined symbols via `get_artifacts` (not prose garbage), while
+    /// `get_content` still returns the verbatim RAW text.
+    #[tokio::test]
+    async fn rmd_document_store_artifacts_masked_content_raw() {
+        let tmp = TempDir::new().unwrap();
+        let rmd = concat!(
+            "# Heading is prose, not a symbol\n",
+            "\n",
+            "Some prose with words like analyze and report.\n",
+            "\n",
+            "```{r}\n",
+            "chunk_symbol <- function() 1\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("analysis.Rmd"), rmd).unwrap();
+        let (svc, uri) = open_in_workspace(&tmp, "analysis.Rmd", "rmd", rmd).await;
+        let backend = svc.inner();
+        let state = backend.state.read().await;
+
+        use crate::content_provider::ContentProvider;
+        let cp = state.content_provider();
+        // RAW content is preserved verbatim (prose included).
+        let content = cp.get_content(&uri).expect("content available");
+        assert_eq!(content, rmd, "get_content must return RAW Rmd text");
+        assert!(
+            content.contains("Heading is prose"),
+            "raw content must still contain prose"
+        );
+
+        // Artifacts expose the chunk-defined symbol, derived from masked text.
+        let artifacts = cp.get_artifacts(&uri).expect("artifacts available");
+        let names: Vec<String> = artifacts
+            .exported_interface
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "chunk_symbol"),
+            "DocumentStore artifacts must include the chunk-defined symbol; got {:?}",
+            names
+        );
+
+        // DocumentStore metadata must be masked-derived (no prose noise).
+        let meta = cp.get_metadata(&uri).expect("metadata available");
+        assert!(
+            meta.sources.is_empty(),
+            "no source() in chunks, so metadata.sources must be empty (prose ignored); got {:?}",
+            meta.sources
+        );
+    }
+
+    /// Flag #2 / DocumentState invariant: the DocumentStore's `tree` must be
+    /// parsed from the masked analysis text. Pairing the tree with the raw
+    /// content would mis-slice; here we assert the tree + analysis_text pair
+    /// is self-consistent (the tree's root spans the masked text length).
+    #[tokio::test]
+    async fn rmd_document_store_tree_paired_with_masked_text() {
+        let tmp = TempDir::new().unwrap();
+        let rmd = "# prose\n\n```{r}\nz <- 1\n```\n";
+        fs::write(tmp.path().join("analysis.Rmd"), rmd).unwrap();
+        let (svc, uri) = open_in_workspace(&tmp, "analysis.Rmd", "rmd", rmd).await;
+        let backend = svc.inner();
+        let state = backend.state.read().await;
+
+        let doc_state = state
+            .document_store
+            .get_without_touch(&uri)
+            .expect("document in store");
+        let analysis = doc_state.analysis_text();
+        let masked = crate::chunks::mask_to_r(rmd);
+        assert_eq!(
+            analysis, masked,
+            "DocumentState analysis_text must be masked"
+        );
+        let tree = doc_state.tree.as_ref().expect("tree parsed");
+        assert_eq!(
+            tree.root_node().end_byte(),
+            analysis.len(),
+            "tree must be parsed from the masked analysis text"
+        );
+    }
+
+    /// Flag #4: opening a `.R` helper that declares `# @lsp-sourced-by
+    /// analysis.Rmd` triggers on-demand indexing of the (closed) Rmd from disk.
+    /// That extraction must be MASKED so `helper_fn` (defined in a chunk) is in
+    /// the helper's inherited scope and is not flagged undefined. The Rmd's
+    /// indexed content stays RAW while its indexed metadata reflects only chunk
+    /// content.
+    #[tokio::test]
+    async fn r_file_sourced_by_rmd_resolves_chunk_symbol_via_masked_on_demand() {
+        let tmp = TempDir::new().unwrap();
+        let rmd = concat!(
+            "# Analysis\n",
+            "\n",
+            "Prose source(\"prose_decoy.R\") here.\n",
+            "\n",
+            "```{r}\n",
+            "library(tools)\n",
+            "helper_fn <- function() 1\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("analysis.Rmd"), rmd).unwrap();
+        let helper = concat!("# @lsp-sourced-by analysis.Rmd\n", "x <- helper_fn()\n",);
+        fs::write(tmp.path().join("helpers.R"), helper).unwrap();
+
+        let (svc, helper_uri) = open_in_workspace(&tmp, "helpers.R", "r", helper).await;
+        let backend = svc.inner();
+        let state = backend.state.read().await;
+
+        // The Rmd was indexed on demand. Its indexed metadata reflects ONLY
+        // chunk content: library(tools) is detected, the prose decoy source()
+        // is NOT.
+        let rmd_uri = Url::from_file_path(tmp.path().join("analysis.Rmd")).unwrap();
+        let rmd_meta = state
+            .get_enriched_metadata(&rmd_uri)
+            .expect("Rmd indexed metadata available");
+        assert!(
+            rmd_meta
+                .library_calls
+                .iter()
+                .any(|lc| lc.package == "tools"),
+            "masked on-demand extraction must find library(tools) from the chunk; got {:?}",
+            rmd_meta.library_calls
+        );
+        assert!(
+            rmd_meta.sources.is_empty(),
+            "prose source() decoy must not appear in indexed Rmd metadata; got {:?}",
+            rmd_meta.sources
+        );
+
+        // The indexed RAW content (file cache) still contains prose.
+        let cached = state
+            .cross_file_file_cache
+            .get(&rmd_uri)
+            .expect("Rmd content cached");
+        assert!(
+            cached.contains("Prose source"),
+            "cross_file_file_cache must hold RAW Rmd content (with prose)"
+        );
+
+        // helper_fn (chunk-defined in the parent Rmd) resolves in helpers.R.
+        let diags = snapshot_diagnostics(&state, &helper_uri);
+        assert!(
+            !diags
+                .iter()
+                .any(|d| d.message.contains("Undefined variable: helper_fn")),
+            "helper_fn from the parent Rmd chunk must resolve in helpers.R; diagnostics: {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -6701,10 +6701,11 @@ pub(crate) async fn publish_diagnostics_inner(
     // snapshot fields, which already mirror `doc.file_type` and
     // `doc.chunk_kind` from build time.
     let sync_diagnostics = match snapshot {
-        Some(snap)
-            if snap.file_type == crate::file_type::FileType::R
-                && snap.chunk_kind != crate::chunks::ChunkKind::Rmd =>
-        {
+        // Rmd/Quarto documents flow through too (issue #343): the snapshot
+        // carries the masked analysis text + tree, so `diagnostics_from_snapshot`
+        // sees only real R chunk-body content. JAGS/Stan stay suppressed via the
+        // `file_type == R` condition.
+        Some(snap) if snap.file_type == crate::file_type::FileType::R => {
             handlers::diagnostics_from_snapshot(&snap, uri, &handlers::DiagCancelToken::never())
                 .unwrap_or_default()
         }
@@ -11132,5 +11133,86 @@ lineLength = 200
             .expect("snapshot built for tests/test-a.R");
         assert_eq!(r_snap.lint_config.line_length, 30);
         assert_eq!(test_snap.lint_config.line_length, 200);
+    }
+
+    /// Issue #343: an open Rmd document must flow through the publish-path
+    /// dispatch (`publish_diagnostics_inner` Phase 1 build + Phase 2 match
+    /// guard) and produce chunk diagnostics. The document is opened via the
+    /// real `did_open` path, so its DocumentStore entry holds raw-derived
+    /// metadata/tree; the snapshot must still be masked-correct (metadata and
+    /// `text`/`tree` re-derived from the masked analysis text in
+    /// `DiagnosticsSnapshot::build`). This mirrors the exact match arm in
+    /// `publish_diagnostics_inner`: build the snapshot, then run
+    /// `diagnostics_from_snapshot` iff `file_type == R`.
+    #[tokio::test]
+    async fn rmd_document_flows_through_publish_path_and_flags_chunk_error() {
+        use tower_lsp::lsp_types::{DidOpenTextDocumentParams, TextDocumentItem};
+
+        let tmp = TempDir::new().unwrap();
+        let rmd_path = tmp.path().join("report.Rmd");
+        // Prose + a chunk with a syntax error (`x <- (`) on document line 5.
+        let content = "# Title\n\nSome [prose](url) here.\n\n```{r}\nx <- (\n```\n";
+        fs::write(&rmd_path, content).unwrap();
+
+        let (svc, _socket) = tower_lsp::LspService::new(Backend::new);
+        let backend = svc.inner();
+        backend
+            .initialize(InitializeParams {
+                workspace_folders: Some(vec![WorkspaceFolder {
+                    uri: Url::from_file_path(tmp.path()).unwrap(),
+                    name: "t".into(),
+                }]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let uri = Url::from_file_path(&rmd_path).unwrap();
+        backend
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "rmd".into(),
+                    version: 1,
+                    text: content.into(),
+                },
+            })
+            .await;
+
+        let state = backend.state.read().await;
+        let snapshot = crate::handlers::DiagnosticsSnapshot::build(&state, &uri)
+            .expect("snapshot built for report.Rmd");
+
+        // Reproduce the publish-path match guard exactly.
+        let diagnostics = if snapshot.file_type == crate::file_type::FileType::R {
+            crate::handlers::diagnostics_from_snapshot(
+                &snapshot,
+                &uri,
+                &crate::handlers::DiagCancelToken::never(),
+            )
+            .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.severity == Some(DiagnosticSeverity::ERROR) && d.range.start.line == 5),
+            "the chunk syntax error must surface on document line 5 through the publish path, got {:?}",
+            diagnostics
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+        // Prose lines (heading, markdown link) must not produce diagnostics.
+        assert!(
+            diagnostics.iter().all(|d| d.range.start.line == 5),
+            "no diagnostics may land on prose lines, got {:?}",
+            diagnostics
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2860,8 +2860,14 @@ impl LanguageServer for Backend {
             // Extract and enrich metadata with inherited working directory.
             // For Rmd/Quarto docs this masks the prose first so the graph,
             // DocumentStore, and on-demand indexing see only chunk-body
-            // source()/library() calls and directives (#343).
-            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
+            // source()/library() calls and directives (#343). Classify by
+            // languageId-then-URI so untitled `.Rmd`/`.qmd` buffers (no file
+            // extension) are masked too — and reuse the same `chunk_kind` for
+            // the DocumentStore open below so its tree/artifacts agree.
+            let chunk_kind =
+                crate::chunks::classify_chunk_document_for(Some(language_id.as_str()), uri.path());
+            let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+            let mut meta = crate::cross_file::extract_metadata(&analysis_text);
             let uri_clone = uri.clone();
             let workspace_root = state.workspace_folders.first().cloned();
             let max_chain_depth = state.cross_file_config.max_chain_depth;
@@ -2876,10 +2882,12 @@ impl LanguageServer for Backend {
                 max_chain_depth,
             );
 
-            // Update new DocumentStore with enriched metadata (Requirement 1.3)
+            // Update new DocumentStore with enriched metadata (Requirement 1.3).
+            // `chunk_kind` was classified above by languageId-then-URI so
+            // untitled `.Rmd`/`.qmd` buffers mask their tree/artifacts (#343).
             state
                 .document_store
-                .open_with_metadata(uri.clone(), &text, version, meta.clone())
+                .open_with_metadata(uri.clone(), &text, version, chunk_kind, meta.clone())
                 .await;
 
             // Update legacy documents HashMap (for migration compatibility)
@@ -3254,8 +3262,15 @@ impl LanguageServer for Backend {
                 let workspace_root = state.workspace_folders.first().cloned();
                 let max_chain_depth = state.cross_file_config.max_chain_depth;
 
-                // Masked for Rmd/Quarto (chunk bodies only); raw otherwise (#343).
-                let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
+                // Masked for Rmd/Quarto (chunk bodies only); raw otherwise.
+                // Classify by languageId-then-URI so untitled buffers mask, and
+                // extract metadata from that same masked view (#343).
+                let chunk_kind = crate::chunks::classify_chunk_document_for(
+                    Some(language_id.as_str()),
+                    uri.path(),
+                );
+                let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+                let mut meta = crate::cross_file::extract_metadata(&analysis_text);
                 log::trace!(
                     "did_open re-enrich: uri={}, sources={}, sourced_by={}",
                     uri,
@@ -3278,7 +3293,7 @@ impl LanguageServer for Backend {
 
                 state
                     .document_store
-                    .open_with_metadata(uri.clone(), &text, version, meta.clone())
+                    .open_with_metadata(uri.clone(), &text, version, chunk_kind, meta.clone())
                     .await;
                 state.open_document_with_language_id(
                     uri.clone(),
@@ -3414,8 +3429,13 @@ impl LanguageServer for Backend {
             let workspace_root = state.workspace_folders.first().cloned();
             let max_chain_depth = state.cross_file_config.max_chain_depth;
 
-            // Masked for Rmd/Quarto (chunk bodies only); raw otherwise (#343).
-            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
+            // languageId-then-URI classification masks untitled buffers (#343);
+            // extract metadata from the same masked view so the graph and the
+            // DocumentStore tree/artifacts agree (chunk bodies only for Rmd).
+            let chunk_kind =
+                crate::chunks::classify_chunk_document_for(Some(language_id.as_str()), uri.path());
+            let analysis_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+            let mut meta = crate::cross_file::extract_metadata(&analysis_text);
             crate::cross_file::enrich_metadata_with_inherited_wd(
                 &mut meta,
                 &uri,
@@ -3426,7 +3446,7 @@ impl LanguageServer for Backend {
 
             state
                 .document_store
-                .open_with_metadata(uri.clone(), &text, version, meta.clone())
+                .open_with_metadata(uri.clone(), &text, version, chunk_kind, meta.clone())
                 .await;
             state.open_document_with_language_id(
                 uri.clone(),

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -6698,8 +6698,7 @@ pub(crate) async fn publish_diagnostics_inner(
     // the heavy phase the snapshot pattern was designed to keep
     // lock-free (see DiagnosticsSnapshot doc comment in handlers.rs).
     // Replicate the remaining `handlers::diagnostics` early-exits via
-    // snapshot fields, which already mirror `doc.file_type` and
-    // `doc.chunk_kind` from build time.
+    // snapshot fields, which already mirror `doc.file_type` from build time.
     let sync_diagnostics = match snapshot {
         // Rmd/Quarto documents flow through too (issue #343): the snapshot
         // carries the masked analysis text + tree, so `diagnostics_from_snapshot`

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -11263,20 +11263,8 @@ lineLength = 200
             .await;
 
         let state = backend.state.read().await;
-        let snapshot = crate::handlers::DiagnosticsSnapshot::build(&state, &uri)
-            .expect("snapshot built for report.Rmd");
-
-        // Reproduce the publish-path match guard exactly.
-        let diagnostics = if snapshot.file_type == crate::file_type::FileType::R {
-            crate::handlers::diagnostics_from_snapshot(
-                &snapshot,
-                &uri,
-                &crate::handlers::DiagCancelToken::never(),
-            )
-            .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        // `snapshot_diagnostics` reproduces the publish-path match guard.
+        let diagnostics = snapshot_diagnostics(&state, &uri);
 
         assert!(
             diagnostics

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -309,6 +309,127 @@ fn parse_header_label(rest: &str) -> Option<String> {
     None
 }
 
+/// True for chunk language tags that should be parsed as R. Pandoc/knitr
+/// permit a few aliases (`r`, `R`, plus the rare `Rscript`). The chunk
+/// detector lower-cases the tag before storing it, so a simple ASCII compare
+/// is sufficient here.
+pub(crate) fn is_r_chunk_language(language: &str) -> bool {
+    matches!(language, "r" | "rscript")
+}
+
+/// A compiled regex for the knitr chunk-reuse reference pattern `<<label>>`.
+///
+/// Lines matching `^\s*<<[^>]+>>\s*$` (optionally with a trailing `\r`) are
+/// knitr meta-syntax, not R code, and must be blanked by [`mask_to_r`].
+fn chunk_reuse_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^\s*<<[^>]+>>\s*\r?$").expect("chunk reuse reference regex"))
+}
+
+/// Produce R-parseable text from an R Markdown / Quarto document with
+/// **identical line/column geometry** to the source.
+///
+/// ## Contract
+///
+/// * The input is split on `\n` (NOT `.lines()`, which strips `\r` and loses
+///   information about trailing newlines). Any `\r` that precedes `\n` stays
+///   attached to its segment.
+/// * [`detect_chunks`] with [`ChunkKind::Rmd`] locates R chunk bodies. A
+///   chunk is R when [`is_r_chunk_language`] returns `true` for its language
+///   tag. Body lines are `(chunk.header_line + 1)..=chunk.end_line`, clamped
+///   the same way as `semantic_tokens_for_rmd_document`:
+///   - skip when `body_start > end_line` (empty chunk) or
+///     `body_start >= total_lines` (header at EOF);
+///   - clamp `end_line` to `total_lines - 1`.
+/// * Each line is emitted **verbatim** (byte-identical, including any trailing
+///   `\r`) when it falls inside an R chunk body; otherwise it is replaced by
+///   an **empty string `""`**.
+/// * Exception inside R bodies: a line matching the knitr chunk-reuse pattern
+///   `^\s*<<[^>]+>>\s*$` (optionally with `\r`) is also blanked — it is
+///   knitr meta-syntax, not R.
+/// * Header fence lines, closing fence lines, prose, YAML front matter, and
+///   non-R chunk bodies (Python, Bash, etc.) all become `""`.
+/// * Segments are rejoined with `\n`. The result has exactly the same number
+///   of `\n`-separated segments as the input (trailing-newline presence is
+///   preserved automatically).
+/// * A leading BOM (U+FEFF) lives on line 0, which is never an R body line,
+///   so it is blanked — that is intentional and harmless for downstream R
+///   parsing.
+///
+/// Net effect: identical line count; within kept R-body lines, identical
+/// byte/column geometry. Downstream tools that parse the masked text obtain
+/// positions they can use directly as document coordinates.
+pub fn mask_to_r(text: &str) -> String {
+    let segments: Vec<&str> = text.split('\n').collect();
+    let total_lines = segments.len();
+
+    // Build a boolean mask: true = keep this line verbatim.
+    let mut keep = vec![false; total_lines];
+
+    let reuse_re = chunk_reuse_re();
+    let chunks = detect_chunks(text, ChunkKind::Rmd);
+
+    for chunk in &chunks {
+        if !is_r_chunk_language(&chunk.language) {
+            continue;
+        }
+        let body_start = chunk.header_line.saturating_add(1);
+        // Mirror bounds logic from `semantic_tokens_for_rmd_document`.
+        if body_start > chunk.end_line {
+            continue;
+        }
+        if body_start >= total_lines as u32 {
+            continue;
+        }
+        let end_line = chunk.end_line.min((total_lines as u32).saturating_sub(1));
+
+        for idx in body_start as usize..=end_line as usize {
+            // Blank knitr chunk-reuse references; keep everything else.
+            if !reuse_re.is_match(segments[idx]) {
+                keep[idx] = true;
+            }
+        }
+    }
+
+    let masked: Vec<&str> = segments
+        .iter()
+        .enumerate()
+        .map(|(i, &seg)| if keep[i] { seg } else { "" })
+        .collect();
+
+    masked.join("\n")
+}
+
+/// Returns `true` iff `line` (0-based) falls within the body of an R chunk
+/// in the given (raw) R Markdown / Quarto text.
+///
+/// "Body" means the lines strictly after the header fence and before (or at)
+/// `end_line` — same bounds as [`mask_to_r`]. Header lines, closing fence
+/// lines, prose, YAML front matter, and non-R chunk bodies all return `false`.
+/// A `line` beyond the end of the document returns `false`.
+pub fn position_in_r_chunk_body(text: &str, line: u32) -> bool {
+    let total_lines = text.split('\n').count();
+    let chunks = detect_chunks(text, ChunkKind::Rmd);
+
+    for chunk in &chunks {
+        if !is_r_chunk_language(&chunk.language) {
+            continue;
+        }
+        let body_start = chunk.header_line.saturating_add(1);
+        if body_start > chunk.end_line {
+            continue;
+        }
+        if body_start >= total_lines as u32 {
+            continue;
+        }
+        let end_line = chunk.end_line.min((total_lines as u32).saturating_sub(1));
+        if line >= body_start && line <= end_line {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -501,5 +622,253 @@ mod tests {
         // and produce one chunk without confusing the comma split.
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].language, "r");
+    }
+
+    // =========================================================================
+    // mask_to_r tests
+    // =========================================================================
+
+    /// Helper: count of '\n'-separated segments (mirrors split('\n').count()).
+    fn seg_count(s: &str) -> usize {
+        s.split('\n').count()
+    }
+
+    #[test]
+    fn mask_preserves_line_count() {
+        let cases: &[&str] = &[
+            // no trailing newline
+            "---\ntitle: T\n---\n\n```{r}\nx <- 1\n```\n\nMore prose.",
+            // trailing newline
+            "---\ntitle: T\n---\n\n```{r}\nx <- 1\n```\n\nMore prose.\n",
+            // empty string
+            "",
+            // single line, no newline
+            "just prose",
+            // single newline
+            "\n",
+            // empty chunk
+            "```{r}\n```\n",
+            // unclosed chunk at EOF
+            "```{r}\nx <- 1",
+        ];
+        for &t in cases {
+            let masked = mask_to_r(t);
+            assert_eq!(
+                seg_count(&masked),
+                seg_count(t),
+                "line count mismatch for input {t:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mask_keeps_r_body_byte_identical() {
+        // Body line has leading and trailing spaces — must survive verbatim.
+        let src = "```{r}\n  x <- f(1)  \n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // Line 0 = header  → ""
+        // Line 1 = body    → "  x <- f(1)  " (verbatim)
+        // Line 2 = close   → ""
+        // Line 3 = trailing → ""
+        assert_eq!(lines[1], "  x <- f(1)  ");
+    }
+
+    #[test]
+    fn mask_blanks_prose_yaml_and_fences() {
+        let src = "---\ntitle: Test\n---\n\n```{r}\nx <- 1\n```\n\nProse.";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // Line 0 = "---"          → ""
+        // Line 1 = "title: Test"  → ""
+        // Line 2 = "---"          → ""
+        // Line 3 = ""  (blank prose line) → ""
+        // Line 4 = "```{r}"       → "" (header fence)
+        // Line 5 = "x <- 1"       → "x <- 1" (R body)
+        // Line 6 = "```"          → "" (closing fence)
+        // Line 7 = ""  (blank)    → ""
+        // Line 8 = "Prose."       → ""
+        assert_eq!(lines[0], "");
+        assert_eq!(lines[1], "");
+        assert_eq!(lines[2], "");
+        assert_eq!(lines[3], "");
+        assert_eq!(lines[4], "");
+        assert_eq!(lines[5], "x <- 1");
+        assert_eq!(lines[6], "");
+        assert_eq!(lines[7], "");
+        assert_eq!(lines[8], "");
+    }
+
+    #[test]
+    fn mask_blanks_non_r_chunks() {
+        let src = "```{python}\nprint('hi')\n```\n\n```{r}\ny <- 2\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // python body (line 1) → ""
+        assert_eq!(lines[1], "");
+        // R body (line 5) → "y <- 2"
+        assert_eq!(lines[5], "y <- 2");
+    }
+
+    #[test]
+    fn mask_crlf_preserves_cr_in_body() {
+        // CRLF document: each raw line ends with '\r'.
+        let src = "prose\r\n```{r}\r\nx <- 1\r\n```\r\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // Line count unchanged.
+        assert_eq!(seg_count(&masked), seg_count(src));
+        // Line 0 = "prose\r"   → "" (prose)
+        assert_eq!(lines[0], "");
+        // Line 1 = "```{r}\r"  → "" (header)
+        assert_eq!(lines[1], "");
+        // Line 2 = "x <- 1\r"  → "x <- 1\r" (body, \r preserved)
+        assert_eq!(lines[2], "x <- 1\r");
+        // Line 3 = "```\r"     → "" (closing fence)
+        assert_eq!(lines[3], "");
+        // Line 4 = "" (trailing after final \n)
+        assert_eq!(lines[4], "");
+        // Blanked lines are "" not "\r".
+        for (i, &l) in lines.iter().enumerate() {
+            if i != 2 {
+                assert!(!l.contains('\r'), "blanked line {i} must not contain \\r");
+            }
+        }
+    }
+
+    #[test]
+    fn mask_bom_first_line() {
+        // BOM on line 0; chunk starts on line 1.
+        let src = "\u{FEFF}\n```{r}\nx <- 1\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // No panic; geometry intact.
+        assert_eq!(seg_count(&masked), seg_count(src));
+        // Line 0 contains BOM → blanked.
+        assert_eq!(lines[0], "");
+        // Line 2 = R body → "x <- 1"
+        assert_eq!(lines[2], "x <- 1");
+    }
+
+    #[test]
+    fn mask_tilde_fences() {
+        let src = "~~~{r}\nx <- 1\n~~~\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(lines[0], ""); // header
+        assert_eq!(lines[1], "x <- 1"); // body
+        assert_eq!(lines[2], ""); // closing
+    }
+
+    #[test]
+    fn mask_nested_fences() {
+        // 4-backtick opener; inner ``` is body content, not a closer.
+        let src = "````{r}\nx <- 1\n```\ny <- 2\n````\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        // detect_chunks handles the nesting: closer is at line 4.
+        assert_eq!(lines[0], ""); // header (````{r})
+        assert_eq!(lines[1], "x <- 1"); // body
+        assert_eq!(lines[2], "```"); // inner ``` preserved as body
+        assert_eq!(lines[3], "y <- 2"); // body
+        assert_eq!(lines[4], ""); // closing (````)
+    }
+
+    #[test]
+    fn mask_unclosed_chunk_at_eof() {
+        // No closing fence: body runs to EOF.
+        let src = "```{r}\nx <- 1\nprint(x)";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(seg_count(&masked), seg_count(src));
+        assert_eq!(lines[0], ""); // header
+        assert_eq!(lines[1], "x <- 1"); // body
+        assert_eq!(lines[2], "print(x)"); // body at EOF
+    }
+
+    #[test]
+    fn mask_empty_chunk() {
+        // Header immediately followed by closing fence — no body lines.
+        let src = "```{r}\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(seg_count(&masked), seg_count(src));
+        assert_eq!(lines[0], ""); // header
+        assert_eq!(lines[1], ""); // closing fence
+    }
+
+    #[test]
+    fn mask_multiple_chunks() {
+        // Two R chunks separated by prose; both bodies at original indices.
+        let src = "```{r}\na <- 1\n```\n\nprose\n\n```{r}\nb <- 2\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(seg_count(&masked), seg_count(src));
+        assert_eq!(lines[0], ""); // first header
+        assert_eq!(lines[1], "a <- 1"); // first body
+        assert_eq!(lines[2], ""); // first close
+        assert_eq!(lines[3], ""); // blank prose
+        assert_eq!(lines[4], ""); // prose
+        assert_eq!(lines[5], ""); // blank prose
+        assert_eq!(lines[6], ""); // second header
+        assert_eq!(lines[7], "b <- 2"); // second body
+        assert_eq!(lines[8], ""); // second close
+    }
+
+    #[test]
+    fn mask_blanks_chunk_reuse_reference() {
+        // <<setup>> inside an R body must be blanked.
+        let src = "```{r}\nx <- 1\n<<setup>>\ny <- 2\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(lines[1], "x <- 1"); // kept
+        assert_eq!(lines[2], ""); // <<setup>> → blanked
+        assert_eq!(lines[3], "y <- 2"); // kept
+    }
+
+    // =========================================================================
+    // position_in_r_chunk_body tests
+    // =========================================================================
+
+    #[test]
+    fn position_in_r_chunk_body_true_for_body_line() {
+        let src = "prose\n```{r}\nx <- 1\n```\n";
+        // Line 2 is the R body.
+        assert!(position_in_r_chunk_body(src, 2));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_for_header_line() {
+        let src = "prose\n```{r}\nx <- 1\n```\n";
+        // Line 1 is the header fence.
+        assert!(!position_in_r_chunk_body(src, 1));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_for_closing_fence_line() {
+        let src = "prose\n```{r}\nx <- 1\n```\n";
+        // Line 3 is the closing fence.
+        assert!(!position_in_r_chunk_body(src, 3));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_for_prose_line() {
+        let src = "prose\n```{r}\nx <- 1\n```\n";
+        // Line 0 is prose.
+        assert!(!position_in_r_chunk_body(src, 0));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_for_python_body_line() {
+        let src = "```{python}\nprint('hi')\n```\n";
+        // Line 1 is a Python body — not R.
+        assert!(!position_in_r_chunk_body(src, 1));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_beyond_eof() {
+        let src = "```{r}\nx <- 1\n```\n";
+        // Line 99 is way past the end.
+        assert!(!position_in_r_chunk_body(src, 99));
     }
 }

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -7,6 +7,9 @@
 //! Used by `SymbolExtractor::extract_chunks` to surface chunk entries in the
 //! document outline. Kept aligned with the TypeScript detector so the two
 //! continue to produce the same `header_line` / `end_line` for any document.
+//! The module also provides [`mask_to_r`] for the geometry-preserving masked
+//! analysis representation of Rmd/Quarto documents, which replaces all
+//! non-R-body lines with empty strings while preserving line/column geometry.
 
 use regex::Regex;
 use std::sync::OnceLock;
@@ -326,6 +329,25 @@ fn chunk_reuse_re() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"^\s*<<[^>]+>>\s*\r?$").expect("chunk reuse reference regex"))
 }
 
+/// Body-line range of an R chunk, clamped to the document.
+///
+/// Returns `None` when the chunk is not R, has no body, or starts past EOF.
+/// The returned `(body_start, end_line)` pair is guaranteed to satisfy
+/// `body_start <= end_line < total_lines`.
+fn r_chunk_body_range(chunk: &Chunk, total_lines: u32) -> Option<(u32, u32)> {
+    if !is_r_chunk_language(&chunk.language) {
+        return None;
+    }
+    let body_start = chunk.header_line.saturating_add(1);
+    if body_start > chunk.end_line || body_start >= total_lines {
+        return None;
+    }
+    Some((
+        body_start,
+        chunk.end_line.min(total_lines.saturating_sub(1)),
+    ))
+}
+
 /// Produce R-parseable text from an R Markdown / Quarto document with
 /// **identical line/column geometry** to the source.
 ///
@@ -370,19 +392,9 @@ pub fn mask_to_r(text: &str) -> String {
     let chunks = detect_chunks(text, ChunkKind::Rmd);
 
     for chunk in &chunks {
-        if !is_r_chunk_language(&chunk.language) {
+        let Some((body_start, end_line)) = r_chunk_body_range(chunk, total_lines as u32) else {
             continue;
-        }
-        let body_start = chunk.header_line.saturating_add(1);
-        // Mirror bounds logic from `semantic_tokens_for_rmd_document`.
-        if body_start > chunk.end_line {
-            continue;
-        }
-        if body_start >= total_lines as u32 {
-            continue;
-        }
-        let end_line = chunk.end_line.min((total_lines as u32).saturating_sub(1));
-
+        };
         for idx in body_start as usize..=end_line as usize {
             // Blank knitr chunk-reuse references; keep everything else.
             if !reuse_re.is_match(segments[idx]) {
@@ -412,17 +424,9 @@ pub fn position_in_r_chunk_body(text: &str, line: u32) -> bool {
     let chunks = detect_chunks(text, ChunkKind::Rmd);
 
     for chunk in &chunks {
-        if !is_r_chunk_language(&chunk.language) {
+        let Some((body_start, end_line)) = r_chunk_body_range(chunk, total_lines as u32) else {
             continue;
-        }
-        let body_start = chunk.header_line.saturating_add(1);
-        if body_start > chunk.end_line {
-            continue;
-        }
-        if body_start >= total_lines as u32 {
-            continue;
-        }
-        let end_line = chunk.end_line.min((total_lines as u32).saturating_sub(1));
+        };
         if line >= body_start && line <= end_line {
             return true;
         }
@@ -870,5 +874,26 @@ mod tests {
         let src = "```{r}\nx <- 1\n```\n";
         // Line 99 is way past the end.
         assert!(!position_in_r_chunk_body(src, 99));
+    }
+
+    #[test]
+    fn mask_bom_on_fence_header_line() {
+        // BOM lives on line 0, which is the header fence itself. The header
+        // is never an R body line, so line 0 must be blanked even though the
+        // BOM-stripped text would match the fence pattern.
+        let src = "\u{FEFF}```{r}\nx <- 1\n```\n";
+        let masked = mask_to_r(src);
+        let lines: Vec<&str> = masked.split('\n').collect();
+        assert_eq!(seg_count(&masked), seg_count(src));
+        assert_eq!(lines[0], ""); // header with BOM → blanked
+        assert_eq!(lines[1], "x <- 1"); // R body → kept verbatim
+        assert_eq!(lines[2], ""); // closing fence → blanked
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_unclosed_chunk() {
+        // Unclosed chunk: body runs to EOF; line 1 is inside the body.
+        let src = "```{r}\nx <- 1";
+        assert!(position_in_r_chunk_body(src, 1));
     }
 }

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -333,8 +333,9 @@ fn chunk_reuse_re() -> &'static Regex {
 ///
 /// Returns `None` when the chunk is not R, has no body, or starts past EOF.
 /// The returned `(body_start, end_line)` pair is guaranteed to satisfy
-/// `body_start <= end_line < total_lines`.
-fn r_chunk_body_range(chunk: &Chunk, total_lines: u32) -> Option<(u32, u32)> {
+/// `body_start <= end_line < total_lines`. Folds the [`is_r_chunk_language`]
+/// guard so callers iterate all chunks and let-else past the non-R ones.
+pub(crate) fn r_chunk_body_range(chunk: &Chunk, total_lines: u32) -> Option<(u32, u32)> {
     if !is_r_chunk_language(&chunk.language) {
         return None;
     }
@@ -359,7 +360,7 @@ fn r_chunk_body_range(chunk: &Chunk, total_lines: u32) -> Option<(u32, u32)> {
 /// * [`detect_chunks`] with [`ChunkKind::Rmd`] locates R chunk bodies. A
 ///   chunk is R when [`is_r_chunk_language`] returns `true` for its language
 ///   tag. Body lines are `(chunk.header_line + 1)..=chunk.end_line`, clamped
-///   the same way as `semantic_tokens_for_rmd_document`:
+///   by [`r_chunk_body_range`] (shared with `semantic_tokens_for_rmd_document`):
 ///   - skip when `body_start > end_line` (empty chunk) or
 ///     `body_start >= total_lines` (header at EOF);
 ///   - clamp `end_line` to `total_lines - 1`.
@@ -441,7 +442,7 @@ pub fn mask_to_r(text: &str) -> String {
 ///   frontmatter delimiters — it pulls in no YAML crate.
 pub fn frontmatter_declares_params(text: &str) -> bool {
     // Strip an optional leading BOM so the first delimiter is recognized.
-    let text = text.strip_prefix('\u{FEFF}').unwrap_or(text);
+    let text = crate::utf16::strip_leading_bom_for_scan(text);
 
     let mut lines = text.split('\n');
 
@@ -469,22 +470,16 @@ pub fn frontmatter_declares_params(text: &str) -> bool {
         if trimmed == "---" || trimmed == "..." {
             return false;
         }
-        if line_is_top_level_params_key(line) {
+        // A top-level `params:` key sits at column 0 (no indentation): a line
+        // beginning with the literal `params:` prefix, whether bare (optionally
+        // a trailing `# comment`) or with an inline value (`params: foo`). A
+        // leading space (`  params:`), a comment (`# params:`), or a different
+        // key (`myparams:`) lacks that prefix and so does not match.
+        if line.starts_with("params:") {
             return true;
         }
     }
     false
-}
-
-/// True for a frontmatter line that declares a top-level `params:` mapping key
-/// (column 0, no indentation). Any line beginning with `params:` at column 0
-/// is a top-level key — whether it has no inline value (`params:`, optionally
-/// with a trailing `# comment`) or an inline value (`params: foo`). A leading
-/// space (`  params:`), a comment (`# params:`), or a different key
-/// (`myparams:`) does not begin with the literal `params:` prefix and so does
-/// not match.
-fn line_is_top_level_params_key(line: &str) -> bool {
-    line.strip_prefix("params:").is_some()
 }
 
 /// Returns `true` iff `line` (0-based) falls within the body of an R chunk

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -488,7 +488,11 @@ pub fn frontmatter_declares_params(text: &str) -> bool {
 /// "Body" means the lines strictly after the header fence and before (or at)
 /// `end_line` — same bounds as [`mask_to_r`]. Header lines, closing fence
 /// lines, prose, YAML front matter, and non-R chunk bodies all return `false`.
-/// A `line` beyond the end of the document returns `false`.
+/// A knitr chunk-reuse line (`<<label>>`) inside an R body also returns
+/// `false` — [`mask_to_r`] blanks it, so reporting it as R would activate
+/// positional features (completion, signature help) on a line the analysis
+/// view treats as blank. A `line` beyond the end of the document returns
+/// `false`.
 pub fn position_in_r_chunk_body(text: &str, line: u32) -> bool {
     let total_lines = text.split('\n').count();
     let chunks = detect_chunks(text, ChunkKind::Rmd);
@@ -498,7 +502,12 @@ pub fn position_in_r_chunk_body(text: &str, line: u32) -> bool {
             continue;
         };
         if line >= body_start && line <= end_line {
-            return true;
+            // Same reuse-line test as `mask_to_r`: split on '\n' keeps any
+            // trailing '\r', which the regex tolerates.
+            return !text
+                .split('\n')
+                .nth(line as usize)
+                .is_some_and(|l| chunk_reuse_re().is_match(l));
         }
     }
     false
@@ -965,6 +974,18 @@ mod tests {
         // Unclosed chunk: body runs to EOF; line 1 is inside the body.
         let src = "```{r}\nx <- 1";
         assert!(position_in_r_chunk_body(src, 1));
+    }
+
+    #[test]
+    fn position_in_r_chunk_body_false_for_chunk_reuse_line() {
+        // A knitr `<<label>>` reuse line sits inside the body range but is
+        // blanked by mask_to_r — the guard must agree with the masked view.
+        let src = "```{r}\nx <- 1\n<<setup>>\n```\n";
+        assert!(position_in_r_chunk_body(src, 1)); // real R body line
+        assert!(!position_in_r_chunk_body(src, 2)); // reuse line → non-R
+        // CRLF variant: split('\n') keeps the '\r'; the regex tolerates it.
+        let crlf = "```{r}\r\n<<setup>>\r\n```\r\n";
+        assert!(!position_in_r_chunk_body(crlf, 1));
     }
 
     // =========================================================================

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -412,6 +412,81 @@ pub fn mask_to_r(text: &str) -> String {
     masked.join("\n")
 }
 
+/// Returns `true` iff the document's leading YAML frontmatter declares a
+/// top-level `params:` key.
+///
+/// knitr/Quarto inject a `params` object into the document's R environment
+/// whenever the YAML frontmatter declares a top-level `params:` mapping. The
+/// masked analysis blanks the frontmatter, so the undefined-variable
+/// diagnostic would otherwise flag every `params$...` use in a parameterized
+/// report. Callers use this sniff (on the RAW document text) to recognize
+/// `params` as a defined global for such documents. See
+/// `diagnostics_from_snapshot` in `handlers.rs` for the injection point.
+///
+/// ## Frontmatter contract (single-key sniff, no YAML parser)
+///
+/// * The frontmatter is a leading YAML block: the first non-empty line — after
+///   an optional leading BOM (U+FEFF) — must be exactly `---` (trimmed). If it
+///   is not, the document has no frontmatter and this returns `false`.
+/// * The block ends at the next line that is exactly `---` or `...` (trimmed).
+///   A `params:` declaration must appear *inside* this block; a `params:` line
+///   in prose after the frontmatter does not count.
+/// * Within the block, a TOP-LEVEL `params:` key is a line whose first
+///   character is `p` (column 0, no leading indentation) matching
+///   `^params:\s*(#.*)?$` (key with no inline value, optional trailing
+///   comment) or `^params:\s*\S` (key with an inline value). Nested/indented
+///   `params:` keys, `# params:` comment lines, and `myparams:` do NOT match.
+/// * This is intentionally a single-key sniff consistent with how the knit
+///   pipeline (`editors/vscode/src/knit/yaml-frontmatter.ts`) sniffs
+///   frontmatter delimiters — it pulls in no YAML crate.
+pub fn frontmatter_declares_params(text: &str) -> bool {
+    // Strip an optional leading BOM so the first delimiter is recognized.
+    let text = text.strip_prefix('\u{FEFF}').unwrap_or(text);
+
+    let mut lines = text.split('\n');
+
+    // Find the opening delimiter: the first non-empty line must be `---`.
+    let opened = loop {
+        match lines.next() {
+            Some(line) => {
+                let trimmed = line.trim_end_matches('\r').trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                break trimmed == "---";
+            }
+            None => break false,
+        }
+    };
+    if !opened {
+        return false;
+    }
+
+    // Scan the block until the closing delimiter (`---` or `...`).
+    for line in lines {
+        let line = line.trim_end_matches('\r');
+        let trimmed = line.trim();
+        if trimmed == "---" || trimmed == "..." {
+            return false;
+        }
+        if line_is_top_level_params_key(line) {
+            return true;
+        }
+    }
+    false
+}
+
+/// True for a frontmatter line that declares a top-level `params:` mapping key
+/// (column 0, no indentation). Any line beginning with `params:` at column 0
+/// is a top-level key — whether it has no inline value (`params:`, optionally
+/// with a trailing `# comment`) or an inline value (`params: foo`). A leading
+/// space (`  params:`), a comment (`# params:`), or a different key
+/// (`myparams:`) does not begin with the literal `params:` prefix and so does
+/// not match.
+fn line_is_top_level_params_key(line: &str) -> bool {
+    line.strip_prefix("params:").is_some()
+}
+
 /// Returns `true` iff `line` (0-based) falls within the body of an R chunk
 /// in the given (raw) R Markdown / Quarto text.
 ///
@@ -895,5 +970,111 @@ mod tests {
         // Unclosed chunk: body runs to EOF; line 1 is inside the body.
         let src = "```{r}\nx <- 1";
         assert!(position_in_r_chunk_body(src, 1));
+    }
+
+    // =========================================================================
+    // frontmatter_declares_params tests
+    // =========================================================================
+
+    #[test]
+    fn params_declared_with_nested_keys() {
+        let src = "---\ntitle: My report\nparams:\n  year: 2024\n  region: \"north\"\n---\n\n```{r}\nprint(params$year)\n```\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_declared_with_inline_value() {
+        // `params:` followed by an inline value (unusual but valid YAML).
+        let src = "---\nparams: ~\n---\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_declared_with_inline_comment() {
+        let src = "---\ntitle: T\nparams:   # report parameters\n  year: 2024\n---\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_declared_with_bom_before_delimiter() {
+        let src = "\u{FEFF}---\nparams:\n  year: 2024\n---\n```{r}\nparams$year\n```\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_declared_after_leading_blank_lines() {
+        // Blank lines before the opening `---` are tolerated.
+        let src = "\n\n---\nparams:\n  year: 2024\n---\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_declared_handles_crlf() {
+        let src = "---\r\nparams:\r\n  year: 2024\r\n---\r\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn params_closing_delimiter_dots() {
+        // YAML allows `...` as a document end marker; `params:` before it counts.
+        let src = "---\nparams:\n  year: 2024\n...\n```{r}\nparams$year\n```\n";
+        assert!(frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_no_frontmatter() {
+        let src = "```{r}\nparams$year\n```\n";
+        assert!(!frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_frontmatter_lacks_params() {
+        let src = "---\ntitle: My report\nauthor: A. Author\n---\n```{r}\nx <- 1\n```\n";
+        assert!(!frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_params_is_nested() {
+        // `params:` indented under another key is NOT a top-level declaration.
+        let src = "---\nrmarkdown:\n  params:\n    year: 2024\n---\n";
+        assert!(!frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_params_only_in_prose() {
+        // `params:` appears after the frontmatter closes — it's prose, not YAML.
+        let src = "---\ntitle: T\n---\n\nThe params: are documented below.\nparams: not yaml\n";
+        assert!(!frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_params_is_comment_in_frontmatter() {
+        // A `# params:` comment line inside the frontmatter does NOT declare
+        // the key (it starts with `#`, not `params:` at column 0). Documented
+        // behavior: comment lines are ignored.
+        let src = "---\ntitle: T\n# params: would go here\n---\n";
+        assert!(!frontmatter_declares_params(src));
+    }
+
+    #[test]
+    fn no_params_when_key_is_a_different_name() {
+        // `myparams:` (prefix) and `params_extra:` (suffix) must not match the
+        // literal `params:` key at column 0.
+        let src = "---\nmyparams:\n  year: 2024\n---\n";
+        assert!(!frontmatter_declares_params(src));
+        let src2 = "---\nparams_extra: 1\n---\n";
+        assert!(!frontmatter_declares_params(src2));
+    }
+
+    #[test]
+    fn no_params_for_empty_document() {
+        assert!(!frontmatter_declares_params(""));
+    }
+
+    #[test]
+    fn no_params_when_first_nonempty_line_is_not_delimiter() {
+        // A document that opens with prose has no frontmatter block at all.
+        let src = "# Heading\n---\nparams:\n  year: 2024\n---\n";
+        assert!(!frontmatter_declares_params(src));
     }
 }

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -1197,6 +1197,59 @@ mod tests {
     }
 
     #[test]
+    fn rmd_params_respected_in_check() {
+        // knitr/Quarto inject a `params` object into parameterized reports
+        // whose frontmatter declares a top-level `params:` key. `raven check`
+        // shares the snapshot diagnostic pipeline, so it must NOT flag `params`
+        // as undefined for such a report. The use is a bare assignment RHS (not
+        // a call argument) so the undefined-variable collector inspects it.
+        let tmp = TempDir::new().unwrap();
+        let rmd = tmp.path().join("report.Rmd");
+        fs::write(
+            &rmd,
+            "---\ntitle: Report\nparams:\n  year: 2024\n---\n\n```{r}\nyr <- params$year\n```\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![rmd.clone()];
+        assert_eq!(run_blocking(args.clone()), EXIT_OK);
+
+        let diags = collect_diagnostics_blocking(&args);
+        assert!(
+            !diags
+                .iter()
+                .any(|(_, d)| d.message.contains("Undefined variable: params")),
+            "params must not be flagged when frontmatter declares it; got {:?}",
+            diags
+                .iter()
+                .map(|(_, d)| d.message.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // Guard against a vacuous pass: the SAME chunk without `params:` in the
+        // frontmatter MUST flag `params` as undefined.
+        let rmd2 = tmp.path().join("noparams.Rmd");
+        fs::write(
+            &rmd2,
+            "---\ntitle: Report\n---\n\n```{r}\nyr <- params$year\n```\n",
+        )
+        .unwrap();
+        let mut args2 = base_args(tmp.path());
+        args2.paths = vec![rmd2.clone()];
+        let diags2 = collect_diagnostics_blocking(&args2);
+        assert!(
+            diags2
+                .iter()
+                .any(|(_, d)| d.message.contains("Undefined variable: params")),
+            "without a params: frontmatter, params must be flagged; got {:?}",
+            diags2
+                .iter()
+                .map(|(_, d)| d.message.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn rmd_missing_source_in_chunk_flagged() {
         // A chunk that source()s an absent file produces a missing-file
         // diagnostic (WARNING by default) at the chunk's document line.

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -927,7 +927,7 @@ mod tests {
     fn walk_includes_rmd_and_qmd() {
         // The empty-PATHS workspace walk collects chunk-bearing documents
         // alongside R sources, including mixed-case extensions
-        // (is_chunk_file is case-insensitive).
+        // (is_chunk_file matches the explicit list Rmd/rmd/RMD/qmd/Qmd/QMD).
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
         fs::write(tmp.path().join("report.Rmd"), "prose\n").unwrap();
@@ -1054,6 +1054,10 @@ mod tests {
                         |parent_uri| state.get_enriched_metadata(parent_uri),
                         max_chain_depth,
                     );
+                    // Unlike `run`, skip the `parent_content` map: no test
+                    // routed through this helper uses backward directives
+                    // (`@lsp-sourced-by` match=/inference), which is all that
+                    // closure feeds. The production path in `run` is complete.
                     state.cross_file_graph.update_file(
                         &uri,
                         &meta,

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -114,10 +114,12 @@ pub fn print_help() {
 Usage: raven check [OPTIONS] [PATHS...]
 
 Indexes the workspace, then reports the full diagnostic set for the requested
-files (or every R file in the workspace when no PATHS are given): syntax errors,
-semantic checks, style lints, cross-file diagnostics (missing source files,
-circular dependencies, out-of-scope usage), missing-package warnings, and
-undefined-variable diagnostics. Honors raven.toml / .lintr.
+files (or every R / R Markdown / Quarto file in the workspace when no PATHS are
+given): syntax errors, semantic checks, style lints, cross-file diagnostics
+(missing source files, circular dependencies, out-of-scope usage),
+missing-package warnings, and undefined-variable diagnostics. For .Rmd / .qmd
+the R code inside chunks is analyzed; prose and non-R chunks are ignored.
+Honors raven.toml / .lintr.
 
 Options:
   --workspace DIR             Workspace root to index (default: current directory)

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -155,6 +155,82 @@ Exit codes:
     );
 }
 
+/// Open a report target that the workspace scan did NOT index (a path reached
+/// through a different symlink alias, OR a chunk file — `.Rmd`/`.qmd` are
+/// deliberately outside the R-only workspace scan) into `state.documents` and
+/// wire its outgoing edges into the dependency graph.
+///
+/// `text` is the already-decoded file contents (the caller owns the
+/// `read_source` error handling). `path` is used only to classify the chunk
+/// kind via its extension.
+///
+/// Workspace-scanned files get their edges from
+/// `build_dependency_graph_from_workspace`, but a disk-fallback target was never
+/// passed to `update_file`. Without this, `cached_neighborhood_subgraph(uri, …)`
+/// returns an empty neighborhood, so a chunk `source("R/util.R")` wouldn't
+/// resolve — producing false undefined-variable positives and losing
+/// missing-file context. This mirrors `backend`'s did_open: extract masked
+/// metadata for the path, enrich it with the inherited working directory,
+/// pre-collect parent content for any backward directives, then update the
+/// graph. The masked extraction reads chunk-body `source()`/`library()` calls
+/// only (never prose).
+///
+/// Single source of truth for both `run`'s report loop and the
+/// `collect_diagnostics_blocking` test helper, so production and test exercise
+/// identical disk-fallback behavior.
+fn open_disk_fallback_target(
+    state: &mut crate::state::WorldState,
+    uri: &Url,
+    path: &Path,
+    text: &str,
+) {
+    // Pass an honest language id so the Document classifies the chunk kind
+    // correctly: "rmd" for `.Rmd`/`.qmd` (the constructor reads the URI to
+    // classify it as Rmd and masks the prose), "r" otherwise.
+    // `file_type_from_language_id("rmd")` is `None`, so the `FileType` still
+    // falls back to R via the URI — only the chunk masking differs.
+    let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
+    state.open_document_with_language_id(uri.clone(), text, Some(1), Some(language_id));
+
+    let workspace_root = state.workspace_folders.first().cloned();
+    let max_chain_depth = state.cross_file_config.max_chain_depth;
+    let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), text);
+    crate::cross_file::enrich_metadata_with_inherited_wd(
+        &mut meta,
+        uri,
+        workspace_root.as_ref(),
+        |parent_uri| state.get_enriched_metadata(parent_uri),
+        max_chain_depth,
+    );
+    // Pre-collect parent content for any backward directives (`@lsp-sourced-by`
+    // with `match=`/inference call sites) before the mutable `update_file`
+    // borrow, mirroring did_open. Forward `source()` edges — the only kind chunk
+    // targets normally have — don't consult this closure, so it's empty in the
+    // common case.
+    let backward_path_ctx =
+        crate::cross_file::path_resolve::PathContext::new(uri, workspace_root.as_ref());
+    let parent_content: std::collections::HashMap<Url, String> = meta
+        .sourced_by
+        .iter()
+        .filter_map(|d| {
+            let ctx = backward_path_ctx.as_ref()?;
+            let resolved = crate::cross_file::path_resolve::resolve_path(&d.path, ctx)?;
+            let parent_uri = Url::from_file_path(resolved).ok()?;
+            let content = state
+                .documents
+                .get(&parent_uri)
+                .map(|doc| doc.text())
+                .or_else(|| state.cross_file_file_cache.get(&parent_uri))?;
+            Some((parent_uri, content))
+        })
+        .collect();
+    state
+        .cross_file_graph
+        .update_file(uri, &meta, workspace_root.as_ref(), |parent_uri| {
+            parent_content.get(parent_uri).cloned()
+        });
+}
+
 pub async fn run(args: CheckArgs) -> i32 {
     let cwd = match std::env::current_dir() {
         Ok(p) => p,
@@ -256,65 +332,7 @@ pub async fn run(args: CheckArgs) -> i32 {
                     continue;
                 }
             };
-            // Pass an honest language id so the Document classifies the chunk
-            // kind correctly: "rmd" for `.Rmd`/`.qmd` (the constructor reads
-            // the URI to classify it as Rmd and masks the prose), "r"
-            // otherwise. `file_type_from_language_id("rmd")` is `None`, so the
-            // `FileType` still falls back to R via the URI — only the chunk
-            // masking differs.
-            let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
-            state.open_document_with_language_id(uri.clone(), &text, Some(1), Some(language_id));
-
-            // Wire the disk-fallback target's outgoing edges into the
-            // dependency graph. Workspace-scanned files get their edges from
-            // `build_dependency_graph_from_workspace`, but a disk-fallback
-            // target (always the case for `.Rmd`/`.qmd`, which the R-only scan
-            // skips) was never passed to `update_file`. Without this,
-            // `cached_neighborhood_subgraph(uri, …)` returns an empty
-            // neighborhood, so a chunk `source("R/util.R")` wouldn't resolve —
-            // producing false undefined-variable positives and losing
-            // missing-file context. Mirror `backend`'s did_open: extract masked
-            // metadata for the path, enrich it with the inherited working
-            // directory, then update the graph. The masked extraction reads
-            // chunk-body `source()`/`library()` calls only (never prose).
-            let workspace_root = state.workspace_folders.first().cloned();
-            let max_chain_depth = state.cross_file_config.max_chain_depth;
-            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
-            crate::cross_file::enrich_metadata_with_inherited_wd(
-                &mut meta,
-                &uri,
-                workspace_root.as_ref(),
-                |parent_uri| state.get_enriched_metadata(parent_uri),
-                max_chain_depth,
-            );
-            // Pre-collect parent content for any backward directives
-            // (`@lsp-sourced-by` with `match=`/inference call sites) before the
-            // mutable `update_file` borrow, mirroring did_open. Forward
-            // `source()` edges — the only kind chunk targets normally have —
-            // don't consult this closure, so it's empty in the common case.
-            let backward_path_ctx =
-                crate::cross_file::path_resolve::PathContext::new(&uri, workspace_root.as_ref());
-            let parent_content: std::collections::HashMap<Url, String> = meta
-                .sourced_by
-                .iter()
-                .filter_map(|d| {
-                    let ctx = backward_path_ctx.as_ref()?;
-                    let resolved = crate::cross_file::path_resolve::resolve_path(&d.path, ctx)?;
-                    let parent_uri = Url::from_file_path(resolved).ok()?;
-                    let content = state
-                        .documents
-                        .get(&parent_uri)
-                        .map(|doc| doc.text())
-                        .or_else(|| state.cross_file_file_cache.get(&parent_uri))?;
-                    Some((parent_uri, content))
-                })
-                .collect();
-            state.cross_file_graph.update_file(
-                &uri,
-                &meta,
-                workspace_root.as_ref(),
-                |parent_uri| parent_content.get(parent_uri).cloned(),
-            );
+            open_disk_fallback_target(&mut state, &uri, path, &text);
         }
         // Both arms above leave the document in `state.documents`; collect its
         // attached packages from the doc already in hand (free — the loop opens
@@ -1039,33 +1057,10 @@ mod tests {
                     state.documents.insert(uri.clone(), doc);
                 } else {
                     let text = crate::state::read_source(path).unwrap();
-                    let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
-                    state.open_document_with_language_id(
-                        uri.clone(),
-                        &text,
-                        Some(1),
-                        Some(language_id),
-                    );
-                    let workspace_root = state.workspace_folders.first().cloned();
-                    let max_chain_depth = state.cross_file_config.max_chain_depth;
-                    let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
-                    crate::cross_file::enrich_metadata_with_inherited_wd(
-                        &mut meta,
-                        &uri,
-                        workspace_root.as_ref(),
-                        |parent_uri| state.get_enriched_metadata(parent_uri),
-                        max_chain_depth,
-                    );
-                    // Unlike `run`, skip the `parent_content` map: no test
-                    // routed through this helper uses backward directives
-                    // (`@lsp-sourced-by` match=/inference), which is all that
-                    // closure feeds. The production path in `run` is complete.
-                    state.cross_file_graph.update_file(
-                        &uri,
-                        &meta,
-                        workspace_root.as_ref(),
-                        |_| None,
-                    );
+                    // Same disk-fallback path `run` uses, so production and test
+                    // exercise identical behavior (including the backward-directive
+                    // parent_content map).
+                    super::open_disk_fallback_target(&mut state, &uri, path, &text);
                 }
                 let diags = compute_file_diagnostics(&state, &uri).await;
                 state.close_document(&uri);

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -947,7 +947,7 @@ mod tests {
     fn walk_includes_rmd_and_qmd() {
         // The empty-PATHS workspace walk collects chunk-bearing documents
         // alongside R sources, including mixed-case extensions
-        // (is_chunk_file matches the explicit list Rmd/rmd/RMD/qmd/Qmd/QMD).
+        // (is_chunk_file matches `.rmd`/`.qmd` case-insensitively).
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
         fs::write(tmp.path().join("report.Rmd"), "prose\n").unwrap();

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -21,7 +21,7 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::cli::shared::{
     ColorChoice, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR, OutputFormat, SeverityLevel,
-    absolute_path, collect_r_file_paths, encoding_diagnostic, is_chunk_file, is_r_file,
+    absolute_path, collect_check_target_paths, encoding_diagnostic, is_chunk_file, is_r_file,
     parse_color_choice, parse_output_format, parse_severity_level, render, resolve_color_from_env,
 };
 
@@ -214,14 +214,6 @@ pub async fn run(args: CheckArgs) -> i32 {
     let mut reported_loaded_packages = std::collections::BTreeSet::new();
 
     for path in &targets {
-        if is_chunk_file(path) {
-            // Chunk extraction isn't supported on the command line; mirror lint.
-            eprintln!(
-                "raven check: skipping {} (chunk-bearing file; diagnostics are R-only — see docs/cli.md)",
-                path.display()
-            );
-            continue;
-        }
         let Ok(uri) = Url::from_file_path(path) else {
             eprintln!(
                 "raven check: cannot convert path to URL: {}",
@@ -238,9 +230,11 @@ pub async fn run(args: CheckArgs) -> i32 {
         // that halves the tree-sitter work (parse once during the scan, not
         // again here). Fall back to reading from disk only for a target the
         // scan didn't index (e.g. a path the report walk reached through a
-        // different symlink alias). Either way the document is removed
-        // afterwards to bound memory across a large report set; the clone keeps
-        // the index entry intact for other files' cross-file resolution.
+        // different symlink alias, OR a chunk file — `.Rmd`/`.qmd` are
+        // deliberately outside the R-only workspace scan). Either way the
+        // document is removed afterwards to bound memory across a large report
+        // set; the clone keeps the index entry intact for other files'
+        // cross-file resolution.
         if let Some(doc) = state.workspace_index.get(&uri).cloned() {
             state.documents.insert(uri.clone(), doc);
         } else {
@@ -260,7 +254,65 @@ pub async fn run(args: CheckArgs) -> i32 {
                     continue;
                 }
             };
-            state.open_document_with_language_id(uri.clone(), &text, Some(1), Some("r"));
+            // Pass an honest language id so the Document classifies the chunk
+            // kind correctly: "rmd" for `.Rmd`/`.qmd` (the constructor reads
+            // the URI to classify it as Rmd and masks the prose), "r"
+            // otherwise. `file_type_from_language_id("rmd")` is `None`, so the
+            // `FileType` still falls back to R via the URI — only the chunk
+            // masking differs.
+            let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
+            state.open_document_with_language_id(uri.clone(), &text, Some(1), Some(language_id));
+
+            // Wire the disk-fallback target's outgoing edges into the
+            // dependency graph. Workspace-scanned files get their edges from
+            // `build_dependency_graph_from_workspace`, but a disk-fallback
+            // target (always the case for `.Rmd`/`.qmd`, which the R-only scan
+            // skips) was never passed to `update_file`. Without this,
+            // `cached_neighborhood_subgraph(uri, …)` returns an empty
+            // neighborhood, so a chunk `source("R/util.R")` wouldn't resolve —
+            // producing false undefined-variable positives and losing
+            // missing-file context. Mirror `backend`'s did_open: extract masked
+            // metadata for the path, enrich it with the inherited working
+            // directory, then update the graph. The masked extraction reads
+            // chunk-body `source()`/`library()` calls only (never prose).
+            let workspace_root = state.workspace_folders.first().cloned();
+            let max_chain_depth = state.cross_file_config.max_chain_depth;
+            let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
+            crate::cross_file::enrich_metadata_with_inherited_wd(
+                &mut meta,
+                &uri,
+                workspace_root.as_ref(),
+                |parent_uri| state.get_enriched_metadata(parent_uri),
+                max_chain_depth,
+            );
+            // Pre-collect parent content for any backward directives
+            // (`@lsp-sourced-by` with `match=`/inference call sites) before the
+            // mutable `update_file` borrow, mirroring did_open. Forward
+            // `source()` edges — the only kind chunk targets normally have —
+            // don't consult this closure, so it's empty in the common case.
+            let backward_path_ctx =
+                crate::cross_file::path_resolve::PathContext::new(&uri, workspace_root.as_ref());
+            let parent_content: std::collections::HashMap<Url, String> = meta
+                .sourced_by
+                .iter()
+                .filter_map(|d| {
+                    let ctx = backward_path_ctx.as_ref()?;
+                    let resolved = crate::cross_file::path_resolve::resolve_path(&d.path, ctx)?;
+                    let parent_uri = Url::from_file_path(resolved).ok()?;
+                    let content = state
+                        .documents
+                        .get(&parent_uri)
+                        .map(|doc| doc.text())
+                        .or_else(|| state.cross_file_file_cache.get(&parent_uri))?;
+                    Some((parent_uri, content))
+                })
+                .collect();
+            state.cross_file_graph.update_file(
+                &uri,
+                &meta,
+                workspace_root.as_ref(),
+                |parent_uri| parent_content.get(parent_uri).cloned(),
+            );
         }
         // Both arms above leave the document in `state.documents`; collect its
         // attached packages from the doc already in hand (free — the loop opens
@@ -513,22 +565,41 @@ async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
 /// (or a configured library path) makes the package installed-but-uncached.
 ///
 /// Covers the directly-attached packages (`library()` / `require()`) of each
-/// reported file, read from the already-parsed workspace index. Cross-file
-/// *inherited* packages (attached in a `source()`d file) and packages of
-/// targets the scan did not index are not prefetched here, so calls relying on
-/// those stay conservatively suppressed — a narrower gap than before, noted in
-/// `docs/cli.md`. No-op when the library isn't ready (e.g. R absent with no
-/// configured library paths).
+/// reported file. R-source targets read their already-parsed `loaded_packages`
+/// from the workspace index (free). Chunk-bearing targets (`.Rmd`/`.qmd`) are
+/// never in the R-only scan, so they're read from disk and masked here so a
+/// chunk `library()` call warms its package's exports too — without this the
+/// undefined-variable check would conservatively suppress bare calls to an
+/// installed-but-uncached package attached only inside a chunk, under-reporting
+/// relative to the editor. Cross-file *inherited* packages (attached in a
+/// `source()`d file) and packages of non-chunk targets the scan did not index
+/// are not prefetched here, so calls relying on those stay conservatively
+/// suppressed — a narrower gap than before, noted in `docs/cli.md`. No-op when
+/// the library isn't ready (e.g. R absent with no configured library paths).
 async fn prefetch_reported_packages(state: &crate::state::WorldState, targets: &[PathBuf]) {
     if !state.package_library_ready {
         return;
     }
     let mut packages: std::collections::HashSet<String> = std::collections::HashSet::new();
     for path in targets {
-        if let Ok(uri) = Url::from_file_path(path)
-            && let Some(doc) = state.workspace_index.get(&uri)
-        {
+        let Ok(uri) = Url::from_file_path(path) else {
+            continue;
+        };
+        if let Some(doc) = state.workspace_index.get(&uri) {
             packages.extend(doc.loaded_packages.iter().cloned());
+        } else if is_chunk_file(path) {
+            // Chunk files are outside the R-only scan, so they have no index
+            // entry. Read + construct a throwaway Document best-effort so its
+            // masked `loaded_packages` (chunk-body `library()`/`require()` calls
+            // only, never prose) drive the warm-up exactly as an indexed R
+            // file's would. An unreadable / mis-encoded file just contributes no
+            // packages — its read failure surfaces as a finding in the report
+            // loop.
+            if let Ok(text) = crate::state::read_source(path) {
+                let doc =
+                    crate::state::Document::new_with_language_id(&text, Some(1), &uri, Some("rmd"));
+                packages.extend(doc.loaded_packages.iter().cloned());
+            }
         }
     }
     let packages: Vec<String> = packages
@@ -622,11 +693,11 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
 }
 
 /// Resolve which files to report diagnostics for. Empty `paths` means every R
-/// file under the workspace root. Explicit paths are taken as-is (files) or
-/// walked (directories). The result is sorted and de-duplicated for stable
-/// output. An explicitly-named chunk file (`.Rmd`/`.qmd`) is included so the
-/// caller can emit the one-line skip note; chunk files found while walking a
-/// directory are not collected (they aren't R sources for diagnostics).
+/// source (`.R`/`.r`) and chunk-bearing document (`.Rmd`/`.qmd`) under the
+/// workspace root. Explicit paths are taken as-is (files) or walked
+/// (directories). The result is sorted and de-duplicated for stable output.
+/// Chunk files are collected both as explicit args and while walking a
+/// directory, so `raven check` diagnoses the R chunks inside them (issue #343).
 ///
 /// Every resolved path is canonicalized so its file URI matches the canonical
 /// `root` used to build the dependency graph. Without this, on platforms where
@@ -644,13 +715,13 @@ fn collect_report_targets(
 ) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if paths.is_empty() {
-        collect_r_file_paths(root, &mut out);
+        collect_check_target_paths(root, &mut out);
     } else {
         for p in paths {
             let abs = absolute_path(root, p);
             let abs = std::fs::canonicalize(&abs).unwrap_or(abs);
             if abs.is_dir() {
-                collect_r_file_paths(&abs, &mut out);
+                collect_check_target_paths(&abs, &mut out);
             } else if abs.is_file() {
                 if is_r_file(&abs) || is_chunk_file(&abs) {
                     out.push(abs);
@@ -844,9 +915,34 @@ mod tests {
 
         let mut operator_error = false;
         let targets = collect_report_targets(&[], tmp.path(), &mut operator_error);
-        // Two .R/.r files; .Rmd not collected during the walk; .git skipped.
-        assert_eq!(targets.len(), 2);
-        assert!(targets.iter().all(|p| is_r_file(p)));
+        // Two .R/.r files + the .Rmd (its R chunks are diagnosed, #343); .git
+        // skipped.
+        assert_eq!(targets.len(), 3, "got {targets:?}");
+        assert!(targets.iter().all(|p| is_r_file(p) || is_chunk_file(p)));
+        assert!(targets.iter().any(|p| is_chunk_file(p)));
+        assert!(!operator_error);
+    }
+
+    #[test]
+    fn walk_includes_rmd_and_qmd() {
+        // The empty-PATHS workspace walk collects chunk-bearing documents
+        // alongside R sources, including mixed-case extensions
+        // (is_chunk_file is case-insensitive).
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
+        fs::write(tmp.path().join("report.Rmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join("paper.qmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join("UPPER.RMD"), "prose\n").unwrap();
+        fs::write(tmp.path().join("UPPER.QMD"), "prose\n").unwrap();
+
+        let mut operator_error = false;
+        let targets = collect_report_targets(&[], tmp.path(), &mut operator_error);
+        assert_eq!(targets.len(), 5, "got {targets:?}");
+        let chunk_count = targets.iter().filter(|p| is_chunk_file(p)).count();
+        assert_eq!(
+            chunk_count, 4,
+            "all four chunk files collected; got {targets:?}"
+        );
         assert!(!operator_error);
     }
 
@@ -913,6 +1009,219 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("clean.R"), "x <- 1\ny <- x + 1\n").unwrap();
         assert_eq!(run_blocking(base_args(tmp.path())), EXIT_OK);
+    }
+
+    /// Run `raven check` and capture the diagnostics it would compute, without
+    /// the process-global stdout capture the renderer uses. Mirrors `run`'s
+    /// indexing + report loop so a test can assert on the exact `(path,
+    /// Diagnostic)` pairs (line/character) rather than just the exit code.
+    /// R-independent: callers that want package awareness configure
+    /// `additionalLibraryPaths`.
+    fn collect_diagnostics_blocking(args: &CheckArgs) -> Vec<(PathBuf, Diagnostic)> {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let root = std::fs::canonicalize(args.workspace.as_ref().unwrap()).unwrap();
+            let workspace_url = Url::from_file_path(&root).unwrap();
+            let mut state =
+                build_indexed_state(&root, &workspace_url, args.no_config, None).unwrap();
+            if !args.report_uninstalled {
+                state.cross_file_config.packages_missing_package_severity = None;
+            }
+            maybe_init_r(&mut state, &root).await;
+            let mut operator_error = false;
+            let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
+            prefetch_reported_packages(&state, &targets).await;
+            let mut all = Vec::new();
+            for path in &targets {
+                let uri = Url::from_file_path(path).unwrap();
+                if let Some(doc) = state.workspace_index.get(&uri).cloned() {
+                    state.documents.insert(uri.clone(), doc);
+                } else {
+                    let text = crate::state::read_source(path).unwrap();
+                    let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
+                    state.open_document_with_language_id(
+                        uri.clone(),
+                        &text,
+                        Some(1),
+                        Some(language_id),
+                    );
+                    let workspace_root = state.workspace_folders.first().cloned();
+                    let max_chain_depth = state.cross_file_config.max_chain_depth;
+                    let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), &text);
+                    crate::cross_file::enrich_metadata_with_inherited_wd(
+                        &mut meta,
+                        &uri,
+                        workspace_root.as_ref(),
+                        |parent_uri| state.get_enriched_metadata(parent_uri),
+                        max_chain_depth,
+                    );
+                    state.cross_file_graph.update_file(
+                        &uri,
+                        &meta,
+                        workspace_root.as_ref(),
+                        |_| None,
+                    );
+                }
+                let diags = compute_file_diagnostics(&state, &uri).await;
+                state.close_document(&uri);
+                for d in diags {
+                    all.push((path.clone(), d));
+                }
+            }
+            all
+        })
+    }
+
+    #[test]
+    fn explicit_rmd_chunk_syntax_error_exits_failed() {
+        // A syntax error inside an R chunk of a `.Rmd` must be reported, and at
+        // DOCUMENT coordinates (not chunk-relative): the masked text preserves
+        // line geometry, so the error's line equals its physical line in the
+        // file. Prose lines precede the chunk to make the offset non-trivial.
+        let tmp = TempDir::new().unwrap();
+        let rmd = tmp.path().join("report.Rmd");
+        // Lines (0-based):
+        //   0: "# Title"
+        //   1: ""
+        //   2: "Some prose."
+        //   3: "```{r}"
+        //   4: "f <- function( {"   <- hard syntax error here
+        //   5: "```"
+        fs::write(
+            &rmd,
+            "# Title\n\nSome prose.\n```{r}\nf <- function( {\n```\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![rmd.clone()];
+        assert_eq!(run_blocking(args.clone()), EXIT_LINT_FAILED);
+
+        // Assert the finding lands on the chunk body line (document line 4),
+        // proving geometry-preserving masking.
+        let diags = collect_diagnostics_blocking(&args);
+        assert!(
+            diags.iter().any(|(_, d)| d.range.start.line == 4
+                && d.severity == Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR)),
+            "syntax error expected at document line 4 (0-based); got {:?}",
+            diags
+                .iter()
+                .map(|(_, d)| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_prose_only_exits_ok() {
+        // A `.Rmd` with no R chunks — only prose and a python chunk whose body
+        // is invalid R — must produce no findings: prose is masked out and the
+        // python chunk is not an R chunk, so its body never reaches the R
+        // parser.
+        let tmp = TempDir::new().unwrap();
+        let rmd = tmp.path().join("prose.Rmd");
+        fs::write(
+            &rmd,
+            "# Heading\n\nJust prose, no R here.\n\n```{python}\nthis is ( not valid R\n```\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![rmd.clone()];
+        assert_eq!(run_blocking(args.clone()), EXIT_OK);
+        assert!(
+            collect_diagnostics_blocking(&args).is_empty(),
+            "prose-only / non-R-chunk Rmd must yield no findings"
+        );
+    }
+
+    #[test]
+    fn rmd_chunk_source_resolves_cross_file() {
+        // A chunk that `source()`s a sibling R file and then calls a function
+        // defined there must NOT flag that function as undefined — proving the
+        // CLI wires the opened Rmd's `source()` edge into the dependency graph
+        // (the did_open parity step). The reverse — the same call WITHOUT the
+        // source() line — IS flagged, so the test can't pass vacuously.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("R")).unwrap();
+        fs::write(
+            tmp.path().join("R/util.R"),
+            "helper_fn <- function(x) x + 1\n",
+        )
+        .unwrap();
+
+        // With source(): clean.
+        let analysis = tmp.path().join("analysis.Rmd");
+        fs::write(
+            &analysis,
+            "# Analysis\n```{r}\nsource(\"R/util.R\")\nresult <- helper_fn(41)\n```\n",
+        )
+        .unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![analysis.clone()];
+        let with_source = collect_diagnostics_blocking(&args);
+        assert!(
+            !with_source
+                .iter()
+                .any(|(_, d)| d.message.contains("helper_fn")),
+            "helper_fn must resolve through the sourced sibling; got {:?}",
+            with_source
+                .iter()
+                .map(|(_, d)| d.message.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // Without source(): helper_fn is undefined and flagged. (Guards against
+        // a vacuous pass where nothing is checked at all.)
+        let no_source = tmp.path().join("nosrc.Rmd");
+        fs::write(
+            &no_source,
+            "# Analysis\n```{r}\nresult <- helper_fn(41)\n```\n",
+        )
+        .unwrap();
+        let mut args2 = base_args(tmp.path());
+        args2.paths = vec![no_source.clone()];
+        let without_source = collect_diagnostics_blocking(&args2);
+        assert!(
+            without_source
+                .iter()
+                .any(|(_, d)| d.message.contains("Undefined variable: helper_fn")),
+            "without source(), helper_fn must be flagged undefined; got {:?}",
+            without_source
+                .iter()
+                .map(|(_, d)| d.message.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_missing_source_in_chunk_flagged() {
+        // A chunk that source()s an absent file produces a missing-file
+        // diagnostic (WARNING by default) at the chunk's document line.
+        // Mirrors `missing_source_passes_when_threshold_raised`: it fails at the
+        // default threshold and passes once --max-severity is raised to warning.
+        let tmp = TempDir::new().unwrap();
+        let rmd = tmp.path().join("main.Rmd");
+        // Lines: 0 "# M", 1 "```{r}", 2 "source(\"nope.R\")", 3 "```"
+        fs::write(&rmd, "# M\n```{r}\nsource(\"nope.R\")\n```\n").unwrap();
+        let mut args = base_args(tmp.path());
+        args.paths = vec![rmd.clone()];
+        assert_eq!(run_blocking(args.clone()), EXIT_LINT_FAILED);
+
+        // The missing-file finding lands on the chunk body line (document line 2).
+        let diags = collect_diagnostics_blocking(&args);
+        assert!(
+            diags
+                .iter()
+                .any(|(_, d)| d.range.start.line == 2 && d.message.to_lowercase().contains("not")),
+            "missing-source finding expected at document line 2; got {:?}",
+            diags
+                .iter()
+                .map(|(_, d)| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        // Raising the threshold to warning lets the WARNING-level missing-file
+        // diagnostic pass, exactly like the plain-R case.
+        let mut raised = args.clone();
+        raised.max_severity = SeverityLevel::Warning;
+        assert_eq!(run_blocking(raised), EXIT_OK);
     }
 
     #[test]

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -315,6 +315,16 @@ fn walk(
         // can never drift from the project-wide `.Rmd`/`.qmd` classifier.
         let chunk_kind = crate::chunks::classify_chunk_document(&path.to_string_lossy());
         let effective_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
+        // The trailing-blank-lines rule describes the FILE's shape, but lints
+        // run on the masked analysis text, where the closing fence / prose
+        // after the last chunk is blanked — it would read as trailing blank
+        // lines at EOF on virtually every Rmd/Quarto document. The raw file's
+        // shape is Markdown, not R, so the rule simply doesn't apply to chunk
+        // documents. Mirrors the editor (`DiagnosticsSnapshot::build`).
+        let mut effective = effective;
+        if chunk_kind == crate::chunks::ChunkKind::Rmd {
+            effective.trailing_blank_lines_severity = None;
+        }
         // Use the same thread-local parser pool the LSP uses; avoids
         // per-file Parser construction.
         let parse_result =
@@ -824,8 +834,6 @@ mod tests {
         let root = tmp.path();
         // Prose-only .Rmd: `x=1` in prose would trigger assignment_operator if
         // treated as R, but masking must blank it. No R chunks at all.
-        // The document deliberately has no trailing newline so trailing_blank_lines
-        // doesn't fire on the masked (all-empty) text.
         let content = "---\ntitle: Test\n---\n\nThis is prose. x=1 here.";
         let file = root.join("prose_only.Rmd");
         fs::write(&file, content).unwrap();
@@ -852,7 +860,6 @@ mod tests {
         let root = tmp.path();
         // Line 5 (0-based) = `x=1 # nolint`  → assignment_operator suppressed
         // Line 6 (0-based) = `y=2`            → assignment_operator flagged (non-vacuous)
-        // The document has no trailing newline to avoid trailing_blank_lines noise.
         let content = "---\ntitle: Test\n---\n\n```{r}\nx=1 # nolint\ny=2\n```";
         let file = root.join("nolint.Rmd");
         fs::write(&file, content).unwrap();
@@ -883,6 +890,49 @@ mod tests {
                         ))
             }),
             "assignment_operator on line 6 (y=2) must not be suppressed; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn lint_rmd_exempt_from_trailing_blank_lines() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // The closing fence and prose after the last chunk are blanked in the
+        // masked analysis text, so the file-shape rule would otherwise read
+        // them as trailing blank lines at EOF on virtually every Rmd. The rule
+        // is disabled for chunk documents (the raw file's shape is Markdown,
+        // not R) — but stays active for plain .R files.
+        let rmd = root.join("doc.Rmd");
+        fs::write(&rmd, "```{r}\nx <- 1\n```\n\nClosing prose.\n").unwrap();
+        let r_file = root.join("plain.R");
+        fs::write(&r_file, "x <- 1\n\n\n").unwrap();
+
+        let settings = serde_json::json!({
+            "linting": { "enabled": true, "trailingBlankLinesSeverity": "warning" }
+        });
+        let trailing = |diags: &[(PathBuf, Diagnostic)]| {
+            diags.iter().any(|(_, d)| {
+                d.code
+                    == Some(tower_lsp::lsp_types::NumberOrString::String(
+                        "trailing_blank_lines".to_string(),
+                    ))
+            })
+        };
+
+        let (rmd_diags, err) = lint_one(root, &rmd, &settings);
+        assert!(!err, "unexpected operator error");
+        assert!(
+            !trailing(&rmd_diags),
+            "masked Rmd must not produce trailing_blank_lines findings; got {rmd_diags:?}"
+        );
+
+        let (r_diags, err) = lint_one(root, &r_file, &settings);
+        assert!(!err, "unexpected operator error");
+        assert!(
+            trailing(&r_diags),
+            "plain .R must still be flagged (non-vacuous); got {r_diags:?}"
         );
     }
 

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -304,16 +304,19 @@ fn walk(
                 return;
             }
         };
-        // For chunk files (.Rmd/.qmd), mask the document to its R chunk bodies
-        // before parsing and linting. `mask_to_r` replaces all non-R-body lines
-        // (prose, YAML, fences, non-R chunk bodies) with empty strings while
-        // keeping every line at its original index, so lint findings computed on
-        // the masked text carry document coordinates directly.
-        let effective_text: std::borrow::Cow<str> = if chunk {
-            std::borrow::Cow::Owned(crate::chunks::mask_to_r(&text))
+        // For chunk files (.Rmd/.qmd), this masks the document to its R chunk
+        // bodies before parsing and linting: all non-R-body lines (prose, YAML,
+        // fences, non-R chunk bodies) become empty strings while every line keeps
+        // its original index, so lint findings carry document coordinates
+        // directly. Routed through the shared `analysis_text_for_kind` chokepoint
+        // so `raven lint` derives its R-analysis view identically to the LSP and
+        // `raven check`. `chunk` is `is_chunk_file(path)`, i.e. `.Rmd`/`.qmd`.
+        let chunk_kind = if chunk {
+            crate::chunks::ChunkKind::Rmd
         } else {
-            std::borrow::Cow::Borrowed(&text)
+            crate::chunks::ChunkKind::R
         };
+        let effective_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
         // Use the same thread-local parser pool the LSP uses; avoids
         // per-file Parser construction.
         let parse_result =

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -83,7 +83,9 @@ pub fn print_help() {
 Usage: raven lint [OPTIONS] [PATHS...]
 
 Lints each .R / .r file against the rules configured in raven.toml
-(or .lintr) and prints diagnostics.
+(or .lintr) and prints diagnostics. R Markdown / Quarto files
+(.Rmd / .qmd) are linted too: the R code inside chunks is checked,
+prose and non-R chunks are ignored.
 
 Options:
   --config PATH               Path to raven.toml (default: search upward)
@@ -889,11 +891,14 @@ mod tests {
         use tempfile::TempDir;
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
-        // A directory with one .Rmd and one plain .R; both have a triggering
-        // pattern so both should produce findings.
+        // A directory with one .Rmd, one .qmd, and one plain .R; all have a
+        // triggering pattern so all should produce findings (.qmd shares the
+        // .Rmd dispatch path via is_chunk_file — pin it end-to-end too).
         let rmd = root.join("doc.Rmd");
+        let qmd = root.join("paper.qmd");
         let r_file = root.join("plain.R");
         fs::write(&rmd, rmd_with_chunk_finding()).unwrap();
+        fs::write(&qmd, rmd_with_chunk_finding()).unwrap();
         fs::write(&r_file, "x=1\n").unwrap();
 
         let settings = assignment_warn_settings();
@@ -914,12 +919,17 @@ mod tests {
         );
 
         assert!(!operator_error, "unexpected operator error");
-        // Both files must contribute findings.
+        // All three files must contribute findings.
         let rmd_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &rmd).collect();
+        let qmd_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &qmd).collect();
         let r_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &r_file).collect();
         assert!(
             !rmd_findings.is_empty(),
             "directory walk must include .Rmd findings; got {diags:?}"
+        );
+        assert!(
+            !qmd_findings.is_empty(),
+            "directory walk must include .qmd findings; got {diags:?}"
         );
         assert!(
             !r_findings.is_empty(),

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -261,16 +261,8 @@ fn walk(
     operator_error: &mut bool,
 ) {
     if path.is_file() {
-        if is_chunk_file(path) {
-            // Design requires a one-line note; the file otherwise contributes
-            // nothing to JSON / SARIF output.
-            eprintln!(
-                "raven lint: skipping {} (chunk-bearing file; lint is R-only — see docs/cli.md)",
-                path.display()
-            );
-            return;
-        }
-        if !is_r_file(path) {
+        let chunk = is_chunk_file(path);
+        if !chunk && !is_r_file(path) {
             return;
         }
         let rel = path.strip_prefix(root).unwrap_or(path);
@@ -310,9 +302,20 @@ fn walk(
                 return;
             }
         };
+        // For chunk files (.Rmd/.qmd), mask the document to its R chunk bodies
+        // before parsing and linting. `mask_to_r` replaces all non-R-body lines
+        // (prose, YAML, fences, non-R chunk bodies) with empty strings while
+        // keeping every line at its original index, so lint findings computed on
+        // the masked text carry document coordinates directly.
+        let effective_text: std::borrow::Cow<str> = if chunk {
+            std::borrow::Cow::Owned(crate::chunks::mask_to_r(&text))
+        } else {
+            std::borrow::Cow::Borrowed(&text)
+        };
         // Use the same thread-local parser pool the LSP uses; avoids
         // per-file Parser construction.
-        let parse_result = crate::parser_pool::with_parser(|p| p.parse(&text, None));
+        let parse_result =
+            crate::parser_pool::with_parser(|p| p.parse(effective_text.as_ref(), None));
         let tree = match parse_result {
             Some(t) => t,
             None => {
@@ -321,7 +324,7 @@ fn walk(
                 return;
             }
         };
-        for d in crate::linting::run_lints(&text, tree.root_node(), &effective) {
+        for d in crate::linting::run_lints(effective_text.as_ref(), tree.root_node(), &effective) {
             out.push((path.to_path_buf(), d));
         }
     } else if path.is_dir() {
@@ -742,5 +745,185 @@ mod tests {
         // Before this migration a non-UTF-8 file set operator_error → exit 2.
         // Now it is an ERROR finding (parity with `raven check`) → exit 1.
         assert_eq!(run(args), EXIT_LINT_FAILED);
+    }
+
+    /// Settings that enable linting with the `assignment_operator` rule set to
+    /// flag `=` as a warning (default style is `<-`, default severity is HINT,
+    /// but for tests we use WARNING so we can distinguish from no-finding).
+    fn assignment_warn_settings() -> serde_json::Value {
+        serde_json::json!({
+            "linting": {
+                "enabled": true,
+                "assignmentOperatorSeverity": "warning"
+            }
+        })
+    }
+
+    /// A minimal .Rmd document with one R chunk containing `x=1` (assignment
+    /// operator finding) on line 3 (0-based), with surrounding prose. The prose
+    /// lines contain `y=2` which would be a finding if treated as R code.
+    fn rmd_with_chunk_finding() -> &'static str {
+        "---\ntitle: Test\n---\n\n```{r}\nx=1\n```\n\nProse y=2 here.\n"
+    }
+
+    #[test]
+    fn lint_flags_finding_inside_rmd_chunk_at_document_coords() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let file = root.join("doc.Rmd");
+        fs::write(&file, rmd_with_chunk_finding()).unwrap();
+
+        let settings = assignment_warn_settings();
+        let (diags, operator_error) = lint_one(root, &file, &settings);
+
+        assert!(!operator_error, "unexpected operator error");
+        // `x=1` is on line 5 (0-based) of the document (after "---", "title:
+        // Test", "---", "", "```{r}"). run_lints reports 0-based lines, so
+        // range.start.line == 5. There must be at least one finding here.
+        let chunk_finding = diags.iter().find(|(p, d)| {
+            p == &file
+                && d.code
+                    == Some(tower_lsp::lsp_types::NumberOrString::String(
+                        "assignment_operator".to_string(),
+                    ))
+        });
+        assert!(
+            chunk_finding.is_some(),
+            "expected an assignment_operator finding; got {diags:?}"
+        );
+        let (_, d) = chunk_finding.unwrap();
+        assert_eq!(
+            d.range.start.line, 5,
+            "finding must be at document line 5 (0-based); got {:?}",
+            d.range.start.line
+        );
+        // Prose line 8 (`Prose y=2 here.`) must NOT produce an
+        // assignment_operator finding — it is masked out as non-R.
+        assert!(
+            !diags.iter().any(|(_, d2)| {
+                d2.range.start.line == 8
+                    && d2.code
+                        == Some(tower_lsp::lsp_types::NumberOrString::String(
+                            "assignment_operator".to_string(),
+                        ))
+            }),
+            "prose line must not produce an assignment_operator finding"
+        );
+    }
+
+    #[test]
+    fn lint_ignores_rmd_prose() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // Prose-only .Rmd: `x=1` in prose would trigger assignment_operator if
+        // treated as R, but masking must blank it. No R chunks at all.
+        // The document deliberately has no trailing newline so trailing_blank_lines
+        // doesn't fire on the masked (all-empty) text.
+        let content = "---\ntitle: Test\n---\n\nThis is prose. x=1 here.";
+        let file = root.join("prose_only.Rmd");
+        fs::write(&file, content).unwrap();
+
+        let settings = assignment_warn_settings();
+        let (diags, operator_error) = lint_one(root, &file, &settings);
+
+        assert!(!operator_error, "unexpected operator error");
+        // No assignment_operator finding must appear — prose is masked.
+        assert!(
+            !diags.iter().any(|(_, d)| d.code
+                == Some(tower_lsp::lsp_types::NumberOrString::String(
+                    "assignment_operator".to_string()
+                ))),
+            "prose-only Rmd must produce no assignment_operator finding; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn lint_nolint_inside_chunk_respected() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // Line 5 (0-based) = `x=1 # nolint`  → assignment_operator suppressed
+        // Line 6 (0-based) = `y=2`            → assignment_operator flagged (non-vacuous)
+        // The document has no trailing newline to avoid trailing_blank_lines noise.
+        let content = "---\ntitle: Test\n---\n\n```{r}\nx=1 # nolint\ny=2\n```";
+        let file = root.join("nolint.Rmd");
+        fs::write(&file, content).unwrap();
+
+        let settings = assignment_warn_settings();
+        let (diags, operator_error) = lint_one(root, &file, &settings);
+
+        assert!(!operator_error, "unexpected operator error");
+        // `x=1 # nolint` on line 5 must be suppressed: no assignment_operator
+        // finding at line 5.
+        assert!(
+            !diags.iter().any(|(_, d)| {
+                d.range.start.line == 5
+                    && d.code
+                        == Some(tower_lsp::lsp_types::NumberOrString::String(
+                            "assignment_operator".to_string(),
+                        ))
+            }),
+            "assignment_operator on line 5 must be suppressed by # nolint; got {diags:?}"
+        );
+        // `y=2` on line 6 must produce an assignment_operator finding (non-vacuous).
+        assert!(
+            diags.iter().any(|(_, d)| {
+                d.range.start.line == 6
+                    && d.code
+                        == Some(tower_lsp::lsp_types::NumberOrString::String(
+                            "assignment_operator".to_string(),
+                        ))
+            }),
+            "assignment_operator on line 6 (y=2) must not be suppressed; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn lint_walk_includes_chunk_files() {
+        use std::fs;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // A directory with one .Rmd and one plain .R; both have a triggering
+        // pattern so both should produce findings.
+        let rmd = root.join("doc.Rmd");
+        let r_file = root.join("plain.R");
+        fs::write(&rmd, rmd_with_chunk_finding()).unwrap();
+        fs::write(&r_file, "x=1\n").unwrap();
+
+        let settings = assignment_warn_settings();
+        let base_lint = crate::backend::parse_lint_config(&settings, false).unwrap();
+        let base_section = settings.get("linting").cloned().unwrap();
+        let overrides = crate::config_file::compile_lint_overrides(&settings, root);
+        let mut diags = Vec::new();
+        let mut operator_error = false;
+        // Walk the directory, not individual files.
+        walk(
+            root,
+            root,
+            &base_section,
+            &base_lint,
+            &overrides,
+            &mut diags,
+            &mut operator_error,
+        );
+
+        assert!(!operator_error, "unexpected operator error");
+        // Both files must contribute findings.
+        let rmd_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &rmd).collect();
+        let r_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &r_file).collect();
+        assert!(
+            !rmd_findings.is_empty(),
+            "directory walk must include .Rmd findings; got {diags:?}"
+        );
+        assert!(
+            !r_findings.is_empty(),
+            "directory walk must include .R findings; got {diags:?}"
+        );
     }
 }

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -310,12 +310,10 @@ fn walk(
         // its original index, so lint findings carry document coordinates
         // directly. Routed through the shared `analysis_text_for_kind` chokepoint
         // so `raven lint` derives its R-analysis view identically to the LSP and
-        // `raven check`. `chunk` is `is_chunk_file(path)`, i.e. `.Rmd`/`.qmd`.
-        let chunk_kind = if chunk {
-            crate::chunks::ChunkKind::Rmd
-        } else {
-            crate::chunks::ChunkKind::R
-        };
+        // `raven check`. Classify via the canonical `classify_chunk_document`
+        // (not a local re-derivation of the `chunk` guard above) so this site
+        // can never drift from the project-wide `.Rmd`/`.qmd` classifier.
+        let chunk_kind = crate::chunks::classify_chunk_document(&path.to_string_lossy());
         let effective_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
         // Use the same thread-local parser pool the LSP uses; avoids
         // per-file Parser construction.

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -903,21 +903,9 @@ mod tests {
         fs::write(&r_file, "x=1\n").unwrap();
 
         let settings = assignment_warn_settings();
-        let base_lint = crate::backend::parse_lint_config(&settings, false).unwrap();
-        let base_section = settings.get("linting").cloned().unwrap();
-        let overrides = crate::config_file::compile_lint_overrides(&settings, root);
-        let mut diags = Vec::new();
-        let mut operator_error = false;
-        // Walk the directory, not individual files.
-        walk(
-            root,
-            root,
-            &base_section,
-            &base_lint,
-            &overrides,
-            &mut diags,
-            &mut operator_error,
-        );
+        // Walk the directory, not individual files (`lint_one` hands its
+        // `file` argument straight to `walk`, which dispatches dirs too).
+        let (diags, operator_error) = lint_one(root, root, &settings);
 
         assert!(!operator_error, "unexpected operator error");
         // All three files must contribute findings.

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -194,10 +194,9 @@ pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
 /// predicate also matches chunk files so their R chunks are diagnosed
 /// (issue #343).
 ///
-/// Used by `raven check`'s report walk (empty `PATHS` or an explicit directory)
-/// and reused by `raven lint`'s walk so the two commands agree on which files a
-/// directory contributes. Results are unsorted; callers that need deterministic
-/// order sort afterwards.
+/// Used by `raven check`'s report walk (empty `PATHS` or an explicit
+/// directory). Results are unsorted; callers that need deterministic order
+/// sort afterwards.
 pub fn collect_check_target_paths(dir: &Path, out: &mut Vec<PathBuf>) {
     crate::state::collect_files_matching(dir, out, |p| is_r_file(p) || is_chunk_file(p));
 }

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -187,6 +187,21 @@ pub fn collect_r_file_paths(dir: &Path, out: &mut Vec<PathBuf>) {
     crate::state::collect_files_matching(dir, out, is_r_file);
 }
 
+/// Recursively collect both R sources (`.R` / `.r`) and chunk-bearing documents
+/// (`.Rmd` / `.qmd`, case-insensitive) under `dir`. Same directory walk as
+/// [`collect_r_file_paths`] — symlinked directories are followed with
+/// canonical-path cycle detection and non-source directories pruned — but the
+/// predicate also matches chunk files so their R chunks are diagnosed
+/// (issue #343).
+///
+/// Used by `raven check`'s report walk (empty `PATHS` or an explicit directory)
+/// and reused by `raven lint`'s walk so the two commands agree on which files a
+/// directory contributes. Results are unsorted; callers that need deterministic
+/// order sort afterwards.
+pub fn collect_check_target_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+    crate::state::collect_files_matching(dir, out, |p| is_r_file(p) || is_chunk_file(p));
+}
+
 /// Build the reported finding for a target that isn't valid UTF-8. A
 /// mis-encoded source file (typically Latin-1 / Windows-1252 saved without a
 /// BOM) can't be parsed, but it's a property of the user's code — so it's an
@@ -578,6 +593,30 @@ mod tests {
         // a.R + sub/b.r; .Rmd is not an R source; .git is pruned.
         assert_eq!(out.len(), 2);
         assert!(out.iter().all(|p| is_r_file(p)));
+    }
+
+    #[test]
+    fn collect_check_target_paths_includes_r_and_chunk_files() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.R"), "1\n").unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::write(tmp.path().join("sub/b.r"), "2\n").unwrap();
+        fs::write(tmp.path().join("c.Rmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join("d.qmd"), "prose\n").unwrap();
+        // Mixed-case chunk extensions are matched (is_chunk_file is
+        // case-insensitive).
+        fs::write(tmp.path().join("e.QMD"), "prose\n").unwrap();
+        fs::write(tmp.path().join("f.txt"), "not source\n").unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/g.R"), "3\n").unwrap();
+
+        let mut out = Vec::new();
+        collect_check_target_paths(tmp.path(), &mut out);
+        // a.R + sub/b.r + c.Rmd + d.qmd + e.QMD; .txt skipped; .git pruned.
+        assert_eq!(out.len(), 5, "got {out:?}");
+        assert!(out.iter().all(|p| is_r_file(p) || is_chunk_file(p)));
+        assert!(out.iter().any(|p| is_chunk_file(p)));
     }
 
     #[cfg(unix)]

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -153,11 +153,15 @@ pub fn is_r_file(p: &Path) -> bool {
     )
 }
 
+/// True for chunk-bearing document extensions (`.Rmd` / `.qmd`), matched
+/// case-insensitively so the CLI walk agrees with the canonical
+/// [`crate::chunks::classify_chunk_document`] (which lowercases the whole
+/// path) — a `report.rMd` saved on a case-insensitive filesystem must be
+/// collected by the same rule that later classifies it.
 pub fn is_chunk_file(p: &Path) -> bool {
-    matches!(
-        p.extension().and_then(|s| s.to_str()),
-        Some("Rmd") | Some("rmd") | Some("RMD") | Some("qmd") | Some("Qmd") | Some("QMD")
-    )
+    p.extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("rmd") || ext.eq_ignore_ascii_case("qmd"))
 }
 
 /// Return `path` unchanged when already absolute; otherwise resolve it against
@@ -573,7 +577,12 @@ mod tests {
         assert!(!is_r_file(Path::new("a.Rmd")));
         assert!(is_chunk_file(Path::new("a.Rmd")));
         assert!(is_chunk_file(Path::new("a.qmd")));
+        // Case-insensitive, matching classify_chunk_document — including
+        // capitalizations outside the common Rmd/rmd/RMD set.
+        assert!(is_chunk_file(Path::new("a.rMd")));
+        assert!(is_chunk_file(Path::new("a.QmD")));
         assert!(!is_chunk_file(Path::new("a.R")));
+        assert!(!is_chunk_file(Path::new("a.rmdx")));
     }
 
     #[test]

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -235,11 +235,14 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
             return Some(doc.metadata.clone());
         }
 
-        // 2. Check legacy documents HashMap (for migration compatibility)
+        // 2. Check legacy documents HashMap (for migration compatibility).
+        //    Use the analysis text (masked for Rmd/Quarto, raw otherwise) so
+        //    directives/source()/library() come from chunk bodies, not prose
+        //    (#343), and so byte offsets stay consistent with downstream uses.
         if let Some(legacy_docs) = self.legacy_documents
             && let Some(doc) = legacy_docs.get(uri)
         {
-            let text = doc.text();
+            let text = doc.analysis_text();
             return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
         }
 
@@ -255,11 +258,12 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
             return Some(metadata);
         }
 
-        // 5. Check legacy workspace_index (for migration compatibility)
+        // 5. Check legacy workspace_index (for migration compatibility).
+        //    Analysis text (masked for Rmd/Quarto, raw otherwise) — see step 2.
         if let Some(legacy_ws) = self.legacy_workspace_index
             && let Some(doc) = legacy_ws.get(uri)
         {
-            let text = doc.text();
+            let text = doc.analysis_text();
             return Some(Arc::new(crate::cross_file::extract_metadata(&text)));
         }
 

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -282,12 +282,15 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
             return Some(doc.artifacts.clone());
         }
 
-        // 2. Check legacy documents HashMap (for migration compatibility)
+        // 2. Check legacy documents HashMap (for migration compatibility).
+        //    Pair the tree with the analysis text it was parsed from (masked
+        //    for Rmd, raw otherwise) so artifact byte offsets align and never
+        //    mis-slice on a non-UTF-8 boundary.
         if let Some(legacy_docs) = self.legacy_documents
             && let Some(doc) = legacy_docs.get(uri)
             && let Some(tree) = &doc.tree
         {
-            let text = doc.text();
+            let text = doc.analysis_text();
             // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
             // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
             let metadata = crate::cross_file::extract_metadata(&text);
@@ -311,12 +314,13 @@ impl<'a> ContentProvider for DefaultContentProvider<'a> {
             return Some(artifacts);
         }
 
-        // 5. Check legacy workspace_index (for migration compatibility)
+        // 5. Check legacy workspace_index (for migration compatibility).
+        //    Analysis text matches the tree's byte offsets (see step 2).
         if let Some(legacy_ws) = self.legacy_workspace_index
             && let Some(doc) = legacy_ws.get(uri)
             && let Some(tree) = &doc.tree
         {
-            let text = doc.text();
+            let text = doc.analysis_text();
             // Extract metadata and use compute_artifacts_with_metadata to include declared symbols
             // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
             let metadata = crate::cross_file::extract_metadata(&text);

--- a/crates/raven/src/cross_file/background_indexer.rs
+++ b/crates/raven/src/cross_file/background_indexer.rs
@@ -290,10 +290,16 @@ impl BackgroundIndexer {
         let content = crate::state::read_source_async(&path).await?;
         let metadata_fs = tokio::fs::metadata(&path).await?;
 
-        let tree = crate::parser_pool::with_parser(|parser| parser.parse(&content, None));
+        // Parse and extract from the analysis text: masked for Rmd/Quarto
+        // (chunk bodies only, never prose), raw for plain R. The raw `content`
+        // is still what gets hashed/cached below — only the derived
+        // tree/metadata/artifacts use the masked view (issue #343).
+        let analysis_text = crate::cross_file::analysis_text_for_path(uri.path(), &content);
+        let tree =
+            crate::parser_pool::with_parser(|parser| parser.parse(analysis_text.as_ref(), None));
 
         // Extract cross-file metadata
-        let mut cross_file_meta = extract_metadata_with_tree(&content, tree.as_ref());
+        let mut cross_file_meta = extract_metadata_with_tree(&analysis_text, tree.as_ref());
 
         // Enrich metadata with inherited working directory
         // Use get_enriched_metadata to prefer already-enriched sources for transitive inheritance
@@ -319,7 +325,7 @@ impl BackgroundIndexer {
             Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
                 uri,
                 tree,
-                &content,
+                &analysis_text,
                 Some(&cross_file_meta),
             ),
             None => crate::cross_file::scope::ScopeArtifacts::default(),

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -92,7 +92,23 @@ pub fn analysis_text_for_path<'a>(
     path_or_uri: &str,
     content: &'a str,
 ) -> std::borrow::Cow<'a, str> {
-    match crate::chunks::classify_chunk_document(path_or_uri) {
+    analysis_text_for_kind(crate::chunks::classify_chunk_document(path_or_uri), content)
+}
+
+/// The R-analysis view of `content` for an already-classified document: the
+/// geometry-preserving [`crate::chunks::mask_to_r`] mask for
+/// [`ChunkKind::Rmd`](crate::chunks::ChunkKind::Rmd), the raw `content`
+/// borrowed unchanged for [`ChunkKind::R`](crate::chunks::ChunkKind::R).
+///
+/// Use this when the caller already knows the kind from the editor's
+/// `languageId`-then-URI classification (e.g. `did_open`, where path-based
+/// classification would mis-handle untitled `.Rmd`/`.qmd` buffers, #343).
+/// [`analysis_text_for_path`] is the path-classified convenience wrapper.
+pub fn analysis_text_for_kind(
+    chunk_kind: crate::chunks::ChunkKind,
+    content: &str,
+) -> std::borrow::Cow<'_, str> {
+    match chunk_kind {
         crate::chunks::ChunkKind::Rmd => std::borrow::Cow::Owned(crate::chunks::mask_to_r(content)),
         crate::chunks::ChunkKind::R => std::borrow::Cow::Borrowed(content),
     }

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -75,6 +75,43 @@ pub fn extract_metadata(content: &str) -> CrossFileMetadata {
     extract_metadata_with_tree(content, tree.as_ref())
 }
 
+/// The R-analysis view of `content` for the file identified by `path_or_uri`:
+/// the geometry-preserving [`crate::chunks::mask_to_r`] mask for R Markdown /
+/// Quarto documents (`.Rmd` / `.qmd`), and the raw `content` borrowed
+/// unchanged for everything else.
+///
+/// This is the single place that pairs path-based classification with masking
+/// for closed-file / on-demand-indexing call sites that only have a path and a
+/// byte string (no constructed `Document`). Open documents should prefer the
+/// already-masked [`crate::state::Document::analysis_text`] instead of
+/// re-masking here.
+///
+/// Returns a `Cow` so the plain-R case (the overwhelming majority) borrows
+/// without allocating.
+pub fn analysis_text_for_path<'a>(
+    path_or_uri: &str,
+    content: &'a str,
+) -> std::borrow::Cow<'a, str> {
+    match crate::chunks::classify_chunk_document(path_or_uri) {
+        crate::chunks::ChunkKind::Rmd => std::borrow::Cow::Owned(crate::chunks::mask_to_r(content)),
+        crate::chunks::ChunkKind::R => std::borrow::Cow::Borrowed(content),
+    }
+}
+
+/// Extract cross-file metadata from `content`, masking R Markdown / Quarto
+/// prose first so directives, `source()` calls, and `library()` calls are
+/// taken from R chunk bodies only (never from prose or YAML front matter).
+///
+/// For non-Rmd files this is identical to [`extract_metadata`]. Use this at any
+/// site that extracts metadata from a path-identified file's *raw* content
+/// (file-cache fallbacks, on-demand indexing, legacy-document arms) so that
+/// `.Rmd` / `.qmd` files contribute outgoing edges from their chunks rather
+/// than spurious prose-derived ones (issue #343).
+pub fn extract_metadata_for_path(path_or_uri: &str, content: &str) -> CrossFileMetadata {
+    let analysis = analysis_text_for_path(path_or_uri, content);
+    extract_metadata(&analysis)
+}
+
 /// Extract cross-file metadata using a pre-parsed tree when available.
 ///
 /// This avoids redundant parsing when the caller already has a tree-sitter `Tree`.

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -114,6 +114,45 @@ pub fn analysis_text_for_kind(
     }
 }
 
+/// The `Option`-returning sibling of [`analysis_text_for_kind`] for callers that
+/// store `masked_text: Option<String>` (an open document's analysis text is the
+/// masked string for Rmd/Quarto, or `None` to mean "use the raw text as-is").
+///
+/// Returns `Some(masked)` for [`ChunkKind::Rmd`](crate::chunks::ChunkKind::Rmd)
+/// (the geometry-preserving [`crate::chunks::mask_to_r`] mask) and `None` for
+/// [`ChunkKind::R`](crate::chunks::ChunkKind::R), where analysis text equals raw
+/// text. This is the single masking chokepoint for `masked_text` fields:
+/// [`crate::state::Document`] and [`crate::document_store::DocumentStore`] both
+/// route through it so their analysis views can never diverge.
+pub(crate) fn masked_analysis_text(
+    chunk_kind: crate::chunks::ChunkKind,
+    text: &str,
+) -> Option<String> {
+    match analysis_text_for_kind(chunk_kind, text) {
+        std::borrow::Cow::Owned(masked) => Some(masked),
+        std::borrow::Cow::Borrowed(_) => None,
+    }
+}
+
+/// Classify a `did_open`'d document by its editor `language_id`-then-URI and
+/// return its [`ChunkKind`](crate::chunks::ChunkKind) paired with the R-analysis
+/// view of `text` ([`analysis_text_for_kind`]).
+///
+/// This is the chokepoint for the `did_open` branches in `backend.rs`, which all
+/// classify the same way before extracting metadata and opening the
+/// `DocumentStore`. `language_id`-then-URI classification (not path-only) is what
+/// lets untitled `.Rmd`/`.qmd` buffers — which have no file extension — mask
+/// correctly (#343).
+pub(crate) fn classify_and_mask<'a>(
+    language_id: Option<&str>,
+    uri: &tower_lsp::lsp_types::Url,
+    text: &'a str,
+) -> (crate::chunks::ChunkKind, std::borrow::Cow<'a, str>) {
+    let chunk_kind = crate::chunks::classify_chunk_document_for(language_id, uri.path());
+    let analysis_text = analysis_text_for_kind(chunk_kind, text);
+    (chunk_kind, analysis_text)
+}
+
 /// Extract cross-file metadata from `content`, masking R Markdown / Quarto
 /// prose first so directives, `source()` calls, and `library()` calls are
 /// taken from R chunk bodies only (never from prose or YAML front matter).

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -17,6 +17,7 @@ use tokio::sync::watch;
 use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
 use tree_sitter::Tree;
 
+use crate::chunks::ChunkKind;
 use crate::cross_file::scope::ScopeArtifacts;
 use crate::cross_file::types::CrossFileMetadata;
 
@@ -107,12 +108,27 @@ pub struct DocumentStoreMetrics {
 /// views — only *byte* offsets are view-specific. Anything pairing `tree` with
 /// a text MUST use [`analysis_text()`](DocumentState::analysis_text).
 ///
+/// Whether a document is masked is fixed by its
+/// [`chunk_kind`](DocumentState::chunk_kind), determined at open time from the
+/// editor's `languageId`-then-URI classification — **not** re-derived by path.
+/// Untitled `.Rmd`/`.qmd` buffers (`untitled:Untitled-1`, languageId
+/// `"rmd"`/`"quarto"`) have no file extension, so re-classifying by path alone
+/// would parse them RAW and leak prose into find-references / workspace-symbol
+/// (#343). Saved `.Rmd` files classify identically either way.
+///
 /// **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
 pub struct DocumentState {
     /// Document URI
     pub uri: Url,
     /// LSP document version
     pub version: i32,
+    /// How this document is classified for chunk masking, fixed at open time
+    /// from the editor's `languageId`-then-URI classification
+    /// ([`chunks::classify_chunk_document_for`](crate::chunks::classify_chunk_document_for)).
+    /// [`ChunkKind::Rmd`] means the analysis-derived fields below are masked;
+    /// [`ChunkKind::R`] means they equal the raw view. Preserved across updates
+    /// (a document's language never changes mid-session).
+    pub chunk_kind: ChunkKind,
     /// File content as a rope for efficient editing (RAW, verbatim source)
     pub contents: Rope,
     /// Masked analysis text for Rmd/Quarto documents
@@ -330,17 +346,22 @@ impl DocumentStore {
         self.mark_update_started(&uri);
         // Parse content. `contents` keeps the RAW source; tree/metadata/
         // artifacts derive from the masked analysis text for Rmd/Quarto (#343).
+        // No `languageId` here, so classify by path — this entry point is for
+        // callers (tests, internal) that always have a real file extension;
+        // the LSP path uses `open_with_metadata` with the editor's languageId.
+        let chunk_kind = crate::chunks::classify_chunk_document(uri.path());
         let contents = Rope::from_str(content);
         let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(
             uri.path(),
             content,
         ));
         let (masked_text, tree, loaded_packages, artifacts) =
-            Self::compute_derived(&uri, content, metadata.as_ref());
+            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref());
 
         let state = DocumentState {
             uri: uri.clone(),
             version,
+            chunk_kind,
             contents,
             masked_text,
             tree,
@@ -397,15 +418,21 @@ impl DocumentStore {
         self.signal_update_complete(&uri);
     }
 
-    /// Open a document with pre-enriched metadata
+    /// Open a document with pre-enriched metadata and an explicit chunk kind.
     ///
-    /// Like `open`, but uses the provided metadata instead of extracting it.
-    /// Use this when metadata has been enriched with inherited_working_directory.
+    /// Like `open`, but uses the provided metadata instead of extracting it,
+    /// and takes the editor-supplied `chunk_kind` (from
+    /// [`chunks::classify_chunk_document_for`](crate::chunks::classify_chunk_document_for)
+    /// on the `did_open` `languageId`-then-URI) rather than re-classifying by
+    /// path. This is the LSP open path; it is the only place that can mask
+    /// untitled `.Rmd`/`.qmd` buffers correctly (#343). Use this when metadata
+    /// has been enriched with inherited_working_directory.
     pub async fn open_with_metadata(
         &mut self,
         uri: Url,
         content: &str,
         version: i32,
+        chunk_kind: ChunkKind,
         metadata: CrossFileMetadata,
     ) {
         self.mark_update_started(&uri);
@@ -416,11 +443,12 @@ impl DocumentStore {
         let contents = Rope::from_str(content);
         let metadata = Arc::new(metadata);
         let (masked_text, tree, loaded_packages, artifacts) =
-            Self::compute_derived(&uri, content, metadata.as_ref());
+            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref());
 
         let state = DocumentState {
             uri: uri.clone(),
             version,
+            chunk_kind,
             contents,
             masked_text,
             tree,
@@ -492,14 +520,19 @@ impl DocumentStore {
 
             // Reparse and recompute derived data. `contents` stays RAW;
             // tree/metadata/artifacts derive from the masked analysis text for
-            // Rmd/Quarto (#343).
+            // Rmd/Quarto (#343). The chunk kind is fixed at open and preserved
+            // here — a document's language never changes mid-session — so an
+            // untitled Rmd buffer keeps masking across edits. Path-based
+            // metadata extraction is acceptable for plain R; for Rmd the
+            // `update_with_metadata` variant supplies masked-derived metadata.
+            let chunk_kind = state.chunk_kind;
             let content = state.contents.to_string();
             let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(
                 uri.path(),
                 &content,
             ));
             let (masked_text, tree, loaded_packages, artifacts) =
-                Self::compute_derived(uri, &content, metadata.as_ref());
+                Self::compute_derived(uri, chunk_kind, &content, metadata.as_ref());
             state.masked_text = masked_text;
             state.tree = tree;
             state.loaded_packages = loaded_packages;
@@ -536,11 +569,14 @@ impl DocumentStore {
 
             // `contents` stays RAW; tree/artifacts derive from the masked
             // analysis text for Rmd/Quarto. Caller-supplied `metadata` is
-            // already masked-derived for Rmd (backend.rs, #343).
+            // already masked-derived for Rmd (backend.rs, #343). The chunk kind
+            // is fixed at open and preserved across edits, so an untitled Rmd
+            // buffer keeps masking its tree/artifacts here.
+            let chunk_kind = state.chunk_kind;
             let content = state.contents.to_string();
             let metadata = Arc::new(metadata);
             let (masked_text, tree, loaded_packages, artifacts) =
-                Self::compute_derived(uri, &content, metadata.as_ref());
+                Self::compute_derived(uri, chunk_kind, &content, metadata.as_ref());
             state.masked_text = masked_text;
             state.tree = tree;
             state.loaded_packages = loaded_packages;
@@ -838,18 +874,20 @@ impl DocumentStore {
         crate::parser_pool::with_parser(|parser| parser.parse(content, None))
     }
 
-    /// Masked analysis text for an Rmd/Quarto `uri`, or `None` for plain R.
+    /// Masked analysis text for a document of the given [`ChunkKind`], or
+    /// `None` for plain R.
     ///
-    /// Pairs path-based classification with [`chunks::mask_to_r`] so the
-    /// `tree`/`metadata`/`artifacts` of an open `.Rmd`/`.qmd` document are
-    /// derived from R chunk bodies only, never prose (issue #343). `contents`
-    /// stays raw; this is purely the analysis view.
-    fn masked_text_for(uri: &Url, content: &str) -> Option<String> {
-        // Delegate to the shared classify-and-mask chokepoint so the two
-        // never drift; `Borrowed` means "plain R, analysis text == raw".
-        match crate::cross_file::analysis_text_for_path(uri.path(), content) {
-            std::borrow::Cow::Owned(masked) => Some(masked),
-            std::borrow::Cow::Borrowed(_) => None,
+    /// Masks via [`chunks::mask_to_r`](crate::chunks::mask_to_r) when
+    /// `chunk_kind` is [`ChunkKind::Rmd`] so the `tree`/`metadata`/`artifacts`
+    /// of an open `.Rmd`/`.qmd` document are derived from R chunk bodies only,
+    /// never prose (issue #343). `contents` stays raw; this is purely the
+    /// analysis view. The kind is the document's stored, open-time
+    /// classification — NOT re-derived by path — so untitled Rmd/Quarto
+    /// buffers (no file extension) mask correctly.
+    fn masked_text_for(chunk_kind: ChunkKind, content: &str) -> Option<String> {
+        match chunk_kind {
+            ChunkKind::Rmd => Some(crate::chunks::mask_to_r(content)),
+            ChunkKind::R => None,
         }
     }
 
@@ -862,8 +900,13 @@ impl DocumentStore {
     ///
     /// Returns `(masked_text, tree, loaded_packages, artifacts)`; the caller
     /// owns assembling the `DocumentState` (and keeps `contents` raw).
+    ///
+    /// `chunk_kind` is the document's stored, open-time classification (see
+    /// [`DocumentState::chunk_kind`]); `uri` is used only for artifact
+    /// attribution, never to re-derive masking (#343).
     fn compute_derived(
         uri: &Url,
+        chunk_kind: ChunkKind,
         content: &str,
         metadata: &CrossFileMetadata,
     ) -> (
@@ -872,7 +915,7 @@ impl DocumentStore {
         Vec<String>,
         Arc<ScopeArtifacts>,
     ) {
-        let masked_text = Self::masked_text_for(uri, content);
+        let masked_text = Self::masked_text_for(chunk_kind, content);
         let analysis_text = masked_text.as_deref().unwrap_or(content);
         let tree = Self::parse_content(analysis_text);
         let loaded_packages = Self::extract_packages(&tree, analysis_text);

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -885,9 +885,12 @@ impl DocumentStore {
     /// classification — NOT re-derived by path — so untitled Rmd/Quarto
     /// buffers (no file extension) mask correctly.
     fn masked_text_for(chunk_kind: ChunkKind, content: &str) -> Option<String> {
-        match chunk_kind {
-            ChunkKind::Rmd => Some(crate::chunks::mask_to_r(content)),
-            ChunkKind::R => None,
+        // Thin adapter over the shared `analysis_text_for_kind` chokepoint: it
+        // returns an owned masked string for Rmd and borrows `content` for plain
+        // R. Owned -> `Some(masked)`; Borrowed -> `None` (raw `content` is used).
+        match crate::cross_file::analysis_text_for_kind(chunk_kind, content) {
+            std::borrow::Cow::Owned(masked) => Some(masked),
+            std::borrow::Cow::Borrowed(_) => None,
         }
     }
 

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -83,24 +83,71 @@ pub struct DocumentStoreMetrics {
 /// Contains all data needed for LSP operations on an open document,
 /// including parsed AST, cross-file metadata, and scope artifacts.
 ///
+/// # Raw content vs. analysis text (Rmd/Quarto invariant)
+///
+/// Like [`crate::state::Document`], an open `DocumentState` keeps two views of
+/// its content distinct for R Markdown / Quarto (`.Rmd` / `.qmd`) documents:
+///
+/// * [`contents`](DocumentState::contents) is **always** the verbatim raw
+///   document — `ContentProvider::get_content` returns it unchanged, so raw
+///   consumers (snippets, find-references text scans for non-R languages) see
+///   the literal source.
+/// * [`tree`](DocumentState::tree), [`metadata`](DocumentState::metadata),
+///   [`artifacts`](DocumentState::artifacts), and
+///   [`loaded_packages`](DocumentState::loaded_packages) are derived from the
+///   **masked analysis text** ([`chunks::mask_to_r`](crate::chunks::mask_to_r))
+///   for Rmd docs, so the R parser and scope engine see only real R chunk
+///   bodies — never prose or YAML. Byte offsets in `tree` index into the masked
+///   analysis text, exposed by [`analysis_text()`](DocumentState::analysis_text);
+///   slicing `contents` with them mis-slices.
+///
+/// For plain R / JAGS / Stan the analysis text equals the raw text and the
+/// distinction collapses. `mask_to_r` is geometry-preserving, so `Position` /
+/// `Range` (line + UTF-16 column) values are interchangeable across the two
+/// views — only *byte* offsets are view-specific. Anything pairing `tree` with
+/// a text MUST use [`analysis_text()`](DocumentState::analysis_text).
+///
 /// **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
 pub struct DocumentState {
     /// Document URI
     pub uri: Url,
     /// LSP document version
     pub version: i32,
-    /// File content as a rope for efficient editing
+    /// File content as a rope for efficient editing (RAW, verbatim source)
     pub contents: Rope,
-    /// Parsed AST (None if parsing failed)
+    /// Masked analysis text for Rmd/Quarto documents
+    /// ([`chunks::mask_to_r`](crate::chunks::mask_to_r) of `contents`), `None`
+    /// for plain R / JAGS / Stan. The `tree`/`metadata`/`artifacts` are derived
+    /// from this when present. Exposed read-only via
+    /// [`analysis_text()`](DocumentState::analysis_text).
+    masked_text: Option<String>,
+    /// Parsed AST (None if parsing failed). Parsed from the analysis text
+    /// (masked for Rmd, raw otherwise).
     pub tree: Option<Tree>,
-    /// Packages loaded via library() calls
+    /// Packages loaded via library() calls (from chunk bodies for Rmd)
     pub loaded_packages: Vec<String>,
-    /// Cross-file metadata (source() calls, directives)
+    /// Cross-file metadata (source() calls, directives; chunk-derived for Rmd)
     pub metadata: Arc<CrossFileMetadata>,
-    /// Scope artifacts (exported symbols, timeline)
+    /// Scope artifacts (exported symbols, timeline; chunk-derived for Rmd)
     pub artifacts: Arc<ScopeArtifacts>,
     /// Internal revision counter for change detection
     pub revision: u64,
+}
+
+impl DocumentState {
+    /// The text the [`tree`](DocumentState::tree) was parsed from: the masked
+    /// analysis text for Rmd/Quarto documents, the raw text otherwise.
+    ///
+    /// Use this — never `contents.to_string()` — whenever you slice the
+    /// document by byte offsets taken from `tree`. For plain R / JAGS / Stan
+    /// this equals the raw text, so the choice is behavior-neutral there. See
+    /// the [`DocumentState`] type docs for the full raw-vs-analysis invariant.
+    pub fn analysis_text(&self) -> String {
+        match &self.masked_text {
+            Some(masked) => masked.clone(),
+            None => self.contents.to_string(),
+        }
+    }
 }
 
 impl DocumentState {
@@ -281,29 +328,21 @@ impl DocumentStore {
     /// * `version` - LSP document version
     pub async fn open(&mut self, uri: Url, content: &str, version: i32) {
         self.mark_update_started(&uri);
-        // Parse content
+        // Parse content. `contents` keeps the RAW source; tree/metadata/
+        // artifacts derive from the masked analysis text for Rmd/Quarto (#343).
         let contents = Rope::from_str(content);
-        let tree = Self::parse_content(content);
-        let loaded_packages = Self::extract_packages(&tree, content);
-        let metadata = Arc::new(crate::cross_file::extract_metadata(content));
-        let artifacts = Arc::new(if let Some(ref tree) = tree {
-            // Use compute_artifacts_with_metadata to include declared symbols from directives
-            // This ensures @lsp-var and @lsp-func declarations are included in scope resolution
-            // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-            crate::cross_file::scope::compute_artifacts_with_metadata(
-                &uri,
-                tree,
-                content,
-                Some(metadata.as_ref()),
-            )
-        } else {
-            ScopeArtifacts::default()
-        });
+        let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(
+            uri.path(),
+            content,
+        ));
+        let (masked_text, tree, loaded_packages, artifacts) =
+            Self::compute_derived(&uri, content, metadata.as_ref());
 
         let state = DocumentState {
             uri: uri.clone(),
             version,
             contents,
+            masked_text,
             tree,
             loaded_packages,
             metadata,
@@ -370,28 +409,20 @@ impl DocumentStore {
         metadata: CrossFileMetadata,
     ) {
         self.mark_update_started(&uri);
+        // `contents` keeps the RAW source; tree/artifacts derive from the
+        // masked analysis text for Rmd/Quarto. The caller-supplied `metadata`
+        // is used as-is — backend.rs already extracts it from the masked
+        // analysis text for Rmd docs (#343).
         let contents = Rope::from_str(content);
-        let tree = Self::parse_content(content);
-        let loaded_packages = Self::extract_packages(&tree, content);
         let metadata = Arc::new(metadata);
-        let artifacts = Arc::new(if let Some(ref tree) = tree {
-            // Use compute_artifacts_with_metadata to include declared symbols from directives
-            // This ensures @lsp-var and @lsp-func declarations are included in scope resolution
-            // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-            crate::cross_file::scope::compute_artifacts_with_metadata(
-                &uri,
-                tree,
-                content,
-                Some(metadata.as_ref()),
-            )
-        } else {
-            ScopeArtifacts::default()
-        });
+        let (masked_text, tree, loaded_packages, artifacts) =
+            Self::compute_derived(&uri, content, metadata.as_ref());
 
         let state = DocumentState {
             uri: uri.clone(),
             version,
             contents,
+            masked_text,
             tree,
             loaded_packages,
             metadata,
@@ -459,24 +490,21 @@ impl DocumentStore {
             state.version = version;
             state.revision += 1;
 
-            // Reparse and recompute derived data
+            // Reparse and recompute derived data. `contents` stays RAW;
+            // tree/metadata/artifacts derive from the masked analysis text for
+            // Rmd/Quarto (#343).
             let content = state.contents.to_string();
-            state.tree = Self::parse_content(&content);
-            state.loaded_packages = Self::extract_packages(&state.tree, &content);
-            state.metadata = Arc::new(crate::cross_file::extract_metadata(&content));
-            state.artifacts = Arc::new(if let Some(ref tree) = state.tree {
-                // Use compute_artifacts_with_metadata to include declared symbols from directives
-                // This ensures @lsp-var and @lsp-func declarations are included in scope resolution
-                // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-                crate::cross_file::scope::compute_artifacts_with_metadata(
-                    uri,
-                    tree,
-                    &content,
-                    Some(state.metadata.as_ref()),
-                )
-            } else {
-                ScopeArtifacts::default()
-            });
+            let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(
+                uri.path(),
+                &content,
+            ));
+            let (masked_text, tree, loaded_packages, artifacts) =
+                Self::compute_derived(uri, &content, metadata.as_ref());
+            state.masked_text = masked_text;
+            state.tree = tree;
+            state.loaded_packages = loaded_packages;
+            state.metadata = metadata;
+            state.artifacts = artifacts;
 
             // Update access order
             self.touch_access(uri);
@@ -506,23 +534,18 @@ impl DocumentStore {
             state.version = version;
             state.revision += 1;
 
+            // `contents` stays RAW; tree/artifacts derive from the masked
+            // analysis text for Rmd/Quarto. Caller-supplied `metadata` is
+            // already masked-derived for Rmd (backend.rs, #343).
             let content = state.contents.to_string();
-            state.tree = Self::parse_content(&content);
-            state.loaded_packages = Self::extract_packages(&state.tree, &content);
-            state.metadata = Arc::new(metadata);
-            state.artifacts = Arc::new(if let Some(ref tree) = state.tree {
-                // Use compute_artifacts_with_metadata to include declared symbols from directives
-                // This ensures @lsp-var and @lsp-func declarations are included in scope resolution
-                // **Validates: Requirements 5.1, 5.2, 5.3, 5.4** (Diagnostic suppression for declared symbols)
-                crate::cross_file::scope::compute_artifacts_with_metadata(
-                    uri,
-                    tree,
-                    &content,
-                    Some(state.metadata.as_ref()),
-                )
-            } else {
-                ScopeArtifacts::default()
-            });
+            let metadata = Arc::new(metadata);
+            let (masked_text, tree, loaded_packages, artifacts) =
+                Self::compute_derived(uri, &content, metadata.as_ref());
+            state.masked_text = masked_text;
+            state.tree = tree;
+            state.loaded_packages = loaded_packages;
+            state.metadata = metadata;
+            state.artifacts = artifacts;
 
             self.touch_access(uri);
             self.signal_update_complete(uri);
@@ -813,6 +836,57 @@ impl DocumentStore {
     /// Parse R content into a tree
     fn parse_content(content: &str) -> Option<Tree> {
         crate::parser_pool::with_parser(|parser| parser.parse(content, None))
+    }
+
+    /// Masked analysis text for an Rmd/Quarto `uri`, or `None` for plain R.
+    ///
+    /// Pairs path-based classification with [`chunks::mask_to_r`] so the
+    /// `tree`/`metadata`/`artifacts` of an open `.Rmd`/`.qmd` document are
+    /// derived from R chunk bodies only, never prose (issue #343). `contents`
+    /// stays raw; this is purely the analysis view.
+    fn masked_text_for(uri: &Url, content: &str) -> Option<String> {
+        match crate::chunks::classify_chunk_document(uri.path()) {
+            crate::chunks::ChunkKind::Rmd => Some(crate::chunks::mask_to_r(content)),
+            crate::chunks::ChunkKind::R => None,
+        }
+    }
+
+    /// Compute the analysis-derived fields (`masked_text`, `tree`,
+    /// `loaded_packages`, `artifacts`) for an open document from its RAW
+    /// `content`, parsing and extracting from the masked analysis text for
+    /// Rmd/Quarto and from raw text otherwise. The supplied `metadata` is used
+    /// for artifact computation (it must already be masked-derived for Rmd —
+    /// callers pass enriched metadata extracted from the same analysis text).
+    ///
+    /// Returns `(masked_text, tree, loaded_packages, artifacts)`; the caller
+    /// owns assembling the `DocumentState` (and keeps `contents` raw).
+    fn compute_derived(
+        uri: &Url,
+        content: &str,
+        metadata: &CrossFileMetadata,
+    ) -> (
+        Option<String>,
+        Option<Tree>,
+        Vec<String>,
+        Arc<ScopeArtifacts>,
+    ) {
+        let masked_text = Self::masked_text_for(uri, content);
+        let analysis_text = masked_text.as_deref().unwrap_or(content);
+        let tree = Self::parse_content(analysis_text);
+        let loaded_packages = Self::extract_packages(&tree, analysis_text);
+        let artifacts = Arc::new(if let Some(ref tree) = tree {
+            // Pair the tree with the analysis text it was parsed from so
+            // artifact byte offsets align (Requirements 5.1-5.4).
+            crate::cross_file::scope::compute_artifacts_with_metadata(
+                uri,
+                tree,
+                analysis_text,
+                Some(metadata),
+            )
+        } else {
+            ScopeArtifacts::default()
+        });
+        (masked_text, tree, loaded_packages, artifacts)
     }
 
     /// Extract loaded packages from parsed tree

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -356,7 +356,7 @@ impl DocumentStore {
             content,
         ));
         let (masked_text, tree, loaded_packages, artifacts) =
-            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref());
+            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref(), None);
 
         let state = DocumentState {
             uri: uri.clone(),
@@ -443,7 +443,7 @@ impl DocumentStore {
         let contents = Rope::from_str(content);
         let metadata = Arc::new(metadata);
         let (masked_text, tree, loaded_packages, artifacts) =
-            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref());
+            Self::compute_derived(&uri, chunk_kind, content, metadata.as_ref(), None);
 
         let state = DocumentState {
             uri: uri.clone(),
@@ -532,7 +532,7 @@ impl DocumentStore {
                 &content,
             ));
             let (masked_text, tree, loaded_packages, artifacts) =
-                Self::compute_derived(uri, chunk_kind, &content, metadata.as_ref());
+                Self::compute_derived(uri, chunk_kind, &content, metadata.as_ref(), None);
             state.masked_text = masked_text;
             state.tree = tree;
             state.loaded_packages = loaded_packages;
@@ -552,12 +552,21 @@ impl DocumentStore {
     ///
     /// Like `update`, but uses the provided metadata instead of extracting it.
     /// Use this when metadata has been enriched with inherited_working_directory.
+    ///
+    /// `precomputed_masked` is forwarded to
+    /// [`compute_derived`](Self::compute_derived): on the `did_change` hot path
+    /// the caller has already masked this exact raw content for this exact
+    /// `chunk_kind` (the legacy [`crate::state::Document`] masks it in
+    /// `apply_change`), so it hands the result in to avoid a second
+    /// [`chunks::mask_to_r`](crate::chunks::mask_to_r) pass per keystroke. Pass
+    /// `None` to mask here. It is consumed only for [`ChunkKind::Rmd`].
     pub async fn update_with_metadata(
         &mut self,
         uri: &Url,
         changes: Vec<TextDocumentContentChangeEvent>,
         version: i32,
         metadata: CrossFileMetadata,
+        precomputed_masked: Option<String>,
     ) {
         self.mark_update_started(uri);
         if let Some(state) = self.documents.get_mut(uri) {
@@ -575,8 +584,13 @@ impl DocumentStore {
             let chunk_kind = state.chunk_kind;
             let content = state.contents.to_string();
             let metadata = Arc::new(metadata);
-            let (masked_text, tree, loaded_packages, artifacts) =
-                Self::compute_derived(uri, chunk_kind, &content, metadata.as_ref());
+            let (masked_text, tree, loaded_packages, artifacts) = Self::compute_derived(
+                uri,
+                chunk_kind,
+                &content,
+                metadata.as_ref(),
+                precomputed_masked,
+            );
             state.masked_text = masked_text;
             state.tree = tree;
             state.loaded_packages = loaded_packages;
@@ -874,26 +888,6 @@ impl DocumentStore {
         crate::parser_pool::with_parser(|parser| parser.parse(content, None))
     }
 
-    /// Masked analysis text for a document of the given [`ChunkKind`], or
-    /// `None` for plain R.
-    ///
-    /// Masks via [`chunks::mask_to_r`](crate::chunks::mask_to_r) when
-    /// `chunk_kind` is [`ChunkKind::Rmd`] so the `tree`/`metadata`/`artifacts`
-    /// of an open `.Rmd`/`.qmd` document are derived from R chunk bodies only,
-    /// never prose (issue #343). `contents` stays raw; this is purely the
-    /// analysis view. The kind is the document's stored, open-time
-    /// classification — NOT re-derived by path — so untitled Rmd/Quarto
-    /// buffers (no file extension) mask correctly.
-    fn masked_text_for(chunk_kind: ChunkKind, content: &str) -> Option<String> {
-        // Thin adapter over the shared `analysis_text_for_kind` chokepoint: it
-        // returns an owned masked string for Rmd and borrows `content` for plain
-        // R. Owned -> `Some(masked)`; Borrowed -> `None` (raw `content` is used).
-        match crate::cross_file::analysis_text_for_kind(chunk_kind, content) {
-            std::borrow::Cow::Owned(masked) => Some(masked),
-            std::borrow::Cow::Borrowed(_) => None,
-        }
-    }
-
     /// Compute the analysis-derived fields (`masked_text`, `tree`,
     /// `loaded_packages`, `artifacts`) for an open document from its RAW
     /// `content`, parsing and extracting from the masked analysis text for
@@ -907,18 +901,35 @@ impl DocumentStore {
     /// `chunk_kind` is the document's stored, open-time classification (see
     /// [`DocumentState::chunk_kind`]); `uri` is used only for artifact
     /// attribution, never to re-derive masking (#343).
+    ///
+    /// `precomputed_masked` lets a caller that has *already* masked the same raw
+    /// content for this exact `chunk_kind` (e.g. the `did_change` path, where
+    /// [`crate::state::Document::apply_change`] just masked it) hand the result
+    /// in to skip a redundant [`chunks::mask_to_r`](crate::chunks::mask_to_r)
+    /// pass on the hot per-keystroke path. It is consumed only for
+    /// [`ChunkKind::Rmd`]; for plain R `masked_text` is always `None` and the
+    /// argument is ignored. Pass `None` to mask here. Correctness rests on the
+    /// caller's promise that it is the mask of the *same content and kind* — the
+    /// store does not (and cannot cheaply) re-verify it.
     fn compute_derived(
         uri: &Url,
         chunk_kind: ChunkKind,
         content: &str,
         metadata: &CrossFileMetadata,
+        precomputed_masked: Option<String>,
     ) -> (
         Option<String>,
         Option<Tree>,
         Vec<String>,
         Arc<ScopeArtifacts>,
     ) {
-        let masked_text = Self::masked_text_for(chunk_kind, content);
+        let masked_text = match chunk_kind {
+            // Reuse the caller's mask when supplied; otherwise mask via the
+            // shared chokepoint. Plain R never has masked text.
+            ChunkKind::Rmd => precomputed_masked
+                .or_else(|| crate::cross_file::masked_analysis_text(chunk_kind, content)),
+            ChunkKind::R => None,
+        };
         let analysis_text = masked_text.as_deref().unwrap_or(content);
         let tree = Self::parse_content(analysis_text);
         let loaded_packages = Self::extract_packages(&tree, analysis_text);

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -845,9 +845,11 @@ impl DocumentStore {
     /// derived from R chunk bodies only, never prose (issue #343). `contents`
     /// stays raw; this is purely the analysis view.
     fn masked_text_for(uri: &Url, content: &str) -> Option<String> {
-        match crate::chunks::classify_chunk_document(uri.path()) {
-            crate::chunks::ChunkKind::Rmd => Some(crate::chunks::mask_to_r(content)),
-            crate::chunks::ChunkKind::R => None,
+        // Delegate to the shared classify-and-mask chokepoint so the two
+        // never drift; `Borrowed` means "plain R, analysis text == raw".
+        match crate::cross_file::analysis_text_for_path(uri.path(), content) {
+            std::borrow::Cow::Owned(masked) => Some(masked),
+            std::borrow::Cow::Borrowed(_) => None,
         }
     }
 

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -175,6 +175,10 @@ impl DocumentState {
         // Rope content (approximate: chars * average bytes per char)
         let content_size = self.contents.len_bytes();
 
+        // Masked analysis text (Rmd/Quarto only): a near-full second copy of
+        // the document, so it must count toward the eviction budget.
+        let masked_size = self.masked_text.as_ref().map_or(0, |s| s.len());
+
         // Tree size (conservative estimate based on typical AST overhead)
         let tree_size = self.tree.as_ref().map(|_| content_size).unwrap_or(0);
 
@@ -195,7 +199,13 @@ impl DocumentState {
             + self.artifacts.exported_interface.len() * 128  // Approximate per-symbol size
             + self.artifacts.timeline.len() * 64;
 
-        base_size + content_size + tree_size + packages_size + metadata_size + artifacts_size
+        base_size
+            + content_size
+            + masked_size
+            + tree_size
+            + packages_size
+            + metadata_size
+            + artifacts_size
     }
 }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3405,14 +3405,16 @@ pub fn selection_range(
     // `descendant_for_point_range` would return the document root and surface a
     // nonsensical whole-document selection. Restrict to chunk-body positions
     // (checked against the RAW text, where fences/prose are still present).
-    let raw_text = doc.text();
-    let is_rmd = doc.is_rmd_document();
+    // Materialized lazily so plain-R requests (the common case) skip the clone.
+    let rmd_raw_text = doc.is_rmd_document().then(|| doc.text());
     let mut results = Vec::new();
     for pos in positions {
         // `position_in_r_chunk_body` re-scans the document per call (O(doc));
         // acceptable here because selection-range requests carry only the
         // active cursors (typically one or two positions).
-        if is_rmd && !crate::chunks::position_in_r_chunk_body(&raw_text, pos.line) {
+        if let Some(raw) = &rmd_raw_text
+            && !crate::chunks::position_in_r_chunk_body(raw, pos.line)
+        {
             continue;
         }
         let point = lsp_position_to_ts_point(&text, pos);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -86,6 +86,10 @@ pub(crate) fn empty_base_exports() -> &'static Arc<HashSet<String>> {
 pub(crate) struct DiagnosticsSnapshot {
     // Document data
     pub tree: tree_sitter::Tree,
+    /// Raw source text — `doc.text()`, not `doc.analysis_text()`.
+    /// Paired with `tree` only after the Rmd early-return at the top of
+    /// `diagnostics_from_snapshot` ensures they are never mixed; if Rmd
+    /// diagnostics are ever enabled, this field must switch to `analysis_text()`.
     pub text: String,
     // Cross-file state (pre-collected)
     pub directive_meta: crate::cross_file::CrossFileMetadata,
@@ -1350,9 +1354,12 @@ pub struct SymbolExtractor<'a> {
 impl<'a> SymbolExtractor<'a> {
     /// Create a new SymbolExtractor for the given source text and AST root node.
     ///
+    /// `text` must be the string the `root` node was parsed from — byte offsets
+    /// from the AST are resolved against it.
+    ///
     /// # Arguments
     ///
-    /// * `text` - The source text of the R document
+    /// * `text` - The source text the `root` node was parsed from
     /// * `root` - The root node of the tree-sitter parse tree
     ///
     /// # Examples
@@ -3754,6 +3761,8 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             // prose lines blanked. The Document carries the resolved kind so
             // untitled buffers (no file extension) still classify correctly via
             // their `languageId`.
+            // `extract_chunks` is purely text-based and never consults `self.root`, so
+            // pairing the analysis-text tree with the raw text is safe here.
             let chunk_extractor = SymbolExtractor::new(&text, tree.root_node());
             raw_symbols.extend(chunk_extractor.extract_chunks(doc.chunk_kind));
             raw_symbols

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3406,9 +3406,12 @@ pub fn selection_range(
     // nonsensical whole-document selection. Restrict to chunk-body positions
     // (checked against the RAW text, where fences/prose are still present).
     let raw_text = doc.text();
-    let is_rmd = doc.chunk_kind == crate::chunks::ChunkKind::Rmd;
+    let is_rmd = doc.is_rmd_document();
     let mut results = Vec::new();
     for pos in positions {
+        // `position_in_r_chunk_body` re-scans the document per call (O(doc));
+        // acceptable here because selection-range requests carry only the
+        // active cursors (typically one or two positions).
         if is_rmd && !crate::chunks::position_in_r_chunk_body(&raw_text, pos.line) {
             continue;
         }
@@ -12382,8 +12385,7 @@ pub fn completion(
     // Short-circuit unless the position is inside an R chunk body. The
     // chunk-position check uses the RAW text (fences are blanked in the masked
     // analysis text).
-    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd
-        && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
+    if doc.is_rmd_document() && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
     {
         return None;
     }
@@ -14273,8 +14275,7 @@ pub fn prepare_signature_help(
     // would already find nothing there, but an explicit guard makes the intent
     // clear and avoids any reliance on masking incidentally yielding no `call`
     // node. Checked against the RAW text (fences are blanked in the mask).
-    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd
-        && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
+    if doc.is_rmd_document() && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
     {
         return None;
     }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -288,7 +288,7 @@ impl DiagnosticsSnapshot {
             }
             base
         };
-        let lint_config = if state.lint_overrides.is_empty() {
+        let mut lint_config = if state.lint_overrides.is_empty() {
             base_lint_config
         } else {
             let merged = crate::config_file::merge_settings(
@@ -306,6 +306,15 @@ impl DiagnosticsSnapshot {
                 uri,
             )
         };
+        // The trailing-blank-lines rule describes the FILE's shape, but lints
+        // run on the masked analysis text, where the closing fence / prose
+        // after the last chunk is blanked — it would read as trailing blank
+        // lines at EOF on virtually every Rmd/Quarto document. The raw file's
+        // shape is Markdown, not R, so the rule simply doesn't apply to chunk
+        // documents. Mirrors `raven lint` (`cli/lint.rs` `walk`).
+        if doc.is_rmd_document() {
+            lint_config.trailing_blank_lines_severity = None;
+        }
 
         Some(DiagnosticsSnapshot {
             tree,
@@ -328,6 +337,16 @@ impl DiagnosticsSnapshot {
             parent_prefix_cache: std::cell::RefCell::new(scope::ParentPrefixCache::new()),
             scope_contribution: state.package_state.scope_contribution().clone(),
         })
+    }
+
+    /// True when `name` is the knitr/Quarto-injected `params` object of a
+    /// parameterized report: the document is Rmd/Quarto and its frontmatter
+    /// declares a top-level `params:` key (see
+    /// [`DiagnosticsSnapshot::rmd_declared_params`]). The undefined-variable
+    /// and out-of-scope collectors both treat such a use as a defined global;
+    /// this helper is the single source of that rule.
+    fn is_implicit_rmd_params(&self, name: &str) -> bool {
+        self.rmd_declared_params && name == "params"
     }
 
     /// Resolve cross-file scope from pre-collected snapshot data.
@@ -3409,18 +3428,31 @@ pub fn selection_range(
     let rmd_raw_text = doc.is_rmd_document().then(|| doc.text());
     let mut results = Vec::new();
     for pos in positions {
+        // The response is positional — `result[i]` answers `positions[i]` —
+        // so every requested position must yield exactly one entry. Positions
+        // with no meaningful selection (Rmd prose, no node at the point) get
+        // an empty range at the cursor (a no-op for "expand selection")
+        // rather than being dropped, which would misalign every later
+        // cursor's selection.
+        let empty_at_cursor = SelectionRange {
+            range: Range {
+                start: pos,
+                end: pos,
+            },
+            parent: None,
+        };
         // `position_in_r_chunk_body` re-scans the document per call (O(doc));
         // acceptable here because selection-range requests carry only the
         // active cursors (typically one or two positions).
         if let Some(raw) = &rmd_raw_text
             && !crate::chunks::position_in_r_chunk_body(raw, pos.line)
         {
+            results.push(empty_at_cursor);
             continue;
         }
         let point = lsp_position_to_ts_point(&text, pos);
-        if let Some(range) = build_selection_range(tree.root_node(), point, &text) {
-            results.push(range);
-        }
+        results
+            .push(build_selection_range(tree.root_node(), point, &text).unwrap_or(empty_at_cursor));
     }
 
     Some(results)
@@ -5294,13 +5326,10 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         if is_reserved_word(name) {
             continue;
         }
-        // knitr/Quarto-injected `params` is a defined global in parameterized
-        // Rmd/Quarto reports (frontmatter declares `params:`). The out-of-scope
-        // collector would otherwise misattribute a `params` use to a later
-        // `source()` whose target happens to export `params`. A matching guard
-        // in the undefined-variable collector keeps the two in sync; update
-        // both together. See `DiagnosticsSnapshot::rmd_declared_params`.
-        if snapshot.rmd_declared_params && name == "params" {
+        // knitr/Quarto-injected `params` (see `is_implicit_rmd_params`): the
+        // out-of-scope collector would otherwise misattribute a `params` use
+        // to a later `source()` whose target happens to export `params`.
+        if snapshot.is_implicit_rmd_params(name) {
             continue;
         }
 
@@ -5615,15 +5644,11 @@ fn collect_undefined_variables_from_snapshot(
             continue;
         }
 
-        // knitr/Quarto inject a `params` object into parameterized reports
-        // whose frontmatter declares a top-level `params:` key. The masked
-        // analysis text blanks that frontmatter, so `params` would otherwise
-        // be flagged undefined. Treat it as a defined global, but ONLY for
-        // Rmd/Quarto docs that actually declare it — plain .R files and Rmd
-        // docs without `params:` still flag legitimate uses. A matching guard
-        // in the out-of-scope collector keeps the two in sync; update both
-        // together. See `DiagnosticsSnapshot::rmd_declared_params`.
-        if snapshot.rmd_declared_params && name == "params" {
+        // knitr/Quarto-injected `params` (see `is_implicit_rmd_params`): the
+        // masked analysis text blanks the frontmatter, so a declared `params`
+        // would otherwise be flagged undefined. Plain .R files and Rmd docs
+        // without `params:` still flag legitimate uses.
+        if snapshot.is_implicit_rmd_params(&name) {
             continue;
         }
 
@@ -10543,6 +10568,32 @@ mod semantic_warning_pipeline_tests {
             !undefined_params_messages(&diags).is_empty(),
             "params must still be flagged in a plain .R file; got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn snapshot_disables_trailing_blank_lines_for_rmd_only() {
+        // Lints run on the masked analysis text, where the closing fence /
+        // prose after the last chunk is blanked — the file-shape
+        // trailing-blank-lines rule would misfire at EOF on virtually every
+        // Rmd. The snapshot build switches it off for Rmd/Quarto docs (the
+        // raw file's shape is Markdown, not R) while leaving plain .R alone.
+        let enable_lints = |state: &mut WorldState| {
+            state.lint_config = LintConfig {
+                enabled: true,
+                ..LintConfig::default()
+            };
+        };
+        let code = "```{r}\nx <- 1\n```\n\nClosing prose.\n";
+        let (snapshot, _) = build_rmd_snapshot(code, "file:///report.Rmd", enable_lints);
+        assert!(
+            snapshot.lint_config.trailing_blank_lines_severity.is_none(),
+            "trailing_blank_lines must be disabled for Rmd documents"
+        );
+        let (snapshot, _) = build_rmd_snapshot("x <- 1\n", "file:///plain.R", enable_lints);
+        assert!(
+            snapshot.lint_config.trailing_blank_lines_severity.is_some(),
+            "trailing_blank_lines must stay active for plain .R (default HINT)"
         );
     }
 
@@ -22295,13 +22346,25 @@ result <- data %>% filter(x > 0)
         let prose_pos = Position::new(6, 4); // inside "Some prose paragraph."
 
         // selection_range must NOT surface the whole-document root range for a
-        // blank masked (prose) line — it yields no range for that position.
+        // blank masked (prose) line. The response is positional (result[i]
+        // answers positions[i]), so the prose position still yields exactly
+        // one entry — an empty range at the cursor with no parent.
         let sel =
             super::selection_range(&state, &uri, vec![prose_pos]).expect("selection_range Some");
-        assert!(
-            sel.is_empty(),
-            "selection_range must be empty at a prose position, got {:?}",
+        assert_eq!(
+            sel.len(),
+            1,
+            "positional contract: one entry per requested position, got {:?}",
             sel
+        );
+        assert_eq!(
+            (sel[0].range.start, sel[0].range.end),
+            (prose_pos, prose_pos),
+            "prose position must yield an empty range at the cursor"
+        );
+        assert!(
+            sel[0].parent.is_none(),
+            "prose fallback must have no parent to expand to"
         );
 
         assert!(

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3716,11 +3716,18 @@ impl BlockDetector {
 pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolResponse> {
     let doc = state.get_document(uri)?;
     let tree = doc.tree.as_ref()?;
+    // Raw text drives the text-based detectors (chunk fences, `# %%` cells,
+    // section dividers, Stan/JAGS block scanning) that must see the verbatim
+    // document. The analysis text is what `tree` was parsed from, so AST symbol
+    // extraction (which slices by `tree` byte offsets) must use it instead.
+    // For plain R / JAGS / Stan the two are identical; only Rmd/Quarto differ,
+    // where the analysis text is the masked R body.
     let text = doc.text();
+    let analysis_text = doc.analysis_text();
 
     let raw_symbols = match doc.file_type {
         FileType::Stan => {
-            let extractor = SymbolExtractor::new(&text, tree.root_node());
+            let extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols =
                 extractor.extract_decorative_sections(ModelCommentStyle::DoubleSlash);
             raw_symbols.extend(collect_stan_document_symbols(&text));
@@ -3729,7 +3736,7 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             raw_symbols
         }
         FileType::Jags => {
-            let extractor = SymbolExtractor::new(&text, tree.root_node());
+            let extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols = extractor.extract_ast_symbols();
             raw_symbols.extend(extractor.extract_decorative_sections(ModelCommentStyle::Hash));
             raw_symbols.extend(extractor.extract_loops());
@@ -3737,18 +3744,24 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             raw_symbols
         }
         FileType::R => {
-            let extractor = SymbolExtractor::new(&text, tree.root_node());
-            let mut raw_symbols = extractor.extract_all();
-            // Surface R Markdown / Quarto code chunks and `.R` `# %%` cells
-            // in the outline. The Document carries the resolved kind so that
-            // untitled buffers (no file extension) still classify correctly
-            // via their `languageId`.
-            raw_symbols.extend(extractor.extract_chunks(doc.chunk_kind));
+            // AST symbols (assignments, S4, R6) and comment-section detection
+            // run against the analysis text so `tree` byte offsets align — for
+            // Rmd docs this surfaces real R symbols defined inside chunk bodies.
+            let ast_extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
+            let mut raw_symbols = ast_extractor.extract_all();
+            // Chunk detection (R Markdown / Quarto fences and `.R` `# %%` cells)
+            // must scan the RAW text: the masked analysis text has its fence and
+            // prose lines blanked. The Document carries the resolved kind so
+            // untitled buffers (no file extension) still classify correctly via
+            // their `languageId`.
+            let chunk_extractor = SymbolExtractor::new(&text, tree.root_node());
+            raw_symbols.extend(chunk_extractor.extract_chunks(doc.chunk_kind));
             raw_symbols
         }
     };
 
-    // Calculate line count for HierarchyBuilder
+    // Calculate line count for HierarchyBuilder. Geometry is identical between
+    // raw and analysis text, so either gives the same count; use the raw text.
     let line_count = text.lines().count() as u32;
 
     // Use HierarchyBuilder to build the hierarchical structure
@@ -4076,7 +4089,9 @@ fn collect_legacy_ast_symbols(
         }
         seen_uris.insert(uri.clone());
         if let Some(tree) = &doc.tree {
-            let text = doc.text();
+            // Pair the tree with the analysis text it was parsed from (masked
+            // for Rmd docs) so byte-offset slices in `collect_symbols` align.
+            let text = doc.analysis_text();
             let mut file_symbols = Vec::new();
             collect_symbols(tree.root_node(), &text, &mut file_symbols);
             let container_name = extract_container_name(uri);
@@ -14712,7 +14727,8 @@ pub fn goto_definition_with_cancel(
             continue;
         }
         if let Some(tree) = &doc.tree {
-            let file_text = doc.text();
+            // Analysis text (masked for Rmd) matches `tree`'s byte offsets.
+            let file_text = doc.analysis_text();
             if let Some(def_range) = find_definition_in_tree(tree.root_node(), name, &file_text) {
                 return Some(GotoDefinitionResponse::Scalar(Location {
                     uri: file_uri.clone(),
@@ -14731,7 +14747,8 @@ pub fn goto_definition_with_cancel(
             continue;
         }
         if let Some(tree) = &doc.tree {
-            let file_text = doc.text();
+            // Analysis text (masked for Rmd) matches `tree`'s byte offsets.
+            let file_text = doc.analysis_text();
             if let Some(def_range) = find_definition_in_tree(tree.root_node(), name, &file_text) {
                 return Some(GotoDefinitionResponse::Scalar(Location {
                     uri: file_uri.clone(),
@@ -15009,7 +15026,8 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
             continue;
         }
         if let Some(tree) = &doc.tree {
-            let file_text = doc.text();
+            // Analysis text (masked for Rmd) matches `tree`'s byte offsets.
+            let file_text = doc.analysis_text();
             find_references_in_tree(tree.root_node(), name, &file_text, file_uri, &mut locations);
         }
     }
@@ -15024,7 +15042,8 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
             continue;
         }
         if let Some(tree) = &doc.tree {
-            let file_text = doc.text();
+            // Analysis text (masked for Rmd) matches `tree`'s byte offsets.
+            let file_text = doc.analysis_text();
             find_references_in_tree(tree.root_node(), name, &file_text, file_uri, &mut locations);
         }
     }
@@ -15217,11 +15236,12 @@ fn find_user_function_signature(
     current_uri: &Url,
     name: &str,
 ) -> Option<String> {
-    // 1. Search current document
+    // 1. Search current document. Analysis text (masked for Rmd) matches the
+    //    tree's byte offsets; identical to raw text for plain R.
     if let Some(doc) = state.get_document(current_uri)
         && let Some(tree) = &doc.tree
     {
-        let text = doc.text();
+        let text = doc.analysis_text();
         if let Some(func_node) = find_function_definition_node(tree.root_node(), name, &text) {
             return Some(extract_function_signature(func_node, name, &text));
         }
@@ -15233,7 +15253,7 @@ fn find_user_function_signature(
             continue;
         }
         if let Some(tree) = &doc.tree {
-            let text = doc.text();
+            let text = doc.analysis_text();
             if let Some(func_node) = find_function_definition_node(tree.root_node(), name, &text) {
                 return Some(extract_function_signature(func_node, name, &text));
             }
@@ -15243,7 +15263,7 @@ fn find_user_function_signature(
     // 3. Search workspace index
     for doc in state.workspace_index.values() {
         if let Some(tree) = &doc.tree {
-            let text = doc.text();
+            let text = doc.analysis_text();
             if let Some(func_node) = find_function_definition_node(tree.root_node(), name, &text) {
                 return Some(extract_function_signature(func_node, name, &text));
             }
@@ -21886,10 +21906,10 @@ result <- data %>% filter(x > 0)
             DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
         };
 
-        // The outline should include both the `x` assignment (R-parsed) and
-        // the `setup` chunk (text-detected). We don't pin the count because
-        // the parser may or may not surface `x` depending on how the prose
-        // confuses tree-sitter-r; the chunk entry is the contract.
+        // The outline includes the `setup` chunk (text-detected from the raw
+        // text). Since Task 2 the masked analysis tree also surfaces the `x`
+        // assignment from the chunk body, nested under the chunk; here we only
+        // pin the chunk entry, which is the stable contract for this test.
         let chunk = symbols
             .iter()
             .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
@@ -21921,6 +21941,48 @@ result <- data %>% filter(x > 0)
             .find(|s| s.kind == SymbolKind::OBJECT && s.name == "setup")
             .expect("chunk entry");
         assert_eq!(chunk.range.start.line, 2);
+    }
+
+    #[test]
+    fn test_document_symbol_surfaces_chunk_body_function_for_rmd() {
+        // Task 2: the masked analysis tree lets AST symbol extraction surface
+        // real R symbols defined inside R chunk bodies, at the correct document
+        // line (ranges align by geometry). The chunk entry is still present.
+        use crate::state::{Document, WorldState};
+
+        let code = "---\ntitle: T\n---\n\nProse.\n\n```{r demo}\nmy_fun <- function(a) a + 1\n```\n\nMore prose.\n";
+        let uri = Url::parse("file:///report.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        // The chunk entry (text-detected from raw text) is still present.
+        let chunk = symbols
+            .iter()
+            .find(|s| s.kind == SymbolKind::OBJECT && s.name == "demo")
+            .expect("chunk entry");
+        assert_eq!(chunk.range.start.line, 6, "chunk header is on line 6");
+
+        // The function defined inside the chunk is now an outline symbol,
+        // nested under the chunk, at the correct document line (line 7).
+        let my_fun = chunk
+            .children
+            .as_ref()
+            .and_then(|kids| kids.iter().find(|s| s.name == "my_fun"))
+            .expect("my_fun should be surfaced under the chunk");
+        assert_eq!(my_fun.kind, SymbolKind::FUNCTION);
+        assert_eq!(
+            my_fun.range.start.line, 7,
+            "my_fun is defined on document line 7 (geometry preserved)"
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -3349,11 +3349,9 @@ fn cross_file_base_exports(state: &WorldState) -> Arc<HashSet<String>> {
 
 pub fn folding_range(state: &WorldState, uri: &Url) -> Option<Vec<FoldingRange>> {
     let doc = state.get_document(uri)?;
-    // Folding on prose/YAML would surface garbage AST regions; chunk-aware
-    // folding for Rmd/Quarto is a future feature.
-    if doc.is_rmd_document() {
-        return Some(Vec::new());
-    }
+    // For Rmd/Quarto the tree is parsed from the masked analysis text, so its
+    // nodes already cover only real R code inside chunk bodies — folding
+    // naturally yields chunk-body R folds and nothing on prose/YAML.
     let tree = doc.tree.as_ref()?;
     let mut ranges = Vec::new();
 
@@ -3399,14 +3397,21 @@ pub fn selection_range(
     positions: Vec<Position>,
 ) -> Option<Vec<SelectionRange>> {
     let doc = state.get_document(uri)?;
-    if doc.is_rmd_document() {
-        return Some(Vec::new());
-    }
     let tree = doc.tree.as_ref()?;
 
-    let text = doc.text();
+    // Byte offsets from `tree` index into the analysis text (masked for Rmd).
+    let text = doc.analysis_text();
+    // For Rmd, a prose position maps to a blank masked line, where
+    // `descendant_for_point_range` would return the document root and surface a
+    // nonsensical whole-document selection. Restrict to chunk-body positions
+    // (checked against the RAW text, where fences/prose are still present).
+    let raw_text = doc.text();
+    let is_rmd = doc.chunk_kind == crate::chunks::ChunkKind::Rmd;
     let mut results = Vec::new();
     for pos in positions {
+        if is_rmd && !crate::chunks::position_in_r_chunk_body(&raw_text, pos.line) {
+            continue;
+        }
         let point = lsp_position_to_ts_point(&text, pos);
         if let Some(range) = build_selection_range(tree.root_node(), point, &text) {
             results.push(range);
@@ -12371,12 +12376,20 @@ pub fn completion(
     context: Option<CompletionContext>,
 ) -> Option<CompletionResponse> {
     let doc = state.get_document(uri)?;
-    // Suppress R-style completions on prose/YAML lines in Rmd/Quarto.
-    // Chunk-aware completion inside fenced R blocks is a follow-up to #230.
-    if doc.is_rmd_document() {
+    // Rmd/Quarto: completions are first-class inside R chunk bodies, but a
+    // prose/YAML line maps to a blank masked line that the R logic below would
+    // treat as top-level R (offering R symbols while the user types prose).
+    // Short-circuit unless the position is inside an R chunk body. The
+    // chunk-position check uses the RAW text (fences are blanked in the masked
+    // analysis text).
+    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd
+        && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
+    {
         return None;
     }
-    let text = doc.text();
+    // Byte offsets paired with `tree` index into the analysis text (masked for
+    // Rmd). Behavior-neutral for plain R, where this equals the raw text.
+    let text = doc.analysis_text();
 
     // JAGS/Stan completion filtering
     match doc.file_type {
@@ -13489,11 +13502,15 @@ fn build_help_panel_link(topic: &str, package: &str) -> String {
 /// Returns `Some(Hover)` when information (definition, signature, package attribution, or help text) is available for the identifier at `position`, `None` when no useful hover content can be produced.
 pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<Hover> {
     let doc = state.get_document(uri)?;
-    if doc.file_type != FileType::R || doc.is_rmd_document() {
+    if doc.file_type != FileType::R {
         return None;
     }
     let tree = doc.tree.as_ref()?;
-    let text = doc.text();
+    // For Rmd the tree is parsed from the masked analysis text; pair byte
+    // offsets with it. A prose position maps to a blank masked line, so the
+    // identifier lookup below finds no `identifier`/`string` node and returns
+    // None — hover is naturally inert on prose without an explicit guard.
+    let text = doc.analysis_text();
 
     // Resolve the R executable path once for all help lookups in this hover call.
     // Falls back to "R" (PATH lookup) when no explicit path is configured.
@@ -14251,11 +14268,20 @@ pub fn prepare_signature_help(
     position: Position,
 ) -> Option<SignatureHelpContext> {
     let doc = state.get_document(uri)?;
-    if doc.is_rmd_document() {
+    // Rmd/Quarto: signature help is first-class inside R chunk bodies, but a
+    // prose position maps to a blank masked line. The call-node search below
+    // would already find nothing there, but an explicit guard makes the intent
+    // clear and avoids any reliance on masking incidentally yielding no `call`
+    // node. Checked against the RAW text (fences are blanked in the mask).
+    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd
+        && !crate::chunks::position_in_r_chunk_body(&doc.text(), position.line)
+    {
         return None;
     }
     let tree = doc.tree.as_ref()?;
-    let text = doc.text();
+    // Byte offsets paired with `tree` index into the analysis text (masked for
+    // Rmd); behavior-neutral for plain R.
+    let text = doc.analysis_text();
 
     let point = lsp_position_to_ts_point(&text, position);
 
@@ -14489,11 +14515,13 @@ pub fn goto_definition_with_cancel(
     let doc = state
         .get_document(uri)
         .or_else(|| state.workspace_index.get(uri))?;
-    if doc.is_rmd_document() {
-        return None;
-    }
     let tree = doc.tree.as_ref()?;
-    let text = doc.text();
+    // For Rmd the tree is parsed from the masked analysis text; pair byte
+    // offsets with it. A prose position maps to a blank masked line, so the
+    // identifier lookup below finds no `identifier` node and returns None —
+    // go-to-definition is naturally inert on prose. Behavior-neutral for plain
+    // R / JAGS / Stan, where this equals the raw text.
+    let text = doc.analysis_text();
 
     // Check for file path context first (source() calls and LSP directives)
     // Requirements 5.1-5.5, 6.1-6.5: Go-to-definition for file paths
@@ -14838,10 +14866,13 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
     let doc = state
         .get_document(uri)
         .or_else(|| state.workspace_index.get(uri))?;
-    if doc.is_rmd_document() {
-        return Some(Vec::new());
-    }
-    let text = doc.text();
+    // For Rmd the current-document tree is parsed from the masked analysis
+    // text; pair byte offsets with it (the cross-file/workspace arms below
+    // already use each document's analysis text or the content provider). A
+    // prose position maps to a blank masked line, so the identifier lookup
+    // returns None — references is naturally inert on prose. Behavior-neutral
+    // for plain R / JAGS / Stan.
+    let text = doc.analysis_text();
 
     if doc.file_type == FileType::Stan {
         let occurrences = collect_stan_identifier_occurrences(&text);
@@ -22011,70 +22042,205 @@ result <- data %>% filter(x > 0)
         );
     }
 
-    #[test]
-    fn test_r_handlers_suppressed_for_rmd_documents() {
-        // Every R-only handler that was gated in the Rmd routing change
-        // (issue #227) should return an empty/no-op response for Rmd
-        // documents. Diagnostics and completion have their own tests; this
-        // covers the remaining sync handlers in one place.
+    /// Multi-chunk Rmd fixture shared by the chunk-body language-feature tests.
+    /// `my_func` is defined in the first chunk and called in the last; lines:
+    ///
+    /// ```text
+    /// 0  ```{r}
+    /// 1  my_func <- function(x) {
+    /// 2    x + 1
+    /// 3  }
+    /// 4  ```
+    /// 5  (blank)
+    /// 6  Some prose paragraph.
+    /// 7  (blank)
+    /// 8  ```{r}
+    /// 9  my_func(2)
+    /// 10 ```
+    /// ```
+    fn rmd_handler_fixture() -> (crate::state::WorldState, Url) {
         use crate::state::{Document, WorldState};
-
-        let code = "Some prose.\n\n```{r}\nfn <- function(x) x\n```\n";
+        let code = "```{r}\nmy_func <- function(x) {\n  x + 1\n}\n```\n\nSome prose paragraph.\n\n```{r}\nmy_func(2)\n```\n";
         let uri = Url::parse("file:///doc.Rmd").unwrap();
         let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
         state
             .documents
             .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+        (state, uri)
+    }
 
-        let pos = Position::new(3, 0);
+    #[test]
+    fn test_r_handlers_active_in_rmd_chunk_body() {
+        // Issue #343 Task 4: the per-feature Rmd gates are gone; language
+        // features are first-class inside R chunk bodies. Every handler below
+        // operates on the masked analysis text, so byte offsets from `tree`
+        // line up with the document coordinates the request carries.
+        let (state, uri) = rmd_handler_fixture();
 
-        assert_eq!(
-            super::folding_range(&state, &uri),
-            Some(Vec::new()),
-            "folding_range"
-        );
-        assert_eq!(
-            super::selection_range(&state, &uri, vec![pos]),
-            Some(Vec::new()),
-            "selection_range"
-        );
+        // `my_func` is called on document line 9 (a chunk body); its
+        // definition is on line 1 of the same document.
+        let use_pos = Position::new(9, 0); // on `my_func` in `my_func(2)`
+
+        // folding_range: the multi-line function definition (lines 1-3) folds.
+        let folds = super::folding_range(&state, &uri).expect("folding_range Some");
         assert!(
-            super::prepare_signature_help(&state, &uri, pos).is_none(),
-            "prepare_signature_help"
+            folds.iter().any(|f| f.start_line == 1 && f.end_line == 3),
+            "the multi-line function in the chunk must yield a fold, got {:?}",
+            folds
+        );
+
+        // selection_range: expands within the chunk code (yields a non-empty,
+        // range hierarchy rooted at the cursor token). The hierarchy nests from
+        // outermost (`.range`) down through `.parent`; the innermost range —
+        // the deepest `.parent` — must hug the chunk-body token on line 9.
+        let sel =
+            super::selection_range(&state, &uri, vec![use_pos]).expect("selection_range Some");
+        assert_eq!(sel.len(), 1, "one selection range per requested position");
+        let mut innermost = &sel[0];
+        while let Some(parent) = &innermost.parent {
+            innermost = parent;
+        }
+        assert_eq!(
+            innermost.range.start.line, 9,
+            "innermost selection range must hug the chunk-body token on line 9"
+        );
+
+        // prepare_signature_help: cursor just inside `my_func(` resolves the
+        // chunk-defined function.
+        assert!(
+            super::prepare_signature_help(&state, &uri, Position::new(9, 8)).is_some(),
+            "signature help must resolve a chunk-defined function"
+        );
+
+        // goto_definition: from the use on line 9 to the def on line 1.
+        let goto = super::goto_definition_with_cancel(
+            &state,
+            &uri,
+            use_pos,
+            &crate::handlers::DiagCancelToken::never(),
+        )
+        .expect("goto_definition Some");
+        match goto {
+            GotoDefinitionResponse::Scalar(loc) => {
+                assert_eq!(loc.uri, uri, "definition is in the same document");
+                assert_eq!(
+                    loc.range.start.line, 1,
+                    "go-to-definition must land on the chunk-1 definition line"
+                );
+            }
+            other => panic!("expected a scalar location, got {:?}", other),
+        }
+
+        // references: both the definition (line 1) and the use (line 9).
+        let refs = super::references(&state, &uri, use_pos).expect("references Some");
+        let ref_lines: Vec<u32> = refs.iter().map(|l| l.range.start.line).collect();
+        assert!(
+            ref_lines.contains(&1) && ref_lines.contains(&9),
+            "references must find both the definition (line 1) and use (line 9), got {:?}",
+            ref_lines
+        );
+    }
+
+    #[test]
+    fn test_r_handlers_inert_at_rmd_prose_position() {
+        // The complement of `test_r_handlers_active_in_rmd_chunk_body`: at a
+        // prose position the masked analysis line is blank, so tree-driven
+        // handlers find no node/identifier and return empty/None. completion
+        // and signature help additionally carry an explicit prose guard.
+        let (state, uri) = rmd_handler_fixture();
+        let prose_pos = Position::new(6, 4); // inside "Some prose paragraph."
+
+        // selection_range must NOT surface the whole-document root range for a
+        // blank masked (prose) line — it yields no range for that position.
+        let sel =
+            super::selection_range(&state, &uri, vec![prose_pos]).expect("selection_range Some");
+        assert!(
+            sel.is_empty(),
+            "selection_range must be empty at a prose position, got {:?}",
+            sel
+        );
+
+        assert!(
+            super::prepare_signature_help(&state, &uri, prose_pos).is_none(),
+            "signature help must be None at a prose position"
         );
         assert!(
             super::goto_definition_with_cancel(
                 &state,
                 &uri,
-                pos,
+                prose_pos,
                 &crate::handlers::DiagCancelToken::never(),
             )
             .is_none(),
-            "goto_definition"
+            "goto_definition must be None at a prose position"
         );
-        assert_eq!(
-            super::references(&state, &uri, pos),
-            Some(Vec::new()),
-            "references"
+        // references finds no `identifier` node on the blank masked line, so it
+        // returns None (no results) — naturally inert.
+        let refs = super::references(&state, &uri, prose_pos);
+        assert!(
+            refs.as_ref().is_none_or(|r| r.is_empty()),
+            "references must yield no results at a prose position, got {:?}",
+            refs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hover_active_in_rmd_chunk_and_inert_in_prose() {
+        let (state, uri) = rmd_handler_fixture();
+
+        // Hovering the use of `my_func` on line 9 surfaces the definition
+        // extracted from chunk 1.
+        let hover = super::hover(&state, &uri, Position::new(9, 0)).await;
+        let hover = hover.expect("hover must return content for a chunk-defined function");
+        let HoverContents::Markup(markup) = hover.contents else {
+            panic!("expected markdown hover contents");
+        };
+        assert!(
+            markup.value.contains("my_func"),
+            "hover content must mention the function name, got {:?}",
+            markup.value
+        );
+
+        // Prose position: blank masked line → no identifier node → None.
+        assert!(
+            super::hover(&state, &uri, Position::new(6, 4))
+                .await
+                .is_none(),
+            "hover must be None at a prose position"
         );
     }
 
     #[test]
-    fn test_completion_suppressed_for_rmd_documents() {
+    fn test_completion_active_in_rmd_chunk_and_inert_in_prose() {
         use crate::state::{Document, WorldState};
 
-        let code = "Some prose with `library(`\n\n```{r}\nx <-\n```\n";
+        // `x` defined in chunk 1; completion partway through chunk 2 offers it.
+        let code = "```{r}\nx <- 1\n```\n\nSome prose with `library(`\n\n```{r}\nx\n```\n";
         let uri = Url::parse("file:///doc.Rmd").unwrap();
         let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
         state
             .documents
             .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
 
-        // Position 0, char 25 — inside the prose `library(` fragment.
-        let result = super::completion(&state, &uri, Position::new(0, 25), None);
+        // Document line 7 holds `x` inside the second chunk body. Completion at
+        // its end must offer the chunk-1 symbol `x`.
+        let result = super::completion(&state, &uri, Position::new(7, 1), None)
+            .expect("completion must return items inside a chunk body");
+        let CompletionResponse::Array(items) = result else {
+            panic!("expected a completion array");
+        };
         assert!(
-            result.is_none(),
-            "Rmd should yield no R completions on prose"
+            items.iter().any(|i| i.label == "x"),
+            "completion inside a chunk must offer the chunk-defined symbol `x`"
+        );
+
+        // Prose position (inside the `library(` fragment on line 4): the prose
+        // guard short-circuits before any R completion logic runs.
+        assert!(
+            super::completion(&state, &uri, Position::new(4, 25), None).is_none(),
+            "Rmd should yield no R completions on a prose line"
         );
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -13015,9 +13015,12 @@ pub fn extract_definition_statement(
     symbol: &ScopedSymbol,
     state: &WorldState,
 ) -> Option<DefinitionInfo> {
-    // Get content provider for the symbol's source file
+    // Get content provider for the symbol's source file.
+    // Use analysis_text() so that byte offsets from doc.tree (which was parsed
+    // from the masked text for Rmd/Quarto) agree with the string we slice.
+    // For plain R documents analysis_text() == text(), so this is neutral there.
     let content = if let Some(doc) = state.documents.get(&symbol.source_uri) {
-        doc.text()
+        doc.analysis_text()
     } else {
         state.cross_file_file_cache.get(&symbol.source_uri)?
     };
@@ -36333,6 +36336,59 @@ mod integration_tests {
         assert!(def_info.is_some());
         let def_info = def_info.unwrap();
         assert_eq!(def_info.statement, "my_var <- 42");
+    }
+
+    #[test]
+    fn test_extract_definition_statement_rmd_source_uri() {
+        // Regression: extract_definition_statement must use analysis_text() (the
+        // masked text) not text() when the source_uri is an Rmd document.  The
+        // tree's byte offsets reference the masked text; slicing the raw text
+        // with those offsets returns garbage (or panics on a char boundary).
+        use crate::cross_file::scope::{ScopedSymbol, SymbolKind};
+
+        let library_paths = r_env::find_library_paths();
+        let mut state = WorldState::new(library_paths);
+
+        // Build an Rmd document whose masked byte length differs from its raw
+        // length: a YAML front matter block (non-R, blanked by masking) followed
+        // by a chunk containing `my_var <- 42`.  The front-matter lines are each
+        // 3–14 bytes in the raw text but 0 bytes in the masked text, so any
+        // byte-slice against the wrong string will land in the wrong position.
+        let rmd_uri = Url::parse("file:///test/report.Rmd").unwrap();
+        let rmd_content = "---\ntitle: Demo\n---\n\n```{r}\nmy_var <- 42\n```\n";
+        // Confirm the invariant we rely on: masked and raw lengths differ.
+        let masked = crate::chunks::mask_to_r(rmd_content);
+        assert_ne!(
+            masked.len(),
+            rmd_content.len(),
+            "test precondition: masked byte length must differ from raw"
+        );
+
+        let doc = Document::new_with_uri(rmd_content, None, &rmd_uri);
+        state.documents.insert(rmd_uri.clone(), doc);
+
+        // `my_var <- 42` is on line 5 (0-based) in both the raw and masked text
+        // because masking preserves newlines.
+        let symbol = ScopedSymbol {
+            name: Arc::from("my_var"),
+            kind: SymbolKind::Variable,
+            source_uri: rmd_uri.clone(),
+            defined_line: 5,
+            defined_column: 0,
+            signature: None,
+            is_declared: false,
+        };
+
+        let def_info = extract_definition_statement(&symbol, &state);
+        assert!(
+            def_info.is_some(),
+            "extract_definition_statement must find the symbol in an Rmd document"
+        );
+        assert_eq!(
+            def_info.unwrap().statement,
+            "my_var <- 42",
+            "extracted statement must match the assignment inside the chunk"
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5292,9 +5292,9 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         // knitr/Quarto-injected `params` is a defined global in parameterized
         // Rmd/Quarto reports (frontmatter declares `params:`). The out-of-scope
         // collector would otherwise misattribute a `params` use to a later
-        // `source()` whose target happens to export `params`. Mirror the
-        // undefined-variable collector's guard. See
-        // `DiagnosticsSnapshot::rmd_declared_params`.
+        // `source()` whose target happens to export `params`. A matching guard
+        // in the undefined-variable collector keeps the two in sync; update
+        // both together. See `DiagnosticsSnapshot::rmd_declared_params`.
         if snapshot.rmd_declared_params && name == "params" {
             continue;
         }
@@ -5615,8 +5615,9 @@ fn collect_undefined_variables_from_snapshot(
         // analysis text blanks that frontmatter, so `params` would otherwise
         // be flagged undefined. Treat it as a defined global, but ONLY for
         // Rmd/Quarto docs that actually declare it — plain .R files and Rmd
-        // docs without `params:` still flag legitimate uses. See
-        // `DiagnosticsSnapshot::rmd_declared_params`.
+        // docs without `params:` still flag legitimate uses. A matching guard
+        // in the out-of-scope collector keeps the two in sync; update both
+        // together. See `DiagnosticsSnapshot::rmd_declared_params`.
         if snapshot.rmd_declared_params && name == "params" {
             continue;
         }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -735,20 +735,14 @@ pub fn semantic_tokens_for_rmd_document(text: &str) -> SemanticTokens {
     }
 
     for chunk in &chunks {
-        if !crate::chunks::is_r_chunk_language(&chunk.language) {
-            continue;
-        }
         // Body lines: lines after the header fence, up to but not including the
-        // closing fence (end_line is the last content line, inclusive). When
-        // body_start > end_line the chunk is empty — skip it.
-        let body_start = chunk.header_line.saturating_add(1);
-        if body_start > chunk.end_line {
+        // closing fence (end_line is the last content line, inclusive).
+        // `r_chunk_body_range` folds the R-language guard, the empty-chunk skip,
+        // and the EOF clamp into one shared chokepoint (see chunks.rs).
+        let Some((body_start, end_line)) = crate::chunks::r_chunk_body_range(chunk, total_lines)
+        else {
             continue;
-        }
-        if body_start >= total_lines {
-            continue;
-        }
-        let end_line = chunk.end_line.min(total_lines.saturating_sub(1));
+        };
         let body_lines = &document_lines[body_start as usize..=end_line as usize];
         let body_text = body_lines.join("\n");
         if body_text.is_empty() {
@@ -3754,31 +3748,35 @@ impl BlockDetector {
 pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolResponse> {
     let doc = state.get_document(uri)?;
     let tree = doc.tree.as_ref()?;
-    // Raw text drives the text-based detectors (chunk fences, `# %%` cells,
-    // section dividers, Stan/JAGS block scanning) that must see the verbatim
-    // document. The analysis text is what `tree` was parsed from, so AST symbol
-    // extraction (which slices by `tree` byte offsets) must use it instead.
-    // For plain R / JAGS / Stan the two are identical; only Rmd/Quarto differ,
-    // where the analysis text is the masked R body.
-    let text = doc.text();
+    // The analysis text is what `tree` was parsed from, so AST symbol extraction
+    // (which slices by `tree` byte offsets) must use it. The text-based detectors
+    // (chunk fences, `# %%` cells, section dividers, Stan/JAGS block scanning)
+    // must see the verbatim document. For plain R / JAGS / Stan the two are
+    // identical, so a single `analysis_text` binding serves both roles there;
+    // only Rmd/Quarto differ (analysis text is the masked R body), and only the
+    // R branch below materializes the raw text in that case.
     let analysis_text = doc.analysis_text();
 
     let raw_symbols = match doc.file_type {
         FileType::Stan => {
+            // Stan is never an Rmd document, so `analysis_text` is the verbatim
+            // text and serves the raw-text detectors too.
             let extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols =
                 extractor.extract_decorative_sections(ModelCommentStyle::DoubleSlash);
-            raw_symbols.extend(collect_stan_document_symbols(&text));
+            raw_symbols.extend(collect_stan_document_symbols(&analysis_text));
             raw_symbols.extend(extractor.extract_loops());
-            raw_symbols.extend(BlockDetector::detect_stan(&text));
+            raw_symbols.extend(BlockDetector::detect_stan(&analysis_text));
             raw_symbols
         }
         FileType::Jags => {
+            // JAGS is never an Rmd document, so `analysis_text` is the verbatim
+            // text and serves the raw-text block detector too.
             let extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols = extractor.extract_ast_symbols();
             raw_symbols.extend(extractor.extract_decorative_sections(ModelCommentStyle::Hash));
             raw_symbols.extend(extractor.extract_loops());
-            raw_symbols.extend(BlockDetector::detect_jags(&text));
+            raw_symbols.extend(BlockDetector::detect_jags(&analysis_text));
             raw_symbols
         }
         FileType::R => {
@@ -3788,21 +3786,26 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             let ast_extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols = ast_extractor.extract_all();
             // Chunk detection (R Markdown / Quarto fences and `.R` `# %%` cells)
-            // must scan the RAW text: the masked analysis text has its fence and
-            // prose lines blanked. The Document carries the resolved kind so
-            // untitled buffers (no file extension) still classify correctly via
-            // their `languageId`.
-            // `extract_chunks` is purely text-based and never consults `self.root`, so
-            // pairing the analysis-text tree with the raw text is safe here.
-            let chunk_extractor = SymbolExtractor::new(&text, tree.root_node());
+            // must scan the RAW text: an Rmd doc's masked analysis text has its
+            // fence and prose lines blanked. For plain R the raw text equals
+            // `analysis_text` (no `# %%` line is masked), so only an Rmd document
+            // needs a distinct raw-text materialization. The Document carries the
+            // resolved kind so untitled buffers (no file extension) still classify
+            // correctly via their `languageId`. `extract_chunks` is purely
+            // text-based and never consults `self.root`, so pairing the
+            // analysis-text tree with the raw text is safe here.
+            let rmd_raw_text = doc.is_rmd_document().then(|| doc.text());
+            let raw_text = rmd_raw_text.as_deref().unwrap_or(&analysis_text);
+            let chunk_extractor = SymbolExtractor::new(raw_text, tree.root_node());
             raw_symbols.extend(chunk_extractor.extract_chunks(doc.chunk_kind));
             raw_symbols
         }
     };
 
     // Calculate line count for HierarchyBuilder. Geometry is identical between
-    // raw and analysis text, so either gives the same count; use the raw text.
-    let line_count = text.lines().count() as u32;
+    // raw and analysis text, so either gives the same count; use the analysis
+    // text (always materialized).
+    let line_count = analysis_text.lines().count() as u32;
 
     // Use HierarchyBuilder to build the hierarchical structure
     let builder = HierarchyBuilder::new(raw_symbols, line_count);
@@ -10408,6 +10411,34 @@ mod invalid_assignment_target_tests {
     }
 }
 
+/// Build a `DiagnosticsSnapshot` for an Rmd document inserted directly into
+/// `state.documents` (so `get_enriched_metadata` resolves the masked
+/// `documents` arm rather than the raw DocumentStore entry). The `.Rmd`/`.qmd`
+/// URI makes the document classify as Rmd (masked analysis). `configure` runs
+/// before the document is inserted, so it can flip `lint_config`,
+/// `cross_file_config`, etc.
+///
+/// Shared file-level helper so `semantic_warning_pipeline_tests` and `tests`
+/// both build Rmd snapshots through one code path.
+#[cfg(test)]
+pub(crate) fn build_rmd_snapshot(
+    code: &str,
+    uri_str: &str,
+    configure: impl FnOnce(&mut crate::state::WorldState),
+) -> (DiagnosticsSnapshot, Url) {
+    use crate::state::{Document, WorldState};
+    let uri = Url::parse(uri_str).unwrap();
+    let mut state = WorldState::new(vec![]);
+    state.cross_file_config.diagnostics_enabled = true;
+    state.workspace_scan_complete = true;
+    configure(&mut state);
+    state
+        .documents
+        .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+    let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+    (snapshot, uri)
+}
+
 /// Regression guard: semantic-warning rules must fire through `diagnostics_from_snapshot`
 /// even when the style-lint master switch (`LintConfig::enabled`) is off.
 ///
@@ -10416,7 +10447,9 @@ mod invalid_assignment_target_tests {
 /// behind `run_lints` would silently suppress them for any user with linting disabled.
 #[cfg(test)]
 mod semantic_warning_pipeline_tests {
-    use super::{DiagCancelToken, DiagnosticsSnapshot, diagnostics_from_snapshot};
+    use super::{
+        DiagCancelToken, DiagnosticsSnapshot, build_rmd_snapshot, diagnostics_from_snapshot,
+    };
     use crate::linting::LintConfig;
     use crate::state::{Document, WorldState};
     use tower_lsp::lsp_types::Url;
@@ -10437,22 +10470,17 @@ mod semantic_warning_pipeline_tests {
         (snapshot, uri)
     }
 
-    /// Build a snapshot for a `.Rmd` document. The URI extension makes the
-    /// document classify as Rmd (masked analysis), exercising the
-    /// `params`-frontmatter recognition path.
-    fn build_rmd_snapshot(code: &str) -> (DiagnosticsSnapshot, Url) {
-        let uri = Url::parse("file:///report.Rmd").unwrap();
-        let mut state = WorldState::new(vec![]);
-        state.workspace_scan_complete = true;
-        state.lint_config = LintConfig {
-            enabled: false,
-            ..LintConfig::default()
-        };
-        state
-            .documents
-            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
-        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
-        (snapshot, uri)
+    /// Build a snapshot for a `.Rmd` document with the opt-in lint master switch
+    /// off, exercising the `params`-frontmatter recognition path. Wraps the
+    /// shared file-level [`build_rmd_snapshot`] with a configure closure that
+    /// disables linting (semantic rules must still fire).
+    fn build_rmd_snapshot_lint_disabled(code: &str) -> (DiagnosticsSnapshot, Url) {
+        build_rmd_snapshot(code, "file:///report.Rmd", |state| {
+            state.lint_config = LintConfig {
+                enabled: false,
+                ..LintConfig::default()
+            };
+        })
     }
 
     fn undefined_params_messages(diags: &[super::Diagnostic]) -> Vec<String> {
@@ -10471,7 +10499,7 @@ mod semantic_warning_pipeline_tests {
         // collector actually inspects it.
         let code =
             "---\ntitle: Report\nparams:\n  year: 2024\n---\n\n```{r}\nx <- params$year\n```\n";
-        let (snapshot, uri) = build_rmd_snapshot(code);
+        let (snapshot, uri) = build_rmd_snapshot_lint_disabled(code);
         assert!(snapshot.rmd_declared_params, "frontmatter declares params:");
         let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
             .expect("diagnostics returned");
@@ -10487,7 +10515,7 @@ mod semantic_warning_pipeline_tests {
         // Same chunk, but no `params:` in the frontmatter → `params` is a
         // genuinely undefined variable and must be flagged.
         let code = "---\ntitle: Report\n---\n\n```{r}\nx <- params$year\n```\n";
-        let (snapshot, uri) = build_rmd_snapshot(code);
+        let (snapshot, uri) = build_rmd_snapshot_lint_disabled(code);
         assert!(
             !snapshot.rmd_declared_params,
             "frontmatter does not declare params:"
@@ -22502,26 +22530,8 @@ result <- data %>% filter(x > 0)
     // would yield for the equivalent chunk-body content.
     // =====================================================================
 
-    /// Build a snapshot for an Rmd document inserted directly into
-    /// `state.documents` (so `get_enriched_metadata` resolves the masked
-    /// `documents` arm rather than the raw DocumentStore entry).
-    fn build_rmd_snapshot(
-        code: &str,
-        uri_str: &str,
-        configure: impl FnOnce(&mut crate::state::WorldState),
-    ) -> (DiagnosticsSnapshot, Url) {
-        use crate::state::{Document, WorldState};
-        let uri = Url::parse(uri_str).unwrap();
-        let mut state = WorldState::new(vec![]);
-        state.cross_file_config.diagnostics_enabled = true;
-        state.workspace_scan_complete = true;
-        configure(&mut state);
-        state
-            .documents
-            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
-        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
-        (snapshot, uri)
-    }
+    // `build_rmd_snapshot` is the shared file-level `#[cfg(test)]` helper (see
+    // above `mod semantic_warning_pipeline_tests`); pulled in via `use super::*`.
 
     fn rmd_diagnostics(
         code: &str,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -153,32 +153,21 @@ impl DiagnosticsSnapshot {
         // parsed from this exact text, so the two stay consistent and every
         // diagnostic range is a valid document coordinate.
         let text = doc.analysis_text();
-        let is_rmd = doc.chunk_kind == crate::chunks::ChunkKind::Rmd;
         // Get enriched metadata. The snapshot owns its `directive_meta` so it
         // can mutate `inherited_working_directory` in place; we deep-clone
         // only this single entry, while neighbors stay Arc-wrapped.
         //
-        // For Rmd/Quarto documents, derive metadata directly from the MASKED
-        // analysis text rather than `get_enriched_metadata`. The DocumentStore
-        // entry for an open Rmd doc is populated at did_open time from the RAW
-        // text (backend.rs), so `get_enriched_metadata` would otherwise return
-        // raw-derived metadata: a `# @lsp-cd` in prose would be (wrongly)
-        // honored as a directive, and `source()`/`library()` calls inside
-        // chunks would be missed. Re-extracting from `(text, tree)` — both
-        // masked — keeps directives prose-aware and chunk-call-aware.
-        // (Rewiring the DocumentStore did_open/did_change path to store
-        // masked-derived metadata is Task 5's territory; this snapshot-local
-        // re-derivation makes the diagnostics path correct in the meantime.)
-        let mut directive_meta = if is_rmd {
-            crate::cross_file::extract_metadata_with_tree(&text, Some(&tree))
-        } else {
-            state
-                .get_enriched_metadata(uri)
-                .map(std::sync::Arc::unwrap_or_clone)
-                .unwrap_or_else(|| {
-                    crate::cross_file::extract_metadata_with_tree(&text, Some(&tree))
-                })
-        };
+        // `get_enriched_metadata` is masked-correct for open Rmd/Quarto docs:
+        // the DocumentStore arm now stores metadata derived from the masked
+        // analysis text at did_open/did_change time (#343 Task 5), and the
+        // remaining tiers mask too. So a `# @lsp-cd` in prose is ignored while
+        // chunk `source()`/`library()` calls are captured — no Rmd special case
+        // needed here. The fallback re-extracts from the masked `(text, tree)`
+        // for the rare case where no enriched entry exists yet.
+        let mut directive_meta = state
+            .get_enriched_metadata(uri)
+            .map(std::sync::Arc::unwrap_or_clone)
+            .unwrap_or_else(|| crate::cross_file::extract_metadata_with_tree(&text, Some(&tree)));
         let metadata_elapsed = build_start.elapsed();
 
         // Compute inherited working directory if needed
@@ -15036,34 +15025,40 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
     // Search current document
     find_references_in_tree(tree.root_node(), name, &text, uri, &mut locations);
 
-    // Search all open documents using new DocumentStore
+    // Search all open documents using new DocumentStore.
+    // Pair the DocumentStore tree with its analysis text (masked for Rmd/Quarto,
+    // raw otherwise) — never `get_content` (which is RAW): the tree's byte
+    // offsets index into the masked text, so slicing raw content mis-slices
+    // (and can panic on a non-UTF-8 boundary) for `.Rmd`/`.qmd` files (#343).
     for file_uri in state.document_store.uris() {
         if &file_uri == uri {
             continue; // Already searched
         }
-        if let Some(content) = content_provider.get_content(&file_uri) {
-            // Parse the content to search for references
-            if let Some(doc_state) = state.document_store.get_without_touch(&file_uri)
-                && let Some(tree) = &doc_state.tree
-            {
-                find_references_in_tree(
-                    tree.root_node(),
-                    name,
-                    &content,
-                    &file_uri,
-                    &mut locations,
-                );
-            }
+        if let Some(doc_state) = state.document_store.get_without_touch(&file_uri)
+            && let Some(tree) = &doc_state.tree
+        {
+            let file_text = doc_state.analysis_text();
+            find_references_in_tree(
+                tree.root_node(),
+                name,
+                &file_text,
+                &file_uri,
+                &mut locations,
+            );
         }
     }
 
-    // Search workspace index using new WorkspaceIndex
+    // Search workspace index using new WorkspaceIndex. The entry's `tree` is
+    // parsed from the masked analysis text for Rmd/Quarto (on-demand indexing),
+    // while `contents` is RAW — pair the tree with the masked analysis view so
+    // byte offsets align (#343).
     for (file_uri, entry) in state.workspace_index_new.iter() {
         if &file_uri == uri || state.document_store.contains(&file_uri) {
             continue; // Already searched
         }
         if let Some(tree) = &entry.tree {
-            let file_text = entry.contents.to_string();
+            let raw = entry.contents.to_string();
+            let file_text = crate::cross_file::analysis_text_for_path(file_uri.path(), &raw);
             find_references_in_tree(
                 tree.root_node(),
                 name,

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -126,6 +126,16 @@ pub(crate) struct DiagnosticsSnapshot {
     // File type (from document, not URI — needed for untitled JAGS/Stan buffers)
     pub file_type: FileType,
 
+    /// True when this is an Rmd/Quarto document whose RAW YAML frontmatter
+    /// declares a top-level `params:` key. knitr/Quarto inject a `params`
+    /// object into the document's R environment for such reports, but the
+    /// masked analysis text blanks the frontmatter — so `params` appears
+    /// undefined. The undefined-variable and out-of-scope collectors treat
+    /// `params` as a defined global when this is set. Computed from
+    /// `doc.text()` (the RAW text) in [`DiagnosticsSnapshot::build`], because
+    /// `snapshot.text` is masked and no longer contains the frontmatter.
+    pub rmd_declared_params: bool,
+
     /// STEP 1 (parent walk) cache shared across all `get_scope` calls in this
     /// snapshot's diagnostic pass. STEP 1 is position-invariant within one
     /// pass for a given URI (parametrized only by `query_inside_function`),
@@ -153,6 +163,12 @@ impl DiagnosticsSnapshot {
         // parsed from this exact text, so the two stay consistent and every
         // diagnostic range is a valid document coordinate.
         let text = doc.analysis_text();
+        // Detect a `params:` frontmatter declaration on the RAW text (the
+        // analysis `text` above is masked, so its YAML frontmatter is blanked
+        // and would never reveal `params:`). Only Rmd/Quarto documents carry a
+        // knitr/Quarto-injected `params` object; plain .R files never do.
+        let rmd_declared_params =
+            doc.is_rmd_document() && crate::chunks::frontmatter_declares_params(&doc.text());
         // Get enriched metadata. The snapshot owns its `directive_meta` so it
         // can mutate `inherited_working_directory` in place; we deep-clone
         // only this single entry, while neighbors stay Arc-wrapped.
@@ -308,6 +324,7 @@ impl DiagnosticsSnapshot {
             cycle_closing_snippet,
             package_library: state.package_library.clone(),
             file_type: doc.file_type,
+            rmd_declared_params,
             parent_prefix_cache: std::cell::RefCell::new(scope::ParentPrefixCache::new()),
             scope_contribution: state.package_state.scope_contribution().clone(),
         })
@@ -5272,6 +5289,15 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         if is_reserved_word(name) {
             continue;
         }
+        // knitr/Quarto-injected `params` is a defined global in parameterized
+        // Rmd/Quarto reports (frontmatter declares `params:`). The out-of-scope
+        // collector would otherwise misattribute a `params` use to a later
+        // `source()` whose target happens to export `params`. Mirror the
+        // undefined-variable collector's guard. See
+        // `DiagnosticsSnapshot::rmd_declared_params`.
+        if snapshot.rmd_declared_params && name == "params" {
+            continue;
+        }
 
         // Stream-based visibility check. Collapses the original
         // `locally_resolved_usages` set + `scope.symbols.contains_key`
@@ -5581,6 +5607,17 @@ fn collect_undefined_variables_from_snapshot(
         }
 
         if is_builtin(&name) {
+            continue;
+        }
+
+        // knitr/Quarto inject a `params` object into parameterized reports
+        // whose frontmatter declares a top-level `params:` key. The masked
+        // analysis text blanks that frontmatter, so `params` would otherwise
+        // be flagged undefined. Treat it as a defined global, but ONLY for
+        // Rmd/Quarto docs that actually declare it — plain .R files and Rmd
+        // docs without `params:` still flag legitimate uses. See
+        // `DiagnosticsSnapshot::rmd_declared_params`.
+        if snapshot.rmd_declared_params && name == "params" {
             continue;
         }
 
@@ -10397,6 +10434,85 @@ mod semantic_warning_pipeline_tests {
             .insert(uri.clone(), Document::new(code, None));
         let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
         (snapshot, uri)
+    }
+
+    /// Build a snapshot for a `.Rmd` document. The URI extension makes the
+    /// document classify as Rmd (masked analysis), exercising the
+    /// `params`-frontmatter recognition path.
+    fn build_rmd_snapshot(code: &str) -> (DiagnosticsSnapshot, Url) {
+        let uri = Url::parse("file:///report.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+        state.lint_config = LintConfig {
+            enabled: false,
+            ..LintConfig::default()
+        };
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        (snapshot, uri)
+    }
+
+    fn undefined_params_messages(diags: &[super::Diagnostic]) -> Vec<String> {
+        diags
+            .iter()
+            .filter(|d| d.message.contains("Undefined variable: params"))
+            .map(|d| d.message.clone())
+            .collect()
+    }
+
+    #[test]
+    fn rmd_params_not_flagged_when_frontmatter_declares() {
+        // Frontmatter declares `params:` → knitr injects `params`, so a
+        // `params$year` use in a chunk must NOT be flagged undefined. The use
+        // is a bare statement (not a call argument), so the undefined-variable
+        // collector actually inspects it.
+        let code =
+            "---\ntitle: Report\nparams:\n  year: 2024\n---\n\n```{r}\nx <- params$year\n```\n";
+        let (snapshot, uri) = build_rmd_snapshot(code);
+        assert!(snapshot.rmd_declared_params, "frontmatter declares params:");
+        let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned");
+        assert!(
+            undefined_params_messages(&diags).is_empty(),
+            "params must not be flagged when frontmatter declares it; got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_params_flagged_when_frontmatter_absent() {
+        // Same chunk, but no `params:` in the frontmatter → `params` is a
+        // genuinely undefined variable and must be flagged.
+        let code = "---\ntitle: Report\n---\n\n```{r}\nx <- params$year\n```\n";
+        let (snapshot, uri) = build_rmd_snapshot(code);
+        assert!(
+            !snapshot.rmd_declared_params,
+            "frontmatter does not declare params:"
+        );
+        let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned");
+        assert!(
+            !undefined_params_messages(&diags).is_empty(),
+            "params must be flagged when frontmatter does not declare it; got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn plain_r_params_still_flagged() {
+        // Regression: a plain .R file using `params` is never an Rmd report, so
+        // the injection must not apply — `params` stays flagged.
+        let (snapshot, uri) = build_snapshot_with_lint_disabled("x <- params$year\n");
+        assert!(!snapshot.rmd_declared_params, "plain .R is never Rmd");
+        let diags = diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned");
+        assert!(
+            !undefined_params_messages(&diags).is_empty(),
+            "params must still be flagged in a plain .R file; got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -22298,6 +22298,89 @@ result <- data %>% filter(x > 0)
         );
     }
 
+    /// Open an untitled `.Rmd` buffer into the `DocumentStore` exactly as
+    /// `did_open` does for an editor `languageId: "rmd"` — no file extension,
+    /// classified by languageId. Before #343's untitled-buffer fix the store
+    /// re-classified by path, parsed the buffer RAW, and leaked prose symbols.
+    async fn open_untitled_rmd(state: &mut crate::state::WorldState, uri: &Url, content: &str) {
+        let chunk_kind = crate::chunks::classify_chunk_document_for(Some("rmd"), uri.path());
+        let meta = crate::cross_file::extract_metadata(&crate::chunks::mask_to_r(content));
+        state
+            .document_store
+            .open_with_metadata(uri.clone(), content, 1, chunk_kind, meta)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_references_skip_untitled_rmd_prose() {
+        // Adversarial probe: a `.R` file references `data_helper`; an untitled
+        // Rmd buffer mentions `data_helper` only in PROSE (its chunk does not).
+        // find-references from the .R file must NOT return a location inside the
+        // untitled Rmd's prose — the buffer's tree must be masked (#343).
+        use crate::state::Document;
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+
+        let r_uri = Url::parse("file:///main.R").unwrap();
+        let r_code = "data_helper <- function() 1\ndata_helper()\n";
+        state
+            .documents
+            .insert(r_uri.clone(), Document::new_with_uri(r_code, None, &r_uri));
+
+        // Untitled Rmd: `data_helper` appears in prose; the R chunk defines an
+        // unrelated function, so a correctly-masked buffer yields no reference.
+        let untitled = Url::parse("untitled:Untitled-1").unwrap();
+        let rmd = "We call data_helper in this report.\n\n```{r}\nother_fn <- function() 2\n```\n";
+        open_untitled_rmd(&mut state, &untitled, rmd).await;
+
+        // Query references for `data_helper` from the .R file (line 1, the use).
+        let refs = super::references(&state, &r_uri, Position::new(1, 0))
+            .expect("references must resolve from the .R file");
+        assert!(
+            refs.iter().all(|loc| loc.uri != untitled),
+            "find-references must not surface a location in the untitled Rmd's prose, got {:?}",
+            refs
+        );
+        // Sanity: the .R definition + use are still found.
+        assert!(
+            refs.iter().any(|loc| loc.uri == r_uri),
+            "find-references must still find the .R occurrences, got {:?}",
+            refs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_symbol_untitled_rmd_chunk_not_prose() {
+        // workspace/symbol on a workspace whose only open document is an untitled
+        // Rmd must surface a CHUNK-defined function and must NOT surface a
+        // prose-"defined" one. Pre-fix, the buffer's artifacts came from a
+        // RAW parse, exposing prose tokens and missing chunk symbols (#343).
+        let mut state = WorldState::new(vec![]);
+        state.workspace_scan_complete = true;
+
+        let untitled = Url::parse("untitled:Untitled-2").unwrap();
+        // Prose contains an assignment-looking line `prose_symbol <- 1` that a
+        // RAW parse would treat as a top-level definition; the real chunk
+        // defines `chunk_symbol`.
+        let rmd =
+            "prose_symbol <- 1 in prose, not code.\n\n```{r}\nchunk_symbol <- function() 3\n```\n";
+        open_untitled_rmd(&mut state, &untitled, rmd).await;
+
+        let chunk_hits = super::workspace_symbol(&state, "chunk_symbol").unwrap_or_default();
+        assert!(
+            chunk_hits.iter().any(|s| s.name == "chunk_symbol"),
+            "workspace/symbol must surface the chunk-defined `chunk_symbol`, got {:?}",
+            chunk_hits.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+
+        let prose_hits = super::workspace_symbol(&state, "prose_symbol").unwrap_or_default();
+        assert!(
+            !prose_hits.iter().any(|s| s.name == "prose_symbol"),
+            "workspace/symbol must NOT surface the prose-only `prose_symbol`, got {:?}",
+            prose_hits.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
     #[tokio::test]
     async fn test_hover_active_in_rmd_chunk_and_inert_in_prose() {
         let (state, uri) = rmd_handler_fixture();

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -86,10 +86,13 @@ pub(crate) fn empty_base_exports() -> &'static Arc<HashSet<String>> {
 pub(crate) struct DiagnosticsSnapshot {
     // Document data
     pub tree: tree_sitter::Tree,
-    /// Raw source text — `doc.text()`, not `doc.analysis_text()`.
-    /// Paired with `tree` only after the Rmd early-return at the top of
-    /// `diagnostics_from_snapshot` ensures they are never mixed; if Rmd
-    /// diagnostics are ever enabled, this field must switch to `analysis_text()`.
+    /// Analysis text — `doc.analysis_text()`, the masked text for Rmd/Quarto
+    /// documents and the raw text for everything else. Paired with `tree`,
+    /// whose byte offsets reference this exact text (never `doc.text()`); the
+    /// two MUST stay consistent so every diagnostic range is a valid document
+    /// coordinate. For plain R / JAGS / Stan this equals the raw text, so the
+    /// choice is behavior-neutral there. See the [`crate::state::Document`]
+    /// type docs for the full raw-vs-analysis invariant.
     pub text: String,
     // Cross-file state (pre-collected)
     pub directive_meta: crate::cross_file::CrossFileMetadata,
@@ -122,10 +125,6 @@ pub(crate) struct DiagnosticsSnapshot {
 
     // File type (from document, not URI — needed for untitled JAGS/Stan buffers)
     pub file_type: FileType,
-    /// Chunk-detection kind for the document, captured from the document so
-    /// that untitled Rmd/Quarto buffers (no file extension) still classify
-    /// correctly. Used to gate diagnostics for prose-bearing documents.
-    pub chunk_kind: crate::chunks::ChunkKind,
 
     /// STEP 1 (parent walk) cache shared across all `get_scope` calls in this
     /// snapshot's diagnostic pass. STEP 1 is position-invariant within one
@@ -150,14 +149,36 @@ impl DiagnosticsSnapshot {
         let build_start = std::time::Instant::now();
         let doc = state.get_document(uri)?;
         let tree = doc.tree.as_ref()?.clone();
-        let text = doc.text();
+        // Analysis text (masked for Rmd/Quarto, raw otherwise). `tree` was
+        // parsed from this exact text, so the two stay consistent and every
+        // diagnostic range is a valid document coordinate.
+        let text = doc.analysis_text();
+        let is_rmd = doc.chunk_kind == crate::chunks::ChunkKind::Rmd;
         // Get enriched metadata. The snapshot owns its `directive_meta` so it
         // can mutate `inherited_working_directory` in place; we deep-clone
         // only this single entry, while neighbors stay Arc-wrapped.
-        let mut directive_meta = state
-            .get_enriched_metadata(uri)
-            .map(std::sync::Arc::unwrap_or_clone)
-            .unwrap_or_else(|| crate::cross_file::extract_metadata_with_tree(&text, Some(&tree)));
+        //
+        // For Rmd/Quarto documents, derive metadata directly from the MASKED
+        // analysis text rather than `get_enriched_metadata`. The DocumentStore
+        // entry for an open Rmd doc is populated at did_open time from the RAW
+        // text (backend.rs), so `get_enriched_metadata` would otherwise return
+        // raw-derived metadata: a `# @lsp-cd` in prose would be (wrongly)
+        // honored as a directive, and `source()`/`library()` calls inside
+        // chunks would be missed. Re-extracting from `(text, tree)` — both
+        // masked — keeps directives prose-aware and chunk-call-aware.
+        // (Rewiring the DocumentStore did_open/did_change path to store
+        // masked-derived metadata is Task 5's territory; this snapshot-local
+        // re-derivation makes the diagnostics path correct in the meantime.)
+        let mut directive_meta = if is_rmd {
+            crate::cross_file::extract_metadata_with_tree(&text, Some(&tree))
+        } else {
+            state
+                .get_enriched_metadata(uri)
+                .map(std::sync::Arc::unwrap_or_clone)
+                .unwrap_or_else(|| {
+                    crate::cross_file::extract_metadata_with_tree(&text, Some(&tree))
+                })
+        };
         let metadata_elapsed = build_start.elapsed();
 
         // Compute inherited working directory if needed
@@ -298,7 +319,6 @@ impl DiagnosticsSnapshot {
             cycle_closing_snippet,
             package_library: state.package_library.clone(),
             file_type: doc.file_type,
-            chunk_kind: doc.chunk_kind,
             parent_prefix_cache: std::cell::RefCell::new(scope::ParentPrefixCache::new()),
             scope_contribution: state.package_state.scope_contribution().clone(),
         })
@@ -369,13 +389,10 @@ pub(crate) fn diagnostics_from_snapshot(
         return Some(Vec::new());
     }
 
-    // Suppress diagnostics for R Markdown / Quarto documents. The tree-sitter
-    // R parser sees prose, YAML, and non-R fenced blocks as garbage, so every
-    // non-R line becomes a syntax error. The outline still works (see
-    // `document_symbol`); only the diagnostic noise is gated.
-    if snapshot.chunk_kind == crate::chunks::ChunkKind::Rmd {
-        return Some(Vec::new());
-    }
+    // Rmd/Quarto documents are diagnosed against their MASKED analysis text
+    // (`snapshot.text` / `snapshot.tree`): prose, YAML, and non-R fenced blocks
+    // are blanked, so only real R chunk-body content is analyzed and every
+    // diagnostic lands at the correct document coordinate (issue #343).
 
     let mut diagnostics = Vec::new();
 
@@ -4323,12 +4340,9 @@ pub fn diagnostics(state: &WorldState, uri: &Url, cancel: &DiagCancelToken) -> V
         return Vec::new();
     }
 
-    // Suppress diagnostics for R Markdown / Quarto documents — prose lines
-    // would otherwise surface as spurious syntax errors. See the matching
-    // guard in `diagnostics_from_snapshot`.
-    if doc.chunk_kind == crate::chunks::ChunkKind::Rmd {
-        return Vec::new();
-    }
+    // Rmd/Quarto documents ARE diagnosed (issue #343): the snapshot pipeline
+    // analyzes the masked analysis text, so only real R chunk-body content is
+    // checked. See `diagnostics_from_snapshot`.
 
     // Delegate to the snapshot-based pipeline (the same path used by the
     // debounced production pipeline in `run_debounced_diagnostics`). Issue
@@ -22065,27 +22079,249 @@ result <- data %>% filter(x > 0)
     }
 
     #[test]
-    fn test_diagnostics_suppressed_for_rmd_documents() {
-        // The R tree-sitter parser sees prose as garbage. Gating prevents
-        // every non-R line from surfacing as a syntax error.
+    fn test_diagnostics_enabled_for_rmd_documents() {
+        // Chunk-aware diagnostics (issue #343): the masked analysis text means
+        // the R parser only sees real R code inside chunk bodies, so prose,
+        // YAML, and markdown links no longer surface as spurious syntax errors,
+        // while real errors inside chunks ARE flagged at document coordinates.
         use crate::state::{Document, WorldState};
 
-        let prose_with_chunk =
+        // Prose-only-plus-valid-chunk Rmd: no diagnostics. The link `[a](url)`
+        // and the heading would each be a syntax error if parsed as raw text.
+        let prose_with_valid_chunk =
             "# A heading\n\nSome prose with [a link](url).\n\n```{r}\nx <- 1\n```\n";
         let uri = Url::parse("file:///doc.Rmd").unwrap();
         let mut state = WorldState::new(vec![]);
         state.cross_file_config.diagnostics_enabled = true;
         state.documents.insert(
             uri.clone(),
-            Document::new_with_uri(prose_with_chunk, None, &uri),
+            Document::new_with_uri(prose_with_valid_chunk, None, &uri),
         );
-
         let diags = super::diagnostics(&state, &uri, &DiagCancelToken::never());
         assert!(
             diags.is_empty(),
-            "Rmd documents should produce zero diagnostics, got {} ({:?})",
+            "prose + a valid chunk should produce zero diagnostics, got {} ({:?})",
             diags.len(),
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+
+        // An R syntax error inside a chunk body IS now flagged.
+        let prose_with_broken_chunk =
+            "# A heading\n\nSome prose with [a link](url).\n\n```{r}\nx <- (\n```\n";
+        let uri2 = Url::parse("file:///broken.Rmd").unwrap();
+        state.documents.insert(
+            uri2.clone(),
+            Document::new_with_uri(prose_with_broken_chunk, None, &uri2),
+        );
+        let diags2 = super::diagnostics(&state, &uri2, &DiagCancelToken::never());
+        assert!(
+            !diags2.is_empty(),
+            "a syntax error inside a chunk must be flagged for Rmd documents"
+        );
+        // The error must be on the chunk body line (line 5), not on a prose line.
+        assert!(
+            diags2
+                .iter()
+                .all(|d| d.range.start.line == 5 && d.range.end.line == 5),
+            "all diagnostics must land on the chunk body line 5, got {:?}",
+            diags2
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // =====================================================================
+    // Chunk-aware diagnostics for Rmd/Quarto documents (issue #343).
+    //
+    // These exercise `DiagnosticsSnapshot::build` + `diagnostics_from_snapshot`
+    // end-to-end on Rmd documents. Geometry-preserving masking (Task 1/2) means
+    // every diagnostic lands at the same document coordinates a plain-R file
+    // would yield for the equivalent chunk-body content.
+    // =====================================================================
+
+    /// Build a snapshot for an Rmd document inserted directly into
+    /// `state.documents` (so `get_enriched_metadata` resolves the masked
+    /// `documents` arm rather than the raw DocumentStore entry).
+    fn build_rmd_snapshot(
+        code: &str,
+        uri_str: &str,
+        configure: impl FnOnce(&mut crate::state::WorldState),
+    ) -> (DiagnosticsSnapshot, Url) {
+        use crate::state::{Document, WorldState};
+        let uri = Url::parse(uri_str).unwrap();
+        let mut state = WorldState::new(vec![]);
+        state.cross_file_config.diagnostics_enabled = true;
+        state.workspace_scan_complete = true;
+        configure(&mut state);
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        (snapshot, uri)
+    }
+
+    fn rmd_diagnostics(
+        code: &str,
+        uri_str: &str,
+        configure: impl FnOnce(&mut crate::state::WorldState),
+    ) -> Vec<Diagnostic> {
+        let (snapshot, uri) = build_rmd_snapshot(code, uri_str, configure);
+        diagnostics_from_snapshot(&snapshot, &uri, &DiagCancelToken::never())
+            .expect("diagnostics returned")
+    }
+
+    #[test]
+    fn rmd_snapshot_flags_syntax_error_in_chunk_at_document_coords() {
+        // Header on line 4, body `x <- (` on line 5 (a syntax error).
+        let code = "# Title\n\nprose here\n\n```{r}\nx <- (\n```\n";
+        let diags = rmd_diagnostics(code, "file:///syntax.Rmd", |_| {});
+        assert!(
+            !diags.is_empty(),
+            "the chunk's syntax error must be flagged"
+        );
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
+            "a syntax-error (ERROR) diagnostic is expected, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.severity, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            diags.iter().all(|d| d.range.start.line == 5),
+            "every diagnostic must land on document line 5 (the chunk body), got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_snapshot_does_not_flag_prose() {
+        // YAML front matter, markdown headings, links, and prose around one
+        // valid chunk must all be silent.
+        let code = "---\ntitle: \"Report\"\nauthor: Me\n---\n\n# Heading\n\nSee [the docs](https://example.com) for [more](url).\n\nSome *emphasis* and `inline code`.\n\n```{r}\nx <- 1\nprint(x)\n```\n\nClosing prose.\n";
+        let diags = rmd_diagnostics(code, "file:///prose.Rmd", |_| {});
+        assert!(
+            diags.is_empty(),
+            "prose / YAML / markdown must not produce diagnostics, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_snapshot_ignores_non_r_chunk() {
+        // A `{python}` chunk whose contents are invalid R must be ignored:
+        // the masked text blanks the python body entirely.
+        let code = "# Title\n\n```{python}\nx = (\ndef broken(:\n```\n\nMore prose.\n";
+        let diags = rmd_diagnostics(code, "file:///python.Rmd", |_| {});
+        assert!(
+            diags.is_empty(),
+            "non-R chunk contents must not be diagnosed, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_cross_chunk_variable_resolves() {
+        // `x` is defined in chunk 1 and used in chunk 3; the masked analysis
+        // text concatenates all R chunk bodies into one tree, so `x` resolves
+        // across chunks and is NOT flagged as undefined.
+        let code = "```{r}\nx <- 1\n```\n\nProse paragraph.\n\n```{r}\ny <- 2\n```\n\nMore prose.\n\n```{r}\nprint(x)\n```\n";
+        let diags = rmd_diagnostics(code, "file:///cross.Rmd", |_| {});
+        assert!(
+            !diags.iter().any(|d| d.message == "Undefined variable: x"),
+            "x defined in an earlier chunk must resolve in a later chunk, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_undefined_var_in_chunk_flagged() {
+        // A bare undefined symbol used inside a chunk is flagged at document
+        // coordinates. Undefined-variable diagnostics require
+        // `workspace_scan_complete` (set by the helper).
+        let code = "# Title\n\nprose\n\n```{r}\ntotally_undefined_symbol\n```\n";
+        let diags = rmd_diagnostics(code, "file:///undef.Rmd", |_| {});
+        let undef = diags
+            .iter()
+            .find(|d| d.message == "Undefined variable: totally_undefined_symbol")
+            .unwrap_or_else(|| {
+                panic!(
+                    "undefined symbol must be flagged, got {:?}",
+                    diags
+                        .iter()
+                        .map(|d| (d.range.start.line, d.message.clone()))
+                        .collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            undef.range.start.line, 5,
+            "the diagnostic must be on document line 5 (the chunk body)"
+        );
+    }
+
+    #[test]
+    fn rmd_nolint_inside_chunk_respected() {
+        // A lint-triggering line inside a chunk carrying `# nolint` must be
+        // suppressed; the same rule must still fire on a sibling line without
+        // the marker (proving the lint pipeline is actually running).
+        let code = "# Title\n\n```{r}\nx<-1 # nolint\ny<-2\n```\n";
+        let diags = rmd_diagnostics(code, "file:///nolint.Rmd", |state| {
+            state.lint_config = crate::linting::LintConfig {
+                enabled: true,
+                infix_spaces_severity: Some(DiagnosticSeverity::WARNING),
+                ..crate::linting::LintConfig::default()
+            };
+        });
+        // Line 3 (`x<-1 # nolint`) must be suppressed.
+        assert!(
+            !diags.iter().any(|d| d.range.start.line == 3),
+            "`# nolint` on line 3 must suppress lint diagnostics there, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+        // Line 4 (`y<-2`, no marker) must still be flagged.
+        assert!(
+            diags.iter().any(|d| d.range.start.line == 4),
+            "the infix-spaces lint must still fire on the un-suppressed line 4, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rmd_eval_false_chunk_still_diagnosed() {
+        // `eval=FALSE` only affects knitr execution, not static analysis: a
+        // syntax error inside such a chunk is still flagged.
+        let code = "# Title\n\n```{r, eval=FALSE}\nx <- (\n```\n";
+        let diags = rmd_diagnostics(code, "file:///eval.Rmd", |_| {});
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Some(DiagnosticSeverity::ERROR) && d.range.start.line == 3),
+            "a syntax error inside an eval=FALSE chunk must still be flagged on line 3, got {:?}",
+            diags
+                .iter()
+                .map(|d| (d.range.start.line, d.message.clone()))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -22332,7 +22332,9 @@ result <- data %>% filter(x > 0)
     /// re-classified by path, parsed the buffer RAW, and leaked prose symbols.
     async fn open_untitled_rmd(state: &mut crate::state::WorldState, uri: &Url, content: &str) {
         let chunk_kind = crate::chunks::classify_chunk_document_for(Some("rmd"), uri.path());
-        let meta = crate::cross_file::extract_metadata(&crate::chunks::mask_to_r(content));
+        let meta = crate::cross_file::extract_metadata(&crate::cross_file::analysis_text_for_kind(
+            chunk_kind, content,
+        ));
         state
             .document_store
             .open_with_metadata(uri.clone(), content, 1, chunk_kind, meta)

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -708,7 +708,7 @@ pub fn semantic_tokens_for_rmd_document(text: &str) -> SemanticTokens {
     }
 
     for chunk in &chunks {
-        if !is_r_chunk_language(&chunk.language) {
+        if !crate::chunks::is_r_chunk_language(&chunk.language) {
             continue;
         }
         // Body lines: lines after the header fence, up to but not including the
@@ -751,14 +751,6 @@ pub fn semantic_tokens_for_rmd_document(text: &str) -> SemanticTokens {
         result_id: None,
         data: encode_semantic_tokens(absolute_tokens),
     }
-}
-
-/// True for chunk language tags that should be tokenized as R. Pandoc/knitr
-/// permit a few aliases (`r`, `R`, plus the rare `Rscript`). The chunk
-/// detector lower-cases the tag before storing it, so a simple ASCII compare
-/// is sufficient here.
-fn is_r_chunk_language(language: &str) -> bool {
-    matches!(language, "r" | "rscript")
 }
 
 fn semantic_tokens_for_r_tree(root: Node, text: &str) -> SemanticTokens {

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -413,10 +413,12 @@ pub(crate) fn get_text_and_tree(
         }
     }
 
-    // 2. Legacy open documents
+    // 2. Legacy open documents. Return the analysis text (masked for Rmd) so
+    //    the caller's byte-offset slices into `tree` align; identical to the
+    //    raw text for plain R / JAGS / Stan.
     if let Some(doc) = state.documents.get(uri) {
         if let Some(tree) = &doc.tree {
-            return Some((doc.text(), tree.clone()));
+            return Some((doc.analysis_text(), tree.clone()));
         } else {
             log::debug!("Document found but has no parsed tree: {}", uri);
         }
@@ -434,10 +436,10 @@ pub(crate) fn get_text_and_tree(
         }
     }
 
-    // 4. Legacy workspace index
+    // 4. Legacy workspace index (analysis text, see step 2).
     if let Some(doc) = state.workspace_index.get(uri) {
         if let Some(tree) = &doc.tree {
-            return Some((doc.text(), tree.clone()));
+            return Some((doc.analysis_text(), tree.clone()));
         } else {
             log::debug!("Document in workspace_index has no parsed tree: {}", uri);
         }
@@ -469,7 +471,10 @@ fn resolve_from_current_file(
 ) -> Option<FunctionSignature> {
     let doc = state.get_document(uri)?;
     let tree = doc.tree.as_ref()?;
-    let text = doc.text();
+    // Analysis text (masked for Rmd) matches `tree`'s byte offsets; equals the
+    // raw text for plain R. Signature help is gated for Rmd at the entry point,
+    // but pairing the tree with the analysis text is the correct invariant.
+    let text = doc.analysis_text();
 
     // Search for the nearest function definition before cursor position
     let func_node =

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -404,10 +404,13 @@ pub(crate) fn get_text_and_tree(
     state: &WorldState,
     uri: &Url,
 ) -> Option<(String, tree_sitter::Tree)> {
-    // 1. Enriched open documents (authoritative for open files)
+    // 1. Enriched open documents (authoritative for open files). Return the
+    //    analysis text (masked for Rmd/Quarto, raw otherwise) so the caller's
+    //    byte-offset slices into `tree` align — `contents` is RAW and would
+    //    mis-slice (or panic on a non-UTF-8 boundary) for `.Rmd`/`.qmd` (#343).
     if let Some(doc) = state.document_store.get_without_touch(uri) {
         if let Some(tree) = &doc.tree {
-            return Some((doc.contents.to_string(), tree.clone()));
+            return Some((doc.analysis_text(), tree.clone()));
         } else {
             log::debug!("Document in document_store has no parsed tree: {}", uri);
         }
@@ -424,10 +427,15 @@ pub(crate) fn get_text_and_tree(
         }
     }
 
-    // 3. New workspace index (indexed closed files)
+    // 3. New workspace index (indexed closed files). The entry's `tree` is
+    //    parsed from the masked analysis text for Rmd/Quarto (on-demand
+    //    indexing), while `contents` is RAW — pair the tree with the masked
+    //    analysis view so byte offsets align (#343).
     if let Some(entry) = state.workspace_index_new.get(uri) {
         if let Some(tree) = &entry.tree {
-            return Some((entry.contents.to_string(), tree.clone()));
+            let raw = entry.contents.to_string();
+            let text = crate::cross_file::analysis_text_for_path(uri.path(), &raw).into_owned();
+            return Some((text, tree.clone()));
         } else {
             log::debug!(
                 "Document in workspace_index_new has no parsed tree: {}",
@@ -445,10 +453,15 @@ pub(crate) fn get_text_and_tree(
         }
     }
 
-    // 5. File cache — content available but no pre-parsed tree; parse on demand
+    // 5. File cache — content available but no pre-parsed tree; parse on demand.
+    //    The cache stores RAW content; parse (and return) the masked analysis
+    //    text for Rmd/Quarto so a closed `.Rmd` resolves chunk-defined symbols
+    //    rather than failing closed, and the (text, tree) pair stays aligned
+    //    (raw == analysis for plain R, so this is behavior-neutral there) (#343).
     if let Some(content) = state.cross_file_file_cache.get(uri) {
-        if let Some(tree) = crate::parser_pool::with_parser(|p| p.parse(&content, None)) {
-            return Some((content, tree));
+        let analysis = crate::cross_file::analysis_text_for_path(uri.path(), &content).into_owned();
+        if let Some(tree) = crate::parser_pool::with_parser(|p| p.parse(&analysis, None)) {
+            return Some((analysis, tree));
         } else {
             log::debug!("Failed to parse file cache content for: {}", uri);
         }
@@ -2018,5 +2031,108 @@ mod property_tests {
                 first_key
             );
         }
+    }
+
+    // -- get_text_and_tree raw/masked pairing (#343, final adversarial review) --
+
+    /// Rmd source whose chunk defines `myfun`, preceded by MULTIBYTE prose.
+    ///
+    /// `mask_to_r` blanks the prose lines but preserves line count, so the
+    /// masked analysis text is SHORTER (in bytes) than the raw source. The
+    /// chunk-defined function's byte offsets in the masked tree therefore land
+    /// at *different* byte positions than the same text in the raw source — and
+    /// the raw source's multibyte prose means those offsets can fall mid-char,
+    /// panicking `&text[start..end]`. Pairing the masked tree with the raw text
+    /// is the regressed behavior this test locks out.
+    const MULTIBYTE_RMD: &str = "Prélude éééé éééé éééé\n\n```{r}\nmyfun <- function(alpha, beta) {\n  alpha + beta\n}\n```\n";
+
+    /// Mirror of `resolve_from_cross_file`'s post-`get_text_and_tree` slicing:
+    /// locate `myfun`'s definition at its known line and extract its formals.
+    /// Returns the parameter names. Panics if the (text, tree) pair mis-aligns
+    /// on a char boundary — exactly the regression under test.
+    fn extract_params_via_get_text_and_tree(state: &WorldState, uri: &Url) -> Vec<String> {
+        let (text, tree) =
+            get_text_and_tree(state, uri).expect("get_text_and_tree must find the document");
+        // `myfun` is defined on document line 3 (0-based) in MULTIBYTE_RMD.
+        let func_node = find_function_definition_at_line(tree.root_node(), "myfun", &text, 3)
+            .expect("function definition must be found at line 3");
+        let params_node = func_node
+            .children(&mut func_node.walk())
+            .find(|c| c.kind() == "parameters")
+            .expect("function must have a parameters node");
+        extract_from_ast(params_node, &text)
+            .into_iter()
+            .map(|p| p.name)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn get_text_and_tree_pairs_masked_tree_with_masked_text_document_store_arm() {
+        // DocumentStore arm (step 1): an open `.Rmd` whose chunk defines a
+        // function, reached via cross-file resolution. Before the fix this
+        // returned RAW text paired with the masked tree, panicking on the
+        // multibyte prose (or silently mis-slicing for ASCII prose).
+        let uri = Url::parse("file:///doc.Rmd").unwrap();
+        let mut state = WorldState::new(vec![]);
+        state
+            .document_store
+            .open(uri.clone(), MULTIBYTE_RMD, 1)
+            .await;
+
+        let params = extract_params_via_get_text_and_tree(&state, &uri);
+        assert_eq!(
+            params,
+            vec!["alpha".to_string(), "beta".to_string()],
+            "chunk-defined function's formals must extract from the masked analysis text"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_text_and_tree_pairs_masked_tree_with_masked_text_workspace_index_arm() {
+        // workspace_index_new arm (step 3): an on-demand-indexed (closed) `.Rmd`
+        // pairs a masked `tree` with RAW `contents`. Mirror that construction
+        // and confirm `get_text_and_tree` returns the masked analysis text so
+        // the tree's byte offsets align.
+        use crate::cross_file::file_cache::FileSnapshot;
+
+        let uri = Url::parse("file:///closed.Rmd").unwrap();
+        let analysis = crate::cross_file::analysis_text_for_path(uri.path(), MULTIBYTE_RMD);
+        let tree = crate::parser_pool::with_parser(|p| p.parse(analysis.as_ref(), None));
+        let metadata = std::sync::Arc::new(crate::cross_file::extract_metadata_with_tree(
+            &analysis,
+            tree.as_ref(),
+        ));
+        let artifacts = std::sync::Arc::new(match tree.as_ref() {
+            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                &uri,
+                tree,
+                &analysis,
+                Some(&metadata),
+            ),
+            None => crate::cross_file::scope::ScopeArtifacts::default(),
+        });
+        let entry = crate::workspace_index::IndexEntry {
+            // RAW contents, as on-demand indexing stores them (#343).
+            contents: ropey::Rope::from_str(MULTIBYTE_RMD),
+            tree,
+            loaded_packages: Vec::new(),
+            snapshot: FileSnapshot {
+                mtime: std::time::SystemTime::UNIX_EPOCH,
+                size: MULTIBYTE_RMD.len() as u64,
+                content_hash: None,
+            },
+            metadata,
+            artifacts,
+            indexed_at_version: 0,
+        };
+        let state = WorldState::new(vec![]);
+        state.workspace_index_new.insert(uri.clone(), entry);
+
+        let params = extract_params_via_get_text_and_tree(&state, &uri);
+        assert_eq!(
+            params,
+            vec!["alpha".to_string(), "beta".to_string()],
+            "chunk-defined function's formals must extract from the masked analysis text"
+        );
     }
 }

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -145,7 +145,36 @@ use crate::package_library::PackageLibrary;
 use crate::parameter_resolver::SignatureCache;
 use crate::workspace_index::WorkspaceIndex;
 
-/// A parsed document
+/// A parsed document.
+///
+/// # Raw text vs. analysis text (Rmd/Quarto invariant)
+///
+/// A `Document` carries two views of its content that are deliberately kept
+/// distinct for R Markdown / Quarto (`ChunkKind::Rmd`) documents:
+///
+/// * **Raw view** — [`contents`](Document::contents) / [`text()`](Document::text)
+///   is *always* the verbatim document as the editor sees it. Anything that
+///   operates on the literal source uses this: LSP incremental sync, chunk/fence
+///   detection, the Markdown outline, raw snippet retrieval, knit/run-chunk, and
+///   semantic-token re-detection of chunks.
+///
+/// * **Analysis view** — [`tree`](Document::tree) together with
+///   [`analysis_text()`](Document::analysis_text). For an Rmd document these are
+///   derived from [`chunks::mask_to_r`]: every non-R-chunk-body line is blanked
+///   so the R tree-sitter parser sees only real R code. All AST work — parsing,
+///   scope/symbol extraction, diagnostics, completion, hover — must pair
+///   `tree` with `analysis_text()`, **never** with `text()`. Byte offsets in
+///   `tree` index into `analysis_text()`; slicing `text()` with them mis-slices
+///   (and can panic on a non-UTF-8 boundary) because the masked text is a
+///   different byte string of a different length.
+///
+/// For plain R / JAGS / Stan documents `analysis_text()` *is* `text()` and the
+/// distinction collapses, so behavior-neutral call sites may use either.
+///
+/// `mask_to_r` is **geometry-preserving**: line count and the line/column of
+/// every kept R-body character are identical between the two views. Therefore
+/// `Position`/`Range` values (line + UTF-16 column) are interchangeable across
+/// the two; only *byte* offsets are view-specific.
 #[derive(Clone)]
 pub struct Document {
     pub contents: Rope,
@@ -157,6 +186,11 @@ pub struct Document {
     /// (i.e. `# %%` cells) otherwise. Mirrors the client-side classifier in
     /// `editors/vscode/src/chunks/chunk-detector.ts`.
     pub chunk_kind: ChunkKind,
+    /// Masked analysis text for Rmd/Quarto documents (`chunks::mask_to_r` of the
+    /// raw contents), or `None` for plain R / JAGS / Stan. The `tree` is parsed
+    /// from this when present. Kept in sync with `contents` by `apply_change`.
+    /// Exposed read-only via [`analysis_text()`](Document::analysis_text).
+    masked_text: Option<String>,
     pub version: Option<i32>,
     pub revision: u64,
 }
@@ -168,9 +202,10 @@ impl Document {
     }
 
     pub fn new_with_uri(text: &str, version: Option<i32>, uri: &Url) -> Self {
-        let mut doc = Self::new_with_file_type(text, version, file_type_from_uri(uri));
-        doc.chunk_kind = classify_chunk_document(uri.path());
-        doc
+        // Determine the chunk kind BEFORE parsing: for Rmd/Quarto documents the
+        // tree must be parsed from the masked analysis text, not the raw text.
+        let chunk_kind = classify_chunk_document(uri.path());
+        Self::new_with_kind(text, version, file_type_from_uri(uri), chunk_kind)
     }
 
     pub fn new_with_language_id(
@@ -179,33 +214,59 @@ impl Document {
         uri: &Url,
         language_id: Option<&str>,
     ) -> Self {
-        let mut doc = Self::new_with_file_type(
+        // Determine the chunk kind BEFORE parsing (see `new_with_uri`).
+        let chunk_kind = classify_chunk_document_for(language_id, uri.path());
+        Self::new_with_kind(
             text,
             version,
             file_type_from_language_id_or_uri(language_id, uri),
-        );
-        doc.chunk_kind = classify_chunk_document_for(language_id, uri.path());
-        doc
+            chunk_kind,
+        )
     }
 
     pub fn new_with_file_type(text: &str, version: Option<i32>, file_type: FileType) -> Self {
+        // No URI/languageId signal, so default to `# %%` cell detection.
+        Self::new_with_kind(text, version, file_type, ChunkKind::R)
+    }
+
+    /// Shared constructor: builds the analysis representation up front so the
+    /// `tree` is parsed from the right text (masked for Rmd, raw otherwise) and
+    /// `loaded_packages` is extracted from the same `(tree, text)` pair.
+    fn new_with_kind(
+        text: &str,
+        version: Option<i32>,
+        file_type: FileType,
+        chunk_kind: ChunkKind,
+    ) -> Self {
         let contents = Rope::from_str(text);
-        let tree = parse_document(&contents, file_type);
-        let loaded_packages = extract_loaded_packages(&tree, text);
+        // Mask Rmd/Quarto bodies so the R parser only sees real R code; plain R
+        // (and JAGS/Stan) keep their raw text.
+        let masked_text = if chunk_kind == ChunkKind::Rmd {
+            Some(crate::chunks::mask_to_r(text))
+        } else {
+            None
+        };
+        let analysis_text = masked_text.as_deref().unwrap_or(text);
+        let tree = parse_document_text(analysis_text, file_type);
+        // Extract from the SAME text the tree was parsed from, so `library()`
+        // calls inside chunks are found and prose mentions are not.
+        let loaded_packages = extract_loaded_packages(&tree, analysis_text);
         Self {
             contents,
             tree,
             loaded_packages,
             file_type,
-            // Default to `# %%` cell detection; URI/languageId-aware
-            // constructors override this above.
-            chunk_kind: ChunkKind::R,
+            chunk_kind,
+            masked_text,
             version,
             revision: 0,
         }
     }
 
     pub fn apply_change(&mut self, change: TextDocumentContentChangeEvent) {
+        // Always apply the edit to the RAW contents exactly as before — LSP
+        // incremental sync, chunk detection, and the outline all rely on the
+        // verbatim source.
         if let Some(range) = change.range {
             let start_line = range.start.line as usize;
             let start_utf16_char = range.start.character as usize;
@@ -229,9 +290,30 @@ impl Document {
         }
 
         self.revision += 1;
-        self.tree = parse_document(&self.contents, self.file_type);
-        let text = self.contents.to_string();
-        self.loaded_packages = extract_loaded_packages(&self.tree, &text);
+
+        let raw_text = self.contents.to_string();
+        // Re-derive the analysis text and parse the tree from it.
+        //
+        // For Rmd documents we re-mask the FULL new raw text and parse from
+        // scratch (no incremental tree-sitter edit). The previous tree's byte
+        // offsets reference the OLD masked text, whereas the LSP edit ranges
+        // are computed against the raw text — feeding the latter into an
+        // incremental `Tree::edit` would corrupt the former. A full reparse per
+        // change is acceptable: tree-sitter is fast, and incremental masking is
+        // a future optimization. (Plain R already reparses from scratch here,
+        // so this is not a regression for the common case.)
+        let analysis_text = if self.chunk_kind == ChunkKind::Rmd {
+            let masked = crate::chunks::mask_to_r(&raw_text);
+            self.masked_text = Some(masked);
+            self.masked_text.as_deref().unwrap_or(&raw_text)
+        } else {
+            // Keep the field `None` for non-Rmd docs; analysis text == raw text.
+            self.masked_text = None;
+            &raw_text
+        };
+
+        self.tree = parse_document_text(analysis_text, self.file_type);
+        self.loaded_packages = extract_loaded_packages(&self.tree, analysis_text);
     }
 
     #[allow(dead_code)]
@@ -241,6 +323,21 @@ impl Document {
 
     pub fn text(&self) -> String {
         self.contents.to_string()
+    }
+
+    /// The text the [`tree`](Document::tree) was parsed from: the masked
+    /// analysis text for Rmd/Quarto documents, the raw text otherwise.
+    ///
+    /// Use this — never [`text()`](Document::text) — whenever you slice the
+    /// document by byte offsets taken from `tree` (e.g. `node.byte_range()` /
+    /// `node.utf8_text(...)`). For plain R / JAGS / Stan this equals `text()`,
+    /// so the choice is behavior-neutral there. See the [`Document`] type docs
+    /// for the full raw-vs-analysis invariant.
+    pub fn analysis_text(&self) -> String {
+        match &self.masked_text {
+            Some(masked) => masked.clone(),
+            None => self.contents.to_string(),
+        }
     }
 
     /// True when the document is an R Markdown / Quarto document. The R
@@ -269,16 +366,18 @@ fn utf16_offset_to_char_offset(line_text: &str, utf16_offset: usize) -> usize {
     char_count
 }
 
-fn parse_r(contents: &Rope) -> Option<Tree> {
+fn parse_r_text(text: &str) -> Option<Tree> {
     let mut parser = Parser::new();
     parser.set_language(&tree_sitter_r::LANGUAGE.into()).ok()?;
-    let text = contents.to_string();
-    parser.parse(&text, None)
+    parser.parse(text, None)
 }
 
-fn parse_document(contents: &Rope, file_type: FileType) -> Option<Tree> {
+/// Parse `text` (the analysis text — masked for Rmd, raw otherwise) into a
+/// tree-sitter tree appropriate for `file_type`. All current file types parse
+/// with the R grammar.
+fn parse_document_text(text: &str, file_type: FileType) -> Option<Tree> {
     match file_type {
-        FileType::R | FileType::Jags | FileType::Stan => parse_r(contents),
+        FileType::R | FileType::Jags | FileType::Stan => parse_r_text(text),
     }
 }
 
@@ -1855,6 +1954,185 @@ mod tests {
         });
 
         assert_eq!(doc.text(), "line1\n🎉test");
+    }
+
+    // ========================================================================
+    // Masked analysis representation for Rmd/Quarto documents (Task 2)
+    // ========================================================================
+
+    /// True iff the tree contains at least one ERROR node anywhere.
+    fn tree_has_error(tree: &Tree) -> bool {
+        let mut stack = vec![tree.root_node()];
+        while let Some(node) = stack.pop() {
+            if node.is_error() || node.kind() == "ERROR" {
+                return true;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                stack.push(child);
+            }
+        }
+        false
+    }
+
+    /// True iff the tree contains an `identifier` node whose text equals `name`.
+    /// Slices against `text`, which MUST be the text the tree was parsed from.
+    fn tree_has_identifier(tree: &Tree, text: &str, name: &str) -> bool {
+        let mut stack = vec![tree.root_node()];
+        while let Some(node) = stack.pop() {
+            if node.kind() == "identifier" && &text[node.byte_range()] == name {
+                return true;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                stack.push(child);
+            }
+        }
+        false
+    }
+
+    fn rmd_uri() -> Url {
+        Url::parse("file:///tmp/report.Rmd").unwrap()
+    }
+
+    fn r_uri() -> Url {
+        Url::parse("file:///tmp/script.R").unwrap()
+    }
+
+    #[test]
+    fn rmd_document_tree_is_parsed_from_masked_text() {
+        // Prose + YAML + a valid R chunk. A raw parse would treat the prose and
+        // YAML as garbage and produce ERROR nodes; the masked parse must not.
+        let src = "---\ntitle: Demo\n---\n\nSome prose here.\n\n```{r}\nx <- 1\nf <- function(a) a + 1\n```\n\nMore prose.\n";
+        let doc = Document::new_with_uri(src, None, &rmd_uri());
+        assert_eq!(doc.chunk_kind, ChunkKind::Rmd);
+        let tree = doc.tree.as_ref().expect("Rmd doc should have a parse tree");
+        assert!(
+            !tree_has_error(tree),
+            "masked-derived tree for an Rmd doc with valid R chunks must have no ERROR nodes"
+        );
+        // The chunk symbol must be visible in the masked tree, sliced against
+        // the analysis text (which is what the tree was parsed from).
+        let analysis = doc.analysis_text();
+        assert!(tree_has_identifier(tree, &analysis, "f"));
+        assert!(tree_has_identifier(tree, &analysis, "x"));
+    }
+
+    #[test]
+    fn analysis_text_is_masked_for_rmd_and_raw_for_plain_r() {
+        let rmd_src = "prose\n```{r}\nx <- 1\n```\n";
+        let rmd_doc = Document::new_with_uri(rmd_src, None, &rmd_uri());
+        assert_eq!(rmd_doc.analysis_text(), crate::chunks::mask_to_r(rmd_src));
+        // The raw contents are untouched.
+        assert_eq!(rmd_doc.text(), rmd_src);
+
+        let r_src = "x <- 1\nf <- function() 2\n";
+        let r_doc = Document::new_with_uri(r_src, None, &r_uri());
+        assert_eq!(r_doc.analysis_text(), r_doc.text());
+        assert_eq!(r_doc.analysis_text(), r_src);
+    }
+
+    #[test]
+    fn rmd_loaded_packages_come_from_chunk_bodies_only() {
+        // `library(dplyr)` lives inside an R chunk; a prose line mentions
+        // `library(ignored)` and a Python chunk loads nothing R-relevant.
+        let src = "Intro mentions library(ignored) inline.\n\n```{r}\nlibrary(dplyr)\nx <- 1\n```\n\n```{python}\nimport os\n```\n";
+        let doc = Document::new_with_uri(src, None, &rmd_uri());
+        assert_eq!(doc.loaded_packages, vec!["dplyr".to_string()]);
+    }
+
+    #[test]
+    fn rmd_apply_change_inside_chunk_reparses_from_masked_text() {
+        let src = "prose\n```{r}\nx <- 1\n```\n";
+        let mut doc = Document::new_with_uri(src, Some(1), &rmd_uri());
+        let v0 = doc.revision;
+
+        // Insert a new statement on the body line: replace "x <- 1" with
+        // "x <- 1\nnewsym <- 2" (line 2, full-line range).
+        doc.apply_change(TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 2,
+                    character: 0,
+                },
+                end: Position {
+                    line: 2,
+                    character: 6,
+                },
+            }),
+            range_length: None,
+            text: "x <- 1\nnewsym <- 2".to_string(),
+        });
+
+        // Raw contents updated.
+        assert!(doc.text().contains("newsym <- 2"));
+        // masked_text re-derived and consistent with the raw contents.
+        assert_eq!(doc.analysis_text(), crate::chunks::mask_to_r(&doc.text()));
+        // Tree reparsed from the masked text: no ERROR nodes, new symbol present.
+        let tree = doc.tree.as_ref().expect("tree after change");
+        assert!(!tree_has_error(tree), "no ERROR nodes after in-chunk edit");
+        assert!(tree_has_identifier(tree, &doc.analysis_text(), "newsym"));
+        // Revision bumped.
+        assert!(doc.revision > v0);
+    }
+
+    #[test]
+    fn rmd_apply_change_to_prose_keeps_tree_clean() {
+        let src = "prose line\n```{r}\nx <- 1\n```\n";
+        let mut doc = Document::new_with_uri(src, Some(1), &rmd_uri());
+
+        // Edit the prose on line 0 only.
+        doc.apply_change(TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 10,
+                },
+            }),
+            range_length: None,
+            text: "different prose entirely".to_string(),
+        });
+
+        assert!(doc.text().contains("different prose entirely"));
+        // Prose is still blanked in the analysis text.
+        assert_eq!(doc.analysis_text(), crate::chunks::mask_to_r(&doc.text()));
+        let tree = doc.tree.as_ref().expect("tree after prose change");
+        assert!(
+            !tree_has_error(tree),
+            "prose edits must not introduce ERROR nodes"
+        );
+        // The R chunk body is still on line 2 (geometry preserved) and the
+        // symbol is still visible.
+        assert!(tree_has_identifier(tree, &doc.analysis_text(), "x"));
+    }
+
+    #[test]
+    fn plain_r_apply_change_uses_raw_text_for_analysis() {
+        // Regression: a plain .R doc's analysis_text tracks the raw contents and
+        // the tree continues to reflect edits.
+        let mut doc = Document::new_with_uri("x <- 1\n", Some(1), &r_uri());
+        doc.apply_change(TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            }),
+            range_length: None,
+            text: "yvar <- 2\n".to_string(),
+        });
+        assert_eq!(doc.text(), "x <- 1\nyvar <- 2\n");
+        assert_eq!(doc.analysis_text(), doc.text());
+        let tree = doc.tree.as_ref().unwrap();
+        assert!(tree_has_identifier(tree, &doc.analysis_text(), "yvar"));
     }
 
     #[test]

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1029,8 +1029,11 @@ impl WorldState {
         uri: &Url,
     ) -> Option<Arc<crate::cross_file::CrossFileMetadata>> {
         if let Some(doc) = self.documents.get(uri) {
+            // Parse from `analysis_text()`: masked for Rmd/Quarto (so a
+            // `# @lsp-cd` in prose is ignored while one inside a chunk is a
+            // real directive), raw for everything else (behavior-neutral).
             return Some(Arc::new(crate::cross_file::directive::parse_directives(
-                &doc.text(),
+                &doc.analysis_text(),
             )));
         }
         if let Some(meta) = self.cross_file_workspace_index.get_metadata(uri) {
@@ -1053,9 +1056,12 @@ impl WorldState {
             .or_else(|| self.workspace_index_new.get_metadata(uri))
             .or_else(|| self.cross_file_workspace_index.get_metadata(uri))
             .or_else(|| {
+                // `analysis_text()`: masked for Rmd/Quarto (directives/source()/
+                // library() come from chunk bodies, not prose), raw otherwise
+                // (behavior-neutral for plain R / JAGS / Stan).
                 self.documents
                     .get(uri)
-                    .map(|doc| Arc::new(crate::cross_file::extract_metadata(&doc.text())))
+                    .map(|doc| Arc::new(crate::cross_file::extract_metadata(&doc.analysis_text())))
             })
             .or_else(|| {
                 self.cross_file_file_cache

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -342,13 +342,22 @@ impl Document {
         }
     }
 
-    /// True when the document is an R Markdown / Quarto document. The R
-    /// tree-sitter parser sees the prose/YAML/non-R portions as syntax
-    /// errors, so handlers that don't understand chunks should treat the
-    /// document as off-limits and return empty results.
+    /// True when the document is an R Markdown / Quarto document.
     ///
-    /// The document outline (`document_symbol`) is the exception — it
-    /// intentionally processes chunk markers via the text-based detector.
+    /// For Rmd documents the analysis view (`tree` + `analysis_text()`) is the
+    /// geometry-preserving [`chunks::mask_to_r`] mask, so R-language features
+    /// (diagnostics, completion, hover, signature help, go-to-definition,
+    /// references, folding, selection, on-type formatting, semantic tokens) are
+    /// first-class **inside R chunk bodies** and operate on document
+    /// coordinates directly.
+    ///
+    /// Callers still use this flag for two reasons: (1) a few handlers must add
+    /// a prose guard — at a prose/YAML position the masked line is blank, which
+    /// would otherwise let completion / signature help / on-type formatting
+    /// behave like top-level R; guard such positions with
+    /// [`chunks::position_in_r_chunk_body`] on the *raw* text. (2) Whole-text
+    /// paths that can't consume the R AST (e.g. chunk-aware semantic tokens,
+    /// the text-based document outline) branch on it.
     pub fn is_rmd_document(&self) -> bool {
         self.chunk_kind == ChunkKind::Rmd
     }

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1513,13 +1513,22 @@ fn process_workspace_file(path: &Path) -> Option<ProcessedFile> {
     log::trace!("Scanning file: {}", uri);
     let doc = Document::new_with_uri(&text, None, &uri);
 
-    let cross_file_meta = crate::cross_file::extract_metadata(&text);
+    // Pair `doc.tree` with the analysis text it was parsed from (masked for
+    // Rmd/Quarto, raw otherwise) for both metadata extraction and artifact
+    // computation, so byte offsets align (#343). The scan currently never sees
+    // chunk files (`is_stat_model_extension` excludes `.rmd`/`.qmd`), so this is
+    // behavior-neutral today; the pairing must stay analysis-consistent in case
+    // that ever changes — feeding raw `&text` against a masked tree would
+    // mis-slice (and panic on a non-UTF-8 boundary in multibyte prose).
+    let analysis_text = doc.analysis_text();
+
+    let cross_file_meta = crate::cross_file::extract_metadata(&analysis_text);
 
     let artifacts = std::sync::Arc::new(if let Some(tree) = doc.tree.as_ref() {
         crate::cross_file::scope::compute_artifacts_with_metadata(
             &uri,
             tree,
-            &text,
+            &analysis_text,
             Some(&cross_file_meta),
         )
     } else {
@@ -2400,5 +2409,52 @@ mod tests {
             }
             assert_eq!(current, chain_url(chain, CHAIN_LEN - 1));
         }
+    }
+
+    /// Finding 3 (#343): `process_workspace_file` must pair the document's
+    /// `tree` with its **analysis text** (masked for Rmd) when extracting
+    /// metadata and computing artifacts. The workspace scan currently never
+    /// hands this function a chunk file (`is_stat_model_extension` excludes
+    /// `.rmd`/`.qmd`), but the raw/masked pairing must stay analysis-consistent
+    /// so a future scan-scope change can't silently mis-slice. Multibyte prose
+    /// makes the regression a hard failure (mid-char slice), not a quiet one.
+    #[test]
+    fn process_workspace_file_pairs_masked_tree_with_masked_text() {
+        use std::fs;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("report.Rmd");
+        // Multibyte prose contains `prose_symbol`; the chunk defines
+        // `chunk_symbol`. A masked-consistent scan yields the chunk symbol only.
+        let src =
+            "Prélude éééé prose_symbol éééé.\n\n```{r}\nchunk_symbol <- function(a) a + 1\n```\n";
+        fs::write(&path, src).unwrap();
+
+        let processed = process_workspace_file(&path).expect("process_workspace_file must succeed");
+
+        // Artifacts derive from the masked analysis text: the chunk symbol is
+        // exported, the prose symbol is not.
+        let interface = &processed.new_index_entry.artifacts.exported_interface;
+        assert!(
+            interface.keys().any(|k| &**k == "chunk_symbol"),
+            "chunk-defined symbol must be in the exported interface, got {:?}",
+            interface.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !interface.keys().any(|k| &**k == "prose_symbol"),
+            "prose token must NOT be in the exported interface, got {:?}",
+            interface.keys().collect::<Vec<_>>()
+        );
+        // The document's tree must slice cleanly against its analysis text
+        // (would panic on the multibyte prose if paired with raw text).
+        let doc_tree = processed
+            .document
+            .tree
+            .as_ref()
+            .expect("Rmd doc must have a tree");
+        let analysis = processed.document.analysis_text();
+        assert!(
+            tree_has_identifier(doc_tree, &analysis, "chunk_symbol"),
+            "masked tree must contain the chunk-defined identifier"
+        );
     }
 }

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1041,7 +1041,12 @@ impl WorldState {
         }
         let content_provider = self.content_provider();
         if let Some(content) = content_provider.get_content(uri) {
-            return Some(Arc::new(crate::cross_file::extract_metadata(&content)));
+            // Cached content is RAW; mask Rmd/Quarto before extracting so
+            // directives come from chunk bodies, not prose (#343).
+            return Some(Arc::new(crate::cross_file::extract_metadata_for_path(
+                uri.path(),
+                &content,
+            )));
         }
         None
     }
@@ -1055,12 +1060,15 @@ impl WorldState {
     /// 4. Legacy documents HashMap (re-extract metadata)
     /// 5. File cache (re-extract metadata)
     ///
-    /// CAVEAT (until Task 5 of issue #343 lands): the DocumentStore arm
-    /// (tier 1) stores metadata extracted from RAW text at `did_open` time,
-    /// so for open Rmd/Quarto documents it can return prose-derived metadata.
-    /// Callers needing masked-correct metadata for open Rmd docs must
-    /// re-derive from `analysis_text()` — see the bypass in
-    /// `DiagnosticsSnapshot::build`.
+    /// Rmd/Quarto note (issue #343): every tier here is masked-correct for
+    /// open R Markdown / Quarto documents. The DocumentStore arm (tier 1)
+    /// stores metadata extracted from the masked analysis text at
+    /// `did_open`/`did_change` time (`backend.rs` passes
+    /// `extract_metadata_for_path`, and `DocumentStore::compute_derived`
+    /// re-derives artifacts from the masked text); the legacy-documents arm
+    /// (tier 4) and the file-cache arm (tier 5) likewise mask via
+    /// `analysis_text()` / `extract_metadata_for_path`. So directives,
+    /// `source()`, and `library()` always reflect chunk bodies, never prose.
     pub fn get_enriched_metadata(
         &self,
         uri: &Url,
@@ -1079,9 +1087,15 @@ impl WorldState {
                     .map(|doc| Arc::new(crate::cross_file::extract_metadata(&doc.analysis_text())))
             })
             .or_else(|| {
-                self.cross_file_file_cache
-                    .get(uri)
-                    .map(|content| Arc::new(crate::cross_file::extract_metadata(&content)))
+                // Cached content is RAW; mask Rmd/Quarto before extracting so
+                // directives/source()/library() come from chunk bodies, not
+                // prose (#343).
+                self.cross_file_file_cache.get(uri).map(|content| {
+                    Arc::new(crate::cross_file::extract_metadata_for_path(
+                        uri.path(),
+                        &content,
+                    ))
+                })
             })
     }
 

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1010,15 +1010,6 @@ impl WorldState {
         self.documents.get(uri)
     }
 
-    /// Get enriched metadata for a URI, preferring already-enriched sources.
-    ///
-    /// Priority order:
-    /// 1. DocumentStore (open documents with enriched metadata)
-    /// 2. WorkspaceIndex (new unified index)
-    /// 3. Legacy cross_file_workspace_index
-    /// 4. Legacy documents HashMap (re-extract metadata)
-    /// 5. File cache (re-extract metadata)
-    ///
     /// Find or parse `CrossFileMetadata` for `uri` for the working-directory
     /// inheritance closures used by snapshot builds and several diagnostic
     /// helpers. Walks the chain: open document → cross-file workspace index
@@ -1046,6 +1037,21 @@ impl WorldState {
         None
     }
 
+    /// Get enriched metadata for a URI, preferring already-enriched sources.
+    ///
+    /// Priority order:
+    /// 1. DocumentStore (open documents with enriched metadata)
+    /// 2. WorkspaceIndex (new unified index)
+    /// 3. Legacy cross_file_workspace_index
+    /// 4. Legacy documents HashMap (re-extract metadata)
+    /// 5. File cache (re-extract metadata)
+    ///
+    /// CAVEAT (until Task 5 of issue #343 lands): the DocumentStore arm
+    /// (tier 1) stores metadata extracted from RAW text at `did_open` time,
+    /// so for open Rmd/Quarto documents it can return prose-derived metadata.
+    /// Callers needing masked-correct metadata for open Rmd docs must
+    /// re-derive from `analysis_text()` — see the bypass in
+    /// `DiagnosticsSnapshot::build`.
     pub fn get_enriched_metadata(
         &self,
         uri: &Url,

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -2006,21 +2006,6 @@ mod tests {
     // Masked analysis representation for Rmd/Quarto documents (Task 2)
     // ========================================================================
 
-    /// True iff the tree contains at least one ERROR node anywhere.
-    fn tree_has_error(tree: &Tree) -> bool {
-        let mut stack = vec![tree.root_node()];
-        while let Some(node) = stack.pop() {
-            if node.is_error() || node.kind() == "ERROR" {
-                return true;
-            }
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                stack.push(child);
-            }
-        }
-        false
-    }
-
     /// True iff the tree contains an `identifier` node whose text equals `name`.
     /// Slices against `text`, which MUST be the text the tree was parsed from.
     fn tree_has_identifier(tree: &Tree, text: &str, name: &str) -> bool {
@@ -2054,7 +2039,7 @@ mod tests {
         assert_eq!(doc.chunk_kind, ChunkKind::Rmd);
         let tree = doc.tree.as_ref().expect("Rmd doc should have a parse tree");
         assert!(
-            !tree_has_error(tree),
+            !tree.root_node().has_error(),
             "masked-derived tree for an Rmd doc with valid R chunks must have no ERROR nodes"
         );
         // The chunk symbol must be visible in the masked tree, sliced against
@@ -2117,7 +2102,10 @@ mod tests {
         assert_eq!(analysis, crate::chunks::mask_to_r(&doc.text()));
         // Tree reparsed from the masked text: no ERROR nodes, new symbol present.
         let tree = doc.tree.as_ref().expect("tree after change");
-        assert!(!tree_has_error(tree), "no ERROR nodes after in-chunk edit");
+        assert!(
+            !tree.root_node().has_error(),
+            "no ERROR nodes after in-chunk edit"
+        );
         assert!(tree_has_identifier(tree, &analysis, "newsym"));
         // Revision bumped.
         assert!(doc.revision > v0);
@@ -2150,7 +2138,7 @@ mod tests {
         assert_eq!(analysis, crate::chunks::mask_to_r(&doc.text()));
         let tree = doc.tree.as_ref().expect("tree after prose change");
         assert!(
-            !tree_has_error(tree),
+            !tree.root_node().has_error(),
             "prose edits must not introduce ERROR nodes"
         );
         // The R chunk body is still on line 2 (geometry preserved) and the

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -240,12 +240,10 @@ impl Document {
     ) -> Self {
         let contents = Rope::from_str(text);
         // Mask Rmd/Quarto bodies so the R parser only sees real R code; plain R
-        // (and JAGS/Stan) keep their raw text.
-        let masked_text = if chunk_kind == ChunkKind::Rmd {
-            Some(crate::chunks::mask_to_r(text))
-        } else {
-            None
-        };
+        // (and JAGS/Stan) keep their raw text. Routed through the shared
+        // `masked_analysis_text` chokepoint so this and the DocumentStore can
+        // never derive divergent analysis views.
+        let masked_text = crate::cross_file::masked_analysis_text(chunk_kind, text);
         let analysis_text = masked_text.as_deref().unwrap_or(text);
         let tree = parse_document_text(analysis_text, file_type);
         // Extract from the SAME text the tree was parsed from, so `library()`
@@ -302,17 +300,9 @@ impl Document {
         // change is acceptable: tree-sitter is fast, and incremental masking is
         // a future optimization. (Plain R already reparses from scratch here,
         // so this is not a regression for the common case.)
-        let analysis_text = if self.chunk_kind == ChunkKind::Rmd {
-            let masked = crate::chunks::mask_to_r(&raw_text);
-            self.masked_text = Some(masked);
-            self.masked_text
-                .as_deref()
-                .expect("masked_text was just set")
-        } else {
-            // Keep the field `None` for non-Rmd docs; analysis text == raw text.
-            self.masked_text = None;
-            &raw_text
-        };
+        self.masked_text = crate::cross_file::masked_analysis_text(self.chunk_kind, &raw_text);
+        // `Some(masked)` for Rmd, `None` for plain R (analysis text == raw text).
+        let analysis_text = self.masked_text.as_deref().unwrap_or(&raw_text);
 
         self.tree = parse_document_text(analysis_text, self.file_type);
         self.loaded_packages = extract_loaded_packages(&self.tree, analysis_text);

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -305,7 +305,9 @@ impl Document {
         let analysis_text = if self.chunk_kind == ChunkKind::Rmd {
             let masked = crate::chunks::mask_to_r(&raw_text);
             self.masked_text = Some(masked);
-            self.masked_text.as_deref().unwrap_or(&raw_text)
+            self.masked_text
+                .as_deref()
+                .expect("masked_text was just set")
         } else {
             // Keep the field `None` for non-Rmd docs; analysis text == raw text.
             self.masked_text = None;
@@ -2067,11 +2069,12 @@ mod tests {
         // Raw contents updated.
         assert!(doc.text().contains("newsym <- 2"));
         // masked_text re-derived and consistent with the raw contents.
-        assert_eq!(doc.analysis_text(), crate::chunks::mask_to_r(&doc.text()));
+        let analysis = doc.analysis_text();
+        assert_eq!(analysis, crate::chunks::mask_to_r(&doc.text()));
         // Tree reparsed from the masked text: no ERROR nodes, new symbol present.
         let tree = doc.tree.as_ref().expect("tree after change");
         assert!(!tree_has_error(tree), "no ERROR nodes after in-chunk edit");
-        assert!(tree_has_identifier(tree, &doc.analysis_text(), "newsym"));
+        assert!(tree_has_identifier(tree, &analysis, "newsym"));
         // Revision bumped.
         assert!(doc.revision > v0);
     }
@@ -2099,7 +2102,8 @@ mod tests {
 
         assert!(doc.text().contains("different prose entirely"));
         // Prose is still blanked in the analysis text.
-        assert_eq!(doc.analysis_text(), crate::chunks::mask_to_r(&doc.text()));
+        let analysis = doc.analysis_text();
+        assert_eq!(analysis, crate::chunks::mask_to_r(&doc.text()));
         let tree = doc.tree.as_ref().expect("tree after prose change");
         assert!(
             !tree_has_error(tree),
@@ -2107,7 +2111,7 @@ mod tests {
         );
         // The R chunk body is still on line 2 (geometry preserved) and the
         // symbol is still visible.
-        assert!(tree_has_identifier(tree, &doc.analysis_text(), "x"));
+        assert!(tree_has_identifier(tree, &analysis, "x"));
     }
 
     #[test]

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -24,7 +24,7 @@ Chunks also appear in the document outline (`Cmd/Ctrl+Shift+O`) as a distinct sy
 
 The R code inside chunk bodies is first-class. Raven analyzes all R chunk bodies as a single R program, so the editor's R language features work inside chunks of `.Rmd` / `.qmd` documents and resolve symbols across chunks (a function defined in one chunk can be used, navigated to, and completed in a later chunk):
 
-- [Diagnostics](./diagnostics.md), [completion](./completion.md), [hover](./hover.md), [signature help](./completion.md), [go-to-definition](./go-to-definition.md), [find-references](./find-references.md), folding, expand-selection, and on-type [indentation](./indentation.md).
+- [Diagnostics](./diagnostics.md), [completion](./completion.md), [hover](./hover.md), signature help, [go-to-definition](./go-to-definition.md), [find-references](./find-references.md), folding, expand-selection, and on-type [indentation](./indentation.md).
 
 These features apply only inside R chunk bodies. On prose, YAML front matter, or non-R chunks they stand down — completion, signature help, and on-type indentation produce nothing rather than treating the line as top-level R. Non-R chunks (`{python}`, `{bash}`, …) are not analyzed as R.
 

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -20,6 +20,14 @@ Only **R** chunks are sent to the R console. Chunks tagged with other languages 
 
 Chunks also appear in the document outline (`Cmd/Ctrl+Shift+O`) as a distinct symbol kind, separate from section headers — see [Document Outline](./document-outline.md#r-markdown--quarto-chunks).
 
+## Language features inside chunks
+
+The R code inside chunk bodies is first-class. Raven analyzes all R chunk bodies as a single R program, so the editor's R language features work inside chunks of `.Rmd` / `.qmd` documents and resolve symbols across chunks (a function defined in one chunk can be used, navigated to, and completed in a later chunk):
+
+- [Diagnostics](./diagnostics.md), [completion](./completion.md), [hover](./hover.md), [signature help](./completion.md), [go-to-definition](./go-to-definition.md), [find-references](./find-references.md), folding, expand-selection, and on-type [indentation](./indentation.md).
+
+These features apply only inside R chunk bodies. On prose, YAML front matter, or non-R chunks they stand down — completion, signature help, and on-type indentation produce nothing rather than treating the line as top-level R. Non-R chunks (`{python}`, `{bash}`, …) are not analyzed as R.
+
 ## Keyboard shortcuts
 
 | Mac | Windows/Linux | Action |

--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -28,6 +28,12 @@ The R code inside chunk bodies is first-class. Raven analyzes all R chunk bodies
 
 These features apply only inside R chunk bodies. On prose, YAML front matter, or non-R chunks they stand down — completion, signature help, and on-type indentation produce nothing rather than treating the line as top-level R. Non-R chunks (`{python}`, `{bash}`, …) are not analyzed as R.
 
+### Cross-file resolution from chunks
+
+Cross-file awareness ([Cross-File Analysis](./cross-file.md)) reads only chunk bodies, never prose. A `source("helpers.R")` written inside an R chunk creates a real dependency edge — symbols defined in the sourced file resolve in later chunks, and a missing target is flagged — while the same text in prose or a comment outside a chunk is ignored. `library()` calls and `# @lsp-cd` / `@lsp-sourced-by`-style directives are likewise honored only inside chunks.
+
+The relationship also works in the other direction: a plain `.R` file can declare `# @lsp-sourced-by analysis.Rmd`, and Raven will read the Rmd's chunks (not its prose) to supply the helper's inherited scope. `.Rmd` / `.qmd` files are not added to the proactive workspace scan, so this incoming direction is established by the directive on the `.R` file, or by opening the Rmd itself.
+
 ## Keyboard shortcuts
 
 | Mac | Windows/Linux | Action |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,7 +123,7 @@ To get installed/local package awareness and exact local package metadata in CI,
 
 ### Scope
 
-Only plain R files (`.R` / `.r`) are reported. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped — chunk extraction isn't supported on the command line — with a one-line note on stderr when one is named explicitly.
+`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.qmd`) are all reported. When a workspace walk or a directory argument includes `.Rmd` / `.qmd` files they are analyzed the same way the editor analyzes them: every R chunk body is treated as R code at its document coordinates, while prose, YAML front matter, and non-R chunks (Python, Bash, …) are ignored. Diagnostics are reported at the coordinates of the chunk body line where they occur, so the line and column in `text` / `json` / `sarif` output map directly to the document. Cross-file resolution from chunks works: a `source()` inside a chunk creates a real dependency edge, and missing-file and cross-file scope diagnostics are reported the same as from a `.R` file.
 
 ## `raven lint`
 
@@ -166,7 +166,7 @@ raven lint [OPTIONS] [PATHS...]
 
 `raven lint` runs the native style linter only. Cross-file, undefined-variable, and package diagnostics need a workspace scan; use [`raven check`](#raven-check) for those.
 
-Only plain R files (`.R` / `.r`) are linted. R Markdown / Quarto files (`.Rmd` / `.qmd`) are skipped with a one-line note on stderr — chunk extraction isn't supported on the command line — and other file types are ignored silently. Passing a directory walks it recursively for R files.
+`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.qmd`) are linted. Inside `.Rmd` / `.qmd` files, lint rules apply to R chunk bodies; prose, YAML front matter, and non-R chunks are ignored. `# nolint` / `# nolint start` / `# nolint end` and `# @lsp-ignore` markers inside chunk bodies work as in plain R files. Other file types are ignored silently. Passing a directory walks it recursively for `.R` / `.r`, `.Rmd`, and `.qmd` files.
 
 ## `raven packages`
 

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -81,6 +81,10 @@ source("utils.R")
 help  # Offers: helper_function — "from utils.R" as the item detail
 ```
 
+## R Markdown / Quarto
+
+Inside `.Rmd` / `.qmd` documents, completions work inside R chunk bodies: local definitions, cross-file symbols, package exports, function parameters, and `$` members all resolve across chunks as if the document were a single R program. On prose, YAML front matter, or non-R chunks, completion returns nothing rather than treating the line as R.
+
 ## JAGS and Stan
 
 For `.stan`, `.jags`, and `.bugs` files, Raven offers completions tailored to each language:

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -39,6 +39,10 @@ Raven also provides **file path intellisense** inside `source()` strings and pat
 
 For dynamic or conditional paths that Raven can't detect, use [directives](directives.md) to declare relationships explicitly.
 
+### R Markdown / Quarto chunks
+
+Inside `.Rmd` / `.qmd` documents, only R chunk bodies feed cross-file analysis — prose and YAML front matter are masked out before detection. A `source()` or `library()` call written in a chunk participates exactly as it would in a `.R` file; the same text in prose is ignored. A `.R` file may also declare `# @lsp-sourced-by report.Rmd`, in which case Raven reads the report's chunks to supply that file's inherited scope. `.Rmd` / `.qmd` files are not added to the proactive workspace scan, so the editor sees these relationships when the Rmd is open or when a `.R` file points at it via a backward directive. See [R Code Chunks](./chunks.md#cross-file-resolution-from-chunks).
+
 ## Package Awareness
 
 Raven recognizes `library()`, `require()`, and `loadNamespace()` calls and makes package exports available for completions, hover, and diagnostics.

--- a/docs/development.md
+++ b/docs/development.md
@@ -261,6 +261,15 @@ On-demand indexing is used to index files that are not currently open in the edi
 
 See `crates/raven/src/cross_file/background_indexer.rs`.
 
+### Rmd/Quarto raw-content vs masked-analysis split (#343)
+
+For `.Rmd` / `.qmd` documents, everywhere we store or extract cross-file data we keep two views distinct (mirroring the `Document` type docs in `state.rs`):
+
+- **Raw content** — `DocumentStore::DocumentState.contents`, `IndexEntry.contents`, and the `cross_file_file_cache` entry stay verbatim. `ContentProvider::get_content` returns raw, serving snippets and non-R-language text scans.
+- **Masked analysis** — the `tree`, `metadata`, `artifacts`, and `loaded_packages` on those same entries are derived from `chunks::mask_to_r` (chunk bodies only). Byte offsets in the stored `tree` index into the masked text, exposed by `DocumentState::analysis_text()`; pairing the tree with raw content mis-slices.
+
+The single chokepoint helpers live in `cross_file/mod.rs`: `analysis_text_for_path(path, content)` (masks for Rmd, borrows raw otherwise) and `extract_metadata_for_path(path, content)`. Every metadata-extraction site that starts from a path-identified file's raw content (did_open, on-demand indexing, file-cache fallbacks in `state.rs`, the legacy-document arms in `content_provider.rs`) routes through these so `.Rmd` files contribute outgoing edges from chunks, never spurious prose-derived ones. `.Rmd`/`.qmd` are intentionally excluded from the proactive workspace scan (outgoing-only); incoming relationships come from an open Rmd or a `.R` file's `@lsp-sourced-by` backward directive.
+
 ## Package library internals
 
 Raven prefers static parsing for package exports and uses R subprocesses selectively.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -221,4 +221,14 @@ When a parent file changes (e.g., a `library()` call is added or removed), Raven
 
 Diagnostics are suppressed for JAGS (`.jags`, `.bugs`) and Stan (`.stan`) files because Raven cannot statically determine what is in scope in these languages.
 
-R Markdown (`.Rmd`) and Quarto (`.qmd`) documents also produce no diagnostics: the tree-sitter R parser sees prose, YAML, and non-R fenced blocks as parse errors, so every non-R line would become spurious noise. Code intelligence for individual R chunks is covered in [chunks.md](chunks.md).
+## R Markdown and Quarto
+
+R Markdown (`.Rmd`) and Quarto (`.qmd`) documents are diagnosed chunk-by-chunk. Raven analyzes a masked view of the document in which every non-R line — prose, YAML front matter, and non-R fenced blocks (Python, Bash, etc.) — is blanked while R chunk bodies are preserved at their original line and column positions. As a result:
+
+- Syntax errors, undefined variables, and lint findings inside `{r}` (and `{rscript}`) chunks are reported at the document's own coordinates, exactly as they would be in a `.R` file.
+- Prose, YAML, markdown links, and non-R chunks never produce diagnostics.
+- Symbols defined in one R chunk are in scope in later R chunks (the chunks share a single analysis), so a variable assigned in an early chunk and used in a later one is not flagged as undefined.
+- Chunk options that only affect knitr execution (such as `eval=FALSE`) do not suppress static analysis — a syntax error in an `eval=FALSE` chunk is still flagged.
+- `# nolint` markers and `# @lsp-ignore` directives work inside chunks just as in plain R.
+
+Code intelligence for individual R chunks is covered in [chunks.md](chunks.md).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -231,4 +231,8 @@ R Markdown (`.Rmd`) and Quarto (`.qmd`) documents are diagnosed chunk-by-chunk. 
 - Chunk options that only affect knitr execution (such as `eval=FALSE`) do not suppress static analysis — a syntax error in an `eval=FALSE` chunk is still flagged.
 - `# nolint` markers and `# @lsp-ignore` directives work inside chunks just as in plain R.
 
+### Parameterized reports (`params`)
+
+When the YAML front matter declares a top-level `params:` key, Raven treats `params` as a defined symbol for that document — undefined-variable and out-of-scope diagnostics will not flag uses of `params` inside R chunks. Without a `params:` key in the front matter, `params` is treated as any other undefined symbol and is flagged normally.
+
 Code intelligence for individual R chunks is covered in [chunks.md](chunks.md).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -223,7 +223,7 @@ Diagnostics are suppressed for JAGS (`.jags`, `.bugs`) and Stan (`.stan`) files 
 
 ## R Markdown and Quarto
 
-R Markdown (`.Rmd`) and Quarto (`.qmd`) documents are diagnosed chunk-by-chunk. Raven analyzes a masked view of the document in which every non-R line — prose, YAML front matter, and non-R fenced blocks (Python, Bash, etc.) — is blanked while R chunk bodies are preserved at their original line and column positions. As a result:
+In R Markdown (`.Rmd`) and Quarto (`.qmd`) documents, the R code inside chunks is diagnosed as a single R program. Raven analyzes a masked view of the document in which every non-R line — prose, YAML front matter, and non-R fenced blocks (Python, Bash, etc.) — is blanked while R chunk bodies are preserved at their original line and column positions. As a result:
 
 - Syntax errors, undefined variables, and lint findings inside `{r}` (and `{rscript}`) chunks are reported at the document's own coordinates, exactly as they would be in a `.R` file.
 - Prose, YAML, markdown links, and non-R chunks never produce diagnostics.

--- a/docs/document-outline.md
+++ b/docs/document-outline.md
@@ -127,6 +127,8 @@ Chunk #3        {python}
 
 Chunks use a distinct symbol kind (`OBJECT`) so the outline filter can include or exclude them separately from section headers.
 
+R symbols defined *inside* an R chunk body — functions, variable assignments, S4/R6 classes — also appear in the outline, nested under their chunk, at their real document line. Prose, YAML front matter, and non-R chunk bodies are ignored, so a `library(...)` call in prose or a Python chunk never produces a phantom outline entry. (For non-R chunks only the chunk entry itself is shown.)
+
 ### `# %%` cells in `.R` files
 
 Plain `.R` files use the VS Code interactive-cell convention: a `# %%` line starts a new cell that runs until the next marker, a section divider, or end of file. Any text after the marker is used as the label:

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -37,7 +37,7 @@ Unlike completions and diagnostics, Find References does **not** consult the `so
 
 If you need a result scoped to one symbol's definition, use [Go-to-Definition](go-to-definition.md), which *is* scope- and dependency-aware.
 
-> Find References returns no results when invoked from an R Markdown / Quarto (`.Rmd` / `.qmd`) document.
+> Find References works inside R code chunks of R Markdown / Quarto (`.Rmd` / `.qmd`) documents — all R chunk bodies are pooled as one R program, so references span chunks. Invoking it on prose, YAML, or a non-R chunk returns no results.
 
 ## Workspace Symbols (Cmd/Ctrl+T)
 

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -83,7 +83,7 @@ Cmd-click on a symbol that comes from an installed package (e.g. `dplyr::mutate`
 
 ## R Markdown and Quarto
 
-Go-to-definition is disabled in `.Rmd` and `.qmd` documents — Raven returns no result rather than resolving across prose and chunk boundaries. Edit a chunk's R in a `.R` file if you need navigation. (Hover and find-references are likewise disabled in these documents.)
+Go-to-definition works inside R code chunks of `.Rmd` and `.qmd` documents. Raven treats all R chunk bodies as one R program, so you can jump from a use in one chunk to a definition in an earlier chunk; the definition lands on the correct document line. Invoking it on prose, YAML front matter, or a non-R chunk returns no result. (Hover and find-references behave the same way.)
 
 ## JAGS and Stan
 

--- a/docs/help-viewer.md
+++ b/docs/help-viewer.md
@@ -16,7 +16,7 @@ The help viewer is triggered from a hover:
 - **From a hover**: Hover over an identifier (e.g., `dplyr::filter` or `plot`). When the symbol resolves to a known package, the hover bubble displays a bold `pkg::name` heading at the top — click it to open the help panel.
 
 > [!NOTE]
-> Hover-triggered help is only active in `.R` files. It is disabled in R Markdown (`.Rmd`) and Quarto (`.qmd`) files.
+> In R Markdown (`.Rmd`) and Quarto (`.qmd`) files, hover-triggered help works on identifiers inside R code chunks (the same as in `.R` files). Hovering prose, YAML front matter, or a non-R chunk produces no hover, so there's no help link there.
 
 There is no command-palette entry: the panel needs a resolved topic and package, which only the hover link supplies, so `raven.openHelpPanel` (and the `raven.help.back` / `raven.help.forward` navigation commands) are hidden from the palette.
 

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -81,7 +81,7 @@ This isn't a Raven bug. Both extensions are answering the hover request independ
 
 - **No navigation to installed package sources.** Hover attributes a symbol to its package and links to the help viewer, but cmd-click on a package export does not jump into the package's source. See [Go-to-Definition: Package Exports](go-to-definition.md#package-exports).
 - **R-help fallback is async.** The first hover for a topic spawns an R subprocess to render help; re-hovering the same topic uses the cached result.
-- **Not available in R Markdown / Quarto.** Hover (and its help-panel link) is disabled in `.Rmd` and `.qmd` documents.
+- **R Markdown / Quarto: chunk bodies only.** Hover (and its help-panel link) works on identifiers inside R code chunks of `.Rmd` and `.qmd` documents. Hovering prose, YAML front matter, or a non-R chunk produces nothing.
 
 ## Related
 

--- a/docs/indentation.md
+++ b/docs/indentation.md
@@ -48,7 +48,7 @@ Two ways to disable AST-aware indentation:
 
 The difference: `"off"` is a Raven setting that keeps `formatOnType` available for other languages. Disabling `formatOnType` is a VS Code editor setting that affects all languages (unless overridden per-language).
 
-Raven sets `editor.formatOnType` to `true` for R, R Markdown, and Quarto files as a default. This is the lowest-priority setting in VS Code — if you explicitly set `editor.formatOnType` to `false` (globally or for `[r]`), your setting takes precedence. Note that Tier 2 indentation applies only to plain R files; Rmd and Quarto files use Tier 1 only.
+Raven sets `editor.formatOnType` to `true` for R, R Markdown, and Quarto files as a default. This is the lowest-priority setting in VS Code — if you explicitly set `editor.formatOnType` to `false` (globally or for `[r]`), your setting takes precedence. Tier 2 indentation also applies inside R code chunks of R Markdown and Quarto files — pressing Enter inside a chunk body indents exactly as it would in a plain `.R` file. On prose, YAML front matter, or a non-R chunk, Tier 2 stands down so markdown isn't reflowed with R rules (Tier 1 still applies).
 
 ## Styles
 

--- a/docs/indentation.md
+++ b/docs/indentation.md
@@ -129,7 +129,7 @@ if (condition) {
 
 ### Indentation not working at all
 
-1. Check that the file's language mode is R (status bar), not R Markdown or Quarto
+1. Check the file's language mode (status bar): R, R Markdown, and Quarto are all supported — but in `.Rmd` / `.qmd` files, Tier 2 indentation applies only inside R chunk bodies, not in prose or YAML
 2. Verify Raven is running (check VS Code's status bar)
 3. Reload VS Code: `Ctrl+Shift+P` → "Developer: Reload Window"
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,7 +13,7 @@ Raven is under active development. The gaps below reflect features that exist in
 R chunk bodies in `.Rmd` / `.qmd` documents are fully analyzed as first-class R code. The following gaps are accepted limitations of the current implementation:
 
 - **Inline R expressions** (`\`r expr\`` in prose) are not analyzed. Only fenced chunk bodies (```` ```{r} ... ``` ```` ) are treated as R.
-- **Cross-chunk delimiter leak** — chunk bodies are analyzed as a single concatenated R program. An unclosed delimiter (`"`, `(`, `{`) in one chunk body can swallow the opening of the next chunk, causing the next chunk's parse to fail. The unclosed delimiter in the offending chunk is itself flagged as a parse error. This is a consequence of the single-parse model knitr uses.
+- **Cross-chunk delimiter leak** — chunk bodies are analyzed as a single concatenated R program. An unclosed delimiter (`"`, `(`, `{`) in one chunk body can swallow the opening of the next chunk, causing the next chunk's parse to fail. The unclosed delimiter in the offending chunk is itself flagged as a parse error. This is a consequence of Raven's single-parse analysis model (knitr itself evaluates chunks one at a time and would stop at the offending chunk).
 - **Non-R chunks not analyzed** — `{python}`, `{bash}`, `{julia}`, and other non-R fenced blocks are never analyzed or linted.
 - **knitr chunk-reuse lines** (`<<label>>`) are blanked (treated as empty lines) and not resolved.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,6 +8,15 @@ Raven is under active development. The gaps below reflect features that exist in
 - **Session-aware completions** — Raven's completions are purely static. REditorSupport can complete symbols from the live R session's `globalenv()`, including column names from data frames that only exist at runtime. See [Comparison: Language intelligence](./comparison.md#language-intelligence).
 - **Nested member completions** — Raven resolves one level of `$` member access: after `foo$` it offers `foo`'s known members (discovered statically from assignments and constructor literals), but it does not resolve deeper chains — after `foo$bar$` it can't offer the members of `foo$bar`. See [Completion: `$` member completions](./completion.md#-member-completions).
 
+## R Markdown / Quarto
+
+R chunk bodies in `.Rmd` / `.qmd` documents are fully analyzed as first-class R code. The following gaps are accepted limitations of the current implementation:
+
+- **Inline R expressions** (`\`r expr\`` in prose) are not analyzed. Only fenced chunk bodies (```` ```{r} ... ``` ```` ) are treated as R.
+- **Cross-chunk delimiter leak** — chunk bodies are analyzed as a single concatenated R program. An unclosed delimiter (`"`, `(`, `{`) in one chunk body can swallow the opening of the next chunk, causing the next chunk's parse to fail. The unclosed delimiter in the offending chunk is itself flagged as a parse error. This is a consequence of the single-parse model knitr uses.
+- **Non-R chunks not analyzed** — `{python}`, `{bash}`, `{julia}`, and other non-R fenced blocks are never analyzed or linted.
+- **knitr chunk-reuse lines** (`<<label>>`) are blanked (treated as empty lines) and not resolved.
+
 ## R-session features
 
 - **Workspace viewer** — REditorSupport has a sidebar panel that introspects the live R session, showing objects in `globalenv()` with their types and dimensions, plus attached and loaded namespaces; objects can be viewed or removed from the panel. Raven has no equivalent. See [Comparison: What REditorSupport's VS Code extension offers that Raven doesn't](./comparison.md#what-reditorsupports-vs-code-extension-offers-that-raven-doesnt).

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -293,6 +293,7 @@ Notes:
 
 ## Performance and scope notes
 
+- **R Markdown / Quarto.** Lint rules apply inside R chunk bodies of `.Rmd` / `.qmd` documents — both in the editor and via `raven lint`. Prose, YAML front matter, and non-R chunks are never linted. `# nolint`, `# nolint start` / `# nolint end`, and `# @lsp-ignore` markers work inside chunk bodies exactly as in plain `.R` files.
 - **Static, no R subprocess.** Raven's lint rules run against the tree-sitter parse it already maintains for completions and diagnostics. There's no `lintr` install, no `R` process, no startup cost. The `commented_code` rule re-parses each candidate comment body via a thread-local parser pool; every other rule walks only the already-parsed tree.
 - **UTF-16 line length.** Raven measures line length in UTF-16 code units (matching LSP position reporting), so a non-BMP character counts as two. `lintr` counts characters; for ASCII-only code the two agree.
 - **`commented_code` differs subtly from `lintr`.** Both decide whether a comment body "looks like code" by parsing it, but Raven parses with tree-sitter and `lintr` parses with R itself. Edge cases that exercise R-specific syntax (very old `_` assignment, non-ASCII operator overloads, etc.) may be classified differently.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -121,6 +121,7 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 - **Raven:** `raven.linting.trailingBlankLinesSeverity` (default `"hint"`).
 - **`lintr` equivalent:** `lintr::trailing_blank_lines_linter()`.
 - Also fires when the file is missing a final newline.
+- Does not apply to `.Rmd` / `.qmd` documents: the rule describes the file's shape, and a chunk document's shape is Markdown, not R.
 
 ### Assignment operator
 
@@ -293,7 +294,7 @@ Notes:
 
 ## Performance and scope notes
 
-- **R Markdown / Quarto.** Lint rules apply inside R chunk bodies of `.Rmd` / `.qmd` documents — both in the editor and via `raven lint`. Prose, YAML front matter, and non-R chunks are never linted. `# nolint`, `# nolint start` / `# nolint end`, and `# @lsp-ignore` markers work inside chunk bodies exactly as in plain `.R` files.
+- **R Markdown / Quarto.** Lint rules apply inside R chunk bodies of `.Rmd` / `.qmd` documents — both in the editor and via `raven lint`. Prose, YAML front matter, and non-R chunks are never linted. `# nolint`, `# nolint start` / `# nolint end`, and `# @lsp-ignore` markers work inside chunk bodies exactly as in plain `.R` files. The one exception is [trailing blank lines](#trailing-blank-lines), which describes the file's shape — Markdown, not R — and is disabled for chunk documents.
 - **Static, no R subprocess.** Raven's lint rules run against the tree-sitter parse it already maintains for completions and diagnostics. There's no `lintr` install, no `R` process, no startup cost. The `commented_code` rule re-parses each candidate comment body via a thread-local parser pool; every other rule walks only the already-parsed tree.
 - **UTF-16 line length.** Raven measures line length in UTF-16 code units (matching LSP position reporting), so a non-BMP character counts as two. `lintr` counts characters; for ASCII-only code the two agree.
 - **`commented_code` differs subtly from `lintr`.** Both decide whether a comment body "looks like code" by parsing it, but Raven parses with tree-sitter and `lintr` parses with R itself. Edge cases that exercise R-specific syntax (very old `_` assignment, non-ASCII operator overloads, etc.) may be classified differently.


### PR DESCRIPTION
Closes #343.

## What this does

R chunks in R Markdown / Quarto documents are now first-class R code across every surface:

- **`raven check`** (the issue's core ask): directory walks include `.Rmd`/`.qmd`; the R code inside chunks gets the full diagnostic set (syntax, lints, semantic checks, undefined-variable, missing-file, cross-file) at **document coordinates** in text/json/sarif output. `raven lint` likewise lints chunk bodies (`# nolint`/`@lsp-ignore` work inside chunks).
- **Editor**: the blanket Rmd diagnostics suppression is gone — chunk bodies are diagnosed, and hover, completion, signature help, go-to-definition, find-references, folding, expand-selection, and on-type indentation now work inside chunks. Prose/YAML/non-R chunks stay inert (completion, signature help, and indentation stand down there rather than treating prose as top-level R).
- **Cross-file (outgoing-only)**: a chunk's `source(\"helpers.R\")` resolves (graph edges, scope, missing-file); a helper declaring `# @lsp-sourced-by analysis.Rmd` inherits chunk context via masked on-demand indexing. Rmd files are deliberately **not** proactively workspace-indexed (R can't `source()` an Rmd).
- **knitr `params`**: when the YAML frontmatter declares a top-level `params:` key, `params` is treated as defined; otherwise it still flags.

> Note: the issue premise said the editor already diagnosed chunks — it didn't (diagnostics were fully suppressed for Rmd). This PR brings both surfaces up together, per discussion.

## How it works

One geometry-preserving mask, no position-mapping layer: `chunks::mask_to_r` blanks every non-R-chunk-body line while keeping chunk lines byte-identical at their original indices, so positions computed on the masked text *are* document coordinates. For Rmd docs, `Document`/`DocumentState` parse their trees from the masked text and expose it via `analysis_text()`; raw text is retained for sync, chunk/fence detection, outline sections, and content caches. All R chunks are analyzed as a single program (matching knitr's shared environment), so cross-chunk definitions resolve. Masking/classification route through shared chokepoints in `cross_file` (`analysis_text_for_kind`/`_for_path`, `masked_analysis_text`, `classify_and_mask`, `extract_metadata_for_path`). Architecture notes in `docs/development.md`; accepted limitations (inline R in prose, cross-chunk delimiter leak, non-R chunks) in `docs/limitations.md`.

## Verification

- `cargo fmt` / `clippy --workspace --all-targets --features test-support -D warnings` / `cargo test -p raven` (4330 lib tests) — clean
- bun suite (1324) + VS Code Mocha suite (311) — green
- Manual end-to-end: chunk error at correct document line/col in text/json/sarif, prose & `{python}` ignored, `source()` from chunk resolves, `params` respected, exit codes correct
- Process: per-task spec + quality reviews, a final adversarial whole-branch review (which caught and fixed two raw/masked pairing gaps, including a multibyte-prose panic), and iterative /simplify passes until two consecutive came back clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full R language intelligence inside R Markdown (`.Rmd`) and Quarto (`.qmd`) chunk bodies: diagnostics, completion, hover, signature help, go-to-definition, find-references, outline, folding, and indentation; diagnostics map to chunk-body line/column positions
  * CLI: `raven check` and `raven lint` now include and analyze R chunks

* **Behavior**
  * Only R chunk bodies are analyzed (prose/YAML/non-R chunks inert); `params:` frontmatter is treated as a defined symbol when declared

* **Documentation**
  * Updated guides covering chunk-aware behavior and CLI changes

* **Tests**
  * Expanded test coverage for chunk handling and regressions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->