### PR TITLE
fix(data-viewer): compute filter histograms lazily (fixes ~1min empty-grid on large frames)

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -279,7 +279,11 @@ and applying updates the existing filter (it does not add a second one — see
 
 For numeric `between` / `not between`, the editor shows a histogram of the
 column's distribution with draggable range thumbs alongside the numeric
-input fields.
+input fields. The histogram is computed the first time you open that
+column's filter (not up front when the table loads), so on a very large
+frame it may appear a moment after the popover opens; it is cached
+thereafter. This keeps the grid itself painting immediately regardless of
+row count.
 
 For factor columns, the editor shows a searchable checklist of levels when
 the column's value dictionary has been shipped; large or unshipped

--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -282,8 +282,9 @@ column's distribution with draggable range thumbs alongside the numeric
 input fields. The histogram is computed the first time you open that
 column's filter (not up front when the table loads), so on a very large
 frame it may appear a moment after the popover opens; it is cached
-thereafter. This keeps the grid itself painting immediately regardless of
-row count.
+thereafter. This keeps the histogram scan off the initial load path, so
+opening a table paints the grid without waiting for every numeric column to
+be scanned.
 
 For factor columns, the editor shows a searchable checklist of levels when
 the column's value dictionary has been shipped; large or unshipped

--- a/editors/vscode/src/data-viewer/histograms.ts
+++ b/editors/vscode/src/data-viewer/histograms.ts
@@ -28,16 +28,23 @@ import type { HistogramBin } from './messages';
 
 const BIN_COUNT = 50;
 
+/** True for the Arrow types that produce a numeric histogram (the same
+ *  types `colKind` classifies as `numeric` / `labelledNumeric`). The host
+ *  uses this as a trust-boundary guard before launching an on-demand scan
+ *  for a webview-supplied column index. */
+export function isNumericArrowType(arrowType: string): boolean {
+    return arrowType.startsWith('Int')
+        || arrowType.startsWith('Uint')
+        || arrowType.startsWith('Float');
+}
+
 export async function computeNumericHistograms(
     reader: ArrowSliceReader,
 ): Promise<Record<number, HistogramBin[]>> {
     const out: Record<number, HistogramBin[]> = {};
     const schema = reader.schema.columns;
     for (let ci = 0; ci < schema.length; ci++) {
-        const t = schema[ci].arrowType;
-        if (!(t.startsWith('Int') || t.startsWith('Uint') || t.startsWith('Float'))) {
-            continue;
-        }
+        if (!isNumericArrowType(schema[ci].arrowType)) continue;
         out[ci] = await computeHistogramForColumn(reader, ci);
     }
     return out;

--- a/editors/vscode/src/data-viewer/histograms.ts
+++ b/editors/vscode/src/data-viewer/histograms.ts
@@ -1,6 +1,6 @@
 /**
- * Precomputed numeric-column histograms for the filter popover. One
- * uniform-width 50-bin histogram per Int/Uint/Float column.
+ * Numeric-column histograms for the filter popover. One uniform-width
+ * 50-bin histogram per Int/Uint/Float column.
  *
  * NA / NaN are excluded from `count` because they are filtered through
  * `includeMissing`, not via the histogram brush. ±Inf is excluded
@@ -11,9 +11,16 @@
  * present value equals min collapse to a single zero-width bin holding
  * the full count.
  *
- * Computed once per panel-init off the open ArrowSliceReader. RSS is
- * bounded by the bin array (50 × 24 bytes per numeric column), not by
- * row count.
+ * IMPORTANT — these are NOT precomputed at panel init. A single column's
+ * histogram requires two full scans of that column (a min/max pass and a
+ * binning pass), so doing every numeric column up front blocks the grid
+ * from painting until the entire frame has been read — on a 10M-row × 50-col
+ * frame that was ~49s of empty grid. Instead `computeHistogramForColumn`
+ * is called on demand the first time a numeric column's filter popover
+ * opens (see `DataViewerPanel`'s getHistogram handler, which also caches
+ * the result per reader). `computeNumericHistograms` (all columns at once)
+ * remains for tests and any future eager use. RSS is bounded by the bin
+ * array (50 × 24 bytes per numeric column), not by row count.
  */
 
 import type { ArrowSliceReader } from './arrow-reader';
@@ -31,12 +38,18 @@ export async function computeNumericHistograms(
         if (!(t.startsWith('Int') || t.startsWith('Uint') || t.startsWith('Float'))) {
             continue;
         }
-        out[ci] = await histogramForColumn(reader, ci);
+        out[ci] = await computeHistogramForColumn(reader, ci);
     }
     return out;
 }
 
-async function histogramForColumn(
+/**
+ * Compute the 50-bin histogram for one column. Returns `[]` for a column
+ * with no present finite values (including non-numeric columns, whose
+ * values are never finite numbers) so callers can treat "no histogram"
+ * and "empty histogram" identically.
+ */
+export async function computeHistogramForColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
 ): Promise<HistogramBin[]> {

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -108,10 +108,10 @@ export const EMPTY_FILTER: FilterState = {
     labelsOnWhenFiltered: true,
 };
 
-/** Bin in a numeric column's precomputed histogram. Bins are
- *  uniform-width over `[min, max]` of the present values; NA / NaN
- *  rows are excluded from `count`. A column with no present values
- *  serializes to an empty array. */
+/** Bin in a numeric column's histogram (computed on demand; see the
+ *  `histogram` message). Bins are uniform-width over `[min, max]` of the
+ *  present values; NA / NaN rows are excluded from `count`. A column with
+ *  no present values serializes to an empty array. */
 export type HistogramBin = {
     lo: number;
     hi: number;

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -142,10 +142,6 @@ export type ExtensionToWebview =
          *  none. Webview reflects this in the chip strip without firing
          *  the apply-pulse animation. */
         filter: FilterState;
-        /** Precomputed histograms keyed by column index, or empty object
-         *  if not yet available. Used to populate filter popover sparklines
-         *  without a round-trip. */
-        histograms: Record<number, HistogramBin[]>;
     }
     | {
         type: 'rows';
@@ -184,10 +180,20 @@ export type ExtensionToWebview =
          *  none. Webview reflects this in the chip strip without firing
          *  the apply-pulse animation. */
         filter: FilterState;
-        /** Precomputed histograms keyed by column index, or empty object
-         *  if not yet available. Used to populate filter popover sparklines
-         *  without a round-trip. */
-        histograms: Record<number, HistogramBin[]>;
+    }
+    | {
+        /** On-demand numeric histogram for a single column, sent in
+         *  response to a `getHistogram` request. Histograms are computed
+         *  lazily (and cached host-side) the first time a numeric column's
+         *  filter popover opens — they are NOT precomputed at init, because
+         *  scanning every numeric column up front blocks the grid from
+         *  painting on large frames (a multi-second to multi-minute stall).
+         *  `bins` is `[]` for a column with no present finite values. */
+        type: 'histogram';
+        panelGeneration: number;
+        requestId: number;
+        columnIndex: number;
+        bins: HistogramBin[];
     }
     | {
         /** Sent after the extension host has finished building the
@@ -306,6 +312,16 @@ export type WebviewToExtension =
         requestId: number;
         columnIndex: number;
         indices: number[];
+    }
+    | {
+        /** Request the numeric histogram for one column. Sent the first
+         *  time a numeric column's filter popover opens and the webview
+         *  has no cached bins for it. The host replies with a `histogram`
+         *  message. */
+        type: 'getHistogram';
+        panelGeneration: number;
+        requestId: number;
+        columnIndex: number;
     }
     | {
         type: 'saveLayout';

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -26,7 +26,7 @@ import {
 } from './messages';
 import { computePermutation } from './sort';
 import { computeFilteredIndices } from './filter';
-import { computeHistogramForColumn } from './histograms';
+import { computeHistogramForColumn, isNumericArrowType } from './histograms';
 import { LayoutStore, schemaHash } from './layout-state';
 import { ToolbarState, ToolbarStateStore } from './toolbar-state';
 import { SortStateStore } from './sort-state';
@@ -609,27 +609,44 @@ export class DataViewerPanel {
             case 'getHistogram': {
                 const reader = this.reader;
                 const ci = m.columnIndex;
-                // panel.ts is the trust boundary for webview messages: a bad
-                // index would throw deep in the column scan. Reply with empty
-                // bins for an out-of-range column rather than computing.
-                if (!Number.isInteger(ci) || ci < 0 || ci >= reader.schema.columns.length) {
-                    await this.webviewPanel.webview.postMessage({
-                        type: 'histogram',
-                        panelGeneration: gen,
-                        requestId: m.requestId,
-                        columnIndex: ci,
-                        bins: [],
-                    } satisfies ExtensionToWebview);
-                    return;
-                }
                 let bins = this.histogramCache.get(ci);
                 if (!bins) {
-                    bins = await computeHistogramForColumn(reader, ci);
-                    // A replace mid-scan swaps the reader; drop this result so a
-                    // histogram for the old dataset never lands under the new
-                    // generation or pollutes the new reader's cache.
-                    if (gen !== this.generation || reader !== this.reader) return;
-                    this.histogramCache.set(ci, bins);
+                    // panel.ts is the trust boundary for webview messages.
+                    // Only scan a valid, numeric column; an out-of-range or
+                    // non-numeric index (a malformed/future caller — the UI
+                    // gates on colKind) degrades to an empty histogram without
+                    // launching a wasted full-column scan. A decode error must
+                    // likewise still produce a reply — otherwise the webview's
+                    // in-flight marker for this column never clears and the
+                    // brush stays blank forever with no retry (unlike getRows,
+                    // a missing histogram reply is unrecoverable). All degrade
+                    // to "no brush". The whole-grid getRows path would also be
+                    // failing if a batch genuinely can't decode, and a decode
+                    // failure on a fixed Arrow file is deterministic, so the
+                    // empty result is cached below rather than re-scanning on
+                    // every popover reopen.
+                    const cols = reader.schema.columns;
+                    const scannable = Number.isInteger(ci) && ci >= 0 && ci < cols.length
+                        && isNumericArrowType(cols[ci].arrowType);
+                    if (!scannable) {
+                        bins = [];
+                    } else {
+                        try {
+                            bins = await computeHistogramForColumn(reader, ci);
+                        } catch {
+                            bins = [];
+                        }
+                    }
+                    // After the await: drop if the panel was disposed or the
+                    // dataset was swapped (mirrors the getRows handler) — no
+                    // reply is owed, the new generation's webview already
+                    // cleared its in-flight marker. A concurrent request for
+                    // the same column may have cached a result meanwhile;
+                    // first writer wins so a late error-[] never clobbers it.
+                    if (this.disposed || gen !== this.generation || reader !== this.reader) return;
+                    const existing = this.histogramCache.get(ci);
+                    if (existing) bins = existing;
+                    else this.histogramCache.set(ci, bins);
                 }
                 const reply: ExtensionToWebview = {
                     type: 'histogram',

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -18,6 +18,7 @@ import {
     EMPTY_SORT,
     ExtensionToWebview,
     FilterState,
+    HistogramBin,
     Layout,
     Settings,
     SortState,
@@ -25,7 +26,7 @@ import {
 } from './messages';
 import { computePermutation } from './sort';
 import { computeFilteredIndices } from './filter';
-import { computeNumericHistograms } from './histograms';
+import { computeHistogramForColumn } from './histograms';
 import { LayoutStore, schemaHash } from './layout-state';
 import { ToolbarState, ToolbarStateStore } from './toolbar-state';
 import { SortStateStore } from './sort-state';
@@ -68,6 +69,11 @@ export class DataViewerPanel {
     /** Monotonic counter — bumped on every setFilters call so stale
      *  async results can be detected and dropped. */
     private filterGeneration = 0;
+    /** Per-column numeric histogram cache, keyed by column index, for the
+     *  current reader. Populated lazily by the `getHistogram` handler (a
+     *  histogram costs two full column scans, so we never recompute one).
+     *  Cleared on `replace()` because the new reader is a different dataset. */
+    private histogramCache = new Map<number, HistogramBin[]>();
     private readonly traceId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     /** Latest visible-row range observed via lifecycle events. Used by
      *  the integration test API. `undefined` until the first lifecycle
@@ -167,6 +173,8 @@ export class DataViewerPanel {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
         this.filterGeneration += 1;
+        // Histograms are reader-scoped; the new reader is a different dataset.
+        this.histogramCache.clear();
         const prevReader = this.reader;
         const prevPath = this.filePath;
         this.reader = reader;
@@ -211,8 +219,6 @@ export class DataViewerPanel {
         if (generation !== this.generation || reader !== this.reader) return false;
         const restoredFilter = await this.restoreFilter(savedFilter, activeToolbar, generation, reader);
         if (generation !== this.generation || reader !== this.reader) return false;
-        const histograms = await computeNumericHistograms(reader);
-        if (generation !== this.generation || reader !== this.reader) return false;
         const msg: ExtensionToWebview = {
             type: 'init',
             panelGeneration: generation,
@@ -226,7 +232,6 @@ export class DataViewerPanel {
             objectClass: reader.schema.objectClass,
             sort: restored,
             filter: restoredFilter,
-            histograms,
         };
         this.trace('post-init', {
             generation,
@@ -279,8 +284,6 @@ export class DataViewerPanel {
         if (generation !== this.generation || reader !== this.reader) return;
         const restoredFilter = await this.restoreFilter(savedFilter, activeToolbar, generation, reader);
         if (generation !== this.generation || reader !== this.reader) return;
-        const histograms = await computeNumericHistograms(reader);
-        if (generation !== this.generation || reader !== this.reader) return;
         const msg: ExtensionToWebview = {
             type: 'replace',
             panelGeneration: generation,
@@ -293,7 +296,6 @@ export class DataViewerPanel {
             objectClass: reader.schema.objectClass,
             sort: restored,
             filter: restoredFilter,
-            histograms,
         };
         this.trace('post-replace', {
             generation,
@@ -600,6 +602,41 @@ export class DataViewerPanel {
                     requestId: m.requestId,
                     columnIndex: m.columnIndex,
                     labels,
+                };
+                await this.webviewPanel.webview.postMessage(reply);
+                return;
+            }
+            case 'getHistogram': {
+                const reader = this.reader;
+                const ci = m.columnIndex;
+                // panel.ts is the trust boundary for webview messages: a bad
+                // index would throw deep in the column scan. Reply with empty
+                // bins for an out-of-range column rather than computing.
+                if (!Number.isInteger(ci) || ci < 0 || ci >= reader.schema.columns.length) {
+                    await this.webviewPanel.webview.postMessage({
+                        type: 'histogram',
+                        panelGeneration: gen,
+                        requestId: m.requestId,
+                        columnIndex: ci,
+                        bins: [],
+                    } satisfies ExtensionToWebview);
+                    return;
+                }
+                let bins = this.histogramCache.get(ci);
+                if (!bins) {
+                    bins = await computeHistogramForColumn(reader, ci);
+                    // A replace mid-scan swaps the reader; drop this result so a
+                    // histogram for the old dataset never lands under the new
+                    // generation or pollutes the new reader's cache.
+                    if (gen !== this.generation || reader !== this.reader) return;
+                    this.histogramCache.set(ci, bins);
+                }
+                const reply: ExtensionToWebview = {
+                    type: 'histogram',
+                    panelGeneration: gen,
+                    requestId: m.requestId,
+                    columnIndex: ci,
+                    bins,
                 };
                 await this.webviewPanel.webview.postMessage(reply);
                 return;

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -313,6 +313,10 @@ export function App({
     const inflightRef = useRef(new Map<number, string>());
     const pendingKeysRef = useRef(new Set<string>());
     const nextRequestIdRef = useRef(0);
+    /** Column indices whose histogram has been requested from the host but
+     *  not yet received, so the lazy-fetch effect fires at most one
+     *  getHistogram per column. Cleared on replace (new dataset). */
+    const histogramRequestedRef = useRef(new Set<number>());
     const viewportGenerationRef = useRef(0);
     const toolbarBootstrappedRef = useRef(false);
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
@@ -578,7 +582,17 @@ export function App({
         setSort(m.sort);
         setSortPending(false);
         setFilter(m.filter);
-        setHistograms(m.histograms ?? {});
+        // Histograms are fetched lazily per column (getHistogram) the first
+        // time a numeric filter popover opens — not shipped in init/replace.
+        // Drop any cached bins + in-flight request markers whenever the
+        // dataset changes (always on replace; on init unless this is the same
+        // dataset being restored from getState, e.g. after a tab hide/show),
+        // since bins are keyed by column index and would be wrong for a
+        // different schema. A same-dataset init keeps the restored cache.
+        if (m.type === 'replace' || !sameDataset) {
+            setHistograms({});
+            histogramRequestedRef.current.clear();
+        }
         setFilterPending(false);
         if (m.filter.entries.length === 0) setNrowFiltered(undefined);
         toolbarBootstrappedRef.current = true;
@@ -634,6 +648,12 @@ export function App({
             gridRef.current?.updateCells(damageList);
         }
     }, [panelGeneration, visibleCols, visibleRange.end, visibleRange.start]);
+
+    const applyHistogram = useCallback((m: Extract<ExtensionToWebview, { type: 'histogram' }>) => {
+        if (m.panelGeneration !== panelGeneration) return;
+        histogramRequestedRef.current.delete(m.columnIndex);
+        setHistograms(prev => ({ ...prev, [m.columnIndex]: m.bins }));
+    }, [panelGeneration]);
 
     const applySortApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'sortApplied' }>) => {
         if (m.panelGeneration !== panelGeneration) return;
@@ -975,6 +995,9 @@ export function App({
                 case 'labels':
                     applyLabels(m);
                     return;
+                case 'histogram':
+                    applyHistogram(m);
+                    return;
                 case 'copyDone':
                     applyCopyDone(m);
                     return;
@@ -1008,6 +1031,7 @@ export function App({
         applyCopyDone,
         applyFilterApplied,
         applyFilterStatus,
+        applyHistogram,
         applyInitOrReplace,
         applyLabels,
         applyRows,
@@ -1028,6 +1052,32 @@ export function App({
             toolbar,
         });
     }, [panelGeneration, schemaHash, toolbar, vscode]);
+
+    // Lazily fetch a numeric column's histogram the first time its filter
+    // popover opens. Histograms are not shipped at init (a full-frame scan
+    // would block the grid from painting — see histograms.ts), so the brush
+    // appears once the host replies. Non-numeric columns have no brush, so
+    // we don't request them.
+    useEffect(() => {
+        if (filterEditor === null) return;
+        const ci = filterEditor.entry?.columnIndex ?? filterEditor.columnIndex;
+        if (ci === undefined) return;
+        const col = columns[ci];
+        if (!col) return;
+        const t = col.arrowType;
+        const isNumeric = t.startsWith('Int') || t.startsWith('Uint') || t.startsWith('Float');
+        if (!isNumeric) return;
+        if (histograms[ci] !== undefined) return;          // already cached
+        if (histogramRequestedRef.current.has(ci)) return;  // request in flight
+        histogramRequestedRef.current.add(ci);
+        const requestId = ++nextRequestIdRef.current;
+        vscode.postMessage({
+            type: 'getHistogram',
+            panelGeneration,
+            requestId,
+            columnIndex: ci,
+        });
+    }, [filterEditor, columns, histograms, panelGeneration, vscode]);
 
     useEffect(() => {
         // Guard on the same bootstrap flag as saveToolbar: until the first

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -65,6 +65,7 @@ import { ColumnContextMenu } from './column-context-menu';
 import { ToolbarSortStrip } from './sort-strip';
 import { FilterStrip } from './filter-strip';
 import { FilterPopover } from './filter-popover';
+import { colKind } from './filter-column-kind';
 import { useToolbarWrap } from './use-toolbar-wrap';
 
 type VscodeApi = {
@@ -1064,9 +1065,12 @@ export function App({
         if (ci === undefined) return;
         const col = columns[ci];
         if (!col) return;
-        const t = col.arrowType;
-        const isNumeric = t.startsWith('Int') || t.startsWith('Uint') || t.startsWith('Float');
-        if (!isNumeric) return;
+        // Only columns that get a histogram brush in the popover. Gate on the
+        // same classifier the popover uses (colKind) so "shows a brush" and
+        // "fetches the bins" can never diverge — both numeric and labelled-
+        // numeric columns offer the between/histogram predicate.
+        const kind = colKind(col);
+        if (kind !== 'numeric' && kind !== 'labelledNumeric') return;
         if (histograms[ci] !== undefined) return;          // already cached
         if (histogramRequestedRef.current.has(ci)) return;  // request in flight
         histogramRequestedRef.current.add(ci);

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -354,6 +354,12 @@ export function App({
     const [filterPending, setFilterPending] = useState(false);
     const [nrowFiltered, setNrowFiltered] = useState<number | undefined>(restored?.nrowFiltered);
     const [histograms, setHistograms] = useState<Record<number, HistogramBin[]>>(restored?.histograms ?? {});
+    /** True until the first init/replace lands. Until then nrow is 0 and the
+     *  row-count readout would say "Showing 0-0 of 0", which reads as an
+     *  empty/broken table; show "Loading…" instead. Starts false when we
+     *  restored a non-empty schema from getState (we already have something
+     *  to show). */
+    const [loading, setLoading] = useState<boolean>(!(restored?.columns && restored.columns.length > 0));
     const [filterEditor, setFilterEditor] = useState<{
         entry?: FilterEntry;
         columnIndex?: number;
@@ -386,7 +392,7 @@ export function App({
      *  All grid-coordinate math must use this count so row indices never
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
-    const rowCountText = describeVisibleRows(effectiveNrow, visibleRange);
+    const rowCountText = describeVisibleRows(effectiveNrow, visibleRange, loading);
     /** Whether the chip group must wrap onto its own second row. `layout.hiddenColumns.length`
      *  is in the deps because the Columns count badge widens the action buttons without
      *  changing the toolbar width — without that the wrap state can be stale. */
@@ -422,7 +428,9 @@ export function App({
         return `filtered to ${nrowFiltered.toLocaleString()}${pct}`;
     }, [nrowFiltered, nrow]);
     const statusText = [
-        describeShape(nrow, columns, objectClass),
+        // While loading, the toolbar lead already shows "Loading…"; don't
+        // also show a misleading "0 rows x 0 columns" in the status bar.
+        loading ? '' : describeShape(nrow, columns, objectClass),
         describeHiddenColumnCount(layout.hiddenColumns.length),
         sortPending ? 'Sorting…' : sortStatusText,
         filterPending ? 'Filtering…' : filterStatusText,
@@ -596,6 +604,7 @@ export function App({
         }
         setFilterPending(false);
         if (m.filter.entries.length === 0) setNrowFiltered(undefined);
+        setLoading(false);
         toolbarBootstrappedRef.current = true;
         clearRows();
         setResolvedLabels({});

--- a/editors/vscode/src/data-viewer/webview/grid-model.ts
+++ b/editors/vscode/src/data-viewer/webview/grid-model.ts
@@ -78,7 +78,10 @@ export function buildVisibleGridColumns(
     return visibleCols.map(index => allColumns[index]).filter(Boolean);
 }
 
-export function describeVisibleRows(nrow: number, range: VisibleRange): string {
+export function describeVisibleRows(nrow: number, range: VisibleRange, loading = false): string {
+    // Before the init/replace message lands, nrow is 0 and a bare
+    // "Showing 0-0 of 0" reads as an empty/broken table; say it's loading.
+    if (loading) return 'Loading…';
     if (nrow <= 0) return 'Showing 0-0 of 0';
     if (range.end <= range.start) return `Showing 0-0 of ${nrow.toLocaleString()}`;
     const start = Math.min(nrow, range.start + 1);

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -79,6 +79,17 @@ describe('React data-viewer grid model', () => {
         expect(describeHiddenColumnCount(2)).toBe('2 columns hidden');
     });
 
+    test('describeVisibleRows shows Loading until the dataset arrives', () => {
+        // Before init lands, nrow is 0 and the bare "Showing 0-0 of 0" reads
+        // as an empty/broken table; show that it is loading instead.
+        expect(describeVisibleRows(0, { start: 0, end: 0 }, true)).toBe('Loading…');
+        // loading wins even if a stale count is around (e.g. getState restore).
+        expect(describeVisibleRows(1000, { start: 0, end: 25 }, true)).toBe('Loading…');
+        // default (not loading) is unchanged.
+        expect(describeVisibleRows(0, { start: 0, end: 0 })).toBe('Showing 0-0 of 0');
+        expect(describeVisibleRows(0, { start: 0, end: 0 }, false)).toBe('Showing 0-0 of 0');
+    });
+
     test('toolbar effect detection still matches Raven column metadata', () => {
         expect(hasFormatEffect(cols)).toBe(true);
         expect(hasLabelsEffect(cols)).toBe(true);

--- a/tests/bun/data-viewer-histograms.test.ts
+++ b/tests/bun/data-viewer-histograms.test.ts
@@ -8,7 +8,7 @@ import { describe, test, expect } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ArrowSliceReader } from '../../editors/vscode/src/data-viewer/arrow-reader';
-import { computeNumericHistograms } from '../../editors/vscode/src/data-viewer/histograms';
+import { computeNumericHistograms, computeHistogramForColumn } from '../../editors/vscode/src/data-viewer/histograms';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIX = (n: string) =>
@@ -60,6 +60,27 @@ describe('computeNumericHistograms', () => {
                 expect(b.count).toBeGreaterThanOrEqual(0);
             }
         }
+        await r.close();
+    });
+});
+
+describe('computeHistogramForColumn (lazy single-column entry point)', () => {
+    test('matches the per-column result computeNumericHistograms produces', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const all = await computeNumericHistograms(r);
+        const x = await computeHistogramForColumn(r, 0);   // x — Int32
+        const y = await computeHistogramForColumn(r, 1);   // y — Float64
+        expect(x).toEqual(all[0]);
+        expect(y).toEqual(all[1]);
+        expect(x.length).toBe(50);
+        expect(x.reduce((s, b) => s + b.count, 0)).toBe(5);
+        await r.close();
+    });
+
+    test('non-numeric column yields an empty histogram (no present finite values)', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const s = await computeHistogramForColumn(r, 2);   // s — Utf8
+        expect(s).toEqual([]);
         await r.close();
     });
 });

--- a/tests/bun/data-viewer-panel-filter.test.ts
+++ b/tests/bun/data-viewer-panel-filter.test.ts
@@ -174,7 +174,7 @@ async function setupPanel(
 }
 
 describe('DataViewerPanel: filter round-trips', () => {
-    test('init carries EMPTY_FILTER and histograms with numeric columns', async () => {
+    test('init carries EMPTY_FILTER and does NOT eagerly compute histograms', async () => {
         const { fakeWebview } = await setupPanel();
 
         fakeWebview.deliverFromWebview({ type: 'webviewReady' });
@@ -183,12 +183,73 @@ describe('DataViewerPanel: filter round-trips', () => {
         expect(init).toBeDefined();
         // Filter should be the empty sentinel.
         expect(init.filter).toEqual({ entries: [], labelsOnWhenFiltered: true });
-        // tiny.arrow has col 0 = x (Int32) — at least that key must be present.
-        expect(init.histograms).toBeDefined();
-        expect(Object.keys(init.histograms).length).toBeGreaterThan(0);
-        expect(init.histograms[0]).toBeDefined();
-        expect(Array.isArray(init.histograms[0])).toBe(true);
-        expect(init.histograms[0].length).toBeGreaterThan(0);
+        // Histograms are no longer precomputed at init — they would force a
+        // full-frame scan before the grid can paint (the ~1-minute empty-grid
+        // regression on large frames). They are fetched lazily per column via
+        // getHistogram when a filter popover opens. See histograms.ts.
+        expect(init.histograms).toBeUndefined();
+    });
+
+    test('REGRESSION: init paints without any batch-level scan (histograms stay lazy)', async () => {
+        // The original regression: histograms were precomputed for every
+        // numeric column inside sendInit, blocking the grid from painting
+        // until the entire frame had been scanned (~49s on a 10M×50 frame).
+        // The old test suite asserted histograms were PRESENT in init, which
+        // locked the slow behavior in. This asserts the opposite invariant:
+        // sending init must not decode a single record batch. Histogram work
+        // (the only per-row scan in this surface) happens lazily on
+        // getHistogram. Re-introducing any full-frame scan on the paint path
+        // makes getBatchCalls non-zero and fails here.
+        const { fakeWebview, reader } = await setupPanel();
+        // reader.open() (in setupPanel) already counted its batches; start
+        // counting only the batch decodes the panel triggers from here on.
+        let getBatchCalls = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = (i: number) => { getBatchCalls++; return origGetBatch(i); };
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        expect(init).toBeDefined();
+        expect(getBatchCalls).toBe(0);
+
+        // Opening a numeric filter is what legitimately triggers the
+        // single-column scan — proving the scan still exists, just deferred.
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 30,
+            columnIndex: 0,
+        });
+        await flush();
+        expect(getBatchCalls).toBeGreaterThan(0);
+    });
+
+    test('getHistogram round-trip: lazily computes one numeric column on demand', async () => {
+        const { fakeWebview } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        // tiny.arrow col 0 = x (Int32). Request its histogram on demand.
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: gen,
+            requestId: 20,
+            columnIndex: 0,
+        });
+        await flush();
+
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 20,
+        ) as any;
+        expect(hist).toBeDefined();
+        expect(hist.columnIndex).toBe(0);
+        expect(Array.isArray(hist.bins)).toBe(true);
+        expect(hist.bins.length).toBe(50);
+        expect(hist.bins.reduce((s: number, b: any) => s + b.count, 0)).toBe(5);
     });
 
     test('setFilters round-trip: filterStatus pending → filterApplied, then getRows returns matching rows', async () => {

--- a/tests/bun/data-viewer-panel-filter.test.ts
+++ b/tests/bun/data-viewer-panel-filter.test.ts
@@ -252,6 +252,82 @@ describe('DataViewerPanel: filter round-trips', () => {
         expect(hist.bins.reduce((s: number, b: any) => s + b.count, 0)).toBe(5);
     });
 
+    test('getHistogram always replies (empty bins) when the column scan throws', async () => {
+        // A reply MUST be posted even on a decode failure, or the webview's
+        // in-flight marker for the column never clears and the brush stays
+        // blank forever with no retry. Degrade to no brush, never silence.
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        (reader as any).getBatch = () => { throw new Error('decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 40,
+            columnIndex: 0,
+        });
+        await flush();
+
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 40,
+        ) as any;
+        expect(hist).toBeDefined();
+        expect(hist.bins).toEqual([]);
+    });
+
+    test('getHistogram replies with empty bins for an out-of-range column index', async () => {
+        const { fakeWebview } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 41,
+            columnIndex: 9999,
+        });
+        await flush();
+
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 41,
+        ) as any;
+        expect(hist).toBeDefined();
+        expect(hist.bins).toEqual([]);
+    });
+
+    test('getHistogram for a non-numeric column replies [] without scanning', async () => {
+        // Trust boundary: the UI only requests numeric/labelledNumeric columns
+        // (colKind gate), but a malformed/future caller must not trigger a
+        // wasted full-column scan that can only return [].
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let getBatchCalls = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = (i: number) => { getBatchCalls++; return origGetBatch(i); };
+
+        // tiny.arrow col 2 = s (Utf8) — not numeric, no histogram brush.
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 42,
+            columnIndex: 2,
+        });
+        await flush();
+
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 42,
+        ) as any;
+        expect(hist).toBeDefined();
+        expect(hist.bins).toEqual([]);
+        expect(getBatchCalls).toBe(0);
+    });
+
     test('setFilters round-trip: filterStatus pending → filterApplied, then getRows returns matching rows', async () => {
         const { fakeWebview } = await setupPanel();
 


### PR DESCRIPTION
## Problem

`View()` on a large frame (the `demo/data-viewer-smoke.R` 10M-row × 50-col case) showed an empty grid — "Showing 0-0 of 0" — for **~1 minute** before the data appeared. This regressed a previously-instant, virtualized load.

## Root cause

It was a **performance** regression, not a correctness bug. The grid's row fetching is still virtualized (`ArrowSliceReader.open()` returns in ~0.3s with the right `nrow`/columns). But `DataViewerPanel.sendInit`/`sendReplace` precomputed a 50-bin histogram for **every** numeric column *before* posting the `init` message that lets the grid paint. Each column costs two full scans, so on the 10M×50 frame this blocked first paint for **~49s** behind a full-frame read.

Measured on a real 3.73 GB Arrow file:

| Init phase | Time |
|---|---|
| `ArrowSliceReader.open()` | 266 ms |
| `computeNumericHistograms()` (all columns) | **48,853 ms** |

The eager scan also re-decoded all batches ~100× due to the 16-entry LRU thrashing under the column-outer/batch-inner loop.

## Fix: lazy per-column histograms

Histograms only feed the filter popover's range brush, so they don't need to exist before the grid paints — or at all for columns the user never filters.

- **init/replace ship no histograms**; the grid paints immediately.
- The webview requests a column's histogram (`getHistogram`) the first time its filter popover opens; the host computes that one column on demand (`computeHistogramForColumn`, ~0.66s for a 10M-row column), caches it per-reader, and replies (`histogram`). Mirrors the existing `getLabels`/`labels` on-demand round-trip.
- Caches cleared on dataset change (host on `replace`; webview on `replace`/non-same-dataset init).

| | Before | After |
|---|---|---|
| First paint | ~49 s (blocked) | **~0.3 s** |
| Open a numeric filter | (already loaded) | ~0.66 s, then cached |
| Non-numeric columns | scanned anyway | 0 |

## Why it regressed silently — test added

The previous suite asserted histograms were **present** in `init`, which locked in the slow path. That's replaced with a regression guard asserting **`sendInit` triggers zero batch decodes** (it fails the instant any full-frame scan creeps back onto the paint path), plus round-trip tests for the on-demand fetch and its degradation paths (decode-throw, out-of-range index, non-numeric column).

## Hardening (from review)

The `getHistogram` handler is a webview trust boundary: it now always posts a reply (out-of-range / non-numeric / decode error all degrade to empty bins — never a stranded in-flight marker or unhandled rejection), follows the `getRows` disposal discipline, and gates scans on a single shared `isNumericArrowType` classifier (the webview fetch gates on `colKind`, so "shows a brush" and "fetches bins" can't diverge).

## Verification

- `bun run typecheck` clean; 379 data-viewer bun tests pass; bundle builds; bundle-size test passes.
- Two consecutive clean `/code-review` passes on the final commit; codex adversarial review (findings addressed).
- Docs: `docs/data-viewer.md` updated for the on-demand histogram behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Optimization**
  * Improved initial table load times by computing numeric column histograms on-demand (when filter editors are opened) rather than upfront. Histograms are cached after first computation for consistent performance.

* **Documentation**
  * Updated data viewer documentation to clarify lazy histogram computation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->