### PR TITLE
fix(release-build): drop dtolnay, use rustup clean install like the gates

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,27 +84,20 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      # Pin to rust-toolchain.toml's channel so release binaries are built with
-      # the same compiler as CI/dev (reproducible). dtolnay can't read that file
-      # AND must install the per-matrix target's std for this toolchain — which
-      # the file's auto-install would not do — so the version is repeated here.
-      # Keep it in sync with rust-toolchain.toml.
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
-        with:
-          toolchain: "1.96.0"
-          targets: ${{ matrix.target }}
-          # Install the same components rust-toolchain.toml pins
-          # (components = ["rustfmt", "clippy"]) up front, in the same rustup
-          # pass that lays down the toolchain. Otherwise the first `cargo` call
-          # in "Build LSP" triggers a rust-toolchain.toml reconcile that tries to
-          # add rustfmt as `rustfmt-preview`, colliding with the `bin/cargo-fmt`
-          # this step already installed: "detected conflict: 'bin/cargo-fmt'".
-          # The gate workflows (integration.yml) dodge this by letting rustup do
-          # one clean install with no dtolnay step; the release build needs
-          # dtolnay for cross-compile `targets`, so it must request the
-          # components explicitly to keep the later reconcile a no-op.
-          components: rustfmt, clippy
+      # Install the toolchain the way the integration.yml gates do: with NO
+      # toolchain action, so rustup auto-installs rust-toolchain.toml's channel
+      # and its components (rustfmt, clippy) in a single clean pass on first use.
+      #
+      # Using dtolnay/rust-toolchain here pre-installed rustfmt for 1.96.0; the
+      # first `cargo` call in "Build LSP" then reconciled against
+      # rust-toolchain.toml and tried to re-add rustfmt as the manifest's
+      # `rustfmt-preview`, colliding with the `bin/cargo-fmt` already on disk
+      # ("detected conflict: 'bin/cargo-fmt'") — a double-install the always-green
+      # gates never hit because they have no toolchain step. `rustup target add`
+      # both triggers that clean auto-install and adds the per-matrix
+      # cross-compile target's std (what dtolnay's `targets:` used to do).
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Cache cargo registry & build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Two problems, one of them the reason it "failed again"

**1. The `v0.9.0` tag never pointed at the fix.** Both release-build runs after #396 merged (run 33 = failed, run 34 = in-progress) have `head_sha: 4b366b14` — the *original* version-bump commit, **not** the fix commit `6d317c44`. The tag was re-pushed but still points at pre-fix code, so the build has never actually run with any fix. The error was byte-identical because it was building byte-identical code.

**2. The previous fix was unverified and probably insufficient.** Requesting `components: rustfmt, clippy` in the `dtolnay` step (PR #396) doesn't remove the collision: `dtolnay` pre-installs rustfmt for 1.96.0, then the first `cargo` call's `rust-toolchain.toml` reconcile re-adds it as the manifest's `rustfmt-preview` and collides on `bin/cargo-fmt` (`detected conflict: 'bin/cargo-fmt'`). The "syncing channel updates / rolling back" lines in the log are that reconcile.

## Fix

Mirror the always-green `integration.yml` gates, which use **no toolchain action** — rustup auto-installs the `rust-toolchain.toml` channel + components in a single clean pass on first use, so there's no second install to collide. Replace `dtolnay`'s `targets:` input with an explicit `rustup target add <target>`, which both triggers that clean install and adds the per-matrix cross-compile target's std:

```yaml
      - name: Install Rust target
        run: rustup target add ${{ matrix.target }}
```

This removes the double-install collision by construction, on the path that's already proven green in this repo.

## ⚠️ Re-tag to the NEW commit

After merge, `main`'s tip will contain this fix. The `v0.9.0` tag must be moved to **that** commit (it's currently on `4b366b14`). Make sure the local tag is actually moved before pushing:

```bash
git fetch origin main
git tag -f v0.9.0 origin/main      # the NEW merge commit, with this fix
git push origin v0.9.0 --force     # or: git push origin :refs/tags/v0.9.0 && git push origin v0.9.0
```

Then confirm the new run's `head_sha` matches `git rev-parse origin/main` before expecting it to pass.

https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L

---
_Generated by [Claude Code](https://claude.ai/code/session_019h8HiWiqpSA9TeNUkBkG7L)_