### PR TITLE
Perf: hub-heavy cross-file (#479) — shared prefix memo, # raven: standalone directive, parallel raven check

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -17,7 +17,7 @@
 
 use std::path::{Path, PathBuf};
 
-use tower_lsp::lsp_types::{Diagnostic, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Url};
 
 use crate::cli::shared::{
     ColorChoice, EXIT_LINT_FAILED, EXIT_OK, EXIT_OPERATOR_ERROR, OutputFormat, SeverityLevel,
@@ -312,6 +312,80 @@ pub async fn run(args: CheckArgs) -> i32 {
     let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
     let mut reported_loaded_packages = std::collections::BTreeSet::new();
 
+    // Issue #479 WI3 — parallelize the CPU-bound diagnostic pass across files.
+    // The graph/index caches are `RwLock`/atomic and immutable after the scan,
+    // so per-file scope resolution is safe to run concurrently. The one hazard
+    // (Codex review) is that open documents outrank index content in the content
+    // provider, so sharing `state.documents` across workers would make each
+    // worker treat the others' targets as "open" and pull the wrong artifacts.
+    // We avoid that entirely: `state.documents` stays empty during the parallel
+    // region, and each worker passes a one-entry overlay holding only its target
+    // (see `compute_file_diagnostics_sync` /
+    // `DiagnosticsSnapshot::build_with_open_documents`). This reproduces the
+    // sequential "exactly one open target" semantics per task, so output is
+    // byte-identical. The async on-disk missing-file checks (cheap I/O) and the
+    // rare disk-fallback targets (not in the workspace index) are handled
+    // afterward on the async runtime.
+    use rayon::prelude::*;
+
+    struct SyncResult {
+        path: PathBuf,
+        uri: Url,
+        sync_diags: Vec<Diagnostic>,
+        directive_meta: crate::cross_file::CrossFileMetadata,
+        missing_file_severity: Option<DiagnosticSeverity>,
+        loaded_packages: Vec<String>,
+    }
+
+    // Phase 1 (parallel, CPU-bound): indexed targets only. A target that is not
+    // in the workspace index (disk-fallback) or whose path can't be a URL is
+    // skipped here and handled sequentially below.
+    let sync_results: Vec<SyncResult> = targets
+        .par_iter()
+        .filter_map(|path| {
+            let uri = Url::from_file_path(path).ok()?;
+            // Reuse the already-parsed `Document` from the scan (tree included),
+            // exactly as the sequential path did — no disk re-read / re-parse.
+            let doc = state.workspace_index.get(&uri).cloned()?;
+            let loaded_packages: Vec<String> = doc.loaded_packages.to_vec();
+            let mut open_documents = std::collections::HashMap::new();
+            open_documents.insert(uri.clone(), doc);
+            let (sync_diags, directive_meta, missing_file_severity) =
+                compute_file_diagnostics_sync(&state, &uri, &open_documents)?;
+            Some(SyncResult {
+                path: path.clone(),
+                uri,
+                sync_diags,
+                directive_meta,
+                missing_file_severity,
+                loaded_packages,
+            })
+        })
+        .collect();
+
+    // Phase 2 (async): finalize the parallel results with on-disk missing-file
+    // checks and collect their attached packages. Order is irrelevant — the
+    // whole `all_diags` set is sorted below.
+    for r in sync_results {
+        reported_loaded_packages.extend(r.loaded_packages);
+        let diags = finalize_file_diagnostics(
+            &state,
+            &r.uri,
+            r.sync_diags,
+            &r.directive_meta,
+            r.missing_file_severity,
+        )
+        .await;
+        for d in diags {
+            all_diags.push((r.path.clone(), d));
+        }
+    }
+
+    // Phase 3 (sequential): targets not handled in phase 1 — a bad URL, or a
+    // disk-fallback target the scan didn't index (e.g. a symlink-alias path, or
+    // an `.Rmd`/`.qmd` chunk file outside the R-only scan). Rare; the existing
+    // open → compute → close path (which uses `state.documents`) is preserved
+    // verbatim, so behavior for these is unchanged.
     for path in &targets {
         let Ok(uri) = Url::from_file_path(path) else {
             eprintln!(
@@ -321,45 +395,26 @@ pub async fn run(args: CheckArgs) -> i32 {
             operator_error = true;
             continue;
         };
-        // `DiagnosticsSnapshot::build` reads the target from `state.documents`,
-        // which the workspace scan does NOT populate — it stores parsed
-        // `Document`s (tree included) in `state.workspace_index`. Reuse that
-        // already-parsed `Document` instead of re-reading the file from disk
-        // and re-parsing it: in the common "report the whole workspace" run
-        // that halves the tree-sitter work (parse once during the scan, not
-        // again here). Fall back to reading from disk only for a target the
-        // scan didn't index (e.g. a path the report walk reached through a
-        // different symlink alias, OR a chunk file — `.Rmd`/`.qmd` are
-        // deliberately outside the R-only workspace scan). Either way the
-        // document is removed afterwards to bound memory across a large report
-        // set; the clone keeps the index entry intact for other files'
-        // cross-file resolution.
-        if let Some(doc) = state.workspace_index.get(&uri).cloned() {
-            state.documents.insert(uri.clone(), doc);
-        } else {
-            let text = match crate::state::read_source(path) {
-                Ok(t) => t,
-                Err(crate::state::SourceReadError::Io(e)) => {
-                    eprintln!("raven check: cannot read {}: {e}", path.display());
-                    operator_error = true;
-                    continue;
-                }
-                // A mis-encoded file is a property of the code, like a syntax
-                // error — not an operator error. Report it as a finding (see
-                // `encoding_diagnostic`) and keep going, so the exit code
-                // reflects findings rather than a half-read abort.
-                Err(crate::state::SourceReadError::InvalidEncoding { offset, byte }) => {
-                    all_diags.push((path.clone(), encoding_diagnostic(offset, byte)));
-                    continue;
-                }
-            };
-            open_disk_fallback_target(&mut state, &uri, path, &text);
+        if state.workspace_index.contains_key(&uri) {
+            continue; // already handled in the parallel phase
         }
-        // Both arms above leave the document in `state.documents`; collect its
-        // attached packages from the doc already in hand (free — the loop opens
-        // each target for diagnostics regardless). This intentionally also covers
-        // the disk-fallback arm, unlike the index-only up-front
-        // `prefetch_reported_packages` warm-up.
+        let text = match crate::state::read_source(path) {
+            Ok(t) => t,
+            Err(crate::state::SourceReadError::Io(e)) => {
+                eprintln!("raven check: cannot read {}: {e}", path.display());
+                operator_error = true;
+                continue;
+            }
+            // A mis-encoded file is a property of the code, like a syntax
+            // error — not an operator error. Report it as a finding (see
+            // `encoding_diagnostic`) and keep going, so the exit code
+            // reflects findings rather than a half-read abort.
+            Err(crate::state::SourceReadError::InvalidEncoding { offset, byte }) => {
+                all_diags.push((path.clone(), encoding_diagnostic(offset, byte)));
+                continue;
+            }
+        };
+        open_disk_fallback_target(&mut state, &uri, path, &text);
         if let Some(doc) = state.documents.get(&uri) {
             reported_loaded_packages.extend(doc.loaded_packages.iter().cloned());
         }
@@ -902,23 +957,63 @@ fn format_traversal_budget_note(state: &crate::state::WorldState) -> Option<Stri
 /// open). A malformed file is not an operator error here — its reportable
 /// syntax errors are surfaced like any other diagnostic when the tree still
 /// builds.
-async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -> Vec<Diagnostic> {
-    let Some(snapshot) = crate::handlers::DiagnosticsSnapshot::build(state, uri) else {
-        return Vec::new();
-    };
+/// The synchronous half of a file's diagnostics: build the snapshot and run the
+/// CPU-bound scope-resolution pass. Returns the pre-async findings plus the
+/// inputs the async missing-file pass needs (`directive_meta`, severity). Split
+/// out so `raven check` can run this — the expensive part — across files in
+/// parallel (issue #479 WI3), then do the cheap async filesystem checks
+/// afterward. `open_documents` is the worker's one-entry overlay (see
+/// [`crate::handlers::DiagnosticsSnapshot::build_with_open_documents`]).
+fn compute_file_diagnostics_sync(
+    state: &crate::state::WorldState,
+    uri: &Url,
+    open_documents: &std::collections::HashMap<Url, crate::state::Document>,
+) -> Option<(
+    Vec<Diagnostic>,
+    crate::cross_file::CrossFileMetadata,
+    Option<DiagnosticSeverity>,
+)> {
+    let snapshot = crate::handlers::DiagnosticsSnapshot::build_with_open_documents(
+        state,
+        uri,
+        open_documents,
+    )?;
     let cancel = crate::handlers::DiagCancelToken::never();
-    let Some(sync_diags) = crate::handlers::diagnostics_from_snapshot(&snapshot, uri, &cancel)
-    else {
-        return Vec::new();
-    };
-    // Replace the snapshot's cache-based missing-file checks with real on-disk
-    // existence checks — exactly what the LSP publish path does.
+    let sync_diags = crate::handlers::diagnostics_from_snapshot(&snapshot, uri, &cancel)?;
     let missing_file_severity = snapshot.cross_file_config.missing_file_severity;
+    Some((sync_diags, snapshot.directive_meta, missing_file_severity))
+}
+
+/// The async half: replace the snapshot's cache-based missing-file checks with
+/// real on-disk existence checks — exactly what the LSP publish path does.
+async fn finalize_file_diagnostics(
+    state: &crate::state::WorldState,
+    uri: &Url,
+    sync_diags: Vec<Diagnostic>,
+    directive_meta: &crate::cross_file::CrossFileMetadata,
+    missing_file_severity: Option<DiagnosticSeverity>,
+) -> Vec<Diagnostic> {
     crate::handlers::diagnostics_async_standalone(
         uri,
         sync_diags,
-        &snapshot.directive_meta,
+        directive_meta,
         state.workspace_folders.first(),
+        missing_file_severity,
+    )
+    .await
+}
+
+async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -> Vec<Diagnostic> {
+    let Some((sync_diags, directive_meta, missing_file_severity)) =
+        compute_file_diagnostics_sync(state, uri, &state.documents)
+    else {
+        return Vec::new();
+    };
+    finalize_file_diagnostics(
+        state,
+        uri,
+        sync_diags,
+        &directive_meta,
         missing_file_severity,
     )
     .await

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -920,6 +920,17 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
 /// `parallel_collection_matches_sequential`). The async on-disk missing-file
 /// checks (cheap I/O) and the rare disk-fallback targets (not in the workspace
 /// index) are handled afterward on the async runtime.
+///
+/// Blocking-in-async note: the phase-1 `par_iter().collect()` is a synchronous,
+/// CPU-bound rayon join that runs on rayon's own thread pool while blocking the
+/// calling tokio worker until it returns. We deliberately do NOT wrap it in
+/// `block_in_place`/`spawn_blocking`. `raven check`'s tokio runtime runs exactly
+/// one root future (`cli::check::run`, awaited inline from `#[tokio::main]`) with
+/// no sibling tasks competing for a worker in this region, so there is nothing
+/// for `block_in_place` to migrate — it would be a runtime no-op here while
+/// adding a panic-on-`current_thread`-runtime hazard. The process exits right
+/// after the report loop. If `raven check` ever gains concurrent tokio tasks
+/// around this call, revisit and wrap the rayon phase then.
 async fn collect_target_diagnostics(
     state: &mut crate::state::WorldState,
     targets: &[PathBuf],
@@ -1733,27 +1744,39 @@ mod tests {
         );
     }
 
+    /// Shared setup for the two diagnostics-collection test drivers below.
+    /// Mirrors `run`'s indexing + R-init + target-collection prelude and returns
+    /// the indexed `WorldState` and report targets. Factored out so the
+    /// sequential and parallel drivers resolve from byte-identical state — the
+    /// precondition that makes `parallel_collection_matches_sequential` a
+    /// like-for-like comparison (drift between two copied preludes would
+    /// silently weaken the equivalence assertion). R-independent: callers that
+    /// want package awareness configure `additionalLibraryPaths`.
+    async fn setup_check_state_and_targets(
+        args: &CheckArgs,
+    ) -> (crate::state::WorldState, Vec<PathBuf>) {
+        let root = std::fs::canonicalize(args.workspace.as_ref().unwrap()).unwrap();
+        let workspace_url = Url::from_file_path(&root).unwrap();
+        let mut state = build_indexed_state(&root, &workspace_url, args.no_config, None).unwrap();
+        if !args.report_uninstalled {
+            state.cross_file_config.packages_missing_package_severity = None;
+        }
+        maybe_init_r(&mut state, &root).await;
+        state.resolve_system_file_in_workspace();
+        maybe_load_sysdata_fallback(&mut state).await;
+        let mut operator_error = false;
+        let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
+        prefetch_reported_packages(&state, &targets).await;
+        (state, targets)
+    }
+
     /// Run `raven check` and capture the diagnostics it would compute, without
     /// the process-global stdout capture the renderer uses. Mirrors `run`'s
     /// indexing + report loop so a test can assert on the exact `(path,
     /// Diagnostic)` pairs (line/character) rather than just the exit code.
-    /// R-independent: callers that want package awareness configure
-    /// `additionalLibraryPaths`.
     fn collect_diagnostics_blocking(args: &CheckArgs) -> Vec<(PathBuf, Diagnostic)> {
         tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let root = std::fs::canonicalize(args.workspace.as_ref().unwrap()).unwrap();
-            let workspace_url = Url::from_file_path(&root).unwrap();
-            let mut state =
-                build_indexed_state(&root, &workspace_url, args.no_config, None).unwrap();
-            if !args.report_uninstalled {
-                state.cross_file_config.packages_missing_package_severity = None;
-            }
-            maybe_init_r(&mut state, &root).await;
-            state.resolve_system_file_in_workspace();
-            maybe_load_sysdata_fallback(&mut state).await;
-            let mut operator_error = false;
-            let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
-            prefetch_reported_packages(&state, &targets).await;
+            let (mut state, targets) = setup_check_state_and_targets(args).await;
             let mut all = Vec::new();
             for path in &targets {
                 let uri = Url::from_file_path(path).unwrap();
@@ -1779,22 +1802,11 @@ mod tests {
     /// Like `collect_diagnostics_blocking` but drives the REAL parallel
     /// collection path (`collect_target_diagnostics`, the rayon phase `run`
     /// uses), so a test can assert the parallel output equals the sequential
-    /// reference. Same setup as the sequential helper.
+    /// reference. Shares `setup_check_state_and_targets` with the sequential
+    /// driver so the two start from identical state.
     fn collect_diagnostics_parallel_blocking(args: &CheckArgs) -> Vec<(PathBuf, Diagnostic)> {
         tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let root = std::fs::canonicalize(args.workspace.as_ref().unwrap()).unwrap();
-            let workspace_url = Url::from_file_path(&root).unwrap();
-            let mut state =
-                build_indexed_state(&root, &workspace_url, args.no_config, None).unwrap();
-            if !args.report_uninstalled {
-                state.cross_file_config.packages_missing_package_severity = None;
-            }
-            maybe_init_r(&mut state, &root).await;
-            state.resolve_system_file_in_workspace();
-            maybe_load_sysdata_fallback(&mut state).await;
-            let mut operator_error = false;
-            let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
-            prefetch_reported_packages(&state, &targets).await;
+            let (mut state, targets) = setup_check_state_and_targets(args).await;
             let (all, _packages, _oe) = collect_target_diagnostics(&mut state, &targets).await;
             all
         })

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -309,128 +309,9 @@ pub async fn run(args: CheckArgs) -> i32 {
     // editor's post-scan prefetch (see [`prefetch_reported_packages`]).
     prefetch_reported_packages(&state, &targets).await;
 
-    let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
-    let mut reported_loaded_packages = std::collections::BTreeSet::new();
-
-    // Issue #479 WI3 — parallelize the CPU-bound diagnostic pass across files.
-    // The graph/index caches are `RwLock`/atomic and immutable after the scan,
-    // so per-file scope resolution is safe to run concurrently. The one hazard
-    // (Codex review) is that open documents outrank index content in the content
-    // provider, so sharing `state.documents` across workers would make each
-    // worker treat the others' targets as "open" and pull the wrong artifacts.
-    // We avoid that entirely: `state.documents` stays empty during the parallel
-    // region, and each worker passes a one-entry overlay holding only its target
-    // (see `compute_file_diagnostics_sync` /
-    // `DiagnosticsSnapshot::build_with_open_documents`). This reproduces the
-    // sequential "exactly one open target" semantics per task, so output is
-    // byte-identical. The async on-disk missing-file checks (cheap I/O) and the
-    // rare disk-fallback targets (not in the workspace index) are handled
-    // afterward on the async runtime.
-    use rayon::prelude::*;
-
-    struct SyncResult {
-        path: PathBuf,
-        uri: Url,
-        sync_diags: Vec<Diagnostic>,
-        directive_meta: crate::cross_file::CrossFileMetadata,
-        missing_file_severity: Option<DiagnosticSeverity>,
-        loaded_packages: Vec<String>,
-    }
-
-    // Phase 1 (parallel, CPU-bound): indexed targets only. A target that is not
-    // in the workspace index (disk-fallback) or whose path can't be a URL is
-    // skipped here and handled sequentially below.
-    let sync_results: Vec<SyncResult> = targets
-        .par_iter()
-        .filter_map(|path| {
-            let uri = Url::from_file_path(path).ok()?;
-            // Reuse the already-parsed `Document` from the scan (tree included),
-            // exactly as the sequential path did — no disk re-read / re-parse.
-            let doc = state.workspace_index.get(&uri).cloned()?;
-            let loaded_packages: Vec<String> = doc.loaded_packages.to_vec();
-            let mut open_documents = std::collections::HashMap::new();
-            open_documents.insert(uri.clone(), doc);
-            let (sync_diags, directive_meta, missing_file_severity) =
-                compute_file_diagnostics_sync(&state, &uri, &open_documents)?;
-            Some(SyncResult {
-                path: path.clone(),
-                uri,
-                sync_diags,
-                directive_meta,
-                missing_file_severity,
-                loaded_packages,
-            })
-        })
-        .collect();
-
-    // Phase 2 (async): finalize the parallel results with on-disk missing-file
-    // checks and collect their attached packages. Order is irrelevant — the
-    // whole `all_diags` set is sorted below.
-    for r in sync_results {
-        reported_loaded_packages.extend(r.loaded_packages);
-        let diags = finalize_file_diagnostics(
-            &state,
-            &r.uri,
-            r.sync_diags,
-            &r.directive_meta,
-            r.missing_file_severity,
-        )
-        .await;
-        for d in diags {
-            all_diags.push((r.path.clone(), d));
-        }
-    }
-
-    // Phase 3 (sequential): targets not handled in phase 1 — a bad URL, or a
-    // disk-fallback target the scan didn't index (e.g. a symlink-alias path, or
-    // an `.Rmd`/`.qmd` chunk file outside the R-only scan). Rare; the existing
-    // open → compute → close path (which uses `state.documents`) is preserved
-    // verbatim, so behavior for these is unchanged.
-    for path in &targets {
-        let Ok(uri) = Url::from_file_path(path) else {
-            eprintln!(
-                "raven check: cannot convert path to URL: {}",
-                path.display()
-            );
-            operator_error = true;
-            continue;
-        };
-        if state.workspace_index.contains_key(&uri) {
-            continue; // already handled in the parallel phase
-        }
-        let text = match crate::state::read_source(path) {
-            Ok(t) => t,
-            Err(crate::state::SourceReadError::Io(e)) => {
-                eprintln!("raven check: cannot read {}: {e}", path.display());
-                operator_error = true;
-                continue;
-            }
-            // A mis-encoded file is a property of the code, like a syntax
-            // error — not an operator error. Report it as a finding (see
-            // `encoding_diagnostic`) and keep going, so the exit code
-            // reflects findings rather than a half-read abort.
-            Err(crate::state::SourceReadError::InvalidEncoding { offset, byte }) => {
-                all_diags.push((path.clone(), encoding_diagnostic(offset, byte)));
-                continue;
-            }
-        };
-        open_disk_fallback_target(&mut state, &uri, path, &text);
-        if let Some(doc) = state.documents.get(&uri) {
-            reported_loaded_packages.extend(doc.loaded_packages.iter().cloned());
-        }
-        let diags = compute_file_diagnostics(&state, &uri).await;
-        state.close_document(&uri);
-        for d in diags {
-            all_diags.push((path.clone(), d));
-        }
-    }
-
-    // Deterministic output regardless of the scan's parallel HashMap order.
-    all_diags.sort_by(|(pa, da), (pb, db)| {
-        pa.cmp(pb)
-            .then(da.range.start.line.cmp(&db.range.start.line))
-            .then(da.range.start.character.cmp(&db.range.start.character))
-    });
+    let (all_diags, reported_loaded_packages, collect_operator_error) =
+        collect_target_diagnostics(&mut state, &targets).await;
+    operator_error |= collect_operator_error;
 
     let any_above_threshold = all_diags
         .iter()
@@ -1017,6 +898,147 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
         missing_file_severity,
     )
     .await
+}
+
+/// Compute the sorted `(path, Diagnostic)` set for every report target (issue
+/// #479 WI3). Returns the diagnostics, the union of attached loaded packages
+/// (for the missing-export-metadata warning), and whether any per-target
+/// operator error occurred (bad URL / unreadable disk-fallback target).
+///
+/// The CPU-bound diagnostic pass is parallelized across files: the graph/index
+/// caches are `RwLock`/atomic and immutable after the scan, so per-file scope
+/// resolution is safe to run concurrently. The one hazard (Codex review) is that
+/// open documents outrank index content in the content provider, so sharing
+/// `state.documents` across workers would make each worker treat the others'
+/// targets as "open" and pull the wrong artifacts. We avoid that entirely:
+/// `state.documents` stays empty during the parallel region, and each worker
+/// passes a one-entry overlay holding only its target (see
+/// `compute_file_diagnostics_sync` /
+/// `DiagnosticsSnapshot::build_with_open_documents`). This reproduces the
+/// sequential "exactly one open target" semantics per task, so output is
+/// byte-identical to a sequential run (asserted by
+/// `parallel_collection_matches_sequential`). The async on-disk missing-file
+/// checks (cheap I/O) and the rare disk-fallback targets (not in the workspace
+/// index) are handled afterward on the async runtime.
+async fn collect_target_diagnostics(
+    state: &mut crate::state::WorldState,
+    targets: &[PathBuf],
+) -> (
+    Vec<(PathBuf, Diagnostic)>,
+    std::collections::BTreeSet<String>,
+    bool,
+) {
+    use rayon::prelude::*;
+
+    struct SyncResult {
+        path: PathBuf,
+        uri: Url,
+        sync_diags: Vec<Diagnostic>,
+        directive_meta: crate::cross_file::CrossFileMetadata,
+        missing_file_severity: Option<DiagnosticSeverity>,
+        loaded_packages: Vec<String>,
+    }
+
+    let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
+    let mut reported_loaded_packages = std::collections::BTreeSet::new();
+    let mut operator_error = false;
+
+    // Phase 1 (parallel, CPU-bound): indexed targets only. A target that is not
+    // in the workspace index (disk-fallback) or whose path can't be a URL is
+    // skipped here and handled sequentially below.
+    let sync_results: Vec<SyncResult> = targets
+        .par_iter()
+        .filter_map(|path| {
+            let uri = Url::from_file_path(path).ok()?;
+            // Reuse the already-parsed `Document` from the scan (tree included),
+            // exactly as the sequential path did — no disk re-read / re-parse.
+            let doc = state.workspace_index.get(&uri).cloned()?;
+            let loaded_packages: Vec<String> = doc.loaded_packages.to_vec();
+            let mut open_documents = std::collections::HashMap::new();
+            open_documents.insert(uri.clone(), doc);
+            let (sync_diags, directive_meta, missing_file_severity) =
+                compute_file_diagnostics_sync(state, &uri, &open_documents)?;
+            Some(SyncResult {
+                path: path.clone(),
+                uri,
+                sync_diags,
+                directive_meta,
+                missing_file_severity,
+                loaded_packages,
+            })
+        })
+        .collect();
+
+    // Phase 2 (async): finalize the parallel results with on-disk missing-file
+    // checks and collect their attached packages. Order is irrelevant — the
+    // whole `all_diags` set is sorted below.
+    for r in sync_results {
+        reported_loaded_packages.extend(r.loaded_packages);
+        let diags = finalize_file_diagnostics(
+            state,
+            &r.uri,
+            r.sync_diags,
+            &r.directive_meta,
+            r.missing_file_severity,
+        )
+        .await;
+        for d in diags {
+            all_diags.push((r.path.clone(), d));
+        }
+    }
+
+    // Phase 3 (sequential): targets not handled in phase 1 — a bad URL, or a
+    // disk-fallback target the scan didn't index (e.g. a symlink-alias path, or
+    // an `.Rmd`/`.qmd` chunk file outside the R-only scan). Rare; the existing
+    // open → compute → close path (which uses `state.documents`) is preserved
+    // verbatim, so behavior for these is unchanged.
+    for path in targets {
+        let Ok(uri) = Url::from_file_path(path) else {
+            eprintln!(
+                "raven check: cannot convert path to URL: {}",
+                path.display()
+            );
+            operator_error = true;
+            continue;
+        };
+        if state.workspace_index.contains_key(&uri) {
+            continue; // already handled in the parallel phase
+        }
+        let text = match crate::state::read_source(path) {
+            Ok(t) => t,
+            Err(crate::state::SourceReadError::Io(e)) => {
+                eprintln!("raven check: cannot read {}: {e}", path.display());
+                operator_error = true;
+                continue;
+            }
+            // A mis-encoded file is a property of the code, like a syntax
+            // error — not an operator error. Report it as a finding (see
+            // `encoding_diagnostic`) and keep going, so the exit code
+            // reflects findings rather than a half-read abort.
+            Err(crate::state::SourceReadError::InvalidEncoding { offset, byte }) => {
+                all_diags.push((path.clone(), encoding_diagnostic(offset, byte)));
+                continue;
+            }
+        };
+        open_disk_fallback_target(state, &uri, path, &text);
+        if let Some(doc) = state.documents.get(&uri) {
+            reported_loaded_packages.extend(doc.loaded_packages.iter().cloned());
+        }
+        let diags = compute_file_diagnostics(state, &uri).await;
+        state.close_document(&uri);
+        for d in diags {
+            all_diags.push((path.clone(), d));
+        }
+    }
+
+    // Deterministic output regardless of the scan's parallel HashMap order.
+    all_diags.sort_by(|(pa, da), (pb, db)| {
+        pa.cmp(pb)
+            .then(da.range.start.line.cmp(&db.range.start.line))
+            .then(da.range.start.character.cmp(&db.range.start.character))
+    });
+
+    (all_diags, reported_loaded_packages, operator_error)
 }
 
 /// Resolve which files to report diagnostics for. Empty `paths` means every R
@@ -1752,6 +1774,80 @@ mod tests {
             }
             all
         })
+    }
+
+    /// Like `collect_diagnostics_blocking` but drives the REAL parallel
+    /// collection path (`collect_target_diagnostics`, the rayon phase `run`
+    /// uses), so a test can assert the parallel output equals the sequential
+    /// reference. Same setup as the sequential helper.
+    fn collect_diagnostics_parallel_blocking(args: &CheckArgs) -> Vec<(PathBuf, Diagnostic)> {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let root = std::fs::canonicalize(args.workspace.as_ref().unwrap()).unwrap();
+            let workspace_url = Url::from_file_path(&root).unwrap();
+            let mut state =
+                build_indexed_state(&root, &workspace_url, args.no_config, None).unwrap();
+            if !args.report_uninstalled {
+                state.cross_file_config.packages_missing_package_severity = None;
+            }
+            maybe_init_r(&mut state, &root).await;
+            state.resolve_system_file_in_workspace();
+            maybe_load_sysdata_fallback(&mut state).await;
+            let mut operator_error = false;
+            let targets = collect_report_targets(&args.paths, &root, &mut operator_error);
+            prefetch_reported_packages(&state, &targets).await;
+            let (all, _packages, _oe) = collect_target_diagnostics(&mut state, &targets).await;
+            all
+        })
+    }
+
+    /// Issue #479 WI3: the parallel per-file collection must be byte-identical to
+    /// a sequential run. The fixture is a hub sourced by several spokes with
+    /// cross-file `source()` references, so neighbor artifacts are resolved —
+    /// exactly the data a cross-worker open-document leak would corrupt. The
+    /// sequential reference opens one doc at a time into `state.documents`; the
+    /// parallel path uses per-worker one-entry overlays.
+    #[test]
+    fn parallel_collection_matches_sequential() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("hub.r"), "shared <- function() 1\n").unwrap();
+        for p in ["a.r", "b.r", "c.r", "d.r"] {
+            fs::write(
+                tmp.path().join(p),
+                "source(\"hub.r\")\nshared()\nbad_symbol\n",
+            )
+            .unwrap();
+        }
+        let args = base_args(tmp.path());
+
+        let normalize = |mut v: Vec<(PathBuf, Diagnostic)>| {
+            v.sort_by(|(pa, da), (pb, db)| {
+                pa.cmp(pb)
+                    .then(da.range.start.line.cmp(&db.range.start.line))
+                    .then(da.range.start.character.cmp(&db.range.start.character))
+                    .then(da.message.cmp(&db.message))
+            });
+            v.into_iter()
+                .map(|(p, d)| (p, d.range.start.line, d.range.start.character, d.message))
+                .collect::<Vec<_>>()
+        };
+
+        let seq = normalize(collect_diagnostics_blocking(&args));
+        let par = normalize(collect_diagnostics_parallel_blocking(&args));
+        assert_eq!(
+            par, seq,
+            "parallel collection must be byte-identical to the sequential reference"
+        );
+        // Sanity: the fixture actually exercises cross-file resolution — each
+        // spoke flags `bad_symbol` (undefined), while `shared()` resolves through
+        // the sourced hub and is NOT flagged.
+        assert!(
+            seq.iter().any(|(_, _, _, m)| m.contains("bad_symbol")),
+            "fixture should produce undefined-variable diagnostics: {seq:?}"
+        );
+        assert!(
+            !seq.iter().any(|(_, _, _, m)| m.contains("shared")),
+            "shared() should resolve cross-file and not be flagged: {seq:?}"
+        );
     }
 
     #[test]

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1605,6 +1605,86 @@ impl DependencyGraph {
         visited
     }
 
+    /// Truncation gate for issue #479's cross-prefix forward-child memo sharing
+    /// within a `ScopeStream`. Returns `true` only when no scope resolution
+    /// rooted in this neighborhood can hit max-depth truncation.
+    ///
+    /// A shared forward-child memo is byte-identical to the un-memoized resolver
+    /// EXCEPT when an entry's resolved scope depends on a per-query input that
+    /// `ForwardChildKey` does not encode (see [`ForwardChildMemo`]'s "never
+    /// shared across queries" discipline). Within one stream there are exactly
+    /// two such varying inputs, handled by two independent mechanisms:
+    ///
+    /// 1. **`query_inside_function` (local scoping).** `source(..., local =
+    ///    TRUE)` / `sys.source(...)` apply a `query_inside_function`-dependent
+    ///    declared-only inheritance policy (`is_local_scoped`,
+    ///    `should_apply_local_scoping`) that the memo key omits. This is handled
+    ///    by **slot isolation** in `ScopeStream`: the `query_inside_function =
+    ///    true` (hoisted, inside-a-function) prefix slot gets its OWN fresh memo,
+    ///    so only the mutually-consistent `false`-context computations (the
+    ///    `false` top slot plus every per-child-source call, which all query at
+    ///    EOF) ever share. This gate does NOT cover that mode.
+    /// 2. **Truncation (visited context).** A memo hit short-circuits a walk that
+    ///    would otherwise mark `visited`, perturbing a sibling path's truncation
+    ///    (`depth_exceeded`/`chain`). THIS gate covers it: disable sharing unless
+    ///    the whole bidirectional neighborhood sits at BFS depth `< max_depth -
+    ///    1`, so no resolution can reach `max_depth`.
+    ///
+    /// The BFS runs over the bidirectional source neighborhood (global
+    /// `visited`, O(V+E)) bounded by `budget`; on exhaustion the method returns
+    /// `false` (conservatively disabling sharing — sound, just no speedup).
+    /// Realistic global-scope hubs (default `maxChainDepth` 64, shallow chains)
+    /// pass and get the full O(N²)→O(N) collapse.
+    ///
+    /// NOTE on the depth check: BFS depth is the *shortest* bidirectional
+    /// distance, while the recursive resolver can in principle reach a node at a
+    /// greater `current_depth` via a longer path (its cloned-`visited`
+    /// isolation). The guard requires the neighborhood's BFS depth to stay
+    /// strictly below `max_depth - 1`, leaving headroom; combined with the
+    /// reality that realistic neighborhoods are far shallower than
+    /// `maxChainDepth`, this admits the global-scope hub case while gating off
+    /// any genuinely deep neighborhood (which could truncate). The equivalence
+    /// suite (`memo_equiv_*`, including the small-`max_depth` truncation case)
+    /// pins the behavior.
+    pub fn prefix_memo_share_safe(&self, from: &Url, max_depth: usize, budget: usize) -> bool {
+        // Need at least one hop of headroom below the truncation limit.
+        if max_depth < 2 {
+            return false;
+        }
+        let depth_cap = max_depth - 1;
+        let mut visited: HashSet<Url> = HashSet::new();
+        let mut queue = std::collections::VecDeque::new();
+        visited.insert(from.clone());
+        queue.push_back((from.clone(), 0usize));
+        let mut steps = 0usize;
+        while let Some((cur, depth)) = queue.pop_front() {
+            steps += 1;
+            if steps > budget {
+                return false; // conservative: cannot verify the whole neighborhood
+            }
+            // Any node sitting at/above the depth cap means the neighborhood is
+            // deep enough that resolution could plausibly truncate — gate off.
+            if depth >= depth_cap {
+                return false;
+            }
+            if let Some(edges) = self.forward.get(&cur) {
+                for e in edges {
+                    if visited.insert(e.to.clone()) {
+                        queue.push_back((e.to.clone(), depth + 1));
+                    }
+                }
+            }
+            if let Some(edges) = self.backward.get(&cur) {
+                for e in edges {
+                    if visited.insert(e.from.clone()) {
+                        queue.push_back((e.from.clone(), depth + 1));
+                    }
+                }
+            }
+        }
+        true
+    }
+
     /// Detect cycles involving a URI.
     ///
     /// Returns a `CycleDetection` containing:
@@ -1930,6 +2010,77 @@ mod tests {
             sources: vec![make_source(path, line)],
             ..Default::default()
         }
+    }
+
+    /// Issue #479: the truncation gate admits a shallow acyclic neighborhood.
+    #[test]
+    fn prefix_memo_share_safe_admits_shallow_acyclic() {
+        // A -> B -> C, queried from A. Max BFS depth 2 ≪ max_depth.
+        let mut graph = DependencyGraph::new();
+        graph.update_file(
+            &url("A.R"),
+            &make_meta_with_source("B.R", 1),
+            Some(&workspace_root()),
+            |_| None,
+        );
+        graph.update_file(
+            &url("B.R"),
+            &make_meta_with_source("C.R", 1),
+            Some(&workspace_root()),
+            |_| None,
+        );
+        assert!(graph.prefix_memo_share_safe(&url("A.R"), 64, 200_000));
+    }
+
+    /// Issue #479: a neighborhood deep enough to truncate is gated off, but a
+    /// generous `max_depth` over the same graph is admitted.
+    #[test]
+    fn prefix_memo_share_safe_gates_off_deep_chain() {
+        // A -> B -> C -> D -> E
+        let mut graph = DependencyGraph::new();
+        for (from, to) in [
+            ("A.R", "B.R"),
+            ("B.R", "C.R"),
+            ("C.R", "D.R"),
+            ("D.R", "E.R"),
+        ] {
+            graph.update_file(
+                &url(from),
+                &make_meta_with_source(to, 1),
+                Some(&workspace_root()),
+                |_| None,
+            );
+        }
+        // max_depth = 3 -> depth_cap = 2; node C at BFS depth 2 trips the gate.
+        assert!(!graph.prefix_memo_share_safe(&url("A.R"), 3, 200_000));
+        // A generous limit admits the same (shallow-relative) neighborhood.
+        assert!(graph.prefix_memo_share_safe(&url("A.R"), 64, 200_000));
+    }
+
+    /// Issue #479: budget exhaustion conservatively disables sharing.
+    #[test]
+    fn prefix_memo_share_safe_budget_exhaustion_is_false() {
+        let mut graph = DependencyGraph::new();
+        graph.update_file(
+            &url("A.R"),
+            &make_meta_with_source("B.R", 1),
+            Some(&workspace_root()),
+            |_| None,
+        );
+        assert!(!graph.prefix_memo_share_safe(&url("A.R"), 64, 0));
+    }
+
+    /// Issue #479: the truncation gate deliberately does NOT consider
+    /// `local`/`sys.source` edges — that divergence mode is handled by slot
+    /// isolation in `ScopeStream`, not here. A shallow graph with a local edge
+    /// is still admitted by this gate.
+    #[test]
+    fn prefix_memo_share_safe_ignores_local_edges() {
+        let mut graph = DependencyGraph::new();
+        let mut meta = make_meta_with_source("B.R", 1);
+        meta.sources[0].local = true;
+        graph.update_file(&url("A.R"), &meta, Some(&workspace_root()), |_| None);
+        assert!(graph.prefix_memo_share_safe(&url("A.R"), 64, 200_000));
     }
 
     #[test]

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -2083,6 +2083,49 @@ mod tests {
         assert!(graph.prefix_memo_share_safe(&url("A.R"), 64, 200_000));
     }
 
+    /// Issue #479: pin the exact admit/reject boundary so an off-by-one in
+    /// `depth_cap = max_depth - 1` or the `depth >= depth_cap` comparison is
+    /// caught (the deep-chain test uses a generous margin and would not). With
+    /// `max_depth = 4`, `depth_cap = 3`: a neighborhood whose deepest node is at
+    /// BFS depth 2 (== depth_cap - 1) is the LAST admitted; depth 3 (== depth_cap)
+    /// is the FIRST rejected.
+    #[test]
+    fn prefix_memo_share_safe_pins_depth_boundary() {
+        let chain = |links: &[(&str, &str)]| {
+            let mut graph = DependencyGraph::new();
+            for (from, to) in links {
+                graph.update_file(
+                    &url(from),
+                    &make_meta_with_source(to, 1),
+                    Some(&workspace_root()),
+                    |_| None,
+                );
+            }
+            graph
+        };
+        // A->B->C : deepest BFS node C at depth 2 == depth_cap-1 → admitted.
+        let admitted = chain(&[("A.R", "B.R"), ("B.R", "C.R")]);
+        assert!(admitted.prefix_memo_share_safe(&url("A.R"), 4, 200_000));
+        // A->B->C->D : D at depth 3 == depth_cap → rejected.
+        let rejected = chain(&[("A.R", "B.R"), ("B.R", "C.R"), ("C.R", "D.R")]);
+        assert!(!rejected.prefix_memo_share_safe(&url("A.R"), 4, 200_000));
+    }
+
+    /// Issue #479: `max_depth < 2` has no headroom below the truncation limit,
+    /// so the gate must refuse outright (the early return).
+    #[test]
+    fn prefix_memo_share_safe_rejects_tiny_max_depth() {
+        let mut graph = DependencyGraph::new();
+        graph.update_file(
+            &url("A.R"),
+            &make_meta_with_source("B.R", 1),
+            Some(&workspace_root()),
+            |_| None,
+        );
+        assert!(!graph.prefix_memo_share_safe(&url("A.R"), 0, 200_000));
+        assert!(!graph.prefix_memo_share_safe(&url("A.R"), 1, 200_000));
+    }
+
     #[test]
     fn test_add_and_get_dependencies() {
         let mut graph = DependencyGraph::new();

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1626,9 +1626,17 @@ impl DependencyGraph {
     ///    EOF) ever share. This gate does NOT cover that mode.
     /// 2. **Truncation (visited context).** A memo hit short-circuits a walk that
     ///    would otherwise mark `visited`, perturbing a sibling path's truncation
-    ///    (`depth_exceeded`/`chain`). THIS gate covers it: disable sharing unless
-    ///    the whole bidirectional neighborhood sits at BFS depth `< max_depth -
-    ///    1`, so no resolution can reach `max_depth`.
+    ///    (`depth_exceeded`/`chain`). This gate bounds the part of that mode that
+    ///    can corrupt the **symbol set**: disable sharing unless the whole
+    ///    bidirectional neighborhood sits at BFS depth `< max_depth - 1`. The
+    ///    bound is SOUND for symbols regardless of the depth check's precision,
+    ///    because a truncating resolution carries a non-empty `depth_exceeded`
+    ///    and is therefore never written to the memo (the
+    ///    `computed.depth_exceeded.is_empty()` guard in
+    ///    `resolve_forward_child_memoized`), so the cache can never feed a
+    ///    truncated (wrong) symbol set to another prefix root. The
+    ///    `depth_exceeded`/`chain` channel itself has a bounded residual — see
+    ///    the NOTE below and issue #484.
     ///
     /// The BFS runs over the bidirectional source neighborhood (global
     /// `visited`, O(V+E)) bounded by `budget`; on exhaustion the method returns
@@ -1636,16 +1644,26 @@ impl DependencyGraph {
     /// Realistic global-scope hubs (default `maxChainDepth` 64, shallow chains)
     /// pass and get the full O(N²)→O(N) collapse.
     ///
-    /// NOTE on the depth check: BFS depth is the *shortest* bidirectional
-    /// distance, while the recursive resolver can in principle reach a node at a
-    /// greater `current_depth` via a longer path (its cloned-`visited`
-    /// isolation). The guard requires the neighborhood's BFS depth to stay
-    /// strictly below `max_depth - 1`, leaving headroom; combined with the
-    /// reality that realistic neighborhoods are far shallower than
-    /// `maxChainDepth`, this admits the global-scope hub case while gating off
-    /// any genuinely deep neighborhood (which could truncate). The equivalence
-    /// suite (`memo_equiv_*`, including the small-`max_depth` truncation case)
-    /// pins the behavior.
+    /// NOTE on the depth check (residual risk — issue #484): BFS depth is the
+    /// *shortest* bidirectional distance, while the resolver can reach a node at
+    /// a greater `current_depth` via a *longer* path (forward children resolve
+    /// with cloned `visited`, and the backward-then-forward walk can revisit).
+    /// So this gate can ADMIT a neighborhood that the resolver then truncates
+    /// via a longer path. The consequence is confined to the heuristic
+    /// `depth_exceeded`/`chain` channel: under such truncation, the shared
+    /// (visited-independent) memo can cause the advisory "Maximum chain depth
+    /// exceeded" diagnostic to be emitted on a file where the un-memoized
+    /// resolver would not, or vice versa. It can NEVER corrupt the symbol set
+    /// (see point 2 — truncated scopes are never cached). It only triggers when
+    /// a `source()` chain actually reaches `maxChainDepth`, which does not occur
+    /// at the default `maxChainDepth = 64` on realistic workspaces (worldwide
+    /// `raven check .` is byte-identical and deterministic). A fully sound depth
+    /// check is a longest-simple-path quantity (NP-hard in general, and a naive
+    /// search would disable sharing on the very star-hub topology this memo
+    /// speeds up), so the residual is accepted and tracked in #484 (proposed
+    /// fix: verify the advisory at emit time, off the hot path). The
+    /// `memo_equiv_*` suite pins the symbol-equivalence guarantee, including the
+    /// gate-admitted-with-truncation case (`memo_equiv_gate_admitted_with_truncation`).
     pub fn prefix_memo_share_safe(&self, from: &Url, max_depth: usize, budget: usize) -> bool {
         // Need at least one hop of headroom below the truncation limit.
         if max_depth < 2 {

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -28,6 +28,7 @@ struct DirectivePatterns {
     declare_var: Regex,
     declare_func: Regex,
     nse: Regex,
+    standalone: Regex,
 }
 
 /// Convert an optional `[code]` selector capture into a [`LineSuppression`].
@@ -493,6 +494,15 @@ fn patterns() -> &'static DirectivePatterns {
                 ]
                 .concat(),
             ).unwrap(),
+            // Callee-side "standalone module" directive (issue #479):
+            // `# raven: standalone` (alias `@lsp-standalone`). Header-only,
+            // file-level, no payload. End-anchored with an optional trailing
+            // `# comment`, so stray trailing text fails to match (a malformed
+            // payload is ignored rather than half-parsed).
+            standalone: Regex::new(
+                &[r"^\s*#\s*", DIRECTIVE_PREFIX, r"standalone\s*(?:#.*)?$"].concat(),
+            )
+            .unwrap(),
         }
     })
 }
@@ -587,6 +597,17 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
                 path
             );
             meta.working_directory = Some(path);
