### PR TITLE
Reduce data viewer webview bundle size

### DIFF
--- a/editors/vscode/scripts/build.js
+++ b/editors/vscode/scripts/build.js
@@ -9,6 +9,7 @@ const sveltePreprocess = require('svelte-preprocess').default ?? require('svelte
 
 const root = path.resolve(__dirname, '..');
 const dist = path.join(root, 'dist');
+const reactProductionDefine = { 'process.env.NODE_ENV': '"production"' };
 
 // `jsonc-parser` ships both a UMD `main` (`./lib/umd/main.js`) and an ESM
 // `module` (`./lib/esm/main.js`). esbuild's Node platform defaults to
@@ -80,7 +81,9 @@ async function buildReactWebview(name, entry) {
         platform: 'browser',
         target: 'chrome108',
         format: 'iife',
+        define: reactProductionDefine,
         loader: { '.css': 'css' },
+        minify: true,
         sourcemap: true,
         outfile: path.join(webviewDist, 'index.js'),
         logLevel: 'info',

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -7,9 +7,12 @@ import React, {
 } from 'react';
 import {
     CompactSelection,
-    DataEditor,
+    DataEditorCore as DataEditor,
     GridCellKind,
+    markerCellRenderer,
+    textCellRenderer,
     type DataEditorRef,
+    type DataEditorCoreProps,
     type DrawCellCallback,
     type DrawHeaderCallback,
     type GridMouseEventArgs,
@@ -102,6 +105,16 @@ type HeaderTooltipState = {
 const EMPTY_LAYOUT: Layout = { columnWidths: {}, hiddenColumns: [] };
 const EMPTY_TOOLBAR: ToolbarState = { labelsOn: true, formatOn: true, digits: 3 };
 const DEFAULT_SETTINGS: Settings = { missingValueStyle: 'foreground', defaultDigits: 3, persistSort: true, persistFilters: true };
+// Glide's renderer type is invariant, but dispatch is by each renderer's `kind`.
+const DATA_VIEWER_RENDERERS = [
+    markerCellRenderer,
+    textCellRenderer,
+] as unknown as NonNullable<DataEditorCoreProps['renderers']>;
+const DATA_VIEWER_IMAGE_LOADER: DataEditorCoreProps['imageWindowLoader'] = {
+    setWindow: () => undefined,
+    loadOrGetImage: () => undefined,
+    setCallback: () => undefined,
+};
 
 function createEmptySelection(): GridSelection {
     return {
@@ -1439,6 +1452,8 @@ export function App({
             <div className="grid-shell" ref={gridShellRef}>
                 <DataEditor
                     ref={gridRef}
+                    renderers={DATA_VIEWER_RENDERERS}
+                    imageWindowLoader={DATA_VIEWER_IMAGE_LOADER}
                     theme={vscodeTheme}
                     width="100%"
                     height="100%"

--- a/tests/bun/data-viewer-build-bundle.test.ts
+++ b/tests/bun/data-viewer-build-bundle.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { spawn } from 'bun';
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+describe('data viewer build bundle', () => {
+    const vscode_dir = join(__dirname, '..', '..', 'editors', 'vscode');
+    const node_modules = join(vscode_dir, 'node_modules');
+    const data_viewer_bundle = join(vscode_dir, 'dist', 'webviews', 'data-viewer', 'index.js');
+    const have_node_modules = existsSync(node_modules);
+
+    beforeAll(async () => {
+        if (!have_node_modules) {
+            console.warn(
+                '[data-viewer-build-bundle] skipping build: editors/vscode/node_modules missing. ' +
+                'Run `bun install` in editors/vscode to enable this check.',
+            );
+            return;
+        }
+
+        const proc = spawn({
+            cmd: ['bun', 'scripts/build.js'],
+            cwd: vscode_dir,
+            stdout: 'pipe',
+            stderr: 'pipe',
+        });
+        const code = await proc.exited;
+        if (code !== 0) {
+            const out = await new Response(proc.stdout).text();
+            const err = await new Response(proc.stderr).text();
+            throw new Error(`bundle build failed (exit ${code})\nstdout:\n${out}\nstderr:\n${err}`);
+        }
+    }, 120_000);
+
+    test.skipIf(!have_node_modules)(
+        'uses production React and stays below the data-viewer size budget',
+        () => {
+            expect(existsSync(data_viewer_bundle)).toBe(true);
+            expect(statSync(data_viewer_bundle).size).toBeLessThan(450_000);
+
+            const bundle = readFileSync(data_viewer_bundle, 'utf8');
+            expect(bundle).not.toContain('react-dom.development');
+            expect(bundle).not.toContain('react.development');
+        },
+    );
+});

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -43,6 +43,7 @@
     "open-exported-file.test.ts",
     "plot-webview-inline-icons.test.ts",
     "plot-share-popover-position.test.ts",
+    "data-viewer-build-bundle.test.ts",
     "data-viewer-filter-popover-seed.test.ts",
     "help-command-palette-gating.test.ts"
   ]


### PR DESCRIPTION
## Summary
- Build the React data-viewer webview in production mode with minification.
- Use Glide's core data editor with only the data-viewer renderers needed for text cells and row markers.
- Add a Bun regression test that rebuilds the bundle and enforces the data-viewer JS size budget.

## Verification
- bun run typecheck
- ./editors/vscode/node_modules/.bin/tsc --project tests/bun/tsconfig.json --noEmit
- git -c filter.lfs.clean=cat -c filter.lfs.smudge=cat -c filter.lfs.process= -c filter.lfs.required=false diff --check -- editors/vscode/scripts/build.js editors/vscode/src/data-viewer/webview/App.tsx tests/bun/data-viewer-build-bundle.test.ts tests/bun/tsconfig.json
- bun scripts/build.js
- bun test tests/bun/data-viewer-build-bundle.test.ts tests/bun/plot-build-smoke.test.ts

Build output now reports dist/webviews/data-viewer/index.js at 381.7kb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive build verification tests for the data viewer bundle, ensuring bundle size remains under acceptable limits and production optimization is applied.

* **Chores**
  * Optimized React webview production builds with minification enabled, reducing bundle size and improving loading performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->