### PR TITLE
Fix #482: hash ScopedSymbol.signature so signature edits revalidate dependents

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -571,13 +571,18 @@ pub enum SymbolKind {
 
 /// A symbol with its definition location
 //
-// `PartialEq`/`Hash` are hand-written below and deliberately EXCLUDE
-// `defined_end_column` (it is positional metadata, not identity — two symbols
-// that differ only in their highlight width are the same binding for cache /
-// dedup purposes). They preserve the pre-existing field sets exactly:
-// `PartialEq` compares every other field (including `signature`); `Hash`
-// omits `signature`. That asymmetry is sound — equal values still hash equal —
-// and is intentionally left unchanged here.
+// `PartialEq`/`Hash` are hand-written below and share the SAME field set:
+// every field EXCEPT `defined_end_column`, which both deliberately EXCLUDE (it
+// is positional highlight metadata, not identity — two symbols that differ only
+// in their highlight width are the same binding for cache / dedup purposes).
+// `signature` is part of both (issue #482): it must be hashed so that
+// `compute_interface_hash` — which hashes a file's exported symbols through
+// this `Hash` impl — is sensitive to a formals-only edit
+// (`f <- function(a)` → `f <- function(a, b)`); otherwise dependents that
+// `source()` the file are not revalidated and cross-file
+// hover/completion/signature-help show a stale signature. The
+// `scoped_symbol_hash_eq_field_parity` test pins this field-set equality so the
+// two impls cannot silently desync.
 #[derive(Debug, Clone, Eq)]
 pub struct ScopedSymbol {
     pub name: Arc<str>,
@@ -623,6 +628,7 @@ impl Hash for ScopedSymbol {
         self.source_uri.hash(state);
         self.defined_line.hash(state);
         self.defined_column.hash(state);
+        self.signature.hash(state);
         self.is_declared.hash(state);
     }
 }
@@ -8261,6 +8267,196 @@ mod tests {
         assert_ne!(
             ha, hb,
             "renaming a top-level export must change interface_hash"
+        );
+    }
+
+    /// Issue #482: `Hash` and `PartialEq` for `ScopedSymbol` MUST cover the
+    /// same field set — every field except `defined_end_column` (positional
+    /// highlight metadata, deliberately excluded from BOTH). This pins that
+    /// parity: mutating any Eq-significant field flips both `==` and the hash;
+    /// mutating the excluded field flips neither. A future field added to one
+    /// impl but not the other trips this test, preventing the two from
+    /// silently desyncing (which is exactly how the pre-#482 `signature`
+    /// omission slipped in).
+    #[test]
+    fn scoped_symbol_hash_eq_field_parity() {
+        fn hash_of(s: &ScopedSymbol) -> u64 {
+            let mut h = DefaultHasher::new();
+            s.hash(&mut h);
+            h.finish()
+        }
+
+        let base = ScopedSymbol {
+            name: Arc::from("f"),
+            kind: SymbolKind::Function,
+            source_uri: test_uri(),
+            defined_line: 3,
+            defined_column: 0,
+            defined_end_column: 1,
+            signature: Some("f(a)".to_string()),
+            is_declared: false,
+        };
+
+        // Each entry mutates exactly one Eq-significant field. Both `!=` and
+        // the hash must change — proving the field is in BOTH impls.
+        let eq_significant: Vec<(&str, ScopedSymbol)> = vec![
+            (
+                "name",
+                ScopedSymbol {
+                    name: Arc::from("g"),
+                    ..base.clone()
+                },
+            ),
+            (
+                "kind",
+                ScopedSymbol {
+                    kind: SymbolKind::Variable,
+                    ..base.clone()
+                },
+            ),
+            (
+                "source_uri",
+                ScopedSymbol {
+                    source_uri: Url::parse("file:///other.R").unwrap(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "defined_line",
+                ScopedSymbol {
+                    defined_line: 4,
+                    ..base.clone()
+                },
+            ),
+            (
+                "defined_column",
+                ScopedSymbol {
+                    defined_column: 1,
+                    ..base.clone()
+                },
+            ),
+            // The field this issue adds to `Hash`:
+            (
+                "signature",
+                ScopedSymbol {
+                    signature: Some("f(a, b)".to_string()),
+                    ..base.clone()
+                },
+            ),
+            (
+                "is_declared",
+                ScopedSymbol {
+                    is_declared: true,
+                    ..base.clone()
+                },
+            ),
+        ];
+
+        for (field, mutated) in &eq_significant {
+            assert_ne!(
+                base, *mutated,
+                "mutating `{field}` must make symbols unequal"
+            );
+            assert_ne!(
+                hash_of(&base),
+                hash_of(mutated),
+                "mutating `{field}` must change the hash (Hash must track every Eq field)"
+            );
+        }
+
+        // `defined_end_column` is excluded from BOTH impls: mutating it changes
+        // neither equality nor the hash.
+        let end_col_only = ScopedSymbol {
+            defined_end_column: 99,
+            ..base.clone()
+        };
+        assert_eq!(
+            base, end_col_only,
+            "mutating `defined_end_column` must NOT affect equality"
+        );
+        assert_eq!(
+            hash_of(&base),
+            hash_of(&end_col_only),
+            "mutating `defined_end_column` must NOT affect the hash"
+        );
+    }
+
+    /// Issue #482: a formals-only edit to a top-level function
+    /// (`f <- function(a)` → `f <- function(a, b)`) changes the exported
+    /// signature, so it MUST change `interface_hash` — otherwise dependents
+    /// that source the file are not revalidated and cross-file
+    /// hover/completion/signature-help show a stale signature. Guards the
+    /// `self.signature.hash(...)` line in `impl Hash for ScopedSymbol`.
+    #[test]
+    fn interface_hash_changes_on_signature_only_edit() {
+        let a = "f <- function(a) a";
+        let b = "f <- function(a, b) a";
+        let ta = parse_r(a);
+        let tb = parse_r(b);
+        let ha = compute_artifacts(&test_uri(), &ta, a).interface_hash;
+        let hb = compute_artifacts(&test_uri(), &tb, b).interface_hash;
+        assert_ne!(
+            ha, hb,
+            "a signature-only edit to a top-level function must change interface_hash"
+        );
+    }
+
+    /// Issue #482, end-to-end at the revalidation level: a signature-only edit
+    /// to a sourced file changes its `interface_hash`, and
+    /// `compute_affected_dependents_after_edit` (which keys on whether the
+    /// interface changed) then includes the dependent that sources it. This is
+    /// the user-visible chain the fix repairs — stale cross-file signatures.
+    #[test]
+    fn signature_only_edit_revalidates_dependents() {
+        use crate::cross_file::dependency::DependencyGraph;
+        use crate::cross_file::revalidation::compute_affected_dependents_after_edit;
+        use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+        let root = Url::parse("file:///proj").unwrap();
+        let child = Url::parse("file:///proj/child.R").unwrap();
+        let parent = Url::parse("file:///proj/parent.R").unwrap();
+
+        // The edit adds a formal to child's exported function (signature only).
+        let v1 = "f <- function(a) a";
+        let v2 = "f <- function(a, b) a";
+        let h1 = compute_artifacts(&child, &parse_r(v1), v1).interface_hash;
+        let h2 = compute_artifacts(&child, &parse_r(v2), v2).interface_hash;
+        assert_ne!(h1, h2, "a signature-only edit must change interface_hash");
+
+        // parent.R sources child.R.
+        let mut graph = DependencyGraph::new();
+        let meta_parent = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "child.R".to_string(),
+                line: 1,
+                column: 0,
+                is_directive: false,
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        graph.update_file(&parent, &meta_parent, Some(&root), |_| None);
+
+        let mut open: std::collections::HashSet<Url> = std::collections::HashSet::new();
+        open.insert(parent.clone());
+        open.insert(child.clone());
+
+        let affected = compute_affected_dependents_after_edit(
+            &child,
+            h1 != h2, // interface_changed — derived from the real hashes
+            false,
+            &graph,
+            |u| open.contains(u),
+            10,
+            200,
+        );
+        assert!(
+            affected.contains(&parent),
+            "a dependent that sources the edited file must be revalidated on a signature edit"
         );
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -217,7 +217,7 @@ The cached/streaming parent prefix is seeded with the queried URI at `(u32::MAX,
 `ScopeArtifacts` includes an `interface_hash` used to avoid cascading revalidation when edits don’t change a file’s “exported interface”.
 
 The hash is deterministic and includes:
-- Exported symbols
+- Exported symbols — each hashed through `impl Hash for ScopedSymbol`, which covers that type's full identity field set (`name`, `kind`, `source_uri`, `defined_line`, `defined_column`, `signature`, `is_declared`) and deliberately excludes only `defined_end_column` (positional highlight metadata). `Hash` must mirror `PartialEq` field-for-field: a field present in one but not the other makes the hash blind to that kind of edit. The `signature` inclusion (issue #482) is what makes a formals-only edit (`f <- function(a)` → `f <- function(a, b)`) bust the hash and revalidate dependents; `scoped_symbol_hash_eq_field_parity` pins the two impls' field sets together.
 - Loaded packages (from `library()` / `require()` / `loadNamespace()`)
 - Declared symbols (from `# raven: var` / `# raven: func` directives)
 


### PR DESCRIPTION
Closes #482.

## Problem (framing)

This is **not** a HashMap-correctness bug. `impl Hash for ScopedSymbol` omitted the `signature` field while `impl PartialEq` includes it, but that never violated the `a == b => hash(a) == hash(b)` contract — Eq-equal values are also signature-equal and hashed equal (benign extra collisions only).

The actual defect is narrower: `compute_interface_hash` hashes a file's exported symbols through this `Hash` impl, so it wasn't signature-sensitive. A formals-only edit to a sourced function (`f <- function(a)` → `f <- function(a, b)`) didn't change the file's `interface_hash`, so `compute_affected_dependents_after_edit` (which keys on whether the interface changed) didn't revalidate dependents — cross-file **hover / completion / signature-help** could show a stale signature. Undefined-variable diagnostics don't use signatures, so this was a quality-of-results gap, not a false diagnostic.

This affects the **incremental (LSP `did_change`) revalidation path**, not `raven check`'s cold full pass (which recomputes regardless of `interface_hash`), so `raven check` output is unaffected.

## Fix

- Add `self.signature.hash(state);` to `impl Hash for ScopedSymbol` so `Hash` mirrors `PartialEq`'s exact field set: `name`, `kind`, `source_uri`, `defined_line`, `defined_column`, `signature`, `is_declared` — and continues to exclude only the positional `defined_end_column` (deliberately excluded from both).
- Rewrite the now-stale struct doc comment to state the new invariant (Hash and Eq share the same field set).
- Document the hashed field set in `docs/development.md`.

## Tests (TDD — written failing first)

- `scoped_symbol_hash_eq_field_parity`: for each Eq field, mutate only it and assert both `a != b` and `hash(a) != hash(b)`; for `defined_end_column`, mutate and assert both `a == b` and `hash(a) == hash(b)`. Pins both impls' field sets so a future field addition can't silently desync them.
- `interface_hash_changes_on_signature_only_edit`: a formals-only edit to a top-level function changes `interface_hash`.
- `signature_only_edit_revalidates_dependents`: end-to-end — `interface_hash` differs across the edit, and `compute_affected_dependents_after_edit` (with `interface_changed` derived from the real hashes, not hardcoded) includes the dependent that sources the edited file.

## Widened revalidation (verified)

A signature edit now correctly invalidates dependents, raising revalidation frequency. No test encoded the old buggy "signature edit doesn't revalidate" behavior. **Eq is unchanged**, so all dedup/equality semantics (HashMap/HashSet of `ScopedSymbol`) are identical — only hash distribution and `interface_hash`'s signature-sensitivity change.

The #472/#479 equivalence + perf tests (`memo_equiv_*`, `parallel_collection_matches_sequential`) and the `prop_interface_hash_*` property tests stay green.

## Gates

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` ✓ (clean)
- `cargo test --lib --features test-support` ✓ (5215 passed; the only failures were sandbox socket-bind restrictions in `cli::packages` network tests, green with sandbox off)

Prerequisite for WI2b (#483).