### PR TITLE
Trim release package contents

### DIFF
--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -14,7 +14,7 @@ use std::env;
 
 fn print_usage() {
     println!(
-        "raven {}, a static R Language Server.",
+        "raven {}, a static analyzer and language server for R.",
         env!("CARGO_PKG_VERSION")
     );
     print!(

--- a/crates/raven/tests/cli_banner.rs
+++ b/crates/raven/tests/cli_banner.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+#[test]
+fn no_args_describes_raven_as_static_analyzer_and_language_server() {
+    let output = Command::new(env!("CARGO_BIN_EXE_raven"))
+        .output()
+        .expect("run raven with no arguments");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    let first_line = stdout.lines().next().unwrap_or_default();
+
+    assert_eq!(
+        first_line,
+        format!(
+            "raven {}, a static analyzer and language server for R.",
+            env!("CARGO_PKG_VERSION")
+        )
+    );
+}

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -11,6 +11,9 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+dist/knit/**
+icon.svg
+test-fixtures/**
 scripts/**
 .vscode-test.mjs
 package-lock.json

--- a/tests/bun/vscode-package-ignore.test.ts
+++ b/tests/bun/vscode-package-ignore.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const vscodeRoot = path.join(repoRoot, "editors", "vscode");
+
+function vscodeIgnoreEntries(): Set<string> {
+  return new Set(
+    readFileSync(path.join(vscodeRoot, ".vscodeignore"), "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#")),
+  );
+}
+
+test("VSIX package keeps runtime assets and excludes development-only files", () => {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(vscodeRoot, "package.json"), "utf8"),
+  ) as { icon?: string };
+  const ignore = vscodeIgnoreEntries();
+
+  expect(packageJson.icon).toBe("icon.png");
+  expect(ignore.has("icon.svg")).toBe(true);
+  expect(ignore.has("icon.png")).toBe(false);
+  expect(ignore.has("dist/knit/**")).toBe(true);
+  expect(ignore.has("test-fixtures/**")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Exclude development-only VSIX files: icon.svg, test-fixtures, and stale dist/knit output.
- Update the no-args CLI banner to describe Raven as a static analyzer and language server for R.
- Add regression tests for the VSIX ignore rules and CLI banner wording.

## Test Plan
- cargo fmt --all
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --features test-support -- -D warnings
- cargo test -p raven --test cli_banner
- bun test tests/bun/vscode-package-ignore.test.ts
- ./node_modules/.bin/vsce ls --no-dependencies