### PR TITLE
Resolve true package owners for transitive exports (#407)

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -7139,8 +7139,8 @@ async fn run_libpath_consumer(
                 // re-fetch from R rather than returning stale HTML or text help.
                 state_arc.read().await.clear_help_caches();
 
-                // Invalidate the package cache and learn which combined_exports
-                // aggregates were dropped as a side effect. A document loading
+                // Invalidate the package cache and learn which combined
+                // aggregate entries were dropped as a side effect. A document loading
                 // a meta-package like `tidyverse` needs revalidation when
                 // `dplyr` changes — `tidyverse` is not in `affected` but its
                 // aggregate was invalidated, so it's in `invalidated_combined`.

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -14625,7 +14625,7 @@ pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<
         return Some(markdown_hover(value, node_range));
     }
 
-    // Check package exports from combined_exports cache (if packages enabled)
+    // Check package exports from the aggregate package cache (if packages enabled)
     // This surfaces package exports without blocking on R subprocess
     if state.cross_file_config.packages_enabled {
         let scope = get_cross_file_scope(

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -11490,6 +11490,20 @@ fn resolve_call_arg_policy(
     if let Some(policy) = crate::nse::base_policy(name) {
         return policy;
     }
+    // 3.5. Owner-preserving NSE resolution (issue #407). Step 2 only sees the
+    //      packages literally in play (plus hardcoded meta expansion). When a
+    //      callee is made visible through a non-hardcoded aggregate (a package
+    //      that `Depends` on / attaches dplyr, etc.), resolve the *true owner*
+    //      of the symbol and consult that owner's NSE policy before falling
+    //      through to the standard-eval classification below. This keeps a
+    //      data-masked column suppressed when the resolved owner (e.g. dplyr)
+    //      has a policy, rather than wrongly checking it as a standard-eval arg.
+    if let Some(lib) = analysis.package_library
+        && let Some(owner) = lib.find_package_owner_for_symbol(name, &analysis.in_play_packages)
+        && let Some(policy) = crate::nse::package_policy(&owner, name)
+    {
+        return policy;
+    }
     // 4. Resolvable standard-eval: builtin, base export, or a confirmed in-play
     //    package export -> check arguments.
     if is_builtin(name)
@@ -13181,9 +13195,14 @@ pub fn completion(
         // Add package exports (after local definitions, before cross-file symbols)
         // Requirement 9.4: Local definitions > package exports > cross-file symbols
         // Requirement 9.3: When multiple packages export same symbol, show all with attribution
+        //
+        // Attribute each export to its true owner (issue #407): under
+        // `library(tidyverse)`, `mutate` is detailed/resolved as `{dplyr}` so
+        // the resolve handler opens dplyr's help topic, not the empty
+        // `help("mutate", package = "tidyverse")`.
         let package_exports = state
             .package_library
-            .get_exports_for_completions(&all_packages);
+            .get_owned_exports_for_completions(&all_packages);
         for (export_name, package_names) in package_exports {
             if seen_names.contains(&export_name) {
                 continue; // Local definitions take precedence
@@ -14626,7 +14645,7 @@ pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<
 
         if let Some(pkg_name) = state
             .package_library
-            .find_package_for_symbol(name, &all_packages)
+            .find_package_owner_for_symbol(name, &all_packages)
         {
             let mut value = String::new();
 
@@ -15256,7 +15275,7 @@ pub fn prepare_signature_help(
 
         if let Some(pkg_name) = state
             .package_library
-            .find_package_for_symbol(func_name, &all_packages)
+            .find_package_owner_for_symbol(func_name, &all_packages)
         {
             SignatureResolution::Package {
                 help_cache: state.help_cache.clone(),
@@ -17440,6 +17459,108 @@ mod tests {
         collect_with_packages(tree.root_node(), code, &["dplyr"], &mut used);
         assert!(was_collected(&used, "df"));
         assert!(!was_collected(&used, "col"));
+    }
+
+    /// Issue #407: a NON-hardcoded aggregate `myagg` that `Depends` on dplyr
+    /// makes `mutate` visible. NSE classification must resolve the true owner
+    /// (dplyr) and apply dplyr's policy, suppressing the data-masked column
+    /// instead of falling through to standard-eval.
+    #[tokio::test]
+    async fn nse_owner_resolved_aggregate_suppresses_masked_column() {
+        use crate::package_library::{PackageInfo, PackageLibrary};
+        use std::collections::HashSet;
+
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        // myagg is NOT a known meta-package; it merely Depends on dplyr.
+        lib.insert_package(PackageInfo::with_details(
+            "myagg".to_string(),
+            HashSet::new(),
+            vec!["dplyr".to_string()],
+            Vec::new(),
+        ))
+        .await;
+        lib.get_all_exports("myagg").await;
+
+        let code = "mutate(df, new = masked_col + 1)";
+        let tree = parse_r_code(code);
+        let in_play = vec!["myagg".to_string()];
+        let analysis = NseAnalysis::build(
+            tree.root_node(),
+            code,
+            true,
+            true,
+            in_play,
+            Some(&lib),
+            None,
+        );
+        let mut used = Vec::new();
+        collect_usages_with_analysis(
+            tree.root_node(),
+            code,
+            &analysis,
+            &UsageContext::default(),
+            &mut used,
+        );
+
+        assert!(
+            !was_collected(&used, "masked_col"),
+            "data-masked column should be suppressed via owner-resolved dplyr policy"
+        );
+        // Positive control: the `.data` argument is still checked.
+        assert!(was_collected(&used, "df"));
+    }
+
+    /// Issue #407: a standard-eval function visible only transitively through an
+    /// aggregate stays standard-eval (the owner has no NSE policy), so its
+    /// argument is still checked.
+    #[tokio::test]
+    async fn nse_owner_resolved_standard_eval_still_checks_args() {
+        use crate::package_library::{PackageInfo, PackageLibrary};
+        use std::collections::HashSet;
+
+        let lib = PackageLibrary::new_empty();
+        let mut helper_exports = HashSet::new();
+        helper_exports.insert("some_std_fn".to_string());
+        lib.insert_package(PackageInfo::new("helperpkg".to_string(), helper_exports))
+            .await;
+        lib.insert_package(PackageInfo::with_details(
+            "myagg2".to_string(),
+            HashSet::new(),
+            vec!["helperpkg".to_string()],
+            Vec::new(),
+        ))
+        .await;
+        lib.get_all_exports("myagg2").await;
+
+        let code = "some_std_fn(typo)";
+        let tree = parse_r_code(code);
+        let in_play = vec!["myagg2".to_string()];
+        let analysis = NseAnalysis::build(
+            tree.root_node(),
+            code,
+            true,
+            true,
+            in_play,
+            Some(&lib),
+            None,
+        );
+        let mut used = Vec::new();
+        collect_usages_with_analysis(
+            tree.root_node(),
+            code,
+            &analysis,
+            &UsageContext::default(),
+            &mut used,
+        );
+
+        assert!(
+            was_collected(&used, "typo"),
+            "a standard-eval transitive export should still check its argument"
+        );
     }
 
     /// An unresolved callee suppresses its arguments while flagging the callee:

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -197,6 +197,25 @@ pub struct NamespaceParseResult {
     /// Dependencies from DESCRIPTION Depends field
     pub depends: Vec<String>,
 }
+/// Cached aggregate package view produced by `get_all_exports`.
+///
+/// `exports` answers availability: every symbol visible through the aggregate
+/// package key, including symbols contributed by `Depends` and meta-package
+/// attachments. `owners` answers attribution for the same snapshot:
+/// `symbol -> true owner package` (e.g. `mutate -> dplyr` under the
+/// `tidyverse` key). Keeping both projections in one entry makes publication,
+/// invalidation, and reads atomic at the aggregate-key level.
+#[derive(Debug)]
+struct CombinedEntry {
+    exports: HashSet<String>,
+    owners: HashMap<String, String>,
+}
+
+impl CombinedEntry {
+    fn new(exports: HashSet<String>, owners: HashMap<String, String>) -> Self {
+        Self { exports, owners }
+    }
+}
 
 /// Package library manager
 ///
@@ -211,21 +230,14 @@ pub struct PackageLibrary {
     /// Cached package information (lazy-loaded)
     /// Uses RwLock for thread-safe concurrent read access
     packages: RwLock<HashMap<String, Arc<PackageInfo>>>,
-    /// Combined exports cache (package name -> all exports including Depends/attached)
-    /// Populated by get_all_exports for efficient repeated lookups
-    combined_exports: RwLock<HashMap<String, Arc<HashSet<String>>>>,
-    /// Owner map cache (aggregate package name -> { symbol -> true owner package }).
+    /// Combined aggregate cache keyed by the loaded package name.
     ///
-    /// Built in lockstep with `combined_exports` by `get_all_exports`. Where
-    /// `combined_exports` answers "is this symbol visible through package X?",
-    /// this answers "which package actually contributed it?" — the documentation
-    /// and NSE-policy owner. For `library(tidyverse)`, `combined_exports`
-    /// aggregates `mutate` under the `tidyverse` key while this map records
-    /// `mutate -> dplyr`. First contributor in the depends-then-attached,
-    /// cycle-guarded traversal wins (the aggregate root is visited first, so it
-    /// owns its own exports). Must be invalidated whenever `combined_exports` is
-    /// (see `invalidate_many` / `clear_cache`). See issue #407.
-    combined_export_owners: RwLock<HashMap<String, Arc<HashMap<String, String>>>>,
+    /// Each entry stores availability (`exports`) and ownership (`owners`) in
+    /// one immutable snapshot. For `library(tidyverse)`, `exports` contains
+    /// `mutate` and `owners` records `mutate -> dplyr`. This single source of
+    /// truth prevents readers from seeing an aggregate export without its owner
+    /// attribution during cache warm-up or invalidation. See issue #407.
+    combined_entries: RwLock<HashMap<String, Arc<CombinedEntry>>>,
     /// Base packages (always available)
     base_packages: HashSet<String>,
     /// Base package exports (combined from all base packages).
@@ -254,8 +266,7 @@ impl PackageLibrary {
         Self {
             lib_paths: Vec::new(),
             packages: RwLock::new(HashMap::new()),
-            combined_exports: RwLock::new(HashMap::new()),
-            combined_export_owners: RwLock::new(HashMap::new()),
+            combined_entries: RwLock::new(HashMap::new()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess: None,
@@ -275,8 +286,7 @@ impl PackageLibrary {
         Self {
             lib_paths: Vec::new(),
             packages: RwLock::new(HashMap::new()),
-            combined_exports: RwLock::new(HashMap::new()),
-            combined_export_owners: RwLock::new(HashMap::new()),
+            combined_entries: RwLock::new(HashMap::new()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess,
@@ -347,7 +357,7 @@ impl PackageLibrary {
     ///
     /// This method returns a map of symbol name to package name for all exports
     /// from the given loaded packages. It uses cached package information,
-    /// preferring combined_exports cache (includes Depends/attached) when available.
+    /// preferring combined_entries cache (includes Depends/attached) when available.
     ///
     /// This is a synchronous method suitable for use in completion handlers where
     /// we cannot use async. It uses `try_read()` to avoid blocking.
@@ -369,8 +379,8 @@ impl PackageLibrary {
         let mut result: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
 
-        // Try combined_exports cache first (includes Depends/attached packages)
-        let combined_cache = self.combined_exports.try_read().ok();
+        // Try combined_entries cache first (includes Depends/attached packages)
+        let combined_cache = self.combined_entries.try_read().ok();
         let packages_cache = self.packages.try_read().ok();
 
         if combined_cache.is_none() && packages_cache.is_none() {
@@ -383,11 +393,11 @@ impl PackageLibrary {
         // Process packages in order (earlier packages appear first in the list)
         // Requirement 9.3: Show all packages that export the same symbol
         for pkg_name in loaded_packages {
-            // Try combined_exports first
+            // Try combined_entries first
             if let Some(ref cache) = combined_cache
-                && let Some(exports) = cache.get(pkg_name)
+                && let Some(entry) = cache.get(pkg_name)
             {
-                for export in exports.iter() {
+                for export in entry.exports.iter() {
                     result
                         .entry(export.clone())
                         .or_default()
@@ -418,10 +428,13 @@ impl PackageLibrary {
     /// (the documentation owner) so completion detail (`{dplyr}`) and the
     /// resolve `data.package` open the correct help topic. See issue #407.
     ///
-    /// Synchronous and cached-only (`try_read`). Falls back to the loaded
-    /// package when the owner map is not yet warmed, preserving the previous
-    /// attribution. Owners are de-duplicated per symbol (two loaded aggregates
-    /// can resolve to the same owner).
+    /// Synchronous and cached-only (`try_read`). A cached aggregate entry is a
+    /// single availability/ownership snapshot, so owner-sensitive completion
+    /// never falls back from a present aggregate entry to loaded-package
+    /// attribution. If no aggregate entry exists yet, it falls back to the
+    /// per-package cache, preserving the previous direct-package behavior.
+    /// Owners are de-duplicated per symbol (two loaded aggregates can resolve
+    /// to the same owner).
     pub fn get_owned_exports_for_completions(
         &self,
         loaded_packages: &[String],
@@ -429,11 +442,9 @@ impl PackageLibrary {
         let mut result: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
 
-        let owner_cache = self.combined_export_owners.try_read().ok();
-        let combined_cache = self.combined_exports.try_read().ok();
+        let combined_cache = self.combined_entries.try_read().ok();
         let packages_cache = self.packages.try_read().ok();
-
-        if owner_cache.is_none() && combined_cache.is_none() && packages_cache.is_none() {
+        if combined_cache.is_none() && packages_cache.is_none() {
             log::trace!(
                 "Could not acquire any package cache lock for owned completions, returning empty"
             );
@@ -448,28 +459,17 @@ impl PackageLibrary {
         };
 
         for pkg_name in loaded_packages {
-            // Prefer the owner map: it covers exactly the symbols in the
+            // Prefer the aggregate entry: it covers exactly the symbols in the
             // combined set and attributes each to its true contributor.
-            if let Some(ref cache) = owner_cache
-                && let Some(owners) = cache.get(pkg_name)
+            if let Some(ref cache) = combined_cache
+                && let Some(entry) = cache.get(pkg_name)
             {
-                for (symbol, owner) in owners.iter() {
+                for (symbol, owner) in entry.owners.iter() {
                     push_unique(symbol, owner);
                 }
                 continue;
             }
-
-            // Fall back to the combined set, attributing to the loaded package.
-            if let Some(ref cache) = combined_cache
-                && let Some(exports) = cache.get(pkg_name)
-            {
-                for export in exports.iter() {
-                    push_unique(export, pkg_name);
-                }
-                continue;
-            }
-
-            // Last resort: per-package exports, attributing to the loaded package.
+            // Fall back to per-package exports, attributing to the loaded package.
             if let Some(ref cache) = packages_cache
                 && let Some(info) = cache.get(pkg_name)
             {
@@ -486,7 +486,7 @@ impl PackageLibrary {
     ///
     /// This method checks if the symbol is exported by any of the loaded packages,
     /// using cached package information. It first checks base exports, then
-    /// checks combined_exports cache (includes Depends/attached), then falls back
+    /// checks combined_entries cache (includes Depends/attached), then falls back
     /// to per-package exports cache.
     ///
     /// This is a synchronous method suitable for use in diagnostic collection where
@@ -507,11 +507,11 @@ impl PackageLibrary {
             return true;
         }
 
-        // Try combined_exports cache first (includes Depends/attached packages)
-        if let Ok(combined_cache) = self.combined_exports.try_read() {
+        // Try combined_entries cache first (includes Depends/attached packages)
+        if let Ok(combined_cache) = self.combined_entries.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(exports) = combined_cache.get(pkg_name)
-                    && exports.contains(symbol)
+                if let Some(entry) = combined_cache.get(pkg_name)
+                    && entry.exports.contains(symbol)
                 {
                     return true;
                 }
@@ -611,7 +611,7 @@ impl PackageLibrary {
         cache.remove(name);
     }
 
-    /// Invalidate a batch of packages, also dropping any `combined_exports`
+    /// Invalidate a batch of packages, also dropping any `combined_entries`
     /// entries whose aggregate export set depends on `names` — including:
     ///
     /// - direct key matches (invalidating `dplyr` drops combined entry for `dplyr`),
@@ -622,7 +622,7 @@ impl PackageLibrary {
     ///   `A` when `A` Depends: `B` Depends: `C`), since the aggregate rolled up
     ///   a now-stale transitive child.
     ///
-    /// Returns the set of `combined_exports` keys that were actually present and
+    /// Returns the set of `combined_entries` keys that were actually present and
     /// dropped. Callers use this to identify documents whose loaded packages
     /// include meta-aggregates that were invalidated even though the aggregate
     /// name itself is not in `names` (e.g. a document using `library(tidyverse)`
@@ -671,7 +671,7 @@ impl PackageLibrary {
         }
         let mut invalidated_combined: HashSet<String> = HashSet::new();
         {
-            let mut combined = self.combined_exports.write().await;
+            let mut combined = self.combined_entries.write().await;
             // Drop direct hits; record only the ones that were actually present.
             for n in names {
                 if combined.remove(n).is_some() {
@@ -699,16 +699,6 @@ impl PackageLibrary {
                 combined.remove(&m);
                 invalidated_combined.insert(m);
             }
-            // Drop the owner map in lockstep, while still holding the
-            // `combined_exports` write guard. `combined_export_owners` shares
-            // the same keys (see `get_all_exports`), so `invalidated_combined`
-            // is exactly the set of owner-map entries to drop. Holding both
-            // guards (order: combined -> owners) keeps the two caches consistent
-            // for readers across the removal, mirroring the publish path.
-            let mut owner_cache = self.combined_export_owners.write().await;
-            for k in &invalidated_combined {
-                owner_cache.remove(k);
-            }
         }
         invalidated_combined
     }
@@ -719,20 +709,14 @@ impl PackageLibrary {
         cache.keys().cloned().collect()
     }
 
-    /// Clear all cached packages, including aggregated `combined_exports` and
-    /// `combined_export_owners` entries.
+    /// Clear all cached packages, including aggregate `combined_entries`.
     pub async fn clear_cache(&self) {
         {
             let mut cache = self.packages.write().await;
             cache.clear();
         }
-        // Clear both aggregate caches under one critical section (order:
-        // combined -> owners), so a reader never sees one cleared without the
-        // other. Mirrors the publish/invalidate lock discipline.
-        let mut combined = self.combined_exports.write().await;
-        let mut owner_cache = self.combined_export_owners.write().await;
+        let mut combined = self.combined_entries.write().await;
         combined.clear();
-        owner_cache.clear();
     }
 
     /// Load pattern packages via the INDEX + explicit-exports fallback and
@@ -760,7 +744,7 @@ impl PackageLibrary {
     /// Prefetch packages by loading their exports into cache
     ///
     /// This method asynchronously loads package exports for the given package names,
-    /// populating both the per-package cache and combined_exports cache.
+    /// populating both the per-package cache and combined_entries cache.
     /// Used for background warm-up after detecting library() calls.
     ///
     /// # Performance - Tiered Prefetch Strategy
@@ -780,7 +764,7 @@ impl PackageLibrary {
 
         // Filter out packages we've already cached
         let uncached_packages: Vec<String> = {
-            let combined_cache = self.combined_exports.read().await;
+            let combined_cache = self.combined_entries.read().await;
             let packages_cache = self.packages.read().await;
             packages
                 .iter()
@@ -925,7 +909,7 @@ impl PackageLibrary {
             }
         }
 
-        // Step 3: Populate combined_exports cache
+        // Step 3: Populate combined_entries cache
         for pkg_name in &uncached_packages {
             let _ = self.get_all_exports(pkg_name).await;
         }
@@ -952,11 +936,11 @@ impl PackageLibrary {
         symbol: &str,
         loaded_packages: &[String],
     ) -> Option<String> {
-        // Check combined_exports cache first
-        if let Ok(cache) = self.combined_exports.try_read() {
+        // Check combined_entries cache first
+        if let Ok(cache) = self.combined_entries.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(exports) = cache.get(pkg_name)
-                    && exports.contains(symbol)
+                if let Some(entry) = cache.get(pkg_name)
+                    && entry.exports.contains(symbol)
                 {
                     return Some(pkg_name.clone());
                 }
@@ -983,33 +967,47 @@ impl PackageLibrary {
     /// Distinct from [`find_package_for_symbol`], which answers "which loaded
     /// package made this visible?" and returns the aggregate key (e.g.
     /// `tidyverse`). This answers "which package actually contributed the
-    /// symbol?" — the documentation / NSE-policy owner (e.g. `dplyr`) — by
-    /// consulting the per-aggregate `combined_export_owners` map. Falls back to
-    /// [`find_package_for_symbol`] when no owner map entry exists (cache not yet
-    /// warmed), preserving the previous behavior. See issue #407.
+    /// symbol?\" — the documentation / NSE-policy owner (e.g. `dplyr`) — by
+    /// consulting the per-aggregate [`CombinedEntry`] snapshot. Falls back to
+    /// direct per-package exports when no aggregate entry exists yet, preserving
+    /// the previous behavior for unwarmed direct package caches. See issue #407.
     pub fn find_package_owner_for_symbol(
         &self,
         symbol: &str,
         loaded_packages: &[String],
     ) -> Option<String> {
-        // Consult the per-aggregate owner map first. For each loaded package,
-        // if the cached owner map for that aggregate records this symbol, the
-        // recorded value is the true contributor (e.g. `dplyr` for a `mutate`
-        // made visible through `tidyverse`).
-        if let Ok(owner_cache) = self.combined_export_owners.try_read() {
+        // Consult the per-aggregate snapshot first. For each loaded package, if
+        // the cached aggregate entry records this symbol's owner, that value is
+        // the true contributor (e.g. `dplyr` for a `mutate` made visible through
+        // `tidyverse`). If the entry says the symbol is available but lacks an
+        // owner, fail closed rather than falling back to aggregate attribution.
+        if let Ok(cache) = self.combined_entries.try_read() {
             for pkg_name in loaded_packages {
-                if let Some(owners) = owner_cache.get(pkg_name)
-                    && let Some(owner) = owners.get(symbol)
-                {
-                    return Some(owner.clone());
+                if let Some(entry) = cache.get(pkg_name) {
+                    if let Some(owner) = entry.owners.get(symbol) {
+                        return Some(owner.clone());
+                    }
+                    if entry.exports.contains(symbol) {
+                        return None;
+                    }
                 }
             }
         }
 
-        // Fall back to availability-based attribution when the owner map has no
-        // entry (combined cache not yet warmed). This preserves the previous
-        // behavior of returning the loaded package that made the symbol visible.
-        self.find_package_for_symbol(symbol, loaded_packages)
+        // Fall back only to direct per-package attribution. Re-reading aggregate
+        // availability here can combine an old owner miss with a newer combined
+        // hit and return the aggregate package as a false owner.
+        if let Ok(cache) = self.packages.try_read() {
+            for pkg_name in loaded_packages {
+                if let Some(info) = cache.get(pkg_name)
+                    && info.exports.contains(symbol)
+                {
+                    return Some(pkg_name.clone());
+                }
+            }
+        }
+
+        None
     }
 
     /// Set the library paths
@@ -1621,10 +1619,10 @@ impl PackageLibrary {
     /// and attached_packages for meta-packages), combining their exports into a single set.
     /// It tracks visited packages to handle circular dependencies.
     ///
-    /// Results are cached in combined_exports for efficient repeated lookups.
+    /// Results are cached in combined_entries for efficient repeated lookups.
     ///
     /// # Behavior
-    /// 1. Check combined_exports cache first
+    /// 1. Check combined_entries cache first
     /// 2. Load the main package using `get_package()`
     /// 3. Add the package's exports to the result set
     /// 4. Recursively load all packages in `depends` and `attached_packages`
@@ -1639,10 +1637,10 @@ impl PackageLibrary {
     pub async fn get_all_exports(&self, name: &str) -> HashSet<String> {
         // Check cache first
         {
-            let cache = self.combined_exports.read().await;
+            let cache = self.combined_entries.read().await;
             if let Some(cached) = cache.get(name) {
                 log::trace!("Using cached combined exports for package '{}'", name);
-                return cached.as_ref().clone();
+                return cached.exports.clone();
             }
         }
 
@@ -1656,22 +1654,15 @@ impl PackageLibrary {
         self.collect_exports_recursive(name, &mut visited, &mut all_exports, &mut owners)
             .await;
 
-        // Publish the combined set and its owner map in a single critical
-        // section: the `combined_exports` write guard is held across the
-        // `combined_export_owners` insert, so a key is only ever *readable* in
-        // `combined_exports` once it is also present in the owner map. Without
-        // this, a reader could observe `combined_exports` populated for `name`
-        // while the owner map still lacks it, making `find_package_owner_for_symbol`
-        // fall back to `find_package_for_symbol` and return the aggregate key
-        // (e.g. `tidyverse`) instead of the true owner (`dplyr`). The lock order
-        // is always `combined_exports` -> `combined_export_owners` (here and in
-        // `invalidate_many` / `clear_cache`) to avoid deadlock; readers use
-        // `try_read`, so they can never be part of a lock cycle.
+        // Publish availability and owner attribution as one immutable entry, so
+        // hot-path readers can never observe a combined export without the
+        // matching owner attribution.
         {
-            let mut cache = self.combined_exports.write().await;
-            let mut owner_cache = self.combined_export_owners.write().await;
-            cache.insert(name.to_string(), Arc::new(all_exports.clone()));
-            owner_cache.insert(name.to_string(), Arc::new(owners));
+            let mut cache = self.combined_entries.write().await;
+            cache.insert(
+                name.to_string(),
+                Arc::new(CombinedEntry::new(all_exports.clone(), owners)),
+            );
             log::trace!(
                 "Cached {} combined exports for package '{}'",
                 all_exports.len(),
@@ -2514,22 +2505,25 @@ mod tests {
             .await;
         lib.insert_package(PackageInfo::new("pkg2".to_string(), HashSet::new()))
             .await;
-        // Seed a combined_exports entry to verify it is also cleared.
+        // Seed a combined_entries entry to verify it is also cleared.
         {
-            let mut combined = lib.combined_exports.write().await;
+            let mut combined = lib.combined_entries.write().await;
             combined.insert(
                 "pkg1".into(),
-                std::sync::Arc::new(["foo".to_string()].into_iter().collect()),
+                std::sync::Arc::new(CombinedEntry::new(
+                    ["foo".to_string()].into_iter().collect(),
+                    HashMap::new(),
+                )),
             );
         }
 
         assert_eq!(lib.cached_count().await, 2);
-        assert!(lib.combined_exports.read().await.contains_key("pkg1"));
+        assert!(lib.combined_entries.read().await.contains_key("pkg1"));
 
         lib.clear_cache().await;
 
         assert_eq!(lib.cached_count().await, 0);
-        assert!(lib.combined_exports.read().await.is_empty());
+        assert!(lib.combined_entries.read().await.is_empty());
     }
 
     #[tokio::test]
@@ -3672,19 +3666,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_owner_falls_back_when_owner_map_absent() {
-        // When the owner map has no entry (combined cache never warmed), the
-        // lookup falls back to the per-package availability semantics of
-        // find_package_for_symbol.
+        // When no aggregate entry has been warmed, the lookup falls back to the
+        // per-package availability semantics of find_package_for_symbol.
         let lib = PackageLibrary::new_empty();
         let mut dplyr_exports = HashSet::new();
         dplyr_exports.insert("mutate".to_string());
         lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
             .await;
-        // Note: no get_all_exports() call, so combined_export_owners is empty.
+        // Note: no get_all_exports() call, so combined_entries is empty.
         let loaded = vec!["dplyr".to_string()];
         assert_eq!(
             lib.find_package_owner_for_symbol("mutate", &loaded),
             Some("dplyr".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owner_lookup_ignores_ownerless_combined_entry() {
+        // A combined availability hit without matching owner attribution is a
+        // partial snapshot. Owner-sensitive lookup must fail closed instead of
+        // attributing a transitive export to the aggregate package.
+        let lib = PackageLibrary::new_empty();
+        lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
+            .await;
+        {
+            let mut combined = lib.combined_entries.write().await;
+            combined.insert(
+                "tidyverse".to_string(),
+                Arc::new(CombinedEntry::new(
+                    ["mutate".to_string()].into_iter().collect(),
+                    HashMap::new(),
+                )),
+            );
+        }
+
+        let loaded = vec!["tidyverse".to_string()];
+        assert_eq!(
+            lib.find_package_owner_for_symbol("mutate", &loaded),
+            None,
+            "owner lookup must not fall back to aggregate attribution from ownerless combined availability"
         );
     }
 
@@ -3711,48 +3731,42 @@ mod tests {
 
     #[tokio::test]
     async fn test_owned_exports_for_completions_falls_back_to_loaded_package() {
-        // When the owner map is not warmed, attribution falls back to the loaded
+        // When no aggregate entry is warmed, attribution falls back to the loaded
         // package (existing get_exports_for_completions behavior).
         let lib = PackageLibrary::new_empty();
         let mut dplyr_exports = HashSet::new();
         dplyr_exports.insert("mutate".to_string());
         lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
             .await;
-        // No get_all_exports(): owner map empty, per-package cache present.
+        // No get_all_exports(): aggregate entry absent, per-package cache present.
         let owned = lib.get_owned_exports_for_completions(&["dplyr".to_string()]);
         assert_eq!(owned.get("mutate"), Some(&vec!["dplyr".to_string()]));
     }
 
     #[tokio::test]
-    async fn test_clear_cache_drops_owner_map() {
-        // clear_cache() must drop combined_export_owners in lockstep with
-        // combined_exports, or a stale owner map could outlive its aggregate.
+    async fn test_clear_cache_drops_combined_entry() {
+        // clear_cache() must drop the unified aggregate entry containing both
+        // availability and ownership.
         let lib = PackageLibrary::new_empty();
         let mut dplyr_exports = HashSet::new();
         dplyr_exports.insert("mutate".to_string());
         lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
             .await;
         lib.get_all_exports("dplyr").await;
-        assert!(
-            lib.combined_export_owners
-                .read()
-                .await
-                .contains_key("dplyr")
-        );
+        assert!(lib.combined_entries.read().await.contains_key("dplyr"));
 
         lib.clear_cache().await;
 
         assert!(
-            lib.combined_export_owners.read().await.is_empty(),
-            "clear_cache must also clear the owner map"
+            lib.combined_entries.read().await.is_empty(),
+            "clear_cache must clear aggregate entries"
         );
     }
 
     #[tokio::test]
-    async fn test_invalidate_many_drops_owner_map_for_dependent_aggregate() {
-        // Invalidating an attached member (dplyr) must drop the cached owner map
-        // for the meta-package aggregate (tidyverse) that rolled it up, exactly
-        // as it drops the combined_exports aggregate.
+    async fn test_invalidate_many_drops_combined_entry_for_dependent_aggregate() {
+        // Invalidating an attached member (dplyr) must drop the cached unified
+        // aggregate entry (tidyverse) that rolled it up.
         let lib = PackageLibrary::new_empty();
         let mut dplyr_exports = HashSet::new();
         dplyr_exports.insert("mutate".to_string());
@@ -3761,23 +3775,15 @@ mod tests {
         lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
             .await;
         lib.get_all_exports("tidyverse").await;
-        assert!(
-            lib.combined_export_owners
-                .read()
-                .await
-                .contains_key("tidyverse")
-        );
+        assert!(lib.combined_entries.read().await.contains_key("tidyverse"));
 
         let mut names = HashSet::new();
         names.insert("dplyr".to_string());
         lib.invalidate_many(&names).await;
 
         assert!(
-            !lib.combined_export_owners
-                .read()
-                .await
-                .contains_key("tidyverse"),
-            "invalidating dplyr must drop the tidyverse owner map in lockstep"
+            !lib.combined_entries.read().await.contains_key("tidyverse"),
+            "invalidating dplyr must drop the tidyverse aggregate entry"
         );
     }
 
@@ -3839,7 +3845,7 @@ mod tests {
     #[tokio::test]
     async fn test_prefetch_static_package_resolves_dataset() {
         // The production LSP warm-up path is `prefetch_packages`, which inserts
-        // PackageInfo and combined_exports directly — bypassing `get_package`.
+        // PackageInfo and combined_entries directly — bypassing `get_package`.
         // A statically-loaded package's datasets must resolve through it too,
         // or `library(nycflights13); flights` stays a false positive in the
         // editor (issue #350).
@@ -4915,7 +4921,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidate_many_clears_combined_exports_for_meta_packages() {
+    async fn invalidate_many_clears_combined_entries_for_meta_packages() {
         use std::collections::HashSet;
 
         let lib = PackageLibrary::new_empty();
@@ -4927,20 +4933,24 @@ mod tests {
             let mut packages = lib.packages.write().await;
             packages.insert("tidyverse".into(), std::sync::Arc::new(tidyverse_info));
         }
-        // Seed combined_exports as though tidyverse had been loaded.
+        // Seed combined_entries as though tidyverse had been loaded.
         {
-            let mut combined = lib.combined_exports.write().await;
+            let mut combined = lib.combined_entries.write().await;
             combined.insert(
                 "tidyverse".into(),
-                std::sync::Arc::new(
+                std::sync::Arc::new(CombinedEntry::new(
                     ["mutate".to_string(), "ggplot".to_string()]
                         .into_iter()
                         .collect(),
-                ),
+                    HashMap::new(),
+                )),
             );
             combined.insert(
                 "dplyr".into(),
-                std::sync::Arc::new(["mutate".to_string()].into_iter().collect()),
+                std::sync::Arc::new(CombinedEntry::new(
+                    ["mutate".to_string()].into_iter().collect(),
+                    HashMap::new(),
+                )),
             );
         }
 
@@ -4948,17 +4958,17 @@ mod tests {
         let set: HashSet<String> = ["dplyr".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_exports.read().await;
+        let combined = lib.combined_entries.read().await;
         assert!(!combined.contains_key("tidyverse"));
         assert!(!combined.contains_key("dplyr"));
 
-        // Returned set surfaces which combined_exports keys were actually
+        // Returned set surfaces which combined_entries keys were actually
         // dropped so callers can revalidate documents that loaded tidyverse
         // (not dplyr) directly.
         assert!(invalidated.contains("tidyverse"));
         assert!(invalidated.contains("dplyr"));
 
-        // invalidate_many must drop combined_exports entries but preserve the
+        // invalidate_many must drop combined_entries entries but preserve the
         // per-package PackageInfo cache: the meta-package itself still exists
         // on disk, so its individual entry should remain available for
         // subsequent re-aggregation.
@@ -4971,7 +4981,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidate_many_returns_empty_for_names_not_in_combined_exports() {
+    async fn invalidate_many_returns_empty_for_names_not_in_combined_entries() {
         use std::collections::HashSet;
         let lib = PackageLibrary::new_empty();
         lib.insert_package(PackageInfo::new(
@@ -4980,7 +4990,7 @@ mod tests {
         ))
         .await;
 
-        // combined_exports is empty for this package name — invalidate_many
+        // combined_entries is empty for this package name — invalidate_many
         // must not claim it was dropped.
         let set: HashSet<String> = ["uncached_meta_child".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
@@ -4988,12 +4998,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidate_many_clears_combined_exports_for_transitive_depends() {
+    async fn invalidate_many_clears_combined_entries_for_transitive_depends() {
         use std::collections::HashSet;
 
         let lib = PackageLibrary::new_empty();
         // Package `A` Depends on `B`. Its PackageInfo is cached, and its
-        // combined_exports aggregate has been built.
+        // combined_entries aggregate has been built.
         let a_info = PackageInfo::with_details(
             "A".into(),
             ["a_fn".to_string()].into_iter().collect(),
@@ -5002,14 +5012,15 @@ mod tests {
         );
         lib.insert_package(a_info).await;
         {
-            let mut combined = lib.combined_exports.write().await;
+            let mut combined = lib.combined_entries.write().await;
             combined.insert(
                 "A".into(),
-                std::sync::Arc::new(
+                std::sync::Arc::new(CombinedEntry::new(
                     ["a_fn".to_string(), "b_fn".to_string()]
                         .into_iter()
                         .collect(),
-                ),
+                    HashMap::new(),
+                )),
             );
         }
 
@@ -5019,10 +5030,10 @@ mod tests {
         let set: HashSet<String> = ["B".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_exports.read().await;
+        let combined = lib.combined_entries.read().await;
         assert!(
             !combined.contains_key("A"),
-            "A's combined_exports aggregate should be cleared when its dependency B is invalidated"
+            "A's combined_entries aggregate should be cleared when its dependency B is invalidated"
         );
         // Returned set surfaces A so consumers know documents using A need revalidation.
         assert!(invalidated.contains("A"));

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -214,6 +214,18 @@ pub struct PackageLibrary {
     /// Combined exports cache (package name -> all exports including Depends/attached)
     /// Populated by get_all_exports for efficient repeated lookups
     combined_exports: RwLock<HashMap<String, Arc<HashSet<String>>>>,
+    /// Owner map cache (aggregate package name -> { symbol -> true owner package }).
+    ///
+    /// Built in lockstep with `combined_exports` by `get_all_exports`. Where
+    /// `combined_exports` answers "is this symbol visible through package X?",
+    /// this answers "which package actually contributed it?" — the documentation
+    /// and NSE-policy owner. For `library(tidyverse)`, `combined_exports`
+    /// aggregates `mutate` under the `tidyverse` key while this map records
+    /// `mutate -> dplyr`. First contributor in the depends-then-attached,
+    /// cycle-guarded traversal wins (the aggregate root is visited first, so it
+    /// owns its own exports). Must be invalidated whenever `combined_exports` is
+    /// (see `invalidate_many` / `clear_cache`). See issue #407.
+    combined_export_owners: RwLock<HashMap<String, Arc<HashMap<String, String>>>>,
     /// Base packages (always available)
     base_packages: HashSet<String>,
     /// Base package exports (combined from all base packages).
@@ -243,6 +255,7 @@ impl PackageLibrary {
             lib_paths: Vec::new(),
             packages: RwLock::new(HashMap::new()),
             combined_exports: RwLock::new(HashMap::new()),
+            combined_export_owners: RwLock::new(HashMap::new()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess: None,
@@ -263,6 +276,7 @@ impl PackageLibrary {
             lib_paths: Vec::new(),
             packages: RwLock::new(HashMap::new()),
             combined_exports: RwLock::new(HashMap::new()),
+            combined_export_owners: RwLock::new(HashMap::new()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess,
@@ -391,6 +405,76 @@ impl PackageLibrary {
                         .entry(export.clone())
                         .or_default()
                         .push(pkg_name.clone());
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Like [`get_exports_for_completions`], but attributes each symbol to its
+    /// true **owner** package rather than the loaded/aggregate package that made
+    /// it visible. For `library(tidyverse)`, `mutate` is attributed to `dplyr`
+    /// (the documentation owner) so completion detail (`{dplyr}`) and the
+    /// resolve `data.package` open the correct help topic. See issue #407.
+    ///
+    /// Synchronous and cached-only (`try_read`). Falls back to the loaded
+    /// package when the owner map is not yet warmed, preserving the previous
+    /// attribution. Owners are de-duplicated per symbol (two loaded aggregates
+    /// can resolve to the same owner).
+    pub fn get_owned_exports_for_completions(
+        &self,
+        loaded_packages: &[String],
+    ) -> std::collections::HashMap<String, Vec<String>> {
+        let mut result: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+
+        let owner_cache = self.combined_export_owners.try_read().ok();
+        let combined_cache = self.combined_exports.try_read().ok();
+        let packages_cache = self.packages.try_read().ok();
+
+        if owner_cache.is_none() && combined_cache.is_none() && packages_cache.is_none() {
+            log::trace!(
+                "Could not acquire any package cache lock for owned completions, returning empty"
+            );
+            return result;
+        }
+
+        let mut push_unique = |symbol: &str, owner: &str| {
+            let owners = result.entry(symbol.to_string()).or_default();
+            if !owners.iter().any(|o| o == owner) {
+                owners.push(owner.to_string());
+            }
+        };
+
+        for pkg_name in loaded_packages {
+            // Prefer the owner map: it covers exactly the symbols in the
+            // combined set and attributes each to its true contributor.
+            if let Some(ref cache) = owner_cache
+                && let Some(owners) = cache.get(pkg_name)
+            {
+                for (symbol, owner) in owners.iter() {
+                    push_unique(symbol, owner);
+                }
+                continue;
+            }
+
+            // Fall back to the combined set, attributing to the loaded package.
+            if let Some(ref cache) = combined_cache
+                && let Some(exports) = cache.get(pkg_name)
+            {
+                for export in exports.iter() {
+                    push_unique(export, pkg_name);
+                }
+                continue;
+            }
+
+            // Last resort: per-package exports, attributing to the loaded package.
+            if let Some(ref cache) = packages_cache
+                && let Some(info) = cache.get(pkg_name)
+            {
+                for export in &info.exports {
+                    push_unique(export, pkg_name);
                 }
             }
         }
@@ -616,6 +700,16 @@ impl PackageLibrary {
                 invalidated_combined.insert(m);
             }
         }
+        // Drop the owner map in lockstep. `combined_export_owners` is always
+        // written together with `combined_exports` (see `get_all_exports`), so
+        // they share the same keys and `invalidated_combined` is exactly the set
+        // of owner-map entries to drop.
+        {
+            let mut owner_cache = self.combined_export_owners.write().await;
+            for k in &invalidated_combined {
+                owner_cache.remove(k);
+            }
+        }
         invalidated_combined
     }
 
@@ -625,14 +719,19 @@ impl PackageLibrary {
         cache.keys().cloned().collect()
     }
 
-    /// Clear all cached packages, including aggregated `combined_exports` entries.
+    /// Clear all cached packages, including aggregated `combined_exports` and
+    /// `combined_export_owners` entries.
     pub async fn clear_cache(&self) {
         {
             let mut cache = self.packages.write().await;
             cache.clear();
         }
-        let mut combined = self.combined_exports.write().await;
-        combined.clear();
+        {
+            let mut combined = self.combined_exports.write().await;
+            combined.clear();
+        }
+        let mut owner_cache = self.combined_export_owners.write().await;
+        owner_cache.clear();
     }
 
     /// Load pattern packages via the INDEX + explicit-exports fallback and
@@ -875,6 +974,41 @@ impl PackageLibrary {
         }
 
         None
+    }
+
+    /// Find the true owner package of a symbol made visible by `loaded_packages`
+    /// (synchronous, cached-only).
+    ///
+    /// Distinct from [`find_package_for_symbol`], which answers "which loaded
+    /// package made this visible?" and returns the aggregate key (e.g.
+    /// `tidyverse`). This answers "which package actually contributed the
+    /// symbol?" — the documentation / NSE-policy owner (e.g. `dplyr`) — by
+    /// consulting the per-aggregate `combined_export_owners` map. Falls back to
+    /// [`find_package_for_symbol`] when no owner map entry exists (cache not yet
+    /// warmed), preserving the previous behavior. See issue #407.
+    pub fn find_package_owner_for_symbol(
+        &self,
+        symbol: &str,
+        loaded_packages: &[String],
+    ) -> Option<String> {
+        // Consult the per-aggregate owner map first. For each loaded package,
+        // if the cached owner map for that aggregate records this symbol, the
+        // recorded value is the true contributor (e.g. `dplyr` for a `mutate`
+        // made visible through `tidyverse`).
+        if let Ok(owner_cache) = self.combined_export_owners.try_read() {
+            for pkg_name in loaded_packages {
+                if let Some(owners) = owner_cache.get(pkg_name)
+                    && let Some(owner) = owners.get(symbol)
+                {
+                    return Some(owner.clone());
+                }
+            }
+        }
+
+        // Fall back to availability-based attribution when the owner map has no
+        // entry (combined cache not yet warmed). This preserves the previous
+        // behavior of returning the loaded package that made the symbol visible.
+        self.find_package_for_symbol(symbol, loaded_packages)
     }
 
     /// Set the library paths
@@ -1511,13 +1645,19 @@ impl PackageLibrary {
             }
         }
 
-        // Compute exports
+        // Compute exports + owner attribution. `owners` records, for each
+        // symbol, the package that actually contributed it (the documentation /
+        // NSE-policy owner) so consumers can distinguish ownership from mere
+        // availability through an aggregate. See issue #407.
         let mut visited = HashSet::new();
         let mut all_exports = HashSet::new();
-        self.collect_exports_recursive(name, &mut visited, &mut all_exports)
+        let mut owners: HashMap<String, String> = HashMap::new();
+        self.collect_exports_recursive(name, &mut visited, &mut all_exports, &mut owners)
             .await;
 
-        // Cache the result
+        // Cache the result. The combined set and its owner map are written under
+        // separate locks but always together, so they stay consistent for
+        // readers (and are invalidated together; see `invalidate_many`).
         {
             let mut cache = self.combined_exports.write().await;
             cache.insert(name.to_string(), Arc::new(all_exports.clone()));
@@ -1526,6 +1666,10 @@ impl PackageLibrary {
                 all_exports.len(),
                 name
             );
+        }
+        {
+            let mut owner_cache = self.combined_export_owners.write().await;
+            owner_cache.insert(name.to_string(), Arc::new(owners));
         }
 
         if all_exports.is_empty() {
@@ -1548,11 +1692,16 @@ impl PackageLibrary {
     /// * `name` - The package name to load
     /// * `visited` - Set of already-visited package names (for cycle detection)
     /// * `all_exports` - Accumulator for all collected exports
+    /// * `owners` - Accumulator mapping each symbol to its contributing package.
+    ///   First contributor wins: because the aggregate root is visited before
+    ///   its `depends`/`attached` members, the root owns its own exports and a
+    ///   member only owns symbols the root does not export itself (issue #407).
     async fn collect_exports_recursive(
         &self,
         name: &str,
         visited: &mut HashSet<String>,
         all_exports: &mut HashSet<String>,
+        owners: &mut HashMap<String, String>,
     ) {
         // Check if we've already visited this package (circular dependency detection)
         if visited.contains(name) {
@@ -1584,6 +1733,19 @@ impl PackageLibrary {
         all_exports.extend(package_info.exports.iter().cloned());
         all_exports.extend(package_info.lazy_data.iter().cloned());
 
+        // Record owner attribution. `or_insert_with` makes the first contributor
+        // win, so the aggregate root (visited first) owns symbols it exports
+        // itself, while members own only the symbols the root does not.
+        for symbol in package_info
+            .exports
+            .iter()
+            .chain(package_info.lazy_data.iter())
+        {
+            owners
+                .entry(symbol.clone())
+                .or_insert_with(|| name.to_string());
+        }
+
         log::trace!(
             "Added {} exports + {} datasets from package '{}' (total: {})",
             package_info.exports.len(),
@@ -1614,7 +1776,7 @@ impl PackageLibrary {
         // Recursively process all dependency packages
         // Use Box::pin for recursive async calls
         for dep_name in packages_to_process {
-            Box::pin(self.collect_exports_recursive(&dep_name, visited, all_exports)).await;
+            Box::pin(self.collect_exports_recursive(&dep_name, visited, all_exports, owners)).await;
         }
     }
 }
@@ -3413,6 +3575,202 @@ mod tests {
         assert!(
             all_exports.contains("diamonds"),
             "dataset from an attached meta-package member should resolve"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owner_for_meta_attached_export_is_member() {
+        // library(tidyverse); mutate -> documentation / NSE owner is dplyr, not
+        // tidyverse. tidyverse makes `mutate` visible only by attaching dplyr;
+        // its own namespace does not export the verb (issue #407).
+        let lib = PackageLibrary::new_empty();
+
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        // tidyverse is a meta-package that attaches dplyr.
+        lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
+            .await;
+
+        // Warm the combined caches the way the diagnostic prefetch does.
+        lib.get_all_exports("tidyverse").await;
+
+        let loaded = vec!["tidyverse".to_string()];
+        // Availability is unchanged: the symbol is still visible.
+        assert!(lib.is_symbol_from_loaded_packages("mutate", &loaded));
+        // But ownership resolves to the true contributor.
+        assert_eq!(
+            lib.find_package_owner_for_symbol("mutate", &loaded),
+            Some("dplyr".to_string()),
+            "owner of mutate under library(tidyverse) should be dplyr"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owner_for_direct_package_is_the_package() {
+        // library(dplyr); mutate -> owner is dplyr (root owns its own export).
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        lib.get_all_exports("dplyr").await;
+
+        let loaded = vec!["dplyr".to_string()];
+        assert_eq!(
+            lib.find_package_owner_for_symbol("mutate", &loaded),
+            Some("dplyr".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owner_root_export_wins_over_dependency() {
+        // A Depends on B, and BOTH export `foo`. A genuine root export wins over
+        // a dependency that also happens to export the name (it is not a
+        // re-export). The aggregate root is visited first, so it owns `foo`.
+        let lib = PackageLibrary::new_empty();
+
+        let mut b_exports = HashSet::new();
+        b_exports.insert("foo".to_string());
+        b_exports.insert("only_b".to_string());
+        lib.insert_package(PackageInfo::new("pkgB".to_string(), b_exports))
+            .await;
+
+        let mut a_exports = HashSet::new();
+        a_exports.insert("foo".to_string());
+        lib.insert_package(PackageInfo::with_details(
+            "pkgA".to_string(),
+            a_exports,
+            vec!["pkgB".to_string()],
+            Vec::new(),
+        ))
+        .await;
+
+        lib.get_all_exports("pkgA").await;
+
+        let loaded = vec!["pkgA".to_string()];
+        assert_eq!(
+            lib.find_package_owner_for_symbol("foo", &loaded),
+            Some("pkgA".to_string()),
+            "a genuine root export should be owned by the root"
+        );
+        // A symbol that only the dependency exports is owned by the dependency.
+        assert_eq!(
+            lib.find_package_owner_for_symbol("only_b", &loaded),
+            Some("pkgB".to_string()),
+            "a dependency-only export should be owned by the dependency"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owner_falls_back_when_owner_map_absent() {
+        // When the owner map has no entry (combined cache never warmed), the
+        // lookup falls back to the per-package availability semantics of
+        // find_package_for_symbol.
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        // Note: no get_all_exports() call, so combined_export_owners is empty.
+        let loaded = vec!["dplyr".to_string()];
+        assert_eq!(
+            lib.find_package_owner_for_symbol("mutate", &loaded),
+            Some("dplyr".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owned_exports_for_completions_attributes_owner() {
+        // Completion attribution must use the true owner: under library(tidyverse)
+        // the `mutate` completion is detailed/resolved as {dplyr}, not {tidyverse}.
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
+            .await;
+        lib.get_all_exports("tidyverse").await;
+
+        let owned = lib.get_owned_exports_for_completions(&["tidyverse".to_string()]);
+        assert_eq!(
+            owned.get("mutate"),
+            Some(&vec!["dplyr".to_string()]),
+            "completion owner of mutate under tidyverse should be dplyr"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_owned_exports_for_completions_falls_back_to_loaded_package() {
+        // When the owner map is not warmed, attribution falls back to the loaded
+        // package (existing get_exports_for_completions behavior).
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        // No get_all_exports(): owner map empty, per-package cache present.
+        let owned = lib.get_owned_exports_for_completions(&["dplyr".to_string()]);
+        assert_eq!(owned.get("mutate"), Some(&vec!["dplyr".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn test_clear_cache_drops_owner_map() {
+        // clear_cache() must drop combined_export_owners in lockstep with
+        // combined_exports, or a stale owner map could outlive its aggregate.
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        lib.get_all_exports("dplyr").await;
+        assert!(
+            lib.combined_export_owners
+                .read()
+                .await
+                .contains_key("dplyr")
+        );
+
+        lib.clear_cache().await;
+
+        assert!(
+            lib.combined_export_owners.read().await.is_empty(),
+            "clear_cache must also clear the owner map"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_many_drops_owner_map_for_dependent_aggregate() {
+        // Invalidating an attached member (dplyr) must drop the cached owner map
+        // for the meta-package aggregate (tidyverse) that rolled it up, exactly
+        // as it drops the combined_exports aggregate.
+        let lib = PackageLibrary::new_empty();
+        let mut dplyr_exports = HashSet::new();
+        dplyr_exports.insert("mutate".to_string());
+        lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
+            .await;
+        lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
+            .await;
+        lib.get_all_exports("tidyverse").await;
+        assert!(
+            lib.combined_export_owners
+                .read()
+                .await
+                .contains_key("tidyverse")
+        );
+
+        let mut names = HashSet::new();
+        names.insert("dplyr".to_string());
+        lib.invalidate_many(&names).await;
+
+        assert!(
+            !lib.combined_export_owners
+                .read()
+                .await
+                .contains_key("tidyverse"),
+            "invalidating dplyr must drop the tidyverse owner map in lockstep"
         );
     }
 

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -699,12 +699,12 @@ impl PackageLibrary {
                 combined.remove(&m);
                 invalidated_combined.insert(m);
             }
-        }
-        // Drop the owner map in lockstep. `combined_export_owners` is always
-        // written together with `combined_exports` (see `get_all_exports`), so
-        // they share the same keys and `invalidated_combined` is exactly the set
-        // of owner-map entries to drop.
-        {
+            // Drop the owner map in lockstep, while still holding the
+            // `combined_exports` write guard. `combined_export_owners` shares
+            // the same keys (see `get_all_exports`), so `invalidated_combined`
+            // is exactly the set of owner-map entries to drop. Holding both
+            // guards (order: combined -> owners) keeps the two caches consistent
+            // for readers across the removal, mirroring the publish path.
             let mut owner_cache = self.combined_export_owners.write().await;
             for k in &invalidated_combined {
                 owner_cache.remove(k);
@@ -726,11 +726,12 @@ impl PackageLibrary {
             let mut cache = self.packages.write().await;
             cache.clear();
         }
-        {
-            let mut combined = self.combined_exports.write().await;
-            combined.clear();
-        }
+        // Clear both aggregate caches under one critical section (order:
+        // combined -> owners), so a reader never sees one cleared without the
+        // other. Mirrors the publish/invalidate lock discipline.
+        let mut combined = self.combined_exports.write().await;
         let mut owner_cache = self.combined_export_owners.write().await;
+        combined.clear();
         owner_cache.clear();
     }
 
@@ -1655,21 +1656,27 @@ impl PackageLibrary {
         self.collect_exports_recursive(name, &mut visited, &mut all_exports, &mut owners)
             .await;
 
-        // Cache the result. The combined set and its owner map are written under
-        // separate locks but always together, so they stay consistent for
-        // readers (and are invalidated together; see `invalidate_many`).
+        // Publish the combined set and its owner map in a single critical
+        // section: the `combined_exports` write guard is held across the
+        // `combined_export_owners` insert, so a key is only ever *readable* in
+        // `combined_exports` once it is also present in the owner map. Without
+        // this, a reader could observe `combined_exports` populated for `name`
+        // while the owner map still lacks it, making `find_package_owner_for_symbol`
+        // fall back to `find_package_for_symbol` and return the aggregate key
+        // (e.g. `tidyverse`) instead of the true owner (`dplyr`). The lock order
+        // is always `combined_exports` -> `combined_export_owners` (here and in
+        // `invalidate_many` / `clear_cache`) to avoid deadlock; readers use
+        // `try_read`, so they can never be part of a lock cycle.
         {
             let mut cache = self.combined_exports.write().await;
+            let mut owner_cache = self.combined_export_owners.write().await;
             cache.insert(name.to_string(), Arc::new(all_exports.clone()));
+            owner_cache.insert(name.to_string(), Arc::new(owners));
             log::trace!(
                 "Cached {} combined exports for package '{}'",
                 all_exports.len(),
                 name
             );
-        }
-        {
-            let mut owner_cache = self.combined_export_owners.write().await;
-            owner_cache.insert(name.to_string(), Arc::new(owners));
         }
 
         if all_exports.is_empty() {

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -205,6 +205,13 @@ pub struct NamespaceParseResult {
 /// `symbol -> true owner package` (e.g. `mutate -> dplyr` under the
 /// `tidyverse` key). Keeping both projections in one entry makes publication,
 /// invalidation, and reads atomic at the aggregate-key level.
+///
+/// Invariant: the sole production writer (`collect_exports_recursive` via
+/// `get_all_exports`) fills `exports` and `owners` from the same traversal, so
+/// every symbol in `exports` has a matching key in `owners`. The fail-closed
+/// guard in `find_package_owner_for_symbol` therefore defends only against a
+/// partial snapshot that production never constructs — exercised by tests that
+/// seed an entry directly.
 #[derive(Debug)]
 struct CombinedEntry {
     exports: HashSet<String>,
@@ -927,6 +934,29 @@ impl PackageLibrary {
         }
     }
 
+    /// Per-package fallback shared by [`find_package_for_symbol`] and
+    /// [`find_package_owner_for_symbol`]: returns the first loaded package whose
+    /// own (non-aggregate) cached exports contain `symbol`. Centralizing the loop
+    /// keeps availability and owner attribution from diverging on direct-package
+    /// lookup. Returns `None` if the `packages` lock is contended (`try_read`
+    /// miss) or no loaded package exports the symbol.
+    fn find_in_per_package_cache(
+        &self,
+        symbol: &str,
+        loaded_packages: &[String],
+    ) -> Option<String> {
+        if let Ok(cache) = self.packages.try_read() {
+            for pkg_name in loaded_packages {
+                if let Some(info) = cache.get(pkg_name)
+                    && info.exports.contains(symbol)
+                {
+                    return Some(pkg_name.clone());
+                }
+            }
+        }
+        None
+    }
+
     /// Find which package exports a symbol (synchronous, cached-only)
     ///
     /// Searches through loaded packages to find which one exports the given symbol.
@@ -948,17 +978,7 @@ impl PackageLibrary {
         }
 
         // Fall back to per-package cache
-        if let Ok(cache) = self.packages.try_read() {
-            for pkg_name in loaded_packages {
-                if let Some(info) = cache.get(pkg_name)
-                    && info.exports.contains(symbol)
-                {
-                    return Some(pkg_name.clone());
-                }
-            }
-        }
-
-        None
+        self.find_in_per_package_cache(symbol, loaded_packages)
     }
 
     /// Find the true owner package of a symbol made visible by `loaded_packages`
@@ -967,7 +987,7 @@ impl PackageLibrary {
     /// Distinct from [`find_package_for_symbol`], which answers "which loaded
     /// package made this visible?" and returns the aggregate key (e.g.
     /// `tidyverse`). This answers "which package actually contributed the
-    /// symbol?\" — the documentation / NSE-policy owner (e.g. `dplyr`) — by
+    /// symbol?" — the documentation / NSE-policy owner (e.g. `dplyr`) — by
     /// consulting the per-aggregate [`CombinedEntry`] snapshot. Falls back to
     /// direct per-package exports when no aggregate entry exists yet, preserving
     /// the previous behavior for unwarmed direct package caches. See issue #407.
@@ -997,17 +1017,7 @@ impl PackageLibrary {
         // Fall back only to direct per-package attribution. Re-reading aggregate
         // availability here can combine an old owner miss with a newer combined
         // hit and return the aggregate package as a false owner.
-        if let Ok(cache) = self.packages.try_read() {
-            for pkg_name in loaded_packages {
-                if let Some(info) = cache.get(pkg_name)
-                    && info.exports.contains(symbol)
-                {
-                    return Some(pkg_name.clone());
-                }
-            }
-        }
-
-        None
+        self.find_in_per_package_cache(symbol, loaded_packages)
     }
 
     /// Set the library paths
@@ -2038,6 +2048,22 @@ mod tests {
     /// instance / one audited `unsafe` mutation site).
     use crate::package_db::{NamesDbEnvGuard, RAVEN_NAMES_DB_ENV_LOCK};
 
+    /// Seed a `combined_entries` cache entry directly, bypassing `get_all_exports`.
+    /// Lets tests construct specific aggregate snapshots — including the
+    /// partial/ownerless states the production warm path never builds — without
+    /// repeating the write-lock + `Arc::new(CombinedEntry::new(..))` boilerplate.
+    async fn seed_combined_entry(
+        lib: &PackageLibrary,
+        name: &str,
+        exports: HashSet<String>,
+        owners: HashMap<String, String>,
+    ) {
+        lib.combined_entries.write().await.insert(
+            name.to_string(),
+            Arc::new(CombinedEntry::new(exports, owners)),
+        );
+    }
+
     #[tokio::test]
     async fn build_library_wires_shipped_db_provider_from_env() {
         use crate::package_db::binary_db::{ShippedDbProvenance, write_shipped_db};
@@ -2506,16 +2532,13 @@ mod tests {
         lib.insert_package(PackageInfo::new("pkg2".to_string(), HashSet::new()))
             .await;
         // Seed a combined_entries entry to verify it is also cleared.
-        {
-            let mut combined = lib.combined_entries.write().await;
-            combined.insert(
-                "pkg1".into(),
-                std::sync::Arc::new(CombinedEntry::new(
-                    ["foo".to_string()].into_iter().collect(),
-                    HashMap::new(),
-                )),
-            );
-        }
+        seed_combined_entry(
+            &lib,
+            "pkg1",
+            ["foo".to_string()].into_iter().collect(),
+            HashMap::new(),
+        )
+        .await;
 
         assert_eq!(lib.cached_count().await, 2);
         assert!(lib.combined_entries.read().await.contains_key("pkg1"));
@@ -3667,7 +3690,8 @@ mod tests {
     #[tokio::test]
     async fn test_owner_falls_back_when_owner_map_absent() {
         // When no aggregate entry has been warmed, the lookup falls back to the
-        // per-package availability semantics of find_package_for_symbol.
+        // per-package availability cache (find_in_per_package_cache), attributing
+        // the symbol to the directly-loaded package that exports it.
         let lib = PackageLibrary::new_empty();
         let mut dplyr_exports = HashSet::new();
         dplyr_exports.insert("mutate".to_string());
@@ -3689,16 +3713,13 @@ mod tests {
         let lib = PackageLibrary::new_empty();
         lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
             .await;
-        {
-            let mut combined = lib.combined_entries.write().await;
-            combined.insert(
-                "tidyverse".to_string(),
-                Arc::new(CombinedEntry::new(
-                    ["mutate".to_string()].into_iter().collect(),
-                    HashMap::new(),
-                )),
-            );
-        }
+        seed_combined_entry(
+            &lib,
+            "tidyverse",
+            ["mutate".to_string()].into_iter().collect(),
+            HashMap::new(),
+        )
+        .await;
 
         let loaded = vec!["tidyverse".to_string()];
         assert_eq!(
@@ -4934,25 +4955,22 @@ mod tests {
             packages.insert("tidyverse".into(), std::sync::Arc::new(tidyverse_info));
         }
         // Seed combined_entries as though tidyverse had been loaded.
-        {
-            let mut combined = lib.combined_entries.write().await;
-            combined.insert(
-                "tidyverse".into(),
-                std::sync::Arc::new(CombinedEntry::new(
-                    ["mutate".to_string(), "ggplot".to_string()]
-                        .into_iter()
-                        .collect(),
-                    HashMap::new(),
-                )),
-            );
-            combined.insert(
-                "dplyr".into(),
-                std::sync::Arc::new(CombinedEntry::new(
-                    ["mutate".to_string()].into_iter().collect(),
-                    HashMap::new(),
-                )),
-            );
-        }
+        seed_combined_entry(
+            &lib,
+            "tidyverse",
+            ["mutate".to_string(), "ggplot".to_string()]
+                .into_iter()
+                .collect(),
+            HashMap::new(),
+        )
+        .await;
+        seed_combined_entry(
+            &lib,
+            "dplyr",
+            ["mutate".to_string()].into_iter().collect(),
+            HashMap::new(),
+        )
+        .await;
 
         // Invalidate a child (dplyr) — the meta-package combined entry must be dropped too.
         let set: HashSet<String> = ["dplyr".to_string()].into_iter().collect();
@@ -5011,18 +5029,15 @@ mod tests {
             vec![],
         );
         lib.insert_package(a_info).await;
-        {
-            let mut combined = lib.combined_entries.write().await;
-            combined.insert(
-                "A".into(),
-                std::sync::Arc::new(CombinedEntry::new(
-                    ["a_fn".to_string(), "b_fn".to_string()]
-                        .into_iter()
-                        .collect(),
-                    HashMap::new(),
-                )),
-            );
-        }
+        seed_combined_entry(
+            &lib,
+            "A",
+            ["a_fn".to_string(), "b_fn".to_string()]
+                .into_iter()
+                .collect(),
+            HashMap::new(),
+        )
+        .await;
 
         // Invalidate B — A's combined aggregate rolled up B's exports, so it
         // must be dropped even though B is not a direct hit and A is not a

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -281,11 +281,14 @@ pub fn resolve(
     let resolved_package = if let Some(ns) = namespace {
         Some(ns.to_string())
     } else {
-        // Use find_package_for_symbol to determine which package exports this function
+        // Resolve the true owner package (issue #407) so formals come from the
+        // package that actually defines the function (e.g. `dplyr` for a
+        // `mutate` made visible through `library(tidyverse)`), not the
+        // aggregate that merely made it visible.
         let pkg_list: Vec<String> = all_packages.to_vec();
         state
             .package_library
-            .find_package_for_symbol(function_name, &pkg_list)
+            .find_package_owner_for_symbol(function_name, &pkg_list)
     };
 
     if let Some(ref pkg_name) = resolved_package {

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -113,6 +113,15 @@ Raven recognizes meta-packages that attach multiple packages:
 - **tidyverse** attaches: dplyr, readr, forcats, stringr, ggplot2, tibble, lubridate, tidyr, purrr
 - **tidymodels** attaches: broom, dials, dplyr, ggplot2, infer, modeldata, parsnip, purrr, recipes, rsample, tibble, tidyr, tune, workflows, workflowsets, yardstick
 
+### Availability vs. ownership
+
+A symbol made visible through a meta-package, an attached package, or a `Depends` chain has two distinct package answers that Raven keeps separate:
+
+- **Availability** — *which loaded package made this visible?* This is what suppresses "undefined variable" warnings. `library(tidyverse)` makes `mutate` available because Raven aggregates the exports of tidyverse's attached members.
+- **Ownership** — *which package actually contributes the symbol?* This is the **documentation / help owner** (used for hover help, the help panel, signature help, and completion detail) and the **NSE-policy owner** (used to classify data-masking arguments). For `mutate` under `library(tidyverse)`, the owner is `dplyr`.
+
+This matters because `help("mutate", package = "tidyverse")` is empty — only `dplyr` owns the topic. So `library(tidyverse); mutate(...)` stays *available* through tidyverse but resolves hover, help, signatures, completion detail, and NSE policy against `dplyr`. A direct `library(dplyr)` and an explicit `dplyr::mutate(...)` resolve to `dplyr` as before, and a genuine package export is always owned by the package that exports it (the aggregate root wins for its own exports). When no contributing owner can be resolved, existing not-found behavior is unchanged.
+
 ### Cross-File Package Propagation
 
 Packages loaded in parent files are available in sourced children:

--- a/docs/development.md
+++ b/docs/development.md
@@ -283,10 +283,13 @@ Key ideas:
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
 ### Availability vs. ownership: unified aggregate entries (#407)
+
 `combined_entries[pkg]` is the aggregate cache built by `get_all_exports` / `collect_exports_recursive`. Each `CombinedEntry` stores two projections from the same traversal:
 - `exports`: *availability* — "is this symbol visible through `pkg`?" This flat aggregate suppresses undefined-variable diagnostics.
 - `owners`: *ownership* — "which package owns the help topic / NSE policy?" For `library(tidyverse)`, `exports` contains `mutate` under the `tidyverse` key while `owners` records `mutate -> dplyr`.
+
 The entry is published and invalidated as one immutable snapshot so a reader cannot observe aggregate availability without matching ownership. As recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export.
+
 Lookups:
 - `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry (`try_read`). If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
 - `get_owned_exports_for_completions(loaded_packages)` mirrors `get_exports_for_completions` but attributes each symbol to its owner for completion detail / resolve `data.package`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -282,16 +282,15 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
-### Availability vs. ownership: the owner map (#407)
-
-`combined_exports[pkg]` answers *availability* ("is this symbol visible through `pkg`?") and is the flat aggregate used to suppress undefined-variable diagnostics. It deliberately loses the contributing package, so it cannot answer *ownership* ("which package owns the help topic / NSE policy?"). For `library(tidyverse)` it aggregates `mutate` under the `tidyverse` key even though `dplyr` owns it.
-
-A sibling cache `combined_export_owners[aggregate] -> { symbol -> owner_pkg }` is built in lockstep by `get_all_exports` / `collect_exports_recursive`: as the recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export. The two caches share identical keys and are always written and invalidated together (`invalidate_many`, `clear_cache`).
-
+### Availability vs. ownership: unified aggregate entries (#407)
+`combined_entries[pkg]` is the aggregate cache built by `get_all_exports` / `collect_exports_recursive`. Each `CombinedEntry` stores two projections from the same traversal:
+- `exports`: *availability* — "is this symbol visible through `pkg`?" This flat aggregate suppresses undefined-variable diagnostics.
+- `owners`: *ownership* — "which package owns the help topic / NSE policy?" For `library(tidyverse)`, `exports` contains `mutate` under the `tidyverse` key while `owners` records `mutate -> dplyr`.
+The entry is published and invalidated as one immutable snapshot so a reader cannot observe aggregate availability without matching ownership. As recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export.
 Lookups:
-- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the owner map (`try_read`) and falls back to `find_package_for_symbol` when the map is not yet warmed. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
+- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry (`try_read`). If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
 - `get_owned_exports_for_completions(loaded_packages)` mirrors `get_exports_for_completions` but attributes each symbol to its owner for completion detail / resolve `data.package`.
-- `is_symbol_from_loaded_packages` is unchanged — availability stays a pure yes/no check.
+- `is_symbol_from_loaded_packages` reads `exports` only — availability stays a pure yes/no check.
 
 All R subprocess calls must:
 - validate user-controlled inputs (package names, paths)

--- a/docs/development.md
+++ b/docs/development.md
@@ -282,6 +282,17 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
+### Availability vs. ownership: the owner map (#407)
+
+`combined_exports[pkg]` answers *availability* ("is this symbol visible through `pkg`?") and is the flat aggregate used to suppress undefined-variable diagnostics. It deliberately loses the contributing package, so it cannot answer *ownership* ("which package owns the help topic / NSE policy?"). For `library(tidyverse)` it aggregates `mutate` under the `tidyverse` key even though `dplyr` owns it.
+
+A sibling cache `combined_export_owners[aggregate] -> { symbol -> owner_pkg }` is built in lockstep by `get_all_exports` / `collect_exports_recursive`: as the recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export. The two caches share identical keys and are always written and invalidated together (`invalidate_many`, `clear_cache`).
+
+Lookups:
+- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the owner map (`try_read`) and falls back to `find_package_for_symbol` when the map is not yet warmed. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
+- `get_owned_exports_for_completions(loaded_packages)` mirrors `get_exports_for_completions` but attributes each symbol to its owner for completion detail / resolve `data.package`.
+- `is_symbol_from_loaded_packages` is unchanged — availability stays a pure yes/no check.
+
 All R subprocess calls must:
 - validate user-controlled inputs (package names, paths)
 - use timeouts to avoid hangs


### PR DESCRIPTION
## Summary
Separates **availability** (what's visible) from **ownership** (the package that owns a symbol's help topic and NSE policy), fixing wrong attribution for re-exported / attached / `Depends` / meta-package symbols. For `library(tidyverse); mutate(...)`, `mutate` stays visible through tidyverse but resolves hover/help/signatures/completion detail and NSE policy against `dplyr`.

- New `combined_export_owners` cache (`aggregate -> {symbol -> owner}`) built in lockstep with `combined_exports` during recursive export collection. First contributor wins, so the aggregate root owns its own exports and members own only what the root does not.
- New `find_package_owner_for_symbol()` (falls back to `find_package_for_symbol` when the map isn't warmed) and `get_owned_exports_for_completions()`.
- Wired into hover, signature help, the parameter resolver, and completion detail/resolve data.
- New owner-preserving NSE step in `resolve_call_arg_policy` before the standard-eval fallback, so non-hardcoded aggregates exposing e.g. `dplyr::mutate` use dplyr's data-masking policy.
- Owner map invalidated in lockstep (`invalidate_many`, `clear_cache`). `is_symbol_from_loaded_packages` (availability) is unchanged.

Direct `library(dplyr)` and explicit `dplyr::mutate(...)` are unaffected; local definitions still shadow; `stats::filter` stays standard-eval; missing-owner keeps existing not-found behavior.

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --features test-support -- -D warnings` (0 warnings)
- [x] `cargo test -p raven` — 4443 lib tests + integration tests pass
- [x] New TDD coverage: owner map (meta/direct/Depends/fallback), invalidation lockstep, owner-aware completions, and NSE classification for non-hardcoded aggregates (+ standard-eval positive control)

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/AEWgG4jFYVuiuwW7GSXFdx
- Conversation: https://app.warp.dev/conversation/fbece826-68ca-4296-b7a7-efe340cb9997

Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Help, signature, and completion now open the correct owning package for symbols visible via meta-packages (e.g., library(tidyverse)).
  * NSE-masked columns are correctly suppressed based on the resolved true package owner, preventing misclassification of arguments.

* **Documentation**
  * Clarified the distinction between symbol availability and ownership and how it affects help/completion and NSE behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #407 