### PR TITLE
fix(hover): don't attribute named-argument labels to a package

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5860,13 +5860,19 @@ fn collect_undefined_variables_from_snapshot(
 /// handling, NSE / formula context) are intentionally NOT included here —
 /// those legitimately differ between pipelines.
 ///
-/// Note on the named-argument branch: it is only observable from
-/// `collect_identifier_usages_utf16` (the use-before-source pipeline). The
-/// undefined-variable pipeline (`collect_usages_with_context`) already
-/// early-returns on every identifier inside call arguments via its
+/// Note on the named-argument branch: within the diagnostics pipelines it is
+/// only observable from `collect_identifier_usages_utf16` (the use-before-source
+/// pipeline). The undefined-variable pipeline (`collect_usages_with_context`)
+/// already early-returns on every identifier inside call arguments via its
 /// `in_call_like_arguments` context flag, so the named-arg check here never
 /// fires for that consumer. The branch is still load-bearing — removing it
 /// would re-introduce the named-arg false positive in the utf16 pipeline.
+///
+/// Consumers beyond diagnostics: `hover` calls this predicate to suppress
+/// hovers on structural non-references — attributing a named-argument label
+/// (`title` in `labs(title = ...)`) to a definition or package was the reported
+/// `from {base}` bug — so hover and the diagnostics pass agree on what counts as
+/// a value reference.
 fn is_structural_non_reference(node: Node, text: &str) -> bool {
     debug_assert_eq!(node.kind(), "identifier");
 
@@ -13758,6 +13764,14 @@ pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<
             }),
             range: Some(node_range),
         });
+    }
+
+    // Suppress hovers on structural non-references; see
+    // `is_structural_non_reference`. Gated on `identifier` because strings
+    // (file-path hover) must not reach the predicate, and placed after the
+    // namespace branch so qualified `pkg::name` hovers still resolve.
+    if node.kind() == "identifier" && is_structural_non_reference(node, &text) {
+        return None;
     }
 
     // Try cross-file symbols (includes local scope with definition extraction)
@@ -37952,6 +37966,33 @@ result <- my_func(1, 2)"#;
         // Should return None for truly undefined symbols (after trying all fallbacks)
         // This tests the graceful handling when no definition is found anywhere
         assert!(hover_result.is_none());
+    }
+
+    #[test]
+    fn test_hover_named_argument_label_is_not_a_reference() {
+        // Regression: hovering the NAME of a named call argument (`title` in
+        // `labs(title = ...)`) must not resolve it as a value reference. The
+        // reported bug attributed it to `from {base}`; here we make the bug
+        // hermetically reproducible by defining a local `title` that the old
+        // code would surface via the cross-file scope. A named-argument label
+        // is a structural non-reference, so hover must return None.
+        let library_paths = r_env::find_library_paths();
+        let mut state = WorldState::new(library_paths);
+
+        let uri = Url::parse("file:///test.R").unwrap();
+        let code = "title <- \"default\"\nlabs(title = \"MPG vs Weight\")";
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+
+        // Column 7 lands inside `title` of `labs(title = ...)` on line 1.
+        let position = Position::new(1, 7);
+        let hover_result = hover_blocking(&state, &uri, position);
+
+        assert!(
+            hover_result.is_none(),
+            "named-argument label must not produce a value-reference hover, got: {hover_result:?}"
+        );
     }
 
     #[test]

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -19,11 +19,12 @@ Hover returns nothing for symbols R doesn't recognize and that aren't in scope.
 Hover tries sources in this order and stops at the first match. This matches the logic in `crates/raven/src/handlers.rs::hover`:
 
 1. **Namespace qualifier.** If the cursor is inside a `pkg::name` or `pkg:::name` expression, the qualifier wins — even if the file-local scope would resolve `name` to something else. Without this rule, hovering `filter` inside `dplyr::filter(...)` could show `stats::filter` whenever the workspace happened to surface that one first.
-2. **Cross-file scope.** Raven resolves the identifier through the dependency graph at the cursor's position. If it finds a local definition, a sourced definition, a declared symbol, or a package export that's in scope, it builds the hover from that symbol.
-3. **Package exports from loaded packages.** If the identifier isn't in the cross-file scope but it matches a symbol exported by any package loaded at the cursor (including packages inherited from parent files), hover shows that package's help topic.
-4. **R help fallback.** For anything left over — base/recommended built-ins, or symbols whose origin Raven can't infer — hover asks R for a help topic and returns it verbatim in a code block.
+2. **Structural non-references stop here.** An identifier that never refers to a value at runtime — a named-argument label (`title` in `labs(title = ...)`), an assignment target, a function-parameter name, or the member name in `obj$name` — produces no hover. These are not lookups, so attributing them to a definition or package (e.g. the misleading `from {base}`) would be wrong. Hover and the diagnostics pass share one predicate for this distinction, so they always agree on what counts as a reference.
+3. **Cross-file scope.** Raven resolves the identifier through the dependency graph at the cursor's position. If it finds a local definition, a sourced definition, a declared symbol, or a package export that's in scope, it builds the hover from that symbol.
+4. **Package exports from loaded packages.** If the identifier isn't in the cross-file scope but it matches a symbol exported by any package loaded at the cursor (including packages inherited from parent files), hover shows that package's help topic.
+5. **R help fallback.** For anything left over — base/recommended built-ins, or symbols whose origin Raven can't infer — hover asks R for a help topic and returns it verbatim in a code block.
 
-Each step takes the first hit and stops; steps 2–4 never run once a match is found.
+Each step takes the first hit and stops; steps 3–5 never run once a match is found.
 
 ## File Location Lines
 


### PR DESCRIPTION
## Problem

Hovering the **name** of a named call argument — e.g. `title` in:

```r
ggplot(data, aes(x = wt, y = mpg)) +
  geom_point() +
  labs(title = "MPG vs Weight")
```

produced a misleading hover:

```
`title`
from {base}
```

`title` there is a function parameter label, not a `{base}` export. The hover handler resolved the identifier under the cursor as a value reference without first checking whether it was a *structural non-reference* (a named-argument label, assignment target, parameter name, or `obj$name` member).

## Fix

Consult `is_structural_non_reference` — the codebase's documented single source of truth for "structural identifier; not a reference", already shared by both diagnostics pipelines — and return no hover for structural non-references.

- Gated to `identifier` nodes, since strings drive file-path hover through a separate path.
- Placed **after** the namespace-qualifier branch, so qualified `pkg::name` hovers still resolve.
- Hover and the diagnostics pass now agree, by construction, on what counts as a value reference.

This also fixes the same class of mis-attribution on assignment targets, parameter names, and `obj$name` member names.

## Testing

- Added hermetic regression test `test_hover_named_argument_label_is_not_a_reference` (defines a local `title` so the bug reproduces without depending on installed R packages — exercising the same `cross_file_symbols` path that produced `from {base}`).
- TDD: red (reproduced the bug) → green.
- Full suite green: `cargo test -p raven` (4334 passed, 0 failed), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`.

## Docs

- `docs/hover.md`: documented the new resolution-order step.
- Expanded the `is_structural_non_reference` doc comment to record `hover` as a consumer.