### PR TITLE
Fix critcmp baseline lookup in benchmark workflow

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -121,7 +121,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: critcmp
         run: |
-          if ! critcmp --list 2>/dev/null | grep -q '^main$'; then
+          if ! critcmp --baselines 2>/dev/null | grep -q '^main$'; then
             echo "No main baseline found — skipping comparison."
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
             echo "no_baseline=true" >> "$GITHUB_OUTPUT"

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,7 +88,9 @@ runs only; PR runs restore that cache and save their results as a local `pr`
 baseline, but must not write the `target/criterion` cache. Allowing PRs to
 save the cache can create branch-scoped entries that contain only `pr`, which
 then shadow the default-branch cache and make future PRs report "No `main`
-baseline found".
+baseline found". The PR comparison guard must use `critcmp --baselines` to
+detect saved baseline names; `critcmp --list` formats comparison output and
+does not prove that a restored `main` baseline exists.
 
 ## Profiling startup
 

--- a/tests/bun/perf-workflow-cache.test.ts
+++ b/tests/bun/perf-workflow-cache.test.ts
@@ -45,4 +45,10 @@ describe("perf workflow criterion baseline cache", () => {
     const baselineStep = stepNamed("Restore Criterion baseline cache");
     expect(baselineStep).not.toContain("uses: actions/cache@");
   });
+
+  test("PR comparison checks critcmp baseline names with the baseline listing command", () => {
+    const compare = stepNamed("Compare benchmarks against main baseline");
+    expect(compare).toContain("critcmp --baselines");
+    expect(compare).not.toContain("critcmp --list");
+  });
 });


### PR DESCRIPTION
## Summary
- Switch the PR benchmark guard to `critcmp --baselines` so it checks saved baseline names correctly.
- Add a regression test covering the perf workflow baseline lookup.
- Document the `critcmp` command choice in the development guide.

## Testing
- Added a Bun unit test for the perf workflow cache behavior.
- Not run (not requested): lint and formatting.