### PR TITLE
fix(nse): plyr *ply follow-up — exclude m*ply (splat), upgrade qualified aliases

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -15137,11 +15137,18 @@ fn resolve_call_arg_policy(
             // Resolve the qualified target's verb policy: a target with no
             // table policy (e.g. `stats::filter`) is standard-eval, so its
             // arguments are checked, while `dplyr::filter` keeps its data-mask
-            // policy.
+            // policy. Apply the plyr `*ply` `.fun`-conditional dots upgrade here
+            // too (issue #467 follow-up), so an aliased split-apply verb
+            // (`my_ddply <- plyr::ddply`) suppresses a data-masked `.fun`'s `...`
+            // identically to the direct call — keyed on the RESOLVED target name.
             LocalCalleeAlias::Qualified {
                 package,
                 name: target,
-            } => crate::nse::package_policy(package, target).unwrap_or(ArgPolicy::Standard),
+            } => {
+                let policy =
+                    crate::nse::package_policy(package, target).unwrap_or(ArgPolicy::Standard);
+                upgrade_plyr_ply_dots(call_node, target, text, analysis, policy)
+            }
             // An opaque callable whose policy we cannot prove: suppress
             // conservatively rather than inherit any package verb's policy.
             LocalCalleeAlias::Unknown => ArgPolicy::WholeCall,
