### PR TITLE
feat(completion): complete a package's exports after `pkg::`

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -811,7 +811,10 @@ const R_CONSTANTS: &[&str] = &[
 const SORT_PREFIX_PARAM: &str = "0-";
 const SORT_PREFIX_SCOPE: &str = "1-";
 const SORT_PREFIX_WORKSPACE: &str = "2-";
-const SORT_PREFIX_PACKAGE: &str = "4-";
+/// Sort bucket for package globals. `pub(crate)` so `namespace_completion`
+/// orders `pkg::` exports identically to bare-identifier package exports
+/// without duplicating the literal.
+pub(crate) const SORT_PREFIX_PACKAGE: &str = "4-";
 const SORT_PREFIX_KEYWORD: &str = "5-";
 
 // ============================================================================
@@ -17584,7 +17587,12 @@ fn is_r_identifier_continue_byte(byte: u8) -> bool {
     is_r_identifier_start_byte(byte) || byte.is_ascii_digit()
 }
 
-fn accessor_member_insert_text(name: &str) -> String {
+/// Completion insert text for a member name: the name verbatim when it is a
+/// syntactic R name (or already carries backticks), otherwise backtick-quoted so
+/// the accepted completion is valid R (`obj$`my var``, `pkg::`%>%``). Shared by
+/// the `$`/`@` member path and the `pkg::` namespace path (`namespace_completion`)
+/// so both quote non-syntactic names by the one [`crate::r_names`] rule.
+pub(crate) fn accessor_member_insert_text(name: &str) -> String {
     if crate::r_names::is_syntactic_r_name(name) || name.contains('`') {
         name.to_string()
     } else {
@@ -17825,17 +17833,41 @@ pub fn completion(
         let items = dollar_member_completion_items(state, uri, position, &member_context);
         return Some(CompletionResponse::Array(items));
     }
+
+    // A cursor with no node in the parsed tree — e.g. a stale request whose
+    // position no longer exists in the current text — has no completions.
     let point = lsp_position_to_ts_point(&text, position);
     let node = tree.root_node().descendant_for_point_range(point, point)?;
 
+    // Namespace-qualified completion: inside `pkg::` / `pkg:::`, offer that
+    // package's exported symbols and nothing else — keywords, scope symbols,
+    // and other packages are irrelevant here. Covers both the complete-AST case
+    // (`pkg::name`) and the incomplete case (`pkg::` with no member typed yet).
+    // A detected context ALWAYS short-circuits (even when it yields no items:
+    // `:::`, the package/LHS side, or an unknown package) because
+    // keywords/locals/params are syntactically invalid around `::`.
+    //
+    // Entered only when package awareness is on: with it off the whole feature
+    // is disabled, so `::` gets no special handling and falls through to general
+    // completion (matching the pre-feature behavior). Deliberately NOT gated on
+    // `package_library_ready` (unlike the bare-identifier package path below):
+    // `get_exports_sync` resolves from the on-disk NAMESPACE as soon as lib
+    // paths are set, so gating on readiness would only delay startup-window
+    // `pkg::` completions.
+    if state.cross_file_config.packages_enabled
+        && let Some(ns_ctx) = crate::namespace_completion::detect_namespace_completion_context(
+            tree, node, point, &text,
+        )
+    {
+        let ns_items = crate::namespace_completion::namespace_completion_items(
+            &ns_ctx,
+            &state.package_library,
+        );
+        return Some(CompletionResponse::Array(ns_items));
+    }
+
     let mut items = Vec::new();
     let mut seen_names = std::collections::HashSet::new();
-
-    // Check if we're in a namespace context (pkg::)
-    if find_namespace_context(&node, &text).is_some() {
-        // TODO: Get package exports from library
-        return Some(CompletionResponse::Array(items));
-    }
 
     // Add R keywords (control flow and common functions)
     let keywords = [
@@ -18020,11 +18052,12 @@ pub fn completion(
     });
 
     // Check if inside function call — if so, prepend parameter completions.
-    // Token detection (namespace accessor check via find_namespace_context above)
-    // happens BEFORE this point — if accessor is present, we already returned early,
-    // so parameter completions are naturally suppressed for namespace-qualified tokens.
-    // For incomplete namespace expressions (e.g., `pkg::` with no RHS), the AST check
-    // may fail, so we also do a text-based check here as a fallback.
+    // Real `pkg::` / `pkg:::` contexts already short-circuited above (via
+    // `detect_namespace_completion_context`, which covers both the complete-AST
+    // and the incomplete-text cases), so we never reach here inside one. The
+    // `has_namespace_accessor_at_cursor` text check below remains a cheap guard
+    // for degenerate prefixes the detector treats as "not a namespace" (e.g.
+    // `::` with no package), where parameter completions would still be noise.
     //
     // When trigger_on_open_paren is false, suppress parameter completions triggered by `(`.
     // Manual invocation (Ctrl+Space) still shows them regardless of config.
@@ -18061,12 +18094,12 @@ pub fn completion(
 
 /// Check if the text before the cursor contains a namespace accessor (`::` or `:::`).
 ///
-/// This is a text-based fallback for the AST-based `find_namespace_context` check.
-/// When the namespace expression is incomplete (e.g., `pkg::` with no RHS), tree-sitter
-/// may not produce a `namespace_operator` node, so the AST check fails. This function
-/// scans the line text backward from the cursor to detect `::` or `:::` in the token
-/// being typed, ensuring parameter completions are suppressed for namespace-qualified
-/// tokens even when the AST is incomplete.
+/// Real `pkg::` contexts are handled (and short-circuited) earlier in
+/// `completion()` by `namespace_completion::detect_namespace_completion_context`,
+/// so this is only a residual guard for degenerate prefixes that detector treats
+/// as "not a namespace" (e.g. `::` with no package). It scans the line text
+/// backward from the cursor to detect a trailing `::` / `:::`, ensuring parameter
+/// completions are still suppressed for such namespace-qualified tokens.
 fn has_namespace_accessor_at_cursor(text: &str, position: Position) -> bool {
     let line_idx = position.line as usize;
     let line = match text.lines().nth(line_idx) {
@@ -25869,6 +25902,275 @@ clean_data <- function(x) {
                 panic!("Expected CompletionResponse::Array");
             }
         });
+    }
+
+    // ========================================================================
+    // `pkg::` namespace-qualified completion (issue: function completions after
+    // a package name). End-to-end through the `completion()` handler.
+    // ========================================================================
+
+    /// Seed a one-package library, drop a single-line R document, and run
+    /// `completion()` with the cursor at the END of `line` (after any `::`).
+    fn namespace_completion_labels(
+        line: &str,
+        package: &str,
+        exports: &[&str],
+        packages_enabled: bool,
+    ) -> Vec<String> {
+        let eol = Position::new(0, line.encode_utf16().count() as u32);
+        namespace_completion_labels_at(line, eol, package, exports, packages_enabled)
+    }
+
+    #[test]
+    fn pkg_double_colon_offers_package_exports() {
+        use crate::package_library::{PackageInfo, PackageLibrary};
+        use crate::state::{Document, WorldState};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut state = WorldState::new();
+            state.cross_file_config.packages_enabled = true;
+            state.package_library = std::sync::Arc::new(PackageLibrary::new_empty());
+            state
+                .package_library
+                .insert_package(PackageInfo::new(
+                    "dplyr".to_string(),
+                    std::collections::HashSet::from(["mutate".to_string(), "filter".to_string()]),
+                ))
+                .await;
+            state.package_library_ready = true;
+
+            let uri = Url::parse("file:///test.R").unwrap();
+            state
+                .documents
+                .insert(uri.clone(), Document::new("dplyr::", None));
+
+            let position = Position::new(0, 7);
+            let items = match completion(&state, &uri, position, None) {
+                Some(CompletionResponse::Array(items)) => items,
+                other => panic!("expected array, got {:?}", other),
+            };
+
+            let filter = items
+                .iter()
+                .find(|i| i.label == "filter")
+                .expect("dplyr::filter offered");
+            assert_eq!(filter.kind, Some(CompletionItemKind::FUNCTION));
+            assert_eq!(filter.detail.as_deref(), Some("{dplyr}"));
+            assert!(filter.data.is_some(), "carries resolve data for help docs");
+            assert!(items.iter().any(|i| i.label == "mutate"));
+
+            // Inside `pkg::`, no general completions leak in.
+            assert!(
+                !items.iter().any(|i| i.label == "if"),
+                "keywords must not appear in a namespace completion list"
+            );
+        });
+    }
+
+    #[test]
+    fn pkg_double_colon_backtick_quotes_non_syntactic_export() {
+        // End-to-end through `completion()`: a non-syntactic export (operator
+        // `%>%`, as real packages declare via `export("%>%")`) must be offered
+        // with backtick-quoted insert text so accepting it yields valid R
+        // (`magrittr::`%>%``), while the label/filter stay the bare name. A
+        // syntactic sibling export needs no insert override. This guards the
+        // handler-seam wiring of `insert_text`/`filter_text`, not just the unit.
+        use crate::package_library::{PackageInfo, PackageLibrary};
+        use crate::state::{Document, WorldState};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut state = WorldState::new();
+            state.cross_file_config.packages_enabled = true;
+            state.package_library = std::sync::Arc::new(PackageLibrary::new_empty());
+            state
+                .package_library
+                .insert_package(PackageInfo::new(
+                    "magrittr".to_string(),
+                    std::collections::HashSet::from(["%>%".to_string(), "set_names".to_string()]),
+                ))
+                .await;
+            state.package_library_ready = true;
+
+            let uri = Url::parse("file:///test.R").unwrap();
+            state
+                .documents
+                .insert(uri.clone(), Document::new("magrittr::", None));
+
+            let items = match completion(&state, &uri, Position::new(0, 10), None) {
+                Some(CompletionResponse::Array(items)) => items,
+                other => panic!("expected array, got {:?}", other),
+            };
+
+            let op = items
+                .iter()
+                .find(|i| i.label == "%>%")
+                .expect("magrittr::%>% offered");
+            assert_eq!(
+                op.insert_text.as_deref(),
+                Some("`%>%`"),
+                "non-syntactic export inserts backtick-quoted text"
+            );
+            assert_eq!(
+                op.filter_text.as_deref(),
+                Some("%>%"),
+                "filter text stays the bare name so typing `%` still matches"
+            );
+            // Resolve data still uses the bare topic for the help lookup.
+            assert_eq!(
+                op.data,
+                Some(serde_json::json!({ "topic": "%>%", "package": "magrittr" }))
+            );
+
+            let plain = items
+                .iter()
+                .find(|i| i.label == "set_names")
+                .expect("magrittr::set_names offered");
+            assert_eq!(
+                plain.insert_text, None,
+                "syntactic export inserts its label verbatim"
+            );
+        });
+    }
+
+    #[test]
+    fn pkg_double_colon_trailing_whitespace_still_offers_exports() {
+        // `dplyr:: ` (a space after the operator, no member yet) is valid R.
+        // The handler must short-circuit to the package's exports and NOT leak
+        // general completions (keywords), honoring the namespace suppression
+        // contract even when the cursor sits past trailing whitespace.
+        let labels = namespace_completion_labels_at(
+            "dplyr:: ",
+            Position::new(0, 8),
+            "dplyr",
+            &["mutate", "filter"],
+            true,
+        );
+        assert!(
+            labels.contains(&"mutate".to_string()) && labels.contains(&"filter".to_string()),
+            "exports offered after `pkg:: `, got: {labels:?}"
+        );
+        assert!(
+            !labels.contains(&"if".to_string()),
+            "keywords must not leak after `pkg:: `, got: {labels:?}"
+        );
+    }
+
+    #[test]
+    fn pkg_double_colon_cursor_on_package_suppresses_completions() {
+        // Cursor on the package identifier itself (`dpl|yr::filter`): only
+        // package names are valid there, so the popup is suppressed entirely —
+        // not the package's members, and not keyword/scope noise (keywords
+        // cannot precede `::`).
+        let labels = namespace_completion_labels_at(
+            "dplyr::filter",
+            Position::new(0, 3),
+            "dplyr",
+            &["mutate", "filter"],
+            true,
+        );
+        assert!(
+            labels.is_empty(),
+            "package-side cursor must suppress completions, got: {labels:?}"
+        );
+    }
+
+    #[test]
+    fn pkg_triple_colon_offers_nothing() {
+        // `:::` (internal access) is detected but deferred — empty list, and
+        // crucially NOT a fall-through to keywords.
+        let labels = namespace_completion_labels("dplyr:::", "dplyr", &["mutate"], true);
+        assert!(labels.is_empty(), "internal access yields no completions");
+    }
+
+    #[test]
+    fn pkg_double_colon_disabled_falls_through_to_general() {
+        // With package awareness off, `::` gets no special handling: the request
+        // falls through to general completion (keywords) rather than an empty
+        // popup, and the package's members are not offered.
+        let labels = namespace_completion_labels("dplyr::", "dplyr", &["mutate"], false);
+        assert!(
+            labels.contains(&"if".to_string()),
+            "disabled `pkg::` falls through to general completion, got: {labels:?}"
+        );
+        assert!(!labels.contains(&"mutate".to_string()));
+    }
+
+    #[test]
+    fn pkg_double_colon_resolves_from_disk_before_library_ready() {
+        // The namespace path is deliberately NOT gated on `package_library_ready`
+        // (unlike the bare-identifier package path): an installed package's
+        // exports resolve from its on-disk NAMESPACE during the startup window,
+        // before the cache is warmed. A future readiness gate would break this.
+        use crate::package_library::PackageLibrary;
+        use crate::state::{Document, WorldState};
+
+        let lib_root = tempfile::tempdir().unwrap();
+        let pkg_dir = lib_root.path().join("diskpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("NAMESPACE"), "export(disk_fn)\n").unwrap();
+
+        let mut state = WorldState::new();
+        state.cross_file_config.packages_enabled = true;
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_lib_paths(vec![lib_root.path().to_path_buf()]);
+        state.package_library = std::sync::Arc::new(lib);
+        // Crucially NOT ready, and the package was never library()-loaded.
+        state.package_library_ready = false;
+
+        let uri = Url::parse("file:///test.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new("diskpkg::", None));
+
+        let labels = match completion(&state, &uri, Position::new(0, 9), None) {
+            Some(CompletionResponse::Array(items)) => {
+                items.into_iter().map(|i| i.label).collect::<Vec<_>>()
+            }
+            other => panic!("expected array, got {:?}", other),
+        };
+        assert_eq!(labels, vec!["disk_fn"]);
+    }
+
+    /// Variant of [`namespace_completion_labels`] with an explicit cursor
+    /// position (for cursor-on-package-side cases).
+    fn namespace_completion_labels_at(
+        text: &str,
+        position: Position,
+        package: &str,
+        exports: &[&str],
+        packages_enabled: bool,
+    ) -> Vec<String> {
+        use crate::package_library::{PackageInfo, PackageLibrary};
+        use crate::state::{Document, WorldState};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut state = WorldState::new();
+            state.cross_file_config.packages_enabled = packages_enabled;
+            state.package_library = std::sync::Arc::new(PackageLibrary::new_empty());
+            state
+                .package_library
+                .insert_package(PackageInfo::new(
+                    package.to_string(),
+                    exports.iter().map(|s| s.to_string()).collect(),
+                ))
+                .await;
+            state.package_library_ready = true;
+
+            let uri = Url::parse("file:///test.R").unwrap();
+            state
+                .documents
+                .insert(uri.clone(), Document::new(text, None));
+
+            match completion(&state, &uri, position, None) {
+                Some(CompletionResponse::Array(items)) => {
+                    items.into_iter().map(|i| i.label).collect()
+                }
+                other => panic!("expected array, got {:?}", other),
+            }
+        })
     }
 
     // ========================================================================

