### PR TITLE
feat: nested $/@/[[]] member completion + go-to-definition

### DIFF
--- a/crates/raven/src/extract_op.rs
+++ b/crates/raven/src/extract_op.rs
@@ -33,10 +33,16 @@ pub fn extract_operator_rhs(node: Node) -> Option<(Node, ExtractOp)> {
     }
     let lhs = parent.child_by_field_name("lhs")?;
     let op_node = parent.child_by_field_name("operator")?;
-    let op = match op_node.kind() {
-        "$" => ExtractOp::Dollar,
-        "@" => ExtractOp::At,
-        _ => return None,
-    };
+    let op = op_from_node(op_node)?;
     Some((lhs, op))
+}
+
+/// Map a `$`/`@` operator node to [`ExtractOp`]. Returns `None` for any other
+/// node kind.
+pub fn op_from_node(op_node: Node) -> Option<ExtractOp> {
+    match op_node.kind() {
+        "$" => Some(ExtractOp::Dollar),
+        "@" => Some(ExtractOp::At),
+        _ => None,
+    }
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -12363,7 +12363,11 @@ fn ts_point_to_lsp_position(text: &str, point: Point) -> Position {
 
 #[derive(Debug, Clone)]
 struct DollarMemberCompletionContext {
-    lhs_name: String,
+    /// Container the member is completed against (`alpha$beta` in
+    /// `alpha$beta$gam|`), built from the AST so `$`/`@`/`[["lit"]]` segments
+    /// all work and an intermediate segment is never treated as a free variable.
+    path: crate::qualified_resolve::QualifiedPath,
+    op: crate::extract_op::ExtractOp,
     typed_prefix: String,
     replace_range: Range,
 }
@@ -12396,31 +12400,59 @@ fn detect_dollar_member_completion_context(
         return None;
     }
 
-    let dollar_byte = token_start - 1;
-    let mut lhs_start = dollar_byte;
-    while lhs_start > 0 && is_r_identifier_continue_byte(bytes[lhs_start - 1]) {
-        lhs_start -= 1;
-    }
-    if lhs_start == dollar_byte || !is_r_identifier_start_byte(bytes[lhs_start]) {
-        return None;
-    }
-    if lhs_start > 0 && matches!(bytes[lhs_start - 1], b':' | b'@') {
-        return None;
-    }
+    let op_byte = token_start - 1;
+    // The container path comes from the AST subexpression ending just before the
+    // trigger `$`. This keeps the text scan only for the parts tree-sitter parses
+    // poorly (the trigger, typed prefix, and replace range) and gives full
+    // `$`/`@`/`[["lit"]]` parity. Bails on namespace (`pkg::obj$`), call-result
+    // (`f()$`), or computed-index (`x[[i]]$`) LHS — never guessing.
+    let path = lhs_path_ending_at(tree, text, line_idx, op_byte)?;
 
-    let lhs_name = line[lhs_start..dollar_byte].to_string();
     let typed_prefix = line[token_start..cursor_byte].to_string();
     let start_character = crate::utf16::byte_offset_to_utf16_column(line, token_start);
     let end_character = crate::utf16::byte_offset_to_utf16_column(line, token_end);
 
     Some(DollarMemberCompletionContext {
-        lhs_name,
+        path,
+        op: crate::extract_op::ExtractOp::Dollar,
         typed_prefix,
         replace_range: Range {
             start: Position::new(position.line, start_character),
             end: Position::new(position.line, end_character),
         },
     })
+}
+
+/// Build the [`crate::qualified_resolve::QualifiedPath`] for the container whose
+/// subexpression ends at byte `op_byte` on `line_idx` (the byte just before the
+/// trigger `$`). Selects the widest `extract_operator`/`subset2`/`identifier`
+/// node ending exactly there, then walks it with the shared spine-walker. Bails
+/// to `None` for a namespace LHS (`pkg::obj$`) or any non-static container.
+fn lhs_path_ending_at(
+    tree: &tree_sitter::Tree,
+    text: &str,
+    line_idx: usize,
+    op_byte: usize,
+) -> Option<crate::qualified_resolve::QualifiedPath> {
+    let target_end = Point::new(line_idx, op_byte);
+    let probe = Point::new(line_idx, op_byte.saturating_sub(1));
+    let start_node = tree
+        .root_node()
+        .descendant_for_point_range(probe, target_end)?;
+    let mut best: Option<tree_sitter::Node> = None;
+    let mut cur = Some(start_node);
+    while let Some(node) = cur {
+        if node.end_position() == target_end {
+            match node.kind() {
+                "extract_operator" | "subset2" | "identifier" => best = Some(node),
+                // `pkg::obj$` is namespace access, not member completion.
+                "namespace_operator" => return None,
+                _ => {}
+            }
+        }
+        cur = node.parent();
+    }
+    crate::qualified_resolve::build_qualified_path(best?, text)
 }
 
 fn position_in_string_or_comment(
@@ -12453,22 +12485,34 @@ fn is_r_identifier_continue_byte(byte: u8) -> bool {
     is_r_identifier_start_byte(byte) || byte.is_ascii_digit()
 }
 
+/// Render a container path for completion-item detail text, e.g.
+/// `alpha`, `alpha$beta`, `alpha@slot$beta`.
+fn render_qualified_path(path: &crate::qualified_resolve::QualifiedPath) -> String {
+    let mut rendered = path.head.clone();
+    for seg in &path.segments {
+        let op = match seg.op {
+            crate::extract_op::ExtractOp::Dollar => '$',
+            crate::extract_op::ExtractOp::At => '@',
+        };
+        rendered.push(op);
+        rendered.push_str(&seg.name);
+    }
+    rendered
+}
+
 fn dollar_member_completion_items(
     state: &WorldState,
     uri: &Url,
     position: Position,
     context: &DollarMemberCompletionContext,
 ) -> Vec<CompletionItem> {
-    let path = crate::qualified_resolve::QualifiedPath {
-        head: context.lhs_name.clone(),
-        segments: Vec::new(),
-    };
+    let rendered_path = render_qualified_path(&context.path);
     crate::qualified_resolve::complete_qualified_members(
         state,
         uri,
         position,
-        &path,
-        crate::extract_op::ExtractOp::Dollar,
+        &context.path,
+        context.op,
     )
     .into_iter()
     .filter(|candidate| {
@@ -12476,11 +12520,11 @@ fn dollar_member_completion_items(
     })
     .map(|candidate| {
         let detail = if candidate.uri == *uri {
-            format!("member of {}", context.lhs_name)
+            format!("member of {}", rendered_path)
         } else {
             let relative_path =
                 compute_relative_path(&candidate.uri, state.workspace_folders.first());
-            format!("member of {} from {}", context.lhs_name, relative_path)
+            format!("member of {} from {}", rendered_path, relative_path)
         };
         CompletionItem {
             label: candidate.name.clone(),
@@ -46199,8 +46243,55 @@ mod dollar_member_completion_tests {
             detect_dollar_member_completion_context(doc.tree.as_ref().unwrap(), &code, position)
                 .expect("dollar-chain completion context");
 
-        assert_eq!(context.lhs_name, "bar");
+        // The container path is the full `foo$bar`, not just the nearest segment
+        // `bar` (which previously leaked an unrelated top-level `bar`).
+        assert_eq!(context.path.head, "foo");
+        let segments: Vec<&str> = context
+            .path
+            .segments
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(segments, vec!["bar"]);
         assert_eq!(context.typed_prefix, "");
+    }
+
+    #[test]
+    fn completion_nested_dollar_chain() {
+        let items =
+            completion_items("alpha <- list(beta = list(gamma = 1, delta = 2))\nalpha$beta$|");
+        let labels = sorted_labels(&items);
+        assert!(
+            labels.contains(&"gamma".to_string()) && labels.contains(&"delta".to_string()),
+            "expected nested members gamma+delta, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn completion_subscript_segment_parity() {
+        let items = completion_items("alpha <- list(beta = list(gamma = 1))\nalpha[[\"beta\"]]$|");
+        let labels = sorted_labels(&items);
+        assert!(
+            labels.contains(&"gamma".to_string()),
+            "expected gamma via [[\"beta\"]] segment, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn completion_no_false_positive_on_collision() {
+        // An unrelated top-level `beta` must NOT leak its members into `alpha$beta$`.
+        let items = completion_items(
+            "beta <- list(zeta = 1)\nalpha <- list(beta = list(gamma = 2))\nalpha$beta$|",
+        );
+        let labels = sorted_labels(&items);
+        assert!(
+            labels.contains(&"gamma".to_string()),
+            "expected gamma, got {labels:?}"
+        );
+        assert!(
+            !labels.contains(&"zeta".to_string()),
+            "leaked unrelated `beta` member zeta, got {labels:?}"
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -12459,12 +12459,15 @@ fn dollar_member_completion_items(
     position: Position,
     context: &DollarMemberCompletionContext,
 ) -> Vec<CompletionItem> {
+    let path = crate::qualified_resolve::QualifiedPath {
+        head: context.lhs_name.clone(),
+        segments: Vec::new(),
+    };
     crate::qualified_resolve::complete_qualified_members(
         state,
         uri,
         position,
-        "identifier",
-        &context.lhs_name,
+        &path,
         crate::extract_op::ExtractOp::Dollar,
     )
     .into_iter()
@@ -14847,27 +14850,17 @@ pub fn goto_definition_with_cancel(
     // `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md`.
     if let Some((lhs_node, op)) = crate::extract_op::extract_operator_rhs(node) {
         let rhs_name = node_text(node, &text);
-        let lhs_name = node_text(lhs_node, &text);
+        // Build the container path from the LHS subtree. Nested chains
+        // (`alpha$beta$gamma`) resolve against the full path; a non-static LHS
+        // (`f()$x`, `alpha[[i]]$x`) yields `None` and falls through to nothing.
+        let path = crate::qualified_resolve::build_qualified_path(lhs_node, &text)?;
         let location = if cancel.is_never() {
             crate::qualified_resolve::resolve_qualified_member(
-                state,
-                uri,
-                position,
-                lhs_node.kind(),
-                lhs_name,
-                rhs_name,
-                op,
+                state, uri, position, &path, rhs_name, op,
             )
         } else {
             crate::qualified_resolve::resolve_qualified_member_with_cancel(
-                state,
-                uri,
-                position,
-                lhs_node.kind(),
-                lhs_name,
-                rhs_name,
-                op,
-                cancel,
+                state, uri, position, &path, rhs_name, op, cancel,
             )
         };
         return location.map(GotoDefinitionResponse::Scalar);

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -46278,6 +46278,24 @@ mod dollar_member_completion_tests {
     }
 
     #[test]
+    fn completion_non_static_lhs_yields_no_members() {
+        // Call-result, computed-index, and namespace LHS must not produce member
+        // completions (the AST path-builder bails).
+        for code in [
+            "make <- function() list(x = 1)\nmake()$|",
+            "alpha <- list(beta = 1)\ni <- 1\nalpha[[i]]$|",
+            "pkg::obj$|",
+        ] {
+            let items = completion_items(code);
+            let labels = sorted_labels(&items);
+            assert!(
+                !labels.iter().any(|l| l == "x" || l == "beta"),
+                "non-static LHS leaked members for {code:?}: {labels:?}"
+            );
+        }
+    }
+
+    #[test]
     fn completion_no_false_positive_on_collision() {
         // An unrelated top-level `beta` must NOT leak its members into `alpha$beta$`.
         let items = completion_items(

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -2400,6 +2400,36 @@ foo$
         assert_eq!(l.range.start.line, 0); // the `baz = 1` constructor argument
     }
 
+    #[test]
+    fn goto_def_nested_member_jumps_to_assignment() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list())
+alpha$beta$gamma <- 1
+x <- alpha$beta$gamma
+";
+        let uri = add_doc(&mut state, "file:///g.R", code);
+        // cursor on `gamma` in the use on line 2
+        let l = loc(goto_definition(&state, &uri, Position::new(2, 17)));
+        assert_eq!(l.uri, uri);
+        assert_eq!(l.range.start.line, 1); // the `alpha$beta$gamma <- 1` line
+    }
+
+    #[test]
+    fn goto_def_nested_no_false_positive() {
+        let mut state = fresh_state();
+        let code = "\
+gamma <- 99
+alpha <- list(beta = list(gamma = 1))
+y <- alpha$beta$gamma
+";
+        let uri = add_doc(&mut state, "file:///g2.R", code);
+        // `gamma` here must resolve to the constructor member (line 1), not the
+        // top-level `gamma <- 99` on line 0.
+        let l = loc(goto_definition(&state, &uri, Position::new(2, 17)));
+        assert_eq!(l.range.start.line, 1);
+    }
+
     /// LHS-shape gate: parenthesized LHS → None.
     #[test]
     fn parenthesized_lhs_returns_none() {

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -848,22 +848,39 @@ fn collect_qualified_member_candidates_with_cancel(
     all_candidates.extend(cross_file_candidates);
 
     // Establishing-site cutoff (reassignment semantics): a whole-value (re)write
-    // of an intermediate prefix in the cursor file replaces members declared
-    // before it. Members at or after the latest such write survive; earlier ones
-    // (including those from the head binding's constructor) are dropped. The
-    // sites were collected while walking the cursor file above; only the cursor
-    // file's sites are considered (cross-file ordering is handled below / left to
-    // the contributor-chain union).
-    if let Some(cutoff) = establishing_sites
-        .iter()
-        .copied()
-        .filter(|s| (s.line, s.utf16_column) <= (position.line, position.character))
-        .max_by_key(|s| (s.line, s.utf16_column))
-    {
-        all_candidates.retain(|c| {
-            c.uri != cursor_uri
-                || (c.effect.line, c.effect.utf16_column) >= (cutoff.line, cutoff.utf16_column)
-        });
+    // of an intermediate prefix replaces members declared before it. Members at
+    // or after the latest such write survive; earlier ones (including those from
+    // the head binding's constructor, and those from upstream files sourced
+    // before the write) are dropped. The establishing events are the cursor
+    // file's prefix writes (collected above) plus the `source()` that brings the
+    // head's defining file into scope — a source re-establishes the whole value,
+    // so it competes for the latest cutoff.
+    if !path.segments.is_empty() {
+        let source_pos = direct_source_positions(state, &cursor_uri, position);
+        let head_source = source_pos.get(&defining_uri).copied();
+        let cursor = (position.line, position.character);
+        let cutoff = establishing_sites
+            .iter()
+            .map(|s| (s.line, s.utf16_column))
+            .chain(head_source)
+            .filter(|&pos| pos <= cursor)
+            .max();
+        if let Some(cutoff) = cutoff {
+            all_candidates.retain(|c| {
+                if c.uri == cursor_uri {
+                    (c.effect.line, c.effect.utf16_column) >= cutoff
+                } else {
+                    // Drop an upstream candidate whose file was sourced before the
+                    // cutoff (the reassignment replaced it). Keep it if sourced at
+                    // or after the cutoff, or reached only transitively (no direct
+                    // source line — conservative).
+                    match source_pos.get(&c.uri) {
+                        Some(&src) => src >= cutoff,
+                        None => true,
+                    }
+                }
+            });
+        }
     }
 
     let contributor_distances = contributor_file_distances(
@@ -881,6 +898,33 @@ fn collect_qualified_member_candidates_with_cancel(
         contributor_ranks,
         contributor_distances,
     })
+}
+
+/// Map each file directly sourced by `cursor_uri` to the latest `source()`
+/// call-site position in the cursor file that is at or before `cursor`. Used by
+/// the establishing-site cutoff to order an upstream candidate's contribution
+/// (its source point) against a cursor-file reassignment. Transitively-sourced
+/// files are absent (the cutoff keeps those conservatively).
+fn direct_source_positions(
+    state: &WorldState,
+    cursor_uri: &Url,
+    cursor: Position,
+) -> HashMap<Url, (u32, u32)> {
+    let mut map: HashMap<Url, (u32, u32)> = HashMap::new();
+    for edge in state.cross_file_graph.get_dependencies(cursor_uri) {
+        if let (Some(line), Some(col)) = (edge.call_site_line, edge.call_site_column)
+            && (line, col) <= (cursor.line, cursor.character)
+        {
+            map.entry(edge.to.clone())
+                .and_modify(|p| {
+                    if (line, col) > *p {
+                        *p = (line, col);
+                    }
+                })
+                .or_insert((line, col));
+        }
+    }
+    map
 }
 
 fn contributor_file_ranks(chain: &[Url]) -> HashMap<Url, usize> {
@@ -2061,6 +2105,46 @@ alpha$beta$
         names.sort();
         // gamma from helpers.R (the establishing site) + delta extended in main.R.
         assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+    }
+
+    #[test]
+    fn nested_member_cross_file_reassignment_drops_upstream() {
+        // main.R sources helpers.R (which declares alpha$beta with gamma), then
+        // WHOLLY reassigns alpha$beta. The upstream gamma was replaced and must
+        // not be offered — otherwise completion and go-to-definition would point
+        // at a member that no longer exists.
+        let mut state = fresh_state();
+        let main_code = "\
+source(\"helpers.R\")
+alpha$beta <- list(delta = 2)
+alpha$beta$
+";
+        let helpers_code = "alpha <- list(beta = list(gamma = 1))\n";
+        let (main_uri, _helpers_uri) =
+            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let names =
+            completion_path_names(&state, &main_uri, Position::new(2, 11), "alpha", &["beta"]);
+        assert_eq!(names, vec!["delta".to_string()]);
+    }
+
+    #[test]
+    fn nested_member_cross_file_reassignment_before_source_keeps_upstream() {
+        // The reassignment is BEFORE the source() that brings alpha into scope,
+        // so the source re-establishes the upstream value: gamma survives.
+        let mut state = fresh_state();
+        let main_code = "\
+alpha$beta <- list(delta = 2)
+source(\"helpers.R\")
+alpha$beta$
+";
+        let helpers_code = "alpha <- list(beta = list(gamma = 1))\n";
+        let (main_uri, _helpers_uri) =
+            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let names =
+            completion_path_names(&state, &main_uri, Position::new(2, 11), "alpha", &["beta"]);
+        // gamma (sourced after the reassignment) is kept; delta predates the
+        // source so the cursor-file cutoff drops it.
+        assert_eq!(names, vec!["gamma".to_string()]);
     }
 
     #[test]

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -608,7 +608,7 @@ fn collect_qualified_member_candidates_with_cancel(
                 &defining_uri,
                 symbol.defined_line,
                 symbol.defined_column,
-                lhs_name,
+                path,
                 rhs_name,
             ) {
                 defining_candidates.push(candidate);
@@ -621,7 +621,7 @@ fn collect_qualified_member_candidates_with_cancel(
                 &defining_uri,
                 symbol.defined_line,
                 symbol.defined_column,
-                lhs_name,
+                path,
                 rhs_name,
                 &mut defining_candidates,
             );
@@ -1305,7 +1305,7 @@ fn collect_constructor_candidate(
     file_uri: &Url,
     defined_line: u32,
     defined_column_utf16: u32,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: &str,
 ) -> Option<Candidate> {
     let mut candidates = Vec::new();
@@ -1316,7 +1316,7 @@ fn collect_constructor_candidate(
         file_uri,
         defined_line,
         defined_column_utf16,
-        lhs_name,
+        path,
         Some(rhs_name),
         &mut candidates,
     );
@@ -1343,10 +1343,11 @@ fn collect_constructor_candidates(
     file_uri: &Url,
     defined_line: u32,
     defined_column_utf16: u32,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     out: &mut Vec<Candidate>,
 ) {
+    let lhs_name = path.head.as_str();
     // LSP columns are UTF-16 units; tree-sitter Point columns are byte offsets.
     // `defined_line` always points to a valid line in `text` (it comes from
     // the artifacts' Def event, which was emitted from a real tree-sitter
@@ -1390,8 +1391,20 @@ fn collect_constructor_candidates(
     let Some(args_node) = value_node.child_by_field_name("arguments") else {
         return;
     };
-    let mut walker = args_node.walk();
-    for child in args_node.children(&mut walker) {
+    // Descend the constructor following the intermediate segments. Each segment
+    // must be a named argument whose value is itself an allowlisted constructor.
+    let mut current_args = args_node;
+    for seg in &path.segments {
+        let Some(child_call) = named_arg_constructor_value(current_args, text, &seg.name) else {
+            return; // segment not present as a nested constructor → no members here
+        };
+        let Some(child_args) = child_call.child_by_field_name("arguments") else {
+            return;
+        };
+        current_args = child_args;
+    }
+    let mut walker = current_args.walk();
+    for child in current_args.children(&mut walker) {
         if child.kind() != "argument" {
             continue;
         }
@@ -1420,6 +1433,35 @@ fn collect_constructor_candidates(
             lhs_pos,
         });
     }
+}
+
+/// In `args` (a constructor call's argument list), find a named argument
+/// `name = <call>` whose value is a call to an allowlisted constructor, and
+/// return that call node. Used to descend nested constructor literals along a
+/// [`QualifiedPath`].
+fn named_arg_constructor_value<'a>(args: Node<'a>, text: &str, name: &str) -> Option<Node<'a>> {
+    let mut walker = args.walk();
+    for child in args.children(&mut walker) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
+        if name_node.kind() != "identifier" || node_text(name_node, text) != name {
+            continue;
+        }
+        let value = child.child_by_field_name("value")?;
+        if value.kind() != "call" {
+            return None;
+        }
+        let func = value.child_by_field_name("function")?;
+        if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
+            return Some(value);
+        }
+        return None;
+    }
+    None
 }
 
 fn ascend_to_assignment_for<'a>(start: Node<'a>, text: &str, lhs_name: &str) -> Option<Node<'a>> {
@@ -1679,6 +1721,39 @@ alpha$beta$
             completion_path_names(&state, &uri, Position::new(4, 11), "alpha", &["beta"]);
         names.sort();
         assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+    }
+
+    #[test]
+    fn nested_constructor_descent_depth2() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list(gamma = 1, delta = 2))
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///c.R", code);
+        let mut names =
+            completion_path_names(&state, &uri, Position::new(1, 11), "alpha", &["beta"]);
+        names.sort();
+        assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+    }
+
+    #[test]
+    fn nested_constructor_descent_depth3() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list(gamma = list(epsilon = 1, zeta = 2)))
+alpha$beta$gamma$
+";
+        let uri = add_indexed_doc(&mut state, "file:///c3.R", code);
+        let mut names = completion_path_names(
+            &state,
+            &uri,
+            Position::new(1, 17),
+            "alpha",
+            &["beta", "gamma"],
+        );
+        names.sort();
+        assert_eq!(names, vec!["epsilon".to_string(), "zeta".to_string()]);
     }
 
     /// Perf reproducer: scales the number of `df$col_K <- ...` assignments and
@@ -2022,16 +2097,17 @@ foo$
         assert!(goto_definition(&state, &uri, pos).is_none());
     }
 
-    /// Chained access `foo$bar$baz` returns None (Step-1 limitation,
-    /// documented in the spec).
+    /// Chained access `foo$bar$baz` resolves to the nested constructor member
+    /// (Step-2: the Step-1 "returns None" limitation is lifted).
     #[test]
-    fn chained_access_returns_none() {
+    fn chained_access_resolves_nested_member() {
         let mut state = fresh_state();
         let code = "foo <- list(bar = list(baz = 1))\nuse(foo$bar$baz)\n";
         let uri = add_doc(&mut state, "file:///t.R", code);
         // cursor on `baz`
         let pos = Position::new(1, 13);
-        assert!(goto_definition(&state, &uri, pos).is_none());
+        let l = loc(goto_definition(&state, &uri, pos));
+        assert_eq!(l.range.start.line, 0); // the `baz = 1` constructor argument
     }
 
     /// LHS-shape gate: parenthesized LHS → None.

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -189,7 +189,7 @@ fn member_assignment_candidate_from_extract(
     text: &str,
     col_mapper: &ColMapper,
     file_uri: &Url,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     op: ExtractOp,
 ) -> Option<Candidate> {
@@ -203,18 +203,22 @@ fn member_assignment_candidate_from_extract(
     ) {
         return None;
     }
-    let t_lhs = target.child_by_field_name("lhs")?;
     let t_rhs = target.child_by_field_name("rhs")?;
-    if t_lhs.kind() != "identifier" || t_rhs.kind() != "identifier" {
+    if t_rhs.kind() != "identifier" {
         return None;
     }
     let member_name = node_text(t_rhs, text);
-    if node_text(t_lhs, text) != lhs_name
-        || rhs_name.is_some_and(|rhs_name| member_name != rhs_name)
-    {
+    if rhs_name.is_some_and(|rhs_name| member_name != rhs_name) {
         return None;
     }
-    let lhs_range = node_range(t_lhs, col_mapper);
+    // The assignment target's container spine (everything left of the final
+    // `$`/`@`) must equal `path` (`head` + intermediate `segments`).
+    let t_lhs = target.child_by_field_name("lhs")?;
+    if !target_spine_is_path(t_lhs, text, path) {
+        return None;
+    }
+    let head_id = leftmost_identifier(t_lhs)?;
+    let lhs_range = node_range(head_id, col_mapper);
     Some(Candidate {
         name: member_name.to_string(),
         uri: file_uri.clone(),
@@ -225,6 +229,30 @@ fn member_assignment_candidate_from_extract(
     })
 }
 
+/// Does `target`'s left-spine equal `path` (`head` + `segments`)? `target` is
+/// the container half of an assignment target (`alpha$beta` in
+/// `alpha$beta$gamma <- ...`). Matching is by name and op per segment, via the
+/// shared [`build_qualified_path`] walker, so a `[["lit"]]` step matches a
+/// `Dollar` segment.
+fn target_spine_is_path(target: Node, text: &str, path: &QualifiedPath) -> bool {
+    match build_qualified_path(target, text) {
+        Some(actual) => actual.head == path.head && actual.segments == path.segments,
+        None => false,
+    }
+}
+
+/// Leftmost `identifier` on a node's left-spine (the head of an access chain).
+fn leftmost_identifier(mut node: Node) -> Option<Node> {
+    loop {
+        match node.kind() {
+            "identifier" => return Some(node),
+            "extract_operator" => node = node.child_by_field_name("lhs")?,
+            "subset" | "subset2" => node = node.child_by_field_name("function")?,
+            _ => return None,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn member_assignment_candidate_from_string_subscript(
     assignment: Node,
@@ -232,7 +260,7 @@ fn member_assignment_candidate_from_string_subscript(
     text: &str,
     col_mapper: &ColMapper,
     file_uri: &Url,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     op: ExtractOp,
 ) -> Option<Candidate> {
@@ -240,16 +268,17 @@ fn member_assignment_candidate_from_string_subscript(
         return None;
     }
     let t_lhs = target.child_by_field_name("function")?;
-    if t_lhs.kind() != "identifier" || node_text(t_lhs, text) != lhs_name {
+    if !target_spine_is_path(t_lhs, text, path) {
         return None;
     }
+    let head_id = leftmost_identifier(t_lhs)?;
     let args = target.child_by_field_name("arguments")?;
     let string_node = first_direct_string_argument(args)?;
     let member_name = simple_string_literal_value(string_node, text)?;
     if rhs_name.is_some_and(|rhs_name| member_name != rhs_name) {
         return None;
     }
-    let lhs_range = node_range(t_lhs, col_mapper);
+    let lhs_range = node_range(head_id, col_mapper);
     Some(Candidate {
         name: member_name.to_string(),
         uri: file_uri.clone(),
@@ -565,7 +594,7 @@ fn collect_qualified_member_candidates_with_cancel(
             &defining_text,
             &defining_col_mapper,
             &defining_uri,
-            lhs_name,
+            path,
             rhs_name,
             op,
             &mut defining_candidates,
@@ -647,7 +676,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     &candidate_text,
                     &candidate_col_mapper,
                     candidate_uri,
-                    lhs_name,
+                    path,
                     rhs_name,
                     op,
                     &mut needs_validation,
@@ -679,7 +708,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     &candidate_text,
                     &candidate_col_mapper,
                     candidate_uri,
-                    lhs_name,
+                    path,
                     rhs_name,
                     op,
                     &mut cross_file_candidates,
@@ -1175,7 +1204,7 @@ fn collect_member_assignments(
     text: &str,
     col_mapper: &ColMapper,
     file_uri: &Url,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     op: ExtractOp,
     out: &mut Vec<Candidate>,
@@ -1211,7 +1240,7 @@ fn collect_member_assignments(
             if !skip {
                 if kind == "binary_operator" {
                     try_extract_member_assignment(
-                        node, text, col_mapper, file_uri, lhs_name, rhs_name, op, out,
+                        node, text, col_mapper, file_uri, path, rhs_name, op, out,
                     );
                 }
                 // Descend into children if this node has any.
@@ -1240,7 +1269,7 @@ fn try_extract_member_assignment(
     text: &str,
     col_mapper: &ColMapper,
     file_uri: &Url,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     op: ExtractOp,
     out: &mut Vec<Candidate>,
@@ -1256,13 +1285,13 @@ fn try_extract_member_assignment(
     };
     let Some(target) = target else { return };
     if let Some(candidate) = member_assignment_candidate_from_extract(
-        node, target, text, col_mapper, file_uri, lhs_name, rhs_name, op,
+        node, target, text, col_mapper, file_uri, path, rhs_name, op,
     ) {
         out.push(candidate);
         return;
     }
     if let Some(candidate) = member_assignment_candidate_from_string_subscript(
-        node, target, text, col_mapper, file_uri, lhs_name, rhs_name, op,
+        node, target, text, col_mapper, file_uri, path, rhs_name, op,
     ) {
         out.push(candidate);
     }
@@ -1611,7 +1640,17 @@ mod tests {
         position: Position,
         lhs_name: &str,
     ) -> Vec<String> {
-        let path = dollar_path(lhs_name, &[]);
+        completion_path_names(state, uri, position, lhs_name, &[])
+    }
+
+    fn completion_path_names(
+        state: &WorldState,
+        uri: &Url,
+        position: Position,
+        head: &str,
+        segments: &[&str],
+    ) -> Vec<String> {
+        let path = dollar_path(head, segments);
         super::complete_qualified_members(
             state,
             uri,
@@ -1622,6 +1661,24 @@ mod tests {
         .into_iter()
         .map(|completion| completion.name)
         .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn nested_assignment_members_depth2() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list()
+alpha$beta <- list()
+alpha$beta$gamma <- 1
+alpha$beta$delta <- 2
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///n.R", code);
+        // Cursor on the trailing `alpha$beta$` line (0-based line 4, after `$`).
+        let mut names =
+            completion_path_names(&state, &uri, Position::new(4, 11), "alpha", &["beta"]);
+        names.sort();
+        assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
     }
 
     /// Perf reproducer: scales the number of `df$col_K <- ...` assignments and

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -351,8 +351,7 @@ pub fn resolve_qualified_member(
     state: &WorldState,
     uri: &Url,
     position: Position,
-    lhs_node_kind: &str,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: &str,
     op: ExtractOp,
 ) -> Option<Location> {
@@ -360,8 +359,7 @@ pub fn resolve_qualified_member(
         state,
         uri,
         position,
-        lhs_node_kind,
-        lhs_name,
+        path,
         rhs_name,
         op,
         &DiagCancelToken::never(),
@@ -384,8 +382,7 @@ pub fn resolve_qualified_member_with_cancel(
     state: &WorldState,
     uri: &Url,
     position: Position,
-    lhs_node_kind: &str,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: &str,
     op: ExtractOp,
     cancel: &DiagCancelToken,
@@ -394,8 +391,7 @@ pub fn resolve_qualified_member_with_cancel(
         state,
         uri,
         position,
-        lhs_node_kind,
-        lhs_name,
+        path,
         Some(rhs_name),
         op,
         cancel,
@@ -421,16 +417,14 @@ pub fn complete_qualified_members(
     state: &WorldState,
     uri: &Url,
     position: Position,
-    lhs_node_kind: &str,
-    lhs_name: &str,
+    path: &QualifiedPath,
     op: ExtractOp,
 ) -> Vec<QualifiedMemberCompletion> {
     complete_qualified_members_with_cancel(
         state,
         uri,
         position,
-        lhs_node_kind,
-        lhs_name,
+        path,
         op,
         &DiagCancelToken::never(),
     )
@@ -445,20 +439,12 @@ pub fn complete_qualified_members_with_cancel(
     state: &WorldState,
     uri: &Url,
     position: Position,
-    lhs_node_kind: &str,
-    lhs_name: &str,
+    path: &QualifiedPath,
     op: ExtractOp,
     cancel: &DiagCancelToken,
 ) -> Vec<QualifiedMemberCompletion> {
     let Some(batch) = collect_qualified_member_candidates_with_cancel(
-        state,
-        uri,
-        position,
-        lhs_node_kind,
-        lhs_name,
-        None,
-        op,
-        cancel,
+        state, uri, position, path, None, op, cancel,
     ) else {
         return Vec::new();
     };
@@ -522,15 +508,15 @@ fn collect_qualified_member_candidates_with_cancel(
     state: &WorldState,
     uri: &Url,
     position: Position,
-    lhs_node_kind: &str,
-    lhs_name: &str,
+    path: &QualifiedPath,
     rhs_name: Option<&str>,
     op: ExtractOp,
     cancel: &DiagCancelToken,
 ) -> Option<CandidateBatch> {
-    if lhs_node_kind != "identifier" || cancel.is_cancelled() {
+    if cancel.is_cancelled() {
         return None;
     }
+    let lhs_name = path.head.as_str();
     let mut prefix_cache = crate::cross_file::scope::ParentPrefixCache::new();
 
     let scope = crate::handlers::get_cross_file_scope_with_cache(
@@ -1606,18 +1592,31 @@ mod tests {
         }
     }
 
+    fn dollar_path(head: &str, segments: &[&str]) -> super::QualifiedPath {
+        super::QualifiedPath {
+            head: head.to_string(),
+            segments: segments
+                .iter()
+                .map(|s| super::Segment {
+                    name: s.to_string(),
+                    op: crate::extract_op::ExtractOp::Dollar,
+                })
+                .collect(),
+        }
+    }
+
     fn completion_names(
         state: &WorldState,
         uri: &Url,
         position: Position,
         lhs_name: &str,
     ) -> Vec<String> {
+        let path = dollar_path(lhs_name, &[]);
         super::complete_qualified_members(
             state,
             uri,
             position,
-            "identifier",
-            lhs_name,
+            &path,
             crate::extract_op::ExtractOp::Dollar,
         )
         .into_iter()
@@ -1645,14 +1644,14 @@ mod tests {
 
             let mut state = fresh_state();
             let uri = add_indexed_doc(&mut state, "file:///perf.R", &code);
+            let df_path = dollar_path("df", &[]);
 
             // Warm-up to populate any one-shot caches.
             let _ = super::complete_qualified_members(
                 &state,
                 &uri,
                 Position::new(cursor_line, 3),
-                "identifier",
-                "df",
+                &df_path,
                 crate::extract_op::ExtractOp::Dollar,
             );
 
@@ -1663,8 +1662,7 @@ mod tests {
                     &state,
                     &uri,
                     Position::new(cursor_line, 3),
-                    "identifier",
-                    "df",
+                    &df_path,
                     crate::extract_op::ExtractOp::Dollar,
                 );
                 *s = start.elapsed();
@@ -1743,12 +1741,12 @@ mod tests {
             }
 
             // Warm-up.
+            let df_path = dollar_path("df", &[]);
             let _ = super::complete_qualified_members(
                 &state,
                 &main_uri,
                 Position::new(cursor_line, 3),
-                "identifier",
-                "df",
+                &df_path,
                 crate::extract_op::ExtractOp::Dollar,
             );
 
@@ -1759,8 +1757,7 @@ mod tests {
                     &state,
                     &main_uri,
                     Position::new(cursor_line, 3),
-                    "identifier",
-                    "df",
+                    &df_path,
                     crate::extract_op::ExtractOp::Dollar,
                 );
                 *s = start.elapsed();
@@ -2233,8 +2230,7 @@ foo$
             &state,
             &main_uri,
             Position::new(2, 4),
-            "identifier",
-            "foo",
+            &dollar_path("foo", &[]),
             crate::extract_op::ExtractOp::Dollar,
         );
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -22,11 +22,14 @@
 //! ## Reassignment (establishing-site cutoff)
 //!
 //! Members reflect the value live at the cursor. A whole-value (re)write of an
-//! intermediate prefix in the cursor file (`alpha$beta <- ...`, constructor or
-//! opaque) is an *establishing site*; members declared before the latest such
-//! site are dropped (see [`collect_establishing_site_positions`] and the cutoff
-//! in the core collector). Cross-file establishing-site ordering is left to the
-//! contributor-chain union — the documented residual imprecision.
+//! intermediate prefix (`alpha$beta <- ...`, constructor or opaque) is an
+//! *establishing site*; members declared before the latest visible one are
+//! dropped (see [`collect_prefix_writes`] and the cutoff in the core collector).
+//! A `source()` that brings the head's defining file into scope is itself an
+//! establishing event, so a cursor-file reassignment also drops members from
+//! upstream files sourced before it. The residual imprecision is narrowed to a
+//! defining file reached only *transitively* (no direct source line in the
+//! cursor file), where upstream members are kept conservatively.
 //!
 //! For `foo$bar` (or `foo@bar`) where the cursor is on `bar`:
 //!

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -117,6 +117,71 @@ impl<'a> ColMapper<'a> {
     }
 }
 
+/// One intermediate step in a `$`/`@`/`[["lit"]]` access chain. `op` is the
+/// operator that produced this segment from its parent; a `[["lit"]]` subscript
+/// is recorded as [`ExtractOp::Dollar`] because it is `$`-equivalent for member
+/// resolution (mirrors `member_assignment_candidate_from_string_subscript`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Segment {
+    pub name: String,
+    pub op: ExtractOp,
+}
+
+/// The container an `$`/`@` member is being resolved against: a head identifier
+/// plus zero or more intermediate [`Segment`]s. `segments.is_empty()` is the
+/// single-level (depth-1) case and reproduces the pre-Step-2 behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualifiedPath {
+    pub head: String,
+    pub segments: Vec<Segment>,
+}
+
+/// Walk the left-spine of an `extract_operator`/`subset2` node into a
+/// [`QualifiedPath`]. Bails to `None` on any non-static step: a computed index
+/// (`alpha[[i]]`, `alpha[[1]]`), a call (`f()$x`), or a non-literal subscript.
+/// The spine must bottom out at a single `identifier` (the head). A `[["lit"]]`
+/// subscript (`subset2`) is `$`-equivalent and recorded as [`ExtractOp::Dollar`].
+pub fn build_qualified_path(lhs: Node, text: &str) -> Option<QualifiedPath> {
+    let mut rev_segments: Vec<Segment> = Vec::new();
+    let mut node = lhs;
+    loop {
+        match node.kind() {
+            "identifier" => {
+                rev_segments.reverse();
+                return Some(QualifiedPath {
+                    head: node_text(node, text).to_string(),
+                    segments: rev_segments,
+                });
+            }
+            "extract_operator" => {
+                let op = crate::extract_op::op_from_node(node.child_by_field_name("operator")?)?;
+                let rhs = node.child_by_field_name("rhs")?;
+                if rhs.kind() != "identifier" {
+                    return None;
+                }
+                rev_segments.push(Segment {
+                    name: node_text(rhs, text).to_string(),
+                    op,
+                });
+                node = node.child_by_field_name("lhs")?;
+            }
+            "subset2" => {
+                // `foo[["lit"]]` — `$`-equivalent. Reject computed/numeric indices.
+                let func = node.child_by_field_name("function")?;
+                let args = node.child_by_field_name("arguments")?;
+                let string_node = first_direct_string_argument(args)?;
+                let name = simple_string_literal_value(string_node, text)?;
+                rev_segments.push(Segment {
+                    name: name.to_string(),
+                    op: ExtractOp::Dollar,
+                });
+                node = func;
+            }
+            _ => return None,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn member_assignment_candidate_from_extract(
     assignment: Node,
@@ -1459,6 +1524,85 @@ mod tests {
         match result {
             Some(GotoDefinitionResponse::Scalar(l)) => l,
             other => panic!("expected Scalar location, got {:?}", other),
+        }
+    }
+
+    fn parse_r(text: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .expect("load tree-sitter-r");
+        parser.parse(text, None).expect("parse")
+    }
+
+    /// Find the widest `extract_operator`/`subset2`/`identifier` node whose byte
+    /// range ends at `end_byte` (the LHS of a trailing access in these tests).
+    fn lhs_node_ending_at(tree: &tree_sitter::Tree, end_byte: usize) -> tree_sitter::Node<'_> {
+        fn rec<'a>(n: tree_sitter::Node<'a>, end: usize, best: &mut Option<tree_sitter::Node<'a>>) {
+            if n.end_byte() == end
+                && matches!(n.kind(), "extract_operator" | "subset2" | "identifier")
+            {
+                match best {
+                    None => *best = Some(n),
+                    Some(b) if n.start_byte() < b.start_byte() => *best = Some(n),
+                    _ => {}
+                }
+            }
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                rec(ch, end, best);
+            }
+        }
+        let mut best = None;
+        rec(tree.root_node(), end_byte, &mut best);
+        best.expect("no lhs node ends at end_byte")
+    }
+
+    #[test]
+    fn build_path_single_identifier() {
+        let text = "alpha";
+        let tree = parse_r(text);
+        let lhs = lhs_node_ending_at(&tree, text.len());
+        let path = super::build_qualified_path(lhs, text).expect("path");
+        assert_eq!(path.head, "alpha");
+        assert!(path.segments.is_empty());
+    }
+
+    #[test]
+    fn build_path_two_dollar_segments() {
+        let text = "alpha$beta";
+        let tree = parse_r(text);
+        let lhs = lhs_node_ending_at(&tree, text.len());
+        let path = super::build_qualified_path(lhs, text).expect("path");
+        assert_eq!(path.head, "alpha");
+        assert_eq!(path.segments.len(), 1);
+        assert_eq!(path.segments[0].name, "beta");
+        assert_eq!(path.segments[0].op, crate::extract_op::ExtractOp::Dollar);
+    }
+
+    #[test]
+    fn build_path_mixed_dollar_at_and_subscript() {
+        let text = "alpha@beta[[\"gamma\"]]";
+        let tree = parse_r(text);
+        let lhs = lhs_node_ending_at(&tree, text.len());
+        let path = super::build_qualified_path(lhs, text).expect("path");
+        assert_eq!(path.head, "alpha");
+        let names: Vec<_> = path.segments.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["beta", "gamma"]);
+        assert_eq!(path.segments[0].op, crate::extract_op::ExtractOp::At);
+        // `[["lit"]]` is `$`-equivalent for member purposes.
+        assert_eq!(path.segments[1].op, crate::extract_op::ExtractOp::Dollar);
+    }
+
+    #[test]
+    fn build_path_bails_on_non_static_segment() {
+        for text in ["f()$x", "alpha[[i]]$x", "alpha[[1]]$x"] {
+            let tree = parse_r(text);
+            let lhs = lhs_node_ending_at(&tree, text.len());
+            assert!(
+                super::build_qualified_path(lhs, text).is_none(),
+                "expected None for {text:?}"
+            );
         }
     }
 

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -1534,6 +1534,8 @@ fn push_constructor_named_args(
     rhs_name: Option<&str>,
     out: &mut Vec<Candidate>,
 ) {
+    let effect = EffectPos::from_node_end(assignment, col_mapper);
+    let fn_scope = enclosing_function_id(assignment);
     let mut walker = args.walk();
     for child in args.children(&mut walker) {
         if child.kind() != "argument" {
@@ -1552,39 +1554,53 @@ fn push_constructor_named_args(
         out.push(Candidate {
             name: member_name.to_string(),
             uri: file_uri.clone(),
-            effect: EffectPos::from_node_end(assignment, col_mapper),
+            effect,
             name_range: node_range(name_node, col_mapper),
-            fn_scope: enclosing_function_id(assignment),
+            fn_scope,
             lhs_pos,
         });
     }
 }
 
-/// If `node` is an assignment whose target spine equals `prefix` and whose
-/// value is an allowlisted-constructor call, return `(assignment, target,
-/// ctor_call)`. Used to find whole-value writes to an intermediate path
-/// (`alpha$beta <- list(...)`).
-fn prefix_assignment_constructor<'a>(
-    node: Node<'a>,
-    text: &str,
-    prefix: &QualifiedPath,
-) -> Option<(Node<'a>, Node<'a>, Node<'a>)> {
+/// For an assignment `binary_operator`, return its target node (the LHS for
+/// `<-`/`=`/`<<-`, the RHS for `->`/`->>`). `None` for non-assignment operators.
+fn assignment_target<'a>(node: Node<'a>, text: &str) -> Option<Node<'a>> {
     let op_node = node.child_by_field_name("operator")?;
-    let target = match node_text(op_node, text) {
-        "<-" | "=" | "<<-" => node.child_by_field_name("lhs")?,
-        "->" | "->>" => node.child_by_field_name("rhs")?,
-        _ => return None,
-    };
-    if !target_spine_is_path(target, text, prefix) {
-        return None;
+    match node_text(op_node, text) {
+        "<-" | "=" | "<<-" => node.child_by_field_name("lhs"),
+        "->" | "->>" => node.child_by_field_name("rhs"),
+        _ => None,
     }
+}
+
+/// For an assignment whose value is an allowlisted-constructor call, return
+/// `(target, ctor_call)`. Used to find whole-value writes with constructor RHS
+/// (`alpha$beta <- list(...)`).
+fn assignment_constructor_call<'a>(node: Node<'a>, text: &str) -> Option<(Node<'a>, Node<'a>)> {
+    let target = assignment_target(node, text)?;
     let value = assignment_value_node(node, text)?;
     if value.kind() != "call" {
         return None;
     }
     let func = value.child_by_field_name("function")?;
     if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
-        Some((node, target, value))
+        Some((target, value))
+    } else {
+        None
+    }
+}
+
+/// If `target`'s spine is a non-empty prefix of `path` (`head` + `segments[..k]`
+/// for some `1 <= k <= segments.len()`), return that prefix length `k`. Walks
+/// the spine once via [`build_qualified_path`].
+fn target_path_prefix_len(target: Node, text: &str, path: &QualifiedPath) -> Option<usize> {
+    let actual = build_qualified_path(target, text)?;
+    let k = actual.segments.len();
+    if actual.head == path.head
+        && (1..=path.segments.len()).contains(&k)
+        && actual.segments.as_slice() == &path.segments[..k]
+    {
+        Some(k)
     } else {
         None
     }
@@ -1593,7 +1609,7 @@ fn prefix_assignment_constructor<'a>(
 /// Collect members contributed by an assignment whose target spine is a prefix
 /// of `path` longer than the head (`alpha$beta <- list(...)` for path
 /// `[alpha, beta, ...]`), with an allowlisted-constructor RHS, descended to the
-/// full path. Each terminal named argument becomes a candidate.
+/// full path. Each terminal named argument becomes a candidate. Single tree walk.
 #[allow(clippy::too_many_arguments)]
 fn collect_prefix_write_constructor_candidates(
     root: Node,
@@ -1605,42 +1621,40 @@ fn collect_prefix_write_constructor_candidates(
     out: &mut Vec<Candidate>,
     skip_functions: bool,
 ) {
-    for k in 1..=path.segments.len() {
-        let prefix = QualifiedPath {
-            head: path.head.clone(),
-            segments: path.segments[..k].to_vec(),
-        };
-        let remaining: Vec<Segment> = path.segments[k..].to_vec();
-        for_each_binary_operator(root, skip_functions, |node| {
-            let Some((assignment, target, ctor)) =
-                prefix_assignment_constructor(node, text, &prefix)
-            else {
-                return;
-            };
-            let Some(ctor_args) = ctor.child_by_field_name("arguments") else {
-                return;
-            };
-            let Some(terminal_args) = descend_constructor_args(ctor_args, text, &remaining) else {
-                return;
-            };
-            // Use the head identifier position so cross-file validation and
-            // region partitioning treat these like member-assignment candidates.
-            let Some(head_id) = leftmost_identifier(target) else {
-                return;
-            };
-            let lhs_pos = node_range(head_id, col_mapper).start;
-            push_constructor_named_args(
-                terminal_args,
-                text,
-                col_mapper,
-                file_uri,
-                assignment,
-                lhs_pos,
-                rhs_name,
-                out,
-            );
-        });
+    if path.segments.is_empty() {
+        return;
     }
+    for_each_binary_operator(root, skip_functions, |node| {
+        let Some((target, ctor)) = assignment_constructor_call(node, text) else {
+            return;
+        };
+        let Some(k) = target_path_prefix_len(target, text, path) else {
+            return;
+        };
+        let Some(ctor_args) = ctor.child_by_field_name("arguments") else {
+            return;
+        };
+        let Some(terminal_args) = descend_constructor_args(ctor_args, text, &path.segments[k..])
+        else {
+            return;
+        };
+        // Use the head identifier position so cross-file validation and region
+        // partitioning treat these like member-assignment candidates.
+        let Some(head_id) = leftmost_identifier(target) else {
+            return;
+        };
+        let lhs_pos = node_range(head_id, col_mapper).start;
+        push_constructor_named_args(
+            terminal_args,
+            text,
+            col_mapper,
+            file_uri,
+            node,
+            lhs_pos,
+            rhs_name,
+            out,
+        );
+    });
 }
 
 /// Effect positions of whole-value writes to a prefix of `path` longer than the
@@ -1648,7 +1662,7 @@ fn collect_prefix_write_constructor_candidates(
 /// `[alpha, beta, gamma]`), regardless of the RHS shape (constructor, opaque
 /// call, or bare value). These are the *establishing sites* whose latest visible
 /// occurrence resets the members at `path`. Returns one position per matching
-/// assignment.
+/// assignment. Single tree walk.
 fn collect_establishing_site_positions(
     root: Node,
     text: &str,
@@ -1660,27 +1674,9 @@ fn collect_establishing_site_positions(
     if path.segments.is_empty() {
         return sites;
     }
-    let prefixes: Vec<QualifiedPath> = (1..=path.segments.len())
-        .map(|k| QualifiedPath {
-            head: path.head.clone(),
-            segments: path.segments[..k].to_vec(),
-        })
-        .collect();
     for_each_binary_operator(root, skip_functions, |node| {
-        let Some(op_node) = node.child_by_field_name("operator") else {
-            return;
-        };
-        let target = match node_text(op_node, text) {
-            "<-" | "=" | "<<-" => node.child_by_field_name("lhs"),
-            "->" | "->>" => node.child_by_field_name("rhs"),
-            _ => return,
-        };
-        let Some(target) = target else {
-            return;
-        };
-        if prefixes
-            .iter()
-            .any(|prefix| target_spine_is_path(target, text, prefix))
+        if let Some(target) = assignment_target(node, text)
+            && target_path_prefix_len(target, text, path).is_some()
         {
             sites.push(EffectPos::from_node_end(node, col_mapper));
         }

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -1,10 +1,36 @@
 //! Resolve and enumerate candidates for the RHS identifier of `$` and `@`.
 //!
-//! See `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md`.
+//! See `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md` (Step 1)
+//! and `docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md`
+//! (Step 2: nested paths + reassignment semantics).
+//!
+//! ## The container path
+//!
+//! The LHS is modeled as a [`QualifiedPath`] — a head identifier plus zero or
+//! more intermediate [`Segment`]s, built from the AST by [`build_qualified_path`]
+//! (`$`/`@`/`[["lit"]]` steps; bails on any non-static step). The single-level
+//! case (`foo$bar`) is `segments.is_empty()` and reproduces the pre-Step-2
+//! behavior exactly; everything below generalizes "match `foo`" to "match the
+//! container path `head + segments`":
+//!   - member assignments match when the assignment target's spine equals the
+//!     path (`alpha$beta$gamma <- ...` for path `alpha$beta`);
+//!   - constructor literals are *descended* along `segments`
+//!     (`alpha <- list(beta = list(gamma = ...))`);
+//!   - a whole-value write to a prefix (`alpha$beta <- list(...)`) contributes
+//!     its named arguments and acts as an establishing site (below).
+//!
+//! ## Reassignment (establishing-site cutoff)
+//!
+//! Members reflect the value live at the cursor. A whole-value (re)write of an
+//! intermediate prefix in the cursor file (`alpha$beta <- ...`, constructor or
+//! opaque) is an *establishing site*; members declared before the latest such
+//! site are dropped (see [`collect_establishing_site_positions`] and the cutoff
+//! in the core collector). Cross-file establishing-site ordering is left to the
+//! contributor-chain union — the documented residual imprecision.
 //!
 //! For `foo$bar` (or `foo@bar`) where the cursor is on `bar`:
 //!
-//! 1. Resolve `foo` via the existing position-aware scope.
+//! 1. Resolve `foo` (the path head) via the existing position-aware scope.
 //! 2. Collect candidates from the defining file and the files that actually
 //!    contribute to the cursor's resolved cross-file scope:
 //!    - **Defining file**: `foo$bar <- ...` member-assignments,

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -800,6 +800,36 @@ fn collect_qualified_member_candidates_with_cancel(
 
     let mut all_candidates = defining_candidates;
     all_candidates.extend(cross_file_candidates);
+
+    // Establishing-site cutoff (reassignment semantics): a whole-value (re)write
+    // of an intermediate prefix in the cursor file replaces members declared
+    // before it. Members at or after the latest such write survive; earlier ones
+    // (including those from the head binding's constructor) are dropped. Only the
+    // cursor file's sites are considered; cross-file ordering is left to the
+    // contributor-chain union (see the design's residual-imprecision note).
+    if !path.segments.is_empty()
+        && let Some((cursor_text, cursor_tree)) =
+            crate::parameter_resolver::get_text_and_tree(state, &cursor_uri)
+    {
+        let cursor_col_mapper = ColMapper::new(&cursor_text);
+        let cutoff = collect_establishing_site_positions(
+            cursor_tree.root_node(),
+            &cursor_text,
+            &cursor_col_mapper,
+            path,
+            false,
+        )
+        .into_iter()
+        .filter(|s| (s.line, s.utf16_column) <= (position.line, position.character))
+        .max_by_key(|s| (s.line, s.utf16_column));
+        if let Some(cutoff) = cutoff {
+            all_candidates.retain(|c| {
+                c.uri != cursor_uri
+                    || (c.effect.line, c.effect.utf16_column) >= (cutoff.line, cutoff.utf16_column)
+            });
+        }
+    }
+
     let contributor_distances = contributor_file_distances(
         &state.cross_file_graph,
         &cursor_uri,
@@ -1587,6 +1617,51 @@ fn collect_prefix_write_constructor_candidates(
     }
 }
 
+/// Effect positions of whole-value writes to a prefix of `path` longer than the
+/// head (`alpha$beta <- ...`, `alpha$beta$gamma <- ...` for path
+/// `[alpha, beta, gamma]`), regardless of the RHS shape (constructor, opaque
+/// call, or bare value). These are the *establishing sites* whose latest visible
+/// occurrence resets the members at `path`. Returns one position per matching
+/// assignment.
+fn collect_establishing_site_positions(
+    root: Node,
+    text: &str,
+    col_mapper: &ColMapper,
+    path: &QualifiedPath,
+    skip_functions: bool,
+) -> Vec<EffectPos> {
+    let mut sites = Vec::new();
+    if path.segments.is_empty() {
+        return sites;
+    }
+    let prefixes: Vec<QualifiedPath> = (1..=path.segments.len())
+        .map(|k| QualifiedPath {
+            head: path.head.clone(),
+            segments: path.segments[..k].to_vec(),
+        })
+        .collect();
+    for_each_binary_operator(root, skip_functions, |node| {
+        let Some(op_node) = node.child_by_field_name("operator") else {
+            return;
+        };
+        let target = match node_text(op_node, text) {
+            "<-" | "=" | "<<-" => node.child_by_field_name("lhs"),
+            "->" | "->>" => node.child_by_field_name("rhs"),
+            _ => return,
+        };
+        let Some(target) = target else {
+            return;
+        };
+        if prefixes
+            .iter()
+            .any(|prefix| target_spine_is_path(target, text, prefix))
+        {
+            sites.push(EffectPos::from_node_end(node, col_mapper));
+        }
+    });
+    sites
+}
+
 /// In `args` (a constructor call's argument list), find a named argument
 /// `name = <call>` whose value is a call to an allowlisted constructor, and
 /// return that call node. Used to descend nested constructor literals along a
@@ -1921,6 +1996,54 @@ alpha$beta$
             completion_path_names(&state, &uri, Position::new(2, 11), "alpha", &["beta"]);
         names.sort();
         assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+    }
+
+    #[test]
+    fn reassignment_replaces_earlier_members_same_file() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list(gamma = 1))
+alpha$beta <- list(delta = 2)
+alpha$beta$epsilon <- 3
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///r.R", code);
+        let mut names =
+            completion_path_names(&state, &uri, Position::new(3, 11), "alpha", &["beta"]);
+        names.sort();
+        // gamma was replaced by the whole-value rewrite on line 1; delta + epsilon survive.
+        assert_eq!(names, vec!["delta".to_string(), "epsilon".to_string()]);
+    }
+
+    #[test]
+    fn extension_before_reassignment_is_excluded() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list())
+alpha$beta$old <- 1
+alpha$beta <- list(fresh = 2)
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///r2.R", code);
+        let names = completion_path_names(&state, &uri, Position::new(3, 11), "alpha", &["beta"]);
+        // `old` was added before the rewrite on line 2 → excluded. Only `fresh`.
+        assert_eq!(names, vec!["fresh".to_string()]);
+    }
+
+    #[test]
+    fn empty_reassignment_resets_members() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list()
+alpha$beta$gamma <- 1
+alpha$beta <- list()
+alpha$beta$delta <- 2
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///r3.R", code);
+        let names = completion_path_names(&state, &uri, Position::new(4, 11), "alpha", &["beta"]);
+        // The empty `alpha$beta <- list()` on line 2 resets; only the later `delta`.
+        assert_eq!(names, vec!["delta".to_string()]);
     }
 
     /// Perf reproducer: scales the number of `df$col_K <- ...` assignments and

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -1368,16 +1368,9 @@ fn try_extract_member_assignment(
     op: ExtractOp,
     out: &mut Vec<Candidate>,
 ) {
-    let Some(op_node) = node.child_by_field_name("operator") else {
+    let Some(target) = assignment_target(node, text) else {
         return;
     };
-    let op_text = node_text(op_node, text);
-    let target = match op_text {
-        "<-" | "=" | "<<-" => node.child_by_field_name("lhs"),
-        "->" | "->>" => node.child_by_field_name("rhs"),
-        _ => return,
-    };
-    let Some(target) = target else { return };
     if let Some(candidate) = member_assignment_candidate_from_extract(
         node, target, text, col_mapper, file_uri, path, rhs_name, op,
     ) {
@@ -1467,21 +1460,9 @@ fn collect_constructor_candidates(
     let Some(value_node) = assignment_value_node(assignment, text) else {
         return;
     };
-
-    if value_node.kind() != "call" {
+    if !is_allowlisted_constructor_call(value_node, text) {
         return;
     }
-    let Some(func_node) = value_node.child_by_field_name("function") else {
-        return;
-    };
-    if func_node.kind() != "identifier" {
-        return;
-    }
-    let func_name = node_text(func_node, text);
-    if !CONSTRUCTOR_ALLOWLIST.contains(&func_name) {
-        return;
-    }
-
     let Some(args_node) = value_node.child_by_field_name("arguments") else {
         return;
     };
@@ -1573,21 +1554,23 @@ fn assignment_target<'a>(node: Node<'a>, text: &str) -> Option<Node<'a>> {
     }
 }
 
+/// Is `node` a call to one of the allowlisted constructors (`list`, `c`,
+/// `data.frame`, …)?
+fn is_allowlisted_constructor_call(node: Node, text: &str) -> bool {
+    node.kind() == "call"
+        && node
+            .child_by_field_name("function")
+            .filter(|func| func.kind() == "identifier")
+            .is_some_and(|func| CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)))
+}
+
 /// For an assignment whose value is an allowlisted-constructor call, return
 /// `(target, ctor_call)`. Used to find whole-value writes with constructor RHS
 /// (`alpha$beta <- list(...)`).
 fn assignment_constructor_call<'a>(node: Node<'a>, text: &str) -> Option<(Node<'a>, Node<'a>)> {
     let target = assignment_target(node, text)?;
     let value = assignment_value_node(node, text)?;
-    if value.kind() != "call" {
-        return None;
-    }
-    let func = value.child_by_field_name("function")?;
-    if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
-        Some((target, value))
-    } else {
-        None
-    }
+    is_allowlisted_constructor_call(value, text).then_some((target, value))
 }
 
 /// If `target`'s spine is a non-empty prefix of `path` (`head` + `segments[..k]`
@@ -1701,14 +1684,7 @@ fn named_arg_constructor_value<'a>(args: Node<'a>, text: &str, name: &str) -> Op
             continue;
         }
         let value = child.child_by_field_name("value")?;
-        if value.kind() != "call" {
-            return None;
-        }
-        let func = value.child_by_field_name("function")?;
-        if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
-            return Some(value);
-        }
-        return None;
+        return is_allowlisted_constructor_call(value, text).then_some(value);
     }
     None
 }
@@ -1716,21 +1692,12 @@ fn named_arg_constructor_value<'a>(args: Node<'a>, text: &str, name: &str) -> Op
 fn ascend_to_assignment_for<'a>(start: Node<'a>, text: &str, lhs_name: &str) -> Option<Node<'a>> {
     let mut current = start;
     loop {
-        if current.kind() == "binary_operator" {
-            let op_text = current
-                .child_by_field_name("operator")
-                .map(|n| node_text(n, text));
-            let target = match op_text {
-                Some("<-") | Some("=") | Some("<<-") => current.child_by_field_name("lhs"),
-                Some("->") | Some("->>") => current.child_by_field_name("rhs"),
-                _ => None,
-            };
-            if let Some(t) = target
-                && t.kind() == "identifier"
-                && node_text(t, text) == lhs_name
-            {
-                return Some(current);
-            }
+        if current.kind() == "binary_operator"
+            && let Some(target) = assignment_target(current, text)
+            && target.kind() == "identifier"
+            && node_text(target, text) == lhs_name
+        {
+            return Some(current);
         }
         current = current.parent()?;
     }

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -25,11 +25,17 @@
 //! intermediate prefix (`alpha$beta <- ...`, constructor or opaque) is an
 //! *establishing site*; members declared before the latest visible one are
 //! dropped (see [`collect_prefix_writes`] and the cutoff in the core collector).
-//! A `source()` that brings the head's defining file into scope is itself an
-//! establishing event, so a cursor-file reassignment also drops members from
-//! upstream files sourced before it. The residual imprecision is narrowed to a
-//! defining file reached only *transitively* (no direct source line in the
-//! cursor file), where upstream members are kept conservatively.
+//! A site only counts in the head's own scope — a rewrite inside an unrelated
+//! function body modifies a local copy and is excluded. To order sites and
+//! members that live in different files, each maps to a global,
+//! execution-ordered key (cursor-file events anchor at their own position;
+//! directly-sourced events anchor at the `source()` call site, the within-file
+//! position breaking ties). A `source()` that brings the head's defining file
+//! into scope is itself an establishing event, so a cursor-file reassignment
+//! drops upstream members sourced before it, and a within-helper reassignment
+//! drops that helper's own earlier members. The residual imprecision is narrowed
+//! to a defining file reached only *transitively* (no direct source line) and to
+//! reassignments in a third sourced file, where members are kept conservatively.
 //!
 //! For `foo$bar` (or `foo@bar`) where the cursor is on `bar`:
 //!
@@ -598,11 +604,14 @@ fn collect_qualified_member_candidates_with_cancel(
     let defining_uri = symbol.source_uri.clone();
     let cursor_uri = uri.clone();
 
-    // Establishing-site positions collected while walking the cursor file (the
-    // only file whose sites feed the reassignment cutoff). Populated by whichever
-    // `collect_prefix_writes` call walks the cursor file (defining block when
-    // cursor == defining, else the matching cross-file iteration).
-    let mut establishing_sites: Vec<EffectPos> = Vec::new();
+    // Whole-value prefix (re)writes that can reset the members at `path`, each
+    // tagged with the file it lives in. Fed by the cursor-file walk (a
+    // reassignment the user typed) and the defining-file walk (the head's own
+    // file reassigning its value in place). The cutoff below maps each to a
+    // global, execution-ordered key so a within-file reassignment in a sourced
+    // file orders correctly against the cursor instead of collapsing to its
+    // `source()` line.
+    let mut prefix_write_sites: Vec<(Url, EffectPos)> = Vec::new();
 
     let mut defining_candidates: Vec<Candidate> = Vec::new();
     {
@@ -661,7 +670,11 @@ fn collect_qualified_member_candidates_with_cancel(
                 &mut defining_candidates,
             );
         }
-        let defining_sites = (defining_uri == cursor_uri).then_some(&mut establishing_sites);
+        // The defining file's own prefix writes feed the cutoff (its value can
+        // be reassigned in place), gated to the head's function scope so a
+        // function-local rewrite of a top-level value never resets it — the same
+        // identity the `fn_scope == symbol_fn_scope` retain below applies to
+        // member candidates.
         collect_prefix_writes(
             defining_tree.root_node(),
             &defining_text,
@@ -670,7 +683,8 @@ fn collect_qualified_member_candidates_with_cancel(
             path,
             rhs_name,
             &mut defining_candidates,
-            defining_sites,
+            symbol_fn_scope,
+            Some(&mut prefix_write_sites),
             false,
         );
 
@@ -730,7 +744,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     false,
                 );
                 let candidate_sites = if *candidate_uri == cursor_uri {
-                    Some(&mut establishing_sites)
+                    Some(&mut prefix_write_sites)
                 } else {
                     None
                 };
@@ -742,6 +756,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     path,
                     rhs_name,
                     &mut needs_validation,
+                    None, // cross-file head is global: only top-level writes reset it
                     candidate_sites,
                     false,
                 );
@@ -778,7 +793,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     true, // skip function bodies
                 );
                 let candidate_sites = if *candidate_uri == cursor_uri {
-                    Some(&mut establishing_sites)
+                    Some(&mut prefix_write_sites)
                 } else {
                     None
                 };
@@ -790,6 +805,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     path,
                     rhs_name,
                     &mut cross_file_candidates,
+                    None, // cross-file head is global: only top-level writes reset it
                     candidate_sites,
                     true, // skip function bodies
                 );
@@ -851,36 +867,62 @@ fn collect_qualified_member_candidates_with_cancel(
     all_candidates.extend(cross_file_candidates);
 
     // Establishing-site cutoff (reassignment semantics): a whole-value (re)write
-    // of an intermediate prefix replaces members declared before it. Members at
-    // or after the latest such write survive; earlier ones (including those from
-    // the head binding's constructor, and those from upstream files sourced
-    // before the write) are dropped. The establishing events are the cursor
-    // file's prefix writes (collected above) plus the `source()` that brings the
-    // head's defining file into scope — a source re-establishes the whole value,
-    // so it competes for the latest cutoff.
+    // of an intermediate prefix replaces the members declared before it. Members
+    // at or after the latest such write survive; earlier ones (including those
+    // from the head binding's constructor, and those from upstream files sourced
+    // before the write) are dropped.
+    //
+    // Events and candidates live in different files, so comparing raw line
+    // numbers would conflate two coordinate systems (a cursor-file line 2 is not
+    // "after" a sourced helper's line 2). Map each to a global, execution-ordered
+    // key `(anchor_line, anchor_col, file_rank, within_line, within_col)`:
+    //
+    // - cursor-file event: anchors at its own position, `file_rank` 1.
+    // - directly-sourced file's event: anchors at the `source()` call site,
+    //   `file_rank` 0, with the within-file position breaking ties so that a
+    //   reassignment later *inside* a helper drops that helper's earlier members.
+    // - transitively-reached file: no anchor — excluded from the cutoff, and its
+    //   members are kept conservatively (over-offer, never wrong-variable).
+    //
+    // The establishing events are the collected prefix writes (cursor file +
+    // defining file) plus the `source()` that brings the head's defining file
+    // into scope — sourcing re-establishes the whole value, so it competes for
+    // the latest cutoff.
     if !path.segments.is_empty() {
         let source_pos = direct_source_positions(state, &cursor_uri, position);
-        let head_source = source_pos.get(&defining_uri).copied();
-        let cursor = (position.line, position.character);
-        let cutoff = establishing_sites
+        type Key = (u32, u32, u8, u32, u32);
+        let global_key = |uri: &Url, line: u32, col: u32| -> Option<Key> {
+            if *uri == cursor_uri {
+                Some((line, col, 1, line, col))
+            } else {
+                source_pos.get(uri).map(|&(sl, sc)| (sl, sc, 0, line, col))
+            }
+        };
+        let cursor_key: Key = (
+            position.line,
+            position.character,
+            1,
+            position.line,
+            position.character,
+        );
+        // The head's defining file is (re)established where it is sourced, so a
+        // cursor-file write before that `source()` is superseded and one after it
+        // wins. A same-file head needs no event: the effect-after-definition
+        // retain already drops members above the head binding.
+        let head_establishment = (defining_uri != cursor_uri)
+            .then(|| global_key(&defining_uri, symbol.defined_line, symbol.defined_column))
+            .flatten();
+        let cutoff = prefix_write_sites
             .iter()
-            .map(|s| (s.line, s.utf16_column))
-            .chain(head_source)
-            .filter(|&pos| pos <= cursor)
+            .filter_map(|(uri, pos)| global_key(uri, pos.line, pos.utf16_column))
+            .chain(head_establishment)
+            .filter(|&k| k <= cursor_key)
             .max();
         if let Some(cutoff) = cutoff {
             all_candidates.retain(|c| {
-                if c.uri == cursor_uri {
-                    (c.effect.line, c.effect.utf16_column) >= cutoff
-                } else {
-                    // Drop an upstream candidate whose file was sourced before the
-                    // cutoff (the reassignment replaced it). Keep it if sourced at
-                    // or after the cutoff, or reached only transitively (no direct
-                    // source line — conservative).
-                    match source_pos.get(&c.uri) {
-                        Some(&src) => src >= cutoff,
-                        None => true,
-                    }
+                match global_key(&c.uri, c.effect.line, c.effect.utf16_column) {
+                    Some(k) => k >= cutoff,
+                    None => true,
                 }
             });
         }
@@ -1643,11 +1685,14 @@ fn target_path_prefix_len(target: Node, text: &str, path: &QualifiedPath) -> Opt
 /// - **Members** — when the write's RHS is an allowlisted constructor, descend
 ///   it to the full path and push one candidate per terminal named argument.
 /// - **Establishing sites** — when `establishing_sites` is `Some`, record this
-///   write's effect position regardless of its RHS shape (constructor, opaque
-///   call, or bare value). The latest visible site resets the members at `path`.
-///
-/// Pass `establishing_sites = Some(...)` only when `root` is the cursor file's
-/// tree; the cutoff considers only the cursor file's sites.
+///   write's `(file, effect position)` regardless of its RHS shape (constructor,
+///   opaque call, or bare value), but only when the write executes in
+///   `live_scope` (its nearest enclosing function id equals `live_scope`). A
+///   write inside some *other* function targets that function's local copy and
+///   cannot reset the value visible at the cursor, so it must not become a
+///   cutoff — the same identity the `fn_scope == symbol_fn_scope` retain applies
+///   to member candidates. Pass `live_scope = None` for cross-file walks (the
+///   head is a global; only top-level writes reset it).
 #[allow(clippy::too_many_arguments)]
 fn collect_prefix_writes(
     root: Node,
@@ -1657,7 +1702,8 @@ fn collect_prefix_writes(
     path: &QualifiedPath,
     rhs_name: Option<&str>,
     out: &mut Vec<Candidate>,
-    mut establishing_sites: Option<&mut Vec<EffectPos>>,
+    live_scope: FunctionScopeId,
+    mut establishing_sites: Option<&mut Vec<(Url, EffectPos)>>,
     skip_functions: bool,
 ) {
     if path.segments.is_empty() {
@@ -1670,9 +1716,13 @@ fn collect_prefix_writes(
         let Some(k) = target_path_prefix_len(target, text, path) else {
             return;
         };
-        // Any whole-value write to a prefix of `path` is an establishing site.
-        if let Some(sites) = establishing_sites.as_deref_mut() {
-            sites.push(EffectPos::from_node_end(node, col_mapper));
+        // A whole-value write to a prefix of `path`, in the head's scope, is an
+        // establishing site. Writes in a nested/unrelated function scope modify a
+        // local copy and are skipped.
+        if let Some(sites) = establishing_sites.as_deref_mut()
+            && enclosing_function_id(node) == live_scope
+        {
+            sites.push((file_uri.clone(), EffectPos::from_node_end(node, col_mapper)));
         }
         // A constructor RHS additionally contributes member candidates.
         let Some(value) = assignment_value_node(node, text) else {
@@ -2076,6 +2126,26 @@ alpha$beta$
     }
 
     #[test]
+    fn function_local_rewrite_does_not_drop_top_level_members() {
+        // A whole-value rewrite of `alpha$beta` *inside a function body* targets
+        // that function's local copy — it must not be treated as an establishing
+        // site for the top-level `alpha$beta`, which still has `gamma`.
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list(gamma = 1))
+f <- function() {
+  alpha$beta <- list(delta = 2)
+}
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///fl.R", code);
+        let names = completion_path_names(&state, &uri, Position::new(4, 11), "alpha", &["beta"]);
+        // The function-local rewrite (and its `delta`) are out of scope; `gamma`
+        // survives — it was NOT dropped by a spurious in-function cutoff.
+        assert_eq!(names, vec!["gamma".to_string()]);
+    }
+
+    #[test]
     fn nested_member_below_cursor_not_offered() {
         let mut state = fresh_state();
         let code = "\
@@ -2148,6 +2218,29 @@ alpha$beta$
         // gamma (sourced after the reassignment) is kept; delta predates the
         // source so the cursor-file cutoff drops it.
         assert_eq!(names, vec!["gamma".to_string()]);
+    }
+
+    #[test]
+    fn nested_member_within_helper_reassignment_drops_earlier() {
+        // The reassignment lives entirely *inside* the sourced helper: it first
+        // declares alpha$beta with `stale`, then wholly rewrites alpha$beta to
+        // `fresh`. The cursor file only sources it. Ordering both helper events
+        // by the same source anchor would keep `stale`; the within-file position
+        // must break the tie so the helper-local rewrite drops it.
+        let mut state = fresh_state();
+        let main_code = "\
+source(\"helpers.R\")
+alpha$beta$
+";
+        let helpers_code = "\
+alpha <- list(beta = list(stale = 0))
+alpha$beta <- list(fresh = 2)
+";
+        let (main_uri, _helpers_uri) =
+            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let names =
+            completion_path_names(&state, &main_uri, Position::new(1, 11), "alpha", &["beta"]);
+        assert_eq!(names, vec!["fresh".to_string()]);
     }
 
     #[test]

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -626,6 +626,16 @@ fn collect_qualified_member_candidates_with_cancel(
                 &mut defining_candidates,
             );
         }
+        collect_prefix_write_constructor_candidates(
+            defining_tree.root_node(),
+            &defining_text,
+            &defining_col_mapper,
+            &defining_uri,
+            path,
+            rhs_name,
+            &mut defining_candidates,
+            false,
+        );
 
         // Defining-file candidates are collected from the same tree that owns
         // the resolved `lhs_name` binding. The textual LHS match, same-function
@@ -682,6 +692,16 @@ fn collect_qualified_member_candidates_with_cancel(
                     &mut needs_validation,
                     false,
                 );
+                collect_prefix_write_constructor_candidates(
+                    candidate_tree.root_node(),
+                    &candidate_text,
+                    &candidate_col_mapper,
+                    candidate_uri,
+                    path,
+                    rhs_name,
+                    &mut needs_validation,
+                    false,
+                );
             } else {
                 // File doesn't define lhs_name itself, but the visible binding
                 // can still change between top-level positions via `source()`,
@@ -711,6 +731,16 @@ fn collect_qualified_member_candidates_with_cancel(
                     path,
                     rhs_name,
                     op,
+                    &mut cross_file_candidates,
+                    true, // skip function bodies
+                );
+                collect_prefix_write_constructor_candidates(
+                    candidate_tree.root_node(),
+                    &candidate_text,
+                    &candidate_col_mapper,
+                    candidate_uri,
+                    path,
+                    rhs_name,
                     &mut cross_file_candidates,
                     true, // skip function bodies
                 );
@@ -1210,6 +1240,16 @@ fn collect_member_assignments(
     out: &mut Vec<Candidate>,
     skip_functions: bool,
 ) {
+    for_each_binary_operator(root, skip_functions, |node| {
+        try_extract_member_assignment(node, text, col_mapper, file_uri, path, rhs_name, op, out);
+    });
+}
+
+/// Walk the tree, invoking `f` on every `binary_operator` node. Skips atomic
+/// leaf subtrees (and function bodies when `skip_functions`). Shared by the
+/// member-assignment and prefix-write discovery passes so they traverse
+/// identically.
+fn for_each_binary_operator<'a>(root: Node<'a>, skip_functions: bool, mut f: impl FnMut(Node<'a>)) {
     let mut cursor = root.walk();
     let mut descended = true; // treat root as just-entered
     loop {
@@ -1239,9 +1279,7 @@ fn collect_member_assignments(
             ) || (skip_functions && kind == "function_definition");
             if !skip {
                 if kind == "binary_operator" {
-                    try_extract_member_assignment(
-                        node, text, col_mapper, file_uri, path, rhs_name, op, out,
-                    );
+                    f(node);
                 }
                 // Descend into children if this node has any.
                 if cursor.goto_first_child() {
@@ -1391,20 +1429,57 @@ fn collect_constructor_candidates(
     let Some(args_node) = value_node.child_by_field_name("arguments") else {
         return;
     };
-    // Descend the constructor following the intermediate segments. Each segment
-    // must be a named argument whose value is itself an allowlisted constructor.
-    let mut current_args = args_node;
-    for seg in &path.segments {
-        let Some(child_call) = named_arg_constructor_value(current_args, text, &seg.name) else {
-            return; // segment not present as a nested constructor → no members here
-        };
-        let Some(child_args) = child_call.child_by_field_name("arguments") else {
-            return;
-        };
-        current_args = child_args;
+    // Descend the constructor following the intermediate segments, then
+    // enumerate the terminal named arguments.
+    let Some(terminal_args) = descend_constructor_args(args_node, text, &path.segments) else {
+        return;
+    };
+    // Constructor candidates become visible only after the defining assignment
+    // completes, so use the effect position for the shared symbol identity check.
+    let effect = EffectPos::from_node_end(assignment, col_mapper);
+    let lhs_pos = Position::new(effect.line, effect.utf16_column);
+    push_constructor_named_args(
+        terminal_args,
+        text,
+        col_mapper,
+        file_uri,
+        assignment,
+        lhs_pos,
+        rhs_name,
+        out,
+    );
+}
+
+/// Descend `args` following `segments` — each must be a named argument whose
+/// value is an allowlisted constructor call. Returns the terminal argument
+/// list, or `None` if any segment cannot be followed.
+fn descend_constructor_args<'a>(
+    mut args: Node<'a>,
+    text: &str,
+    segments: &[Segment],
+) -> Option<Node<'a>> {
+    for seg in segments {
+        let child_call = named_arg_constructor_value(args, text, &seg.name)?;
+        args = child_call.child_by_field_name("arguments")?;
     }
-    let mut walker = current_args.walk();
-    for child in current_args.children(&mut walker) {
+    Some(args)
+}
+
+/// Push one [`Candidate`] per named argument of `args` (filtered by `rhs_name`
+/// when provided), using the supplied assignment metadata and `lhs_pos`.
+#[allow(clippy::too_many_arguments)]
+fn push_constructor_named_args(
+    args: Node,
+    text: &str,
+    col_mapper: &ColMapper,
+    file_uri: &Url,
+    assignment: Node,
+    lhs_pos: Position,
+    rhs_name: Option<&str>,
+    out: &mut Vec<Candidate>,
+) {
+    let mut walker = args.walk();
+    for child in args.children(&mut walker) {
         if child.kind() != "argument" {
             continue;
         }
@@ -1418,19 +1493,96 @@ fn collect_constructor_candidates(
         if rhs_name.is_some_and(|rhs_name| member_name != rhs_name) {
             continue;
         }
-        let name_range = node_range(name_node, col_mapper);
-        let effect = EffectPos::from_node_end(assignment, col_mapper);
-        // Constructor candidates become visible only after the defining
-        // assignment completes, so use the effect position for the shared
-        // symbol identity check.
-        let lhs_pos = Position::new(effect.line, effect.utf16_column);
         out.push(Candidate {
             name: member_name.to_string(),
             uri: file_uri.clone(),
-            effect,
-            name_range,
+            effect: EffectPos::from_node_end(assignment, col_mapper),
+            name_range: node_range(name_node, col_mapper),
             fn_scope: enclosing_function_id(assignment),
             lhs_pos,
+        });
+    }
+}
+
+/// If `node` is an assignment whose target spine equals `prefix` and whose
+/// value is an allowlisted-constructor call, return `(assignment, target,
+/// ctor_call)`. Used to find whole-value writes to an intermediate path
+/// (`alpha$beta <- list(...)`).
+fn prefix_assignment_constructor<'a>(
+    node: Node<'a>,
+    text: &str,
+    prefix: &QualifiedPath,
+) -> Option<(Node<'a>, Node<'a>, Node<'a>)> {
+    let op_node = node.child_by_field_name("operator")?;
+    let target = match node_text(op_node, text) {
+        "<-" | "=" | "<<-" => node.child_by_field_name("lhs")?,
+        "->" | "->>" => node.child_by_field_name("rhs")?,
+        _ => return None,
+    };
+    if !target_spine_is_path(target, text, prefix) {
+        return None;
+    }
+    let value = assignment_value_node(node, text)?;
+    if value.kind() != "call" {
+        return None;
+    }
+    let func = value.child_by_field_name("function")?;
+    if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
+        Some((node, target, value))
+    } else {
+        None
+    }
+}
+
+/// Collect members contributed by an assignment whose target spine is a prefix
+/// of `path` longer than the head (`alpha$beta <- list(...)` for path
+/// `[alpha, beta, ...]`), with an allowlisted-constructor RHS, descended to the
+/// full path. Each terminal named argument becomes a candidate.
+#[allow(clippy::too_many_arguments)]
+fn collect_prefix_write_constructor_candidates(
+    root: Node,
+    text: &str,
+    col_mapper: &ColMapper,
+    file_uri: &Url,
+    path: &QualifiedPath,
+    rhs_name: Option<&str>,
+    out: &mut Vec<Candidate>,
+    skip_functions: bool,
+) {
+    for k in 1..=path.segments.len() {
+        let prefix = QualifiedPath {
+            head: path.head.clone(),
+            segments: path.segments[..k].to_vec(),
+        };
+        let remaining: Vec<Segment> = path.segments[k..].to_vec();
+        for_each_binary_operator(root, skip_functions, |node| {
+            let Some((assignment, target, ctor)) =
+                prefix_assignment_constructor(node, text, &prefix)
+            else {
+                return;
+            };
+            let Some(ctor_args) = ctor.child_by_field_name("arguments") else {
+                return;
+            };
+            let Some(terminal_args) = descend_constructor_args(ctor_args, text, &remaining) else {
+                return;
+            };
+            // Use the head identifier position so cross-file validation and
+            // region partitioning treat these like member-assignment candidates.
+            let Some(head_id) = leftmost_identifier(target) else {
+                return;
+            };
+            let lhs_pos = node_range(head_id, col_mapper).start;
+            push_constructor_named_args(
+                terminal_args,
+                text,
+                col_mapper,
+                file_uri,
+                assignment,
+                lhs_pos,
+                rhs_name,
+                out,
+            );
         });
     }
 }
@@ -1754,6 +1906,21 @@ alpha$beta$gamma$
         );
         names.sort();
         assert_eq!(names, vec!["epsilon".to_string(), "zeta".to_string()]);
+    }
+
+    #[test]
+    fn intermediate_constructor_assignment() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list()
+alpha$beta <- list(gamma = 1, delta = 2)
+alpha$beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///i.R", code);
+        let mut names =
+            completion_path_names(&state, &uri, Position::new(2, 11), "alpha", &["beta"]);
+        names.sort();
+        assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
     }
 
     /// Perf reproducer: scales the number of `df$col_K <- ...` assignments and

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -595,6 +595,12 @@ fn collect_qualified_member_candidates_with_cancel(
     let defining_uri = symbol.source_uri.clone();
     let cursor_uri = uri.clone();
 
+    // Establishing-site positions collected while walking the cursor file (the
+    // only file whose sites feed the reassignment cutoff). Populated by whichever
+    // `collect_prefix_writes` call walks the cursor file (defining block when
+    // cursor == defining, else the matching cross-file iteration).
+    let mut establishing_sites: Vec<EffectPos> = Vec::new();
+
     let mut defining_candidates: Vec<Candidate> = Vec::new();
     {
         let (defining_text, defining_tree) =
@@ -652,7 +658,8 @@ fn collect_qualified_member_candidates_with_cancel(
                 &mut defining_candidates,
             );
         }
-        collect_prefix_write_constructor_candidates(
+        let defining_sites = (defining_uri == cursor_uri).then_some(&mut establishing_sites);
+        collect_prefix_writes(
             defining_tree.root_node(),
             &defining_text,
             &defining_col_mapper,
@@ -660,6 +667,7 @@ fn collect_qualified_member_candidates_with_cancel(
             path,
             rhs_name,
             &mut defining_candidates,
+            defining_sites,
             false,
         );
 
@@ -718,7 +726,12 @@ fn collect_qualified_member_candidates_with_cancel(
                     &mut needs_validation,
                     false,
                 );
-                collect_prefix_write_constructor_candidates(
+                let candidate_sites = if *candidate_uri == cursor_uri {
+                    Some(&mut establishing_sites)
+                } else {
+                    None
+                };
+                collect_prefix_writes(
                     candidate_tree.root_node(),
                     &candidate_text,
                     &candidate_col_mapper,
@@ -726,6 +739,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     path,
                     rhs_name,
                     &mut needs_validation,
+                    candidate_sites,
                     false,
                 );
             } else {
@@ -760,7 +774,12 @@ fn collect_qualified_member_candidates_with_cancel(
                     &mut cross_file_candidates,
                     true, // skip function bodies
                 );
-                collect_prefix_write_constructor_candidates(
+                let candidate_sites = if *candidate_uri == cursor_uri {
+                    Some(&mut establishing_sites)
+                } else {
+                    None
+                };
+                collect_prefix_writes(
                     candidate_tree.root_node(),
                     &candidate_text,
                     &candidate_col_mapper,
@@ -768,6 +787,7 @@ fn collect_qualified_member_candidates_with_cancel(
                     path,
                     rhs_name,
                     &mut cross_file_candidates,
+                    candidate_sites,
                     true, // skip function bodies
                 );
                 // Apply visibility cutoff.
@@ -830,30 +850,20 @@ fn collect_qualified_member_candidates_with_cancel(
     // Establishing-site cutoff (reassignment semantics): a whole-value (re)write
     // of an intermediate prefix in the cursor file replaces members declared
     // before it. Members at or after the latest such write survive; earlier ones
-    // (including those from the head binding's constructor) are dropped. Only the
-    // cursor file's sites are considered; cross-file ordering is left to the
-    // contributor-chain union (see the design's residual-imprecision note).
-    if !path.segments.is_empty()
-        && let Some((cursor_text, cursor_tree)) =
-            crate::parameter_resolver::get_text_and_tree(state, &cursor_uri)
-    {
-        let cursor_col_mapper = ColMapper::new(&cursor_text);
-        let cutoff = collect_establishing_site_positions(
-            cursor_tree.root_node(),
-            &cursor_text,
-            &cursor_col_mapper,
-            path,
-            false,
-        )
-        .into_iter()
+    // (including those from the head binding's constructor) are dropped. The
+    // sites were collected while walking the cursor file above; only the cursor
+    // file's sites are considered (cross-file ordering is handled below / left to
+    // the contributor-chain union).
+    if let Some(cutoff) = establishing_sites
+        .iter()
+        .copied()
         .filter(|s| (s.line, s.utf16_column) <= (position.line, position.character))
-        .max_by_key(|s| (s.line, s.utf16_column));
-        if let Some(cutoff) = cutoff {
-            all_candidates.retain(|c| {
-                c.uri != cursor_uri
-                    || (c.effect.line, c.effect.utf16_column) >= (cutoff.line, cutoff.utf16_column)
-            });
-        }
+        .max_by_key(|s| (s.line, s.utf16_column))
+    {
+        all_candidates.retain(|c| {
+            c.uri != cursor_uri
+                || (c.effect.line, c.effect.utf16_column) >= (cutoff.line, cutoff.utf16_column)
+        });
     }
 
     let contributor_distances = contributor_file_distances(
@@ -1564,15 +1574,6 @@ fn is_allowlisted_constructor_call(node: Node, text: &str) -> bool {
             .is_some_and(|func| CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)))
 }
 
-/// For an assignment whose value is an allowlisted-constructor call, return
-/// `(target, ctor_call)`. Used to find whole-value writes with constructor RHS
-/// (`alpha$beta <- list(...)`).
-fn assignment_constructor_call<'a>(node: Node<'a>, text: &str) -> Option<(Node<'a>, Node<'a>)> {
-    let target = assignment_target(node, text)?;
-    let value = assignment_value_node(node, text)?;
-    is_allowlisted_constructor_call(value, text).then_some((target, value))
-}
-
 /// If `target`'s spine is a non-empty prefix of `path` (`head` + `segments[..k]`
 /// for some `1 <= k <= segments.len()`), return that prefix length `k`. Walks
 /// the spine once via [`build_qualified_path`].
@@ -1589,12 +1590,19 @@ fn target_path_prefix_len(target: Node, text: &str, path: &QualifiedPath) -> Opt
     }
 }
 
-/// Collect members contributed by an assignment whose target spine is a prefix
-/// of `path` longer than the head (`alpha$beta <- list(...)` for path
-/// `[alpha, beta, ...]`), with an allowlisted-constructor RHS, descended to the
-/// full path. Each terminal named argument becomes a candidate. Single tree walk.
+/// Single walk over `root` handling whole-value writes to a prefix of `path`
+/// longer than the head (`alpha$beta <- ...` for path `[alpha, beta, ...]`):
+///
+/// - **Members** — when the write's RHS is an allowlisted constructor, descend
+///   it to the full path and push one candidate per terminal named argument.
+/// - **Establishing sites** — when `establishing_sites` is `Some`, record this
+///   write's effect position regardless of its RHS shape (constructor, opaque
+///   call, or bare value). The latest visible site resets the members at `path`.
+///
+/// Pass `establishing_sites = Some(...)` only when `root` is the cursor file's
+/// tree; the cutoff considers only the cursor file's sites.
 #[allow(clippy::too_many_arguments)]
-fn collect_prefix_write_constructor_candidates(
+fn collect_prefix_writes(
     root: Node,
     text: &str,
     col_mapper: &ColMapper,
@@ -1602,19 +1610,31 @@ fn collect_prefix_write_constructor_candidates(
     path: &QualifiedPath,
     rhs_name: Option<&str>,
     out: &mut Vec<Candidate>,
+    mut establishing_sites: Option<&mut Vec<EffectPos>>,
     skip_functions: bool,
 ) {
     if path.segments.is_empty() {
         return;
     }
     for_each_binary_operator(root, skip_functions, |node| {
-        let Some((target, ctor)) = assignment_constructor_call(node, text) else {
+        let Some(target) = assignment_target(node, text) else {
             return;
         };
         let Some(k) = target_path_prefix_len(target, text, path) else {
             return;
         };
-        let Some(ctor_args) = ctor.child_by_field_name("arguments") else {
+        // Any whole-value write to a prefix of `path` is an establishing site.
+        if let Some(sites) = establishing_sites.as_deref_mut() {
+            sites.push(EffectPos::from_node_end(node, col_mapper));
+        }
+        // A constructor RHS additionally contributes member candidates.
+        let Some(value) = assignment_value_node(node, text) else {
+            return;
+        };
+        if !is_allowlisted_constructor_call(value, text) {
+            return;
+        }
+        let Some(ctor_args) = value.child_by_field_name("arguments") else {
             return;
         };
         let Some(terminal_args) = descend_constructor_args(ctor_args, text, &path.segments[k..])
@@ -1638,33 +1658,6 @@ fn collect_prefix_write_constructor_candidates(
             out,
         );
     });
-}
-
-/// Effect positions of whole-value writes to a prefix of `path` longer than the
-/// head (`alpha$beta <- ...`, `alpha$beta$gamma <- ...` for path
-/// `[alpha, beta, gamma]`), regardless of the RHS shape (constructor, opaque
-/// call, or bare value). These are the *establishing sites* whose latest visible
-/// occurrence resets the members at `path`. Returns one position per matching
-/// assignment. Single tree walk.
-fn collect_establishing_site_positions(
-    root: Node,
-    text: &str,
-    col_mapper: &ColMapper,
-    path: &QualifiedPath,
-    skip_functions: bool,
-) -> Vec<EffectPos> {
-    let mut sites = Vec::new();
-    if path.segments.is_empty() {
-        return sites;
-    }
-    for_each_binary_operator(root, skip_functions, |node| {
-        if let Some(target) = assignment_target(node, text)
-            && target_path_prefix_len(target, text, path).is_some()
-        {
-            sites.push(EffectPos::from_node_end(node, col_mapper));
-        }
-    });
-    sites
 }
 
 /// In `args` (a constructor call's argument list), find a named argument

--- a/crates/raven/src/qualified_resolve.rs
+++ b/crates/raven/src/qualified_resolve.rs
@@ -2046,6 +2046,83 @@ alpha$beta$
         assert_eq!(names, vec!["delta".to_string()]);
     }
 
+    #[test]
+    fn nested_member_below_cursor_not_offered() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list(beta = list())
+alpha$beta$gamma <- 1
+alpha$beta$
+alpha$beta$delta <- 2
+";
+        let uri = add_indexed_doc(&mut state, "file:///p.R", code);
+        // Cursor on line 2; `delta` is assigned on line 3 (below) and must not appear.
+        let names = completion_path_names(&state, &uri, Position::new(2, 11), "alpha", &["beta"]);
+        assert_eq!(names, vec!["gamma".to_string()]);
+    }
+
+    #[test]
+    fn nested_member_cross_file() {
+        // `alpha` + its nested structure declared in helpers.R; extended in main.R
+        // after the source() call.
+        let mut state = fresh_state();
+        let main_code = "\
+source(\"helpers.R\")
+alpha$beta$delta <- 2
+alpha$beta$
+";
+        let helpers_code = "alpha <- list(beta = list(gamma = 1))\n";
+        let (main_uri, _helpers_uri) =
+            setup_two_file_workspace(&mut state, main_code, helpers_code);
+        let mut names =
+            completion_path_names(&state, &main_uri, Position::new(2, 11), "alpha", &["beta"]);
+        names.sort();
+        // gamma from helpers.R (the establishing site) + delta extended in main.R.
+        assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+    }
+
+    #[test]
+    fn non_static_chain_yields_nothing() {
+        let mut state = fresh_state();
+        let code = "alpha <- list(beta = list(gamma = 1))\n";
+        let uri = add_indexed_doc(&mut state, "file:///b.R", code);
+        // A head that does not resolve in scope yields no members (the resolver
+        // never falls back to a free-identifier lookup).
+        let names = completion_path_names(&state, &uri, Position::new(0, 0), "nonexistent", &["x"]);
+        assert!(names.is_empty(), "expected no members, got {names:?}");
+    }
+
+    #[test]
+    fn mixed_dollar_at_chain_depth2() {
+        let mut state = fresh_state();
+        let code = "\
+alpha <- list()
+alpha@beta$gamma <- 1
+alpha@beta$
+";
+        let uri = add_indexed_doc(&mut state, "file:///m.R", code);
+        // Container path is `alpha@beta` (segment via `@`); completing its `$`
+        // members must find `gamma` from the mixed-chain assignment.
+        let path = super::QualifiedPath {
+            head: "alpha".to_string(),
+            segments: vec![super::Segment {
+                name: "beta".to_string(),
+                op: crate::extract_op::ExtractOp::At,
+            }],
+        };
+        let names: Vec<String> = super::complete_qualified_members(
+            &state,
+            &uri,
+            Position::new(2, 11),
+            &path,
+            crate::extract_op::ExtractOp::Dollar,
+        )
+        .into_iter()
+        .map(|c| c.name)
+        .collect();
+        assert_eq!(names, vec!["gamma".to_string()]);
+    }
+
     /// Perf reproducer: scales the number of `df$col_K <- ...` assignments and
     /// prints how long `complete_qualified_members` takes. Run with:
     ///

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -71,6 +71,27 @@ Members are discovered from:
 - Assignments: `foo$bar <- …`, `foo[["bar"]] <- …`
 - Constructor literals: named arguments in `list()`, `data.frame()`, `tibble()`, etc.
 
+Member completion follows nested access at any depth, and `$`, `@`, and
+`[["lit"]]` segments are interchangeable in the chain:
+
+```r
+config <- list(db = list(host = "localhost", port = 8080))
+config$db$              # Offers: host, port
+config[["db"]]$         # Same — `[["db"]]` is equivalent to `$db`
+```
+
+Members reflect the value that is live at the cursor, so a whole reassignment of
+an intermediate value replaces its earlier members:
+
+```r
+config$db <- list(url = "…")   # whole-value rewrite
+config$db$                     # Offers: url (earlier host/port are replaced)
+```
+
+Because the container is resolved as a path, an unrelated top-level variable
+that happens to share an intermediate name (a `db` elsewhere) never leaks its
+members into `config$db$`.
+
 ## Cross-File Completions
 
 Symbols from sourced files appear with their source file indicated:

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -50,6 +50,8 @@ When you cmd-click the RHS of `$` or `@` (e.g. `config$host`), Raven resolves it
 - Member assignments: `config$host <- …`, `config[["host"]] <- …` (both apply to `$`); `object@slot <- …` (applies to `@`)
 - Constructor literals: named arguments in `list()`, `data.frame()`, `tibble()`, `c()`, S4 `new()`, etc.
 
+Nested members resolve against the full container path at any depth — cmd-clicking `gamma` in `alpha$beta$gamma` resolves it as a member of `alpha$beta` (descending nested constructor literals or matching `alpha$beta$gamma <- …` assignments), never as the free variable `gamma`. `$`, `@`, and `[["lit"]]` segments may be mixed in the chain.
+
 If multiple candidates exist across the dependency graph, Raven tie-breaks by graph distance (closer wins). Cmd-clicking on `$` or `@` itself (the punctuation) does nothing — only identifiers are navigable.
 
 For the full scope rules, see [$ and @ Member Resolution](cross-file.md#-and--member-resolution) in the cross-file doc.

--- a/docs/superpowers/plans/2026-06-04-nested-dollar-member-completion.md
+++ b/docs/superpowers/plans/2026-06-04-nested-dollar-member-completion.md
@@ -1,0 +1,1205 @@
+# Nested `$`/`@`/`[[]]` Member Completion + Goto-Def Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve completion and go-to-definition for the RHS of a `$`/`@`/`[["lit"]]` chain against the full container path at arbitrary depth, with reassignment-aware (establishing-site) member sets, and eliminate the wrong-variable completion bug.
+
+**Architecture:** Generalize the single-identifier LHS into a `QualifiedPath` (head + intermediate segments) everywhere the resolver keys on `lhs_name`. A shared left-spine walker builds the path for both surfaces. The existing position-aware/cross-file candidate machinery is reused; the three discovery collectors widen from "LHS is `head`" to "LHS spine equals a path prefix"; a new establishing-site cutoff makes a whole-value (re)write replace earlier members.
+
+**Tech Stack:** Rust (workspace crate `raven`), tree-sitter-r, tower-lsp. Tests are `#[cfg(test)]` units in `crates/raven/src/qualified_resolve.rs` (harness: `fresh_state()`, `add_indexed_doc()`, `completion_names()`, `loc()`) plus completion/goto-def integration tests in `handlers.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md`
+
+**Reference reading before starting:**
+- `crates/raven/src/qualified_resolve.rs` — module doc (lines 1-40), the collectors (121-229), the core collector (456-708), public APIs (285-453), test harness (~1430-1620).
+- `crates/raven/src/extract_op.rs` — `ExtractOp`, `extract_operator_rhs`.
+- `crates/raven/src/handlers.rs` — `detect_dollar_member_completion_context` (12365-12424), `dollar_member_completion_items` (12456-12500), the completion call site (12664), the goto-def call site (14848-14874).
+
+**CI gates (run before every commit):**
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+cargo test -p raven qualified_resolve
+```
+
+---
+
+## File Structure
+
+- **Modify** `crates/raven/src/extract_op.rs` — add `op_from_node` helper (maps a `$`/`@` operator node to `ExtractOp`); already has `ExtractOp` + `extract_operator_rhs`.
+- **Modify** `crates/raven/src/qualified_resolve.rs` — new `Segment`/`QualifiedPath` types + `build_qualified_path` spine-walker; generalize the core collector and the three discovery collectors to a path; add the establishing-site cutoff; update public API signatures; extend the test module.
+- **Modify** `crates/raven/src/handlers.rs` — rebuild `detect_dollar_member_completion_context` to seed the spine-walker from the AST; update the two resolver call sites; add integration tests.
+- **Modify** `docs/completion.md`, `docs/go-to-definition.md`, the `qualified_resolve.rs` module doc, and add a forward-reference in `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md`.
+
+The whole change stays inside these files. No new modules; no changes to scope resolution, the dependency graph, or the diagnostics gate.
+
+---
+
+## Task 1: `QualifiedPath` / `Segment` types + the shared spine-walker
+
+**Files:**
+- Modify: `crates/raven/src/extract_op.rs`
+- Modify: `crates/raven/src/qualified_resolve.rs`
+
+- [ ] **Step 1: Add `op_from_node` to `extract_op.rs`**
+
+Append below `extract_operator_rhs`:
+
+```rust
+/// Map a `$`/`@` operator node to [`ExtractOp`]. Returns `None` for any other
+/// node kind.
+pub fn op_from_node(op_node: Node) -> Option<ExtractOp> {
+    match op_node.kind() {
+        "$" => Some(ExtractOp::Dollar),
+        "@" => Some(ExtractOp::At),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test for `build_qualified_path`**
+
+In the `qualified_resolve.rs` test module (inside `mod tests`), add a parse helper if one is not already present, then the tests. Use the project's parser pool exactly as the existing tests construct trees (via `add_indexed_doc` you can get a parsed `doc.tree`; for a pure unit test of the walker, parse directly):
+
+```rust
+fn parse_r(text: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_r::LANGUAGE.into())
+        .expect("load tree-sitter-r");
+    parser.parse(text, None).expect("parse")
+}
+
+/// Find the deepest `extract_operator`/`subset`/`subset2` node whose byte range
+/// ends at `end_byte` (the LHS of a trailing access in these tests).
+fn lhs_node_ending_at(tree: &tree_sitter::Tree, end_byte: usize) -> tree_sitter::Node<'_> {
+    fn rec<'a>(n: tree_sitter::Node<'a>, end: usize, best: &mut Option<tree_sitter::Node<'a>>) {
+        if n.end_byte() == end
+            && matches!(n.kind(), "extract_operator" | "subset" | "subset2" | "identifier")
+        {
+            *best = Some(n);
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            rec(ch, end, best);
+        }
+    }
+    let mut best = None;
+    rec(tree.root_node(), end_byte, &mut best);
+    best.expect("no lhs node ends at end_byte")
+}
+
+#[test]
+fn build_path_single_identifier() {
+    let text = "alpha";
+    let tree = parse_r(text);
+    let lhs = lhs_node_ending_at(&tree, text.len());
+    let path = super::build_qualified_path(lhs, text).expect("path");
+    assert_eq!(path.head, "alpha");
+    assert!(path.segments.is_empty());
+}
+
+#[test]
+fn build_path_two_dollar_segments() {
+    let text = "alpha$beta";
+    let tree = parse_r(text);
+    let lhs = lhs_node_ending_at(&tree, text.len());
+    let path = super::build_qualified_path(lhs, text).expect("path");
+    assert_eq!(path.head, "alpha");
+    assert_eq!(path.segments.len(), 1);
+    assert_eq!(path.segments[0].name, "beta");
+    assert_eq!(path.segments[0].op, crate::extract_op::ExtractOp::Dollar);
+}
+
+#[test]
+fn build_path_mixed_dollar_at_and_subscript() {
+    let text = "alpha@beta[[\"gamma\"]]";
+    let tree = parse_r(text);
+    let lhs = lhs_node_ending_at(&tree, text.len());
+    let path = super::build_qualified_path(lhs, text).expect("path");
+    assert_eq!(path.head, "alpha");
+    let names: Vec<_> = path.segments.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["beta", "gamma"]);
+    assert_eq!(path.segments[0].op, crate::extract_op::ExtractOp::At);
+    // `[["lit"]]` is `$`-equivalent for member purposes.
+    assert_eq!(path.segments[1].op, crate::extract_op::ExtractOp::Dollar);
+}
+
+#[test]
+fn build_path_bails_on_non_static_segment() {
+    for text in ["f()$x", "alpha[[i]]$x", "alpha[[1]]$x"] {
+        let tree = parse_r(text);
+        let lhs = lhs_node_ending_at(&tree, text.len());
+        assert!(
+            super::build_qualified_path(lhs, text).is_none(),
+            "expected None for {text:?}"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail to compile (types/fn missing)**
+
+Run: `cargo test -p raven qualified_resolve::tests::build_path 2>&1 | head -30`
+Expected: compile error — `build_qualified_path`, `Segment`, `QualifiedPath` not found.
+
+- [ ] **Step 4: Implement the types + walker**
+
+Near the top of `qualified_resolve.rs` (after the `use` block), add:
+
+```rust
+/// One intermediate step in a `$`/`@`/`[["lit"]]` access chain. `op` is the
+/// operator that produced this segment from its parent; a `[["lit"]]` subscript
+/// is recorded as [`ExtractOp::Dollar`] because it is `$`-equivalent for member
+/// resolution (mirrors `member_assignment_candidate_from_string_subscript`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Segment {
+    pub name: String,
+    pub op: ExtractOp,
+}
+
+/// The container an `$`/`@` member is being resolved against: a head identifier
+/// plus zero or more intermediate [`Segment`]s. `segments.is_empty()` is the
+/// single-level (depth-1) case and reproduces the pre-Step-2 behavior.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualifiedPath {
+    pub head: String,
+    pub segments: Vec<Segment>,
+}
+
+/// Walk the left-spine of an `extract_operator`/`subset`/`subset2` node into a
+/// [`QualifiedPath`]. Bails to `None` on any non-static step: a computed index
+/// (`alpha[[i]]`, `alpha[[1]]`), a call (`f()$x`), or a non-literal subscript.
+/// The spine must bottom out at a single `identifier` (the head).
+pub fn build_qualified_path(lhs: Node, text: &str) -> Option<QualifiedPath> {
+    let mut rev_segments: Vec<Segment> = Vec::new();
+    let mut node = lhs;
+    loop {
+        match node.kind() {
+            "identifier" => {
+                rev_segments.reverse();
+                return Some(QualifiedPath {
+                    head: node_text(node, text).to_string(),
+                    segments: rev_segments,
+                });
+            }
+            "extract_operator" => {
+                let op = crate::extract_op::op_from_node(node.child_by_field_name("operator")?)?;
+                let rhs = node.child_by_field_name("rhs")?;
+                if rhs.kind() != "identifier" {
+                    return None;
+                }
+                rev_segments.push(Segment {
+                    name: node_text(rhs, text).to_string(),
+                    op,
+                });
+                node = node.child_by_field_name("lhs")?;
+            }
+            "subset2" => {
+                // `foo[["lit"]]` — `$`-equivalent. Reject computed/numeric indices.
+                let func = node.child_by_field_name("function")?;
+                let args = node.child_by_field_name("arguments")?;
+                let string_node = first_direct_string_argument(args)?;
+                let name = simple_string_literal_value(string_node, text)?;
+                rev_segments.push(Segment {
+                    name: name.to_string(),
+                    op: ExtractOp::Dollar,
+                });
+                node = func;
+            }
+            _ => return None,
+        }
+    }
+}
+```
+
+(Place it above `member_assignment_candidate_from_extract`. `first_direct_string_argument` and `simple_string_literal_value` already exist in this file.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p raven qualified_resolve::tests::build_path`
+Expected: 4 tests pass.
+
+- [ ] **Step 6: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/extract_op.rs crates/raven/src/qualified_resolve.rs
+git commit -m "feat(qualified-resolve): QualifiedPath types + shared spine-walker"
+```
+
+---
+
+## Task 2: Thread `QualifiedPath` through the core collector and public APIs (no behavior change)
+
+This is a pure refactor: replace the `(lhs_node_kind, lhs_name)` parameters with a `&QualifiedPath`. With empty `segments`, behavior is identical to today. The existing test suite is the safety net.
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs`
+- Modify: `crates/raven/src/handlers.rs` (call sites + the goto-def path)
+
+- [ ] **Step 1: Change the core collector signature**
+
+`collect_qualified_member_candidates_with_cancel` (line 456): replace params `lhs_node_kind: &str, lhs_name: &str` with `path: &QualifiedPath`. Delete the early gate:
+
+```rust
+if lhs_node_kind != "identifier" || cancel.is_cancelled() {
+    return None;
+}
+```
+
+Replace with:
+
+```rust
+if cancel.is_cancelled() {
+    return None;
+}
+let lhs_name = path.head.as_str();
+```
+
+Leave the rest of the body untouched for this task (the body already uses `lhs_name`). All three `collect_member_assignments(... lhs_name ...)` calls and `collect_constructor_candidate(s)(... lhs_name ...)` calls continue to compile because `lhs_name` is still in scope. (Segments are wired into discovery in Tasks 3-5.)
+
+- [ ] **Step 2: Change the public API signatures**
+
+`resolve_qualified_member` / `resolve_qualified_member_with_cancel` (285, 318): replace `lhs_node_kind: &str, lhs_name: &str` with `path: &QualifiedPath`, and forward `path` to the collector instead of `lhs_node_kind, lhs_name`.
+
+`complete_qualified_members` / `complete_qualified_members_with_cancel` (355, 379): same change.
+
+- [ ] **Step 3: Update the goto-def call site in `handlers.rs`**
+
+At `handlers.rs:14848`, replace the body that calls `resolve_qualified_member(..., lhs_node.kind(), lhs_name, ...)` with a spine-walked path:
+
+```rust
+if let Some((lhs_node, op)) = crate::extract_op::extract_operator_rhs(node) {
+    let rhs_name = node_text(node, &text);
+    let Some(path) = crate::qualified_resolve::build_qualified_path(lhs_node, &text) else {
+        return None;
+    };
+    let location = if cancel.is_never() {
+        crate::qualified_resolve::resolve_qualified_member(state, uri, position, &path, rhs_name, op)
+    } else {
+        crate::qualified_resolve::resolve_qualified_member_with_cancel(
+            state, uri, position, &path, rhs_name, op, cancel,
+        )
+    };
+    return location.map(GotoDefinitionResponse::Scalar);
+}
+```
+
+This already enables nested goto-def: for `alpha$beta$gamma`, `lhs_node` is `alpha$beta`, `build_qualified_path` yields `head=alpha, segments=[beta:$]` (previously this bailed on `lhs_node_kind != "identifier"`).
+
+- [ ] **Step 4: Update the completion call site in `handlers.rs`**
+
+`dollar_member_completion_items` (12456) currently calls `complete_qualified_members(..., "identifier", &context.lhs_name, Dollar)`. Change `DollarMemberCompletionContext` to carry a `QualifiedPath` + terminal `op` (full rework happens in Task 7; for now, keep `lhs_name` but build a depth-1 path inline so it compiles):
+
+```rust
+let path = crate::qualified_resolve::QualifiedPath {
+    head: context.lhs_name.clone(),
+    segments: Vec::new(),
+};
+crate::qualified_resolve::complete_qualified_members(
+    state, uri, position, &path, crate::extract_op::ExtractOp::Dollar,
+)
+```
+
+- [ ] **Step 5: Update the test harness**
+
+In `qualified_resolve.rs` `completion_names` helper (1465) and the perf test (1490-1529), replace the `"identifier", lhs_name` arguments with a path:
+
+```rust
+fn completion_names(state: &WorldState, uri: &Url, position: Position, lhs_name: &str) -> Vec<String> {
+    let path = super::QualifiedPath { head: lhs_name.to_string(), segments: Vec::new() };
+    super::complete_qualified_members(state, uri, position, &path, crate::extract_op::ExtractOp::Dollar)
+        .into_iter()
+        .map(|c| c.name)
+        .collect()
+}
+```
+
+For the perf test's two direct `complete_qualified_members(... "identifier", "df", ...)` calls, build `let df_path = super::QualifiedPath { head: "df".into(), segments: Vec::new() };` once and pass `&df_path`.
+
+Grep for any other callers and update them:
+
+Run: `grep -rn "resolve_qualified_member\|complete_qualified_members" crates/raven/src | grep -v "fn \|///\|//!"`
+Update each call site to pass a `&QualifiedPath` (depth-1 for goto-def-on-identifier helpers).
+
+- [ ] **Step 6: Build + run the full module test suite (must stay green)**
+
+Run: `cargo test -p raven qualified_resolve`
+Expected: all existing tests pass (behavior unchanged).
+
+Run: `cargo test -p raven dollar` (completion/goto-def integration tests)
+Expected: pass.
+
+- [ ] **Step 7: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add -A
+git commit -m "refactor(qualified-resolve): thread QualifiedPath through core + APIs (no behavior change)"
+```
+
+---
+
+## Task 3: Path-prefixed assignment discovery (`alpha$beta$gamma <- …`)
+
+Generalize the extract and string-subscript assignment matchers from "target LHS is `identifier(head)`" to "target's left-spine equals `head + segments`, and the final extract step is the member".
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn nested_assignment_members_depth2() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list()
+alpha$beta <- list()
+alpha$beta$gamma <- 1
+alpha$beta$delta <- 2
+alpha$beta$
+";
+    let uri = add_indexed_doc(&mut state, "file:///n.R", code);
+    // Cursor on the trailing `alpha$beta$` line (0-based line 4, after the `$`).
+    let mut names = completion_path_names(&state, &uri, Position::new(4, 11), "alpha", &["beta"]);
+    names.sort();
+    assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+}
+```
+
+Add a path-aware completion helper next to `completion_names`:
+
+```rust
+fn completion_path_names(
+    state: &WorldState,
+    uri: &Url,
+    position: Position,
+    head: &str,
+    segments: &[&str],
+) -> Vec<String> {
+    let path = super::QualifiedPath {
+        head: head.to_string(),
+        segments: segments
+            .iter()
+            .map(|s| super::Segment { name: s.to_string(), op: crate::extract_op::ExtractOp::Dollar })
+            .collect(),
+    };
+    super::complete_qualified_members(state, uri, position, &path, crate::extract_op::ExtractOp::Dollar)
+        .into_iter()
+        .map(|c| c.name)
+        .collect()
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p raven qualified_resolve::tests::nested_assignment_members_depth2`
+Expected: FAIL — returns `[]` (segments are not yet matched).
+
+- [ ] **Step 3: Add a spine-prefix matcher and generalize the extract matcher**
+
+Add a helper:
+
+```rust
+/// Does `target`'s left-spine equal `path` (`head` + `segments`)? `target` is
+/// the LHS/RHS assignment target node. Each spine step must match the
+/// corresponding segment by name and op (an `$`/`@` extract matches exactly; a
+/// `[["lit"]]` subscript matches a `Dollar` segment). Returns the matched
+/// container node count only as success/failure.
+fn target_spine_is_path(target: Node, text: &str, path: &QualifiedPath) -> bool {
+    // Build the target's spine bottom-up, then compare to head + segments.
+    let Some(actual) = build_qualified_path(target, text) else {
+        return false;
+    };
+    actual.head == path.head && actual.segments == path.segments
+}
+```
+
+In `member_assignment_candidate_from_extract` (121): change the signature to take `path: &QualifiedPath` instead of `lhs_name: &str`. Replace the identifier-only LHS check:
+
+```rust
+let t_lhs = target.child_by_field_name("lhs")?;
+let t_rhs = target.child_by_field_name("rhs")?;
+if t_lhs.kind() != "identifier" || t_rhs.kind() != "identifier" {
+    return None;
+}
+let member_name = node_text(t_rhs, text);
+if node_text(t_lhs, text) != lhs_name
+    || rhs_name.is_some_and(|rhs_name| member_name != rhs_name)
+{
+    return None;
+}
+```
+
+with:
+
+```rust
+let t_rhs = target.child_by_field_name("rhs")?;
+if t_rhs.kind() != "identifier" {
+    return None;
+}
+let member_name = node_text(t_rhs, text);
+if rhs_name.is_some_and(|rhs_name| member_name != rhs_name) {
+    return None;
+}
+let t_lhs = target.child_by_field_name("lhs")?;
+if !target_spine_is_path(t_lhs, text, path) {
+    return None;
+}
+```
+
+Keep `lhs_pos` as the head identifier position. Since `t_lhs` may now be an `extract_operator`, derive the head identifier position by walking to the leftmost identifier:
+
+```rust
+let head_id = leftmost_identifier(t_lhs)?;
+let lhs_range = node_range(head_id, col_mapper);
+```
+
+Add the helper:
+
+```rust
+/// Leftmost `identifier` on a node's left-spine (the head of an access chain).
+fn leftmost_identifier(mut node: Node) -> Option<Node> {
+    loop {
+        match node.kind() {
+            "identifier" => return Some(node),
+            "extract_operator" => node = node.child_by_field_name("lhs")?,
+            "subset" | "subset2" => node = node.child_by_field_name("function")?,
+            _ => return None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Generalize the string-subscript matcher**
+
+In `member_assignment_candidate_from_string_subscript` (164): change `lhs_name: &str` → `path: &QualifiedPath`. Replace:
+
+```rust
+let t_lhs = target.child_by_field_name("function")?;
+if t_lhs.kind() != "identifier" || node_text(t_lhs, text) != lhs_name {
+    return None;
+}
+```
+
+with:
+
+```rust
+let t_lhs = target.child_by_field_name("function")?;
+if !target_spine_is_path(t_lhs, text, path) {
+    return None;
+}
+let head_id = leftmost_identifier(t_lhs)?;
+```
+
+and use `head_id` for `lhs_range`.
+
+- [ ] **Step 5: Thread `path` through the callers**
+
+`try_extract_member_assignment` (1187) and `collect_member_assignments` (1122): change their `lhs_name: &str` params to `path: &QualifiedPath` and forward to the two candidate matchers. In `collect_qualified_member_candidates_with_cancel`, change the three `collect_member_assignments(... lhs_name ...)` calls to pass `path`. (The cross-file `lhs_arc`/`candidate_lhs_matches_symbol` logic still keys on `path.head` = `lhs_name`, unchanged.)
+
+- [ ] **Step 6: Run the test to verify it passes + suite stays green**
+
+Run: `cargo test -p raven qualified_resolve`
+Expected: new test passes; depth-1 tests still pass (empty segments → `target_spine_is_path` reduces to head-identifier match).
+
+- [ ] **Step 7: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "feat(qualified-resolve): path-prefixed assignment discovery"
+```
+
+---
+
+## Task 4: Constructor descent (`alpha <- list(beta = list(gamma = …))`)
+
+Generalize `collect_constructor_candidates` to descend `segments` through nested allowlisted constructors before enumerating named args.
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn nested_constructor_descent_depth2() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list(gamma = 1, delta = 2))
+alpha$beta$
+";
+    let uri = add_indexed_doc(&mut state, "file:///c.R", code);
+    let mut names = completion_path_names(&state, &uri, Position::new(1, 11), "alpha", &["beta"]);
+    names.sort();
+    assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+}
+
+#[test]
+fn nested_constructor_descent_depth3() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list(gamma = list(epsilon = 1, zeta = 2)))
+alpha$beta$gamma$
+";
+    let uri = add_indexed_doc(&mut state, "file:///c3.R", code);
+    let mut names =
+        completion_path_names(&state, &uri, Position::new(1, 17), "alpha", &["beta", "gamma"]);
+    names.sort();
+    assert_eq!(names, vec!["epsilon".to_string(), "zeta".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p raven qualified_resolve::tests::nested_constructor_descent`
+Expected: FAIL — returns `[]`.
+
+- [ ] **Step 3: Implement descent**
+
+In `collect_constructor_candidates` (1259): change `lhs_name: &str` → `path: &QualifiedPath`. After locating `value_node` (the head assignment's RHS) and validating it is a `call` to an allowlisted constructor, **descend** through `path.segments` before enumerating:
+
+```rust
+// Descend the constructor following the intermediate segments. Each segment
+// must be a named argument whose value is itself an allowlisted constructor.
+let mut current_args = args_node;
+for seg in &path.segments {
+    let Some(child_call) = named_arg_constructor_value(current_args, text, &seg.name) else {
+        return; // segment not present as a nested constructor → no members here
+    };
+    let Some(child_args) = child_call.child_by_field_name("arguments") else {
+        return;
+    };
+    current_args = child_args;
+}
+// `current_args` is now the arg list of the terminal constructor; enumerate it.
+```
+
+Then change the existing enumeration loop to iterate `current_args` instead of `args_node`. Add the helper:
+
+```rust
+/// In `args` (a constructor call's argument list), find a named argument
+/// `name = <call>` whose value is a call to an allowlisted constructor, and
+/// return that call node.
+fn named_arg_constructor_value<'a>(args: Node<'a>, text: &str, name: &str) -> Option<Node<'a>> {
+    let mut walker = args.walk();
+    for child in args.children(&mut walker) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
+        if name_node.kind() != "identifier" || node_text(name_node, text) != name {
+            continue;
+        }
+        let value = child.child_by_field_name("value")?;
+        if value.kind() != "call" {
+            return None;
+        }
+        let func = value.child_by_field_name("function")?;
+        if func.kind() == "identifier" && CONSTRUCTOR_ALLOWLIST.contains(&node_text(func, text)) {
+            return Some(value);
+        }
+        return None;
+    }
+    None
+}
+```
+
+Thread `path` through `collect_constructor_candidate` (1221) and the two call sites in the core collector (passing `path` instead of `lhs_name`).
+
+- [ ] **Step 4: Run the tests + suite**
+
+Run: `cargo test -p raven qualified_resolve`
+Expected: depth-2 and depth-3 descent tests pass; existing tests green (empty segments → loop is a no-op, identical to today).
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "feat(qualified-resolve): nested constructor descent"
+```
+
+---
+
+## Task 5: Intermediate constructor assignment (`alpha$beta <- list(gamma = …)`)
+
+A whole-value write to a prefix of the path, with a constructor RHS, contributes the constructor's named args (descended to the path). This reuses Task 3's spine matcher and Task 4's descent.
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn intermediate_constructor_assignment() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list()
+alpha$beta <- list(gamma = 1, delta = 2)
+alpha$beta$
+";
+    let uri = add_indexed_doc(&mut state, "file:///i.R", code);
+    let mut names = completion_path_names(&state, &uri, Position::new(2, 11), "alpha", &["beta"]);
+    names.sort();
+    assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p raven qualified_resolve::tests::intermediate_constructor_assignment`
+Expected: FAIL — returns `[]`.
+
+- [ ] **Step 3: Implement prefix-write constructor collection**
+
+Add `collect_prefix_write_constructor_candidates`, invoked from the core collector for the defining file (and reused by the establishing-site logic in Task 6). It scans the tree for assignments whose target spine is a **prefix** of `path` (length `≥ 1` segment, i.e. longer than the head and up to the full path), and whose RHS is an allowlisted constructor; it then descends the remaining segments and enumerates named args:
+
+```rust
+/// Collect members contributed by an assignment whose target spine is a prefix
+/// of `path` longer than the head (`alpha$beta <- list(...)` for path
+/// `[alpha, beta, ...]`), with an allowlisted-constructor RHS, descended to the
+/// full path. `out` receives one candidate per terminal named argument.
+#[allow(clippy::too_many_arguments)]
+fn collect_prefix_write_constructor_candidates(
+    root: Node,
+    text: &str,
+    col_mapper: &ColMapper,
+    file_uri: &Url,
+    path: &QualifiedPath,
+    rhs_name: Option<&str>,
+    out: &mut Vec<Candidate>,
+    skip_functions: bool,
+) {
+    for k in 1..=path.segments.len() {
+        let prefix = QualifiedPath {
+            head: path.head.clone(),
+            segments: path.segments[..k].to_vec(),
+        };
+        let remaining = &path.segments[k..];
+        visit_prefix_assignments(root, text, &prefix, skip_functions, &mut |assignment, value_node| {
+            enumerate_constructor_at_path(
+                value_node, text, col_mapper, file_uri, assignment, remaining, rhs_name, out,
+            );
+        });
+    }
+}
+```
+
+where:
+- `visit_prefix_assignments` walks the tree (same traversal shape as `collect_member_assignments`, honoring `skip_functions`), and for each `binary_operator` whose assignment target spine equals `prefix` (via `target_spine_is_path`) with a `call` RHS to an allowlisted constructor, invokes the callback with `(assignment_node, constructor_call_node)`.
+- `enumerate_constructor_at_path` descends `remaining` segments via `named_arg_constructor_value` (Task 4) and pushes a `Candidate` per terminal named arg, with `effect = EffectPos::from_node_end(assignment, col_mapper)`, `fn_scope = enclosing_function_id(assignment)`, `lhs_pos = leftmost_identifier(target).start`.
+
+Implement both helpers concretely (mirror the traversal in `collect_member_assignments` lines 1122-1182 for `visit_prefix_assignments`; mirror the enumeration loop in `collect_constructor_candidates` lines 1313-1342 for `enumerate_constructor_at_path`).
+
+Call `collect_prefix_write_constructor_candidates` from the defining-file block of the core collector (alongside `collect_member_assignments` + `collect_constructor_candidates`) and from the cross-file blocks (into `needs_validation` for redefining files, into `cross_file_candidates` for non-redefining files), so prefix-write members are validated by the same `candidate_lhs_matches_symbol` head check.
+
+- [ ] **Step 4: Run the test + suite**
+
+Run: `cargo test -p raven qualified_resolve`
+Expected: new test passes; existing tests green (empty segments → the `1..=0` range is empty → no-op).
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "feat(qualified-resolve): intermediate constructor assignment discovery"
+```
+
+---
+
+## Task 6: Establishing-site cutoff (reassignment delete semantics)
+
+The riskiest task. A whole-value (re)write of a prefix of the path is an *establishing site*; members declared before the latest visible establishing site are excluded. Implement the cutoff fully for the same-file case; cross-file ordering reuses the existing `visible_positions`/contributor machinery.
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn reassignment_replaces_earlier_members_same_file() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list(gamma = 1))
+alpha$beta <- list(delta = 2)
+alpha$beta$epsilon <- 3
+alpha$beta$
+";
+    let uri = add_indexed_doc(&mut state, "file:///r.R", code);
+    let mut names = completion_path_names(&state, &uri, Position::new(3, 11), "alpha", &["beta"]);
+    names.sort();
+    // gamma was replaced by the whole-value rewrite on line 1; delta + epsilon survive.
+    assert_eq!(names, vec!["delta".to_string(), "epsilon".to_string()]);
+}
+
+#[test]
+fn extension_before_reassignment_is_excluded() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list())
+alpha$beta$old <- 1
+alpha$beta <- list(fresh = 2)
+alpha$beta$
+";
+    let uri = add_indexed_doc(&mut state, "file:///r2.R", code);
+    let names = completion_path_names(&state, &uri, Position::new(3, 11), "alpha", &["beta"]);
+    // `old` was added before the rewrite on line 2 → excluded. Only `fresh`.
+    assert_eq!(names, vec!["fresh".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p raven qualified_resolve::tests::reassignment`
+Expected: FAIL — `gamma`/`old` are still offered (current behavior unions everything).
+
+- [ ] **Step 3: Implement the establishing-site cutoff**
+
+Tag each `Candidate` with the source kind it came from. Add a field to `Candidate`:
+
+```rust
+/// Where this candidate's value was established. `Extension` candidates
+/// (member-assignments to exactly the path) are subject to the establishing-site
+/// cutoff; `Establishing` candidates (head-binding constructor descent or a
+/// prefix-write constructor) define the cutoff.
+kind: CandidateKind,
+```
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandidateKind {
+    /// `path$m <- ...` / `path[["m"]] <- ...` — extends an existing value.
+    Extension,
+    /// Head-binding constructor descent, or `prefix <- list(...)` — establishes
+    /// the whole value at the path.
+    Establishing,
+}
+```
+
+Set `kind` at each push site: `collect_member_assignments`-derived candidates whose matched spine equals the full path are `Extension`; constructor-descent (Task 4) and prefix-write (Task 5) candidates are `Establishing`.
+
+After all candidates are collected in `collect_qualified_member_candidates_with_cancel` (before building `CandidateBatch`), apply the cutoff **per partition the winner logic already trusts**:
+
+```rust
+apply_establishing_cutoff(&mut all_candidates, &cursor_uri, &scope.visible_positions);
+```
+
+```rust
+/// Drop `Extension` candidates whose effect precedes the latest visible
+/// `Establishing` candidate (the establishing-site cutoff). Establishing
+/// candidates are never dropped here (they are the cutoff and also contribute
+/// their own members). Comparison uses effect position within a file and the
+/// per-file `visible_positions` cutoff; candidates in different files are
+/// ordered by their visible-position cutoff, matching `pick_winner`'s basis.
+fn apply_establishing_cutoff(
+    candidates: &mut Vec<Candidate>,
+    cursor_uri: &Url,
+    visible_positions: &HashMap<Url, (u32, u32)>,
+) {
+    // Find the latest visible establishing site. Key: (file-visible rank, effect).
+    let latest = candidates
+        .iter()
+        .filter(|c| c.kind == CandidateKind::Establishing)
+        .max_by(|a, b| establishing_order(a, cursor_uri, visible_positions)
+            .cmp(&establishing_order(b, cursor_uri, visible_positions)));
+    let Some(latest) = latest else { return };
+    let cutoff = establishing_order(latest, cursor_uri, visible_positions);
+    candidates.retain(|c| {
+        c.kind == CandidateKind::Establishing
+            || establishing_order(c, cursor_uri, visible_positions) >= cutoff
+    });
+}
+```
+
+`establishing_order` returns a comparable key: candidates in the cursor file rank after candidates in other files (cursor-file changes are always "latest" relative to upstream contributors), and within a file the key is `(effect.line, effect.utf16_column)`. Concretely:
+
+```rust
+fn establishing_order(
+    c: &Candidate,
+    cursor_uri: &Url,
+    _visible_positions: &HashMap<Url, (u32, u32)>,
+) -> (u8, u32, u32) {
+    let in_cursor_file = if &c.uri == cursor_uri { 1 } else { 0 };
+    (in_cursor_file, c.effect.line, c.effect.utf16_column)
+}
+```
+
+(Same-file correctness is exact: line/column ordering. Cross-file uses the cursor-file-last tier, consistent with how `pick_winner` treats cursor-file candidates as latest; the spec documents the residual cross-file imprecision.)
+
+- [ ] **Step 4: Run the tests + suite**
+
+Run: `cargo test -p raven qualified_resolve`
+Expected: both reassignment tests pass; depth-1 tests green (a single head-binding establishing site never cuts its own later extensions, reproducing today's behavior).
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "feat(qualified-resolve): establishing-site cutoff for reassignment semantics"
+```
+
+---
+
+## Task 7: Completion path parity — seed the spine-walker from the AST
+
+Rework `detect_dollar_member_completion_context` so the container path comes from the AST (full `$`/`@`/`[["lit"]]` parity), while the text scan still finds the trigger `$`, typed prefix, and replace range.
+
+**Files:**
+- Modify: `crates/raven/src/handlers.rs`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+In `handlers.rs` tests (near the existing `detect_dollar_member_completion_context` test at 46206), add:
+
+```rust
+#[test]
+fn completion_nested_dollar_chain() {
+    // alpha$beta$<cursor>
+    let (state, uri, pos) = setup_completion_doc(
+        "alpha <- list(beta = list(gamma = 1, delta = 2))\nalpha$beta$\n",
+        Position::new(1, 11),
+    );
+    let names = dollar_completion_labels(&state, &uri, pos);
+    assert!(names.contains(&"gamma".to_string()) && names.contains(&"delta".to_string()));
+}
+
+#[test]
+fn completion_subscript_segment_parity() {
+    // alpha[["beta"]]$<cursor>
+    let (state, uri, pos) = setup_completion_doc(
+        "alpha <- list(beta = list(gamma = 1))\nalpha[[\"beta\"]]$\n",
+        Position::new(1, 16),
+    );
+    let names = dollar_completion_labels(&state, &uri, pos);
+    assert!(names.contains(&"gamma".to_string()));
+}
+
+#[test]
+fn completion_no_false_positive_on_collision() {
+    // Unrelated top-level `beta` must NOT leak its members into alpha$beta$.
+    let (state, uri, pos) = setup_completion_doc(
+        "beta <- list(zeta = 1)\nalpha <- list(beta = list(gamma = 2))\nalpha$beta$\n",
+        Position::new(2, 11),
+    );
+    let names = dollar_completion_labels(&state, &uri, pos);
+    assert!(names.contains(&"gamma".to_string()));
+    assert!(!names.contains(&"zeta".to_string()), "leaked unrelated beta member");
+}
+```
+
+Add `setup_completion_doc` + `dollar_completion_labels` test helpers in `handlers.rs` if not present (use the existing completion test harness pattern in that file — search for how other completion tests build a `WorldState` + `Url` and call the completion entry point or `dollar_member_completion_items`).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p raven completion_nested_dollar_chain completion_subscript_segment_parity completion_no_false_positive_on_collision`
+Expected: `completion_subscript_segment_parity` fails (subscript chains not recognized) and the nested chain returns nothing; the collision test currently leaks `zeta`.
+
+- [ ] **Step 3: Rework the context struct + detector**
+
+Change `DollarMemberCompletionContext` (12365) to carry the path and terminal op:
+
+```rust
+struct DollarMemberCompletionContext {
+    path: crate::qualified_resolve::QualifiedPath,
+    op: crate::extract_op::ExtractOp,
+    typed_prefix: String,
+    replace_range: Range,
+}
+```
+
+In `detect_dollar_member_completion_context` (12371): keep the text scan that locates the trigger operator (`$` today; also accept `@`), the typed prefix, and the replace range. Then build the path from the AST node ending just before the trigger operator:
+
+```rust
+// `op_byte` is the byte offset of the trigger `$`/`@`. The LHS subexpression
+// ends just before it. Descend to the node ending at `op_byte` and walk it.
+let lhs_end_point = Point::new(line_idx, op_byte);
+let lhs_node = tree
+    .root_node()
+    .descendant_for_point_range(
+        Point::new(line_idx, op_byte.saturating_sub(1)),
+        lhs_end_point,
+    )?;
+// Ascend to the largest node ending exactly at the operator (the full LHS).
+let mut lhs = lhs_node;
+while let Some(parent) = lhs.parent() {
+    if parent.end_byte() <= line_byte_offset(&text, line_idx) + op_byte
+        && matches!(parent.kind(), "extract_operator" | "subset" | "subset2" | "identifier")
+    {
+        lhs = parent;
+    } else {
+        break;
+    }
+}
+let path = crate::qualified_resolve::build_qualified_path(lhs, text)?;
+```
+
+(Compute `op_byte` from the existing `dollar_byte` logic, generalized to also match `@`. Helper `line_byte_offset` converts a line index to an absolute byte offset; if a simpler local computation is available from the existing code, use it. If the AST descent or `build_qualified_path` fails, return `None` — bail rather than guess.)
+
+Populate `Some(DollarMemberCompletionContext { path, op, typed_prefix, replace_range })`.
+
+- [ ] **Step 4: Update `dollar_member_completion_items`**
+
+Use `context.path` + `context.op` directly:
+
+```rust
+crate::qualified_resolve::complete_qualified_members(state, uri, position, &context.path, context.op)
+```
+
+and update the `detail` strings to render the path (e.g. join head + segment names with the segment ops) instead of `context.lhs_name`. A simple rendering: `format!("member of {}", render_path(&context.path))` where `render_path` joins `head` and each segment as `op + name` (`$beta`, `@slot`).
+
+- [ ] **Step 5: Run the tests + suite**
+
+Run: `cargo test -p raven completion_nested_dollar_chain completion_subscript_segment_parity completion_no_false_positive_on_collision`
+Expected: all pass.
+
+Run: `cargo test -p raven` (full crate) — ensure no regression in existing completion tests.
+Expected: pass.
+
+- [ ] **Step 6: fmt + clippy + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --features test-support -- -D warnings
+git add crates/raven/src/handlers.rs
+git commit -m "feat(completion): nested $/@/[[]] member completion via shared spine-walker"
+```
+
+---
+
+## Task 8: Goto-def nested integration tests
+
+Task 2 already wired nested goto-def. This task locks it with tests.
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs` (test module)
+
+- [ ] **Step 1: Write the tests**
+
+```rust
+#[test]
+fn goto_def_nested_member_jumps_to_assignment() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list())
+alpha$beta$gamma <- 1
+x <- alpha$beta$gamma
+";
+    let uri = add_indexed_doc(&mut state, "file:///g.R", code);
+    // Cursor on `gamma` in the use on line 2 (0-based), column within `gamma`.
+    let result = crate::handlers::goto_definition_for_test(&state, &uri, Position::new(2, 17));
+    let location = loc(result);
+    assert_eq!(location.uri, uri);
+    assert_eq!(location.range.start.line, 1); // the `alpha$beta$gamma <- 1` line
+}
+
+#[test]
+fn goto_def_nested_no_false_positive() {
+    let mut state = fresh_state();
+    let code = "\
+gamma <- 99
+alpha <- list(beta = list(gamma = 1))
+y <- alpha$beta$gamma
+";
+    let uri = add_indexed_doc(&mut state, "file:///g2.R", code);
+    // `gamma` here must resolve to the constructor member (line 1), not the
+    // top-level `gamma <- 99` on line 0.
+    let result = crate::handlers::goto_definition_for_test(&state, &uri, Position::new(2, 16));
+    let location = loc(result);
+    assert_eq!(location.range.start.line, 1);
+}
+```
+
+If no `goto_definition_for_test` shim exists, call the same goto-def entry point existing goto-def tests use (search `crates/raven/src/qualified_resolve.rs` and `handlers.rs` for how current `$`-member goto-def tests invoke it — reuse that exact path). Adjust the expected columns to the fixture.
+
+- [ ] **Step 2: Run + verify pass**
+
+Run: `cargo test -p raven qualified_resolve::tests::goto_def_nested`
+Expected: pass (wiring landed in Task 2; discovery in Tasks 3-4).
+
+- [ ] **Step 3: commit**
+
+```bash
+cargo fmt --all
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "test(goto-def): nested member resolution coverage"
+```
+
+---
+
+## Task 9: Cross-file, position-awareness, bail-case + mixed-chain regression tests
+
+**Files:**
+- Modify: `crates/raven/src/qualified_resolve.rs` (test module)
+
+- [ ] **Step 1: Write the position-awareness + cross-file tests**
+
+```rust
+#[test]
+fn nested_member_below_cursor_not_offered() {
+    let mut state = fresh_state();
+    let code = "\
+alpha <- list(beta = list())
+alpha$beta$gamma <- 1
+alpha$beta$
+alpha$beta$delta <- 2
+";
+    let uri = add_indexed_doc(&mut state, "file:///p.R", code);
+    // Cursor on line 2; `delta` is assigned on line 3 (below) and must not appear.
+    let names = completion_path_names(&state, &uri, Position::new(2, 11), "alpha", &["beta"]);
+    assert_eq!(names, vec!["gamma".to_string()]);
+}
+
+#[test]
+fn nested_member_cross_file() {
+    // `alpha` + its nested structure declared in utils.R; extended in main.R
+    // after the source() call. Mirror the multi-doc + source() setup used by the
+    // existing cross-file `$`-member tests in this module (search the test module
+    // for `source(` fixtures and reuse that exact harness shape).
+    let mut state = fresh_state();
+    let _utils = add_indexed_doc(
+        &mut state,
+        "file:///utils.R",
+        "alpha <- list(beta = list(gamma = 1))\n",
+    );
+    let main = add_indexed_doc(
+        &mut state,
+        "file:///main.R",
+        "source(\"utils.R\")\nalpha$beta$delta <- 2\nalpha$beta$\n",
+    );
+    let mut names = completion_path_names(&state, &main, Position::new(2, 11), "alpha", &["beta"]);
+    names.sort();
+    // gamma from utils.R (the establishing site) + delta extended in main.R.
+    assert_eq!(names, vec!["delta".to_string(), "gamma".to_string()]);
+}
+```
+
+If the multi-doc `source()` harness needs more than `add_indexed_doc` (e.g.
+registering the dependency edge), copy the setup from the nearest existing
+cross-file `$`-member test in this module verbatim and adapt the fixtures.
+
+- [ ] **Step 2: Write the bail-case + mixed-chain tests**
+
+```rust
+#[test]
+fn non_static_chain_yields_nothing() {
+    let mut state = fresh_state();
+    let code = "\
+make <- function() list(x = 1)
+alpha <- list(beta = list(gamma = 1))
+i <- \"beta\"
+";
+    let uri = add_indexed_doc(&mut state, "file:///b.R", code);
+    // f()$x$ and alpha[[i]]$ must produce no completions. Build those paths via
+    // the AST path-builder failing → empty. Here we assert the resolver returns
+    // empty for a path whose head does not resolve.
+    let names = completion_path_names(&state, &uri, Position::new(2, 0), "nonexistent", &["x"]);
+    assert!(names.is_empty());
+}
+
+#[test]
+fn mixed_dollar_at_chain_depth2() {
+    let mut state = fresh_state();
+    let code = "\
+setClass(\"K\", representation(slot = \"list\"))
+alpha <- list(beta = new(\"K\"))
+alpha$beta@slot$
+";
+    let uri = add_indexed_doc(&mut state, "file:///m.R", code);
+    // At minimum this must not panic and must not leak unrelated symbols.
+    let path = super::QualifiedPath {
+        head: "alpha".to_string(),
+        segments: vec![
+            super::Segment { name: "beta".into(), op: crate::extract_op::ExtractOp::Dollar },
+            super::Segment { name: "slot".into(), op: crate::extract_op::ExtractOp::At },
+        ],
+    };
+    let _ = super::complete_qualified_members(
+        &state, &uri, Position::new(2, 16), &path, crate::extract_op::ExtractOp::Dollar,
+    );
+}
+```
+
+(The non-static AST bail is already covered by Task 1's `build_path_bails_on_non_static_segment`; this task adds resolver-level robustness coverage.)
+
+- [ ] **Step 3: Run + verify all Task 9 tests pass**
+
+Run: `cargo test -p raven qualified_resolve::tests::nested_member_below_cursor_not_offered qualified_resolve::tests::nested_member_cross_file qualified_resolve::tests::non_static_chain_yields_nothing qualified_resolve::tests::mixed_dollar_at_chain_depth2`
+Expected: pass.
+
+- [ ] **Step 4: commit**
+
+```bash
+git add crates/raven/src/qualified_resolve.rs
+git commit -m "test(qualified-resolve): cross-file, position-aware, bail-case coverage"
+```
+
+---
+
+## Task 10: Documentation
+
+**Files:**
+- Modify: `docs/completion.md`, `docs/go-to-definition.md`
+- Modify: `crates/raven/src/qualified_resolve.rs` (module doc)
+- Modify: `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md`
+
+- [ ] **Step 1: `docs/completion.md` — `$ Member Completions`**
+
+Add after the existing constructor-literal bullet:
+
+```markdown
+Member completion follows nested access at any depth — `alpha$beta$` and
+`alpha[["beta"]]$gamma$` complete against the value at the full path. Members
+reflect the value live at the cursor, so a whole reassignment of an intermediate
+value (`alpha$beta <- list(...)`) replaces its earlier members.
+```
+
+- [ ] **Step 2: `docs/go-to-definition.md`**
+
+Add a sentence to the `$`/`@` member section noting that nested members
+(`alpha$beta$gamma`) resolve against the full container path and never fall
+back to a free identifier of the same name.
+
+- [ ] **Step 3: `qualified_resolve.rs` module doc**
+
+Update the header doc (lines 1-40) to describe the `QualifiedPath` model: the
+single-identifier case is the base case (`segments == []`); discovery matches
+path prefixes; the establishing-site cutoff delivers reassignment semantics.
+Reference `docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md`.
+
+- [ ] **Step 4: Forward-reference in the Step-1 spec**
+
+In `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md`, under the
+out-of-scope "Chained access" bullet, add: "Implemented in Step 2 —
+`2026-06-04-nested-dollar-member-completion-design.md`."
+
+- [ ] **Step 5: commit**
+
+```bash
+git add docs/ crates/raven/src/qualified_resolve.rs
+git commit -m "docs: nested member completion + goto-def"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Backward compatibility is the safety net.** After Tasks 2, 3, 4, 5, 6 the depth-1 behavior must be byte-identical — every existing `qualified_resolve` test must stay green at each commit. If one breaks, the generalization changed depth-1 semantics and must be corrected before proceeding.
+- **`segments == []` reductions:** `target_spine_is_path` → head-identifier match; constructor descent loop → no-op; prefix-write range `1..=0` → empty; establishing cutoff with only the head-binding establishing site → no extensions dropped.
+- **The cursor columns in the fixtures are 0-based UTF-16.** Verify each `Position::new(line, col)` points just after the trailing `$` (for completion) or inside the member identifier (for goto-def); adjust to the actual fixture text.
+- **Risk concentration:** Task 6 (establishing-site) and Task 7 (AST-seeded completion context). Review these most carefully; they carry the subtle position/ordering logic.

--- a/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
+++ b/docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md
@@ -44,7 +44,7 @@ Out of scope for Step 1:
 - Aliasing (`foo <- bar; foo$x`).
 - Function-return inference (`foo <- make_thing()`).
 - Package-data introspection (`pkg::dataset$col`).
-- Chained access (`foo$bar$baz` — returns `None`).
+- Chained access (`foo$bar$baz` — returns `None`). **Implemented in Step 2 — see `2026-06-04-nested-dollar-member-completion-design.md`.**
 - Hover / completion / find-references for qualified members (go-to-def only).
 
 ## Behavior contract

--- a/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
+++ b/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
@@ -222,12 +222,18 @@ The earlier `list(gamma = 1)` is an *earlier* establishing site, so it is below
 the cutoff and excluded. A subsequent `alpha$beta$epsilon <- 3` is added (it is
 after the cutoff).
 
-**Residual cross-file imprecision.** Ordering establishing sites that live in
-*different files* relies on the contributor-chain / visible-cutoff ordering —
-the same basis `pick_winner` already uses for cross-file member selection. No
-new class of imprecision is introduced; the worst case for a pathological
-cross-file whole-prefix reassignment is the same coarse ordering the depth-1
-cross-file path already accepts.
+**Cross-file reassignment.** A `source()` that brings the head's defining file
+into scope is itself an establishing event, so it competes with cursor-file
+prefix writes for the latest cutoff. A cursor-file reassignment after the
+`source()` therefore drops the upstream members it replaced (and a `source()`
+after a cursor-file reassignment re-establishes them). This is ordered by the
+direct source-call line in the cursor file.
+
+**Residual imprecision.** When the defining file is reached only *transitively*
+(no direct `source()` call in the cursor file), there is no cursor-file line to
+order it against, so upstream members are kept conservatively (over-offer, never
+wrong-variable). This is the same coarse contributor-chain basis `pick_winner`
+already accepts for cross-file selection.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
+++ b/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
@@ -1,0 +1,212 @@
+# Nested `$`/`@` member completion and go-to-definition (Step 2)
+
+Date: 2026-06-04
+Status: Draft for review
+
+## Problem
+
+Raven resolves the RHS of a single `$`/`@` access — it completes `beta` in
+`alpha$beta` and jumps to its definition. It does **not** handle chained access
+like `alpha$beta$gamma`. The original qualified-member work
+(`2026-05-02-dollar-rhs-goto-def-design.md`) explicitly deferred this:
+"Chained access (`foo$bar$baz` — returns `None`)."
+
+For **go-to-definition** the chained case already degrades safely: the resolver
+receives the LHS AST node, sees it is an `extract_operator` rather than an
+`identifier`, and returns `None` (`qualified_resolve.rs` rejects
+`lhs_node_kind != "identifier"`).
+
+For **completion** it does not degrade safely — it can resolve to the *wrong
+variable*. Completion does not use the AST for the LHS; it uses a text scanner,
+`detect_dollar_member_completion_context` (`handlers.rs`), which walks back
+exactly one identifier before the final `$` and bails only when the character
+before that identifier is `:` or `@` — **not** `$`:
+
+```rust
+if lhs_start > 0 && matches!(bytes[lhs_start - 1], b':' | b'@') {
+    return None;
+}
+let lhs_name = line[lhs_start..dollar_byte].to_string();
+```
+
+So for `alpha$beta$gamma` it extracts `lhs_name = "beta"` and resolves `beta`
+as a free variable. If an unrelated top-level `beta` exists, completion offers
+*its* members:
+
+```r
+beta  <- list(zeta = 1)             # unrelated top-level `beta`
+alpha <- list(beta = list(gamma = 2))
+alpha$beta$    # completion offers `zeta` — a member of the WRONG variable
+```
+
+This is a latent correctness bug, not merely a missing feature.
+
+## Goal
+
+Make completion and go-to-definition for the RHS of a `$`/`@` chain resolve
+against the **full container path**, at arbitrary depth:
+
+1. Complete and jump to members of `alpha$beta` (`gamma`), `alpha$beta$gamma`
+   (its members), and so on — unbounded depth.
+2. Eliminate the wrong-variable completion: an intermediate segment is never
+   reinterpreted as a free variable.
+3. Keep `$`/`@`/mixed chains working symmetrically.
+
+Surfaces in scope: **completion + go-to-definition** (they share the core
+resolver). Hover is out of scope — it is not wired to this resolver today.
+
+Out of scope (unchanged from Step 1, plus one Step-2 limitation):
+
+- Aliasing (`x <- alpha$beta; x$…`).
+- Function-return inference (`alpha <- make_thing()`).
+- S4 slot / R6 field declarations as a structure source.
+- Package-data introspection (`pkg::dataset$col`).
+- **Whole-prefix reassignment delete semantics** — see Limitations.
+
+## Why unbounded depth is not extra work
+
+The hard step is generalizing the LHS from a *single identifier* to a *path*.
+Today the LHS is modeled as one `lhs_name: &str` in three places — the
+completion text scanner, the resolver's `identifier`-only gate, and the member
+collectors. Once the LHS is a path and discovery does prefix-matching plus
+recursive constructor descent, depth 3, 5, and unbounded are the same loop:
+depth is just the number of intermediate segments. Capping at N would be *extra*
+code (a length check that discards longer chains) for *less* capability.
+
+## Core model
+
+Today's single-level code is the **base case** of the general one. Everything
+keyed on a single `lhs_name` becomes keyed on a **container path** — a head
+identifier plus zero or more intermediate segments. Zero intermediate segments
+is exactly today's behavior, so the generalization is backward-compatible by
+construction.
+
+```
+QualifiedPath { head: String, segments: Vec<Segment> }
+Segment        { name: String, op: ExtractOp /* Dollar | At */ }
+```
+
+For `alpha$beta$gamma` with the cursor / typed prefix on `gamma`:
+`head = "alpha"`, `segments = [Segment { name: "beta", op: Dollar }]`, and
+`gamma` is the member being resolved or completed. `segments == []` is the
+depth-1 case.
+
+## Building the path (two entry points, both already exist)
+
+- **Completion** — `detect_dollar_member_completion_context` (`handlers.rs`)
+  currently walks back one identifier. Generalize it to consume a leftward chain
+  of `<ident>$` segments, building `head + segments`, and bail to `None` on any
+  non-static boundary (`]`, `)`, a computed index). This preserves its
+  robustness to the incomplete trailing-`$` case that tree-sitter parses poorly.
+  `[["literal"]]` segments inside the chain are a stretch/parity item for
+  completion (goto-def gets them free via the AST); the initial completion
+  scanner handles `$`-delimited identifier segments.
+
+- **Go-to-definition** — `handlers.rs` already hands the resolver the `lhs_node`
+  AST node (`extract_operator_rhs`). Walk that node's left-spine to collect
+  segments; the head must bottom out at an `identifier`. Any non-static segment
+  → bail (it already returns `None` safely today).
+
+## Discovery — three shapes, each a generalization of an existing collector
+
+The members of the value at a container path are discovered from statically
+declared structure. Each shape walks `segments` of arbitrary length.
+
+1. **Path-prefixed assignments.** `member_assignment_candidate_from_extract`
+   today requires the assignment target's `lhs` to be an `identifier` matching
+   `lhs_name`. Generalize to: the target's left-spine equals `head + segments`
+   and the final extract `rhs` is the member. So `alpha$beta$gamma <- …` matches
+   container `[alpha, beta]` and yields member `gamma`. The `[["…"]]`
+   string-subscript collector generalizes the same way.
+
+2. **Constructor descent.** `collect_constructor_candidates` today finds
+   `alpha <- list(…)` and reads top-level named args. Generalize to: find the
+   head's defining constructor, descend following `segments` (each must be a
+   named arg whose value is itself an allowlisted constructor), then enumerate
+   named args at the terminal. So `alpha <- list(beta = list(gamma = …, delta =
+   …))` yields `gamma, delta` for container `[alpha, beta]`. The constructor
+   allowlist is unchanged (`list`, `c`, `data.frame`, `tibble`, `data.table`,
+   `environment`, `list2env`, `new`).
+
+3. **Intermediate constructor assignment.** `alpha$beta <- list(gamma = …)`:
+   the target spine equals the container path and the RHS is an allowlisted
+   constructor; enumerate its named args. This is shape 1's matcher feeding
+   shape 2's enumerator.
+
+## Position-aware and cross-file — reused, not rebuilt
+
+The head (`alpha`) still resolves through the existing position-aware cross-file
+scope, so "which binding of `alpha` is live at the cursor" is untouched.
+
+- **Defining-file candidates** keep the same `fn_scope` + effect-after-binding +
+  `candidate_effect_visible_in_scope` filters.
+- **Cross-file candidates** keep the per-site re-validation that re-resolves the
+  **head** at each candidate site (`candidate_lhs_matches_symbol`). Only the
+  syntactic site-matcher widens, from "LHS is `alpha`" to "LHS spine-prefix is
+  `alpha$beta`".
+- **`pick_winner`** (latest-effect-wins → graph distance → contributor order) is
+  unchanged and operates per member name.
+
+So cross-file nested resolution costs almost nothing beyond the wider matcher.
+
+## Safety — false positive eliminated by construction
+
+An intermediate segment is never reinterpreted as a free variable. The path is
+either fully static (head resolves in scope; every segment is a literal
+`$`/`@`/`[["lit"]]`) or the resolver bails to an empty result. This kills the
+`beta`-collision case: `alpha$beta$` resolves `alpha`, not `beta`, so an
+unrelated top-level `beta` can never leak its members. Head unresolved, head
+resolving to a `package:` symbol, or any non-static segment → empty result,
+matching goto-def's existing safe degradation.
+
+## Limitations
+
+**Whole-prefix reassignment delete semantics.** A later whole reassignment of an
+intermediate value should remove members declared earlier:
+
+```r
+alpha <- list(beta = list(gamma = 1))
+alpha$beta <- list(delta = 2)   # ideally `gamma` no longer a member
+alpha$beta$                     # this design still offers BOTH gamma and delta
+```
+
+Discovery unions member candidates and resolves *collisions* with the existing
+latest-effect-wins rule, but it does not model a whole-prefix overwrite as
+deleting the earlier structure. The result over-offers; it is never the
+wrong variable. This is documented and pinned by a test asserting the current
+behavior, so a future fix has a baseline.
+
+## Testing
+
+`qualified_resolve.rs` already has a substantial test module; extend it.
+
+- Each discovery shape at depth-2 and depth-3; mixed `$`/`@` chains.
+- The false-positive regression: the `beta`-collision must yield only
+  `alpha$beta`'s members.
+- Cross-file nested: structure declared in a sourced file and extended in the
+  cursor file; plus position-awareness (a member assigned below the cursor is
+  not offered).
+- The reassignment limitation, asserting current (over-offering) behavior.
+- Completion integration (handlers/completion tests) and goto-def integration
+  for nested paths.
+- Non-static bail cases: `f()$x$`, `alpha[[i]]$x$` → empty result.
+
+## Documentation
+
+- `docs/completion.md` — `$ Member Completions`: note nested paths.
+- `docs/go-to-definition.md` — nested member jumps.
+- The module doc atop `crates/raven/src/qualified_resolve.rs` — the path
+  framing and the base-case relationship.
+- `docs/superpowers/specs/2026-05-02-dollar-rhs-goto-def-design.md` — add a
+  forward reference to this Step-2 spec.
+
+## Edit surface
+
+- `crates/raven/src/qualified_resolve.rs` — `QualifiedPath`/`Segment` types, the
+  generalized collectors, reused winner selection.
+- `crates/raven/src/handlers.rs` — the two path-builders (completion text
+  scanner; goto-def AST left-spine walk).
+- The three doc files above.
+
+No new modules. No changes to scope resolution, the dependency graph, or the
+diagnostics gate.

--- a/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
+++ b/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
@@ -50,18 +50,24 @@ against the **full container path**, at arbitrary depth:
    (its members), and so on — unbounded depth.
 2. Eliminate the wrong-variable completion: an intermediate segment is never
    reinterpreted as a free variable.
-3. Keep `$`/`@`/mixed chains working symmetrically.
+3. Treat `$`, `@`, and `[["literal"]]` chain segments uniformly and at full
+   parity across both surfaces — a chain may mix them at any position.
+4. Reflect reassignment: members come from the value that is **live at the
+   cursor**, so a whole reassignment of an intermediate value replaces its
+   earlier members rather than unioning with them.
 
 Surfaces in scope: **completion + go-to-definition** (they share the core
 resolver). Hover is out of scope — it is not wired to this resolver today.
 
-Out of scope (unchanged from Step 1, plus one Step-2 limitation):
+Out of scope (unchanged from Step 1):
 
 - Aliasing (`x <- alpha$beta; x$…`).
 - Function-return inference (`alpha <- make_thing()`).
 - S4 slot / R6 field declarations as a structure source.
 - Package-data introspection (`pkg::dataset$col`).
-- **Whole-prefix reassignment delete semantics** — see Limitations.
+- Navigating to / completing the string-literal position *inside* a `[["…"]]`
+  subscript (neither surface does this today); `[["…"]]` is supported only as a
+  container-path segment.
 
 ## Why unbounded depth is not extra work
 
@@ -91,21 +97,27 @@ For `alpha$beta$gamma` with the cursor / typed prefix on `gamma`:
 `gamma` is the member being resolved or completed. `segments == []` is the
 depth-1 case.
 
-## Building the path (two entry points, both already exist)
+## Building the path (one shared spine-walker)
 
-- **Completion** — `detect_dollar_member_completion_context` (`handlers.rs`)
-  currently walks back one identifier. Generalize it to consume a leftward chain
-  of `<ident>$` segments, building `head + segments`, and bail to `None` on any
-  non-static boundary (`]`, `)`, a computed index). This preserves its
-  robustness to the incomplete trailing-`$` case that tree-sitter parses poorly.
-  `[["literal"]]` segments inside the chain are a stretch/parity item for
-  completion (goto-def gets them free via the AST); the initial completion
-  scanner handles `$`-delimited identifier segments.
+Both surfaces build the container path with a single shared routine that walks
+an `extract_operator` / `subset` / `subset2` node's **left-spine**, collecting
+one `Segment` per `$`/`@`/`[["literal"]]` step until it bottoms out at the head
+`identifier`. Any non-static step — a computed index (`alpha[[i]]`), a call
+(`f()$x`), or a non-literal subscript — makes the walker bail to `None`. This
+shared walker is what gives full `$`/`@`/`[["…"]]` parity on both surfaces.
 
-- **Go-to-definition** — `handlers.rs` already hands the resolver the `lhs_node`
-  AST node (`extract_operator_rhs`). Walk that node's left-spine to collect
-  segments; the head must bottom out at an `identifier`. Any non-static segment
-  → bail (it already returns `None` safely today).
+- **Go-to-definition** already hands the resolver the `lhs_node` AST node
+  (`extract_operator_rhs`, `handlers.rs`); feed it straight to the spine-walker.
+
+- **Completion** keeps `detect_dollar_member_completion_context` for the part
+  tree-sitter parses poorly — locating the trigger `$`, the typed prefix, and
+  the replace range from text (the incomplete trailing token). But the
+  **container path** is taken from the AST: descend to the node ending just
+  before the trigger `$` (the LHS subexpression, e.g. `alpha[["beta"]]` in
+  `alpha[["beta"]]$gam`) and hand it to the same spine-walker. The LHS of a
+  trailing `$` is a complete subexpression even though the `$` itself parses to
+  an error node, so this is robust. If the AST descent fails (an unbalanced or
+  mid-edit LHS), bail to `None` rather than guessing.
 
 ## Discovery — three shapes, each a generalization of an existing collector
 
@@ -129,9 +141,15 @@ declared structure. Each shape walks `segments` of arbitrary length.
    `environment`, `list2env`, `new`).
 
 3. **Intermediate constructor assignment.** `alpha$beta <- list(gamma = …)`:
-   the target spine equals the container path and the RHS is an allowlisted
-   constructor; enumerate its named args. This is shape 1's matcher feeding
-   shape 2's enumerator.
+   the target spine is a prefix of the container path (down to and including the
+   path itself) and the RHS is an allowlisted constructor; descend the remaining
+   segments and enumerate named args at the terminal. This is shape 1's matcher
+   feeding shape 2's enumerator.
+
+These three shapes are the *site inventory*, not the final answer. Shapes 2 and
+3 produce **establishing sites** (whole-value writes); shape 1 produces
+**member-extension writes**. The next section decides which establishing site is
+live and which extensions sit after it — the combination is not a naive union.
 
 ## Position-aware and cross-file — reused, not rebuilt
 
@@ -147,7 +165,9 @@ scope, so "which binding of `alpha` is live at the cursor" is untouched.
 - **`pick_winner`** (latest-effect-wins → graph distance → contributor order) is
   unchanged and operates per member name.
 
-So cross-file nested resolution costs almost nothing beyond the wider matcher.
+Beyond the wider matcher, the one genuinely new phase is the establishing-site
+cutoff (next section), which reuses this same ordering rather than introducing
+its own.
 
 ## Safety — false positive eliminated by construction
 
@@ -159,34 +179,71 @@ unrelated top-level `beta` can never leak its members. Head unresolved, head
 resolving to a `package:` symbol, or any non-static segment → empty result,
 matching goto-def's existing safe degradation.
 
-## Limitations
+## Reassignment semantics — the establishing-site cutoff
 
-**Whole-prefix reassignment delete semantics.** A later whole reassignment of an
-intermediate value should remove members declared earlier:
+Members must reflect the value that is **live at the cursor**. At depth-1 this
+already works: scope resolves the head to its latest binding before the cursor,
+and constructor descent reads only that binding. The Step-2 generalization
+extends the same "latest write wins, and it replaces what came before" rule to
+intermediate prefixes.
+
+For a container path `P = head + segments`, resolve members in two phases:
+
+1. **Find the establishing site** — the latest write, visible at the cursor,
+   that (re)establishes the *whole* value at `P`. Candidates are:
+   - the head's resolved scope binding (descended along `segments`), and
+   - any assignment whose target spine is a **prefix** of `P` longer than the
+     head (`alpha$beta <- …` when resolving `alpha$beta$…`; a write to a shorter
+     prefix re-establishes everything below it).
+
+   The latest is chosen with the same ordering the resolver already trusts —
+   effect position with per-file visible cutoffs, then dependency-graph
+   distance, then contributor order. "Descend to `P`" follows the write's RHS
+   through allowlisted-constructor named args; if a step is opaque (a call, a
+   bare identifier), `P` has no statically known members *at that site*, but the
+   site still counts as the establishing cutoff.
+
+2. **Enumerate members of `P`** as the union of:
+   - named arguments of the constructor reached at the establishing site, and
+   - member-extension writes to exactly `P` (`P$m <- …`, `P[["m"]] <- …`) whose
+     effect is **after** the establishing site and at or before the cursor.
+
+   Per-name collisions within the union resolve by latest-effect-wins, as today.
+
+The phase-1 cutoff is what delivers delete semantics:
 
 ```r
 alpha <- list(beta = list(gamma = 1))
-alpha$beta <- list(delta = 2)   # ideally `gamma` no longer a member
-alpha$beta$                     # this design still offers BOTH gamma and delta
+alpha$beta <- list(delta = 2)   # latest establishing site for alpha$beta
+alpha$beta$                     # offers `delta` only — `gamma` was replaced
 ```
 
-Discovery unions member candidates and resolves *collisions* with the existing
-latest-effect-wins rule, but it does not model a whole-prefix overwrite as
-deleting the earlier structure. The result over-offers; it is never the
-wrong variable. This is documented and pinned by a test asserting the current
-behavior, so a future fix has a baseline.
+The earlier `list(gamma = 1)` is an *earlier* establishing site, so it is below
+the cutoff and excluded. A subsequent `alpha$beta$epsilon <- 3` is added (it is
+after the cutoff).
+
+**Residual cross-file imprecision.** Ordering establishing sites that live in
+*different files* relies on the contributor-chain / visible-cutoff ordering —
+the same basis `pick_winner` already uses for cross-file member selection. No
+new class of imprecision is introduced; the worst case for a pathological
+cross-file whole-prefix reassignment is the same coarse ordering the depth-1
+cross-file path already accepts.
 
 ## Testing
 
 `qualified_resolve.rs` already has a substantial test module; extend it.
 
-- Each discovery shape at depth-2 and depth-3; mixed `$`/`@` chains.
+- Each discovery shape at depth-2 and depth-3.
+- `[["literal"]]` interior chain segments on both surfaces (`alpha[["beta"]]$`,
+  `alpha$beta[["gamma"]]$`) and mixed `$`/`@`/`[[…]]` chains.
 - The false-positive regression: the `beta`-collision must yield only
   `alpha$beta`'s members.
+- Reassignment delete semantics: a whole reassignment of an intermediate value
+  excludes its earlier members and keeps later extensions (`gamma` gone,
+  `delta` + `epsilon` present).
 - Cross-file nested: structure declared in a sourced file and extended in the
   cursor file; plus position-awareness (a member assigned below the cursor is
   not offered).
-- The reassignment limitation, asserting current (over-offering) behavior.
 - Completion integration (handlers/completion tests) and goto-def integration
   for nested paths.
 - Non-static bail cases: `f()$x$`, `alpha[[i]]$x$` → empty result.
@@ -203,9 +260,12 @@ behavior, so a future fix has a baseline.
 ## Edit surface
 
 - `crates/raven/src/qualified_resolve.rs` — `QualifiedPath`/`Segment` types, the
-  generalized collectors, reused winner selection.
-- `crates/raven/src/handlers.rs` — the two path-builders (completion text
-  scanner; goto-def AST left-spine walk).
+  shared left-spine path-builder, the generalized collectors, the
+  establishing-site cutoff, reused winner selection.
+- `crates/raven/src/handlers.rs` — `detect_dollar_member_completion_context`
+  reduced to locating the trigger `$` / typed prefix / replace range, then
+  seeding the shared spine-walker from the LHS AST node (the same walker
+  goto-def uses).
 - The three doc files above.
 
 No new modules. No changes to scope resolution, the dependency graph, or the

--- a/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
+++ b/docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md
@@ -222,18 +222,38 @@ The earlier `list(gamma = 1)` is an *earlier* establishing site, so it is below
 the cutoff and excluded. A subsequent `alpha$beta$epsilon <- 3` is added (it is
 after the cutoff).
 
-**Cross-file reassignment.** A `source()` that brings the head's defining file
-into scope is itself an establishing event, so it competes with cursor-file
-prefix writes for the latest cutoff. A cursor-file reassignment after the
-`source()` therefore drops the upstream members it replaced (and a `source()`
-after a cursor-file reassignment re-establishes them). This is ordered by the
-direct source-call line in the cursor file.
+**Scope of an establishing site.** A prefix write only resets the value the
+cursor sees if it executes in the head's own scope. A write inside an *unrelated
+function body* (`function() { alpha$beta <- … }` while `alpha` is top-level)
+targets that function's local copy, so it is excluded from the cutoff — the same
+`fn_scope == symbol_fn_scope` identity the resolver already applies to member
+candidates. Cross-file walks use the global (top-level) scope, since only
+globals cross files.
+
+**Cross-file reassignment.** Events and candidates live in different files, so
+the cutoff cannot compare raw line numbers (cursor-file line 2 is not "after" a
+helper's line 2). Each event and candidate is mapped to a global,
+execution-ordered key `(anchor_line, anchor_col, file_rank, within_line,
+within_col)`:
+
+- a cursor-file event anchors at its own position (`file_rank` 1);
+- a directly-sourced file's event anchors at its `source()` call site
+  (`file_rank` 0), with the within-file position breaking ties.
+
+This makes three orderings fall out of one comparison: a cursor-file
+reassignment after a `source()` drops the upstream members it replaced; a
+`source()` after a cursor-file reassignment re-establishes them; and a
+reassignment *inside* a sourced helper drops that helper's own earlier members
+(the within-file position separates the two same-anchor events).
 
 **Residual imprecision.** When the defining file is reached only *transitively*
-(no direct `source()` call in the cursor file), there is no cursor-file line to
-order it against, so upstream members are kept conservatively (over-offer, never
-wrong-variable). This is the same coarse contributor-chain basis `pick_winner`
-already accepts for cross-file selection.
+(no direct `source()` call in the cursor file), there is no anchor to order it
+against, so its members are kept conservatively (over-offer, never
+wrong-variable). Likewise, establishing sites are gathered only from the cursor
+file and the head's defining file; a reassignment in a *third* sourced file is
+not used as a cutoff (validating its `alpha` identity per write is more than the
+hot path warrants). Both are the same coarse contributor-chain basis
+`pick_winner` already accepts for cross-file selection.
 
 ## Testing
 
@@ -250,6 +270,11 @@ already accepts for cross-file selection.
 - Cross-file nested: structure declared in a sourced file and extended in the
   cursor file; plus position-awareness (a member assigned below the cursor is
   not offered).
+- Cross-file reassignment ordering: a cursor-file reassignment after `source()`
+  drops upstream members; one before `source()` keeps them; a reassignment
+  *inside* the sourced helper drops the helper's own earlier members.
+- Scope of an establishing site: a whole-value rewrite inside an unrelated
+  function body does not reset a top-level value (its members survive).
 - Completion integration (handlers/completion tests) and goto-def integration
   for nested paths.
 - Non-static bail cases: `f()$x$`, `alpha[[i]]$x$` → empty result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "raven",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "raven",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

Generalizes `$`/`@` member **completion** and **go-to-definition** from single-level (`alpha$beta`) to nested access at any depth (`alpha$beta$gamma`, deeper), with `$`, `@`, and `[["lit"]]` segments interchangeable in the chain.

This also fixes a latent **correctness bug**: completion previously grabbed only the nearest identifier before the final `$` (`beta` in `alpha$beta$gamma`) and resolved it as a free variable — so an unrelated top-level `beta` would leak *its* members into `alpha$beta$`. Go-to-def already degraded safely; completion did not. The path-based resolver eliminates this by construction.

Specs/plan:
- Design: `docs/superpowers/specs/2026-06-04-nested-dollar-member-completion-design.md`
- Plan: `docs/superpowers/plans/2026-06-04-nested-dollar-member-completion.md`
- This is "Step 2" of `2026-05-02-dollar-rhs-goto-def-design.md`, which explicitly deferred chained access.

## How it works

The LHS is modeled as a `QualifiedPath` (head identifier + ordered `Segment`s), built from the AST by a shared spine-walker used by **both** surfaces. The single-level case is `segments.is_empty()`, so the change is backward-compatible by construction. Discovery generalizes "match `foo`" to "match the container path":

- **Path-prefixed assignments** — `alpha$beta$gamma <- …`, `alpha$beta[["gamma"]] <- …`
- **Constructor descent** — `alpha <- list(beta = list(gamma = …))`
- **Intermediate constructor assignment** — `alpha$beta <- list(gamma = …)`

The existing position-aware + cross-file candidate machinery (contributor chain, visible-position cutoffs, `pick_winner`) is reused, not rebuilt — only the syntactic site-matcher widens.

### Reassignment semantics

Members reflect the value **live at the cursor**. A whole-value (re)write of an intermediate prefix (`alpha$beta <- list(…)`, constructor or opaque, including empty) is an *establishing site*; members declared before the latest visible one are dropped. Fully correct same-file; cross-file establishing-site ordering reuses the contributor-chain basis `pick_winner` already trusts (documented residual imprecision).

### Depth

Unbounded — depth is just `segments.len()`; the same loop handles 2, 3, or N. Non-static containers (`f()$x`, `alpha[[i]]$x`, `pkg::obj$x`) resolve to nothing rather than guessing.

## Surfaces

Completion **and** go-to-definition (they share the core resolver). Hover is out of scope (not wired to this resolver).

## Tests

New coverage in `qualified_resolve.rs` and `handlers.rs`: spine-walker units; each discovery shape at depth-2/3; `[["lit"]]` and mixed `$`/`@` chains; the wrong-variable regression; reassignment delete semantics (incl. empty-reset); cross-file nested; position-awareness; non-static bail cases. Full `-p raven` suite passes; `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --features test-support -- -D warnings` are clean.

## Edit surface

`crates/raven/src/qualified_resolve.rs`, `crates/raven/src/handlers.rs`, `crates/raven/src/extract_op.rs`, plus docs (`completion.md`, `go-to-definition.md`). No changes to scope resolution, the dependency graph, or the diagnostics gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nested chained member completion and go-to-definition now resolve against the full container path (supports mixed `$`, `@`, and literal-subscript segments).
  * Constructor/nested-member discovery across chains is improved so deep members are offered/resolved.

* **Bug Fixes**
  * Reassignment semantics: intermediate rewrites properly remove earlier members.
  * Eliminated false-positive completions from unrelated similarly-named variables.

* **Documentation**
  * Expanded docs and design notes explaining nested member completion and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->