@@ -15220,6 +15227,14 @@ fn resolve_call_arg_policy(
 /// so it cannot drift from the call-site rules) and resolved shadow-aware. This
 /// is inherently a call-site decision (it depends on `.fun`, an argument), so it
 /// lives here rather than in the pure `package_policy` table.
+///
+/// KNOWN LIMITATION (shared with all per-formal NSE matching): `.fun` is matched
+/// by EXACT argument name, but R also resolves unambiguous partial names before
+/// `...` — so `ddply(df, .(g), .f = summarise, …)` (where `.f` partial-matches
+/// `.fun`) is not located, the upgrade does not fire, and the `...` stay checked.
+/// This is the safe direction (over-checking, a possible false positive — never a
+/// hidden bug); a fix would have to teach `suppressed_arguments` partial matching
+/// for every policy, not just this one.
 fn upgrade_plyr_ply_dots<'tree>(
     call_node: Node<'tree>,
     name: &str,
@@ -15281,14 +15296,24 @@ fn upgrade_plyr_ply_dots<'tree>(
 /// Whether a plyr `*ply` `.fun` argument value resolves to a verb whose NSE
 /// policy data-masks its `...` (`captured_dots: true`) — the condition under
 /// which the forwarded `*ply` `...` are columns. Resolved shadow-aware to match
-/// R's dispatch: a local definition or alias for an identifier `.fun` beats the
-/// package verb; an opaque local binding (e.g. an enclosing formal) shadows the
-/// package verb but its policy is unknown, so it is treated as not-data-masking
-/// (the safe direction — leaves `...` checked, never hides a bug). With no local
-/// binding it is resolved one level deep through the built-in tables
-/// ([`table_verb_policy`]) — the same one-level discipline as the wrapper-dots
-/// inference ([`body_forwards_dots_to_covered_verb`]). Non-identifier `.fun`
-/// values (anonymous functions, strings, computed calls) are not data-masking.
+/// R's dispatch: a **top-level** local definition or alias for an identifier
+/// `.fun` beats the package verb; a top-level opaque callee binding (in
+/// `local_callee_shadows`) is treated as not-data-masking (the safe direction —
+/// leaves `...` checked, never hides a bug). With no such local binding it is
+/// resolved one level deep through the built-in tables ([`table_verb_policy`]) —
+/// the same one-level discipline as the wrapper-dots inference
+/// ([`body_forwards_dots_to_covered_verb`]). Non-identifier `.fun` values
+/// (anonymous functions, strings, computed calls) are not data-masking.
+///
+/// KNOWN LIMITATION (pre-existing, shared with direct-callee resolution in
+/// [`resolve_call_arg_policy`]): only **top-level** bindings are tracked —
+/// `collect_nse_facts` skips in-function assignments and formals (see its doc).
+/// A binding that shadows a data-masking verb name *inside an enclosing
+/// function* — e.g. `f <- function(summarise) ddply(df, .(g), summarise, ...)` —
+/// is invisible here, so that `.fun` is wrongly resolved to the package verb and
+/// its `...` suppressed (a false negative). Fixing it would require
+/// function-scoped binding tracking across the whole NSE machinery, not just
+/// this `.fun` path.
 fn fun_resolves_to_data_masking_verb(value: Node, text: &str, analysis: &NseAnalysis) -> bool {
     use crate::nse::ArgPolicy;
     let policy = match value.kind() {
@@ -26336,6 +26361,61 @@ clean_data <- function(x) {
                 .iter()
                 .any(|m| m.contains("Undefined variable: value_col")),
             "a named `.fun = summarise` must still be located and data-mask the `...`; messages: {messages:?}"
+        );
+    }
+
+    /// Issue #467 follow-up (Codex review): the `m*ply` family wraps `.fun` in
+    /// `splat()` — `mdply(.data, .fun, ...)` calls `do.call(splat(.fun),
+    /// c(row_values, list(...)))`, so the m*ply call's `...` are spread as
+    /// ORDINARY arguments, never forwarded into `.fun`'s per-group data mask.
+    /// Verified against plyr 1.8.9: `mdply(df, summarise, z = sum(x))` errors
+    /// with "object 'x' not found" because `x` is not a visible column. So the
+    /// `m*ply` verbs must NOT get the data-mask upgrade — their `...` stay
+    /// checked even with a data-masking `.fun`, so a typo is still flagged.
+    #[tokio::test]
+    async fn nse_plyr_mdply_splat_fun_keeps_dots_checked_end_to_end() {
+        let code = "library(plyr)\n\
+                    mdply(some_df, summarise, n = undefined_typo)\n\
+                    totally_undefined_baseline\n";
+        let messages = plyr_undefined_messages(code, &["mdply", "summarise", "some_df"]).await;
+        assert!(
+            messages
+                .iter()
+                .any(|m| m == "Undefined variable: totally_undefined_baseline"),
+            "baseline must be flagged; messages: {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("Undefined variable: undefined_typo")),
+            "`mdply` splats `.fun`, so its `...` are NOT data-masked and the typo must be flagged; messages: {messages:?}"
+        );
+    }
+
+    /// Issue #467 follow-up (Codex review): a local qualified alias of a `*ply`
+    /// verb (`my_ddply <- plyr::ddply`) resolves through the alias path of
+    /// `resolve_call_arg_policy`, which must apply the same `.fun`-conditional
+    /// dots upgrade — otherwise `my_ddply(df, .(g), summarise, …)` would keep a
+    /// data-masked column checked while the identical direct `ddply(...)` call
+    /// suppresses it.
+    #[tokio::test]
+    async fn nse_plyr_qualified_alias_applies_dots_upgrade_end_to_end() {
+        let code = "library(plyr)\n\
+                    my_ddply <- plyr::ddply\n\
+                    my_ddply(some_df, .(year), summarise, n = length(unique(team)))\n\
+                    totally_undefined_baseline\n";
+        let messages = plyr_undefined_messages(code, &[".", "ddply", "summarise", "some_df"]).await;
+        assert!(
+            messages
+                .iter()
+                .any(|m| m == "Undefined variable: totally_undefined_baseline"),
+            "baseline must be flagged; messages: {messages:?}"
+        );
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.contains("Undefined variable: team")),
+            "an aliased `*ply` (`my_ddply <- plyr::ddply`) must apply the data-mask upgrade; messages: {messages:?}"
         );
     }
 