+            continue;
+        }
+
+        // Header-only: standalone-module directive (issue #479). File-level, no
+        // payload. Like the backward/working-dir directives it is only honored
+        // in the header so a `standalone` token deeper in the file (e.g. inside
+        // a string or a later comment) cannot retroactively change the file's
+        // cross-file scoping semantics.
+        if in_header && patterns.standalone.is_match(line) {
+            log::trace!("  Parsed standalone directive at line {}", line_num);
+            meta.standalone = true;
             continue;
         }
 
@@ -2820,5 +2841,41 @@ x <- undefined"#;
             formals.iter().all(|f| is_formal_name(f)),
             "non-name formal recorded: {formals:?}"
         );
+    }
+
+    // ---- issue #479: `# raven: standalone` ----
+
+    #[test]
+    fn standalone_directive_sets_flag() {
+        assert!(parse_directives("# raven: standalone\nx <- 1\n").standalone);
+    }
+
+    #[test]
+    fn standalone_directive_lsp_alias_sets_flag() {
+        assert!(parse_directives("# @lsp-standalone\nx <- 1\n").standalone);
+    }
+
+    #[test]
+    fn standalone_directive_allows_trailing_comment() {
+        assert!(parse_directives("# raven: standalone  # a module\n").standalone);
+    }
+
+    #[test]
+    fn standalone_directive_is_header_only() {
+        // A `standalone` token after code must NOT set the flag (header-only,
+        // like the backward/working-dir directives).
+        assert!(!parse_directives("x <- 1\n# raven: standalone\n").standalone);
+    }
+
+    #[test]
+    fn standalone_directive_absent_by_default() {
+        assert!(!parse_directives("x <- 1\n").standalone);
+    }
+
+    #[test]
+    fn standalone_directive_rejects_payload() {
+        // End-anchored: an unexpected payload fails to match rather than being
+        // half-parsed.
+        assert!(!parse_directives("# raven: standalone foo\n").standalone);
     }
 }

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -1631,6 +1631,8 @@ pub fn compute_artifacts(uri: &Url, tree: &Tree, content: &str) -> ScopeArtifact
         &removal_refs,
         &data_loads,
         &declarations,
