### PR TITLE
fix(check): 3-state shipped-DB load signal for missing-metadata warning

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -276,8 +276,9 @@ pub async fn run(args: CheckArgs) -> i32 {
 
     // Auto-detect R for installed-package / base-symbol awareness. Any failure
     // (R absent, init error, no library paths) degrades gracefully and prints
-    // its own one-line note to stderr.
-    maybe_init_r(&mut state, &root).await;
+    // its own one-line note to stderr. The returned verdict feeds the
+    // missing-export-metadata warning below.
+    let shipped_db_load = maybe_init_r(&mut state, &root).await;
 
     // Resolve which files to report diagnostics for. A named path that does not
     // exist is an operator error (exit 2), matching `raven lint`.
@@ -371,14 +372,11 @@ pub async fn run(args: CheckArgs) -> i32 {
     render(args.format, &all_diags, &root, args.quiet, use_color);
 
     if !missing_export_metadata_packages.is_empty() {
-        let tier3_present = crate::package_db::locate_shipped_db_candidates()
-            .into_iter()
-            .any(|p| p.exists());
         eprintln!(
             "{}",
             format_missing_export_metadata_warning(
                 &missing_export_metadata_packages,
-                tier3_present
+                shipped_db_load
             )
         );
     }
@@ -526,7 +524,15 @@ fn resolve_project_config(
 /// readiness gate. The three R-related degradations each print a one-line note
 /// to stderr so CI shows what was missing; `Disabled` (the user turned package
 /// awareness off in `raven.toml`) is silent, matching the editor.
-async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
+///
+/// Returns the build's [`ShippedDbLoad`] verdict so the caller can tailor the
+/// missing-export-metadata warning (absent / loaded / present-but-failed)
+/// without re-stat-ing disk — the build already knows whether the shipped
+/// `names.db` actually loaded, which a bare `Path::exists()` cannot tell.
+async fn maybe_init_r(
+    state: &mut crate::state::WorldState,
+    root: &Path,
+) -> crate::package_library::ShippedDbLoad {
     // Snapshot config into locals before the call so the later `state`
     // mutation doesn't conflict with the borrow.
     let r_path = state.cross_file_config.packages_r_path.clone();
@@ -559,6 +565,7 @@ async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
     use crate::package_library::PackageLibraryStatus::*;
     state.package_library_ready = outcome.consumer_ready();
     let status = outcome.status;
+    let shipped_db_load = outcome.shipped_db_load;
     state.package_library = outcome.library;
     match status {
         Ready | Disabled => {}
@@ -572,6 +579,7 @@ async fn maybe_init_r(state: &mut crate::state::WorldState, root: &Path) {
             "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
         ),
     }
+    shipped_db_load
 }
 
 /// Warm the package-export cache for the packages the reported files attach,
@@ -668,15 +676,27 @@ async fn collect_missing_export_metadata_packages(
 /// Warn that some attached packages' exported symbols couldn't be loaded, so the
 /// undefined-variable diagnostics above may be unreliable — then steer the user
 /// to a fix. Leads with impact, then the obvious remedy (install the package),
-/// then a CI-specific fallback.
+/// then a database-specific fallback.
 ///
-/// `tier3_present` is computed by the caller from `p.exists()` over the shipped
-/// database's candidate paths — it means *a database file is on disk*, NOT that
-/// it loaded and was searched successfully (a corrupt/unsupported file also sets
-/// it, and separately produces its own load note). So the present-database
-/// branch must not claim a successful lookup; it states the actionable
-/// conclusion (the package isn't available from the database → use `freeze`).
-fn format_missing_export_metadata_warning(packages: &[String], tier3_present: bool) -> String {
+/// The fallback depends on the Tier 3 shipped database's actual load state
+/// ([`ShippedDbLoad`]) — a three-way signal, not a present/absent boolean. The
+/// distinction matters because `p.exists()` ("a database file is on disk") does
+/// NOT mean it loaded and was searched: a corrupt/unsupported file also exists.
+///
+/// - `Loaded` — the database loaded and was searched; the package genuinely
+///   isn't in it, so it's likely private or off CRAN/Bioconductor → `freeze`.
+/// - `Absent` — no database installed → `raven packages update` to download it
+///   (or `freeze` a snapshot from a machine where the package is installed).
+/// - `Failed` — a database file is present but corrupt/unsupported, so it was
+///   never searched. `freeze` is the wrong advice here (the package may well be
+///   in a working copy); steer to `raven packages update` to re-download a good
+///   copy. The specific load error is printed separately as a load note.
+fn format_missing_export_metadata_warning(
+    packages: &[String],
+    shipped_db_load: crate::package_library::ShippedDbLoad,
+) -> String {
+    use crate::package_library::ShippedDbLoad::*;
+
     let mut names = packages.to_vec();
     names.sort();
     names.dedup();
@@ -697,18 +717,22 @@ fn format_missing_export_metadata_warning(packages: &[String], tier3_present: bo
          To fix: install {noun} in your R library."
     );
 
-    if tier3_present {
-        format!(
+    match shipped_db_load {
+        Loaded => format!(
             "{head}\n\
              Raven's package symbol database doesn't provide {obj} — {inst} likely private or not on CRAN/Bioconductor.\n\
              Capture {obj} with `raven packages freeze` on a machine where {inst} installed, and commit the result."
-        )
-    } else {
-        format!(
+        ),
+        Absent => format!(
             "{head}\n\
              In CI without R, run `raven packages update` before `raven check` to download Raven's package symbol database,\n\
              or commit a `raven packages freeze` snapshot made on a machine where {inst} installed."
-        )
+        ),
+        Failed => format!(
+            "{head}\n\
+             Raven's package symbol database is present but failed to load (corrupt or unsupported format), so it was not searched — see the load note above.\n\
+             Run `raven packages update` to re-download a working database."
+        ),
     }
 }
 
@@ -820,12 +844,15 @@ mod tests {
 
     #[test]
     fn formats_missing_metadata_warning_for_absent_tier3() {
-        let msg =
-            super::format_missing_export_metadata_warning(&["foo".into(), "bar".into()], false);
+        use crate::package_library::ShippedDbLoad;
+        let msg = super::format_missing_export_metadata_warning(
+            &["foo".into(), "bar".into()],
+            ShippedDbLoad::Absent,
+        );
         // Names are sorted, so order is deterministic.
         assert!(msg.contains("couldn't load exported symbols for bar, foo"));
         assert!(msg.contains("install these packages in your R library"));
-        // Variant A steers to `update` (then `freeze`) as the CI fallback.
+        // Absent steers to `update` (then `freeze`) as the CI fallback.
         assert!(msg.contains("run `raven packages update` before `raven check`"));
         assert!(msg.contains("raven packages freeze"));
         assert!(!msg.contains("Tier"));
@@ -833,7 +860,9 @@ mod tests {
 
     #[test]
     fn formats_missing_metadata_warning_absent_tier3_singular() {
-        let msg = super::format_missing_export_metadata_warning(&["foo".into()], false);
+        use crate::package_library::ShippedDbLoad;
+        let msg =
+            super::format_missing_export_metadata_warning(&["foo".into()], ShippedDbLoad::Absent);
         assert!(msg.contains("couldn't load exported symbols for foo"));
         assert!(msg.contains("install this package in your R library"));
         assert!(msg.contains("where it's installed"));
@@ -842,13 +871,31 @@ mod tests {
 
     #[test]
     fn formats_missing_metadata_warning_for_present_tier3_miss() {
-        let msg = super::format_missing_export_metadata_warning(&["foo".into()], true);
+        use crate::package_library::ShippedDbLoad;
+        let msg =
+            super::format_missing_export_metadata_warning(&["foo".into()], ShippedDbLoad::Loaded);
         assert!(msg.contains("couldn't load exported symbols for foo"));
         // Singular wording for a single package.
         assert!(msg.contains("install this package in your R library"));
         assert!(msg.contains("Raven's package symbol database doesn't provide it"));
         assert!(msg.contains("raven packages freeze"));
         assert!(!msg.contains("Tier"));
+    }
+
+    #[test]
+    fn formats_missing_metadata_warning_for_failed_tier3() {
+        use crate::package_library::ShippedDbLoad;
+        let msg =
+            super::format_missing_export_metadata_warning(&["foo".into()], ShippedDbLoad::Failed);
+        assert!(msg.contains("couldn't load exported symbols for foo"));
+        // A present-but-unusable DB: explain that, and steer toward re-downloading
+        // a good copy rather than freezing project metadata.
+        assert!(msg.contains("present but failed to load"));
+        assert!(msg.contains("Run `raven packages update` to re-download"));
+        assert!(
+            !msg.contains("raven packages freeze"),
+            "freeze is wrong advice when the DB merely failed to load: {msg}"
+        );
     }
 
     #[test]

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -1713,6 +1713,30 @@ impl PackageLibrary {
     }
 }
 
+/// Load result of the Tier 3 shipped `names.db`, captured during
+/// [`build_package_library`]. This is a richer signal than "a names.db file is
+/// on disk": it distinguishes *absent* from *present-but-unusable*, which a bare
+/// `Path::exists()` check cannot. Consumers that advise the user (e.g. `raven
+/// check`'s missing-metadata warning) need that distinction — a corrupt or
+/// unsupported DB should steer toward `raven packages update` (re-download a
+/// good copy), not `raven packages freeze` (which only helps when the DB loaded
+/// fine but genuinely lacks the package).
+///
+/// Derived from the same [`crate::package_db::binary_db::ShippedDbProvider::from_file`]
+/// calls that wire the provider, so it never disagrees with whether a working
+/// Tier 3 provider was actually installed. `load_notes` carries the human-readable
+/// failure text; this carries the structured verdict so callers don't parse strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShippedDbLoad {
+    /// No shipped `names.db` candidate exists on disk.
+    Absent,
+    /// A shipped `names.db` was found and loaded successfully (provider wired).
+    Loaded,
+    /// A shipped `names.db` file is present but failed to load — `Corrupt` or
+    /// `UnsupportedFormat`. The detail is also recorded in `load_notes`.
+    Failed,
+}
+
 /// Outcome of [`build_package_library`]: the constructed library plus a single
 /// build status that records R/Tier-1 initialization and any degradation reason.
 /// Consumer readiness is derived by [`PackageLibraryOutcome::consumer_ready`],
@@ -1731,6 +1755,10 @@ pub struct PackageLibraryOutcome {
     /// `Disabled` early-return and the Tier-1-only capture path, which wire no
     /// providers.
     pub load_notes: Vec<String>,
+    /// Whether the Tier 3 shipped `names.db` was absent, loaded, or
+    /// present-but-failed. `Absent` on the `Disabled` early-return and the
+    /// Tier-1-only capture path, which never open the shipped DB.
+    pub shipped_db_load: ShippedDbLoad,
 }
 
 impl PackageLibraryOutcome {
@@ -1827,6 +1855,7 @@ pub async fn build_package_library(
             library: Arc::new(PackageLibrary::new_empty()),
             status: PackageLibraryStatus::Disabled,
             load_notes: Vec::new(),
+            shipped_db_load: ShippedDbLoad::Absent,
         };
     }
 
@@ -1840,7 +1869,7 @@ pub async fn build_package_library(
 
     // Open the fallback DBs off the async runtime (mmap + ~10-20 ms blake3).
     let shipped_db_candidates = crate::package_db::locate_shipped_db_candidates();
-    let (providers, notes) = tokio::task::spawn_blocking(move || {
+    let (providers, notes, shipped_db_load) = tokio::task::spawn_blocking(move || {
         let mut providers: Vec<Box<dyn crate::package_db::PackageMetadataProvider>> = Vec::new();
         let mut notes: Vec<String> = Vec::new();
         // Tier 2 first (repo DB), then Tier 3 (shipped DB).
@@ -1851,20 +1880,29 @@ pub async fn build_package_library(
                 Err(e) => notes.push(e.to_string()), // explain-and-continue
             }
         }
+        // Track the Tier 3 verdict alongside the provider: `Absent` until a
+        // candidate proves otherwise. A successful load wins and stops the scan;
+        // a failed candidate records `Failed` but keeps looking, so a later
+        // working candidate still upgrades the verdict to `Loaded`.
+        let mut shipped_db_load = ShippedDbLoad::Absent;
         for path in shipped_db_candidates {
             match crate::package_db::binary_db::ShippedDbProvider::from_file(&path) {
                 Ok(Some(p)) => {
                     providers.push(Box::new(p));
+                    shipped_db_load = ShippedDbLoad::Loaded;
                     break;
                 }
                 Ok(None) => {}
-                Err(e) => notes.push(format!("{}: {e}", path.display())),
+                Err(e) => {
+                    notes.push(format!("{}: {e}", path.display()));
+                    shipped_db_load = ShippedDbLoad::Failed;
+                }
             }
         }
-        (providers, notes)
+        (providers, notes, shipped_db_load)
     })
     .await
-    .unwrap_or_else(|_| (Vec::new(), Vec::new()));
+    .unwrap_or_else(|_| (Vec::new(), Vec::new(), ShippedDbLoad::Absent));
 
     for note in &notes {
         log::warn!("{note}");
@@ -1875,6 +1913,7 @@ pub async fn build_package_library(
         library: Arc::new(lib),
         status,
         load_notes: notes,
+        shipped_db_load,
     }
 }
 
@@ -1920,6 +1959,7 @@ pub async fn build_package_library_tier1_only(
         library: Arc::new(lib),
         status,
         load_notes: Vec::new(),
+        shipped_db_load: ShippedDbLoad::Absent,
     }
 }
 
@@ -1988,6 +2028,12 @@ mod tests {
         // Too short / bad magic => ShippedDb::open returns Corrupt => a load note.
         std::fs::write(&bad, b"NOT A RAVEN DB").unwrap();
 
+        // Point the user-data candidate at an empty dir so the bad env DB is the
+        // only shipped-DB candidate that exists — otherwise a real machine-level
+        // names.db would load after it and flip the verdict to `Loaded`.
+        let empty_user_data = dir.path().join("user-data");
+        std::fs::create_dir_all(&empty_user_data).unwrap();
+        let _user_data_guard = crate::package_db::test_user_data_dir_guard(empty_user_data);
         let _db_env = NamesDbEnvGuard::set(&bad);
         let outcome = build_package_library(None, &[], None, true).await;
 
@@ -2001,6 +2047,8 @@ mod tests {
             "the note should mention names.db; got {:?}",
             outcome.load_notes
         );
+        // ...and the structured verdict reports present-but-failed, not absent.
+        assert_eq!(outcome.shipped_db_load, ShippedDbLoad::Failed);
     }
 
     #[tokio::test]
@@ -2049,6 +2097,9 @@ mod tests {
                 .exports
                 .contains("lower_export")
         );
+        // A failed candidate followed by a working one resolves to `Loaded`:
+        // the working DB was searched, so `freeze` would be the right advice.
+        assert_eq!(outcome.shipped_db_load, ShippedDbLoad::Loaded);
     }
 
     /// Pins the readiness predicate and degradation precedence
@@ -2110,6 +2161,7 @@ mod tests {
             library: Arc::new(PackageLibrary::new_empty()),
             status: PackageLibraryStatus::RNotFound,
             load_notes: Vec::new(),
+            shipped_db_load: ShippedDbLoad::Absent,
         };
 
         assert!(!outcome.consumer_ready());
@@ -2123,6 +2175,7 @@ mod tests {
             library: Arc::new(lib),
             status: PackageLibraryStatus::RNotFound,
             load_notes: Vec::new(),
+            shipped_db_load: ShippedDbLoad::Absent,
         };
 
         assert!(outcome.consumer_ready());
@@ -2145,6 +2198,7 @@ mod tests {
             library: Arc::new(lib),
             status: PackageLibraryStatus::RNotFound,
             load_notes: Vec::new(),
+            shipped_db_load: ShippedDbLoad::Absent,
         };
 
         assert!(outcome.consumer_ready());
@@ -2156,6 +2210,7 @@ mod tests {
             library: Arc::new(PackageLibrary::new_empty()),
             status: PackageLibraryStatus::Ready,
             load_notes: Vec::new(),
+            shipped_db_load: ShippedDbLoad::Absent,
         };
 
         assert!(outcome.consumer_ready());


### PR DESCRIPTION
## Summary

The `raven check` missing-export-metadata warning chose between `raven packages freeze` and `raven packages update` based on a `tier3_present: bool` that the call site recomputed by re-stat-ing disk:

```rust
let tier3_present = crate::package_db::locate_shipped_db_candidates()
    .into_iter()
    .any(|p| p.exists());
```

`p.exists()` only means *a database file is on disk* — a **corrupt or unsupported** `names.db` also set it `true`. So when the shipped DB was present-but-unusable, the warning steered users to `raven packages freeze` (correct only when the DB loaded fine but genuinely lacks the package) instead of `raven packages update` (re-download a good copy).

## What changed

- **`package_library.rs`** — added a structured `ShippedDbLoad` enum (`Absent` / `Loaded` / `Failed`) and a `shipped_db_load` field on `PackageLibraryOutcome`. It's computed at the source, inside `build_package_library`'s shipped-DB candidate loop, from the same `ShippedDbProvider::from_file` results that wire the provider — so it can never disagree with whether a working Tier 3 provider actually loaded. A failed candidate records `Failed` but keeps scanning, so a later working candidate still upgrades the verdict to `Loaded`. The `Disabled` and tier1-only/freeze paths set `Absent` (they never open the shipped DB).
- **`check.rs`** — `maybe_init_r` returns the verdict; `run` threads it to the warning formatter instead of re-stating disk. The formatter matches on the three states; the new `Failed` arm explains the DB is present-but-unusable and steers to `raven packages update` only (no `freeze`).

This removes a redundant disk-stat pass at the consumer and replaces a string-parse-prone signal (`load_notes`) with a structured verdict.

## Tests

- New `formats_missing_metadata_warning_for_failed_tier3` covering the `Failed` arm (asserts the present-but-failed wording and that `freeze` is *not* suggested); existing format tests migrated to the enum.
- Asserted the source verdict in two `build_library_*` tests — `Failed` for a corrupt DB (isolating the user-data candidate to an empty dir so a real machine `names.db` can't flip it to `Loaded`) and `Loaded` for the bad-then-good fallback case.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` — clean
- `cargo test --features test-support` — 4336 passed, 0 failed

Code quality was reviewed via two consecutive clean `/simplify` passes (reuse, simplification, efficiency, altitude) with no findings.