### PR TITLE
refactor(lint): use centralized extract_operator_rhs in T/F-symbol rule

### DIFF
--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -66,9 +66,10 @@ fn is_excluded_position(ident: Node<'_>) -> bool {
         "binary_operator" => is_assignment_target(parent, ident),
         "extract_operator" => {
             // `$` / `@`: skip the RHS field name; LHS is a real reference.
-            parent
-                .child_by_field_name("rhs")
-                .is_some_and(|rhs| rhs.id() == ident.id())
+            // Centralized in `crate::extract_op` so this predicate,
+            // go-to-def's qualified-member resolver, and
+            // `handlers.rs::is_structural_label` cannot drift on the AST shape.
+            crate::extract_op::extract_operator_rhs(ident).is_some()
         }
         "argument" => {
             // Named argument: `foo(T = TRUE)` — `T` here is a parameter label.


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `extract_operator` RHS detection in `t_and_f_symbol.rs::is_excluded_position` with a call to the centralized `crate::extract_op::extract_operator_rhs` helper, matching how `handlers.rs::is_structural_label` already consumes it.

The codebase has a single source of truth for "this identifier is the structural member-name half of `$`/`@`, not a free-variable reference" — `crate::extract_op::extract_operator_rhs`. Its whole purpose is to keep go-to-definition's qualified-member resolver and the structural-non-reference predicates from drifting on the AST shape. The T/F-symbol lint had its own copy of that AST-shape logic (`parent.child_by_field_name("rhs")` + `id()` comparison), which defeated the centralization. This enrolls the third drift-prone site onto the shared helper.

The call is kept inside the existing `"extract_operator" =>` match arm, so all non-reference positions (binary_operator, extract_operator, argument, parameter) remain enumerated as sibling arms — no structural change to the dispatcher.

**No behavior change intended.** The helper is strictly equal-or-narrower than the inline check (it also validates the operator kind is `$`/`@`), and the T/F lint still skips `obj$T`-style member names while flagging `obj$T`'s LHS.

## Testing
- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` — zero warnings ✓
- `cargo test -p raven --lib t_and_f` — 10 passed (incl. `t_and_f_skips_extract_rhs`, `t_and_f_flags_extract_lhs`) ✓
- `cargo test -p raven --lib extract_op` — 9 passed ✓

## Context
Surfaced during a `/simplify` review of #381 (hover structural-non-reference decomposition); flagged as pre-existing and out of scope for that PR.