### PR TITLE
perf(bench): add NSE-saturated diagnostics benchmark

### DIFF
--- a/crates/raven/benches/lsp_operations.rs
+++ b/crates/raven/benches/lsp_operations.rs
@@ -13,7 +13,8 @@ use url::Url;
 
 use raven::state::{Document, WorldState, scan_workspace};
 use raven::test_utils::fixture_workspace::{
-    FixtureConfig, create_fanout_fixture_workspace, create_fixture_workspace, fanout_parent_uris,
+    FixtureConfig, create_fanout_fixture_workspace, create_fixture_workspace,
+    create_single_file_workspace, fanout_parent_uris,
 };
 
 // ---------------------------------------------------------------------------
@@ -323,6 +324,86 @@ fn bench_diagnostics_fanout(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// Benchmark: Diagnostics over NSE-saturated code
+//
+// `bench_diagnostics` above runs the full pipeline over the generic fixture,
+// where the NSE (non-standard-evaluation) policy resolver is a small slice of
+// total time and its argument-suppression branches are barely entered. This
+// bench instead saturates the document with the shapes that drive the NSE path
+// — bare data-masking verb calls (dplyr/data.table), local function defs that
+// shadow verbs, and non-literal local callee aliases (`f <- stats::filter`,
+// `f <- get_filter()`; issue #450) — so NSE work dominates and a regression in
+// `collect_nse_facts` / `resolve_call_arg_policy` actually moves the number.
+// Unlike a full-pipeline bench over a noisy workspace scan, this is a single
+// in-memory document, keeping run-to-run variance low.
+// ---------------------------------------------------------------------------
+
+/// Generate a deterministic, NSE-saturated R document of `blocks` repeated
+/// units. Each unit pulls dplyr/data.table into play, defines a verb-shadowing
+/// local function, binds qualified aliases (standard-eval `stats::filter` and
+/// masking `dplyr::filter`) and opaque callables (`get_filter()`, bare
+/// identifier), then issues bare covered-verb calls and calls through every
+/// alias — so collection records many disjoint definition/alias entries and the
+/// resolver walks every policy branch. Names are unique per block (no
+/// last-binding-wins collapse), and the many undefined references are
+/// intentional: deciding which to suppress is exactly the NSE work being timed.
+fn generate_nse_dense_file(blocks: usize) -> String {
+    use std::fmt::Write;
+    let mut content = String::from("library(dplyr)\nlibrary(data.table)\n\n");
+    for i in 0..blocks {
+        write!(
+            content,
+            "mutate_helper_{i} <- function(x, y) x + y\n\
+             std_filter_{i} <- stats::filter\n\
+             masked_filter_{i} <- dplyr::filter\n\
+             opaque_{i} <- get_filter()\n\
+             ref_{i} <- some_fn\n\
+             res_a_{i} <- filter(df_{i}, value_{i} > threshold_{i})\n\
+             res_b_{i} <- mutate(df_{i}, z_{i} = x_{i} + y_{i})\n\
+             res_c_{i} <- select(df_{i}, col_a_{i}, col_b_{i})\n\
+             res_d_{i} <- summarise(group_by(df_{i}, grp_{i}), m_{i} = mean(x_{i}))\n\
+             res_e_{i} <- std_filter_{i}(df_{i}, typo_{i})\n\
+             res_f_{i} <- masked_filter_{i}(df_{i}, col_{i})\n\
+             res_g_{i} <- opaque_{i}(df_{i}, arg_{i})\n\
+             dt_{i} <- data.table(a_{i} = 1, b_{i} = 2)\n\
+             dt_{i}[value_{i} > 1, sum(x_{i}), by = grp_{i}]\n\n",
+        )
+        .unwrap();
+    }
+    content
+}
+
+fn bench_diagnostics_nse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp_diagnostics_nse");
+    group.sample_size(20);
+
+    let sizes: &[(&str, usize)] = &[("nse_20", 20), ("nse_80", 80)];
+
+    for (label, blocks) in sizes {
+        let workspace = create_single_file_workspace(&generate_nse_dense_file(*blocks));
+        let state = build_state_from_fixture(workspace.path());
+        let uri = file_0_uri(workspace.path());
+        let cancel = raven::handlers::DiagCancelToken::never();
+
+        group.bench_with_input(
+            BenchmarkId::new("diagnostics_nse", *label),
+            &(&state, &uri, &cancel),
+            |b, &(state, uri, cancel)| {
+                b.iter(|| {
+                    black_box(raven::handlers::diagnostics(
+                        black_box(state),
+                        black_box(uri),
+                        black_box(cancel),
+                    ))
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_completion,
@@ -330,5 +411,6 @@ criterion_group!(
     bench_goto_definition,
     bench_diagnostics,
     bench_diagnostics_fanout,
+    bench_diagnostics_nse,
 );
 criterion_main!(benches);

--- a/crates/raven/benches/lsp_operations.rs
+++ b/crates/raven/benches/lsp_operations.rs
@@ -340,22 +340,30 @@ fn bench_diagnostics_fanout(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 
 /// Generate a deterministic, NSE-saturated R document of `blocks` repeated
-/// units. Each unit pulls dplyr/data.table into play, defines a verb-shadowing
-/// local function, binds qualified aliases (standard-eval `stats::filter` and
-/// masking `dplyr::filter`) and opaque callables (`get_filter()`, bare
-/// identifier), then issues bare covered-verb calls and calls through every
-/// alias — so collection records many disjoint definition/alias entries and the
-/// resolver walks every policy branch. Names are unique per block (no
-/// last-binding-wins collapse), and the many undefined references are
-/// intentional: deciding which to suppress is exactly the NSE work being timed.
+/// units. A preamble pulls dplyr/data.table into play and defines a local
+/// function over the covered verb `mutate`, which shadows the package export.
+/// Each unit binds qualified aliases (standard-eval `stats::filter` and masking
+/// `dplyr::filter`) and opaque callables (`get_filter()`, a bare identifier),
+/// then **calls** bare covered verbs, the shadowing local def, and every alias —
+/// so the resolver walks each branch of `resolve_call_arg_policy`: the
+/// local-definition shadow (`mutate(...)`), the qualified-target policy
+/// (`std_filter`/`masked_filter`), the opaque `Unknown` suppression (`opaque`,
+/// `ref`), and the built-in package policy (the bare verbs). Alias/def names are
+/// unique per block (no last-binding-wins collapse) so collection records many
+/// disjoint entries; the many undefined references are intentional — deciding
+/// which to suppress is exactly the NSE work being timed.
 fn generate_nse_dense_file(blocks: usize) -> String {
     use std::fmt::Write;
-    let mut content = String::from("library(dplyr)\nlibrary(data.table)\n\n");
+    // The shadowing def lives in the preamble: `mutate` is a single top-level
+    // binding (R semantics), but the per-block `mutate(...)` calls below drive
+    // the local-definition branch on every iteration.
+    let mut content = String::from(
+        "library(dplyr)\nlibrary(data.table)\nmutate <- function(data, expr) data\n\n",
+    );
     for i in 0..blocks {
         write!(
             content,
-            "mutate_helper_{i} <- function(x, y) x + y\n\
-             std_filter_{i} <- stats::filter\n\
+            "std_filter_{i} <- stats::filter\n\
              masked_filter_{i} <- dplyr::filter\n\
              opaque_{i} <- get_filter()\n\
              ref_{i} <- some_fn\n\
@@ -366,6 +374,7 @@ fn generate_nse_dense_file(blocks: usize) -> String {
              res_e_{i} <- std_filter_{i}(df_{i}, typo_{i})\n\
              res_f_{i} <- masked_filter_{i}(df_{i}, col_{i})\n\
              res_g_{i} <- opaque_{i}(df_{i}, arg_{i})\n\
+             res_h_{i} <- ref_{i}(df_{i}, more_{i})\n\
              dt_{i} <- data.table(a_{i} = 1, b_{i} = 2)\n\
              dt_{i}[value_{i} > 1, sum(x_{i}), by = grp_{i}]\n\n",
         )

--- a/crates/raven/src/test_utils/fixture_workspace.rs
+++ b/crates/raven/src/test_utils/fixture_workspace.rs
@@ -124,6 +124,21 @@ pub fn create_fixture_workspace(config: &FixtureConfig) -> TempDir {
     temp_dir
 }
 
+/// Create a temporary single-file workspace containing exactly `file_0.R` with
+/// the given content.
+///
+/// For benchmarks/tests that need to exercise a specific code shape (e.g. an
+/// NSE-saturated document) rather than the synthetic [`FixtureConfig`] output.
+/// The returned `TempDir` cleans up on drop; the file is always named
+/// `file_0.R` so callers can reuse the existing `file_0_uri` helper.
+pub fn create_single_file_workspace(content: &str) -> TempDir {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory for fixture workspace");
+    let filepath = temp_dir.path().join("file_0.R");
+    std::fs::write(&filepath, content)
+        .unwrap_or_else(|e| panic!("Failed to write single-file fixture: {}", e));
+    temp_dir
+}
+
 /// Write fixture files into an existing directory.
 ///
 /// Useful when you need to control the directory path (e.g., for named temp dirs).


### PR DESCRIPTION
## Why

The #450 performance review flagged 5–7% regressions in the `startup` benches (`tree_sitter_parsing/parse_large`, `parse_batch_init_output`, `workspace_scan/scan/medium_50`). Investigation showed these were **machine noise, not a real regression**:

- None of those benches execute any NSE code — `parse_batch_init_output` is a self-contained inline string parser that calls zero raven-lib functions, and `parse_large` is the bare tree-sitter parser.
- On re-run, `parse_large`'s "regression" vanished (p=0.21), while `parse_batch_init_output` still "regressed" (+2.3%) despite sharing **zero** code with the diff — proving the label tracks CPU-frequency drift, not the change.

The real gap: **no benchmark meaningfully guards the NSE policy resolver.** The existing `lsp_diagnostics` bench runs the full pipeline, but over the generic fixture NSE is a small slice of total time and its argument-suppression branches are barely entered.

## What

- **`bench_diagnostics_nse`** (group `lsp_diagnostics_nse`, sizes `nse_20` / `nse_80`): times `diagnostics()` over a single in-memory, NSE-saturated document — bare dplyr/data.table verb calls, verb-shadowing local defs, and non-literal local callee aliases (`f <- stats::filter`, `f <- get_filter()`). NSE work dominates, so a regression in `collect_nse_facts` / `resolve_call_arg_policy` actually moves the number. The single-doc shape keeps variance low (smoke-run CI ±0.3%, vs ±5–8% for the workspace benches).
- **`create_single_file_workspace()`** added to the fixture helper, for tests/benches that need a specific code shape rather than synthetic `FixtureConfig` output.

## Sensitivity check

Holding this bench constant and swapping only `handlers.rs` (main vs the #450 merge):

| Case | change | verdict |
|---|---|---|
| `nse_20` | [-1.3%, +3.1%, +7.4%] | No change (p=0.20) |
| `nse_80` | [-2.2%, +0.4%, +3.2%] | No change (p=0.79) |

Confirms both that the bench is wired to the changed code and that #450 carried no regression.

## CI

- `cargo fmt --all` applied
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for the diagnostics handler with non-standard evaluation patterns, measuring analysis speed on documents with varying complexity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->