+        // No metadata available in this path → cannot be standalone.
+        false,
     );
 
     artifacts
@@ -1914,6 +1916,7 @@ pub fn compute_artifacts_with_metadata(
         &removal_refs,
         &data_loads,
         &declarations,
+        metadata.is_some_and(|m| m.standalone),
     );
 
     artifacts
@@ -4490,6 +4493,7 @@ fn extract_top_level_declarations(timeline: &[ScopeEvent]) -> Vec<(Arc<str>, u32
 /// `top_level_removals`, `data_loads`, and `declarations` (the
 /// `(name, line)` pairs of all timeline `Declaration` events — see
 /// [`extract_top_level_declarations`]).
+#[allow(clippy::too_many_arguments)]
 fn compute_interface_hash(
     interface: &HashMap<Arc<str>, ScopedSymbol>,
     packages: &[String],
@@ -4498,8 +4502,16 @@ fn compute_interface_hash(
     top_level_removals: &[TopLevelRemoval<'_>],
     data_loads: &[DataCallInfo],
     declarations: &[(Arc<str>, u32)],
+    standalone: bool,
 ) -> u64 {
     let mut hasher = DefaultHasher::new();
+
+    // Issue #479: a `# raven: standalone` callee no longer inherits packages
+    // from its callers, which changes the inherited-package set it propagates
+    // forward to OTHER callers (it removes the caller-union package leakage). So
+    // toggling the directive in any connected file must invalidate dependents —
+    // include it in the interface hash.
+    standalone.hash(&mut hasher);
 
     // Sort keys for deterministic hashing of symbols
     let mut keys: Vec<_> = interface.keys().collect();
@@ -4991,6 +5003,26 @@ where
     G: Fn(&Url) -> Option<std::sync::Arc<super::types::CrossFileMetadata>>,
 {
     let mut prefix = ParentPrefix::default();
+
+    // Issue #479 — callee-side `# raven: standalone`. A standalone file is
+    // resolved in ISOLATION from the files that source it: its STEP-1 backward
+    // parent-prefix walk is skipped entirely, so it inherits NO symbols, NO
+    // packages, and NO `DataAliasProvider`/working-directory context from any
+    // caller. Returning the empty prefix here is the single load-bearing switch
+    // (knob 1): it covers every entry point that computes a file's prefix (the
+    // streaming `compute_or_get_cached_prefix`, the cached
+    // `scope_at_position_with_graph_cached`, and the per-child-source call in
+    // `resolve_source_contribution`). The file's OWN definitions and forward
+    // closure are still resolved by STEP 2 and still flow forward to callers
+    // (the additive merge is unchanged), so a standalone library that
+    // `library()`-loads packages still contributes them upward. Caller-inherited
+    // packages specifically arrive via this backward walk, so skipping it is
+    // exactly what drops them. Opt-in and safe-direction: if the file actually
+    // relied on a caller-provided binding, the worst case is a false "undefined"
+    // INSIDE the file — never a hidden bug in a caller.
+    if get_metadata(uri).is_some_and(|m| m.standalone) {
+        return prefix;
+    }
 
     // Get edges where this file is the child (callee)
     //
@@ -9275,6 +9307,150 @@ mod tests {
         assert!(
             !scope.symbols.contains_key("y"),
             "Should NOT have 'y' - after call site"
+        );
+    }
+
+    /// Issue #479 knob 1: a `# raven: standalone` callee is resolved in
+    /// isolation — it does NOT inherit symbols from the files that source it.
+    /// Without the directive the callee sees the parent's pre-call bindings;
+    /// with it, the callee must not (a deliberately caller-relied binding becomes
+    /// undefined INSIDE the callee — the safe-direction trade-off). Knob 2: the
+    /// caller still sees the callee's own definitions regardless.
+    #[test]
+    fn standalone_callee_resolved_in_isolation() {
+        use crate::cross_file::dependency::DependencyGraph;
+        use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+        let parent_uri = Url::parse("file:///project/parent.R").unwrap();
+        let child_uri = Url::parse("file:///project/child.R").unwrap();
+        let workspace_root = Url::parse("file:///project").unwrap();
+
+        // parent defines `parent_sym` (line 0), then sources child (line 1).
+        let parent_code = "parent_sym <- 1\nsource(\"child.R\")\n";
+        let parent_artifacts = compute_artifacts(&parent_uri, &parse_r(parent_code), parent_code);
+        // child references the parent-provided binding and defines its own.
+        let child_code = "child_sym <- parent_sym\n";
+        let child_artifacts = compute_artifacts(&child_uri, &parse_r(child_code), child_code);
+
+        let parent_metadata = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "child.R".to_string(),
+                line: 1,
+                column: 0,
+                sys_source_global_env: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut graph = DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&workspace_root), |_| {
+            None
+        });
+
+        let get_artifacts = |uri: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if uri == &parent_uri {
+                Some(Arc::new(parent_artifacts.clone()))
+            } else if uri == &child_uri {
+                Some(Arc::new(child_artifacts.clone()))
+            } else {
+                None
+            }
+        };
+
+        let resolve_child = |standalone: bool| {
+            let cu = child_uri.clone();
+            let pu = parent_uri.clone();
+            let child_metadata = std::sync::Arc::new(CrossFileMetadata {
+                standalone,
+                ..Default::default()
+            });
+            let parent_md = std::sync::Arc::new(parent_metadata.clone());
+            let get_metadata = move |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> {
+                if uri == &cu {
+                    Some(child_metadata.clone())
+                } else if uri == &pu {
+                    Some(parent_md.clone())
+                } else {
+                    None
+                }
+            };
+            scope_at_position_with_graph(
+                &child_uri,
+                0,
+                u32::MAX,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                64,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+                &|| false,
+                None,
+                None,
+            )
+        };
+
+        // Without standalone: the callee inherits the parent's pre-call binding.
+        let inherited = resolve_child(false);
+        assert!(
+            inherited.symbols.contains_key("parent_sym"),
+            "non-standalone callee should inherit `parent_sym` from its caller"
+        );
+
+        // With standalone (knob 1): the callee is isolated — no `parent_sym`.
+        let isolated = resolve_child(true);
+        assert!(
+            !isolated.symbols.contains_key("parent_sym"),
+            "standalone callee must NOT inherit caller bindings"
+        );
+        // The callee still defines its own symbol in both cases.
+        assert!(
+            isolated.symbols.contains_key("child_sym"),
+            "standalone callee keeps its own definitions"
+        );
+
+        // Knob 2: the caller still sees the callee's own definition regardless
+        // of the directive (the additive forward merge is unchanged).
+        let resolve_parent = |standalone: bool| {
+            let cu = child_uri.clone();
+            let pu = parent_uri.clone();
+            let child_metadata = std::sync::Arc::new(CrossFileMetadata {
+                standalone,
+                ..Default::default()
+            });
+            let parent_md = std::sync::Arc::new(parent_metadata.clone());
+            let get_metadata = move |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> {
+                if uri == &cu {
+                    Some(child_metadata.clone())
+                } else if uri == &pu {
+                    Some(parent_md.clone())
+                } else {
+                    None
+                }
+            };
+            scope_at_position_with_graph(
+                &parent_uri,
+                2,
+                u32::MAX,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&workspace_root),
+                64,
+                &HashSet::new(),
+                false,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+                &|| false,
+                None,
+                None,
+            )
+        };
+        assert!(
+            resolve_parent(true).symbols.contains_key("child_sym"),
+            "caller must still see a standalone callee's own definitions (knob 2)"
         );
     }
 

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -6796,7 +6796,37 @@ where
     /// level below, keyed by `(child_uri, path_fp, pkg_fp)`. See
     /// [`ForwardChildMemo`].
     forward_child_memo: std::cell::RefCell<ForwardChildMemo>,
+
+    /// Shared forward-child memo for STEP-1 **prefix** computation (issue
+    /// #479), SEPARATE from the actual-depth `forward_child_memo` above. When
+    /// `Some`, it is threaded into every `compute_or_get_cached_prefix` call in
+    /// this stream (both top-level precomputes and the per-child-source calls
+    /// in `resolve_source_contribution`), so the hub closure is resolved once
+    /// per stream instead of once per prefix slot — collapsing the O(N²)
+    /// re-resolution on hub-heavy global-scope workspaces.
+    ///
+    /// `Some` ONLY when
+    /// [`super::dependency::DependencyGraph::prefix_memo_share_safe`] proves this
+    /// stream cannot hit max-depth truncation (the visited-context divergence
+    /// mode). The OTHER divergence mode — `query_inside_function`-dependent
+    /// `local`/`sys.source` scoping — is handled separately by **slot
+    /// isolation**: this shared memo is threaded into the `false` top slot and
+    /// every per-child-source call (all of which query at EOF), but the
+    /// `query_inside_function = true` slot always gets its own fresh memo (see
+    /// the `None` passed at its call site). When the gate returns `false`, this
+    /// is `None` and each prefix gets a fresh ephemeral memo — the pre-#479
+    /// behavior exactly. The win is in the common global-scope hub (shallow
+    /// chains), which the gate admits.
+    prefix_forward_child_memo: Option<std::cell::RefCell<ForwardChildMemo>>,
 }
+
+/// Budget (edge relaxations / path steps) for the
+/// [`super::dependency::DependencyGraph::prefix_memo_share_safe`] gate that
+/// decides whether a stream may share its prefix forward-child memo (issue
+/// #479). Large enough that realistic neighborhoods finish both gate probes
+/// well within it; a dense/deep graph that exhausts it conservatively disables
+/// sharing (sound, just no speedup).
+const PREFIX_MEMO_SHARE_PROBE_BUDGET: usize = 200_000;
 
 impl<'a, F, G> ScopeStream<'a, F, G>
 where
@@ -6832,9 +6862,23 @@ where
         // sweep's `resolve_source_contribution` calls. The prefix
         // pre-computation below deliberately does NOT use this memo —
         // `compute_or_get_cached_prefix` resolves prefixes at a canonical
-        // depth-0 origin and uses its own ephemeral memo to avoid polluting this
+        // depth-0 origin and uses a SEPARATE prefix memo (or, when sharing is
+        // gated off, its own ephemeral memo) to avoid polluting this
         // actual-depth one (see its doc comment).
         let forward_child_memo = std::cell::RefCell::new(ForwardChildMemo::default());
