### PR TITLE
Fix Criterion baseline cache poisoning

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,9 +68,11 @@ jobs:
         run: sccache --zero-stats
 
       # Criterion baselines are stored under target/criterion/.
-      # We cache them so PR runs can compare against the main baseline.
+      # PR runs restore the main-branch baseline but must not save their
+      # branch-local `pr` baseline, or future PR runs can shadow the default
+      # branch cache with a cache that contains no `main` baseline.
       - name: Restore Criterion baseline cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target/criterion
           key: criterion-baseline-${{ runner.os }}-main-${{ github.run_id }}
@@ -100,6 +102,13 @@ jobs:
       - name: Run benchmarks (PR — compare against main)
         if: github.event_name == 'pull_request'
         run: cargo bench -p raven --features test-support --bench startup -- --save-baseline pr
+
+      - name: Save Criterion baseline cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target/criterion
+          key: criterion-baseline-${{ runner.os }}-main-${{ github.run_id }}
 
       - name: Report cache status
         if: always()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -75,9 +75,9 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target/criterion
-          key: criterion-baseline-${{ runner.os }}-main-${{ github.run_id }}
+          key: criterion-main-baseline-v2-${{ runner.os }}-main-${{ github.run_id }}
           restore-keys: |
-            criterion-baseline-${{ runner.os }}-
+            criterion-main-baseline-v2-${{ runner.os }}-main-
 
       - name: Install critcmp
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -108,7 +108,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target/criterion
-          key: criterion-baseline-${{ runner.os }}-main-${{ github.run_id }}
+          key: criterion-main-baseline-v2-${{ runner.os }}-main-${{ github.run_id }}
 
       - name: Report cache status
         if: always()

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,6 +82,14 @@ All benchmarks except `startup` require `--features test-support`. Set `RAVEN_BE
 - `cargo bench --bench libpath_capture --features test-support`
 - `cargo bench --bench edit_to_publish --features test-support`
 
+The `Performance` GitHub Actions workflow uses the `startup` benchmark for PR
+comparison comments. Criterion's `main` baseline is cached from push-to-`main`
+runs only; PR runs restore that cache and save their results as a local `pr`
+baseline, but must not write the `target/criterion` cache. Allowing PRs to
+save the cache can create branch-scoped entries that contain only `pr`, which
+then shadow the default-branch cache and make future PRs report "No `main`
+baseline found".
+
 ## Profiling startup
 
 Python scripts under `scripts/` measure LSP startup latency:

--- a/tests/bun/perf-workflow-cache.test.ts
+++ b/tests/bun/perf-workflow-cache.test.ts
@@ -28,7 +28,9 @@ describe("perf workflow criterion baseline cache", () => {
     const restore = stepNamed("Restore Criterion baseline cache");
     expect(restore).toContain("uses: actions/cache/restore@");
     expect(restore).toContain("path: target/criterion");
+    expect(restore).toContain("criterion-main-baseline-v2-${{ runner.os }}-main-");
     expect(restore).toContain("restore-keys:");
+    expect(restore).not.toContain("criterion-baseline-${{ runner.os }}-");
 
     const save = stepNamed("Save Criterion baseline cache");
     expect(save).toContain("uses: actions/cache/save@");
@@ -36,6 +38,7 @@ describe("perf workflow criterion baseline cache", () => {
       "if: github.event_name == 'push' && github.ref == 'refs/heads/main'",
     );
     expect(save).toContain("path: target/criterion");
+    expect(save).toContain("criterion-main-baseline-v2-${{ runner.os }}-main-");
   });
 
   test("combined actions/cache is not used for criterion baselines", () => {

--- a/tests/bun/perf-workflow-cache.test.ts
+++ b/tests/bun/perf-workflow-cache.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const perfWorkflow = readFileSync(
+  path.join(repoRoot, ".github", "workflows", "perf.yml"),
+  "utf8",
+);
+
+function stepNamed(name: string): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = perfWorkflow.match(
+    new RegExp(
+      `^      - name: ${escaped}\\n(?<body>.*?)(?=^      - name: |(?![\\s\\S]))`,
+      "ms",
+    ),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Missing perf.yml step named ${name}`);
+  }
+  return match.groups.body;
+}
+
+describe("perf workflow criterion baseline cache", () => {
+  test("PR benchmark runs restore baselines without saving branch-scoped caches", () => {
+    const restore = stepNamed("Restore Criterion baseline cache");
+    expect(restore).toContain("uses: actions/cache/restore@");
+    expect(restore).toContain("path: target/criterion");
+    expect(restore).toContain("restore-keys:");
+
+    const save = stepNamed("Save Criterion baseline cache");
+    expect(save).toContain("uses: actions/cache/save@");
+    expect(save).toContain(
+      "if: github.event_name == 'push' && github.ref == 'refs/heads/main'",
+    );
+    expect(save).toContain("path: target/criterion");
+  });
+
+  test("combined actions/cache is not used for criterion baselines", () => {
+    const baselineStep = stepNamed("Restore Criterion baseline cache");
+    expect(baselineStep).not.toContain("uses: actions/cache@");
+  });
+});


### PR DESCRIPTION
## Summary
- split the Criterion baseline cache into restore-only and main-only save steps
- prevent PR runs from saving branch-scoped target/criterion caches that only contain the pr baseline
- move baseline caches to a fresh criterion-main-baseline-v2 namespace so old poisoned PR caches are ignored
- add a Bun regression test and maintainer docs for the cache invariant

## Why
PR runs were using the combined actions/cache action for target/criterion. When no main baseline was present, the PR run still saved a branch-scoped cache containing only the pr baseline. Future PR runs on that branch could restore that newer branch cache before the default-branch cache, so critcmp kept reporting that no main baseline existed even after main had benchmark runs.

## Verification
- bun test tests/bun/perf-workflow-cache.test.ts
- actionlint .github/workflows/perf.yml