### PR TITLE
docs: polished v0.9.0 release notes

### DIFF
--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,0 +1,46 @@
+v0.9.0 teaches Raven to follow **nested data structures** — `config$db$host`, `obj@slot$field`, `x[["a"]]$b` — through completion and go-to-definition at any depth, and turns **hover** from "stays silent on structural names" into "resolves and explains them." Under the hood, the downloadable package-symbol database is now built from a broader, fresher source.
+
+## Highlights
+
+- **Nested `$` / `@` / `[[ ]]` member resolution.** Completion and go-to-definition now follow a chain of accessors at arbitrary depth. Cmd-clicking `gamma` in `alpha$beta$gamma`, or typing `config$db$`, resolves against the **full container path** — descending nested constructor literals (`list(db = list(host = …))`) and matching path-prefixed assignments (`alpha$beta$gamma <- …`). `$`, `@`, and `[["literal"]]` segments are interchangeable and may be mixed anywhere in the chain.
+- **Members reflect the value live at the cursor.** A whole reassignment of an intermediate value replaces its earlier members rather than unioning with them: after `config$db <- list(url = …)`, completing `config$db$` offers `url`, not the earlier `host`/`port`. This holds across `source()` chains, ordered by execution.
+- **A latent wrong-variable bug is fixed.** Because the container is now resolved as a path, an unrelated top-level variable that happens to share an intermediate name can no longer leak its members. Previously `alpha$beta$` could offer the members of an unrelated `beta <- …` defined elsewhere; now it resolves `alpha`, never the stray `beta`.
+- **Hover resolves structural names instead of suppressing them.** Hovering a named-argument label, a parameter name, or a `$`/`@` member used to return nothing (a blunt fix for an earlier mis-attribution). Each now resolves to the right thing — see below — with no spurious `from {pkg}` attribution.
+
+## Nested member resolution, in detail
+
+The single-level resolver from earlier releases is now the base case of a general one that walks the accessor chain's left-spine into a container path:
+
+```r
+config <- list(db = list(host = "localhost", port = 8080))
+config$db$              # Completion offers: host, port
+config[["db"]]$         # Same — [["db"]] is equivalent to $db
+config$db$host          # Go-to-definition jumps to the `host =` field
+```
+
+- **Discovery** follows three statically-declared shapes at any depth: path-prefixed assignments (`alpha$beta$gamma <- …`), constructor descent through nested allowlisted constructors (`list`, `c`, `data.frame`, `tibble`, `data.table`, `environment`, `list2env`, `new`), and intermediate constructor assignments (`alpha$beta <- list(…)`).
+- **Reassignment semantics** use an establishing-site cutoff: the latest whole-value write visible at the cursor wins, and only member extensions *after* it are added. This delivers delete semantics — a replaced value's old members disappear — uniformly within a file and across `source()` chains (events are ordered by execution position, with sourced-file writes anchored at their `source()` call site).
+- **Safe by construction.** The path is either fully static (head resolves in scope; every segment is a literal `$`/`@`/`[["lit"]]`) or the resolver returns nothing. Non-static steps — a call (`f()$x`), a computed index (`x[[i]]`), an unresolved head — degrade to an empty result rather than a guess.
+- **Out of scope** (unchanged): aliasing (`x <- alpha$beta; x$…`), function-return inference, S4 slot / R6 field declarations as a structure source, and package-data introspection.
+
+See [`docs/completion.md`](../completion.md) and [`docs/go-to-definition.md`](../go-to-definition.md).
+
+## Hover, in detail
+
+Hover now answers for the structural names it used to skip, resolving each precisely rather than attributing it to a package:
+
+- **Named-argument label** (`title` in `labs(title = …)`) → the enclosing call's matching **user-defined formal**, with its default value and `@param` documentation. The `@param` doc resolves even when the function is defined in a sourced helper that is indexed but not open. Unknown, package, or data-keyword callees fall through to no hover rather than a misleading attribution.
+- **Parameter name at a definition site** → its `@param` roxygen, when the enclosing named function is documented.
+- **`obj$name` / `obj@slot` member** → its local definition, reusing the same resolver as go-to-definition. Runtime and package members stay unhovered.
+- **Package side of `pkg::name`** → the package's Title and Description from its installed `DESCRIPTION` (or a clear "not installed" note), with the prose properly Markdown-escaped so titles containing `*`, `_`, or backticks render correctly.
+
+See [`docs/hover.md`](../hover.md).
+
+## Package database
+
+- **`names.db` is now built from r-universe's bulk `/api/dbdump`** instead of per-package queries — broader, more consistent CRAN + Bioconductor coverage in a single pass, with a coverage floor that rejects a short or empty dump.
+- **Release hardening.** Every release now validates the exact `names.db` it bundles — decoding every record and checking it against provenance — before packaging binaries, and the scheduled refresh builds from a protected source branch.
+
+---
+
+**Full Changelog**: https://github.com/jbearak/raven/compare/v0.8.1...v0.9.0

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,4 +1,4 @@
-v0.9.0 teaches Raven to follow **nested data structures** — `config$db$host`, `obj@slot$field`, `x[["a"]]$b` — through completion and go-to-definition at any depth, and turns **hover** from "stays silent on structural names" into "resolves and explains them." Under the hood, the downloadable package-symbol database is now built from a broader, fresher source.
+v0.9.0 teaches Raven to follow **nested data structures** — `config$db$host`, `obj@slot$field`, `x[["a"]]$b` — through completion and go-to-definition at any depth, and turns **hover** from "stays silent on structural names" into "resolves and explains them." Under the hood it rebuilds the downloadable package-symbol database from a broader, fresher source and lands a large dead-code sweep that retires ~3,000 lines of unreachable code.
 
 ## Highlights
 