+
+        // Shared prefix forward-child memo (issue #479) — enabled only when the
+        // gate proves cross-prefix sharing is byte-identical for this stream
+        // (no local/sys.source edges, no possible truncation). `None`
+        // reproduces the pre-#479 behavior exactly (a fresh ephemeral memo per
+        // prefix computation).
+        let prefix_forward_child_memo =
+            if graph.prefix_memo_share_safe(queried_uri, max_depth, PREFIX_MEMO_SHARE_PROBE_BUDGET)
+            {
+                Some(std::cell::RefCell::new(ForwardChildMemo::default()))
+            } else {
+                None
+            };
 
         // Pre-compute both prefix slots through the shared cache.
         let prefix_top = compute_or_get_cached_prefix(
@@ -6850,6 +6894,7 @@ where
             backward_dep_mode,
             is_cancelled,
             prefix_cache,
+            prefix_forward_child_memo.as_ref(),
         );
         let prefix_in_function = if hoist_globals {
             compute_or_get_cached_prefix(
@@ -6865,6 +6910,16 @@ where
                 backward_dep_mode,
                 is_cancelled,
                 prefix_cache,
+                // SLOT ISOLATION (issue #479): the `query_inside_function = true`
+                // (hoisted, inside-a-function) prefix slot gets its OWN fresh
+                // memo — NEVER the shared one — because `local`/`sys.source`
+                // scoping is `query_inside_function`-dependent and the memo key
+                // omits that, so a `false`-context entry must not serve this
+                // `true`-context slot (and vice versa). Passing `None` forces a
+                // fresh ephemeral memo for this one slot; the expensive
+                // per-child-source calls all query at EOF (`false`) and keep
+                // sharing.
+                None,
             )
         } else {
             prefix_top.clone()
@@ -6926,6 +6981,7 @@ where
             contribution_symbol_names,
             data_alias_provider,
             forward_child_memo,
+            prefix_forward_child_memo,
         })
     }
 
@@ -7765,6 +7821,7 @@ where
             self.backward_dep_mode,
             self.is_cancelled,
             self.prefix_cache,
+            self.prefix_forward_child_memo.as_ref(),
         );
 
         // Run STEP 2 for the child at EOF, supplying the cached prefix.
@@ -8010,6 +8067,7 @@ fn compute_or_get_cached_prefix<F, G>(
     backward_dep_mode: super::config::BackwardDependencyMode,
     is_cancelled: &dyn Fn() -> bool,
     prefix_cache: &std::cell::RefCell<ParentPrefixCache>,
+    shared_prefix_forward_child_memo: Option<&std::cell::RefCell<ForwardChildMemo>>,
 ) -> Arc<ParentPrefix>
 where
     F: Fn(&Url) -> Option<Arc<ScopeArtifacts>>,
@@ -8023,15 +8081,27 @@ where
     }
     // The prefix is computed at a canonical `current_depth = 0` origin (it is
     // depth-invariant and cached as such in `ParentPrefixCache`). Its internal
-    // forward-child resolutions therefore use depth-0-origin depths, which do
-    // NOT match the actual depth a streaming forward sweep reaches the same
-    // child at. Give them a FRESH, ephemeral forward-child memo so they cannot
-    // pollute the caller's actual-depth memo — otherwise a child's prefix
-    // forward-children (resolved here at the artificial origin) could be
-    // reused by the real sweep and perturb depth-dependent bookkeeping
-    // (`depth_exceeded`, `chain`) under a small `maxChainDepth`. The backward
-    // walk's own dedup is already handled by `ParentPrefixCache`.
-    let prefix_forward_child_memo = std::cell::RefCell::new(ForwardChildMemo::default());
+    // forward-child resolutions use depth-0-origin depths, which do NOT match
+    // the actual depth a streaming forward sweep reaches the same child at, so
+    // the prefix memo is ALWAYS kept separate from the caller's actual-depth
+    // `forward_child_memo`.
+    //
+    // Issue #479: when `prefix_memo_share_safe` proved cross-prefix sharing is
+    // byte-identical for this stream, callers pass a shared memo reused across
+    // all of the stream's prefix computations, collapsing the O(N²) hub
+    // re-resolution. When `None` (sharing gated off, or non-stream callers), a
+    // FRESH ephemeral memo per call reproduces the pre-#479 behavior exactly —
+    // so context the key omits (`query_inside_function`/local scoping, visited
+    // under truncation) cannot leak across prefix roots. The backward walk's own
+    // dedup is handled by `ParentPrefixCache` in both cases.
+    let ephemeral_prefix_memo;
+    let prefix_forward_child_memo = match shared_prefix_forward_child_memo {
+        Some(memo) => memo,
+        None => {
+            ephemeral_prefix_memo = std::cell::RefCell::new(ForwardChildMemo::default());
+            &ephemeral_prefix_memo
+        }
+    };
     // Compute outside the borrow so `parent_prefix_at`'s recursive
     // `scope_at_position_with_graph_recursive` call doesn't transitively
     // try to re-enter the cache.
@@ -8059,7 +8129,7 @@ where
         hoist_globals,
         backward_dep_mode,
         is_cancelled,
