### PR TITLE
docs: describe Raven as a static analyzer; tune per-surface framing and discoverability

### DIFF
--- a/.kiro/specs/performance-testing/requirements.md
+++ b/.kiro/specs/performance-testing/requirements.md
@@ -7,7 +7,7 @@ Raven needs a performance testing infrastructure that detects regressions, valid
 This spec draws on analysis of four LSP codebases:
 
 - **rust-analyzer** — the gold standard: real-world benchmarks on actual codebases, an `analysis-stats` CLI, a CI metrics workflow on every push to master, hierarchical profiling, and multi-metric tracking (time, memory, CPU instructions).
-- **Sight** (Raven's sister Stata LSP) — time-budget regression tests with specific thresholds, CI-adapted thresholds (3× relaxed), cache-effectiveness benchmarks, and algorithm-comparison benchmarks.
+- **Sight** (Raven's sibling Stata LSP) — time-budget regression tests with specific thresholds, CI-adapted thresholds (3× relaxed), cache-effectiveness benchmarks, and algorithm-comparison benchmarks.
 - **pyright** — a cautionary example: no benchmarks, no profiling, no performance CI despite being a widely-used LSP.
 
 The goal is a layered system: (1) real Criterion benchmarks that exercise actual code paths, (2) in-tree time-budget tests that fail on regression, (3) a CI workflow that runs benchmarks and detects regressions, and (4) a lightweight analysis command for ad-hoc profiling.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Raven
 
-Raven is a static R language server that resolves what's in scope at each line — catching undefined and used-before-defined variables even in a single script, and across files by following `source()` chains — without running your code. The same scope model drives the rest of its code intelligence — completions, go-to-definition, find-references, hover — so each reflects what's reachable at your cursor, not just what exists somewhere in the project. It also diagnoses syntax errors, and can optionally check code style and formatting.
+Raven is a static analyzer for R that resolves what's in scope at each line — catching undefined and used-before-defined variables even in a single script, and across files by following `source()` chains — without running your code. The same scope model drives the rest of its code intelligence — completions, go-to-definition, find-references, hover — so each reflects what's reachable at your cursor, not just what exists somewhere in the project. It also diagnoses syntax errors, and can optionally check code style and formatting.
 
 Raven is fast and runs all of this in realtime in your editor, with diagnostics updating instantly as you type. It also fills a gap at the other end of the workflow: automated checks in pull requests — running `raven check` flags undefined variables and other errors before code merges, the kind of automated review that's table stakes for other languages but has long been missing for R.
 
@@ -14,7 +14,7 @@ Raven is fully open source ([GPL-3.0](LICENSE)) and editor-agnostic: it speaks t
 
 > **Quick Start:** Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=jbearak.raven-r) or [OpenVSX](https://open-vsx.org/extension/jbearak/raven-r), or download from the [releases page](https://github.com/jbearak/raven/releases). See [Installation](#installation) for details.
 
-Raven's sister project [Sight](https://github.com/jbearak/sight) implements a language server for Stata. Together they bring cross-file navigation, error detection, and code intelligence to two languages widely used in social science research.
+Raven's sibling project [Sight](https://github.com/jbearak/sight) implements a language server for Stata. Together they bring cross-file navigation, error detection, and code intelligence to two languages widely used in social science research.
 
 ## Features
 

--- a/crates/raven/Cargo.toml
+++ b/crates/raven/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raven"
 version.workspace = true
-description = "Static R Language Server with workspace symbol indexing"
+description = "Static analyzer for R — a language server in your editor, a checker in CI"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -62,7 +62,7 @@ For a deeper comparison see [docs/comparison.md](https://github.com/jbearak/rave
 
 ## More Information
 
-See the [main repository](https://github.com/jbearak/raven) for full documentation including cross-file directives, editor integrations, and comparison with other R tools.
+See the [main repository](https://github.com/jbearak/raven) for full documentation, including running the same analysis in CI with [`raven check`](https://github.com/jbearak/raven/blob/main/docs/cli.md), cross-file directives, editor integrations, and comparison with other R tools.
 
 If you work with Stata, see Raven's sibling project, [Sight](https://github.com/jbearak/sight), a Stata language server with the same cross-file awareness model.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,8 +4,12 @@
   "description": "R language server with cross-file awareness, diagnostics, completion, and navigation. Also provides lightweight support for Stan and JAGS/BUGS (syntax highlighting, completions, navigation, outline).",
   "keywords": [
     "R",
+    "language server",
+    "lsp",
+    "static analysis",
+    "linter",
+    "diagnostics",
     "Rmarkdown",
-    "Quarto",
     "Stan",
     "JAGS",
     "BUGS"


### PR DESCRIPTION
## What

Repositions how Raven is described and tightens discoverability metadata.

- **Root README + crate description** now lead with **"static analyzer for R"** rather than "R language server." The tool has two surfaces — an LSP server in the editor and `raven check` in CI — and "language server" alone undersells the CLI/CI half.
- **VS Code marketplace `description` stays a language server** — that *is* what Raven is in the editor, and it's the term people search the marketplace for. Instead of conflating surfaces in the blurb, the extension README now carries a single CI pointer to `docs/cli.md` near the bottom.
- **Marketplace keywords**: added `language server`, `lsp`, `static analysis`, `linter`, `diagnostics` (recovering the discoverability the prose description no longer carries); dropped `Quarto` — Raven only does Quarto *chunk detection*, not Quarto-wide support, so the tag would attract the wrong audience.
- **`sister` → `sibling`** wording for Sight in the README and the perf-testing spec.

## Why

Positioning (the headline noun, optimized for accuracy) and discoverability (keywords/topics, optimized for how people search) are different jobs and are allowed to diverge: we don't headline "linter" or "language server," but both stay as searchable keywords. The per-surface rule: the noun should match what the artifact *is in that context* — analyzer for the whole tool, language server inside VS Code.

## Follow-up (not in this PR)

GitHub repo **topics** are a repo setting, not a file. Suggested:
`r, rstats, language-server, lsp, static-analysis, linter, diagnostics, vscode-extension, rmarkdown, stan, jags, rust, tree-sitter`

## Notes

Docs/metadata only — no code paths touched. `package.json` JSON validated; keywords/description aren't part of the settings-reference index, so no regeneration needed.