### PR TITLE
test(vscode): ignore stale toolbar harness snapshots

### DIFF
--- a/editors/vscode/src/data-viewer/webview/test-harness/harness-app.tsx
+++ b/editors/vscode/src/data-viewer/webview/test-harness/harness-app.tsx
@@ -245,8 +245,13 @@ export function HarnessApp() {
             toolbarFlexWrap: toolbarStyle.flexWrap,
             chipsOrder: chipsStyle.order,
             chipsFlexBasis: chipsStyle.flexBasis,
+            widthPx,
+            sortChipCount,
+            filterChipCount,
+            hiddenColCount,
+            rowCountText,
         });
-    }, []);
+    }, [widthPx, sortChipCount, filterChipCount, hiddenColCount, rowCountText]);
 
     // Keep a ref to the latest `postSnapshot` so the message handler
     // (subscribed once) can read the live DOM synchronously on an explicit

--- a/editors/vscode/src/test/toolbar-wrap-harness-panel.ts
+++ b/editors/vscode/src/test/toolbar-wrap-harness-panel.ts
@@ -21,43 +21,16 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {
+    snapshotReflectsMessage,
+    type LayoutSnapshot,
+} from './toolbar-wrap-protocol';
+
+export type { LayoutSnapshot } from './toolbar-wrap-protocol';
 
 // From `editors/vscode/out/test/toolbar-wrap-harness-panel.js`, the
 // harness bundle lives at `editors/vscode/dist-test/toolbar-wrap-harness/`.
 const HARNESS_DIR = path.resolve(__dirname, '..', '..', 'dist-test', 'toolbar-wrap-harness');