--- a/crates/raven/src/nse.rs
+++ b/crates/raven/src/nse.rs
@@ -438,10 +438,13 @@ pub(crate) fn package_policy(package: &str, name: &str) -> Option<ArgPolicy> {
 }
 
 /// The empirically verified formal order of each plyr `*ply` split-apply verb
-/// (the `a*`/`d*`/`l*`/`m*` families), or `None` for any other name. The
-/// `r*ply` family (`raply`/`rdply`/`rlply`/`r_ply`) is intentionally absent: it
-/// takes `.n, .expr` rather than `.fun`, so the `.fun`-forwarding model does not
-/// apply and it stays standard-eval. This is the single source of truth for
+/// that forwards `...` directly into `.fun(piece, ...)` — the `a*`/`d*`/`l*`
+/// families (12 verbs) — or `None` for any other name. Two families are
+/// intentionally absent: `r*ply` (`raply`/`rdply`/`rlply`/`r_ply`) takes
+/// `.n, .expr` rather than `.fun`; and `m*ply` (`maply`/`mdply`/`mlply`/`m_ply`)
+/// wraps `.fun` in `splat()`, spreading its `...` as ordinary arguments rather
+/// than into `.fun`'s data mask (see the `m*ply` note at the end of the match).
+/// Both stay standard-eval. This is the single source of truth for
 /// [`is_plyr_split_apply_verb`] and the `*ply` arm of [`package_policy`], so the
 /// recognition predicate and the formal order it consumes cannot drift. The
 /// post-`...` control formals are listed so a named control argument
@@ -574,48 +577,25 @@ fn plyr_split_apply_formals(name: &str) -> Option<&'static [&'static str]> {
             ".parallel",
             ".paropts",
         ],
-        // m*ply: `(.data, .fun, ...)` — `.fun` is the 2nd formal.
-        "maply" => &[
-            ".data",
-            ".fun",
-            "...",
-            ".expand",
-            ".progress",
-            ".inform",
-            ".drop",
-            ".parallel",
-            ".paropts",
-        ],
-        "mdply" | "mlply" => &[
-            ".data",
-            ".fun",
-            "...",
-            ".expand",
-            ".progress",
-            ".inform",
-            ".parallel",
-            ".paropts",
-        ],
-        "m_ply" => &[
-            ".data",
-            ".fun",
-            "...",
-            ".expand",
-            ".progress",
-            ".inform",
-            ".print",
-            ".parallel",
-            ".paropts",
-        ],
+        // The `m*ply` family (`maply`/`mdply`/`mlply`/`m_ply`) is deliberately
+        // ABSENT: it wraps `.fun` in `splat()` (`f <- splat(.fun)`), calling
+        // `do.call(.fun, c(as.list(row), list(...)))` per row, so the m*ply
+        // call's `...` are spread as ordinary arguments — NOT forwarded into
+        // `.fun`'s per-group data mask the way `a*`/`d*`/`l*ply` forward
+        // `.fun(piece, ...)`. Empirically (plyr 1.8.9 + R 4.6.0)
+        // `mdply(df, summarise, z = sum(x))` errors "object 'x' not found",
+        // confirming `x` is not a visible column. Modeling m*ply would suppress
+        // genuine free-variable references in those `...` (a false negative), so
+        // it stays standard-eval — same exclusion rationale as `r*ply`.
         _ => return None,
     })
 }
 
-/// True when `name` is one of plyr's 16 `*ply` split-apply verbs that forward
-/// their `...` to `.fun` (the `a*`/`d*`/`l*`/`m*` families). See
-/// [`plyr_split_apply_formals`] for the excluded `r*ply` family and the
-/// empirical-verification note. Consumed by `handlers.rs` to gate the
-/// call-site `captured_dots` upgrade to plyr `*ply` callees only.
+/// True when `name` is one of plyr's 12 `*ply` split-apply verbs that forward
+/// their `...` directly into `.fun(piece, ...)` (the `a*`/`d*`/`l*` families).
+/// See [`plyr_split_apply_formals`] for the excluded `r*ply` and `m*ply`
+/// families and the empirical-verification note. Consumed by `handlers.rs` to
+/// gate the call-site `captured_dots` upgrade to plyr `*ply` callees only.
 pub(crate) fn is_plyr_split_apply_verb(name: &str) -> bool {
     plyr_split_apply_formals(name).is_some()
 }
