### PR TITLE
Fix package cache contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1613,7 @@ version = "0.9.0"
 dependencies = [
  "ammonia",
  "anyhow",
+ "arc-swap",
  "async-trait",
  "blake3",
  "bson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "lru",
  "memmap2",
  "notify",
+ "parking_lot",
  "percent-encoding",
  "postcard",
  "proptest",

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -21,6 +21,7 @@ name = "raven"
 path = "src/main.rs"
 
 [dependencies]
+arc-swap = "1"
 ammonia = "4"
 blake3 = "1"
 bson = "2"

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -91,6 +91,10 @@ required-features = ["test-support"]
 name = "edit_to_publish"
 harness = false
 required-features = ["test-support"]
+[[bench]]
+name = "package_cache_and_fanout"
+harness = false
+required-features = ["test-support"]
 
 [[example]]
 name = "profile_diagnostics"

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -48,6 +48,7 @@ ropey = "1.6"
 streaming-iterator = "0.1"
 lru = "0.16"
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
+parking_lot = "0.12"
 percent-encoding = "2"
 tempfile = "3"
 toml = "0.8"

--- a/crates/raven/benches/package_cache_and_fanout.rs
+++ b/crates/raven/benches/package_cache_and_fanout.rs
@@ -13,7 +13,7 @@ use raven::package_library::{PackageInfo, PackageLibrary};
 use std::collections::HashSet;
 use std::sync::{Arc, mpsc};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::runtime::{Builder, Runtime};
 
 const PACKAGE_COUNT: usize = 24;
@@ -67,34 +67,53 @@ fn seeded_package_library(
 struct HoldRequest {
     duration: Duration,
     acquired: mpsc::Sender<()>,
+    released: mpsc::Sender<()>,
 }
 
-struct PackageWriteContention {
+struct HoldLease {
+    released: mpsc::Receiver<()>,
+}
+
+impl HoldLease {
+    fn wait(self) {
+        self.released
+            .recv()
+            .expect("publication gate worker should release the hold");
+    }
+}
+
+struct PackagePublishGate {
     requests: mpsc::Sender<HoldRequest>,
 }
-
-impl PackageWriteContention {
+impl PackagePublishGate {
     fn start(lib: Arc<PackageLibrary>) -> Self {
         let (requests, receiver) = mpsc::channel::<HoldRequest>();
         let _ = thread::spawn(move || {
             while let Ok(request) = receiver.recv() {
-                lib.with_packages_write_lock_for_test(|| {
+                lib.with_packages_publish_gate_for_test(|| {
                     let _ = request.acquired.send(());
                     thread::sleep(request.duration);
                 });
+                let _ = request.released.send(());
             }
         });
         Self { requests }
     }
 
-    fn hold_for(&self, duration: Duration) {
+    fn hold_for(&self, duration: Duration) -> HoldLease {
         let (acquired, ready) = mpsc::channel();
+        let (released, done) = mpsc::channel();
         self.requests
-            .send(HoldRequest { duration, acquired })
+            .send(HoldRequest {
+                duration,
+                acquired,
+                released,
+            })
             .expect("contention worker should be alive");
         ready
             .recv()
             .expect("contention worker should acquire the write lock");
+        HoldLease { released: done }
     }
 }
 
@@ -152,29 +171,35 @@ fn bench_package_cache(c: &mut Criterion) {
         })
     });
 
-    // Measures time-to-correct-answer while an unrelated writer holds the same
-    // package-cache write lock. On the pre-refactor try_read implementation, a
-    // single read during this window returned a false cache miss; this benchmark
-    // loops until the correct hit is observed so both main and PR can be compared
-    // without failing the benchmark. The attempt count is black-boxed: old code
-    // spins/yields through repeated false misses, while the refactored reader
-    // blocks once and returns the correct hit when the writer releases the lock.
-    let contention = PackageWriteContention::start(Arc::clone(&lib));
-    group.bench_function("contention/time_to_correct_symbol_read", |b| {
-        b.iter(|| {
-            contention.hold_for(Duration::from_micros(100));
-            let mut attempts = 0usize;
-            loop {
-                attempts += 1;
-                if lib.is_symbol_from_loaded_packages(
-                    black_box(&target_symbol),
-                    black_box(&loaded_packages),
-                ) {
-                    break;
+    // Measures time-to-correct-answer while a package-cache publication is in
+    // progress. On the old try_read/RwLock implementation, a read during this
+    // window returned a false cache miss; on the snapshot implementation,
+    // readers keep using the last published map and should answer immediately.
+    // The attempt count is black-boxed so both implementations can be compared
+    // without failing the benchmark.
+    let publication_gate = PackagePublishGate::start(Arc::clone(&lib));
+    group.bench_function("publication_gate/time_to_correct_symbol_read", |b| {
+        b.iter_custom(|iters| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iters {
+                let lease = publication_gate.hold_for(Duration::from_micros(100));
+                let start = Instant::now();
+                let mut attempts = 0usize;
+                loop {
+                    attempts += 1;
+                    if lib.is_symbol_from_loaded_packages(
+                        black_box(&target_symbol),
+                        black_box(&loaded_packages),
+                    ) {
+                        break;
+                    }
+                    thread::yield_now();
                 }
-                thread::yield_now();
+                elapsed += start.elapsed();
+                black_box(attempts);
+                lease.wait();
             }
-            black_box(attempts);
+            elapsed
         })
     });
 

--- a/crates/raven/benches/package_cache_and_fanout.rs
+++ b/crates/raven/benches/package_cache_and_fanout.rs
@@ -36,11 +36,19 @@ fn package_info(index: usize) -> PackageInfo {
     PackageInfo::with_details(format!("pkg_{index}"), exports, Vec::new(), Vec::new())
 }
 
-fn seeded_package_library(rt: &Runtime) -> (Arc<PackageLibrary>, Vec<String>, String) {
+fn seeded_package_library(
+    rt: &Runtime,
+    warm_combined_entries: bool,
+) -> (Arc<PackageLibrary>, Vec<String>, String) {
     let lib = Arc::new(PackageLibrary::new_empty());
     rt.block_on(async {
         for index in 0..PACKAGE_COUNT {
             lib.insert_package(package_info(index)).await;
+        }
+        if warm_combined_entries {
+            for index in 0..PACKAGE_COUNT {
+                let _ = lib.get_all_exports(&format!("pkg_{index}")).await;
+            }
         }
     });
 
@@ -92,7 +100,9 @@ impl PackageWriteContention {
 
 fn bench_package_cache(c: &mut Criterion) {
     let rt = runtime();
-    let (lib, loaded_packages, target_symbol) = seeded_package_library(&rt);
+    let (lib, loaded_packages, target_symbol) = seeded_package_library(&rt, false);
+    let (combined_lib, combined_loaded_packages, combined_target_symbol) =
+        seeded_package_library(&rt, true);
 
     let mut group = c.benchmark_group("package_cache");
 
@@ -110,6 +120,25 @@ fn bench_package_cache(c: &mut Criterion) {
             let owner = lib.find_package_owner_for_symbol(
                 black_box(&target_symbol),
                 black_box(&loaded_packages),
+            );
+            black_box(owner);
+        })
+    });
+
+    group.bench_function("uncontended_combined/is_symbol_hit_24_loaded", |b| {
+        b.iter(|| {
+            assert!(black_box(combined_lib.is_symbol_from_loaded_packages(
+                black_box(&combined_target_symbol),
+                black_box(&combined_loaded_packages),
+            )));
+        })
+    });
+
+    group.bench_function("uncontended_combined/find_owner_hit_24_loaded", |b| {
+        b.iter(|| {
+            let owner = combined_lib.find_package_owner_for_symbol(
+                black_box(&combined_target_symbol),
+                black_box(&combined_loaded_packages),
             );
             black_box(owner);
         })
@@ -187,7 +216,6 @@ fn bench_diagnostic_fanout(c: &mut Criterion) {
     let payload = diagnostic_payload();
 
     let mut group = c.benchmark_group("diagnostic_fanout");
-    group.sample_size(10);
 
     group.bench_function("serial_32_diagnostic_like_items", |b| {
         b.iter_batched(

--- a/crates/raven/benches/package_cache_and_fanout.rs
+++ b/crates/raven/benches/package_cache_and_fanout.rs
@@ -1,0 +1,226 @@
+// Targeted benchmarks for issue #414.
+//
+// Run with:
+//   cargo bench -p raven --features test-support --bench package_cache_and_fanout
+//
+// These benchmarks intentionally exercise the paths changed by the package-cache
+// contention refactor and the bounded diagnostic fan-out driver. They complement
+// `startup.rs`, whose metadata/tree-sitter/workspace-scan groups are mostly
+// orthogonal to those changes.
+
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use raven::package_library::{PackageInfo, PackageLibrary};
+use std::collections::HashSet;
+use std::sync::{Arc, mpsc};
+use std::thread;
+use std::time::Duration;
+use tokio::runtime::{Builder, Runtime};
+
+const PACKAGE_COUNT: usize = 24;
+const EXPORTS_PER_PACKAGE: usize = 400;
+const FANOUT_ITEMS: usize = 32;
+const FANOUT_LIMIT: usize = 8;
+
+fn runtime() -> Runtime {
+    Builder::new_multi_thread()
+        .worker_threads(FANOUT_LIMIT)
+        .enable_all()
+        .build()
+        .expect("benchmark runtime should build")
+}
+
+fn package_info(index: usize) -> PackageInfo {
+    let exports = (0..EXPORTS_PER_PACKAGE)
+        .map(|export| format!("pkg_{index}_symbol_{export}"))
+        .collect::<HashSet<_>>();
+    PackageInfo::with_details(format!("pkg_{index}"), exports, Vec::new(), Vec::new())
+}
+
+fn seeded_package_library(rt: &Runtime) -> (Arc<PackageLibrary>, Vec<String>, String) {
+    let lib = Arc::new(PackageLibrary::new_empty());
+    rt.block_on(async {
+        for index in 0..PACKAGE_COUNT {
+            lib.insert_package(package_info(index)).await;
+        }
+    });
+
+    let loaded_packages = (0..PACKAGE_COUNT)
+        .map(|index| format!("pkg_{index}"))
+        .collect::<Vec<_>>();
+    let target_symbol = format!(
+        "pkg_{}_symbol_{}",
+        PACKAGE_COUNT - 1,
+        EXPORTS_PER_PACKAGE - 1
+    );
+
+    (lib, loaded_packages, target_symbol)
+}
+
+struct HoldRequest {
+    duration: Duration,
+    acquired: mpsc::Sender<()>,
+}
+
+struct PackageWriteContention {
+    requests: mpsc::Sender<HoldRequest>,
+}
+
+impl PackageWriteContention {
+    fn start(lib: Arc<PackageLibrary>) -> Self {
+        let (requests, receiver) = mpsc::channel::<HoldRequest>();
+        let _ = thread::spawn(move || {
+            while let Ok(request) = receiver.recv() {
+                lib.with_packages_write_lock_for_test(|| {
+                    let _ = request.acquired.send(());
+                    thread::sleep(request.duration);
+                });
+            }
+        });
+        Self { requests }
+    }
+
+    fn hold_for(&self, duration: Duration) {
+        let (acquired, ready) = mpsc::channel();
+        self.requests
+            .send(HoldRequest { duration, acquired })
+            .expect("contention worker should be alive");
+        ready
+            .recv()
+            .expect("contention worker should acquire the write lock");
+    }
+}
+
+fn bench_package_cache(c: &mut Criterion) {
+    let rt = runtime();
+    let (lib, loaded_packages, target_symbol) = seeded_package_library(&rt);
+
+    let mut group = c.benchmark_group("package_cache");
+
+    group.bench_function("uncontended/is_symbol_hit_24_loaded", |b| {
+        b.iter(|| {
+            assert!(black_box(lib.is_symbol_from_loaded_packages(
+                black_box(&target_symbol),
+                black_box(&loaded_packages),
+            )));
+        })
+    });
+
+    group.bench_function("uncontended/find_owner_hit_24_loaded", |b| {
+        b.iter(|| {
+            let owner = lib.find_package_owner_for_symbol(
+                black_box(&target_symbol),
+                black_box(&loaded_packages),
+            );
+            black_box(owner);
+        })
+    });
+
+    group.bench_function("uncontended/completions_24x400_exports", |b| {
+        b.iter(|| {
+            let completions = lib.get_exports_for_completions(black_box(&loaded_packages));
+            assert_eq!(completions.len(), PACKAGE_COUNT * EXPORTS_PER_PACKAGE);
+            black_box(completions);
+        })
+    });
+
+    // Measures time-to-correct-answer while an unrelated writer holds the same
+    // package-cache write lock. On the pre-refactor try_read implementation, a
+    // single read during this window returned a false cache miss; this benchmark
+    // loops until the correct hit is observed so both main and PR can be compared
+    // without failing the benchmark. The attempt count is black-boxed: old code
+    // spins/yields through repeated false misses, while the refactored reader
+    // blocks once and returns the correct hit when the writer releases the lock.
+    let contention = PackageWriteContention::start(Arc::clone(&lib));
+    group.bench_function("contention/time_to_correct_symbol_read", |b| {
+        b.iter(|| {
+            contention.hold_for(Duration::from_micros(100));
+            let mut attempts = 0usize;
+            loop {
+                attempts += 1;
+                if lib.is_symbol_from_loaded_packages(
+                    black_box(&target_symbol),
+                    black_box(&loaded_packages),
+                ) {
+                    break;
+                }
+                thread::yield_now();
+            }
+            black_box(attempts);
+        })
+    });
+
+    group.finish();
+}
+
+fn diagnostic_payload() -> Arc<Vec<u64>> {
+    Arc::new(
+        (0..2048)
+            .map(|i| {
+                let value = i as u64;
+                value.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            })
+            .collect(),
+    )
+}
+
+async fn diagnostic_like_work(item: usize, payload: Arc<Vec<u64>>) {
+    let mut acc = item as u64;
+    for round in 0..32u64 {
+        for value in payload.iter() {
+            acc = acc.rotate_left(7) ^ value.wrapping_add(round);
+            acc = acc.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        }
+    }
+    black_box(acc);
+    tokio::task::yield_now().await;
+}
+
+async fn run_serial_fanout(items: Vec<usize>, payload: Arc<Vec<u64>>) {
+    for item in items {
+        diagnostic_like_work(item, Arc::clone(&payload)).await;
+    }
+}
+
+fn bench_diagnostic_fanout(c: &mut Criterion) {
+    let rt = runtime();
+    let items = (0..FANOUT_ITEMS).collect::<Vec<_>>();
+    let payload = diagnostic_payload();
+
+    let mut group = c.benchmark_group("diagnostic_fanout");
+    group.sample_size(10);
+
+    group.bench_function("serial_32_diagnostic_like_items", |b| {
+        b.iter_batched(
+            || items.clone(),
+            |items| rt.block_on(run_serial_fanout(items, Arc::clone(&payload))),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("bounded_8_of_32_diagnostic_like_items", |b| {
+        b.iter_batched(
+            || items.clone(),
+            |items| {
+                rt.block_on(raven::backend::run_bounded_fanout_for_test(
+                    items,
+                    FANOUT_LIMIT,
+                    {
+                        let payload = Arc::clone(&payload);
+                        move |item| {
+                            let payload = Arc::clone(&payload);
+                            async move {
+                                diagnostic_like_work(item, payload).await;
+                            }
+                        }
+                    },
+                ))
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_package_cache, bench_diagnostic_fanout);
+criterion_main!(benches);

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -564,6 +564,18 @@ async fn run_bounded_fanout<T, MakeFuture, FutureOutput>(
     }
 }
 
+#[cfg(feature = "test-support")]
+pub async fn run_bounded_fanout_for_test<T, MakeFuture, FutureOutput>(
+    items: Vec<T>,
+    limit: usize,
+    make_future: MakeFuture,
+) where
+    T: Send + 'static,
+    MakeFuture: Fn(T) -> FutureOutput + Send + Sync + 'static,
+    FutureOutput: Future<Output = ()> + Send + 'static,
+{
+    run_bounded_fanout(items, limit, make_future).await;
+}
 /// Parse linting configuration from merged client + project settings.
 ///
 /// Reads the `linting` section and constructs a [`LintConfig`]. The

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -42,6 +42,7 @@ enum IndexCategory {
     /// Files referenced by backward directives (@lsp-run-by, @lsp-sourced-by)
     BackwardDirective,
 }
+const DIAGNOSTIC_FANOUT_CONCURRENCY: usize = 8;
 
 use crate::r_subprocess::is_valid_package_name;
 
@@ -523,6 +524,42 @@ fn parse_lint_enabled(raw: Option<&serde_json::Value>) -> crate::linting::LintEn
                 "linting.enabled must be boolean or string \"auto|on|off\"; got {kind}. Defaulting to 'auto'."
             );
             LintEnabled::Auto
+        }
+    }
+}
+
+async fn run_bounded_fanout<T, MakeFuture, FutureOutput>(
+    items: Vec<T>,
+    limit: usize,
+    make_future: MakeFuture,
+) where
+    T: Send + 'static,
+    MakeFuture: Fn(T) -> FutureOutput + Send + Sync + 'static,
+    FutureOutput: Future<Output = ()> + Send + 'static,
+{
+    if items.is_empty() {
+        return;
+    }
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(limit.max(1)));
+    let make_future = Arc::new(make_future);
+    let mut join_set = tokio::task::JoinSet::new();
+
+    for item in items {
+        let permit = match Arc::clone(&semaphore).acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => return,
+        };
+        let make_future = Arc::clone(&make_future);
+        join_set.spawn(async move {
+            let _permit = permit;
+            make_future(item).await;
+        });
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        if let Err(err) = result {
+            log::trace!("bounded diagnostic fan-out task failed: {err}");
         }
     }
 }
@@ -2660,20 +2697,18 @@ impl LanguageServer for Backend {
                 // Route through the same debounced pipeline the watcher consumer
                 // uses, so refresh runs in parallel (not serial) and cooperates
                 // with revalidation cancellation/freshness gates.
-                for uri in open_uris {
-                    let state_arc = Arc::clone(&self.state);
-                    let client = self.client.clone();
-                    let traversal_truncation = self.traversal_truncation.clone();
-                    tokio::spawn(async move {
-                        Backend::publish_diagnostics_via_arc(
-                            state_arc,
-                            client,
-                            &uri,
-                            Some(traversal_truncation),
-                        )
-                        .await;
-                    });
-                }
+                let state_arc = Arc::clone(&self.state);
+                let client = self.client.clone();
+                let traversal_truncation = self.traversal_truncation.clone();
+                tokio::spawn(async move {
+                    Backend::publish_diagnostics_for_uris_bounded(
+                        state_arc,
+                        client,
+                        open_uris,
+                        Some(traversal_truncation),
+                    )
+                    .await;
+                });
                 Ok(Some(serde_json::json!({ "cleared": cleared })))
             }
             "raven.getHelpHtml" => {
@@ -5083,15 +5118,13 @@ impl LanguageServer for Backend {
                         .diagnostics_gate
                         .mark_force_republish_many(affected_for_async.iter());
                 }
-                for uri in affected_for_async {
-                    Backend::publish_diagnostics_via_arc(
-                        state_arc.clone(),
-                        client.clone(),
-                        &uri,
-                        Some(traversal_truncation.clone()),
-                    )
-                    .await;
-                }
+                Backend::publish_diagnostics_for_uris_bounded(
+                    state_arc.clone(),
+                    client.clone(),
+                    affected_for_async,
+                    Some(traversal_truncation.clone()),
+                )
+                .await;
             });
         } else {
             // DELETED-only path: the sync block already mutated the graph
@@ -6502,7 +6535,7 @@ impl Backend {
     }
 
     /// Free-standing variant of `publish_diagnostics` usable from background tasks.
-    /// Delegates to the same debounced pipeline.
+    /// Runs the same debounced pipeline to completion.
     async fn publish_diagnostics_via_arc(
         state_arc: Arc<RwLock<WorldState>>,
         client: Client,
@@ -6516,7 +6549,7 @@ impl Backend {
             let r = doc.map(|d| d.revision);
             (state.cross_file_config.revalidation_debounce_ms, v, r)
         };
-        tokio::spawn(run_debounced_diagnostics(
+        run_debounced_diagnostics(
             state_arc,
             client,
             uri.clone(),
@@ -6524,7 +6557,29 @@ impl Backend {
             trigger_version,
             trigger_revision,
             traversal_truncation,
-        ));
+        )
+        .await;
+    }
+
+    /// Publish diagnostics for an already-computed affected-URI set with bounded
+    /// parallelism. Each worker runs the normal debounced pipeline, which
+    /// rebuilds its own snapshot and commits through the monotonic gate.
+    async fn publish_diagnostics_for_uris_bounded(
+        state_arc: Arc<RwLock<WorldState>>,
+        client: Client,
+        uris: Vec<Url>,
+        traversal_truncation: Option<Arc<TraversalTruncationState>>,
+    ) {
+        run_bounded_fanout(uris, DIAGNOSTIC_FANOUT_CONCURRENCY, move |uri| {
+            let state_arc = Arc::clone(&state_arc);
+            let client = client.clone();
+            let traversal_truncation = traversal_truncation.clone();
+            async move {
+                Backend::publish_diagnostics_via_arc(state_arc, client, &uri, traversal_truncation)
+                    .await;
+            }
+        })
+        .await;
     }
 
     async fn publish_diagnostics(&self, uri: &Url) {
@@ -6633,15 +6688,18 @@ impl Backend {
             affected
         };
 
-        for uri in affected_uris {
-            Backend::publish_diagnostics_via_arc(
-                self.state.clone(),
-                self.client.clone(),
-                &uri,
-                Some(self.traversal_truncation.clone()),
+        let state_arc = self.state.clone();
+        let client = self.client.clone();
+        let traversal_truncation = self.traversal_truncation.clone();
+        tokio::spawn(async move {
+            Backend::publish_diagnostics_for_uris_bounded(
+                state_arc,
+                client,
+                affected_uris,
+                Some(traversal_truncation),
             )
             .await;
-        }
+        });
     }
 }
 
@@ -7261,15 +7319,13 @@ async fn run_libpath_consumer(
                         .diagnostics_gate
                         .mark_force_republish_many(affected_uris.iter());
                 }
-
-                // Schedule diagnostics for each affected open URI.
-                for uri in affected_uris {
-                    let state_arc2 = Arc::clone(&state_arc);
-                    let client2 = client.clone();
-                    tokio::spawn(async move {
-                        Backend::publish_diagnostics_via_arc(state_arc2, client2, &uri, None).await;
-                    });
-                }
+                Backend::publish_diagnostics_for_uris_bounded(
+                    Arc::clone(&state_arc),
+                    client.clone(),
+                    affected_uris,
+                    None,
+                )
+                .await;
             }
             LibpathEvent::Dropped => {
                 log::warn!(
@@ -7283,13 +7339,13 @@ async fn run_libpath_consumer(
                 state_arc.read().await.clear_help_caches();
 
                 let open_uris = prepare_dropped_recovery(&state_arc).await;
-                for uri in open_uris {
-                    let state_arc2 = Arc::clone(&state_arc);
-                    let client2 = client.clone();
-                    tokio::spawn(async move {
-                        Backend::publish_diagnostics_via_arc(state_arc2, client2, &uri, None).await;
-                    });
-                }
+                Backend::publish_diagnostics_for_uris_bounded(
+                    Arc::clone(&state_arc),
+                    client.clone(),
+                    open_uris,
+                    None,
+                )
+                .await;
 
                 // Attempt a one-shot recovery. The replacement consumer runs
                 // with `allow_recovery = false` so a persistent failure cannot
@@ -7318,6 +7374,65 @@ mod tests {
             assert_eq!(super::super::normalize_document_indent_unit(0), 1);
             assert_eq!(super::super::normalize_document_indent_unit(4), 4);
             assert_eq!(super::super::normalize_document_indent_unit(99), 8);
+        }
+    }
+
+    mod bounded_fanout {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        fn record_max(max_seen: &AtomicUsize, current: usize) {
+            let mut observed = max_seen.load(Ordering::Acquire);
+            while current > observed {
+                match max_seen.compare_exchange_weak(
+                    observed,
+                    current,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(next) => observed = next,
+                }
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn run_bounded_fanout_runs_all_items_without_exceeding_limit() {
+            let active = Arc::new(AtomicUsize::new(0));
+            let max_seen = Arc::new(AtomicUsize::new(0));
+            let completed = Arc::new(AtomicUsize::new(0));
+            let limit = 3;
+            let items: Vec<usize> = (0..24).collect();
+
+            super::super::run_bounded_fanout(items, limit, {
+                let active = Arc::clone(&active);
+                let max_seen = Arc::clone(&max_seen);
+                let completed = Arc::clone(&completed);
+                move |_| {
+                    let active = Arc::clone(&active);
+                    let max_seen = Arc::clone(&max_seen);
+                    let completed = Arc::clone(&completed);
+                    async move {
+                        let now = active.fetch_add(1, Ordering::AcqRel) + 1;
+                        record_max(&max_seen, now);
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        active.fetch_sub(1, Ordering::AcqRel);
+                        completed.fetch_add(1, Ordering::AcqRel);
+                    }
+                }
+            })
+            .await;
+
+            assert_eq!(completed.load(Ordering::Acquire), 24);
+            assert!(
+                max_seen.load(Ordering::Acquire) <= limit,
+                "bounded fan-out exceeded concurrency limit"
+            );
+            assert!(
+                max_seen.load(Ordering::Acquire) > 1,
+                "test should exercise actual parallelism"
+            );
         }
     }
 

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -616,6 +616,14 @@ impl PackageLibrary {
         let mut cache = self.packages.write();
         cache.insert(info.name.clone(), Arc::new(info));
     }
+    /// Test-support hook for benchmarks that need deterministic package-cache
+    /// write contention. Kept behind `test-support` so production code cannot
+    /// hold the cache lock through arbitrary work.
+    #[cfg(feature = "test-support")]
+    pub fn with_packages_write_lock_for_test<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _guard = self.packages.write();
+        f()
+    }
 
     /// Invalidate cache for a package
     ///

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -7,7 +7,8 @@
 // Requirement 13.1: THE Package_Cache SHALL store parsed exports per package
 // Requirement 13.4: THE Package_Cache SHALL support concurrent read access from multiple LSP handlers
 
-use parking_lot::{RwLock, RwLockReadGuard};
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -97,17 +98,6 @@ fn meta_package_fields(name: &str) -> (bool, Vec<String>) {
 /// so it is negligible on the init / package-resolution path.
 fn is_readable_file(path: &Path) -> bool {
     path.is_file() && std::fs::File::open(path).is_ok()
-}
-
-/// Take a package-cache read guard, using the uncontended fast path but never
-/// treating contention as absence.
-///
-/// The pre-#414 bug was not `try_read()` itself; it was returning false/empty
-/// when `try_read()` failed. This helper preserves the blocking-read contract
-/// while avoiding the slower parking-lot blocking path when the lock is
-/// immediately available.
-fn cache_read<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
-    lock.try_read().unwrap_or_else(|| lock.read())
 }
 
 /// Cached package information
@@ -237,6 +227,9 @@ impl CombinedEntry {
         }
     }
 }
+
+type PackageCache = HashMap<String, Arc<PackageInfo>>;
+type CombinedCache = HashMap<String, Arc<CombinedEntry>>;
 enum CachedCompletionEntry {
     Combined {
         loaded_package: String,
@@ -251,16 +244,20 @@ enum CachedCompletionEntry {
 /// Package library manager
 ///
 /// Manages the collection of installed R packages and their cached exports.
-/// Uses RwLock for thread-safe concurrent read access from multiple LSP handlers.
+/// Uses atomic read-copy snapshots for thread-safe concurrent read access from
+/// multiple LSP handlers.
 ///
 /// Requirement 13.1: THE Package_Cache SHALL store parsed exports per package
 /// Requirement 13.4: THE Package_Cache SHALL support concurrent read access from multiple LSP handlers
 pub struct PackageLibrary {
     /// Library paths (from R or configuration)
     lib_paths: Vec<PathBuf>,
-    /// Cached package information (lazy-loaded)
-    /// Uses RwLock for thread-safe concurrent read access
-    packages: RwLock<HashMap<String, Arc<PackageInfo>>>,
+    /// Cached package information (lazy-loaded).
+    ///
+    /// Readers load immutable snapshots without taking a read lock. Writers
+    /// serialize copy-on-write publications through `packages_write`.
+    packages: ArcSwap<PackageCache>,
+    packages_write: Mutex<()>,
     /// Combined aggregate cache keyed by the loaded package name.
     ///
     /// Each entry stores availability (`exports`) and ownership (`owners`) in
@@ -268,7 +265,8 @@ pub struct PackageLibrary {
     /// `mutate` and `owners` records `mutate -> dplyr`. This single source of
     /// truth prevents readers from seeing an aggregate export without its owner
     /// attribution during cache warm-up or invalidation. See issue #407.
-    combined_entries: RwLock<HashMap<String, Arc<CombinedEntry>>>,
+    combined_entries: ArcSwap<CombinedCache>,
+    combined_entries_write: Mutex<()>,
     /// Base packages (always available)
     base_packages: HashSet<String>,
     /// Base package exports (combined from all base packages).
@@ -296,8 +294,10 @@ impl PackageLibrary {
     pub fn new_empty() -> Self {
         Self {
             lib_paths: Vec::new(),
-            packages: RwLock::new(HashMap::new()),
-            combined_entries: RwLock::new(HashMap::new()),
+            packages: ArcSwap::from_pointee(HashMap::new()),
+            packages_write: Mutex::new(()),
+            combined_entries: ArcSwap::from_pointee(HashMap::new()),
+            combined_entries_write: Mutex::new(()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess: None,
@@ -316,8 +316,10 @@ impl PackageLibrary {
     pub fn with_subprocess(r_subprocess: Option<RSubprocess>) -> Self {
         Self {
             lib_paths: Vec::new(),
-            packages: RwLock::new(HashMap::new()),
-            combined_entries: RwLock::new(HashMap::new()),
+            packages: ArcSwap::from_pointee(HashMap::new()),
+            packages_write: Mutex::new(()),
+            combined_entries: ArcSwap::from_pointee(HashMap::new()),
+            combined_entries_write: Mutex::new(()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
             r_subprocess,
@@ -372,6 +374,35 @@ impl PackageLibrary {
         !self.providers.is_empty()
     }
 
+    /// Publish a new per-package cache snapshot after applying `f` to a clone of
+    /// the current map.
+    fn update_packages<R>(&self, f: impl FnOnce(&mut PackageCache) -> R) -> R {
+        let _guard = self.packages_write.lock();
+        let mut next = self.packages.load_full().as_ref().clone();
+        let result = f(&mut next);
+        self.packages.store(Arc::new(next));
+        result
+    }
+
+    /// Publish a new combined-entry cache snapshot after applying `f` to a clone
+    /// of the current map.
+    fn update_combined_entries<R>(&self, f: impl FnOnce(&mut CombinedCache) -> R) -> R {
+        let _guard = self.combined_entries_write.lock();
+        let mut next = self.combined_entries.load_full().as_ref().clone();
+        let result = f(&mut next);
+        self.combined_entries.store(Arc::new(next));
+        result
+    }
+
+    /// Test-support hook for benchmarks that need to model an in-progress
+    /// package-cache publication. Snapshot readers do not use this gate, so
+    /// they continue to read the last published map while the gate is held.
+    #[cfg(feature = "test-support")]
+    pub fn with_packages_publish_gate_for_test<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _guard = self.packages_write.lock();
+        f()
+    }
+
     /// Consult the fallback providers (Tier 2 → Tier 3) in order; return the
     /// first source that knows `name`. Pure, synchronous reads.
     fn resolve_from_providers(&self, name: &str) -> Option<PackageInfo> {
@@ -386,13 +417,13 @@ impl PackageLibrary {
 
     /// Clone only the cache entry handles needed by completion readers.
     ///
-    /// Completion materialization can clone many strings, so the cache read
-    /// locks are held only for the O(loaded_packages) lookup/Arc-clone phase.
+    /// Completion materialization can clone many strings, so snapshot reads
+    /// only do the O(loaded_packages) lookup/Arc-clone phase.
     /// Aggregate entries win over direct per-package entries, preserving the
     /// existing "combined first, package fallback" behavior.
     fn cached_completion_entries(&self, loaded_packages: &[String]) -> Vec<CachedCompletionEntry> {
-        let combined_cache = cache_read(&self.combined_entries);
-        let packages_cache = cache_read(&self.packages);
+        let combined_cache = self.combined_entries.load();
+        let packages_cache = self.packages.load();
         let mut entries = Vec::with_capacity(loaded_packages.len());
 
         if combined_cache.is_empty() {
@@ -430,7 +461,7 @@ impl PackageLibrary {
     /// preferring combined_entries cache (includes Depends/attached) when available.
     ///
     /// This is a synchronous method suitable for use in completion handlers where
-    /// we cannot use async. It takes brief blocking read locks and clones only
+    /// we cannot use async. It reads immutable cache snapshots and clones only
     /// the relevant cache entry handles before materializing completion strings.
     ///
     /// Returns a HashMap where:
@@ -496,7 +527,7 @@ impl PackageLibrary {
     /// (the documentation owner) so completion detail (`{dplyr}`) and the
     /// resolve `data.package` open the correct help topic. See issue #407.
     ///
-    /// Synchronous and cached-only. It takes brief blocking read locks and
+    /// Synchronous and cached-only. It reads immutable cache snapshots and
     /// clones only relevant cache entry handles before materializing completion
     /// strings. A cached aggregate entry is a single availability/ownership
     /// snapshot, so owner-sensitive completion never falls back from a present
@@ -554,8 +585,8 @@ impl PackageLibrary {
     /// to per-package exports cache.
     ///
     /// This is a synchronous method suitable for use in diagnostic collection where
-    /// we cannot use async. It takes brief blocking read locks so contention is
-    /// never interpreted as absence.
+    /// we cannot use async. It reads immutable cache snapshots, so an
+    /// in-progress writer publication is never interpreted as absence.
     ///
     /// Returns true if:
     /// - The symbol is a base export, OR
@@ -573,7 +604,7 @@ impl PackageLibrary {
 
         // Check combined_entries cache first (includes Depends/attached packages)
         {
-            let combined_cache = cache_read(&self.combined_entries);
+            let combined_cache = self.combined_entries.load();
             if !combined_cache.is_empty() {
                 for pkg_name in loaded_packages {
                     if let Some(entry) = combined_cache.get(pkg_name)
@@ -586,7 +617,7 @@ impl PackageLibrary {
         }
 
         // Fall back to per-package exports cache
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
 
         // Check each loaded package
         for pkg_name in loaded_packages {
@@ -605,13 +636,13 @@ impl PackageLibrary {
     /// This is a synchronous method that only checks the cache.
     /// For loading packages that aren't cached, use `get_package()`.
     pub async fn get_cached_package(&self, name: &str) -> Option<Arc<PackageInfo>> {
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
         cache.get(name).cloned()
     }
 
     /// Check if a package is cached
     pub async fn is_cached(&self, name: &str) -> bool {
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
         cache.contains_key(name)
     }
 
@@ -638,14 +669,15 @@ impl PackageLibrary {
     /// Synchronous cache probe for use in hot diagnostic paths.
     ///
     /// Returns true when package metadata is currently cached, false otherwise.
-    /// Takes a brief blocking read lock so contention is never interpreted as absence.
+    /// Reads the current immutable snapshot, so writer contention is never
+    /// interpreted as absence.
     pub fn is_cached_sync(&self, name: &str) -> bool {
-        cache_read(&self.packages).contains_key(name)
+        self.packages.load().contains_key(name)
     }
 
     /// Get the number of cached packages
     pub async fn cached_count(&self) -> usize {
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
         cache.len()
     }
 
@@ -653,16 +685,9 @@ impl PackageLibrary {
     ///
     /// This is primarily used for testing and initialization.
     pub async fn insert_package(&self, info: PackageInfo) {
-        let mut cache = self.packages.write();
-        cache.insert(info.name.clone(), Arc::new(info));
-    }
-    /// Test-support hook for benchmarks that need deterministic package-cache
-    /// write contention. Kept behind `test-support` so production code cannot
-    /// hold the cache lock through arbitrary work.
-    #[cfg(feature = "test-support")]
-    pub fn with_packages_write_lock_for_test<R>(&self, f: impl FnOnce() -> R) -> R {
-        let _guard = self.packages.write();
-        f()
+        self.update_packages(|cache| {
+            cache.insert(info.name.clone(), Arc::new(info));
+        });
     }
 
     /// Invalidate cache for a package
@@ -670,8 +695,9 @@ impl PackageLibrary {
     /// Removes the package from the cache, forcing it to be reloaded
     /// on the next access.
     pub async fn invalidate(&self, name: &str) {
-        let mut cache = self.packages.write();
-        cache.remove(name);
+        self.update_packages(|cache| {
+            cache.remove(name);
+        });
     }
 
     /// Invalidate a batch of packages, also dropping any `combined_entries`
@@ -698,7 +724,7 @@ impl PackageLibrary {
         // mutating it so the dependent lookup sees the previous
         // `depends`/`attached_packages` graph.
         let dependent_combined_keys: HashSet<String> = {
-            let cache = cache_read(&self.packages);
+            let cache = self.packages.load();
             // Worklist: start with the directly invalidated names, then
             // transitively find every cached package that depends on them.
             let mut frontier: HashSet<String> = names.clone();
@@ -726,15 +752,13 @@ impl PackageLibrary {
             }
             dependents
         };
-        {
-            let mut cache = self.packages.write();
+        self.update_packages(|cache| {
             for n in names {
                 cache.remove(n);
             }
-        }
+        });
         let mut invalidated_combined: HashSet<String> = HashSet::new();
-        {
-            let mut combined = self.combined_entries.write();
+        self.update_combined_entries(|combined| {
             // Drop direct hits; record only the ones that were actually present.
             for n in names {
                 if combined.remove(n).is_some() {
@@ -762,24 +786,24 @@ impl PackageLibrary {
                 combined.remove(&m);
                 invalidated_combined.insert(m);
             }
-        }
+        });
         invalidated_combined
     }
 
     /// Snapshot of the keys currently in the per-package cache.
     pub async fn cached_package_names(&self) -> HashSet<String> {
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
         cache.keys().cloned().collect()
     }
 
     /// Clear all cached packages, including aggregate `combined_entries`.
     pub async fn clear_cache(&self) {
-        {
-            let mut cache = self.packages.write();
+        self.update_packages(|cache| {
             cache.clear();
-        }
-        let mut combined = self.combined_entries.write();
-        combined.clear();
+        });
+        self.update_combined_entries(|combined| {
+            combined.clear();
+        });
     }
 
     /// Load pattern packages via the INDEX + explicit-exports fallback and
@@ -827,8 +851,8 @@ impl PackageLibrary {
 
         // Filter out packages we've already cached
         let uncached_packages: Vec<String> = {
-            let combined_cache = cache_read(&self.combined_entries);
-            let packages_cache = cache_read(&self.packages);
+            let combined_cache = self.combined_entries.load();
+            let packages_cache = self.packages.load();
             packages
                 .iter()
                 .filter(|p| !combined_cache.contains_key(*p) && !packages_cache.contains_key(*p))
@@ -1001,7 +1025,7 @@ impl PackageLibrary {
         symbol: &str,
         loaded_packages: &[String],
     ) -> Option<String> {
-        let cache = cache_read(&self.packages);
+        let cache = self.packages.load();
         for pkg_name in loaded_packages {
             if let Some(info) = cache.get(pkg_name)
                 && info.exports.contains(symbol)
@@ -1023,7 +1047,7 @@ impl PackageLibrary {
     ) -> Option<String> {
         // Check combined_entries cache first
         {
-            let cache = cache_read(&self.combined_entries);
+            let cache = self.combined_entries.load();
             if !cache.is_empty() {
                 for pkg_name in loaded_packages {
                     if let Some(entry) = cache.get(pkg_name)
@@ -1060,7 +1084,7 @@ impl PackageLibrary {
         // `tidyverse`). If the entry says the symbol is available but lacks an
         // owner, fail closed rather than falling back to aggregate attribution.
         {
-            let cache = cache_read(&self.combined_entries);
+            let cache = self.combined_entries.load();
             if !cache.is_empty() {
                 for pkg_name in loaded_packages {
                     if let Some(entry) = cache.get(pkg_name) {
@@ -1719,7 +1743,7 @@ impl PackageLibrary {
     async fn warm_all_exports(&self, name: &str) -> Arc<HashSet<String>> {
         // Check cache first
         {
-            let cache = cache_read(&self.combined_entries);
+            let cache = self.combined_entries.load();
             if let Some(cached) = cache.get(name) {
                 log::trace!("Using cached combined exports for package '{}'", name);
                 return Arc::clone(&cached.exports);
@@ -1739,8 +1763,7 @@ impl PackageLibrary {
         // Publish availability and owner attribution as one immutable entry, so
         // hot-path readers can never observe a combined export without the
         // matching owner attribution.
-        {
-            let mut cache = self.combined_entries.write();
+        self.update_combined_entries(|cache| {
             let cached = Arc::new(CombinedEntry::new(all_exports, owners));
             cache.insert(name.to_string(), Arc::clone(&cached));
             log::trace!(
@@ -1755,7 +1778,7 @@ impl PackageLibrary {
                 );
             }
             Arc::clone(&cached.exports)
-        }
+        })
     }
 
     /// Helper method to recursively collect exports from a package and its dependencies
@@ -2119,17 +2142,19 @@ mod tests {
     /// Seed a `combined_entries` cache entry directly, bypassing `get_all_exports`.
     /// Lets tests construct specific aggregate snapshots — including the
     /// partial/ownerless states the production warm path never builds — without
-    /// repeating the write-lock + `Arc::new(CombinedEntry::new(..))` boilerplate.
+    /// repeating the copy-on-write publication boilerplate.
     async fn seed_combined_entry(
         lib: &PackageLibrary,
         name: &str,
         exports: HashSet<String>,
         owners: HashMap<String, String>,
     ) {
-        lib.combined_entries.write().insert(
-            name.to_string(),
-            Arc::new(CombinedEntry::new(exports, owners)),
-        );
+        lib.update_combined_entries(|combined| {
+            combined.insert(
+                name.to_string(),
+                Arc::new(CombinedEntry::new(exports, owners)),
+            );
+        });
     }
 
     #[tokio::test]
@@ -2609,12 +2634,12 @@ mod tests {
         .await;
 
         assert_eq!(lib.cached_count().await, 2);
-        assert!(lib.combined_entries.read().contains_key("pkg1"));
+        assert!(lib.combined_entries.load().contains_key("pkg1"));
 
         lib.clear_cache().await;
 
         assert_eq!(lib.cached_count().await, 0);
-        assert!(lib.combined_entries.read().is_empty());
+        assert!(lib.combined_entries.load().is_empty());
     }
 
     #[tokio::test]
@@ -2740,20 +2765,22 @@ mod tests {
     }
 
     #[test]
-    fn sync_reader_blocks_on_package_cache_contention_instead_of_missing() {
+    fn sync_reader_uses_published_snapshot_while_package_writer_gate_is_held() {
         let lib = Arc::new(PackageLibrary::new_empty());
         let package = "ravencontentionpkg".to_string();
         let symbol = "raven_contention_symbol".to_string();
         {
             let mut exports = HashSet::new();
             exports.insert(symbol.clone());
-            lib.packages.write().insert(
-                package.clone(),
-                Arc::new(PackageInfo::new(package.clone(), exports)),
-            );
+            lib.update_packages(|packages| {
+                packages.insert(
+                    package.clone(),
+                    Arc::new(PackageInfo::new(package.clone(), exports)),
+                );
+            });
         }
 
-        let write_guard = lib.packages.write();
+        let publish_gate = lib.packages_write.lock();
         let (tx, rx) = std::sync::mpsc::channel();
         let lib_for_reader = Arc::clone(&lib);
         let package_for_reader = package.clone();
@@ -2764,22 +2791,21 @@ mod tests {
                 .expect("reader result receiver should be alive");
         });
 
-        match rx.recv_timeout(std::time::Duration::from_millis(50)) {
-            Ok(value) => panic!("sync reader returned before write lock released: {value}"),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        let result = match rx.recv_timeout(std::time::Duration::from_secs(1)) {
+            Ok(value) => value,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("snapshot reader blocked while package publication gate was held")
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 panic!("reader thread disconnected before sending a result")
             }
-        }
+        };
 
-        drop(write_guard);
-        let result = rx
-            .recv_timeout(std::time::Duration::from_secs(1))
-            .expect("sync reader should finish after write lock is released");
+        drop(publish_gate);
         reader.join().expect("reader thread should not panic");
         assert!(
             result,
-            "sync reader must wait for the package cache and observe the seeded symbol"
+            "sync reader must observe the last published package snapshot"
         );
     }
 
@@ -2791,10 +2817,8 @@ mod tests {
         {
             let mut exports = HashSet::new();
             exports.insert(stable_symbol.clone());
-            lib.packages.write().insert(
-                stable_package.clone(),
-                Arc::new(PackageInfo::new(stable_package.clone(), exports)),
-            );
+            lib.insert_package(PackageInfo::new(stable_package.clone(), exports))
+                .await;
         }
 
         let mut tasks = Vec::new();
@@ -3947,12 +3971,12 @@ mod tests {
         lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
             .await;
         lib.get_all_exports("dplyr").await;
-        assert!(lib.combined_entries.read().contains_key("dplyr"));
+        assert!(lib.combined_entries.load().contains_key("dplyr"));
 
         lib.clear_cache().await;
 
         assert!(
-            lib.combined_entries.read().is_empty(),
+            lib.combined_entries.load().is_empty(),
             "clear_cache must clear aggregate entries"
         );
     }
@@ -3969,14 +3993,14 @@ mod tests {
         lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
             .await;
         lib.get_all_exports("tidyverse").await;
-        assert!(lib.combined_entries.read().contains_key("tidyverse"));
+        assert!(lib.combined_entries.load().contains_key("tidyverse"));
 
         let mut names = HashSet::new();
         names.insert("dplyr".to_string());
         lib.invalidate_many(&names).await;
 
         assert!(
-            !lib.combined_entries.read().contains_key("tidyverse"),
+            !lib.combined_entries.load().contains_key("tidyverse"),
             "invalidating dplyr must drop the tidyverse aggregate entry"
         );
     }
@@ -4081,7 +4105,7 @@ mod tests {
         assert!(warmed.contains("bar"));
 
         let cached = {
-            let cache = lib.combined_entries.read();
+            let cache = lib.combined_entries.load();
             cache
                 .get("pkg")
                 .map(|entry| Arc::clone(&entry.exports))
@@ -5150,10 +5174,7 @@ mod tests {
         // combined keys from cached PackageInfo.attached_packages.
         let tidyverse_info =
             PackageInfo::with_details("tidyverse".into(), HashSet::new(), vec![], vec![]);
-        {
-            let mut packages = lib.packages.write();
-            packages.insert("tidyverse".into(), std::sync::Arc::new(tidyverse_info));
-        }
+        lib.insert_package(tidyverse_info).await;
         // Seed combined_entries as though tidyverse had been loaded.
         seed_combined_entry(
             &lib,
@@ -5176,7 +5197,7 @@ mod tests {
         let set: HashSet<String> = ["dplyr".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_entries.read();
+        let combined = lib.combined_entries.load();
         assert!(!combined.contains_key("tidyverse"));
         assert!(!combined.contains_key("dplyr"));
 
@@ -5191,7 +5212,7 @@ mod tests {
         // on disk, so its individual entry should remain available for
         // subsequent re-aggregation.
         drop(combined);
-        let packages = lib.packages.read();
+        let packages = lib.packages.load();
         assert!(
             packages.contains_key("tidyverse"),
             "PackageInfo for tidyverse must survive invalidate_many"
@@ -5245,7 +5266,7 @@ mod tests {
         let set: HashSet<String> = ["B".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_entries.read();
+        let combined = lib.combined_entries.load();
         assert!(
             !combined.contains_key("A"),
             "A's combined_entries aggregate should be cleared when its dependency B is invalidated"

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -695,9 +695,8 @@ impl PackageLibrary {
     /// Removes the package from the cache, forcing it to be reloaded
     /// on the next access.
     pub async fn invalidate(&self, name: &str) {
-        self.update_packages(|cache| {
-            cache.remove(name);
-        });
+        let names = HashSet::from([name.to_string()]);
+        let _ = self.invalidate_many(&names).await;
     }
 
     /// Invalidate a batch of packages, also dropping any `combined_entries`
@@ -2538,12 +2537,37 @@ mod tests {
 
         let info = PackageInfo::new("testpkg".to_string(), HashSet::new());
         lib.insert_package(info).await;
+        lib.insert_package(PackageInfo::with_details(
+            "dependent".to_string(),
+            HashSet::new(),
+            vec!["testpkg".to_string()],
+            Vec::new(),
+        ))
+        .await;
+        seed_combined_entry(
+            &lib,
+            "testpkg",
+            ["stale_export".to_string()].into_iter().collect(),
+            HashMap::new(),
+        )
+        .await;
+        seed_combined_entry(
+            &lib,
+            "dependent",
+            ["dependent_export".to_string()].into_iter().collect(),
+            HashMap::new(),
+        )
+        .await;
 
         assert!(lib.is_cached("testpkg").await);
+        assert!(lib.combined_entries.load().contains_key("testpkg"));
+        assert!(lib.combined_entries.load().contains_key("dependent"));
 
         lib.invalidate("testpkg").await;
 
         assert!(!lib.is_cached("testpkg").await);
+        assert!(!lib.combined_entries.load().contains_key("testpkg"));
+        assert!(!lib.combined_entries.load().contains_key("dependent"));
     }
 
     #[tokio::test]

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -7,7 +7,7 @@
 // Requirement 13.1: THE Package_Cache SHALL store parsed exports per package
 // Requirement 13.4: THE Package_Cache SHALL support concurrent read access from multiple LSP handlers
 
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockReadGuard};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -97,6 +97,17 @@ fn meta_package_fields(name: &str) -> (bool, Vec<String>) {
 /// so it is negligible on the init / package-resolution path.
 fn is_readable_file(path: &Path) -> bool {
     path.is_file() && std::fs::File::open(path).is_ok()
+}
+
+/// Take a package-cache read guard, using the uncontended fast path but never
+/// treating contention as absence.
+///
+/// The pre-#414 bug was not `try_read()` itself; it was returning false/empty
+/// when `try_read()` failed. This helper preserves the blocking-read contract
+/// while avoiding the slower parking-lot blocking path when the lock is
+/// immediately available.
+fn cache_read<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    lock.try_read().unwrap_or_else(|| lock.read())
 }
 
 /// Cached package information
@@ -380,21 +391,32 @@ impl PackageLibrary {
     /// Aggregate entries win over direct per-package entries, preserving the
     /// existing "combined first, package fallback" behavior.
     fn cached_completion_entries(&self, loaded_packages: &[String]) -> Vec<CachedCompletionEntry> {
-        let combined_cache = self.combined_entries.read();
-        let packages_cache = self.packages.read();
-        let mut entries = Vec::new();
+        let combined_cache = cache_read(&self.combined_entries);
+        let packages_cache = cache_read(&self.packages);
+        let mut entries = Vec::with_capacity(loaded_packages.len());
 
-        for pkg_name in loaded_packages {
-            if let Some(entry) = combined_cache.get(pkg_name) {
-                entries.push(CachedCompletionEntry::Combined {
-                    loaded_package: pkg_name.clone(),
-                    entry: Arc::clone(entry),
-                });
-            } else if let Some(info) = packages_cache.get(pkg_name) {
-                entries.push(CachedCompletionEntry::Package {
-                    loaded_package: pkg_name.clone(),
-                    info: Arc::clone(info),
-                });
+        if combined_cache.is_empty() {
+            for pkg_name in loaded_packages {
+                if let Some(info) = packages_cache.get(pkg_name) {
+                    entries.push(CachedCompletionEntry::Package {
+                        loaded_package: pkg_name.clone(),
+                        info: Arc::clone(info),
+                    });
+                }
+            }
+        } else {
+            for pkg_name in loaded_packages {
+                if let Some(entry) = combined_cache.get(pkg_name) {
+                    entries.push(CachedCompletionEntry::Combined {
+                        loaded_package: pkg_name.clone(),
+                        entry: Arc::clone(entry),
+                    });
+                } else if let Some(info) = packages_cache.get(pkg_name) {
+                    entries.push(CachedCompletionEntry::Package {
+                        loaded_package: pkg_name.clone(),
+                        info: Arc::clone(info),
+                    });
+                }
             }
         }
 
@@ -425,12 +447,20 @@ impl PackageLibrary {
         &self,
         loaded_packages: &[String],
     ) -> std::collections::HashMap<String, Vec<String>> {
+        let entries = self.cached_completion_entries(loaded_packages);
+        let capacity = entries
+            .iter()
+            .map(|entry| match entry {
+                CachedCompletionEntry::Combined { entry, .. } => entry.exports.len(),
+                CachedCompletionEntry::Package { info, .. } => info.exports.len(),
+            })
+            .sum();
         let mut result: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
+            std::collections::HashMap::with_capacity(capacity);
 
         // Process packages in order (earlier packages appear first in the list)
         // Requirement 9.3: Show all packages that export the same symbol
-        for entry in self.cached_completion_entries(loaded_packages) {
+        for entry in entries {
             match entry {
                 CachedCompletionEntry::Combined {
                     loaded_package,
@@ -478,8 +508,16 @@ impl PackageLibrary {
         &self,
         loaded_packages: &[String],
     ) -> std::collections::HashMap<String, Vec<String>> {
+        let entries = self.cached_completion_entries(loaded_packages);
+        let capacity = entries
+            .iter()
+            .map(|entry| match entry {
+                CachedCompletionEntry::Combined { entry, .. } => entry.owners.len(),
+                CachedCompletionEntry::Package { info, .. } => info.exports.len(),
+            })
+            .sum();
         let mut result: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
+            std::collections::HashMap::with_capacity(capacity);
 
         let mut push_unique = |symbol: &str, owner: &str| {
             let owners = result.entry(symbol.to_string()).or_default();
@@ -487,7 +525,7 @@ impl PackageLibrary {
                 owners.push(owner.to_string());
             }
         };
-        for entry in self.cached_completion_entries(loaded_packages) {
+        for entry in entries {
             match entry {
                 CachedCompletionEntry::Combined { entry, .. } => {
                     for (symbol, owner) in entry.owners.iter() {
@@ -535,18 +573,20 @@ impl PackageLibrary {
 
         // Check combined_entries cache first (includes Depends/attached packages)
         {
-            let combined_cache = self.combined_entries.read();
-            for pkg_name in loaded_packages {
-                if let Some(entry) = combined_cache.get(pkg_name)
-                    && entry.exports.contains(symbol)
-                {
-                    return true;
+            let combined_cache = cache_read(&self.combined_entries);
+            if !combined_cache.is_empty() {
+                for pkg_name in loaded_packages {
+                    if let Some(entry) = combined_cache.get(pkg_name)
+                        && entry.exports.contains(symbol)
+                    {
+                        return true;
+                    }
                 }
             }
         }
 
         // Fall back to per-package exports cache
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
 
         // Check each loaded package
         for pkg_name in loaded_packages {
@@ -565,13 +605,13 @@ impl PackageLibrary {
     /// This is a synchronous method that only checks the cache.
     /// For loading packages that aren't cached, use `get_package()`.
     pub async fn get_cached_package(&self, name: &str) -> Option<Arc<PackageInfo>> {
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
         cache.get(name).cloned()
     }
 
     /// Check if a package is cached
     pub async fn is_cached(&self, name: &str) -> bool {
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
         cache.contains_key(name)
     }
 
@@ -600,12 +640,12 @@ impl PackageLibrary {
     /// Returns true when package metadata is currently cached, false otherwise.
     /// Takes a brief blocking read lock so contention is never interpreted as absence.
     pub fn is_cached_sync(&self, name: &str) -> bool {
-        self.packages.read().contains_key(name)
+        cache_read(&self.packages).contains_key(name)
     }
 
     /// Get the number of cached packages
     pub async fn cached_count(&self) -> usize {
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
         cache.len()
     }
 
@@ -658,7 +698,7 @@ impl PackageLibrary {
         // mutating it so the dependent lookup sees the previous
         // `depends`/`attached_packages` graph.
         let dependent_combined_keys: HashSet<String> = {
-            let cache = self.packages.read();
+            let cache = cache_read(&self.packages);
             // Worklist: start with the directly invalidated names, then
             // transitively find every cached package that depends on them.
             let mut frontier: HashSet<String> = names.clone();
@@ -728,7 +768,7 @@ impl PackageLibrary {
 
     /// Snapshot of the keys currently in the per-package cache.
     pub async fn cached_package_names(&self) -> HashSet<String> {
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
         cache.keys().cloned().collect()
     }
 
@@ -787,8 +827,8 @@ impl PackageLibrary {
 
         // Filter out packages we've already cached
         let uncached_packages: Vec<String> = {
-            let combined_cache = self.combined_entries.read();
-            let packages_cache = self.packages.read();
+            let combined_cache = cache_read(&self.combined_entries);
+            let packages_cache = cache_read(&self.packages);
             packages
                 .iter()
                 .filter(|p| !combined_cache.contains_key(*p) && !packages_cache.contains_key(*p))
@@ -961,7 +1001,7 @@ impl PackageLibrary {
         symbol: &str,
         loaded_packages: &[String],
     ) -> Option<String> {
-        let cache = self.packages.read();
+        let cache = cache_read(&self.packages);
         for pkg_name in loaded_packages {
             if let Some(info) = cache.get(pkg_name)
                 && info.exports.contains(symbol)
@@ -983,12 +1023,14 @@ impl PackageLibrary {
     ) -> Option<String> {
         // Check combined_entries cache first
         {
-            let cache = self.combined_entries.read();
-            for pkg_name in loaded_packages {
-                if let Some(entry) = cache.get(pkg_name)
-                    && entry.exports.contains(symbol)
-                {
-                    return Some(pkg_name.clone());
+            let cache = cache_read(&self.combined_entries);
+            if !cache.is_empty() {
+                for pkg_name in loaded_packages {
+                    if let Some(entry) = cache.get(pkg_name)
+                        && entry.exports.contains(symbol)
+                    {
+                        return Some(pkg_name.clone());
+                    }
                 }
             }
         }
@@ -1018,14 +1060,16 @@ impl PackageLibrary {
         // `tidyverse`). If the entry says the symbol is available but lacks an
         // owner, fail closed rather than falling back to aggregate attribution.
         {
-            let cache = self.combined_entries.read();
-            for pkg_name in loaded_packages {
-                if let Some(entry) = cache.get(pkg_name) {
-                    if let Some(owner) = entry.owners.get(symbol) {
-                        return Some(owner.clone());
-                    }
-                    if entry.exports.contains(symbol) {
-                        return None;
+            let cache = cache_read(&self.combined_entries);
+            if !cache.is_empty() {
+                for pkg_name in loaded_packages {
+                    if let Some(entry) = cache.get(pkg_name) {
+                        if let Some(owner) = entry.owners.get(symbol) {
+                            return Some(owner.clone());
+                        }
+                        if entry.exports.contains(symbol) {
+                            return None;
+                        }
                     }
                 }
             }
@@ -1675,7 +1719,7 @@ impl PackageLibrary {
     async fn warm_all_exports(&self, name: &str) -> Arc<HashSet<String>> {
         // Check cache first
         {
-            let cache = self.combined_entries.read();
+            let cache = cache_read(&self.combined_entries);
             if let Some(cached) = cache.get(name) {
                 log::trace!("Using cached combined exports for package '{}'", name);
                 return Arc::clone(&cached.exports);

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -7,10 +7,10 @@
 // Requirement 13.1: THE Package_Cache SHALL store parsed exports per package
 // Requirement 13.4: THE Package_Cache SHALL support concurrent read access from multiple LSP handlers
 
+use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 use crate::namespace_parser::{
     parse_data_symbols, parse_description_depends, parse_index_exports, parse_namespace_exports,
@@ -226,6 +226,16 @@ impl CombinedEntry {
         }
     }
 }
+enum CachedCompletionEntry {
+    Combined {
+        loaded_package: String,
+        entry: Arc<CombinedEntry>,
+    },
+    Package {
+        loaded_package: String,
+        info: Arc<PackageInfo>,
+    },
+}
 
 /// Package library manager
 ///
@@ -363,6 +373,34 @@ impl PackageLibrary {
         None
     }
 
+    /// Clone only the cache entry handles needed by completion readers.
+    ///
+    /// Completion materialization can clone many strings, so the cache read
+    /// locks are held only for the O(loaded_packages) lookup/Arc-clone phase.
+    /// Aggregate entries win over direct per-package entries, preserving the
+    /// existing "combined first, package fallback" behavior.
+    fn cached_completion_entries(&self, loaded_packages: &[String]) -> Vec<CachedCompletionEntry> {
+        let combined_cache = self.combined_entries.read();
+        let packages_cache = self.packages.read();
+        let mut entries = Vec::new();
+
+        for pkg_name in loaded_packages {
+            if let Some(entry) = combined_cache.get(pkg_name) {
+                entries.push(CachedCompletionEntry::Combined {
+                    loaded_package: pkg_name.clone(),
+                    entry: Arc::clone(entry),
+                });
+            } else if let Some(info) = packages_cache.get(pkg_name) {
+                entries.push(CachedCompletionEntry::Package {
+                    loaded_package: pkg_name.clone(),
+                    info: Arc::clone(info),
+                });
+            }
+        }
+
+        entries
+    }
+
     /// Get all exports from loaded packages for completions (synchronous, cached-only)
     ///
     /// This method returns a map of symbol name to package name for all exports
@@ -370,7 +408,8 @@ impl PackageLibrary {
     /// preferring combined_entries cache (includes Depends/attached) when available.
     ///
     /// This is a synchronous method suitable for use in completion handlers where
-    /// we cannot use async. It uses `try_read()` to avoid blocking.
+    /// we cannot use async. It takes brief blocking read locks and clones only
+    /// the relevant cache entry handles before materializing completion strings.
     ///
     /// Returns a HashMap where:
     /// - Key: export name (symbol)
@@ -389,42 +428,31 @@ impl PackageLibrary {
         let mut result: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
 
-        // Try combined_entries cache first (includes Depends/attached packages)
-        let combined_cache = self.combined_entries.try_read().ok();
-        let packages_cache = self.packages.try_read().ok();
-
-        if combined_cache.is_none() && packages_cache.is_none() {
-            log::trace!(
-                "Could not acquire any package cache lock for completions, returning empty"
-            );
-            return result;
-        }
-
         // Process packages in order (earlier packages appear first in the list)
         // Requirement 9.3: Show all packages that export the same symbol
-        for pkg_name in loaded_packages {
-            // Try combined_entries first
-            if let Some(ref cache) = combined_cache
-                && let Some(entry) = cache.get(pkg_name)
-            {
-                for export in entry.exports.iter() {
-                    result
-                        .entry(export.clone())
-                        .or_default()
-                        .push(pkg_name.clone());
+        for entry in self.cached_completion_entries(loaded_packages) {
+            match entry {
+                CachedCompletionEntry::Combined {
+                    loaded_package,
+                    entry,
+                } => {
+                    for export in entry.exports.iter() {
+                        result
+                            .entry(export.clone())
+                            .or_default()
+                            .push(loaded_package.clone());
+                    }
                 }
-                continue; // Found in combined cache, skip per-package lookup
-            }
-
-            // Fall back to per-package exports
-            if let Some(ref cache) = packages_cache
-                && let Some(info) = cache.get(pkg_name)
-            {
-                for export in &info.exports {
-                    result
-                        .entry(export.clone())
-                        .or_default()
-                        .push(pkg_name.clone());
+                CachedCompletionEntry::Package {
+                    loaded_package,
+                    info,
+                } => {
+                    for export in &info.exports {
+                        result
+                            .entry(export.clone())
+                            .or_default()
+                            .push(loaded_package.clone());
+                    }
                 }
             }
         }
@@ -438,13 +466,14 @@ impl PackageLibrary {
     /// (the documentation owner) so completion detail (`{dplyr}`) and the
     /// resolve `data.package` open the correct help topic. See issue #407.
     ///
-    /// Synchronous and cached-only (`try_read`). A cached aggregate entry is a
-    /// single availability/ownership snapshot, so owner-sensitive completion
-    /// never falls back from a present aggregate entry to loaded-package
-    /// attribution. If no aggregate entry exists yet, it falls back to the
-    /// per-package cache, preserving the previous direct-package behavior.
-    /// Owners are de-duplicated per symbol (two loaded aggregates can resolve
-    /// to the same owner).
+    /// Synchronous and cached-only. It takes brief blocking read locks and
+    /// clones only relevant cache entry handles before materializing completion
+    /// strings. A cached aggregate entry is a single availability/ownership
+    /// snapshot, so owner-sensitive completion never falls back from a present
+    /// aggregate entry to loaded-package attribution. If no aggregate entry
+    /// exists yet, it falls back to the per-package cache, preserving the
+    /// previous direct-package behavior. Owners are de-duplicated per symbol
+    /// (two loaded aggregates can resolve to the same owner).
     pub fn get_owned_exports_for_completions(
         &self,
         loaded_packages: &[String],
@@ -452,39 +481,26 @@ impl PackageLibrary {
         let mut result: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
 
-        let combined_cache = self.combined_entries.try_read().ok();
-        let packages_cache = self.packages.try_read().ok();
-        if combined_cache.is_none() && packages_cache.is_none() {
-            log::trace!(
-                "Could not acquire any package cache lock for owned completions, returning empty"
-            );
-            return result;
-        }
-
         let mut push_unique = |symbol: &str, owner: &str| {
             let owners = result.entry(symbol.to_string()).or_default();
             if !owners.iter().any(|o| o == owner) {
                 owners.push(owner.to_string());
             }
         };
-
-        for pkg_name in loaded_packages {
-            // Prefer the aggregate entry: it covers exactly the symbols in the
-            // combined set and attributes each to its true contributor.
-            if let Some(ref cache) = combined_cache
-                && let Some(entry) = cache.get(pkg_name)
-            {
-                for (symbol, owner) in entry.owners.iter() {
-                    push_unique(symbol, owner);
+        for entry in self.cached_completion_entries(loaded_packages) {
+            match entry {
+                CachedCompletionEntry::Combined { entry, .. } => {
+                    for (symbol, owner) in entry.owners.iter() {
+                        push_unique(symbol, owner);
+                    }
                 }
-                continue;
-            }
-            // Fall back to per-package exports, attributing to the loaded package.
-            if let Some(ref cache) = packages_cache
-                && let Some(info) = cache.get(pkg_name)
-            {
-                for export in &info.exports {
-                    push_unique(export, pkg_name);
+                CachedCompletionEntry::Package {
+                    loaded_package,
+                    info,
+                } => {
+                    for export in &info.exports {
+                        push_unique(export, &loaded_package);
+                    }
                 }
             }
         }
@@ -500,7 +516,8 @@ impl PackageLibrary {
     /// to per-package exports cache.
     ///
     /// This is a synchronous method suitable for use in diagnostic collection where
-    /// we cannot use async. It uses `try_read()` to avoid blocking.
+    /// we cannot use async. It takes brief blocking read locks so contention is
+    /// never interpreted as absence.
     ///
     /// Returns true if:
     /// - The symbol is a base export, OR
@@ -508,7 +525,6 @@ impl PackageLibrary {
     ///
     /// Returns false if:
     /// - The symbol is not found in base exports or any cached loaded package
-    /// - The cache lock cannot be acquired (returns false to be conservative)
     ///
     /// Requirements 8.1, 8.2: Check if symbol is exported by loaded packages at position
     pub fn is_symbol_from_loaded_packages(&self, symbol: &str, loaded_packages: &[String]) -> bool {
@@ -517,8 +533,9 @@ impl PackageLibrary {
             return true;
         }
 
-        // Try combined_entries cache first (includes Depends/attached packages)
-        if let Ok(combined_cache) = self.combined_entries.try_read() {
+        // Check combined_entries cache first (includes Depends/attached packages)
+        {
+            let combined_cache = self.combined_entries.read();
             for pkg_name in loaded_packages {
                 if let Some(entry) = combined_cache.get(pkg_name)
                     && entry.exports.contains(symbol)
@@ -529,16 +546,7 @@ impl PackageLibrary {
         }
 
         // Fall back to per-package exports cache
-        let cache = match self.packages.try_read() {
-            Ok(guard) => guard,
-            Err(_) => {
-                log::trace!(
-                    "Could not acquire package cache lock for symbol '{}', returning false",
-                    symbol
-                );
-                return false;
-            }
-        };
+        let cache = self.packages.read();
 
         // Check each loaded package
         for pkg_name in loaded_packages {
@@ -557,13 +565,13 @@ impl PackageLibrary {
     /// This is a synchronous method that only checks the cache.
     /// For loading packages that aren't cached, use `get_package()`.
     pub async fn get_cached_package(&self, name: &str) -> Option<Arc<PackageInfo>> {
-        let cache = self.packages.read().await;
+        let cache = self.packages.read();
         cache.get(name).cloned()
     }
 
     /// Check if a package is cached
     pub async fn is_cached(&self, name: &str) -> bool {
-        let cache = self.packages.read().await;
+        let cache = self.packages.read();
         cache.contains_key(name)
     }
 
@@ -590,17 +598,14 @@ impl PackageLibrary {
     /// Synchronous cache probe for use in hot diagnostic paths.
     ///
     /// Returns true when package metadata is currently cached, false otherwise.
-    /// Uses `try_read()` to avoid blocking.
+    /// Takes a brief blocking read lock so contention is never interpreted as absence.
     pub fn is_cached_sync(&self, name: &str) -> bool {
-        self.packages
-            .try_read()
-            .map(|cache| cache.contains_key(name))
-            .unwrap_or(false)
+        self.packages.read().contains_key(name)
     }
 
     /// Get the number of cached packages
     pub async fn cached_count(&self) -> usize {
-        let cache = self.packages.read().await;
+        let cache = self.packages.read();
         cache.len()
     }
 
@@ -608,7 +613,7 @@ impl PackageLibrary {
     ///
     /// This is primarily used for testing and initialization.
     pub async fn insert_package(&self, info: PackageInfo) {
-        let mut cache = self.packages.write().await;
+        let mut cache = self.packages.write();
         cache.insert(info.name.clone(), Arc::new(info));
     }
 
@@ -617,7 +622,7 @@ impl PackageLibrary {
     /// Removes the package from the cache, forcing it to be reloaded
     /// on the next access.
     pub async fn invalidate(&self, name: &str) {
-        let mut cache = self.packages.write().await;
+        let mut cache = self.packages.write();
         cache.remove(name);
     }
 
@@ -645,7 +650,7 @@ impl PackageLibrary {
         // mutating it so the dependent lookup sees the previous
         // `depends`/`attached_packages` graph.
         let dependent_combined_keys: HashSet<String> = {
-            let cache = self.packages.read().await;
+            let cache = self.packages.read();
             // Worklist: start with the directly invalidated names, then
             // transitively find every cached package that depends on them.
             let mut frontier: HashSet<String> = names.clone();
@@ -674,14 +679,14 @@ impl PackageLibrary {
             dependents
         };
         {
-            let mut cache = self.packages.write().await;
+            let mut cache = self.packages.write();
             for n in names {
                 cache.remove(n);
             }
         }
         let mut invalidated_combined: HashSet<String> = HashSet::new();
         {
-            let mut combined = self.combined_entries.write().await;
+            let mut combined = self.combined_entries.write();
             // Drop direct hits; record only the ones that were actually present.
             for n in names {
                 if combined.remove(n).is_some() {
@@ -715,17 +720,17 @@ impl PackageLibrary {
 
     /// Snapshot of the keys currently in the per-package cache.
     pub async fn cached_package_names(&self) -> HashSet<String> {
-        let cache = self.packages.read().await;
+        let cache = self.packages.read();
         cache.keys().cloned().collect()
     }
 
     /// Clear all cached packages, including aggregate `combined_entries`.
     pub async fn clear_cache(&self) {
         {
-            let mut cache = self.packages.write().await;
+            let mut cache = self.packages.write();
             cache.clear();
         }
-        let mut combined = self.combined_entries.write().await;
+        let mut combined = self.combined_entries.write();
         combined.clear();
     }
 
@@ -774,8 +779,8 @@ impl PackageLibrary {
 
         // Filter out packages we've already cached
         let uncached_packages: Vec<String> = {
-            let combined_cache = self.combined_entries.read().await;
-            let packages_cache = self.packages.read().await;
+            let combined_cache = self.combined_entries.read();
+            let packages_cache = self.packages.read();
             packages
                 .iter()
                 .filter(|p| !combined_cache.contains_key(*p) && !packages_cache.contains_key(*p))
@@ -942,20 +947,18 @@ impl PackageLibrary {
     /// [`find_package_owner_for_symbol`]: returns the first loaded package whose
     /// own (non-aggregate) cached exports contain `symbol`. Centralizing the loop
     /// keeps availability and owner attribution from diverging on direct-package
-    /// lookup. Returns `None` if the `packages` lock is contended (`try_read`
-    /// miss) or no loaded package exports the symbol.
+    /// lookup. Returns `None` if no loaded package exports the symbol.
     fn find_in_per_package_cache(
         &self,
         symbol: &str,
         loaded_packages: &[String],
     ) -> Option<String> {
-        if let Ok(cache) = self.packages.try_read() {
-            for pkg_name in loaded_packages {
-                if let Some(info) = cache.get(pkg_name)
-                    && info.exports.contains(symbol)
-                {
-                    return Some(pkg_name.clone());
-                }
+        let cache = self.packages.read();
+        for pkg_name in loaded_packages {
+            if let Some(info) = cache.get(pkg_name)
+                && info.exports.contains(symbol)
+            {
+                return Some(pkg_name.clone());
             }
         }
         None
@@ -971,7 +974,8 @@ impl PackageLibrary {
         loaded_packages: &[String],
     ) -> Option<String> {
         // Check combined_entries cache first
-        if let Ok(cache) = self.combined_entries.try_read() {
+        {
+            let cache = self.combined_entries.read();
             for pkg_name in loaded_packages {
                 if let Some(entry) = cache.get(pkg_name)
                     && entry.exports.contains(symbol)
@@ -1005,7 +1009,8 @@ impl PackageLibrary {
         // the true contributor (e.g. `dplyr` for a `mutate` made visible through
         // `tidyverse`). If the entry says the symbol is available but lacks an
         // owner, fail closed rather than falling back to aggregate attribution.
-        if let Ok(cache) = self.combined_entries.try_read() {
+        {
+            let cache = self.combined_entries.read();
             for pkg_name in loaded_packages {
                 if let Some(entry) = cache.get(pkg_name) {
                     if let Some(owner) = entry.owners.get(symbol) {
@@ -1662,7 +1667,7 @@ impl PackageLibrary {
     async fn warm_all_exports(&self, name: &str) -> Arc<HashSet<String>> {
         // Check cache first
         {
-            let cache = self.combined_entries.read().await;
+            let cache = self.combined_entries.read();
             if let Some(cached) = cache.get(name) {
                 log::trace!("Using cached combined exports for package '{}'", name);
                 return Arc::clone(&cached.exports);
@@ -1683,7 +1688,7 @@ impl PackageLibrary {
         // hot-path readers can never observe a combined export without the
         // matching owner attribution.
         {
-            let mut cache = self.combined_entries.write().await;
+            let mut cache = self.combined_entries.write();
             let cached = Arc::new(CombinedEntry::new(all_exports, owners));
             cache.insert(name.to_string(), Arc::clone(&cached));
             log::trace!(
@@ -2069,7 +2074,7 @@ mod tests {
         exports: HashSet<String>,
         owners: HashMap<String, String>,
     ) {
-        lib.combined_entries.write().await.insert(
+        lib.combined_entries.write().insert(
             name.to_string(),
             Arc::new(CombinedEntry::new(exports, owners)),
         );
@@ -2552,12 +2557,12 @@ mod tests {
         .await;
 
         assert_eq!(lib.cached_count().await, 2);
-        assert!(lib.combined_entries.read().await.contains_key("pkg1"));
+        assert!(lib.combined_entries.read().contains_key("pkg1"));
 
         lib.clear_cache().await;
 
         assert_eq!(lib.cached_count().await, 0);
-        assert!(lib.combined_entries.read().await.is_empty());
+        assert!(lib.combined_entries.read().is_empty());
     }
 
     #[tokio::test]
@@ -2679,6 +2684,111 @@ mod tests {
         for handle in handles {
             let result = handle.await;
             assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn sync_reader_blocks_on_package_cache_contention_instead_of_missing() {
+        let lib = Arc::new(PackageLibrary::new_empty());
+        let package = "ravencontentionpkg".to_string();
+        let symbol = "raven_contention_symbol".to_string();
+        {
+            let mut exports = HashSet::new();
+            exports.insert(symbol.clone());
+            lib.packages.write().insert(
+                package.clone(),
+                Arc::new(PackageInfo::new(package.clone(), exports)),
+            );
+        }
+
+        let write_guard = lib.packages.write();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let lib_for_reader = Arc::clone(&lib);
+        let package_for_reader = package.clone();
+        let symbol_for_reader = symbol.clone();
+        let reader = std::thread::spawn(move || {
+            let loaded = vec![package_for_reader];
+            tx.send(lib_for_reader.is_symbol_from_loaded_packages(&symbol_for_reader, &loaded))
+                .expect("reader result receiver should be alive");
+        });
+
+        match rx.recv_timeout(std::time::Duration::from_millis(50)) {
+            Ok(value) => panic!("sync reader returned before write lock released: {value}"),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("reader thread disconnected before sending a result")
+            }
+        }
+
+        drop(write_guard);
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("sync reader should finish after write lock is released");
+        reader.join().expect("reader thread should not panic");
+        assert!(
+            result,
+            "sync reader must wait for the package cache and observe the seeded symbol"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sync_readers_stay_correct_during_unrelated_package_churn() {
+        let lib = Arc::new(PackageLibrary::new_empty());
+        let stable_package = "ravenstablepkg".to_string();
+        let stable_symbol = "raven_stable_symbol".to_string();
+        {
+            let mut exports = HashSet::new();
+            exports.insert(stable_symbol.clone());
+            lib.packages.write().insert(
+                stable_package.clone(),
+                Arc::new(PackageInfo::new(stable_package.clone(), exports)),
+            );
+        }
+
+        let mut tasks = Vec::new();
+        for writer_id in 0..4 {
+            let lib = Arc::clone(&lib);
+            tasks.push(tokio::spawn(async move {
+                for i in 0..100 {
+                    let package = format!("ravenchurnpkg{writer_id}_{i}");
+                    let mut exports = HashSet::new();
+                    exports.insert(format!("raven_churn_symbol_{writer_id}_{i}"));
+                    lib.insert_package(PackageInfo::new(package.clone(), exports))
+                        .await;
+                    let to_invalidate: HashSet<String> = [package].into_iter().collect();
+                    lib.invalidate_many(&to_invalidate).await;
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+
+        for _ in 0..4 {
+            let lib = Arc::clone(&lib);
+            let loaded = vec![stable_package.clone()];
+            let stable_package = stable_package.clone();
+            let stable_symbol = stable_symbol.clone();
+            tasks.push(tokio::spawn(async move {
+                for _ in 0..200 {
+                    assert!(
+                        lib.is_symbol_from_loaded_packages(&stable_symbol, &loaded),
+                        "stable symbol must remain available during unrelated cache churn"
+                    );
+                    assert_eq!(
+                        lib.find_package_owner_for_symbol(&stable_symbol, &loaded),
+                        Some(stable_package.clone())
+                    );
+                    let completions = lib.get_owned_exports_for_completions(&loaded);
+                    assert_eq!(
+                        completions.get(&stable_symbol),
+                        Some(&vec![stable_package.clone()])
+                    );
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+
+        for task in tasks {
+            task.await.expect("contention stress task should not panic");
         }
     }
 
@@ -3785,12 +3895,12 @@ mod tests {
         lib.insert_package(PackageInfo::new("dplyr".to_string(), dplyr_exports))
             .await;
         lib.get_all_exports("dplyr").await;
-        assert!(lib.combined_entries.read().await.contains_key("dplyr"));
+        assert!(lib.combined_entries.read().contains_key("dplyr"));
 
         lib.clear_cache().await;
 
         assert!(
-            lib.combined_entries.read().await.is_empty(),
+            lib.combined_entries.read().is_empty(),
             "clear_cache must clear aggregate entries"
         );
     }
@@ -3807,14 +3917,14 @@ mod tests {
         lib.insert_package(PackageInfo::new("tidyverse".to_string(), HashSet::new()))
             .await;
         lib.get_all_exports("tidyverse").await;
-        assert!(lib.combined_entries.read().await.contains_key("tidyverse"));
+        assert!(lib.combined_entries.read().contains_key("tidyverse"));
 
         let mut names = HashSet::new();
         names.insert("dplyr".to_string());
         lib.invalidate_many(&names).await;
 
         assert!(
-            !lib.combined_entries.read().await.contains_key("tidyverse"),
+            !lib.combined_entries.read().contains_key("tidyverse"),
             "invalidating dplyr must drop the tidyverse aggregate entry"
         );
     }
@@ -3919,7 +4029,7 @@ mod tests {
         assert!(warmed.contains("bar"));
 
         let cached = {
-            let cache = lib.combined_entries.read().await;
+            let cache = lib.combined_entries.read();
             cache
                 .get("pkg")
                 .map(|entry| Arc::clone(&entry.exports))
@@ -4989,7 +5099,7 @@ mod tests {
         let tidyverse_info =
             PackageInfo::with_details("tidyverse".into(), HashSet::new(), vec![], vec![]);
         {
-            let mut packages = lib.packages.write().await;
+            let mut packages = lib.packages.write();
             packages.insert("tidyverse".into(), std::sync::Arc::new(tidyverse_info));
         }
         // Seed combined_entries as though tidyverse had been loaded.
@@ -5014,7 +5124,7 @@ mod tests {
         let set: HashSet<String> = ["dplyr".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_entries.read().await;
+        let combined = lib.combined_entries.read();
         assert!(!combined.contains_key("tidyverse"));
         assert!(!combined.contains_key("dplyr"));
 
@@ -5029,7 +5139,7 @@ mod tests {
         // on disk, so its individual entry should remain available for
         // subsequent re-aggregation.
         drop(combined);
-        let packages = lib.packages.read().await;
+        let packages = lib.packages.read();
         assert!(
             packages.contains_key("tidyverse"),
             "PackageInfo for tidyverse must survive invalidate_many"
@@ -5083,7 +5193,7 @@ mod tests {
         let set: HashSet<String> = ["B".to_string()].into_iter().collect();
         let invalidated = lib.invalidate_many(&set).await;
 
-        let combined = lib.combined_entries.read().await;
+        let combined = lib.combined_entries.read();
         assert!(
             !combined.contains_key("A"),
             "A's combined_entries aggregate should be cleared when its dependency B is invalidated"

--- a/docs/development.md
+++ b/docs/development.md
@@ -294,7 +294,7 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
-`PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both use `parking_lot::RwLock<HashMap<...>>`. Synchronous cache readers use the `cache_read` helper: it takes the uncontended `try_read()` fast path, but falls back to a blocking `read()` on contention. Lock contention is never semantic absence, so a contended cache must wait briefly rather than returning false/empty and producing transient diagnostics. Keep these guards small and never hold them across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles under the guard and do string iteration/dedupe after dropping it. Writers should likewise keep write sections narrow and acquire the two maps sequentially rather than nesting locks.
+`PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both are atomic read-copy snapshots (`arc_swap::ArcSwap<HashMap<...>>`) with a small writer mutex per map to serialize copy-on-write publication. Synchronous cache readers load an immutable snapshot and do normal `HashMap` lookups, so an in-progress writer publication is never semantic absence and cannot produce transient diagnostics. Writers clone the current map, mutate the clone, and publish a new `Arc<HashMap<...>>`; keep those publication sections small and never hold a writer mutex across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Multi-map operations such as invalidation publish the two maps sequentially rather than nesting writer gates. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles from snapshots before doing string iteration/dedupe.
 
 ### Availability vs. ownership: unified aggregate entries (#407)
 
@@ -305,7 +305,7 @@ Key ideas:
 The entry is published and invalidated as one immutable snapshot so a reader cannot observe aggregate availability without matching ownership. As recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export.
 
 Lookups:
-- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry through the blocking cached-read contract above. If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
+- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry through the snapshot cache contract above. If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
 - `get_owned_exports_for_completions(loaded_packages)` mirrors `get_exports_for_completions` but attributes each symbol to its owner for completion detail / resolve `data.package`.
 - `is_symbol_from_loaded_packages` reads `exports` only — availability stays a pure yes/no check.
 
@@ -408,8 +408,8 @@ contaminated by Tier 2/3 guesses. Construction is split into
 
 ### Performance discipline (§12)
 
-The LSP hot path (diagnostic collection) reads the in-memory caches with short
-`parking_lot` read guards via `cache_read` and must not take a disk/page-fault stall. So:
+The LSP hot path (diagnostic collection) reads the in-memory package caches from
+already-published snapshots and must not take a disk/page-fault stall. So:
 
 - the Tier 3 index is **preloaded at open**; per-package payloads decode lazily
   from the mmap on first lookup;

--- a/docs/development.md
+++ b/docs/development.md
@@ -294,7 +294,7 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
-`PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both use `parking_lot::RwLock<HashMap<...>>`. Synchronous cache readers must take blocking read locks, not `try_read()`: lock contention is never semantic absence, so a contended cache must wait briefly rather than returning false/empty and producing transient diagnostics. Keep these guards small and never hold them across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles under the guard and do string iteration/dedupe after dropping it. Writers should likewise keep write sections narrow and acquire the two maps sequentially rather than nesting locks.
+`PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both use `parking_lot::RwLock<HashMap<...>>`. Synchronous cache readers use the `cache_read` helper: it takes the uncontended `try_read()` fast path, but falls back to a blocking `read()` on contention. Lock contention is never semantic absence, so a contended cache must wait briefly rather than returning false/empty and producing transient diagnostics. Keep these guards small and never hold them across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles under the guard and do string iteration/dedupe after dropping it. Writers should likewise keep write sections narrow and acquire the two maps sequentially rather than nesting locks.
 
 ### Availability vs. ownership: unified aggregate entries (#407)
 
@@ -409,7 +409,7 @@ contaminated by Tier 2/3 guesses. Construction is split into
 ### Performance discipline (§12)
 
 The LSP hot path (diagnostic collection) reads the in-memory caches with short
-blocking `parking_lot` read guards and must not take a disk/page-fault stall. So:
+`parking_lot` read guards via `cache_read` and must not take a disk/page-fault stall. So:
 
 - the Tier 3 index is **preloaded at open**; per-package payloads decode lazily
   from the mmap on first lookup;

--- a/docs/development.md
+++ b/docs/development.md
@@ -251,6 +251,8 @@ A diagnostics gate enforces monotonic publishing:
 
 See `crates/raven/src/cross_file/revalidation.rs`.
 
+Raven intentionally keeps `tower-lsp` at `.concurrency_level(1)` so text-sync notifications remain ordered. Do not use global LSP concurrency to speed up diagnostics. Dependency-triggered fan-out is localized in `crates/raven/src/backend.rs`: `publish_diagnostics_for_uris_bounded` runs the normal debounced diagnostic pipeline for an already-computed URI set with a small fixed concurrency limit (`DIAGNOSTIC_FANOUT_CONCURRENCY`). Each worker rebuilds its own snapshot and commits through the monotonic gate.
+
 ### Interactive request cancellation
 
 Raven keeps `tower-lsp` at `.concurrency_level(1)` to preserve ordered text sync, which means tower-lsp's built-in `$/cancelRequest` notification can be delayed behind the in-flight request it is supposed to cancel. `start_lsp()` wraps the `LspService` in `RequestCancellationService`, which intercepts `$/cancelRequest` synchronously in `Service::call` and records cancellations in a request-id keyed registry before tower-lsp queues the notification.
@@ -292,6 +294,8 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
+`PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both use `parking_lot::RwLock<HashMap<...>>`. Synchronous cache readers must take blocking read locks, not `try_read()`: lock contention is never semantic absence, so a contended cache must wait briefly rather than returning false/empty and producing transient diagnostics. Keep these guards small and never hold them across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles under the guard and do string iteration/dedupe after dropping it. Writers should likewise keep write sections narrow and acquire the two maps sequentially rather than nesting locks.
+
 ### Availability vs. ownership: unified aggregate entries (#407)
 
 `combined_entries[pkg]` is the aggregate cache built by `get_all_exports` / `collect_exports_recursive`. Each `CombinedEntry` stores two projections from the same traversal:
@@ -301,7 +305,7 @@ Key ideas:
 The entry is published and invalidated as one immutable snapshot so a reader cannot observe aggregate availability without matching ownership. As recursion visits each contributor it records `owners.entry(symbol).or_insert(contributing_pkg)`. **First contributor wins**, and because the aggregate root is visited before its `depends`/`attached` members, the root owns its own exports while a member owns only symbols the root does not export itself. A symbol the root genuinely re-exports in its own namespace is attributed to the root — an accepted limitation, since names alone cannot tell a re-export from an original export.
 
 Lookups:
-- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry (`try_read`). If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
+- `find_package_owner_for_symbol(symbol, loaded_packages)` consults the unified entry through the blocking cached-read contract above. If a present aggregate entry says the symbol is available but lacks ownership, it fails closed instead of falling back to aggregate attribution. If no aggregate entry is warmed, it falls back only to direct per-package exports. Used by hover, the help panel, signature help, the parameter resolver, and the NSE callee resolver (`resolve_call_arg_policy` step 3.5, before the standard-eval fallback).
 - `get_owned_exports_for_completions(loaded_packages)` mirrors `get_exports_for_completions` but attributes each symbol to its owner for completion detail / resolve `data.package`.
 - `is_symbol_from_loaded_packages` reads `exports` only — availability stays a pure yes/no check.
 
@@ -404,8 +408,8 @@ contaminated by Tier 2/3 guesses. Construction is split into
 
 ### Performance discipline (§12)
 
-The LSP hot path (diagnostic collection) reads the in-memory cache `try_read`-only
-and must not take a disk/page-fault stall. So:
+The LSP hot path (diagnostic collection) reads the in-memory caches with short
+blocking `parking_lot` read guards and must not take a disk/page-fault stall. So:
 
 - the Tier 3 index is **preloaded at open**; per-package payloads decode lazily
   from the mmap on first lookup;
@@ -418,7 +422,7 @@ and must not take a disk/page-fault stall. So:
   (decision #13) — ~10–20 ms once during library init, off the async runtime —
   catching truncation/corruption/tampering;
 - provider results feed the existing per-package cache, so steady-state lookups
-  are lock-free reads with no provider call.
+  stay in-memory and make no provider call.
 
 ### Tier 3 build pipeline
 


### PR DESCRIPTION
## Summary
- Fixes #414 by switching PackageLibrary package caches to `parking_lot::RwLock` and using blocking cached reads so lock contention is not treated as package/export absence.
- Keeps cache lock scopes short by cloning relevant `Arc` handles under guards and doing completion materialization outside the locks.
- Adds targeted bounded diagnostic fan-out for dependency-triggered republishing while preserving global ordered LSP dispatch.
- Documents the new cache-lock and diagnostic fan-out invariants in `docs/development.md`.

## Validation
- `cargo test -p raven bounded_fanout::run_bounded_fanout_runs_all_items_without_exceeding_limit`
- `cargo test -p raven sync_reader`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `cargo test -p raven`

## Artifacts
- Warp conversation: https://app.warp.dev/conversation/78ffda55-d951-406d-866d-de7b413ea111
- Plan: https://app.warp.dev/drive/notebook/c1MQ5S2ttP0JPgJSU2ZIYF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Implemented bounded-concurrency diagnostic publishing across document and file-watch events to prevent resource exhaustion and improve stability under high parallelism
  * Reworked package-cache into snapshot-based reads with serialized publication to reduce contention and make lookups more deterministic

* **Chores**
  * Updated developer documentation to reflect concurrency handling and cache locking guidance

* **Tests**
  * Added tests validating bounded fan-out behavior and cache snapshot correctness

* **Benchmarks**
  * Added benchmarks for package-cache lookups and diagnostic fan-out performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->