-
-interface PlainRect {
-    top: number;
-    bottom: number;
-    left: number;
-    right: number;
-    width: number;
-    height: number;
-}
-
-export interface LayoutSnapshot {
-    type: 'test:layoutSnapshot';
-    seq: number;
-    isWrapped: boolean;
-    toolbarRect: PlainRect;
-    chipsRect: PlainRect;
-    actionsRect: PlainRect;
-    leadRect: PlainRect;
-    rootRect: PlainRect;
-    /** Intrinsic widths the hook itself uses — see `intrinsicWidthPx`
-     *  in use-toolbar-wrap.ts. Calibration tests rely on these. */
-    leadIntrinsicWidth: number;
-    chipsIntrinsicWidth: number;
-    actionsIntrinsicWidth: number;
-    chipsScrollWidth: number;
-    chipsClientWidth: number;
-    sortStripScrollWidth: number;
-    sortStripClientWidth: number;
-    filterStripScrollWidth: number;
-    toolbarFlexWrap: string;
-    chipsOrder: string;
-    chipsFlexBasis: string;
-}
 
 export interface HarnessController {
     panel: vscode.WebviewPanel;
@@ -187,9 +160,11 @@ export function openHarnessPanel(): HarnessController {
 
     /**
      * Send a control message, then poll snapshots (via test:requestSnapshot)
-     * until `predicate(snap)` holds or the deadline passes. Each requested
-     * snapshot is posted after the change is applied, so it reflects the
-     * settled DOM. With no predicate, returns the first post-change snapshot.
+     * until the snapshot reflects that message and `predicate(snap)` holds,
+     * or the deadline passes. React state updates in the webview are async:
+     * a requested snapshot can report the previous render, and late rAF
+     * snapshots can also arrive after a new control message. Those snapshots
+     * are valid telemetry but not valid answers to the current `apply()`.
      * Returns the last snapshot seen if the predicate never matches (the
      * caller's assertion then reports the mismatch).
      */
@@ -209,7 +184,9 @@ export function openHarnessPanel(): HarnessController {
             } catch {
                 continue;
             }
-            if (!predicate || predicate(snap)) return snap;
+            if (snapshotReflectsMessage(message, snap) && (!predicate || predicate(snap))) {
+                return snap;
+            }
         }
         if (snap) return snap;
         throw new Error('apply: no snapshot received within timeout');

--- a/editors/vscode/src/test/toolbar-wrap-protocol.ts
+++ b/editors/vscode/src/test/toolbar-wrap-protocol.ts
@@ -1,0 +1,77 @@
+export interface PlainRect {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+}
+
+export interface LayoutSnapshot {
+    type: 'test:layoutSnapshot';
+    seq: number;
+    isWrapped: boolean;
+    toolbarRect: PlainRect;
+    chipsRect: PlainRect;
+    actionsRect: PlainRect;
+    leadRect: PlainRect;
+    rootRect: PlainRect;
+    /** Intrinsic widths the hook itself uses — see `intrinsicWidthPx`
+     *  in use-toolbar-wrap.ts. Calibration tests rely on these. */
+    leadIntrinsicWidth: number;
+    chipsIntrinsicWidth: number;
+    actionsIntrinsicWidth: number;
+    chipsScrollWidth: number;
+    chipsClientWidth: number;
+    sortStripScrollWidth: number;
+    sortStripClientWidth: number;
+    filterStripScrollWidth: number;
+    toolbarFlexWrap: string;
+    chipsOrder: string;
+    chipsFlexBasis: string;
+    widthPx: number | null;
+    sortChipCount: number;
+    filterChipCount: number;
+    hiddenColCount: number;
+    rowCountText: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Tell whether a layout snapshot reflects the control message just sent by
+ * the extension-host test. React state updates in the webview are async, so
+ * a synchronous `test:requestSnapshot` can legitimately report the previous
+ * render. The host must ignore those stale-but-well-formed snapshots.
+ */
+export function snapshotReflectsMessage(message: unknown, snap: LayoutSnapshot): boolean {
+    if (!isRecord(message) || typeof message.type !== 'string') return true;
+
+    switch (message.type) {
+        case 'test:reset':
+            return snap.widthPx === null
+                && snap.sortChipCount === 0
+                && snap.filterChipCount === 0
+                && snap.hiddenColCount === 0
+                && snap.rowCountText === '';
+
+        case 'test:setWidth':
+            return typeof message.widthPx === 'number'
+                && snap.widthPx === message.widthPx;
+
+        case 'test:setState':
+            return typeof message.sortChipCount === 'number'
+                && typeof message.filterChipCount === 'number'
+                && typeof message.hiddenColCount === 'number'
+                && typeof message.rowCountText === 'string'
+                && snap.sortChipCount === message.sortChipCount
+                && snap.filterChipCount === message.filterChipCount
+                && snap.hiddenColCount === message.hiddenColCount
+                && snap.rowCountText === message.rowCountText;
+
+        default:
+            return true;
+    }
+}

--- a/tests/bun/toolbar-wrap-protocol.test.ts
+++ b/tests/bun/toolbar-wrap-protocol.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  snapshotReflectsMessage,
+  type LayoutSnapshot,
+} from "../../editors/vscode/src/test/toolbar-wrap-protocol";
+
+const rect = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  width: 0,
+  height: 0,
+};
+
+function snapshot(overrides: Partial<LayoutSnapshot> = {}): LayoutSnapshot {
+  return {
+    type: "test:layoutSnapshot",
+    seq: 1,
+    isWrapped: false,
+    toolbarRect: rect,
+    chipsRect: rect,
+    actionsRect: rect,
+    leadRect: rect,
+    rootRect: rect,
+    leadIntrinsicWidth: 0,
+    chipsIntrinsicWidth: 1,
+    actionsIntrinsicWidth: 100,
+    chipsScrollWidth: 0,
+    chipsClientWidth: 0,
+    sortStripScrollWidth: 0,
+    sortStripClientWidth: 0,
+    filterStripScrollWidth: 0,
+    toolbarFlexWrap: "nowrap",
+    chipsOrder: "0",
+    chipsFlexBasis: "auto",
+    widthPx: 2000,
+    sortChipCount: 6,
+    filterChipCount: 0,
+    hiddenColCount: 0,
+    rowCountText: "74 rows",
+    ...overrides,
+  };
+}
+
+describe("toolbar-wrap harness protocol", () => {
+  test("setState waits for the requested hidden-column badge state", () => {
+    const message = {
+      type: "test:setState",
+      sortChipCount: 6,
+      filterChipCount: 0,
+      hiddenColCount: 999,
+      rowCountText: "74 rows",
+    };
+
+    expect(snapshotReflectsMessage(message, snapshot({ hiddenColCount: 0 }))).toBe(false);
+    expect(snapshotReflectsMessage(message, snapshot({ hiddenColCount: 999 }))).toBe(true);
+  });
+
+  test("setWidth waits for the requested harness width state", () => {
+    expect(
+      snapshotReflectsMessage(
+        { type: "test:setWidth", widthPx: 520 },
+        snapshot({ widthPx: 2000 }),
+      ),
+    ).toBe(false);
+    expect(
+      snapshotReflectsMessage(
+        { type: "test:setWidth", widthPx: 520 },
+        snapshot({ widthPx: 520 }),
+      ),
+    ).toBe(true);
+  });
+
+  test("reset waits for cleared state", () => {
+    expect(
+      snapshotReflectsMessage(
+        { type: "test:reset" },
+        snapshot({ widthPx: 400, sortChipCount: 10, hiddenColCount: 7 }),
+      ),
+    ).toBe(false);
+    expect(
+      snapshotReflectsMessage(
+        { type: "test:reset" },
+        snapshot({ widthPx: null, sortChipCount: 0, hiddenColCount: 0, rowCountText: "" }),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the data-viewer toolbar-wrap real-layout harness so `apply()` ignores snapshots that do not reflect the control message it just sent.
- Include the harness state in layout snapshots, covering width, chip counts, hidden-column count, and row-count text.
- Add a Bun regression test for the stale no-badge snapshot race that caused main CI to fail after PR #511 merged.

## Diagnosis
Main failed in `VS Code Mocha Suite` at merge commit `b5f4efd` even though PR #511 passed the same suite at `05646bc8`. The merge commit tree is identical to the PR head, so this was a timing-sensitive test harness failure rather than a code difference.

The failing assertion measured identical no-badge and with-badge action widths. `apply()` sent `test:setState`, then immediately requested a synchronous snapshot; React could still be on the previous render, and the old no-badge snapshot satisfied the weak predicate. The harness now waits until the snapshot state matches the requested message before evaluating test predicates.

## Test Plan
- [x] `bun test tests/bun/toolbar-wrap-protocol.test.ts` (red before helper existed, green after implementation)
- [x] `bun test tests/bun/data-viewer-toolbar-wrap.test.ts tests/bun/toolbar-wrap-protocol.test.ts`
- [x] `bun run pretest` from `editors/vscode`
- [x] `bun run typecheck` from `editors/vscode`
- [x] `bun editors/vscode/scripts/generate-settings-reference.mjs --check`
- [x] `cargo fmt --all --check`

Note: local macOS `vscode-test --grep "Columns badge widens actions"` timed out waiting for the harness `test:ready` message before any layout assertion; that is a separate local Electron/webview readiness issue, so the Linux PR checks remain the authoritative reproduction for the failed CI path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating toolbar wrap protocol message-snapshot consistency
  * Enhanced snapshot validation to ensure layout state changes are properly reflected
  * Improved test harness with better state capture and validation for layout properties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->