@@ -2432,9 +2412,10 @@ mod tests {
         }
     }
 
-    /// The 16 plyr `*ply` split-apply verbs (the `a*`/`d*`/`l*`/`m*` families;
-    /// the `r*ply` family takes `.n, .expr` rather than `.fun` and is excluded)
-    /// are modeled with a base per-formal policy that captures nothing: `.data`,
+    /// The 12 plyr `*ply` split-apply verbs that forward `...` into
+    /// `.fun(piece, ...)` (the `a*`/`d*`/`l*` families; `r*ply` takes
+    /// `.n, .expr` and `m*ply` splats `.fun`, so both are excluded) are modeled
+    /// with a base per-formal policy that captures nothing: `.data`,
     /// `.variables`/`.margins`, and `.fun` stay checked, and the trailing `...`
     /// stay checked unless the call-site `.fun` resolves to a data-masking verb
     /// (the upgrade in `handlers.rs`). The formals carry `.fun` and `...`.
@@ -2443,7 +2424,7 @@ mod tests {
     fn plyr_split_apply_verbs_base_policy() {
         for name in [
             "aaply", "adply", "alply", "a_ply", "daply", "ddply", "dlply", "d_ply", "laply",
-            "ldply", "llply", "l_ply", "maply", "mdply", "mlply", "m_ply",
+            "ldply", "llply", "l_ply",
         ] {
             match package_policy("plyr", name) {
                 Some(ArgPolicy::PerFormal {
@@ -2472,7 +2453,8 @@ mod tests {
 
     /// `.fun`'s positional index per family, pinning the empirically verified
     /// signatures: `a*ply`/`d*ply` are `(.data, .margins|.variables, .fun, ...)`
-    /// (index 2); `l*ply`/`m*ply` are `(.data, .fun, ...)` (index 1).
+    /// (index 2); `l*ply` is `(.data, .fun, ...)` (index 1). `m*ply` is excluded
+    /// (splat — see `is_plyr_split_apply_verb_recognition`).
     #[test]
     fn plyr_split_apply_fun_formal_position() {
         let fun_index = |verb: &str| match package_policy("plyr", verb) {
@@ -2484,21 +2466,22 @@ mod tests {
         ] {
             assert_eq!(fun_index(v), Some(2), "{v}: .fun at index 2");
         }
-        for v in [
-            "laply", "ldply", "llply", "l_ply", "maply", "mdply", "mlply", "m_ply",
-        ] {
+        for v in ["laply", "ldply", "llply", "l_ply"] {
             assert_eq!(fun_index(v), Some(1), "{v}: .fun at index 1");
         }
     }
 
-    /// `is_plyr_split_apply_verb` recognizes exactly the 16 `*ply` verbs that
-    /// forward `...` to a `.fun` — never the `r*ply` family (no `.fun`), the
-    /// `.()` quoting helper, or the data-masking verbs themselves.
+    /// `is_plyr_split_apply_verb` recognizes exactly the 12 `*ply` verbs that
+    /// forward `...` directly into `.fun(piece, ...)` (the `a*`/`d*`/`l*`
+    /// families) — never the `r*ply` family (no `.fun`), never the `m*ply`
+    /// family (which wraps `.fun` in `splat()`, so its `...` are spread as
+    /// ordinary args, not data-masked — verified against plyr 1.8.9), and never
+    /// the `.()` quoting helper or the data-masking verbs themselves.
     #[test]
     fn is_plyr_split_apply_verb_recognition() {
         for name in [
             "aaply", "adply", "alply", "a_ply", "daply", "ddply", "dlply", "d_ply", "laply",
-            "ldply", "llply", "l_ply", "maply", "mdply", "mlply", "m_ply",
+            "ldply", "llply", "l_ply",
         ] {
             assert!(
                 is_plyr_split_apply_verb(name),
@@ -2506,10 +2489,17 @@ mod tests {
             );
         }
         for name in [
+            // m*ply splats `.fun` -> `...` are not data-masked (issue #467 f/u).
+            "maply",
+            "mdply",
+            "mlply",
+            "m_ply",
+            // r*ply takes `.n, .expr` (no `.fun`).
             "raply",
             "rdply",
             "rlply",
             "r_ply",
+            // Not split-apply verbs at all.
             ".",
             "summarise",
             "mutate",

--- a/docs/superpowers/specs/2026-06-14-issue-467-plyr-ply-dots-datamask-design.md
+++ b/docs/superpowers/specs/2026-06-14-issue-467-plyr-ply-dots-datamask-design.md
@@ -1,6 +1,6 @@
 # Issue #467 — plyr `*ply` verbs: data-masked `...` forwarded to `summarise`/`mutate`/`transform` (design spec)
 
-**Status:** v2 — reconciled with the implementation after the review passes (§3.2 helper signature/return and the `suppressed_arguments`-vs-`call_argument_suppression` choice; §5 test list expanded to match the shipped tests). The on-function doc comments in the code are authoritative.
+**Status:** v3 — post-merge Codex adversarial review (follow-up PR). **v3 changes:** (1) **exclude the `m*ply` family** — it wraps `.fun` in `splat()`, so its `...` are spread as ordinary args, never data-masked; modeling it was a false negative (§2, §4). (2) Apply the `.fun`-conditional dots upgrade in the **qualified-alias path** of `resolve_call_arg_policy`, so `my_ddply <- plyr::ddply` behaves like the direct call (§4). (3) Document two **pre-existing** limitations now inherited by `.fun` resolution: function-scoped shadowing of a verb name, and exact-only argument-name matching (§4). v2 reconciled §3.2/§5 with the shipped code. The on-function doc comments in the code are authoritative.
 **Issue:** #467 "NSE: model plyr *ply verbs' data-masked `...` forwarded to summarise/mutate/transform"
 **Builds on:** #466 (`plyr::.()` modeled as a `WholeCall` quoting helper), branch `issue467`
 **Verified against:** plyr 1.8.9 + R 4.6.0
@@ -42,8 +42,15 @@ Formal orders, grouped by leading shape:
 | `a*ply` | `aaply` `adply` `alply` `a_ply` | `.data, .margins, .fun, ...` | 3rd |
 | `d*ply` | `daply` `ddply` `dlply` `d_ply` | `.data, .variables, .fun, ...` | 3rd |
 | `l*ply` | `laply` `ldply` `llply` `l_ply` | `.data, .fun, ...` | 2nd |
-| `m*ply` | `maply` `mdply` `mlply` `m_ply` | `.data, .fun, ...` | 2nd |
+| `m*ply` | `maply` `mdply` `mlply` `m_ply` | `.data, .fun, ...` | — (excluded, see v3) |
 | `r*ply` | `raply` `rdply` `rlply` `r_ply` | `.n, .expr, .progress, ...` | — (excluded) |
+
+> **v3 correction:** `m*ply` is **excluded**. It wraps `.fun` in `splat()`
+> (`f <- splat(.fun)`; `do.call(.fun, c(as.list(row), list(...)))`), so the call's
+> `...` are spread as ordinary arguments, NOT forwarded into `.fun`'s data mask —
+> `mdply(df, summarise, z = sum(x))` errors `object 'x' not found` (verified, plyr
+> 1.8.9). Only `a*`/`d*`/`l*ply` (12 verbs) forward `.fun(piece, ...)` and
+> data-mask. See the `m*ply` note in `plyr_split_apply_formals`.
 
 Post-`...` control formals differ per verb (`.progress`, `.inform`, `.drop`,
 `.parallel`, `.paropts`, `.expand`, `.id`, `.print`, `.drop_i`, `.drop_o`,
@@ -71,8 +78,9 @@ named/positional formal but not `...` (e.g. base `subset`) is *under*-suppressed
 `summarise`/`summarize`/`mutate`/`transform`, plus `filter`/`with`/etc. when those
 are the `.fun` — is exactly the set whose forwarded dots are genuinely data-masked.
 
-**Family scope — all 16** (`a*ply`/`d*ply`/`l*ply`/`m*ply`), excluding `r*ply`.
-Uniform mechanism, no confusing gaps.
+**Family scope — 12** (`a*ply`/`d*ply`/`l*ply`); `r*ply` (no `.fun`) and `m*ply`
+(splats `.fun` — v3) are excluded. (Originally scoped as "all 16"; the `m*ply`
+exclusion was a v3 correction from the Codex adversarial review — see §2.)
 
 **Architecture — hybrid (mirrors the existing wrapper-dots upgrade at
 `handlers.rs` ~13301).** A static base policy in `package_policy` plus a
@@ -85,8 +93,8 @@ call-site `captured_dots` upgrade in `resolve_call_arg_policy`:
    - (Side benefit: fixes direct `summarise(df, x = mean(y))` false positives in
      plyr-only files, where `summarise` previously resolved as a no-policy export →
      `Standard`.)
-2. Add the 16 `*ply` verbs → a **base** `PerFormal` carrying the empirically
-   verified formal order, `captured: []`, `captured_dots: false`. With nothing
+2. Add the 12 `*ply` verbs (`a*`/`d*`/`l*`) → a **base** `PerFormal` carrying the
+   empirically verified formal order, `captured: []`, `captured_dots: false`. With nothing
    captured this is behaviorally identical to `Standard` (every arg checked) —
    the base policy exists only to (a) supply the formal order so the call-site
    step can locate `.fun`/`...` by R's matching rules, and (b) mark the call as a
@@ -151,16 +159,29 @@ of the existing `table_verb_policy` result.
   passed when `.fun` is data-masking may have their value suppressed if not listed
   among the verb's formals; the per-verb formal lists include the control formals
   to avoid this for the common cases.
-- `r*ply` stays unmodeled (no `.fun`).
+- `r*ply` (no `.fun`) and `m*ply` (splats `.fun` — v3) stay unmodeled; their `...`
+  are always checked.
+- **Function-scoped shadowing (pre-existing class).** `.fun` resolution — like
+  direct-callee resolution in `resolve_call_arg_policy` — only consults
+  **top-level** local bindings (`collect_nse_facts` skips in-function assignments
+  and formals). A binding that shadows a data-masking verb name *inside an
+  enclosing function* — `f <- function(summarise) ddply(df, .(g), summarise, …)` —
+  is invisible, so that `.fun` is wrongly treated as the package verb and its
+  `...` suppressed (a false negative). A real fix needs function-scoped binding
+  tracking across the whole NSE machinery, not just this path.
+- **Exact-only argument-name matching (pre-existing class).** `.fun` is located by
+  exact name; R's unambiguous partial matching (`.f = summarise` → `.fun`) is not
+  honored, so a partially-named `.fun` is not located and the `...` stay checked
+  (safe direction — a possible false positive). Shared by every per-formal policy.
 
 ## 5. Testing
 
 Unit (`nse.rs`):
 - `package_policy("plyr", "summarise"|"summarize"|"mutate")` → `PerFormal`,
   `captured_dots: true`.
-- Each of the 16 `*ply` verbs → `PerFormal`, `captured: []`, `captured_dots: false`,
-  with `.fun` and `...` in the formals at the verified positions.
-- `is_plyr_split_apply_verb` true for the 16, false for `r*ply` and `.`.
+- Each of the 12 `*ply` verbs (`a*`/`d*`/`l*`) → `PerFormal`, `captured: []`,
+  `captured_dots: false`, with `.fun` and `...` in the formals at the verified positions.
+- `is_plyr_split_apply_verb` true for the 12, false for `r*ply`, `m*ply`, and `.`.
 - Update the #466 table-shape assertions (`("plyr","ddply",None)` → `PerFormal`;
   `plyr_dot_is_whole_call_quoting_helper`'s `ddply`/`llply` `is_none()` lines).
 
@@ -185,6 +206,10 @@ End-to-end (`handlers.rs`, mirroring the #466 synthetic-package harness):
   is suppressed.
 - `.fun` supplied by name (`ddply(df, .variables = .(g), .fun = summarise, …)`) —
   exercises the named-matching pass.
+- **(v3)** `mdply(df, summarise, n = undefined_typo)` — `undefined_typo` IS flagged
+  (m*ply splats `.fun`, so its `...` are not data-masked).
+- **(v3)** `my_ddply <- plyr::ddply; my_ddply(df, .(year), summarise, n = length(unique(team)))`
+  — `team` NOT flagged (the qualified-alias path applies the upgrade).
 
 ## 6. Docs
 


### PR DESCRIPTION
Follow-up to #469 (issue #467), addressing a **post-merge Codex adversarial review**. Two real fixes + two documented pre-existing limitations.

## F1 — exclude the `m*ply` family (false negative) — **fixed**

`m*ply` (`maply`/`mdply`/`mlply`/`m_ply`) wraps `.fun` in `splat()` (`f <- splat(.fun)`; `do.call(.fun, c(as.list(row), list(...)))` per row), so the m*ply call's `...` are spread as **ordinary arguments**, not forwarded into `.fun`'s per-group data mask the way `a*`/`d*`/`l*ply` forward `.fun(piece, ...)`.

Verified against plyr 1.8.9:
```r
ddply(df, .(y), summarise, z = sum(x))   # OK — x is a column (data-masked)
mdply(df, summarise, z = sum(x))         # Error: object 'x' not found
```
So #469 modeling m*ply could **suppress genuine undefined-variable references** in those `...`. Removed the 4 m*ply verbs from `plyr_split_apply_formals` (16 → 12, `a*`/`d*`/`l*`); they revert to standard-eval like `r*ply`.

## F4 — qualified-alias path bypassed the upgrade (false positive) — **fixed**

`my_ddply <- plyr::ddply; my_ddply(df, .(g), summarise, n = mean(team))` resolved through `resolve_call_arg_policy`'s alias path, which never called `upgrade_plyr_ply_dots`, so `team` stayed checked while the identical direct `ddply(...)` suppressed it. The alias arm now applies the upgrade, keyed on the **resolved** target name (gated so a non-plyr alias can't be wrongly upgraded).

## F2, F3 — pre-existing classes — **documented**

- **Function-scoped shadowing**: `.fun` (and direct-callee) resolution only consults **top-level** binding facts (`collect_nse_facts` skips in-function assignments/formals), so a verb name shadowed inside an enclosing function is treated as the package verb. Documented on `fun_resolves_to_data_masking_verb`; also corrected a now-inaccurate sentence that claimed an enclosing formal is caught.
- **Exact-only argument-name matching**: partial names (`.f = summarise` → `.fun`) aren't located (safe direction). Documented on `upgrade_plyr_ply_dots`.

Both are shared with the broader NSE machinery; fixing properly is out of scope here.

## Tests / gates

New e2e: `mdply(df, summarise, n = undefined_typo)` flags the typo; `my_ddply <- plyr::ddply` alias applies the upgrade. Unit tests updated to the 12-verb scope. `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, and the full test suite (5146 lib + integration + doctests) all pass. Spec updated to v3.