@@ -6,6 +6,7 @@ v0.9.0 teaches Raven to follow **nested data structures** — `config$db$host`, 
 - **Members reflect the value live at the cursor.** A whole reassignment of an intermediate value replaces its earlier members rather than unioning with them: after `config$db <- list(url = …)`, completing `config$db$` offers `url`, not the earlier `host`/`port`. This holds across `source()` chains, ordered by execution.
 - **A latent wrong-variable bug is fixed.** Because the container is now resolved as a path, an unrelated top-level variable that happens to share an intermediate name can no longer leak its members. Previously `alpha$beta$` could offer the members of an unrelated `beta <- …` defined elsewhere; now it resolves `alpha`, never the stray `beta`.
 - **Hover resolves structural names instead of suppressing them.** Hovering a named-argument label, a parameter name, or a `$`/`@` member used to return nothing (a blunt fix for an earlier mis-attribution). Each now resolves to the right thing — see below — with no spurious `from {pkg}` attribution.
+- **A large internal cleanup.** A repo-wide dead-code sweep removes the inert background indexer and roughly 3,000 net lines of unreachable code across the cross-file engine, indentation, handlers, and package internals — no behavior change, but a smaller, sharper codebase. Two now-meaningless settings go with it (see Upgrade notes).
 
 ## Nested member resolution, in detail
 
@@ -40,6 +41,18 @@ See [`docs/hover.md`](../hover.md).
 
 - **`names.db` is now built from r-universe's bulk `/api/dbdump`** instead of per-package queries — broader, more consistent CRAN + Bioconductor coverage in a single pass, with a coverage floor that rejects a short or empty dump.
 - **Release hardening.** Every release now validates the exact `names.db` it bundles — decoding every record and checking it against provenance — before packaging binaries, and the scheduled refresh builds from a protected source branch.
+
+## Under the hood
+
+A multi-agent dead-code sweep removed code that nothing in the repository — library, binary, tests, benches, or examples — reaches. The result is **~6,300 insertions against ~9,400 deletions** across 74 files, a net loss of roughly 3,000 lines, with no change in behavior:
+
+- The **inert background indexer** (`BackgroundIndexer`, ~730 lines) and its dead on-demand indexing knobs are gone; on-demand indexing of unopened files still works through the live path.
+- Unreachable clusters fall away across the board: an indentation operator-classification block with no production callers (`indentation/context.rs`), superseded property-test scaffolding (`cross_file/property_tests.rs`), duplicate `r_env` discovery, and a long tail of `pub`/`pub(crate)` items that rustc couldn't prove dead because they were reachable-by-visibility. Six file-level `#![allow(dead_code)]` escape hatches and dozens of scattered `#[allow(dead_code)]` came off in the process.
+- Several refactors with no behavior change tightened ownership — e.g. indentation chain-start and operator detection now live in a single owner, and `find_chain_start` takes a `line: u32` rather than a `Position`.
+
+## Upgrade notes
+
+- Two cross-file settings were **removed** because they configured the retired background indexer and no longer did anything: `raven.crossFile.onDemandIndexing.maxTransitiveDepth` and `raven.crossFile.onDemandIndexing.maxQueueSize`. If you set either, you can delete it; `raven.crossFile.onDemandIndexing.enabled` is unchanged.
 
 ---
 


### PR DESCRIPTION
## What & why

The `v0.9.0` tag exists (on the version-bump commit), but **no GitHub Release was ever published for it** — the release workflow never produced one, so there are no notes to ship and nothing to polish on GitHub. This adds hand-authored release notes in the established house style (intro → **Highlights** with bold lead-ins → per-feature detail → Full Changelog link), matching v0.8.x.

The notes live at `docs/release-notes/v0.9.0.md` so they can be reviewed here and pasted into the GitHub Release when 0.9.0 is re-cut. *(There's no existing in-repo changelog convention — release bodies have always lived only on GitHub — so this is a staging doc, not a new canonical home. Happy to relocate or drop it if you'd rather I produce the text another way.)*

## Coverage

Every user-facing change between `v0.8.1` and the `v0.9.0` tag:

- **Nested `$` / `@` / `[[ ]]` member completion & go-to-definition** — chained access at any depth against the full container path, mixed segment kinds, live-at-cursor reassignment semantics, and the wrong-variable correctness fix.
- **Hover resolves structural labels** instead of suppressing them — named-arg labels → resolved formal + default + `@param` (cross-file too), parameter names → roxygen, `obj$name`/`obj@slot` → local definition, `pkg::name` package side → Title/Description with Markdown escaping.
- **Package database** — `names.db` built from r-universe's bulk `/api/dbdump`, plus release-time validation hardening.

Refactors and dead-code removal in the range are intentionally omitted (not user-facing).

https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L

---
_Generated by [Claude Code](https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L)_