### PR TITLE
Drop orphaned external index entries when system.file resolutions clear or re-target

### DIFF
--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1124,8 +1124,11 @@ impl WorldState {
         // Resolve into a cloned sources Vec; only a real change pays for the
         // full-metadata clone (`Arc::make_mut`), re-insertion, and the edge
         // rebuild below (resolution is idempotent, so unchanged entries need
-        // none of them).
+        // none of them). Previous targets of changed resolutions are
+        // collected so the cleanup below can drop external entries nothing
+        // references anymore.
         let mut changed_uris: Vec<Url> = Vec::new();
+        let mut old_targets: std::collections::HashSet<Url> = std::collections::HashSet::new();
         for (uri, mut entry) in affected {
             let mut new_sources = entry.metadata.sources.clone();
             crate::cross_file::resolve_system_file_source_entries(
@@ -1135,6 +1138,13 @@ impl WorldState {
                 &lib_paths,
             );
             if new_sources != entry.metadata.sources {
+                old_targets.extend(
+                    entry
+                        .metadata
+                        .sources
+                        .iter()
+                        .filter_map(|s| s.resolved_uri.clone()),
+                );
                 Arc::make_mut(&mut entry.metadata).sources = new_sources;
                 changed_uris.push(uri.clone());
                 self.workspace_index_new.insert(uri, entry);
@@ -1183,6 +1193,12 @@ impl WorldState {
             );
             let resolution_changed = new_sources != doc.metadata.sources;
             let meta = if resolution_changed {
+                old_targets.extend(
+                    doc.metadata
+                        .sources
+                        .iter()
+                        .filter_map(|s| s.resolved_uri.clone()),
+                );
                 let mut new_meta = (*doc.metadata).clone();
                 new_meta.sources = new_sources;
                 let new_meta = Arc::new(new_meta);
@@ -1215,7 +1231,75 @@ impl WorldState {
         // so their artifacts are available to scope resolution.
         self.index_cross_package_resolved_files();
 
+        // Drop external entries the changed resolutions no longer point at.
+        self.drop_orphaned_external_entries(old_targets);
+
         changed_uris
+    }
+
+    /// Drop outside-workspace index entries that were indexed as
+    /// cross-package `system.file()` targets (see
+    /// [`Self::index_cross_package_resolved_files`]) but lost their last
+    /// referencing resolution — without this, a cleared or re-targeted
+    /// `resolved_uri` leaves the previously indexed external file occupying
+    /// an LRU slot until natural eviction.
+    ///
+    /// `candidates` are the previous targets of resolutions that just
+    /// changed. A candidate is dropped only when it is (a) outside every
+    /// workspace folder — workspace files are owned by the workspace scan,
+    /// e.g. an renv library inside the project — (b) not an open document,
+    /// and (c) no longer referenced by any `resolved_uri` in the index or an
+    /// open buffer. The reference check is a full scan of sources, which is
+    /// acceptable because resolutions only change on rare package lifecycle
+    /// events.
+    fn drop_orphaned_external_entries(&mut self, candidates: std::collections::HashSet<Url>) {
+        if candidates.is_empty() {
+            return;
+        }
+        let workspace_dirs: Vec<std::path::PathBuf> = self
+            .workspace_folders
+            .iter()
+            .filter_map(|f| f.to_file_path().ok())
+            .collect();
+        for uri in candidates {
+            if !self.workspace_index_new.contains(&uri) {
+                continue;
+            }
+            if self.document_store.get_without_touch(&uri).is_some()
+                || self.documents.contains_key(&uri)
+            {
+                continue;
+            }
+            if let Ok(path) = uri.to_file_path()
+                && workspace_dirs.iter().any(|dir| path.starts_with(dir))
+            {
+                continue;
+            }
+            let referenced_from_index = self.workspace_index_new.any_entry(|entry| {
+                entry
+                    .metadata
+                    .sources
+                    .iter()
+                    .any(|s| s.resolved_uri.as_ref() == Some(&uri))
+            });
+            let referenced_from_open_doc = || {
+                self.document_store.uris().into_iter().any(|doc_uri| {
+                    self.document_store
+                        .get_without_touch(&doc_uri)
+                        .is_some_and(|doc| {
+                            doc.metadata
+                                .sources
+                                .iter()
+                                .any(|s| s.resolved_uri.as_ref() == Some(&uri))
+                        })
+                })
+            };
+            if referenced_from_index || referenced_from_open_doc() {
+                continue;
+            }
+            self.workspace_index_new.invalidate(&uri);
+            self.cross_file_graph.remove_file(&uri);
+        }
     }
 
     /// Expand the changed-URI list from

--- a/crates/raven/tests/system_file_source.rs
+++ b/crates/raven/tests/system_file_source.rs
@@ -476,6 +476,255 @@ mod lifecycle {
         );
     }
 
+    /// Index entry whose only source carries an already-resolved
+    /// cross-package target (`resolved_uri` set), as left behind by a prior
+    /// successful branch-2 resolution.
+    fn resolved_entry(pkg: &str, target: &Url) -> IndexEntry {
+        let metadata = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                system_file: Some(SystemFileCall {
+                    parts: vec!["helper.R".to_string()],
+                    package: pkg.to_string(),
+                }),
+                resolved_uri: Some(target.clone()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        IndexEntry {
+            contents: ropey::Rope::from_str(&format!(
+                "source(system.file(\"helper.R\", package = \"{pkg}\"))\n"
+            )),
+            tree: None,
+            loaded_packages: Vec::new(),
+            snapshot: FileSnapshot {
+                mtime: std::time::SystemTime::UNIX_EPOCH,
+                size: 1,
+                content_hash: Some(1),
+            },
+            metadata: Arc::new(metadata),
+            artifacts: Arc::new(raven::cross_file::scope::ScopeArtifacts::default()),
+            indexed_at_version: 1,
+        }
+    }
+
+    /// A successful cross-package resolution indexes the outside-workspace
+    /// target so its artifacts reach scope resolution. When the package is
+    /// removed and the resolution clears, nothing references that external
+    /// entry anymore — it must be dropped from the index rather than linger
+    /// in an LRU slot until natural eviction (#425).
+    #[test]
+    fn orphaned_external_entry_dropped_after_package_removal() {
+        let libdir = tempfile::tempdir().unwrap();
+        let pkg_dir = libdir.path().join("otherpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("helper.R"), "helper_fn <- function() 42\n").unwrap();
+
+        let uri = Url::parse("file:///workspace/uses_helper.R").unwrap();
+        let mut state = state_with_lib(libdir.path());
+        state
+            .workspace_index_new
+            .insert(uri.clone(), system_file_entry("helper.R", "otherpkg"));
+
+        state.resolve_system_file_in_workspace();
+        let target = state
+            .workspace_index_new
+            .get(&uri)
+            .expect("entry still indexed")
+            .metadata
+            .sources[0]
+            .resolved_uri
+            .clone()
+            .expect("source must resolve while the package is installed");
+        assert!(
+            state.workspace_index_new.contains(&target),
+            "precondition: the cross-package target is indexed after resolution"
+        );
+
+        std::fs::remove_dir_all(&pkg_dir).unwrap();
+        state.resolve_system_file_in_workspace();
+
+        assert!(
+            !state.workspace_index_new.contains(&target),
+            "orphaned external index entry must be dropped once no resolution references it"
+        );
+    }
+
+    /// A library swap re-targets the resolution to a different installed
+    /// copy: the new target must be indexed and the previous one dropped —
+    /// nothing points at it anymore (#425).
+    #[test]
+    fn orphaned_external_entry_dropped_after_libpath_retarget() {
+        let libdir_a = tempfile::tempdir().unwrap();
+        let libdir_b = tempfile::tempdir().unwrap();
+        for lib in [&libdir_a, &libdir_b] {
+            let pkg_dir = lib.path().join("otherpkg");
+            std::fs::create_dir_all(&pkg_dir).unwrap();
+            std::fs::write(pkg_dir.join("helper.R"), "helper_fn <- function() 42\n").unwrap();
+        }
+
+        let uri = Url::parse("file:///workspace/uses_helper.R").unwrap();
+        let mut state = state_with_lib(libdir_a.path());
+        state
+            .workspace_index_new
+            .insert(uri.clone(), system_file_entry("helper.R", "otherpkg"));
+
+        state.resolve_system_file_in_workspace();
+        let old_target = state
+            .workspace_index_new
+            .get(&uri)
+            .expect("entry still indexed")
+            .metadata
+            .sources[0]
+            .resolved_uri
+            .clone()
+            .expect("source must resolve against libdir_a");
+        assert!(
+            state.workspace_index_new.contains(&old_target),
+            "precondition: libdir_a target indexed"
+        );
+
+        // Library swap: libdir_b now wins resolution.
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_lib_paths(vec![libdir_b.path().to_path_buf()]);
+        state.package_library = Arc::new(lib);
+        state.resolve_system_file_in_workspace();
+
+        let new_target = state
+            .workspace_index_new
+            .get(&uri)
+            .expect("entry still indexed")
+            .metadata
+            .sources[0]
+            .resolved_uri
+            .clone()
+            .expect("source must re-resolve against libdir_b");
+        assert_ne!(
+            old_target, new_target,
+            "precondition: resolution re-targeted"
+        );
+        assert!(
+            state.workspace_index_new.contains(&new_target),
+            "the re-targeted external file must be indexed"
+        );
+        assert!(
+            !state.workspace_index_new.contains(&old_target),
+            "the previous external target must be dropped after the re-target"
+        );
+    }
+
+    /// The external entry must be RETAINED while any other resolution still
+    /// points at it. Here a second file's resolution (whose package the
+    /// filtered event pass does not touch) references the same target as the
+    /// one being cleared.
+    #[test]
+    fn external_entry_retained_while_another_resolution_references_it() {
+        let libdir = tempfile::tempdir().unwrap();
+        let pkg_dir = libdir.path().join("otherpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("helper.R"), "helper_fn <- function() 42\n").unwrap();
+
+        let uri = Url::parse("file:///workspace/uses_helper.R").unwrap();
+        let mut state = state_with_lib(libdir.path());
+        state
+            .workspace_index_new
+            .insert(uri.clone(), system_file_entry("helper.R", "otherpkg"));
+
+        state.resolve_system_file_in_workspace();
+        let target = state
+            .workspace_index_new
+            .get(&uri)
+            .expect("entry still indexed")
+            .metadata
+            .sources[0]
+            .resolved_uri
+            .clone()
+            .expect("source must resolve while the package is installed");
+        assert!(
+            state.workspace_index_new.contains(&target),
+            "precondition: target indexed"
+        );
+
+        // A second file's resolution still points at the same target; its
+        // package is untouched by the filtered event below.
+        let keeper_uri = Url::parse("file:///workspace/keeper.R").unwrap();
+        state
+            .workspace_index_new
+            .insert(keeper_uri, resolved_entry("keeperpkg", &target));
+
+        // otherpkg removed; the libpath-event consumer re-resolves only
+        // entries referencing {otherpkg}.
+        std::fs::remove_dir_all(&pkg_dir).unwrap();
+        let pkgs: std::collections::HashSet<String> =
+            std::iter::once("otherpkg".to_string()).collect();
+        state.resolve_system_file_in_workspace_for_packages(Some(&pkgs));
+
+        assert!(
+            state
+                .workspace_index_new
+                .get(&uri)
+                .expect("entry still indexed")
+                .metadata
+                .sources[0]
+                .resolved_uri
+                .is_none(),
+            "precondition: the cleared resolution actually cleared"
+        );
+        assert!(
+            state.workspace_index_new.contains(&target),
+            "external entry must be retained while another resolved_uri still references it"
+        );
+    }
+
+    /// renv-style layout: the package library lives INSIDE a workspace
+    /// folder, so the resolved target is a workspace file owned by the
+    /// workspace scan. The orphan cleanup must never drop entries under a
+    /// workspace folder.
+    #[test]
+    fn workspace_entry_not_dropped_by_orphan_cleanup() {
+        let workspace = tempfile::tempdir().unwrap();
+        // Canonicalize so the resolved target and the folder agree on
+        // symlinked temp paths (macOS /var -> /private/var).
+        let ws_root = workspace.path().canonicalize().unwrap();
+        let libdir = ws_root.join("renv").join("library");
+        let pkg_dir = libdir.join("otherpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("helper.R"), "helper_fn <- function() 42\n").unwrap();
+
+        let uri = Url::parse("file:///workspace/uses_helper.R").unwrap();
+        let mut state = state_with_lib(&libdir);
+        state
+            .workspace_folders
+            .push(Url::from_directory_path(&ws_root).unwrap());
+        state
+            .workspace_index_new
+            .insert(uri.clone(), system_file_entry("helper.R", "otherpkg"));
+
+        state.resolve_system_file_in_workspace();
+        let target = state
+            .workspace_index_new
+            .get(&uri)
+            .expect("entry still indexed")
+            .metadata
+            .sources[0]
+            .resolved_uri
+            .clone()
+            .expect("source must resolve while the package is installed");
+        assert!(
+            state.workspace_index_new.contains(&target),
+            "precondition: target indexed"
+        );
+
+        std::fs::remove_dir_all(&pkg_dir).unwrap();
+        state.resolve_system_file_in_workspace();
+
+        assert!(
+            state.workspace_index_new.contains(&target),
+            "entries under a workspace folder are owned by the workspace scan \
+             and must not be dropped by the orphan cleanup"
+        );
+    }
+
     /// Open buffers are authoritative: their metadata lives in the document
     /// store, not the workspace index, so the resolution pass must cover it
     /// too. An open buffer (here not even present in the workspace index —


### PR DESCRIPTION
Fixes #425

## Problem

When a cross-package `source(system.file("x.R", package = "pkg"))` edge resolves (branch 2), `index_cross_package_resolved_files` reads, parses, and inserts the outside-workspace target into `workspace_index_new`. Nothing ever removed those entries: when the referencing resolution later cleared (package removed) or re-targeted (different library path wins after a swap), the external `IndexEntry` lingered with nothing pointing at it, retaining memory and occupying an LRU slot until natural eviction. Repeated install/remove/swap cycles in a long session could accumulate several such orphans.

## Fix

`resolve_system_file_in_workspace_for_packages` now collects the previous `resolved_uri` targets of every resolution that changed — in both the index pass and the open-buffer pass — and, after `index_cross_package_resolved_files` runs, hands them to a new `drop_orphaned_external_entries` cleanup. A candidate is dropped only when it is:

- (a) outside every workspace folder — workspace files (e.g. an renv library inside the project) are owned by the workspace scan;
- (b) not an open document; and
- (c) no longer referenced by any `resolved_uri` in the index or an open buffer (full scan of sources, acceptable because resolutions change only on rare package lifecycle events — the direction suggested in the issue).

Dropped entries are also removed from the dependency graph. Transitive chains cascade naturally: an external entry's own `system.file` source participates in the same resolution pass, so its target is collected and dropped in the same call.

## Tests

Four new tests in the `lifecycle` module of `crates/raven/tests/system_file_source.rs` (written first, watched fail):

- `orphaned_external_entry_dropped_after_package_removal` — the indexed target is dropped once the resolution clears.
- `orphaned_external_entry_dropped_after_libpath_retarget` — after a library swap, the new target is indexed and the previous one dropped.
- `external_entry_retained_while_another_resolution_references_it` — a filtered event pass that clears one resolution must not drop a target another file's `resolved_uri` still references.
- `workspace_entry_not_dropped_by_orphan_cleanup` — renv-style library inside a workspace folder is never dropped.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, and the full `cargo test -p raven --features test-support` suite (4719 lib tests + integration suites) all pass.