-        &prefix_forward_child_memo,
+        prefix_forward_child_memo,
     );
     let arc = Arc::new(computed);
     let mut cache = prefix_cache.borrow_mut();

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -8272,7 +8272,11 @@ mod tests {
     /// line in `compute_interface_hash` against silent removal.
     #[test]
     fn interface_hash_changes_when_standalone_directive_added() {
-        let a = "f <- function() 1\n";
+        // Hold `f`'s line constant across both inputs (a plain comment vs the
+        // directive, both on line 0) so the ONLY difference is the `standalone`
+        // flag — otherwise `defined_line` (part of the symbol hash) would shift
+        // and the assertion would pass even if `standalone.hash(...)` were removed.
+        let a = "# not a directive\nf <- function() 1\n";
         let b = "# raven: standalone\nf <- function() 1\n";
         let ta = parse_r(a);
         let tb = parse_r(b);

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -4506,11 +4506,12 @@ fn compute_interface_hash(
 ) -> u64 {
     let mut hasher = DefaultHasher::new();
 
-    // Issue #479: a `# raven: standalone` callee no longer inherits packages
-    // from its callers, which changes the inherited-package set it propagates
-    // forward to OTHER callers (it removes the caller-union package leakage). So
-    // toggling the directive in any connected file must invalidate dependents —
-    // include it in the interface hash.
+    // Issue #479: toggling a `# raven: standalone` directive changes the file's
+    // resolved cross-file scope — its backward parent-prefix walk is skipped, so
+    // its own scope (and thus the contribution it propagates forward to callers)
+    // no longer includes the symbols/packages it would otherwise inherit via its
+    // backward edges. Dependents must therefore revalidate when the directive is
+    // toggled in any connected file, so include it in the interface hash.
     standalone.hash(&mut hasher);
 
     // Sort keys for deterministic hashing of symbols
@@ -5004,22 +5005,34 @@ where
 {
     let mut prefix = ParentPrefix::default();
 
-    // Issue #479 — callee-side `# raven: standalone`. A standalone file is
-    // resolved in ISOLATION from the files that source it: its STEP-1 backward
-    // parent-prefix walk is skipped entirely, so it inherits NO symbols, NO
-    // packages, and NO `DataAliasProvider`/working-directory context from any
-    // caller. Returning the empty prefix here is the single load-bearing switch
-    // (knob 1): it covers every entry point that computes a file's prefix (the
-    // streaming `compute_or_get_cached_prefix`, the cached
+    // Issue #479 — callee-side `# raven: standalone`. A standalone file's STEP-1
+    // backward parent-prefix walk is skipped entirely: this `parent_prefix_at`
+    // returns the empty prefix, so the file's backward contribution carries none
+    // of the caller symbols or packages it would otherwise inherit. (The
+    // backward `ParentPrefix` carries only symbols, packages, chain, and
+    // visible-position/depth data — never a provider or working directory; those
+    // are forward-threaded inputs, see the SCOPE note below.) Returning the empty
+    // prefix here is the single
+    // load-bearing switch (knob 1): it covers every entry point that computes a
+    // file's prefix (the streaming `compute_or_get_cached_prefix`, the cached
     // `scope_at_position_with_graph_cached`, and the per-child-source call in
     // `resolve_source_contribution`). The file's OWN definitions and forward
     // closure are still resolved by STEP 2 and still flow forward to callers
     // (the additive merge is unchanged), so a standalone library that
-    // `library()`-loads packages still contributes them upward. Caller-inherited
-    // packages specifically arrive via this backward walk, so skipping it is
-    // exactly what drops them. Opt-in and safe-direction: if the file actually
-    // relied on a caller-provided binding, the worst case is a false "undefined"
-    // INSIDE the file — never a hidden bug in a caller.
+    // `library()`-loads packages still contributes them upward.
+    //
+    // SCOPE — backward walk only (shipped "part 1"). Skipping the backward walk
+    // is what isolates the file when computing its OWN diagnostics (queried as a
+    // root, its prefix is empty). It does NOT drop the inputs a caller threads
+    // *forward* into this file when this file is resolved as that caller's
+    // forward child: the forward-source path below still threads the caller's
+    // `inherited`/`loaded` packages into `packages_for_child`, the caller's
+    // working directory into `child_ctx`, and the caller's `data_alias_provider`
+    // — none gated by `standalone`. Making that forward resolution
+    // caller-independent ("part 2") is deferred to WI2b (#483). Opt-in and
+    // safe-direction: if the file actually relied on a caller-provided binding,
+    // the worst case is a false "undefined" INSIDE the file — never a hidden bug
+    // in a caller.
     if get_metadata(uri).is_some_and(|m| m.standalone) {
         return prefix;
     }
@@ -6838,9 +6851,15 @@ where
     /// re-resolution on hub-heavy global-scope workspaces.
     ///
     /// `Some` ONLY when
-    /// [`super::dependency::DependencyGraph::prefix_memo_share_safe`] proves this
-    /// stream cannot hit max-depth truncation (the visited-context divergence
-    /// mode). The OTHER divergence mode — `query_inside_function`-dependent
+    /// [`super::dependency::DependencyGraph::prefix_memo_share_safe`] admits this
+    /// stream (a BFS-shortest-depth bound on the truncation/visited-context
+    /// divergence mode). That bound keeps the shared **symbol set** byte-identical
+    /// to the un-memoized resolver — truncated scopes are never cached, so a
+    /// longer-path truncation the gate failed to exclude cannot corrupt symbols.
+    /// It leaves a bounded residual on the heuristic `depth_exceeded`/`chain`
+    /// advisory under such truncation (issue #484); that channel only diverges
+    /// when a chain actually reaches `maxChainDepth`. The OTHER divergence mode —
+    /// `query_inside_function`-dependent
     /// `local`/`sys.source` scoping — is handled separately by **slot
     /// isolation**: this shared memo is threaded into the `false` top slot and
     /// every per-child-source call (all of which query at EOF), but the
@@ -6899,11 +6918,17 @@ where
         // actual-depth one (see its doc comment).
         let forward_child_memo = std::cell::RefCell::new(ForwardChildMemo::default());
 
-        // Shared prefix forward-child memo (issue #479) — enabled only when the
-        // gate proves cross-prefix sharing is byte-identical for this stream
-        // (no local/sys.source edges, no possible truncation). `None`
-        // reproduces the pre-#479 behavior exactly (a fresh ephemeral memo per
-        // prefix computation).
+        // Shared prefix forward-child memo (issue #479). The gate
+        // (`prefix_memo_share_safe`) proves only the no-possible-truncation half
+        // (the neighborhood is BFS-shallow relative to `maxChainDepth`); the
+        // other divergence mode — `local`/`sys.source` scoping — is NOT checked
+        // by the gate but handled separately by slot isolation (the
+        // `query_inside_function = true` slot is passed `None` below). With both
+        // in place, cross-prefix sharing is byte-identical for the symbol set
+        // (see the field doc on `prefix_forward_child_memo` and #484 for the
+        // residual on the `depth_exceeded` advisory). `None` reproduces the
+        // pre-#479 behavior exactly (a fresh ephemeral memo per prefix
+        // computation).
         let prefix_forward_child_memo =
             if graph.prefix_memo_share_safe(queried_uri, max_depth, PREFIX_MEMO_SHARE_PROBE_BUDGET)
             {
@@ -8118,10 +8143,13 @@ where
     // the prefix memo is ALWAYS kept separate from the caller's actual-depth
     // `forward_child_memo`.
     //
-    // Issue #479: when `prefix_memo_share_safe` proved cross-prefix sharing is
-    // byte-identical for this stream, callers pass a shared memo reused across
-    // all of the stream's prefix computations, collapsing the O(N²) hub
-    // re-resolution. When `None` (sharing gated off, or non-stream callers), a
+    // Issue #479: when the share gate (`prefix_memo_share_safe`) admitted this
+    // stream, callers pass a shared memo (`Some`) reused across all of the
+    // stream's prefix computations, collapsing the O(N²) hub re-resolution. The
+    // gate covers only the truncation mode; the `query_inside_function`/local
+    // mode is covered separately by slot isolation at the call site (the
+    // `query_inside_function = true` slot is passed `None`). When `None`
+    // (sharing gated off, the isolated `true` slot, or non-stream callers), a
     // FRESH ephemeral memo per call reproduces the pre-#479 behavior exactly —
     // so context the key omits (`query_inside_function`/local scoping, visited
     // under truncation) cannot leak across prefix roots. The backward walk's own
@@ -16488,6 +16516,214 @@ x <- 1"#;
         for depth in [3usize, 4, 5] {
             assert_memo_equivalence_with_depth(&root, &files, depth);
         }
+    }
+
+    #[test]
+    fn memo_equiv_gate_admitted_with_truncation() {
+        // Issue #479 hardening — the one interaction no other `memo_equiv_*`
+        // test covers: the shared-prefix-memo gate (`prefix_memo_share_safe`)
+        // ADMITS sharing, yet the recursive resolver still TRUNCATES. The gate
+        // admits on *shortest-path* BFS depth, while the resolver (cloned
+        // `visited` per branch) can reach a node at a greater `current_depth`
+        // via a *longer simple path* and truncate there. `memo_equiv_dense_hub_*`
+        // admits but is too shallow to truncate; `memo_equiv_depth_truncation_*`
+        // truncates but is deep enough that the gate DISABLES sharing — neither
+        // hits both at once.
+        //
+        // Construction: hub `q` sources `a..e` directly (so every node sits at
+        // BFS depth 1 from `q` and the gate admits at small `max_depth`), AND
+        // `a -> b -> c -> d -> e` is chained, giving a length-5 simple path that
+        // truncates under a small `max_depth`. The shared-vs-unshared memo
+        // result must still be byte-identical: a truncated subtree carries a
+        // non-empty `depth_exceeded` and is therefore never written to the memo
+        // (`resolve_forward_child_memoized`), so a gate-admitted-but-truncating
+        // graph behaves exactly like the un-shared baseline.
+        use crate::cross_file::dependency::DependencyGraph;
+        use crate::cross_file::types::CrossFileMetadata;
+
+        let root = Url::parse("file:///project").unwrap();
+        let q = Url::parse("file:///project/q.r").unwrap();
+        let a = Url::parse("file:///project/a.r").unwrap();
+        let files: Vec<(Url, &str)> = vec![
+            (
+                q.clone(),
+                "source(\"a.r\")\nsource(\"b.r\")\nsource(\"c.r\")\nsource(\"d.r\")\nsource(\"e.r\")\n",
+            ),
+            (a.clone(), "source(\"b.r\")\nsym_a <- 1\n"),
+            (
+                Url::parse("file:///project/b.r").unwrap(),
+                "source(\"c.r\")\nsym_b <- 1\n",
+            ),
+            (
+                Url::parse("file:///project/c.r").unwrap(),
+                "source(\"d.r\")\nsym_c <- 1\n",
+            ),
+            (
+                Url::parse("file:///project/d.r").unwrap(),
+                "source(\"e.r\")\nsym_d <- 1\n",
+            ),
+            (Url::parse("file:///project/e.r").unwrap(), "sym_e <- 1\n"),
+        ];
+
+        // Build the graph + artifacts/metas once (mirrors
+        // `assert_memo_equivalence_with_depth`'s internal construction) so the
+        // two non-vacuity checks below can probe the gate and the truncation
+        // directly.
+        let mut graph = DependencyGraph::new();
+        let mut artifacts: HashMap<Url, Arc<ScopeArtifacts>> = HashMap::new();
+        let mut metas: HashMap<Url, std::sync::Arc<CrossFileMetadata>> = HashMap::new();
+        for (uri, code) in &files {
+            let tree = parse_r(code);
+            artifacts.insert(uri.clone(), Arc::new(compute_artifacts(uri, &tree, code)));
+            let meta = std::sync::Arc::new(crate::cross_file::extract_metadata_with_tree(
+                code,
+                Some(&tree),
+            ));
+            graph.update_file(uri, &meta, Some(&root), |_| None);
+            metas.insert(uri.clone(), meta);
+        }
+
+        // Non-vacuity 1 — the gate ADMITS sharing for `q` at these small depths
+        // (every node sits at BFS depth 1 from `q` via the direct edges), so the
+        // shared-prefix path is genuinely active in the equivalence check below.
+        for depth in [3usize, 4] {
+            assert!(
+                graph.prefix_memo_share_safe(&q, depth, PREFIX_MEMO_SHARE_PROBE_BUDGET),
+                "gate must ADMIT q at max_depth={depth} (all nodes at BFS depth 1)"
+            );
+        }
+
+        // Non-vacuity 2 — the resolver actually TRUNCATES the a->...->e chain
+        // under a small `max_depth`: resolving `a` at depth 4 drops the deepest
+        // chain symbol `sym_e`, while at depth 64 it is reached.
+        let get_artifacts =
+            |uri: &Url| -> Option<Arc<ScopeArtifacts>> { artifacts.get(uri).cloned() };
+        let get_metadata =
+            |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> { metas.get(uri).cloned() };
+        let base_exports = HashSet::new();
+        let resolve = |uri: &Url, depth: usize| {
+            scope_at_position_with_graph(
+                uri,
+                u32::MAX,
+                u32::MAX,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root),
+                depth,
+                &base_exports,
+                true,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+                &|| false,
+                None,
+                None,
+            )
+        };
+        assert!(
+            !canonical_scope(&resolve(&a, 4)).contains("sym_e|"),
+            "depth 4 must truncate the a->b->c->d->e chain before sym_e"
+        );
+        assert!(
+            canonical_scope(&resolve(&a, 64)).contains("sym_e|"),
+            "depth 64 must reach sym_e through the chain"
+        );
+
+        // The regression pin. Issue #479's shared-prefix memo guarantees the
+        // resolved **symbol set** is byte-identical whether sharing is enabled
+        // (gate-admitted, as proven above) or disabled — *even when the resolver
+        // truncates via a longer path the BFS-shortest gate failed to exclude*.
+        // This holds because a truncating resolution carries a non-empty
+        // `depth_exceeded` and is never written to the memo
+        // (`resolve_forward_child_memoized`'s cache guard), so the cache can
+        // never feed a truncated (wrong) symbol set to another prefix root. We
+        // compare the memo-enabled vs memo-disabled symbol set of every
+        // gate-admitted query on BOTH the recursive path and the `ScopeStream`
+        // path (where #479's shared prefix memo lives).
+        //
+        // We deliberately do NOT assert `depth_exceeded`/`chain` equality. Those
+        // are the heuristic "Maximum chain depth exceeded" advisory channel
+        // (`handlers.rs`, `exceeded_uri == uri`), and under a gate-admitted
+        // graph the resolver truncates anyway — the visited-independent shared
+        // memo can then emit/suppress that advisory on a file vs the un-memoized
+        // resolver. That is the accepted, documented residual of WI1's
+        // BFS-shortest gate (see `prefix_memo_share_safe`'s NOTE) and is tracked
+        // for a fix in issue #484. It is invisible at the default
+        // `maxChainDepth = 64` (no real chain is that deep) and never affects
+        // symbols — which is exactly what this test pins.
+        let project = |scope: &ScopeAtPosition| -> String {
+            let mut syms: Vec<String> = scope
+                .symbols
+                .iter()
+                .map(|(n, s)| {
+                    format!(
+                        "{n}|{:?}|{}|{}:{}|decl={}",
+                        s.kind, s.source_uri, s.defined_line, s.defined_column, s.is_declared
+                    )
+                })
+                .collect();
+            syms.sort();
+            format!("SYM[{}]", syms.join(";"))
+        };
+        let resolve_stream = |uri: &Url, depth: usize| {
+            let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+            let mut stream = ScopeStream::new(
+                uri,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root),
+                depth,
+                &base_exports,
+                true,
+                crate::cross_file::config::BackwardDependencyMode::Auto,
+                &|| false,
+                &prefix_cache,
+                None,
+                None,
+            )
+            .expect("stream construction must succeed");
+            stream.advance_to(u32::MAX, u32::MAX);
+            stream.snapshot()
+        };
+        // #479's shared prefix memo is active for a query ONLY when the gate
+        // admits it, so the loop gates each query dynamically and asserts only
+        // on admitted ones (that is the property #479 introduces; gate-rejected
+        // queries fall back to the pre-#479 fresh-ephemeral prefix memo, covered
+        // by the other `memo_equiv_*` tests). Admission here depends on
+        // `max_depth`: at `max_depth=3` (`depth_cap=2`) only `q` is admitted
+        // (every other file reaches `c`/`d`/`e` at BFS depth 2); at
+        // `max_depth=4` (`depth_cap=3`) the whole neighborhood is BFS-shallow
+        // enough that every file is admitted. `q` is admitted at both depths and
+        // its per-child-source prefix computations resolve the truncating chain
+        // through the shared memo, so the gate-admitted-with-truncation
+        // interaction is exercised regardless.
+        let mut asserted_any = false;
+        for depth in [3usize, 4] {
+            for (uri, _) in &files {
+                if !graph.prefix_memo_share_safe(uri, depth, PREFIX_MEMO_SHARE_PROBE_BUDGET) {
+                    continue;
+                }
+                asserted_any = true;
+                FORWARD_CHILD_MEMO_DISABLED.with(|c| c.set(true));
+                let off = project(&resolve(uri, depth));
+                let off_stream = project(&resolve_stream(uri, depth));
+                FORWARD_CHILD_MEMO_DISABLED.with(|c| c.set(false));
+                let on = project(&resolve(uri, depth));
+                let on_stream = project(&resolve_stream(uri, depth));
+                assert_eq!(
+                    off, on,
+                    "forward-child memo changed the recursive symbol set for {uri} (max_depth={depth})"
+                );
+                assert_eq!(
+                    off_stream, on_stream,
+                    "shared prefix memo changed the ScopeStream symbol set for {uri} (max_depth={depth})"
+                );
+            }
+        }
+        assert!(
+            asserted_any,
+            "fixture must exercise at least one gate-admitted query (else the test is vacuous)"
+        );
     }
 
     #[test]

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -8265,6 +8265,37 @@ mod tests {
         );
     }
 
+    /// Issue #479: a `# raven: standalone` directive changes the inherited-package
+    /// set the file propagates to its other callers, so adding it must change
+    /// `interface_hash` (else dependents that source the file would not be
+    /// revalidated when the directive is toggled). Guards the `standalone.hash(...)`
+    /// line in `compute_interface_hash` against silent removal.
+    #[test]
+    fn interface_hash_changes_when_standalone_directive_added() {
+        let a = "f <- function() 1\n";
+        let b = "# raven: standalone\nf <- function() 1\n";
+        let ta = parse_r(a);
+        let tb = parse_r(b);
+        let ha = compute_artifacts_with_metadata(
+            &test_uri(),
+            &ta,
+            a,
+            Some(&crate::cross_file::extract_metadata(a)),
+        )
+        .interface_hash;
+        let hb = compute_artifacts_with_metadata(
+            &test_uri(),
+            &tb,
+            b,
+            Some(&crate::cross_file::extract_metadata(b)),
+        )
+        .interface_hash;
+        assert_ne!(
+            ha, hb,
+            "adding a # raven: standalone directive must change interface_hash"
+        );
+    }
+
     /// Issue #460 Gap A: two declarations for the same callee; swapping their
     /// lines changes which is "last" under file-level cross-file collapse, so
     /// dependents must be revalidated — hence `line` is part of the NSE hash.

--- a/crates/raven/src/cross_file/types.rs
+++ b/crates/raven/src/cross_file/types.rs
@@ -227,14 +227,25 @@ pub struct CrossFileMetadata {
     #[serde(default)]
     pub nse_declarations: Vec<NseDeclaration>,
     /// Callee-side `# raven: standalone` directive (issue #479). When `true`,
-    /// this file is a self-contained "module": its cross-file scope is resolved
-    /// in ISOLATION from the files that `source()` it — no backward parent-prefix
-    /// walk and no caller-inherited packages / `DataAliasProvider` / working
-    /// directory. It still contributes its own definitions AND its own loaded
-    /// packages forward to callers (the additive forward merge is unchanged).
-    /// Header-only (must appear before any code). Opt-in and safe-direction: a
-    /// mislabeled standalone file can at worst raise a false "undefined" INSIDE
-    /// itself, never hide a real bug in a caller. See `docs/directives.md`.
+    /// this file is a self-contained "module": **when computing its own
+    /// diagnostics** its cross-file scope is resolved in ISOLATION from the files
+    /// that `source()` it — its backward parent-prefix walk is skipped, so it
+    /// inherits no symbols or packages from its callers (those are the only
+    /// caller contributions the backward walk carries; `DataAliasProvider` and
+    /// working directory are forward-threaded, not backward-inherited — see the
+    /// shipped-scope note below). It still contributes its own definitions AND its own
+    /// loaded packages forward to callers (the additive forward merge is
+    /// unchanged). Header-only (must appear before any code). Opt-in and
+    /// safe-direction: a mislabeled standalone file can at worst raise a false
+    /// "undefined" INSIDE itself, never hide a real bug in a caller. See
+    /// `docs/directives.md`.
+    ///
+    /// SHIPPED SCOPE: only this backward-walk skip ("part 1") shipped. The
+    /// caller-independent forward-child resolution ("part 2" — dropping a
+    /// caller's threaded packages/provider/cd when this file is resolved as that
+    /// caller's forward child) is deferred to WI2b (#483); until then, a caller
+    /// sourcing a standalone file still threads its own packages/provider/cd into
+    /// the child's forward resolution.
     #[serde(default)]
     pub standalone: bool,
 }

--- a/crates/raven/src/cross_file/types.rs
+++ b/crates/raven/src/cross_file/types.rs
@@ -226,6 +226,17 @@ pub struct CrossFileMetadata {
     /// NSE contracts declared via `# raven: nse` directives.
     #[serde(default)]
     pub nse_declarations: Vec<NseDeclaration>,
+    /// Callee-side `# raven: standalone` directive (issue #479). When `true`,
+    /// this file is a self-contained "module": its cross-file scope is resolved
+    /// in ISOLATION from the files that `source()` it — no backward parent-prefix
+    /// walk and no caller-inherited packages / `DataAliasProvider` / working
+    /// directory. It still contributes its own definitions AND its own loaded
+    /// packages forward to callers (the additive forward merge is unchanged).
+    /// Header-only (must appear before any code). Opt-in and safe-direction: a
+    /// mislabeled standalone file can at worst raise a false "undefined" INSIDE
+    /// itself, never hide a real bug in a caller. See `docs/directives.md`.
+    #[serde(default)]
+    pub standalone: bool,
 }
 
 impl CrossFileMetadata {

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -188,8 +188,26 @@ pub(crate) struct DiagnosticsSnapshot {
 impl DiagnosticsSnapshot {
     /// Build a snapshot from WorldState under the read lock.
     pub fn build(state: &WorldState, uri: &Url) -> Option<Self> {
+        Self::build_with_open_documents(state, uri, &state.documents)
+    }
+
+    /// Like [`Self::build`] but with an explicit open-documents map instead of
+    /// `state.documents`. `raven check`'s parallel loop (issue #479 WI3) passes a
+    /// one-entry map holding just the worker's target, so exactly one document
+    /// is "open" per task without sharing/mutating `state.documents`. The LSP
+    /// path calls [`Self::build`], which forwards `&state.documents` and so is
+    /// behavior-identical. `get_enriched_metadata` is intentionally NOT
+    /// redirected: for an indexed target it resolves from the workspace index
+    /// (tier 2) before ever consulting `state.documents`, so both paths agree;
+    /// `raven check` keeps un-indexed disk-fallback targets on the sequential
+    /// path where the document still lives in `state.documents`.
+    pub fn build_with_open_documents(
+        state: &WorldState,
+        uri: &Url,
+        open_documents: &HashMap<Url, crate::state::Document>,
+    ) -> Option<Self> {
         let build_start = std::time::Instant::now();
-        let doc = state.get_document(uri)?;
+        let doc = open_documents.get(uri)?;
         let tree = doc.tree.as_ref()?.clone();
         // Analysis text (masked for Rmd/Quarto, raw otherwise). `tree` was
         // parsed from this exact text, so the two stay consistent and every
@@ -251,7 +269,7 @@ impl DiagnosticsSnapshot {
                 .cross_file_graph
                 .cached_neighborhood_subgraph(uri, max_depth, max_visited);
         let neighborhood_elapsed = neighborhood_start.elapsed();
-        let content_provider = state.content_provider();
+        let content_provider = state.content_provider_with_documents(open_documents);
 
         let precollect_start = std::time::Instant::now();
         let mut artifacts_map = HashMap::new();
@@ -295,8 +313,7 @@ impl DiagnosticsSnapshot {
         let cycle_closing_snippet = cycle_detection.as_ref().and_then(|cycle| {
             let close = &cycle.closing_edge;
             close.call_site_line.and_then(|cl| {
-                let content = state
-                    .documents
+                let content = open_documents
                     .get(&close.from)
                     .map(|d| d.text())
                     .or_else(|| state.cross_file_file_cache.get(&close.from));

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -742,11 +742,26 @@ impl WorldState {
     ///
     /// **Validates: Requirements 4.1, 13.1, 13.2**
     pub fn content_provider(&self) -> DefaultContentProvider<'_> {
+        self.content_provider_with_documents(&self.documents)
+    }
+
+    /// Like [`Self::content_provider`] but with an explicit open-documents map
+    /// instead of `self.documents`. Used by `raven check`'s parallel per-file
+    /// loop (issue #479 WI3): each rayon worker supplies a one-entry map holding
+    /// just its target, so exactly one document is "open" per task without
+    /// mutating the shared `self.documents` (open docs outrank index content, so
+    /// sharing one `documents` map across workers would make each worker treat
+    /// the others' targets as open and pull the wrong artifacts). Every other
+    /// field is shared by reference (immutable after the workspace scan).
+    pub fn content_provider_with_documents<'a>(
+        &'a self,
+        documents: &'a HashMap<Url, Document>,
+    ) -> DefaultContentProvider<'a> {
         DefaultContentProvider::with_legacy(
             &self.document_store,
             &self.workspace_index_new,
             &self.cross_file_file_cache,
-            &self.documents,
+            documents,
             &self.workspace_index,
             &self.cross_file_workspace_index,
         )

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -194,6 +194,39 @@ See [Configuration](configuration.md) for watcher settings (`packages.watchLibra
 
 Propagation reuses the same dependency graph and path-resolution rules (`# raven: cd`, workspace-root fallback, `max_chain_depth`) as the scope and package facts above; backward directives participate as ordinary edges but gain no extra path fallback. The propagation set is the revalidation-consistent neighborhood — a file's ancestors plus the descendant subtrees of itself and its ancestors — so editing a `# raven: nse` (or a `# raven: func` whose formals feed cross-file positional matching) in any connected file revalidates the dependents that rely on it. Cross-file propagation is intentionally **coarse and file-level**: a propagated directive ignores its original line and governs the whole connected file, and it is consulted below the precise built-in NSE policy tables so it cannot coarsen a known verb. Two unconnected files never share NSE directives.
 
+## Standalone modules (`# raven: standalone`)
+
+By default a file's cross-file scope includes a **backward** contribution: the
+bindings visible at every `source()` call that pulls the file in. For a *hub* —
+one file sourced by many others — that means resolving the file's scope as the
+union over all its callers, which is both a performance cost (the hub's
+neighborhood is re-resolved per caller) and a source of over-approximation (one
+caller's bindings can mask a genuine "undefined" that another caller would
+expose).
+
+The header directive `# raven: standalone` (see
+[directives](directives.md#standalone-module-directive)) opts a file out of that
+backward contribution. A standalone file is resolved **in isolation**: no
+backward parent-prefix walk and no caller-inherited packages / working directory
+/ data-alias provider. Its scope becomes a pure function of `(file, its own
+forward source() closure)`, independent of who sources it.
+
+The isolation is **asymmetric**. Nothing flows *in* from a caller, but the file
+still contributes *out*: its own definitions and its own `library()`-loaded
+packages still propagate to every caller through the normal additive forward
+merge. So a standalone setup file that loads shared packages still makes them
+available to its callers.
+
+Because a standalone file's scope no longer depends on its callers, it can be
+resolved once and reused across all of them (and across keystrokes) — the basis
+for the caching of declared library hubs. The directive is the sound, opt-in
+form of that reuse: you assert the independence, so Raven never has to
+over-approximate it. If the assertion is wrong (the file truly needs a
+caller-provided binding), the only consequence is a false-positive "undefined"
+*inside the standalone file* — a safe direction, never a missed bug in a caller.
+`# raven: nse` / `# raven: func` propagation over `source()` edges is unaffected
+(it is graph-level, not scope-level).
+
 ## Position-Aware Scope
 
 Symbols from sourced files are only available **after** the `source()` call:

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -206,22 +206,21 @@ expose).
 
 The header directive `# raven: standalone` (see
 [directives](directives.md#standalone-module-directive)) opts a file out of that
-backward contribution. A standalone file is resolved **in isolation**: no
-backward parent-prefix walk and no caller-inherited packages / working directory
-/ data-alias provider. Its scope becomes a pure function of `(file, its own
-forward source() closure)`, independent of who sources it.
+backward contribution. **When computing the standalone file's own diagnostics**,
+Raven resolves it **in isolation**: no backward parent-prefix walk, so it does
+not inherit symbols, loaded packages, working directory, or data-alias provider
+from the files that source it. Its own scope is determined by the file itself
+plus its own forward `source()` closure — not by who sources it.
 
-The isolation is **asymmetric**. Nothing flows *in* from a caller, but the file
-still contributes *out*: its own definitions and its own `library()`-loaded
-packages still propagate to every caller through the normal additive forward
-merge. So a standalone setup file that loads shared packages still makes them
-available to its callers.
+The isolation is **asymmetric**. Nothing flows *in* from a caller into the
+file's own scope, but the file still contributes *out*: its own definitions and
+its own `library()`-loaded packages still propagate to every caller through the
+normal additive forward merge. So a standalone setup file that loads shared
+packages still makes them available to its callers.
 
-Because a standalone file's scope no longer depends on its callers, it can be
-resolved once and reused across all of them (and across keystrokes) — the basis
-for the caching of declared library hubs. The directive is the sound, opt-in
-form of that reuse: you assert the independence, so Raven never has to
-over-approximate it. If the assertion is wrong (the file truly needs a
+The directive is the sound, opt-in way to assert this independence, so Raven
+never has to over-approximate it. If the assertion is wrong (the file truly
+needs a
 caller-provided binding), the only consequence is a false-positive "undefined"
 *inside the standalone file* — a safe direction, never a missed bug in a caller.
 `# raven: nse` / `# raven: func` propagation over `source()` edges is unaffected

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -208,9 +208,9 @@ The header directive `# raven: standalone` (see
 [directives](directives.md#standalone-module-directive)) opts a file out of that
 backward contribution. **When computing the standalone file's own diagnostics**,
 Raven resolves it **in isolation**: no backward parent-prefix walk, so it does
-not inherit symbols, loaded packages, working directory, or data-alias provider
-from the files that source it. Its own scope is determined by the file itself
-plus its own forward `source()` closure — not by who sources it.
+not inherit symbols or loaded packages from the files that source it. Its own
+scope is determined by the file itself plus its own forward `source()` closure —
+not by who sources it.
 
 The isolation is **asymmetric**. Nothing flows *in* from a caller into the
 file's own scope, but the file still contributes *out*: its own definitions and

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -132,11 +132,13 @@ Place `# raven: standalone` in the **header** of a sourced *library* file to
 declare it self-contained. It takes no arguments and is **header-only** (it must
 appear before any code; a `standalone` token after code is ignored).
 
-A standalone file is resolved **in isolation** from the files that `source()` it:
+When computing a standalone file's **own** diagnostics, it is resolved **in
+isolation** from the files that `source()` it:
 
 - It does **not** inherit symbols, loaded packages, or working-directory context
-  from any caller — no backward parent-prefix walk. Its cross-file scope is a
-  pure function of the file itself and its own forward `source()` closure.
+  from any caller — no backward parent-prefix walk. Its own cross-file scope is
+  determined by the file itself and its own forward `source()` closure, not by
+  who sources it.
 - It **still contributes** its own definitions *and* its own `library()`-loaded
   packages forward to callers (the normal additive `source()` merge is
   unchanged). A module that loads the packages its callers rely on still works.

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -135,10 +135,9 @@ appear before any code; a `standalone` token after code is ignored).
 When computing a standalone file's **own** diagnostics, it is resolved **in
 isolation** from the files that `source()` it:
 
-- It does **not** inherit symbols, loaded packages, or working-directory context
-  from any caller — no backward parent-prefix walk. Its own cross-file scope is
-  determined by the file itself and its own forward `source()` closure, not by
-  who sources it.
+- It does **not** inherit symbols or loaded packages from any caller — no
+  backward parent-prefix walk. Its own cross-file scope is determined by the file
+  itself and its own forward `source()` closure, not by who sources it.
 - It **still contributes** its own definitions *and* its own `library()`-loaded
   packages forward to callers (the normal additive `source()` merge is
   unchanged). A module that loads the packages its callers rely on still works.

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -121,6 +121,47 @@ source("child.R")
 source("utils.R")  # Resolves to <workspace>/data/project/utils.R
 ```
 
+## Standalone Module Directive
+
+```r
+# raven: standalone
+# @lsp-standalone        # alias
+```
+
+Place `# raven: standalone` in the **header** of a sourced *library* file to
+declare it self-contained. It takes no arguments and is **header-only** (it must
+appear before any code; a `standalone` token after code is ignored).
+
+A standalone file is resolved **in isolation** from the files that `source()` it:
+
+- It does **not** inherit symbols, loaded packages, or working-directory context
+  from any caller — no backward parent-prefix walk. Its cross-file scope is a
+  pure function of the file itself and its own forward `source()` closure.
+- It **still contributes** its own definitions *and* its own `library()`-loaded
+  packages forward to callers (the normal additive `source()` merge is
+  unchanged). A module that loads the packages its callers rely on still works.
+- Its own `rm()`/`remove()` of its own symbols still affects what it exports
+  (unchanged); it never removes a caller's bindings.
+
+**When to use it.** A self-contained helper/library file that is sourced by many
+others (a hub). Declaring it standalone both **prevents** caller-union
+over-approximation (one caller's bindings leaking into the file's analysis on
+behalf of another) and makes Raven much faster on hub-heavy workspaces, because
+the file's scope no longer depends on its callers.
+
+**Opt-in and safe-direction.** You vouch that the file is self-contained. If it
+actually relies on a binding a caller provides, the worst case is a
+false-positive *“undefined variable”* **inside the standalone file itself** —
+never a hidden real bug in a caller. (Mark the *root* setup file that provides
+the shared environment as standalone, not a leaf that consumes it.)
+
+**Interactions.** `standalone` only suppresses the *caller→file* direction. It
+composes with `# raven: cd` (the file uses its own working directory),
+`# raven: nse` / `# raven: func` (directive propagation over `source()` edges is
+unaffected), package mode, and per-call `local = TRUE` / `sys.source()` (which
+govern how a *caller* sources the file, independent of the file's own
+isolation). See `docs/cross-file.md` for the resolution model.
+
 ## Declaration Directives
 
 Declare symbols created dynamically that the parser cannot detect. These suppress false-positive "undefined variable" diagnostics for symbols from `eval()`, `assign()`, `load()`, or external data loading.

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -376,6 +376,20 @@ read locks `peek()` (no promotion), write locks `push()`.
 
 ## Work item 3 — Tier 2: parallelize the CLI per-file loop
 
+**STATUS: IMPLEMENTED (commit `82e2209d`). worldwide (release): `raven check .`
+21.45s → 3.83s (5.6×); byte-identical (361, diff empty) and deterministic across
+runs. Full arc vs pre-#479 main: 25.6s → 3.83s — single-digit for ALL repos,
+directive-free.**
+
+> Implemented as a sync/async split: the CPU-bound phase (snapshot build +
+> `diagnostics_from_snapshot`) runs across files via rayon; the cheap async
+> on-disk missing-file checks run afterward. Each worker passes a one-entry
+> open-documents overlay (`build_with_open_documents` /
+> `content_provider_with_documents`) so exactly one target is "open" per task and
+> `state.documents` is never shared/mutated — reproducing the sequential
+> semantics byte-for-byte. Disk-fallback / bad-URL targets stay on the sequential
+> path.
+
 **Independent of items 1–2. CLI-only (does not help the IDE, already async).**
 
 ### Design

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -270,58 +270,56 @@ in `ForwardChildKey` (`path_fp`/`pkg_fp`/`provider_fp`, `scope.rs:1015`). So C's
 URI is a sufficient key *for the scope value* — provided invalidation correctly
 detects changes to C or its forward closure.
 
-**Invalidation — per-closure source-text fingerprint (chosen design).**
+**Invalidation — per-closure `interface_hash` fingerprint (chosen design).**
 
-Cache key = C's URI. Validity = `(edge_revision, closure_fingerprint)` where:
+Cache key = `(C_uri, edge_revision, closure_interface_fingerprint,
+package_config_generation)`:
 
 - `edge_revision` (`dependency.rs:535`) pins the **membership** of C's forward
   closure. It bumps on any structural edge change (`dependency.rs:959-983`),
-  including a closure member adding/retargeting a `source()`.
-- `closure_fingerprint` = a hash over the **source-text content hash** of every
-  file in `{C} ∪ forward_closure(C)`. Source-text hashing captures *everything*
-  observable in the resolved scope — symbol names, signatures, package loads,
-  `rm()`s — so it is sound where `interface_hash` is **not**
-  (`Hash for ScopedSymbol` omits `signature`, `scope.rs:619` vs `PartialEq` at
-  `scope.rs:614`; reusing `interface_hash` would serve stale hover/completion
-  after a formals-only edit).
+  including a closure member adding/retargeting a `source()` or moving a call
+  site.
+- `closure_interface_fingerprint` = a hash over the per-file `interface_hash` of
+  every file in `{C} ∪ forward_closure(C)` (all already computed and cached in
+  artifacts). C's isolated scope is the composition of the closure members'
+  *exported interfaces* in `source()` order, so `(edge_revision, Σ
+  interface_hash)` fully determines it.
+- `package_config_generation`: a coarse counter bumped whenever the package
+  library or relevant config changes (R re-init, `packages_*` settings,
+  `maxChainDepth`). C's isolated scope also depends on `base_exports` /
+  package-library state / config, which the other key components do not capture.
 
-Editing a **caller** of C changes the caller's content but the caller is **not**
-in C's forward closure, so the fingerprint is unchanged → cache hit → full
-cross-keystroke reuse while editing callers. Editing C or any closure member
-changes that member's content hash → fingerprint mismatch → recompute (and C's
-dependents revalidate through the existing `compute_interface_hash` path,
-unchanged). Validating the fingerprint is O(closure size) over per-file content
-hashes — cheap relative to full scope re-resolution. Closure *membership*
-itself is a cheap graph walk already cached by `edge_revision` (the
-`subgraph_cache`), so computing the fingerprint does not re-do the expensive
-scope work.
+**Why `interface_hash`, not source-text (decision revised after review).** The
+dominant IDE editing pattern on a hub workspace is editing a file *inside* the
+hub's closure (e.g. `functions.r`, which `bootstrap.r` sources). Computing
+diagnostics for that file resolves the standalone parent's isolated scope, so it
+consults this cache on **every keystroke**. A **source-text** fingerprint would
+miss on every comment / whitespace / function-body / local edit — i.e. most
+edits — recomputing the whole closure each keystroke and defeating the cache's
+purpose for the active file. `interface_hash` busts **only** when a closure
+member's *top-level exported interface* changes (add/rename/remove a top-level
+symbol, signature, or package load) — exactly when C's scope genuinely changed —
+so body/comment/local edits stay cache hits.
 
-> Implementation note: prefer an already-maintained per-file content hash /
-> document revision if one exists (e.g. `document_store` revision, workspace
-> index entry) over hashing source bytes afresh each lookup. Confirm during
-> implementation; fall back to hashing source text if no stable per-file content
-> hash is available.
+Editing a **caller** of C (not in C's closure) leaves the fingerprint unchanged
+either way → hit. Validating the fingerprint is O(closure size) over precomputed
+`u64`s. Closure *membership* is the cheap graph walk already cached by
+`edge_revision` (the `subgraph_cache`).
 
-**Why source-text and NOT `interface_hash` (decided).** `interface_hash` is
-unsound as a scope-value fingerprint today (it omits `ScopedSymbol.signature` —
-filed as **#482**), and even once fixed, keying the cache on it would
-**permanently couple** WI2b's soundness to "`interface_hash` captures everything
-observable in a resolved scope." A future observable field added to
-`ScopedSymbol` without extending its `Hash` impl would then silently serve stale
-cached scopes — a soundness landmine with no failing test. Source-text hashing
-is robust by construction (any byte change ⇒ miss). Its only cost is
-over-invalidating on comment/whitespace edits *inside* the closure (a rare case;
-the dominant cross-keystroke win is editing a *caller*, which is not in the
-closure and so is unaffected either way). **#482 is fixed separately** (it is a
-real revalidation gap) and is NOT a prerequisite for, nor relied on by, WI2b.
+**Soundness depends on `interface_hash` completeness — already a system
+invariant.** Dependent revalidation correctness (`compute_affected_dependents_
+after_edit`) already relies on `interface_hash` capturing every interface change,
+so keying the cache on it reuses an existing requirement rather than adding a
+new one. Two guards make this safe:
 
-**Additional key component — package/config generation (required).** A standalone
-callee's isolated scope also depends on `base_exports` / package-library state
-and config (`max_chain_depth`), which neither source-text nor `interface_hash`
-captures. The cache key MUST therefore also include a coarse generation counter
-bumped whenever the package library or relevant config changes (R re-init,
-`packages_*` settings, `maxChainDepth`). Key = `(C_uri, edge_revision,
-closure_source_fingerprint, package_config_generation)`.
+1. **#482 is a PREREQUISITE.** `Hash for ScopedSymbol` currently omits
+   `signature` (`scope.rs:619` vs `PartialEq` at `scope.rs:614`), so a
+   formals-only edit would not bust the fingerprint → stale cached signature.
+   The cache MUST NOT be keyed on `interface_hash` until #482 lands.
+2. **Add a `ScopedSymbol` `Hash`/`Eq` field-parity test** (mutate each field,
+   assert the hash changes — except the deliberately-excluded positional
+   `defined_end_column`, derived from name+column). This converts the
+   "future field omitted from `Hash`" landmine into a guarded invariant.
 
 **Where the cache lives & lock discipline.** The per-snapshot `DependencyGraph`
 is cloned and resets its caches (`dependency.rs:585-610`), so a cross-snapshot
@@ -335,9 +333,12 @@ read locks `peek()` (no promotion), write locks `push()`.
 
 > **Codex review targets (round 2):** (a) the canonical-input resolution in WI2a
 > — is there any other caller-varying input beyond packages/provider/cd that
-> feeds C's scope? (b) the source-text fingerprint (option 2) — is per-file
-> source hash sound and is the closure membership truly pinned by edge_revision?
-> (c) the `Arc`-handle-out lock discipline.
+> feeds C's scope (so URI is a sufficient cache key)? (b) is `interface_hash`
+> (post-#482) a *complete* fingerprint of a file's scope-contributing exported
+> interface — does C's isolated scope depend on anything in a closure member
+> beyond what `interface_hash` covers? — and is closure membership truly pinned
+> by `edge_revision`? (c) the `Arc`-handle-out lock discipline under concurrent
+> `did_change`.
 
 ### Interactions (resolved; Codex round 2 to stress-test)
 
@@ -385,10 +386,14 @@ read locks `peek()` (no promotion), write locks `push()`.
   loaded packages (proves caller-independent canonical resolution); (c) toggling
   `standalone` revalidates dependents (interface-hash wiring); (d) header-only
   gate: `# raven: standalone` after code is ignored; (e) `# raven: cd` / `nse` /
-  `local=TRUE` interaction tests; (f) WI2b cache: editing a caller leaves
-  C's `closure_fingerprint` unchanged → cache hit (assert no recompute); editing
-  C or a closure member changes the fingerprint → cache miss → recompute; and
-  packages C loads still propagate to the caller after a cache hit.
+  `local=TRUE` interaction tests; (f) WI2b cache: editing a caller, or a
+  comment / function-body / local binding *inside* a closure member, leaves C's
+  `closure_interface_fingerprint` unchanged → cache hit (assert no recompute);
+  changing a closure member's top-level interface (add/rename/remove a top-level
+  symbol, signature, or package load) → cache miss → recompute; package/config
+  generation bump → miss; and packages C loads still propagate to the caller
+  after a cache hit. (g) `ScopedSymbol` `Hash`/`Eq` field-parity test (#482
+  prerequisite).
 - On worldwide: add `# raven: standalone` to `scripts/functions.r` (and/or
   `bootstrap.r` per measurement), re-measure `functions.r` and `raven check .`,
   report deltas. Diagnostics byte-identical except in the directive-bearing file.

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -302,6 +302,27 @@ scope work.
 > implementation; fall back to hashing source text if no stable per-file content
 > hash is available.
 
+**Why source-text and NOT `interface_hash` (decided).** `interface_hash` is
+unsound as a scope-value fingerprint today (it omits `ScopedSymbol.signature` —
+filed as **#482**), and even once fixed, keying the cache on it would
+**permanently couple** WI2b's soundness to "`interface_hash` captures everything
+observable in a resolved scope." A future observable field added to
+`ScopedSymbol` without extending its `Hash` impl would then silently serve stale
+cached scopes — a soundness landmine with no failing test. Source-text hashing
+is robust by construction (any byte change ⇒ miss). Its only cost is
+over-invalidating on comment/whitespace edits *inside* the closure (a rare case;
+the dominant cross-keystroke win is editing a *caller*, which is not in the
+closure and so is unaffected either way). **#482 is fixed separately** (it is a
+real revalidation gap) and is NOT a prerequisite for, nor relied on by, WI2b.
+
+**Additional key component — package/config generation (required).** A standalone
+callee's isolated scope also depends on `base_exports` / package-library state
+and config (`max_chain_depth`), which neither source-text nor `interface_hash`
+captures. The cache key MUST therefore also include a coarse generation counter
+bumped whenever the package library or relevant config changes (R re-init,
+`packages_*` settings, `maxChainDepth`). Key = `(C_uri, edge_revision,
+closure_source_fingerprint, package_config_generation)`.
+
 **Where the cache lives & lock discipline.** The per-snapshot `DependencyGraph`
 is cloned and resets its caches (`dependency.rs:585-610`), so a cross-snapshot
 cache must NOT live there. Store it as an `Arc<StandaloneScopeCache>` owned by

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -131,20 +131,29 @@ explicitly deferred).
 
 ### Semantics (three knobs — only knob 1 is a behavior change)
 
-1. **(LOAD-BEARING) The callee is resolved in isolation.** When computing scope
-   for a position *inside* a standalone file C, Raven does **not** walk backward
-   to the files that `source()` C (no STEP-1 parent-prefix walk), **and** does
-   **not** inherit any caller-provided inputs: caller packages
-   (`scope.rs:5412,5715`), the caller's `DataAliasProvider`, or the caller's
-   working directory. C's scope is computed from C's own definitions, C's own
-   loaded packages, C's own `# raven: cd`, and C's own forward closure — nothing
-   from any caller. This is what makes C's EOF scope a pure function of
-   `(C, C's forward closure)` and therefore caller-independent (the precondition
-   for both correctness and caching).
+1. **(LOAD-BEARING) The callee is resolved in isolation — asymmetrically.**
+   When computing scope for a position *inside* a standalone file C, Raven does
+   **not** walk backward to the files that `source()` C (no STEP-1 parent-prefix
+   walk), **and** does **not** inherit any caller-provided *inputs*: caller
+   packages (`scope.rs:5412,5715`), the caller's `DataAliasProvider`, or the
+   caller's working directory. C's scope is computed from C's own definitions,
+   C's own loaded packages, C's own `# raven: cd`, and C's own forward closure —
+   nothing flows **in** from any caller. This is what makes C's EOF scope a pure
+   function of `(C, C's forward closure)` and therefore caller-independent (the
+   precondition for both correctness and caching).
+
+   **Asymmetry — the OUTPUT direction is unchanged.** C still contributes its
+   own bindings AND its own loaded packages **out** to every caller via the
+   normal additive forward merge (`merge_child_source_packages`,
+   `scope.rs:5960`). A primary, intended use of `standalone` is a module that
+   `library()`-loads the packages its callers rely on: those package loads must
+   still propagate up to callers. Isolation drops caller→C inheritance; it does
+   NOT drop C→caller contribution. Both the symbols C defines and the packages C
+   loads remain part of C's cached isolated EOF scope and flow to callers.
 2. **It only ADDS to a caller's scope.** Already the default forward behavior
-   (the forward merge at `scope.rs:5905` only *inserts* the child's surviving
-   symbols). `standalone` does not change this. Recorded for completeness; no
-   code.
+   (the forward merge at `scope.rs:5905` / `scope.rs:5960` only *inserts* the
+   child's surviving symbols and *merges in* its packages). `standalone` does not
+   change this. Recorded for completeness; no code.
 3. **C's `rm()`/`remove()` effects do not propagate out to callers.** **Already
    guaranteed by the existing additive merge** — verified at `scope.rs:5905`,
    which iterates `child_scope.symbols` (C's EOF map, with C's own removals
@@ -232,32 +241,37 @@ in `ForwardChildKey` (`path_fp`/`pkg_fp`/`provider_fp`, `scope.rs:1015`). So C's
 URI is a sufficient key *for the scope value* — provided invalidation correctly
 detects changes to C or its forward closure.
 
-**Invalidation — staged, measure-driven:**
+**Invalidation — per-closure source-text fingerprint (chosen design).**
 
-1. **Start sound and simple: coarse content-edit generation bump.** Maintain one
-   global monotonic `content_generation` counter, bumped on every document
-   content change. Cache key = `(C_uri, edge_revision, content_generation)`.
-   This is **unconditionally sound** (any edit anywhere invalidates) and is the
-   exact mechanism the issue calls for. It delivers (a) and (b) fully — within
-   one snapshot/pass the generation is stable, so C is computed once and shared
-   ×84. For `raven check .` (c), the generation is stable for the whole run
-   (no edits mid-run), so C is computed once and reused by all 245 files. The
-   only thing it sacrifices: cross-*keystroke* reuse while editing an unrelated
-   file (the next snapshot recomputes C once — shared, not ×84).
-   **Do NOT reuse `interface_hash` as a scope-value fingerprint:**
-   `Hash for ScopedSymbol` omits `signature` (`scope.rs:619` vs `PartialEq` at
-   `scope.rs:614`), so a formals-only edit changes the scope without changing
-   `interface_hash` — unsound for hover/completion/signature consumers.
-2. **Tighten only if measurement demands it: per-closure source fingerprint.**
-   If after WI1 + WI2a + the coarse bump, editing a *caller* still leaves a
-   perceptible pause (re-resolving C once per keystroke), replace the
-   `content_generation` component with a fingerprint over the **source-text
-   content hash** of `{C} ∪ forward_closure(C)` (membership pinned by
-   `edge_revision`). Source-text hashing captures *everything* observable
-   (including signatures), so it is sound where `interface_hash` is not. Editing
-   a caller (not in C's closure) leaves the fingerprint unchanged → hit. This is
-   the only part that approaches #480's territory; gate it behind a measurement
-   that shows it is needed.
+Cache key = C's URI. Validity = `(edge_revision, closure_fingerprint)` where:
+
+- `edge_revision` (`dependency.rs:535`) pins the **membership** of C's forward
+  closure. It bumps on any structural edge change (`dependency.rs:959-983`),
+  including a closure member adding/retargeting a `source()`.
+- `closure_fingerprint` = a hash over the **source-text content hash** of every
+  file in `{C} ∪ forward_closure(C)`. Source-text hashing captures *everything*
+  observable in the resolved scope — symbol names, signatures, package loads,
+  `rm()`s — so it is sound where `interface_hash` is **not**
+  (`Hash for ScopedSymbol` omits `signature`, `scope.rs:619` vs `PartialEq` at
+  `scope.rs:614`; reusing `interface_hash` would serve stale hover/completion
+  after a formals-only edit).
+
+Editing a **caller** of C changes the caller's content but the caller is **not**
+in C's forward closure, so the fingerprint is unchanged → cache hit → full
+cross-keystroke reuse while editing callers. Editing C or any closure member
+changes that member's content hash → fingerprint mismatch → recompute (and C's
+dependents revalidate through the existing `compute_interface_hash` path,
+unchanged). Validating the fingerprint is O(closure size) over per-file content
+hashes — cheap relative to full scope re-resolution. Closure *membership*
+itself is a cheap graph walk already cached by `edge_revision` (the
+`subgraph_cache`), so computing the fingerprint does not re-do the expensive
+scope work.
+
+> Implementation note: prefer an already-maintained per-file content hash /
+> document revision if one exists (e.g. `document_store` revision, workspace
+> index entry) over hashing source bytes afresh each lookup. Confirm during
+> implementation; fall back to hashing source text if no stable per-file content
+> hash is available.
 
 **Where the cache lives & lock discipline.** The per-snapshot `DependencyGraph`
 is cloned and resets its caches (`dependency.rs:585-610`), so a cross-snapshot
@@ -321,10 +335,10 @@ read locks `peek()` (no promotion), write locks `push()`.
   loaded packages (proves caller-independent canonical resolution); (c) toggling
   `standalone` revalidates dependents (interface-hash wiring); (d) header-only
   gate: `# raven: standalone` after code is ignored; (e) `# raven: cd` / `nse` /
-  `local=TRUE` interaction tests; (f) WI2b cache: editing a caller does NOT
-  change C's cached isolated scope value (under option 2, a cache-hit; under the
-  coarse bump, a recompute that yields the identical value); editing C or a
-  closure member changes it.
+  `local=TRUE` interaction tests; (f) WI2b cache: editing a caller leaves
+  C's `closure_fingerprint` unchanged → cache hit (assert no recompute); editing
+  C or a closure member changes the fingerprint → cache miss → recompute; and
+  packages C loads still propagate to the caller after a cache hit.
 - On worldwide: add `# raven: standalone` to `scripts/functions.r` (and/or
   `bootstrap.r` per measurement), re-measure `functions.r` and `raven check .`,
   report deltas. Diagnostics byte-identical except in the directive-bearing file.

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -30,10 +30,39 @@ review gate.
 
 ---
 
-## Work item 1 — Tier 1: share the prefix `ForwardChildMemo` within a snapshot
+## Work item 1 — Tier 1: share the prefix `ForwardChildMemo` within a stream
 
-**Status: validated in the #476 session (8.4× on `functions.r`, byte-identical).
-Low risk. Do this first — it proves memo-sharing is behavior-preserving.**
+**STATUS: IMPLEMENTED (commit `073d322c`). worldwide (release): `functions.r`
+3.54s → 1.60s; `raven check .` 25.6s → 21.45s; undefined-variable output
+byte-identical (361, diff empty). All #472 equivalence + the local=TRUE property
+tests green.**
+
+> **Design evolved during implementation.** The naive "share one prefix memo
+> across all prefix computations" is **unsound** — `ForwardChildMemo` is
+> documented "never shared across queries" because its value depends on
+> per-query inputs the key omits. Two such inputs vary within a stream and each
+> is handled separately (confirmed empirically; the simple hoist-into-cache
+> approach failed two equivalence/property tests):
+>
+> 1. **`query_inside_function` (local/sys.source scoping)** → **slot isolation**:
+>    the inside-function (`true`) prefix slot keeps its own fresh memo. Only the
+>    `false`-context computations (the `false` top slot + every per-child-source
+>    call, all of which query at EOF) share. Fixes the `local=TRUE`
+>    function-scoped declaration-inheritance divergence.
+> 2. **Truncation (visited context)** → **gate**
+>    `DependencyGraph::prefix_memo_share_safe`: a bidirectional BFS shares only
+>    when the neighborhood is provably too shallow to reach `maxChainDepth`.
+>    Fixes the small-`maxChainDepth` `depth_exceeded`/`chain` divergence.
+>
+> When either condition is unmet the stream falls back to fresh-per-prefix
+> (pre-#479 behavior). Per the user's guidance, the deliberately-unoptimized case
+> is `source()`-inside-a-function (`local=TRUE`); the win targets global-scope
+> hubs. Residual risk (accepted): the analysis that these are the *only* two
+> unkeyed varying inputs within a `false`-context stream is backed by the full
+> test suite (5200 lib tests, incl. the #472 `memo_equiv_*` suite and the
+> cross-file property tests) rather than a formal proof.
+
+Original analysis (kept for context):
 
 ### Root cause (re-verified against code)
 

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -51,16 +51,38 @@ tests green.**
 >    function-scoped declaration-inheritance divergence.
 > 2. **Truncation (visited context)** → **gate**
 >    `DependencyGraph::prefix_memo_share_safe`: a bidirectional BFS shares only
->    when the neighborhood is provably too shallow to reach `maxChainDepth`.
->    Fixes the small-`maxChainDepth` `depth_exceeded`/`chain` divergence.
+>    when the neighborhood is BFS-shallow relative to `maxChainDepth`. This
+>    SOUNDLY bounds the part of the mode that could corrupt the **symbol set**
+>    (truncated scopes are never cached, so a longer-path truncation the gate
+>    failed to exclude cannot feed a wrong symbol set to another prefix root). It
+>    leaves a **bounded residual on the heuristic `depth_exceeded`/`chain`
+>    advisory** — see "Residual risk" below and issue #484.
 >
 > When either condition is unmet the stream falls back to fresh-per-prefix
 > (pre-#479 behavior). Per the user's guidance, the deliberately-unoptimized case
 > is `source()`-inside-a-function (`local=TRUE`); the win targets global-scope
-> hubs. Residual risk (accepted): the analysis that these are the *only* two
+> hubs.
+>
+> **Residual risk (accepted; tracked in #484).** Two parts:
+> (a) The analysis that `query_inside_function` and truncation are the *only* two
 > unkeyed varying inputs within a `false`-context stream is backed by the full
-> test suite (5200 lib tests, incl. the #472 `memo_equiv_*` suite and the
+> test suite (5200+ lib tests, incl. the #472 `memo_equiv_*` suite and the
 > cross-file property tests) rather than a formal proof.
+> (b) The gate's depth check is BFS-*shortest*-path, while the resolver can reach
+> a node at a greater `current_depth` via a *longer* path and truncate there. So
+> sharing can be admitted for a neighborhood the resolver then truncates. This
+> can NEVER corrupt the symbol set (point above), but under such truncation the
+> shared, visited-independent memo can cause the advisory "Maximum chain depth
+> exceeded" diagnostic to be emitted on a file where the un-memoized resolver
+> would not (or vice versa). It only triggers when a `source()` chain actually
+> reaches `maxChainDepth`, so it does not occur at the default `maxChainDepth =
+> 64` on realistic workspaces (worldwide `raven check .` is byte-identical and
+> deterministic). A fully sound depth check is a longest-simple-path quantity
+> (NP-hard in general; a naive search would disable sharing on the star-hub
+> topology WI1 targets), so the residual is accepted and tracked in #484
+> (proposed fix: verify the advisory at emit time, off the hot path). Pinned by
+> `memo_equiv_gate_admitted_with_truncation` (symbol equivalence under a
+> gate-admitted-with-truncation graph).
 
 Original analysis (kept for context):
 
@@ -92,8 +114,12 @@ Crucially, that hazard is **prefix-memo ↔ stream-memo**, not **prefix ↔ pref
 *All* prefix computations within a snapshot share the same canonical depth-0
 origin, so a child resolved for one prefix slot is byte-identical to the same
 child resolved for another prefix slot. Sharing one memo **across all prefix
-computations** is therefore sound, provided it stays **separate** from the
-stream's actual-depth `forward_child_memo`.
+computations** is therefore sound for the **symbol set**, provided it stays
+**separate** from the stream's actual-depth `forward_child_memo`. (This original
+analysis understated one case: under a longer-path truncation the gate admits,
+the cross-prefix-root reuse can still diverge on the `depth_exceeded`/`chain`
+advisory — never on symbols. See the corrected "Residual risk" note above and
+issue #484.)
 
 The depth-reuse rule (`scope.rs:1159-1192`, reuse only when
 `child_depth <= compute_depth`, cache only `depth_exceeded.is_empty()` scopes)
@@ -196,6 +222,18 @@ caller-inherited packages/provider/cd for C). Knobs 2 and 3 are pre-existing
 properties of the additive forward merge, documented here so the contract is
 explicit.
 
+> **Design vs shipped.** This section describes knob 1 as fully *designed*. Knob
+> 1 has two halves: (a) the **backward-walk skip**, which drops the caller
+> **symbols and packages** C would inherit through its backward edges (the only
+> things the backward `ParentPrefix` carries); and (b) **caller-independent
+> forward resolution**, which would additionally drop the caller's
+> forward-threaded `DataAliasProvider` / working directory / packages when C is
+> resolved as a caller's forward child. Only half (a) shipped in WI2a; half (b)
+> — and thus the full "pure function of `(C, C's forward closure)`" property the
+> perf/caching argument relies on — is deferred to WI2b (#483). See the "Shipped
+> scope (WI2a)" note below. References to knob 1 in this design section describe
+> the intended whole.
+
 ### Why required (perf + correctness)
 
 - **Perf:** knob 1 makes C's EOF scope a **pure function of `(C, C's forward
@@ -242,6 +280,22 @@ packages/provider/cd (`scope.rs:5412,5715`) — so C's scope is byte-identical
 whether computed for C's own diagnostics or as A's forward child. This canonical
 resolution is the precondition that makes the WI2b cache key (C's URI alone)
 sound.
+
+> **Shipped scope (WI2a) — part 1 only; part 2 deferred to WI2b (#483).** Only
+> the **backward-walk skip** shipped: `parent_prefix_at` returns the empty
+> `ParentPrefix` for a standalone `uri` (`scope.rs:5023`), which isolates C's
+> *own* diagnostics from its callers' backward contribution. The **caller-
+> independent forward-child resolution** (dropping caller A's inherited
+> packages/provider/`cd` when resolving standalone C as A's forward child, the
+> "canonical inputs" paragraph above) did **not** ship — when C is sourced by A,
+> A's threaded packages/provider/cd still flow into C's forward resolution. That
+> part 2 is the precondition for the WI2b cache key and is deferred to WI2b
+> (#483) along with the cache itself. The two are decoupled deliberately: part 1
+> delivers the own-diagnostics isolation and the hub-perf win that WI2a targets,
+> while part 2 only matters once the cross-snapshot cache exists. User-facing
+> docs (`docs/directives.md`, `docs/cross-file.md`) describe **only** the
+> shipped part-1 semantics ("when computing a standalone file's *own*
+> diagnostics").
 
 This alone removes the ~84-caller backward union when computing `functions.r`'s
 own diagnostics and fixes the caller-union over-approximation class (#476
@@ -342,12 +396,16 @@ read locks `peek()` (no promotion), write locks `push()`.
 
 ### Interactions (resolved; Codex round 2 to stress-test)
 
-- **`# raven: cd`** — `standalone` only suppresses C's *backward* parent-prefix
-  walk and caller-inherited inputs; backward directives already ignore
-  `# raven: cd` (`PathContext::new`). C's own forward path resolution respects
-  C's own `# raven: cd` exactly as today. No change to path resolution. (Note
-  knob 1 explicitly drops the *caller's* inherited working directory for C — C
-  uses only its own.)
+- **`# raven: cd`** — `standalone` (knob 1, shipped) suppresses C's *backward*
+  parent-prefix walk, which drops the caller-inherited **symbols and packages**
+  (the only contributions the backward `ParentPrefix` carries). Backward
+  directives already ignore `# raven: cd` (`PathContext::new`), and the backward
+  walk never threads a caller working directory into C, so knob 1 has nothing
+  cd-related to drop. C's own forward path resolution respects C's own
+  `# raven: cd` exactly as today. No change to path resolution. (Dropping the
+  *caller's* forward-threaded working directory / provider when C is resolved as
+  a caller's forward child is the deferred part 2 / WI2b — see the "Shipped scope
+  (WI2a)" note.)
 - **`# raven: nse` / `# raven: func`** — NSE/func propagation is **graph-only**:
   `collect_cross_file_nse` walks the revalidation-consistent set `S(Q)` over the
   source graph and reads only `nse_declarations`/`declared_functions`, never

--- a/specs/issue-479-spec.md
+++ b/specs/issue-479-spec.md
@@ -1,0 +1,408 @@
+# Spec — #479: Behavior-preserving performance for hub-heavy workspaces
+
+Make Raven performant on hub-heavy workspaces **without changing diagnostic
+behavior**. Bar: IDE completions/diagnostics with no perceptible pause, and
+`raven check .` in single-digit seconds, on the case study repo.
+
+Case study (the benchmark): `~/repos/worldwide` (~245 R files). ~84 files
+`source("bootstrap.r")`; `bootstrap.r` → `scripts/functions.r` → ~52
+single-function files; `bootstrap.r` is itself sourced by ~84 files (a dense
+hub). Baseline (release, merged #476 at `d15afd67`):
+
+- `raven check .` ≈ **25.6s** (measured on this build), **361 undefined-variable**
+  findings (saved sorted to `/tmp/baseline_undefined.txt` as the byte-identical
+  reference).
+- `raven check scripts/functions.r` ≈ **3.54s** wall (incl. ~0.4s scan) while
+  `DiagnosticsSnapshot::build` ≈ **1.56ms** (neighborhood 211 files, 162µs) —
+  the cost is in `diagnostics_from_snapshot` / scope resolution, not the
+  snapshot build.
+
+**Hard constraint — behavior-preserving.** Diagnostics must stay byte-identical
+(`raven check . 2>/dev/null | grep undefined-variable | sort` unchanged
+before/after each change, **except** in files where the new directive is added).
+The #472 forward-child-memo equivalence tests and the recursive/streaming
+equivalence tests must stay green. A real bug found while refactoring is fixed
+or filed separately — never silently changed output.
+
+This issue has **three** work items, done in this order. #480 (the general,
+automatic cross-query scope cache) is **out of scope** — high-risk, separate
+review gate.
+
+---
+
+## Work item 1 — Tier 1: share the prefix `ForwardChildMemo` within a snapshot
+
+**Status: validated in the #476 session (8.4× on `functions.r`, byte-identical).
+Low risk. Do this first — it proves memo-sharing is behavior-preserving.**
+
+### Root cause (re-verified against code)
+
+`compute_or_get_cached_prefix` (`scope.rs:8000`) memoizes STEP-1 backward-walk
+prefixes per `(uri, query_inside_function)` in the per-snapshot
+`ParentPrefixCache`. But at **`scope.rs:8034` it allocates a fresh
+`ForwardChildMemo` per prefix computation**:
+
+```rust
+let prefix_forward_child_memo = std::cell::RefCell::new(ForwardChildMemo::default());
+```
+
+Each of the ~54 prefix slots therefore re-resolves the hub's forward children
+from scratch → O(N²) re-resolution of the hub closure. For `functions.r`:
+~115k forward-child computes, 98% inside prefix resolution.
+
+### Why sharing is safe (the invariant that licenses it)
+
+The doc comment at `scope.rs:8024-8034` explains why the memo is currently
+fresh-per-prefix: the prefix is computed at a **canonical `current_depth = 0`
+origin**, whose forward-child depths do NOT match the actual depth a streaming
+forward sweep reaches the same child at. Reusing prefix-resolved children in the
+**stream's actual-depth memo** could perturb depth-dependent bookkeeping
+(`depth_exceeded`, `chain`) under a small `maxChainDepth`.
+
+Crucially, that hazard is **prefix-memo ↔ stream-memo**, not **prefix ↔ prefix**.
+*All* prefix computations within a snapshot share the same canonical depth-0
+origin, so a child resolved for one prefix slot is byte-identical to the same
+child resolved for another prefix slot. Sharing one memo **across all prefix
+computations** is therefore sound, provided it stays **separate** from the
+stream's actual-depth `forward_child_memo`.
+
+The depth-reuse rule (`scope.rs:1159-1192`, reuse only when
+`child_depth <= compute_depth`, cache only `depth_exceeded.is_empty()` scopes)
+and the cycle-disable (`scope.rs:1138-1152`, `graph_has_cycle` cell → bypass
+memo on any cyclic graph) are properties of `ForwardChildMemo` itself and carry
+over unchanged to a shared instance.
+
+### Design
+
+Give the prefix memo the **snapshot** lifetime instead of the
+**per-prefix-call** lifetime, keyed to the same scope as `ParentPrefixCache`
+(which is already one-per-snapshot, see its doc at `scope.rs:4767`). Concretely:
+add a `prefix_forward_child_memo: RefCell<ForwardChildMemo>` field to
+`ParentPrefixCache`, and at `scope.rs:8034` (the **streaming** entry point's
+prefix path, the diagnostics hot path) borrow that field instead of allocating a
+fresh memo.
+
+**Scope of WI1 — stream path only.** The other prefix entry point,
+`scope_at_position_with_graph_cached` (`scope.rs:4846`), allocates ONE
+`forward_child_memo` *per position query* and shares it between its single
+prefix computation (`scope.rs:4867`) and STEP 2 (`scope.rs:4902`). Both legs run
+at `current_depth = 0` there, so that local memo is already correct and is NOT
+the O(N²) site (it is per-query, not per-prefix). The validated 8.4× prototype
+touched only the stream path. Sharing a memo *across* position queries within a
+snapshot is a separate, unvalidated optimization (interactive hover/completion
+latency) and is **explicitly out of WI1** to preserve its "validated,
+byte-identical, low-risk" property. Leave `scope.rs:4846` unchanged.
+
+- It rides `ParentPrefixCache`'s existing one-per-snapshot discipline and
+  snapshot-boundary warning (`scope.rs:4767-4798`), so it cannot leak across
+  snapshots.
+- It stays strictly separate from the stream's actual-depth
+  `forward_child_memo` (a different `RefCell`, never passed where the stream's
+  memo is expected). The separation the doc comment requires is preserved.
+- The shared memo accumulates across all `compute_or_get_cached_prefix` calls
+  within the snapshot, collapsing the O(N²) re-resolution to O(N).
+
+`ParentPrefixCache` is constructed in ~30 sites (production: `handlers.rs:393`
+`DiagnosticsSnapshot`, the streaming collectors; plus `qualified_resolve.rs` and
+many tests). Because the new field is `Default`, `ParentPrefixCache::new()` /
+`::default()` keep working at every site with no signature change.
+
+### Verification
+
+- `cargo test --lib --features test-support` green, **including** the #472
+  forward-child-memo equivalence tests and the recursive/streaming equivalence
+  tests.
+- `raven check . 2>/dev/null | grep undefined-variable | sort` **byte-identical**
+  before/after (diff empty) on worldwide.
+- Re-measure `raven check scripts/functions.r` and `raven check .`; report the
+  delta. Expectation from the prototype: `functions.r` ~2.8s → ~0.3s, internal
+  child computes ~113k → ~1.7k, `raven check .` ~25s → ~21s.
+- Re-run `cargo bench --bench cross_file --features test-support --
+  cross_file_forward_child_memo` and report the delta vs main.
+
+---
+
+## Work item 2 — Callee-side `# raven: standalone` directive (REQUIRED)
+
+A file-level directive placed at the top of a sourced *library* file (e.g.
+`scripts/functions.r`) declaring it self-contained. Final name: **`# raven:
+standalone`** (callee-side only; a caller-side per-`source()` variant is
+explicitly deferred).
+
+### Semantics (three knobs — only knob 1 is a behavior change)
+
+1. **(LOAD-BEARING) The callee is resolved in isolation.** When computing scope
+   for a position *inside* a standalone file C, Raven does **not** walk backward
+   to the files that `source()` C (no STEP-1 parent-prefix walk), **and** does
+   **not** inherit any caller-provided inputs: caller packages
+   (`scope.rs:5412,5715`), the caller's `DataAliasProvider`, or the caller's
+   working directory. C's scope is computed from C's own definitions, C's own
+   loaded packages, C's own `# raven: cd`, and C's own forward closure — nothing
+   from any caller. This is what makes C's EOF scope a pure function of
+   `(C, C's forward closure)` and therefore caller-independent (the precondition
+   for both correctness and caching).
+2. **It only ADDS to a caller's scope.** Already the default forward behavior
+   (the forward merge at `scope.rs:5905` only *inserts* the child's surviving
+   symbols). `standalone` does not change this. Recorded for completeness; no
+   code.
+3. **C's `rm()`/`remove()` effects do not propagate out to callers.** **Already
+   guaranteed by the existing additive merge** — verified at `scope.rs:5905`,
+   which iterates `child_scope.symbols` (C's EOF map, with C's own removals
+   already applied during C's resolution at `scope.rs:5992`) and never replays
+   C's `Removal` events against the caller's accumulated scope. A caller's own
+   bindings are therefore untouched by C's `rm()` regardless of `standalone`.
+   No code; asserted as part of the contract.
+
+**Net:** the only behavioral switch is knob 1 (skip backward walk + drop
+caller-inherited packages/provider/cd for C). Knobs 2 and 3 are pre-existing
+properties of the additive forward merge, documented here so the contract is
+explicit.
+
+### Why required (perf + correctness)
+
+- **Perf:** knob 1 makes C's EOF scope a **pure function of `(C, C's forward
+  closure)`**, independent of who sources it. So it is cacheable and reused by
+  all 84 callers and across keystrokes (see Caching below). It is the direct fix
+  for the bootstrap/`functions.r` hub: computing `functions.r`'s own diagnostics
+  no longer resolves the ~84-caller backward union.
+- **Correctness:** the caller-union over-approximation that knob 1 removes is the
+  same class that produced #476's `getArray` false positive. Declaring the hub
+  standalone prevents that class.
+
+**Opt-in safety (safe direction).** The user vouches for the property. If a
+"standalone" callee actually relies on a caller-provided binding, the worst case
+is a false-positive *undefined inside the callee* — never a hidden real bug in a
+caller. This is why it needs no over-approximation/provider/trimmed-view
+soundness machinery (those are #480's traps): the directive *asserts* the
+independence rather than inferring it.
+
+### Parsing & metadata
+
+- Parse in `crates/raven/src/cross_file/directive.rs` alongside the other
+  `# raven:` families. The directive is **file-level** and **header-only**: it
+  must appear in the header region (consecutive blank/comment lines from file
+  start). Note the existing parser has two precedents: backward/working-dir
+  directives are gated on an `in_header` flag (`directive.rs:549`), while
+  `ignore-file` is parsed *without* that gate (`directive.rs:737`). `standalone`
+  follows the **backward/cd precedent**: add an explicit `in_header` gate.
+  Accept the `@lsp-standalone` alias for parity (`DIRECTIVE_PREFIX`
+  alternation). No payload; an optional trailing `# comment` is allowed.
+- Add `pub standalone: bool` (`#[serde(default)]`) to `CrossFileMetadata`
+  (`types.rs:185`). `false` by default = today's behavior everywhere.
+- Test: a `# raven: standalone` appearing *after* code is silently ignored
+  (header-only gate).
+
+### WI2a — knob 1 hook (the load-bearing semantic; the correctness+perf core)
+
+The STEP-1 backward walk is `parent_prefix_at` / `compute_or_get_cached_prefix`.
+When the **queried URI** C has `metadata(C).standalone == true`, short-circuit
+the backward walk: return an **empty `ParentPrefix`** for C (no walk to C's
+`backward` edges). Additionally, when C is resolved as a forward child of a
+caller A, resolve C with **canonical, caller-independent inputs** (empty/base
+package set, `None` provider, C's own `PathContext`) rather than A's inherited
+packages/provider/cd (`scope.rs:5412,5715`) — so C's scope is byte-identical
+whether computed for C's own diagnostics or as A's forward child. This canonical
+resolution is the precondition that makes the WI2b cache key (C's URI alone)
+sound.
+
+This alone removes the ~84-caller backward union when computing `functions.r`'s
+own diagnostics and fixes the caller-union over-approximation class (#476
+`getArray`). Combined with WI1's shared prefix memo, `functions.r`'s own
+diagnostic cost drops sharply with **no caching machinery at all**.
+
+Interface-hash wiring (revalidation): `standalone` changes cross-file scope, so
+it MUST feed `compute_interface_hash` (`scope.rs:4493`) — add the `standalone`
+bool so toggling the directive in any connected file revalidates dependents. The
+metadata-free hash path passes `false`; the metadata-aware path passes
+`metadata.standalone`.
+
+### WI2b — persistent isolated-scope cache (the cross-snapshot/IDE win) — MEASURE-GATED
+
+Knob 1 (WI2a) makes C's isolated EOF scope a pure function of `(C, C's forward
+closure)`. WI2b caches that scope so it is computed once and reused (a) across
+all 84 callers within one diagnostic pass, (b) across the ×84 revalidation
+fan-out when the hub is edited, and (c) across the 245 separate per-file
+snapshots of `raven check .` (each caller's snapshot would otherwise re-resolve
+C). Within-pass reuse alone kills the IDE hub-edit pause; cross-snapshot reuse is
+what additionally speeds `raven check .` for the hub.
+
+**Soundness of the cache key.** Because WI2a resolves C with caller-independent
+inputs, C's isolated scope does NOT depend on any of the caller-varying fields
+in `ForwardChildKey` (`path_fp`/`pkg_fp`/`provider_fp`, `scope.rs:1015`). So C's
+URI is a sufficient key *for the scope value* — provided invalidation correctly
+detects changes to C or its forward closure.
+
+**Invalidation — staged, measure-driven:**
+
+1. **Start sound and simple: coarse content-edit generation bump.** Maintain one
+   global monotonic `content_generation` counter, bumped on every document
+   content change. Cache key = `(C_uri, edge_revision, content_generation)`.
+   This is **unconditionally sound** (any edit anywhere invalidates) and is the
+   exact mechanism the issue calls for. It delivers (a) and (b) fully — within
+   one snapshot/pass the generation is stable, so C is computed once and shared
+   ×84. For `raven check .` (c), the generation is stable for the whole run
+   (no edits mid-run), so C is computed once and reused by all 245 files. The
+   only thing it sacrifices: cross-*keystroke* reuse while editing an unrelated
+   file (the next snapshot recomputes C once — shared, not ×84).
+   **Do NOT reuse `interface_hash` as a scope-value fingerprint:**
+   `Hash for ScopedSymbol` omits `signature` (`scope.rs:619` vs `PartialEq` at
+   `scope.rs:614`), so a formals-only edit changes the scope without changing
+   `interface_hash` — unsound for hover/completion/signature consumers.
+2. **Tighten only if measurement demands it: per-closure source fingerprint.**
+   If after WI1 + WI2a + the coarse bump, editing a *caller* still leaves a
+   perceptible pause (re-resolving C once per keystroke), replace the
+   `content_generation` component with a fingerprint over the **source-text
+   content hash** of `{C} ∪ forward_closure(C)` (membership pinned by
+   `edge_revision`). Source-text hashing captures *everything* observable
+   (including signatures), so it is sound where `interface_hash` is not. Editing
+   a caller (not in C's closure) leaves the fingerprint unchanged → hit. This is
+   the only part that approaches #480's territory; gate it behind a measurement
+   that shows it is needed.
+
+**Where the cache lives & lock discipline.** The per-snapshot `DependencyGraph`
+is cloned and resets its caches (`dependency.rs:585-610`), so a cross-snapshot
+cache must NOT live there. Store it as an `Arc<StandaloneScopeCache>` owned by
+`WorldState`. Per CLAUDE.md's locking-discipline invariant and `handlers.rs`
+(read lock must not be held across cross-file scope resolution): **clone the
+`Arc` handle out of `WorldState` under the read lock, drop the guard, then do
+lookup + miss-compute holding no `WorldState` guard.** The cache's own internal
+`RwLock`/LRU follows the `subgraph_cache` pattern (`dependency.rs:521-547`):
+read locks `peek()` (no promotion), write locks `push()`.
+
+> **Codex review targets (round 2):** (a) the canonical-input resolution in WI2a
+> — is there any other caller-varying input beyond packages/provider/cd that
+> feeds C's scope? (b) the source-text fingerprint (option 2) — is per-file
+> source hash sound and is the closure membership truly pinned by edge_revision?
+> (c) the `Arc`-handle-out lock discipline.
+
+### Interactions (resolved; Codex round 2 to stress-test)
+
+- **`# raven: cd`** — `standalone` only suppresses C's *backward* parent-prefix
+  walk and caller-inherited inputs; backward directives already ignore
+  `# raven: cd` (`PathContext::new`). C's own forward path resolution respects
+  C's own `# raven: cd` exactly as today. No change to path resolution. (Note
+  knob 1 explicitly drops the *caller's* inherited working directory for C — C
+  uses only its own.)
+- **`# raven: nse` / `# raven: func`** — NSE/func propagation is **graph-only**:
+  `collect_cross_file_nse` walks the revalidation-consistent set `S(Q)` over the
+  source graph and reads only `nse_declarations`/`declared_functions`, never
+  scope data (`handlers.rs`). `standalone` changes *scope content* resolution,
+  not graph edges, so the two are independent: `standalone` does NOT sever NSE
+  propagation. **Scope boundary to document explicitly:** because knob 1 also
+  drops caller-inherited *packages*, a package the caller loads that an NSE
+  policy depends on is no longer in-play *inside* C (ancestor packages are
+  otherwise included, `handlers.rs:5607`). This is intended isolation
+  (safe-direction: worst case a false-positive inside C). Document that
+  `standalone` isolates C's lexical scope **and** its in-play package set from
+  callers, while leaving NSE/func *directive* propagation over graph edges
+  intact.
+- **Package mode** — orthogonal; `standalone` is about `source()` topology, not
+  package exports. No change.
+- **`sys.source` / `local = TRUE`** — these already get local scoping
+  (`should_apply_local_scoping`, `scope.rs:1201`). `standalone` is about the
+  *callee's* backward walk, independent of how a caller sources it. Document that
+  `standalone` and per-call local scoping compose without conflict.
+
+### Docs
+
+- `docs/directives.md`: add `# raven: standalone` (header-only, file-level,
+  `@lsp-standalone` alias, three-knob semantics, opt-in safety note).
+- `docs/cross-file.md`: explain the standalone callee model and the caching it
+  enables; cross-link from the hub-pattern discussion.
+- Behavior identical across editor and CLI (it is a directive, not a setting —
+  the three-places settings rule does not apply).
+
+### Verification
+
+- New unit/integration tests: (a) standalone callee with a deliberately
+  caller-provided binding → false-positive *inside the callee* (proves knob 1);
+  (b) a standalone callee's scope is byte-identical whether computed for its own
+  diagnostics or as a forward child of two different callers with *different*
+  loaded packages (proves caller-independent canonical resolution); (c) toggling
+  `standalone` revalidates dependents (interface-hash wiring); (d) header-only
+  gate: `# raven: standalone` after code is ignored; (e) `# raven: cd` / `nse` /
+  `local=TRUE` interaction tests; (f) WI2b cache: editing a caller does NOT
+  change C's cached isolated scope value (under option 2, a cache-hit; under the
+  coarse bump, a recompute that yields the identical value); editing C or a
+  closure member changes it.
+- On worldwide: add `# raven: standalone` to `scripts/functions.r` (and/or
+  `bootstrap.r` per measurement), re-measure `functions.r` and `raven check .`,
+  report deltas. Diagnostics byte-identical except in the directive-bearing file.
+
+---
+
+## Work item 3 — Tier 2: parallelize the CLI per-file loop
+
+**Independent of items 1–2. CLI-only (does not help the IDE, already async).**
+
+### Design
+
+The per-file loop in `cli/check.rs:366` (`run()`) is sequential
+(`compute_file_diagnostics` per target). The graph caches are
+`RwLock`/atomic (Send+Sync) and immutable after the workspace scan, so per-file
+diagnostics parallelize with rayon.
+
+**Codex caveat (load-bearing):** do **not** open all targets into shared
+`state.documents`. Open documents outrank index content in the content provider
+for content, metadata, AND artifacts (`content_provider.rs:103-117`, and the
+open-doc-wins branches at the content/metadata/artifacts accessors). If every
+target were open at once, each worker's cross-file resolution would treat
+*other* targets as open and use the wrong artifacts source, changing output.
+Today the loop opens **exactly one** target at a time (`open` → `compute` →
+`close_document`, `check.rs:337-367`) and mutates shared `state.documents`
+(`check.rs:315`) — which is exactly what must NOT be shared-mutable across rayon
+workers.
+
+Preserve the invariant under parallelism with a **per-task read-only overlay**
+that overrides content + metadata + artifacts for **exactly one** URI, layered
+over a shared immutable view of the scanned index/graph (computed once, before
+the parallel region). No worker mutates shared `state.documents`. Each task
+computes `{shared index/graph} + {this one open target}` → `(path,
+Vec<Diagnostic>)`.
+
+**Async/rayon bridge (must be explicit):** `compute_file_diagnostics` is
+`async` (`check.rs:366`) while rayon is sync. Resolve deliberately — either keep
+the orchestration on the async runtime and parallelize with bounded
+`tokio` tasks / `spawn_blocking`, or `block_on` per rayon worker. Pick one in
+the implementation plan; do not leave it implicit.
+
+**Shared-state aggregation:** `reported_loaded_packages` (`check.rs:363`) is
+accumulated in the loop today; under parallelism, collect per-task and merge
+after the join. Budget counters live on the shared graph as atomics
+(`check.rs:404`) — confirm they remain correct under concurrent access, or
+return per-task counts and sum. The package-metadata warm-up
+(`prefetch_reported_packages`) runs before the loop and is unaffected.
+
+Output is already sorted after collection (`check.rs:374`), so result order is
+deterministic regardless of completion order.
+
+> **Codex review target (round 2):** the exact overlay type (a per-task content
+> provider / cheap `state` view holding one open doc) that avoids cloning the
+> whole index per task; the chosen async/rayon bridge; and that
+> `reported_loaded_packages` / budget counters aggregate correctly.
+
+### Verification
+
+- `raven check . 2>/dev/null | grep undefined-variable | sort` **byte-identical**
+  before/after (full output diff empty: same findings, same order).
+- Re-measure `raven check .`; expect ~3–5× → single-digit seconds.
+- Determinism: run `raven check .` 3× and diff — identical (the #476 sort fix +
+  post-loop sort must hold under parallel completion).
+
+---
+
+## Workflow & gates
+
+1. Tier 1 → measure → prove byte-identical.
+2. Directive → spec interactions resolved with Codex → implement → measure.
+3. Tier 2 → implement → measure.
+
+CI gates before each commit:
+
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
+- `cargo test --lib --features test-support`
+
+Final gate: two consecutive clean `/code-review` rounds + a final Codex
+adversarial pass before merge. Report the #472 bench delta vs main. Never claim a
+speedup without a before/after number on worldwide.


### PR DESCRIPTION
Hub-heavy cross-file performance for #479. On a real 245-file workspace, `raven check .` drops from ~24s to ~3.5s with **byte-identical** diagnostics.

## Work items

**WI1 — Share the prefix `ForwardChildMemo` within a `ScopeStream`** (`scope.rs`, `dependency.rs`). A hub file sourced by N callers was re-resolving its forward closure once per prefix slot (O(N²)). WI1 shares one prefix forward-child memo across a stream's prefix computations, gated by `DependencyGraph::prefix_memo_share_safe` (a bidirectional-BFS truncation gate) and protected by slot-isolation (the `query_inside_function = true` slot gets a fresh memo). Sound for the symbol set by the equivalence suite; the gate's BFS-shortest-path depth leaves a bounded, accepted residual on the heuristic "max chain depth exceeded" advisory under truncation (never on symbols) — documented and tracked in **#484**.

**WI2a — Callee-side `# raven: standalone` directive** (`directive.rs`, `types.rs`, `scope.rs`, docs). A header-only directive that resolves a file's own diagnostics in isolation from its callers by skipping the backward parent-prefix walk (drops caller-inherited symbols + packages). Wired into `compute_interface_hash` so toggling revalidates dependents. **Shipped = part 1 (backward-walk skip) only**; part 2 (caller-independent forward-child resolution) is deferred to **WI2b (#483)**.

**WI3 — Parallel `raven check`** (`cli/check.rs`, `handlers.rs`, `state.rs`). Per-file diagnostics run on a rayon `par_iter`; `state.documents` stays empty in the parallel region and each worker uses a one-entry open-documents overlay, so output is byte-identical to a sequential run (pinned by `parallel_collection_matches_sequential`).

## Verification (worldwide, branch `debug-raven`, 245 files, release build)

- **Byte-identical to `main`**: 600 `[undefined-variable]` diagnostics, and the **full** output (38,879 issues: 19 errors / 1862 warnings / 36,998 hints) is identical between branch and `main`.
- **Deterministic** across 3 runs.
- **Wall-clock**: `main` 23.9s (single-threaded) → branch **3.55s** (~6.7×), warm.
- **#472 micro-bench** (`cross_file_forward_child_memo`): no regression (`hub_30x20` 161→162µs, `hub_60x40` 440→442µs).

(The 600 count is environment-dependent — without the R package symbol DB in CI, more symbols are flagged; the handoff's machine with packages saw 361. The branch-vs-`main` equivalence is environment-independent and is the safety property.)

## Review

Two consecutive clean review passes (5 fresh-context read-only reviewers each: correctness, invariants/conventions, tests, docs, simplification/reuse; every finding adversarially verified). Pass-2 review findings resolved: a real-but-narrow gate residual (B) → documented + **#484** filed; blocking-rayon-in-async (C) → documented (single-root-future CLI, `block_in_place` would be a no-op + a panic hazard); spec part-1/part-2 accuracy (E); and a shared test-setup helper (F). Gates green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -D warnings`, `cargo test --lib --features test-support` (5212 pass).

## Follow-ups

- **#481** filed, **#482** (add signature to `ScopedSymbol` Hash + Hash/Eq parity test) — prerequisite for WI2b.
- **#483** (WI2b — persistent isolated-scope cache) deferred until this merges.
- **#484** (gate's `depth_exceeded` advisory residual) — fix proposed off the hot path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `# raven: standalone` header directive (alias `@lsp-standalone`) to isolate a file's diagnostics from inherited parent scope while preserving normal package loading and definition propagation to callers.

* **Performance**
  * Significantly improved `raven check` command performance through parallelized per-target diagnostics collection and computation.

* **Documentation**
  * Added comprehensive documentation for the new standalone directive and cross-file scope analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->