### PR TITLE
fix(release-build): install rustfmt/clippy in the toolchain step to avoid cargo-fmt conflict

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -94,6 +94,17 @@ jobs:
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
+          # Install the same components rust-toolchain.toml pins
+          # (components = ["rustfmt", "clippy"]) up front, in the same rustup
+          # pass that lays down the toolchain. Otherwise the first `cargo` call
+          # in "Build LSP" triggers a rust-toolchain.toml reconcile that tries to
+          # add rustfmt as `rustfmt-preview`, colliding with the `bin/cargo-fmt`
+          # this step already installed: "detected conflict: 'bin/cargo-fmt'".
+          # The gate workflows (integration.yml) dodge this by letting rustup do
+          # one clean install with no dtolnay step; the release build needs
+          # dtolnay for cross-compile `targets`, so it must request the
+          # components explicitly to keep the later reconcile a no-op.
+          components: rustfmt, clippy
 
       - name: Cache cargo registry & build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Problem

The `v0.9.0` release build fails — **reproducibly** (both the original run and a re-run failed identically) — at the `Build LSP` step on every platform:

```
info: syncing channel updates for 1.96.0-x86_64-unknown-linux-gnu
info: downloading component clippy
info: rolling back changes
error: failed to install component: 'rustfmt-preview-x86_64-unknown-linux-gnu', detected conflict: 'bin/cargo-fmt'
```

This is **not** a v0.9.0 code or config problem: `rust-toolchain.toml` and `release-build.yml` are byte-identical between v0.8.1 (built fine on 2026-06-04) and v0.9.0 (fails 2026-06-05). The runner/rustup environment drifted under an unchanged config.

## Root cause

1. `build-lsp` installs the toolchain with `dtolnay/rust-toolchain` (it must, to add cross-compile `targets`). That lays down a `rustfmt` / `bin/cargo-fmt` for 1.96.0.
2. The first `cargo` call in **Build LSP** makes rustup reconcile against `rust-toolchain.toml`, which pins `components = ["rustfmt", "clippy"]`. rustup tries to add rustfmt as the manifest's `rustfmt-preview`, which collides with the `bin/cargo-fmt` already present → the error above.
3. The gate workflows (`integration.yml`) never hit this: they use **no** toolchain step, so rustup does a single clean install straight from `rust-toolchain.toml`. Only the release build does the dtolnay-then-reconcile two-step.

## Fix

Request the same components in the `dtolnay/rust-toolchain` step so the toolchain is installed once, complete, and the later `rust-toolchain.toml` reconcile is a no-op:

```yaml
        with:
          toolchain: "1.96.0"
          targets: ${{ matrix.target }}
          components: rustfmt, clippy
```

## ⚠️ Re-tag required to actually release 0.9.0

`release-build.yml` triggers on `push: tags: v*` and checks out the tagged commit. The current `v0.9.0` tag points at `4b366b14`, which predates this fix, so merging alone won't fix the 0.9.0 build. After this lands on `main`, the `v0.9.0` tag needs to be re-pointed to a commit that includes it (or cut a `v0.9.1`). Happy to help with whichever you prefer.

https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L

---
_Generated by [Claude Code](https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline reliability to support smoother release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->