### PR TITLE
chore: refresh names.db bootstrap seed

### DIFF
--- a/crates/raven/data/names-db-seed.db
+++ b/crates/raven/data/names-db-seed.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0209d9fac2d6e1204c29ac6d42d73833b7050f8cdef1c31058fe58783bb17dc8
-size 9987389
+oid sha256:a921dbbdc42e7c8076e7881742a3127ad6bcb0ea6723aa244aeb62517b83f3ba
+size 9748098


### PR DESCRIPTION
## Summary
- refresh the committed Git LFS bootstrap seed from the post-#429 names-db Release asset
- preserve the normal Release-first delivery path; this only updates disaster-recovery/bootstrap fallback

## Validation
- build-names-db.yml workflow_dispatch succeeded: https://github.com/jbearak/raven/actions/runs/27469197679
- target/debug/raven packages validate-shipped-db crates/raven/data/names-db-seed.db
- SHA-256 matches downloaded Release asset: a921dbbdc42e7c8076e7881742a3127ad6bcb0ea6723aa244aeb62517b83f3ba
- survival lazy_data count: 56; contains lung: true