--- a/crates/raven/src/lib.rs
+++ b/crates/raven/src/lib.rs
@@ -35,6 +35,7 @@ pub mod indentation;
 pub mod jags_builtins;
 pub mod libpath_watcher;
 pub mod linting;
+pub mod namespace_completion;
 pub mod namespace_parser;
 pub mod nse;
 pub mod package_db;

--- a/crates/raven/src/namespace_completion.rs
+++ b/crates/raven/src/namespace_completion.rs
@@ -1,0 +1,499 @@
+//
+// namespace_completion.rs
+//
+// Completion of a package's exported symbols after a `pkg::` namespace
+// qualifier. Typing `dplyr::` offers `mutate`, `filter`, `starwars`, ... each
+// attributed `{dplyr}` and resolving to its help topic.
+//
+// Shape mirrors `file_path_intellisense`: a context type, one `detect_*` entry
+// point, and an item builder. The completion handler calls
+// `detect_namespace_completion_context` and, on `Some`, returns the items from
+// `namespace_completion_items` and short-circuits.
+//
+// Suppression contract: inside a `::` expression the only valid completions are
+// the package's exported names (on the member/RHS side) or package names (on
+// the LHS, which is not yet offered). Keywords, local symbols, and call
+// parameters are all syntactically invalid around `::`, so a detected context
+// ALWAYS short-circuits the handler — even when it yields no items (unknown
+// package, or the package/LHS side). Falling through to general completion
+// there would offer suggestions that cannot parse (`dplyr::if`, `if::filter`).
+//
+// Scope: exported symbols only (`::`). Internal access (`:::`) is detected (the
+// `internal` flag on `Member`) but intentionally yields no items — internal
+// symbols are not stored in the package library and would need an R subprocess.
+// The flag is the seam to add them later without touching the handler wiring.
+
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
+use tree_sitter::{Node, Point, Tree};
+
+use crate::handlers::SORT_PREFIX_PACKAGE;
+use crate::package_library::PackageLibrary;
+
+/// What the cursor's `::` position calls for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceCompletionContext {
+    /// Cursor on the member (RHS) side — offer `package`'s exported symbols.
+    /// `internal` is true for `:::` (deferred, so it yields no items).
+    Member { package: String, internal: bool },
+    /// Cursor on the package (LHS) side of a `::`, including the operator
+    /// boundary (`dplyr|::x`). Members are wrong here and keywords/locals are
+    /// invalid around `::`, so the handler short-circuits with no completions —
+    /// matching the pre-existing behavior and preventing parameter/keyword
+    /// leakage inside a qualified call argument (`foo(pkg::bar)`).
+    PackageSide,
+}
+
+/// Detect whether `point` sits inside a `pkg::` / `pkg:::` expression.
+///
+/// `node` is the deepest AST node at the cursor and `point` its tree-sitter
+/// position (both computed once by the caller). Detection is purely AST-based:
+/// it finds the `namespace_operator` enclosing the cursor, or — for an
+/// incomplete `pkg::` where the cursor sits just *past* the operator (including
+/// past trailing whitespace, as in `pkg:: `) — the one enclosing the nearest
+/// token before the cursor. Trailing-whitespace step-back applies only to a
+/// member-less operator, so a cursor past a complete `pkg::name ` is correctly
+/// treated as outside the expression.
+///
+/// tree-sitter forms a `namespace_operator` even for an incomplete `pkg::` (and
+/// for a quoted/backtick qualifier, whose `lhs` is a `string`/identifier node we
+/// unquote), but NOT for a non-name LHS (`a$b::`, `1::` → `extract_operator` /
+/// `float` + `ERROR`) nor inside a comment/string (those are `comment`/`string`
+/// nodes). So this naturally accepts exactly the valid qualifier shapes and
+/// rejects the rest — no text scanning or string/comment guard needed.
+///
+/// Returns `None` when the cursor is not inside a `::` expression at all.
+pub fn detect_namespace_completion_context(
+    tree: &Tree,
+    node: Node,
+    point: Point,
+    text: &str,
+) -> Option<NamespaceCompletionContext> {
+    let ns = enclosing_namespace_operator(node).or_else(|| {
+        // Incomplete `pkg::`: the cursor resolves past the operator, so look at
+        // the token immediately before it. The cursor may also sit on trailing
+        // horizontal whitespace (`pkg:: `, still valid R), so step back over
+        // same-line spaces/tabs to reach that token.
+        //
+        // Crucially, only step over whitespace when the operator has no member
+        // yet: a cursor immediately after a partial member (`pkg:: x|`, no
+        // space) is editing that member and must resolve, but a cursor past a
+        // *complete* member and a space (`pkg::name |`) is past the whole
+        // expression — stepping back there would wrongly re-enter it.
+        let line = text.lines().nth(point.row)?;
+        let bytes = line.as_bytes();
+        let c0 = point.column.checked_sub(1)?;
+        let stepped_over_whitespace = matches!(bytes.get(c0), Some(b' ' | b'\t'));
+        let mut probe_col = c0;
+        while matches!(bytes.get(probe_col), Some(b' ' | b'\t')) {
+            probe_col = probe_col.checked_sub(1)?;
+        }
+        let before = Point::new(point.row, probe_col);
+        let ns = enclosing_namespace_operator(
+            tree.root_node()
+                .descendant_for_point_range(before, before)?,
+        )?;
+        if stepped_over_whitespace && ns.child_by_field_name("rhs").is_some() {
+            return None;
+        }
+        Some(ns)
+    })?;
+    classify_namespace_cursor(ns, point, text)
+}
+
+/// Walk up from `node` to its enclosing `namespace_operator`, if any.
+fn enclosing_namespace_operator(node: Node) -> Option<Node> {
+    let mut current = node;
+    while current.kind() != "namespace_operator" {
+        current = current.parent()?;
+    }
+    Some(current)
+}
+
+/// Classify a cursor inside `ns` as member- vs package-side and read the
+/// qualifier package (unquoting a `"pkg"` / `` `pkg` `` lhs) and `::` vs `:::`.
+fn classify_namespace_cursor(
+    ns: Node,
+    point: Point,
+    text: &str,
+) -> Option<NamespaceCompletionContext> {
+    let lhs = ns.child_by_field_name("lhs")?;
+    // The grammar permits a quoted lhs (`"pkg"::name`, `` `pkg`::name `` — both
+    // valid R), whose node text keeps the delimiters; strip them so the package
+    // name resolves.
+    let package = unquote_package(node_text(lhs, text));
+    if package.is_empty() {
+        return None;
+    }
+
+    // The operator (`::` / `:::`) is the unnamed child between lhs and rhs; only
+    // it can read as a double/triple colon (identifiers cannot contain colons).
+    let mut walk = ns.walk();
+    let op = ns
+        .children(&mut walk)
+        .find(|c| matches!(node_text(*c, text), "::" | ":::"))?;
+
+    // A cursor at or before the operator end — `dp|lyr::x`, the boundary
+    // `dplyr|::x` (node ranges are end-exclusive, so that cursor resolves to the
+    // `::` token), or on the operator — is editing the package name.
+    let op_end = op.end_position();
+    if (point.row, point.column) < (op_end.row, op_end.column) {
+        return Some(NamespaceCompletionContext::PackageSide);
+    }
+
+    Some(NamespaceCompletionContext::Member {
+        package: package.to_string(),
+        internal: node_text(op, text) == ":::",
+    })
+}
+
+/// Build completion items for a detected `pkg::` context.
+///
+/// Only a member-side `::` context with a resolvable package yields items;
+/// `PackageSide`, internal (`:::`), and unknown packages yield an empty `Vec`
+/// (the handler still short-circuits — see the module suppression contract).
+/// Exports are fetched synchronously via [`PackageLibrary::get_exports_sync`].
+/// Each symbol becomes a `FUNCTION` item detailed `{pkg}` and carrying the
+/// `{topic, package}` resolve data the existing `completionItem/resolve`
+/// handler turns into help docs. Symbols arrive already sorted.
+pub fn namespace_completion_items(
+    ctx: &NamespaceCompletionContext,
+    library: &PackageLibrary,
+) -> Vec<CompletionItem> {
+    let NamespaceCompletionContext::Member { package, internal } = ctx else {
+        return Vec::new();
+    };
+    if *internal {
+        return Vec::new();
+    }
+    let Some(exports) = library.get_exports_sync(package) else {
+        return Vec::new();
+    };
+    let package = package.clone();
+    exports
+        .into_iter()
+        .map(move |symbol| {
+            // A package can export non-syntactic names (operators like `%>%`,
+            // exported S3 methods). Accepting `pkg::%>%` would be invalid R, so
+            // the inserted text is backtick-quoted (`pkg::`%>%``) via the shared
+            // completion rule, while the label/filter stay the bare name. A
+            // syntactic name needs no override (the label inserts verbatim).
+            let insert = crate::handlers::accessor_member_insert_text(&symbol);
+            let needs_quoting = insert != symbol;
+            CompletionItem {
+                label: symbol.clone(),
+                // FUNCTION for every export — the same kind the bare-identifier
+                // package-export path uses. The export set mixes functions,
+                // datasets, and S4 classes; distinguishing them needs per-symbol
+                // type info we don't have synchronously, so we don't try.
+                kind: Some(CompletionItemKind::FUNCTION),
+                detail: Some(format!("{{{package}}}")),
+                sort_text: Some(format!("{SORT_PREFIX_PACKAGE}{symbol}")),
+                insert_text: needs_quoting.then(|| insert.clone()),
+                filter_text: needs_quoting.then(|| symbol.clone()),
+                data: Some(serde_json::json!({
+                    "topic": symbol,
+                    "package": package.clone(),
+                })),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+/// Strip a single matching pair of surrounding string/backtick delimiters, so a
+/// quoted package qualifier (`"dplyr"`, `'dplyr'`, `` `dplyr` ``) resolves to
+/// the bare package name. Leaves a plain identifier untouched.
+fn unquote_package(raw: &str) -> &str {
+    let bytes = raw.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        if matches!(first, b'"' | b'\'' | b'`') && *bytes.last().unwrap() == first {
+            return &raw[1..raw.len() - 1];
+        }
+    }
+    raw
+}
+
+/// Borrow a node's source text.
+fn node_text<'a>(node: Node, text: &'a str) -> &'a str {
+    &text[node.byte_range()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::Position;
+
+    fn parse_r(code: &str) -> Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .unwrap();
+        parser.parse(code, None).unwrap()
+    }
+
+    /// Split a `|`-marked snippet into (code, cursor position).
+    fn at(marked: &str) -> (String, Position) {
+        let marker = marked.find('|').expect("cursor marker `|`");
+        let prefix = &marked[..marker];
+        let line = prefix.chars().filter(|&c| c == '\n').count() as u32;
+        let line_start = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let character = prefix[line_start..].encode_utf16().count() as u32;
+        let mut code = marked.to_string();
+        code.remove(marker);
+        (code, Position::new(line, character))
+    }
+
+    fn detect(marked: &str) -> Option<NamespaceCompletionContext> {
+        let (code, position) = at(marked);
+        let tree = parse_r(&code);
+        let point = crate::handlers::lsp_position_to_ts_point(&code, position);
+        let node = tree
+            .root_node()
+            .descendant_for_point_range(point, point)
+            .unwrap();
+        detect_namespace_completion_context(&tree, node, point, &code)
+    }
+
+    fn member(package: &str, internal: bool) -> Option<NamespaceCompletionContext> {
+        Some(NamespaceCompletionContext::Member {
+            package: package.to_string(),
+            internal,
+        })
+    }
+
+    // ----- detection ------------------------------------------------------
+
+    #[test]
+    fn package_side_at_operator_boundary() {
+        // Cursor exactly between the package name and `::` (`dplyr|::filter`):
+        // node ranges are end-exclusive, so the cursor resolves to the `::`
+        // token, but it is still the package side.
+        assert_eq!(
+            detect("dplyr|::filter"),
+            Some(NamespaceCompletionContext::PackageSide)
+        );
+    }
+
+    #[test]
+    fn package_side_inside_package_name() {
+        assert_eq!(
+            detect("dp|lyr::filter"),
+            Some(NamespaceCompletionContext::PackageSide)
+        );
+    }
+
+    #[test]
+    fn detects_complete_ast_member_side() {
+        assert_eq!(detect("dplyr::fil|ter"), member("dplyr", false));
+    }
+
+    #[test]
+    fn unquotes_string_package_qualifier() {
+        // `"pkg"::name` is valid R; the package name must drop its quotes.
+        assert_eq!(detect("\"dplyr\"::fil|ter"), member("dplyr", false));
+    }
+
+    #[test]
+    fn unquotes_backtick_package_qualifier() {
+        assert_eq!(detect("`dplyr`::fil|ter"), member("dplyr", false));
+    }
+
+    #[test]
+    fn unquotes_incomplete_string_package_qualifier() {
+        // Incomplete quoted qualifier (no member yet) still resolves — the
+        // `namespace_operator` forms with a `string` lhs.
+        assert_eq!(detect("\"dplyr\"::|"), member("dplyr", false));
+    }
+
+    #[test]
+    fn no_context_for_member_access_before_colons() {
+        // `a$b::` is not a package qualifier (the lhs is an extract expression,
+        // which never forms a namespace_operator) — must not attribute `{b}`.
+        assert_eq!(detect("a$b::|"), None);
+    }
+
+    #[test]
+    fn no_context_for_numeric_before_colons() {
+        // `1::` is not valid R; the numeric lhs never forms a namespace_operator.
+        assert_eq!(detect("1::|"), None);
+    }
+
+    #[test]
+    fn detects_incomplete_double_colon() {
+        assert_eq!(detect("dplyr::|"), member("dplyr", false));
+    }
+
+    #[test]
+    fn detects_incomplete_triple_colon_as_internal() {
+        assert_eq!(detect("dplyr:::|"), member("dplyr", true));
+    }
+
+    #[test]
+    fn detects_complete_triple_colon_as_internal() {
+        assert_eq!(detect("dplyr:::int|ernal"), member("dplyr", true));
+    }
+
+    #[test]
+    fn no_context_for_plain_identifier() {
+        assert_eq!(detect("x <- foo|"), None);
+    }
+
+    #[test]
+    fn no_context_for_empty_package() {
+        assert_eq!(detect("::|"), None);
+    }
+
+    #[test]
+    fn detects_incomplete_double_colon_with_trailing_whitespace() {
+        // `stats:: ` (a space after the operator, no member yet) is valid R and
+        // a real qualifier context. The cursor sits past the operator on
+        // whitespace, so the fallback must step back over the space to reach the
+        // `::` token. (`stats::x` already works because the rhs node spans the
+        // cursor; the no-member-yet form is the gap.)
+        assert_eq!(detect("stats:: |"), member("stats", false));
+        assert_eq!(detect("stats::  |"), member("stats", false));
+        assert_eq!(detect("stats:::  |"), member("stats", true));
+    }
+
+    #[test]
+    fn trailing_whitespace_walk_does_not_overreach() {
+        // The whitespace step-back must not turn an unrelated trailing space into
+        // a namespace context: a plain identifier or expression followed by a
+        // space is still not a `::` context.
+        assert_eq!(detect("foo |"), None);
+        assert_eq!(detect("x <- 1 |"), None);
+        assert_eq!(detect("stats::median |"), None);
+    }
+
+    #[test]
+    fn no_context_inside_namespaced_call_args() {
+        // Inside `dplyr::filter(<args>)` we are completing arguments, not a
+        // member of the package — parameter completion owns this.
+        assert_eq!(detect("dplyr::filter(x|)"), None);
+    }
+
+    #[test]
+    fn no_context_inside_comment() {
+        // `:` is a completion trigger, so `pkg::` in a comment fires a request;
+        // the raw-text fallback must not treat prose as a namespace operator.
+        assert_eq!(detect("# see dplyr::|"), None);
+    }
+
+    #[test]
+    fn no_context_inside_string() {
+        assert_eq!(detect("x <- \"dplyr::|\""), None);
+    }
+
+    #[test]
+    fn no_context_inside_unterminated_string() {
+        // No closing quote: tree-sitter error-recovers. The cursor is still
+        // inside string content, so `::` must not be treated as an operator.
+        assert_eq!(detect("x <- \"dplyr::|"), None);
+    }
+
+    #[test]
+    fn no_context_inside_raw_string() {
+        // R raw string `r"(...)"` — a distinct node kind the canonical
+        // string/comment predicate still matches via `.contains("string")`.
+        assert_eq!(detect("x <- r\"(dplyr::|)\""), None);
+    }
+
+    // ----- item building --------------------------------------------------
+
+    #[tokio::test]
+    async fn items_for_cached_package() {
+        use crate::package_library::PackageInfo;
+        let library = PackageLibrary::new_empty();
+        library
+            .insert_package(PackageInfo::new(
+                "dplyr".to_string(),
+                std::collections::HashSet::from(["mutate".to_string(), "filter".to_string()]),
+            ))
+            .await;
+
+        let ctx = NamespaceCompletionContext::Member {
+            package: "dplyr".to_string(),
+            internal: false,
+        };
+        let items = namespace_completion_items(&ctx, &library);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(labels, vec!["filter", "mutate"]); // sorted
+
+        let filter = items.iter().find(|i| i.label == "filter").unwrap();
+        assert_eq!(filter.kind, Some(CompletionItemKind::FUNCTION));
+        assert_eq!(filter.detail.as_deref(), Some("{dplyr}"));
+        assert_eq!(filter.sort_text.as_deref(), Some("4-filter"));
+        assert_eq!(
+            filter.data,
+            Some(serde_json::json!({ "topic": "filter", "package": "dplyr" }))
+        );
+    }
+
+    #[tokio::test]
+    async fn non_syntactic_export_is_backtick_quoted_on_insert() {
+        // A package can export operators (`%>%`) and other non-syntactic names.
+        // Accepting `magrittr::%>%` would produce invalid R; the inserted text
+        // must be backtick-quoted (`magrittr::`%>%``) while the label stays bare
+        // for display/filtering. A syntactic export is inserted verbatim.
+        use crate::package_library::PackageInfo;
+        let library = PackageLibrary::new_empty();
+        library
+            .insert_package(PackageInfo::new(
+                "magrittr".to_string(),
+                std::collections::HashSet::from(["%>%".to_string(), "set_names".to_string()]),
+            ))
+            .await;
+
+        let ctx = NamespaceCompletionContext::Member {
+            package: "magrittr".to_string(),
+            internal: false,
+        };
+        let items = namespace_completion_items(&ctx, &library);
+
+        let op = items.iter().find(|i| i.label == "%>%").unwrap();
+        assert_eq!(
+            op.insert_text.as_deref(),
+            Some("`%>%`"),
+            "non-syntactic export must insert backtick-quoted text"
+        );
+        assert_eq!(
+            op.filter_text.as_deref(),
+            Some("%>%"),
+            "filter text stays the bare name so typing `%` still matches"
+        );
+
+        // A syntactic export needs no insert override (label is inserted as-is).
+        let plain = items.iter().find(|i| i.label == "set_names").unwrap();
+        assert_eq!(plain.insert_text, None);
+    }
+
+    #[test]
+    fn no_items_for_internal_context() {
+        let library = PackageLibrary::new_empty();
+        let ctx = NamespaceCompletionContext::Member {
+            package: "dplyr".to_string(),
+            internal: true,
+        };
+        assert!(namespace_completion_items(&ctx, &library).is_empty());
+    }
+
+    #[test]
+    fn no_items_for_package_side() {
+        let library = PackageLibrary::new_empty();
+        assert!(
+            namespace_completion_items(&NamespaceCompletionContext::PackageSide, &library)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn no_items_for_unknown_package() {
+        let library = PackageLibrary::new_empty();
+        let ctx = NamespaceCompletionContext::Member {
+            package: "nopkg".to_string(),
+            internal: false,
+        };
+        assert!(namespace_completion_items(&ctx, &library).is_empty());
+    }
+}

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -51,6 +51,33 @@ pub fn parse_namespace_exports(namespace_path: &Path) -> Result<Vec<String>> {
     Ok(parse_namespace_content(&content))
 }
 
+/// Split a package's NAMESPACE into its explicit exports and whether it uses any
+/// pattern export (`exportPattern` / `exportClassPattern`).
+///
+/// "Explicit" exports are the `export()` / `S3method()` / `exportClasses()` /
+/// `exportMethods()` names, with the internal `__PATTERN__:` markers removed.
+/// The bool is `true` when any pattern marker was present (those need INDEX or R
+/// to expand). A missing or unreadable NAMESPACE yields `(vec![], true)` — the
+/// same "treat as pattern, fall back to INDEX/R" stance the async loader takes —
+/// so callers never mistake "couldn't read" for "exports nothing".
+///
+/// Single source of truth for the explicit-vs-pattern split, shared by
+/// [`crate::package_library::PackageLibrary::parse_package_static`] (async load)
+/// and `PackageLibrary::get_exports_sync` (sync `pkg::` completion).
+pub fn parse_namespace_explicit_exports(namespace_path: &Path) -> (Vec<String>, bool) {
+    match parse_namespace_exports(namespace_path) {
+        Ok(raw) => {
+            let has_pattern = raw.iter().any(|e| e.starts_with("__PATTERN__:"));
+            let explicit = raw
+                .into_iter()
+                .filter(|e| !e.starts_with("__PATTERN__:"))
+                .collect();
+            (explicit, has_pattern)
+        }
+        Err(_) => (Vec::new(), true),
+    }
+}
+
 /// Parse NAMESPACE file content to extract exported symbols and pattern markers.
 ///
 /// This function scans normalized NAMESPACE directives and collects:

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -13,9 +13,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::namespace_parser::{
-    parse_data_symbols, parse_description_depends, parse_index_exports, parse_namespace_exports,
-};
+use crate::namespace_parser::{parse_data_symbols, parse_description_depends, parse_index_exports};
 use crate::package_db::PackageMetadataProvider;
 use crate::r_subprocess::RSubprocess;
 
@@ -235,6 +233,14 @@ async fn package_info_from_dir(
 ) -> PackageInfo {
     let lazy_data = parse_data_symbols(pkg_dir).await;
     PackageInfo::with_details(name, exports, depends, lazy_data)
+}
+
+/// Collect borrowed symbol names into a sorted, de-duplicated owned `Vec`.
+fn sorted_unique_symbols<'a>(symbols: impl Iterator<Item = &'a String>) -> Vec<String> {
+    let mut names: Vec<String> = symbols.cloned().collect();
+    names.sort();
+    names.dedup();
+    names
 }
 
 /// Fold R's `data(package=)` enumeration into a freshly-built `PackageInfo`.
@@ -727,6 +733,77 @@ impl PackageLibrary {
         }
 
         result
+    }
+
+    /// Synchronously fetch a single package's exported symbol names for `pkg::`
+    /// completion, without ever touching the R subprocess.
+    ///
+    /// Returns the first **non-empty** export set across these tiers, else
+    /// `None`. Each tier is consulted only as a fallback when the prior one
+    /// yields nothing, so a stale or partial source never shadows a better one:
+    /// 1. **Cache** — an already-loaded `PackageInfo` (its `exports` plus
+    ///    `lazy_data` datasets, both of which `pkg::name` resolves). An *empty*
+    ///    cached entry is NOT trusted: `get_package`/`prefetch_packages` cache an
+    ///    empty-export placeholder when a package's namespace fails to load,
+    ///    which is exactly why [`package_exists`] ignores the cache. So an empty
+    ///    entry falls through to disk rather than suppressing completions.
+    /// 2. **Installed on disk** — when the package is in `lib_paths`, its
+    ///    `NAMESPACE` is parsed directly for `export()` entries (no DESCRIPTION
+    ///    read; `Depends` is irrelevant here). Datasets (under `data/`) and
+    ///    `exportPattern()`-only packages (~6%) yield nothing statically and
+    ///    fall through; both gaps close once the async `get_package` path has
+    ///    run (e.g. via `prefetch_packages` on `did_open`) and Tier 1 hits.
+    /// 3. **Metadata providers** — the repo / shipped package DB.
+    ///
+    /// For the caller, an empty result and `None` are equivalent (both suppress
+    /// the popup), so this returns `None` rather than `Some(vec![])` when no
+    /// tier yields exports. Names are sorted and de-duplicated.
+    ///
+    /// Blocking file reads on the request thread are acceptable here for the
+    /// same reason file-path completion reads directories synchronously:
+    /// NAMESPACE files are small and the completion handler runs off the main
+    /// loop. Unlike `get_package`, this does not populate the cache — a package
+    /// referenced only through `::` (never attached) is re-parsed each request;
+    /// the reads are cheap and the alternative (a sync write path) is not worth
+    /// the added locking.
+    pub fn get_exports_sync(&self, name: &str) -> Option<Vec<String>> {
+        // The load_all() sentinel is a synthetic package name, never a real
+        // installed package; its internals are served through the overlay path,
+        // never as `sentinel::name` completions.
+        if is_load_all_sentinel(name) {
+            return None;
+        }
+
+        // Tier 1: already-loaded cache snapshot (lock-free read). Trust only a
+        // non-empty entry; an empty one may be a failed-load placeholder.
+        if let Some(info) = self.packages.load().get(name) {
+            let syms = sorted_unique_symbols(info.exports.iter().chain(info.lazy_data.iter()));
+            if !syms.is_empty() {
+                return Some(syms);
+            }
+        }
+
+        // Tier 2: installed on disk — parse NAMESPACE for its explicit exports
+        // (no DESCRIPTION read; `Depends` is irrelevant here).
+        if let Some(pkg_dir) = self.find_package_directory(name) {
+            let (exports, _has_pattern) = crate::namespace_parser::parse_namespace_explicit_exports(
+                &pkg_dir.join("NAMESPACE"),
+            );
+            let syms = sorted_unique_symbols(exports.iter());
+            if !syms.is_empty() {
+                return Some(syms);
+            }
+        }
+
+        // Tier 3: repo / shipped package DB.
+        if let Some(info) = self.resolve_from_providers(name) {
+            let syms = sorted_unique_symbols(info.exports.iter().chain(info.lazy_data.iter()));
+            if !syms.is_empty() {
+                return Some(syms);
+            }
+        }
+
+        None
     }
 
     /// Check if a symbol is exported by any of the given packages (synchronous, cached-only)
@@ -1454,37 +1531,14 @@ impl PackageLibrary {
     /// - `Some(NamespaceParseResult)` with exports, pattern flag, and dependencies
     /// - `None` if the package directory doesn't exist
     pub fn parse_package_static(&self, pkg_dir: &Path) -> Option<NamespaceParseResult> {
-        let namespace_path = pkg_dir.join("NAMESPACE");
-
-        // Parse NAMESPACE file if it exists
-        let (explicit_exports, has_export_pattern) = if namespace_path.exists() {
-            match parse_namespace_exports(&namespace_path) {
-                Ok(raw_exports) => {
-                    let has_pattern = raw_exports.iter().any(|e| e.starts_with("__PATTERN__:"));
-                    let explicit: Vec<String> = raw_exports
-                        .into_iter()
-                        .filter(|e| !e.starts_with("__PATTERN__:"))
-                        .collect();
-                    (explicit, has_pattern)
-                }
-                Err(e) => {
-                    log::trace!("Failed to parse NAMESPACE at {:?}: {}", namespace_path, e);
-                    // NAMESPACE exists but failed to parse - treat as having pattern
-                    (Vec::new(), true)
-                }
-            }
-        } else {
-            // No NAMESPACE file (e.g., `base` package) - needs INDEX fallback
-            log::trace!(
-                "No NAMESPACE file at {:?}, treating as pattern package",
-                namespace_path
-            );
-            (Vec::new(), true)
-        };
+        // Explicit exports + pattern flag from NAMESPACE (a missing NAMESPACE,
+        // e.g. `base`, yields no explicit exports and the pattern flag → INDEX
+        // fallback). Shared with the sync `pkg::` completion path.
+        let (explicit_exports, has_export_pattern) =
+            crate::namespace_parser::parse_namespace_explicit_exports(&pkg_dir.join("NAMESPACE"));
 
         // Parse DESCRIPTION for Depends
-        let description_path = pkg_dir.join("DESCRIPTION");
-        let depends = parse_description_depends(&description_path).unwrap_or_default();
+        let depends = parse_description_depends(&pkg_dir.join("DESCRIPTION")).unwrap_or_default();
 
         Some(NamespaceParseResult {
             explicit_exports,
@@ -6358,5 +6412,111 @@ mod tests {
         assert!(
             !lib.is_symbol_from_loaded_packages("not_a_symbol", &[LOAD_ALL_SENTINEL.to_string()])
         );
+    }
+
+    // ========================================================================
+    // get_exports_sync: on-demand synchronous export fetch for `pkg::`
+    // completions (cache -> on-disk NAMESPACE -> providers).
+    // ========================================================================
+
+    #[tokio::test]
+    async fn get_exports_sync_returns_cached_exports_and_data_sorted() {
+        let lib = PackageLibrary::new_empty();
+        let info = PackageInfo::with_details(
+            "dplyr".to_string(),
+            HashSet::from(["mutate".to_string(), "filter".to_string()]),
+            Vec::new(),
+            vec!["starwars".to_string()],
+        );
+        lib.insert_package(info).await;
+
+        let exports = lib
+            .get_exports_sync("dplyr")
+            .expect("cached package resolves");
+        // Functions and datasets are folded together, sorted, deduped.
+        assert_eq!(exports, vec!["filter", "mutate", "starwars"]);
+    }
+
+    #[test]
+    fn get_exports_sync_unknown_package_returns_none() {
+        let lib = PackageLibrary::new_empty();
+        assert_eq!(lib.get_exports_sync("nopkg"), None);
+    }
+
+    #[test]
+    fn get_exports_sync_skips_load_all_sentinel() {
+        let lib = PackageLibrary::new_empty();
+        assert_eq!(lib.get_exports_sync(LOAD_ALL_SENTINEL), None);
+    }
+
+    #[test]
+    fn get_exports_sync_parses_namespace_from_disk() {
+        let lib_root = tempfile::tempdir().unwrap();
+        let pkg_dir = lib_root.path().join("mypkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("DESCRIPTION"),
+            "Package: mypkg\nVersion: 1.0\n",
+        )
+        .unwrap();
+        std::fs::write(pkg_dir.join("NAMESPACE"), "export(foo)\nexport(bar)\n").unwrap();
+
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_lib_paths(vec![lib_root.path().to_path_buf()]);
+
+        // Never library()-loaded, never prefetched, not cached — still resolves
+        // by parsing the installed NAMESPACE synchronously.
+        let exports = lib
+            .get_exports_sync("mypkg")
+            .expect("installed package resolves from disk");
+        assert_eq!(exports, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn get_exports_sync_resolves_from_providers_when_not_on_disk() {
+        use crate::package_db::PackageMetadataProvider;
+
+        struct Fake;
+        impl PackageMetadataProvider for Fake {
+            fn lookup(&self, name: &str) -> Option<PackageInfo> {
+                (name == "repopkg").then(|| {
+                    PackageInfo::with_details(
+                        "repopkg".to_string(),
+                        HashSet::from(["alpha".to_string(), "beta".to_string()]),
+                        Vec::new(),
+                        Vec::new(),
+                    )
+                })
+            }
+        }
+
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_providers(vec![Box::new(Fake)]);
+
+        let exports = lib
+            .get_exports_sync("repopkg")
+            .expect("provider-known package resolves");
+        assert_eq!(exports, vec!["alpha", "beta"]);
+    }
+
+    #[tokio::test]
+    async fn get_exports_sync_empty_cache_entry_falls_through_to_disk() {
+        // A failed-load placeholder (empty exports) was cached for an installed
+        // package — `get_package`/`prefetch` do this when a namespace fails to
+        // load. The empty entry must NOT shadow the real on-disk NAMESPACE.
+        let lib_root = tempfile::tempdir().unwrap();
+        let pkg_dir = lib_root.path().join("fallpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("NAMESPACE"), "export(real_fn)\n").unwrap();
+
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_lib_paths(vec![lib_root.path().to_path_buf()]);
+        lib.insert_package(PackageInfo::new("fallpkg".to_string(), HashSet::new()))
+            .await;
+
+        let exports = lib
+            .get_exports_sync("fallpkg")
+            .expect("empty cache entry falls through to the on-disk NAMESPACE");
+        assert_eq!(exports, vec!["real_fn"]);
     }
 }

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -1531,6 +1531,13 @@ impl PackageLibrary {
     /// - `Some(NamespaceParseResult)` with exports, pattern flag, and dependencies
     /// - `None` if the package directory doesn't exist
     pub fn parse_package_static(&self, pkg_dir: &Path) -> Option<NamespaceParseResult> {
+        // A non-existent package directory yields nothing to parse (see contract
+        // above). Callers normally pass a directory from `find_package_directory`
+        // (which guarantees existence), so this guards only direct/foreign calls.
+        if !pkg_dir.is_dir() {
+            return None;
+        }
+
         // Explicit exports + pattern flag from NAMESPACE (a missing NAMESPACE,
         // e.g. `base`, yields no explicit exports and the pattern flag → INDEX
         // fallback). Shared with the sync `pkg::` completion path.

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -9,6 +9,7 @@ Raven offers context-aware completions for R symbols, package exports, function 
 | **Local definitions** | Symbols defined in the current file, above the cursor |
 | **Cross-file symbols** | Symbols from sourced files, available after the `source()` call / `# raven: source` directive |
 | **Package exports** | Functions and variables from loaded packages, with `{pkg}` attribution |
+| **Namespace-qualified exports** | A package's exported symbols after `pkg::` (e.g. `dplyr::`) |
 | **Function parameters** | Parameter names when inside a function call |
 | **File paths** | `.R`/`.r` files and directories inside `source()` strings and path directives |
 | **$ members** | Known members after `$` (from assignments and constructors) |
@@ -37,6 +38,20 @@ mut  # Offers: mutate {dplyr}, mutate_all {dplyr}, ...
 ```
 
 Package completions are position-aware — they only appear after the `library()` call. Packages loaded in parent files (before the `source()` call to the current file) are also available. They require package awareness (`raven.packages.enabled`, on by default); base-package symbols additionally wait until the package library has finished loading.
+
+### Namespace-Qualified Completions (`pkg::`)
+
+After a `::` namespace qualifier, Raven completes the package's **exported** symbols:
+
+```r
+dplyr::  # Offers: mutate {dplyr}, filter {dplyr}, select {dplyr}, ...
+```
+
+Each item is attributed `{package}` and resolves to that topic's help, exactly like ordinary package completions, and covers the package's `NAMESPACE` exports. Non-syntactic exports — operators such as `%>%`, or exported names that are not valid bare identifiers — are inserted backtick-quoted (so accepting `magrittr::%>%` produces `` magrittr::`%>%` ``) and the accepted completion is valid R.
+
+Unlike the position-aware completions above, `pkg::` does **not** require a prior `library(pkg)` call: any installed package resolves on demand by reading its `NAMESPACE` (the same way `pkg::name` works in R without attaching the package). Two refinements arrive once a package has been loaded (in the background, or by an earlier `library()`/`pkg::` use in the session): exported **datasets** (which live in `data/`, not the `NAMESPACE`), and the complete export set for the ~6% of packages that export via `exportPattern()` — those offer their explicitly-exported names immediately.
+
+Inside a `pkg::` expression no other completions are offered (keywords, local symbols, and other packages are irrelevant there). Internal access via `pkg:::` (non-exported symbols) is not yet completed. Like the other package completions, this requires `raven.packages.enabled`.
 
 ## Function Parameter Completions
 


### PR DESCRIPTION
## What

Completes a package's exported symbols after a `pkg::` namespace qualifier. Typing `dplyr::` now offers `mutate`, `filter`, `starwars`, … each attributed `{dplyr}` and resolving to its help topic. This finishes the old `// TODO: Get package exports from library` stub in `handlers.rs::completion`.

## Behavior

- Inside a `pkg::` / `pkg:::` expression, only the package's exported symbols are offered — keywords, local symbols, parameters, and other packages are syntactically invalid around `::`, so a detected context always short-circuits (even when it yields no items: the package/LHS side, `:::`, or an unknown package).
- Does **not** require a prior `library(pkg)`: any installed package resolves on demand by reading its `NAMESPACE` (the way `pkg::name` works in R without attaching), so completions appear during the startup window before the package library is warm. Gated only on `raven.packages.enabled`.
- Non-syntactic exports — operators such as `%>%` (declared `export("%>%")`) or other names that are not valid bare identifiers — are inserted backtick-quoted (accepting `magrittr::%>%` produces `` magrittr::`%>%` ``), reusing the same rule as the `$`/`@` member path.
- `pkg:: ` with trailing whitespace (valid R) is detected too, without re-entering a completed `pkg::name ` expression.
- Internal access via `pkg:::` is detected but intentionally yields no items — internal symbols are not in the package library and would need an R subprocess. Deferred and tracked in #503.

## Files

- `crates/raven/src/namespace_completion.rs` (new): AST-only context detection (`detect_namespace_completion_context`) and item builder (`namespace_completion_items`).
- `crates/raven/src/package_library.rs`: `get_exports_sync` (cache → on-disk `NAMESPACE` → providers, first non-empty tier); `parse_package_static` now delegates to the shared helper.
- `crates/raven/src/namespace_parser.rs`: `parse_namespace_explicit_exports` (shared explicit-vs-pattern split).
- `crates/raven/src/handlers.rs`: wiring at the completion seam; `accessor_member_insert_text` shared with the namespace path.
- `crates/raven/src/lib.rs`, `docs/completion.md`.

## Testing

- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --features test-support -- -D warnings` clean.
- `cargo test -p raven --lib` passes (the single pre-existing, unrelated failure `cli::check::tests::package_own_sysdata_objects_resolve_without_data_raw` requires an R-subprocess `.rda` behavior absent on this host and also fails on `main`).
- New coverage: `namespace_completion::tests` (detection, item building, backtick-quoting, trailing whitespace) and handler end-to-end `pkg_double_colon_*` tests.

https://claude.ai/code/session_011UNMFm8ecbDcVvYBeQdPsC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pkg::` namespace-qualified completion to access package exports without requiring `library(pkg)`.
  * Non-syntactic exports are automatically backtick-quoted for valid R syntax.
  * Supports packages using `exportPattern()` for dynamic exports.
  * Requires `raven.packages.enabled` configuration.

* **Documentation**
  * Updated completion documentation to describe `pkg::` completion behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->