### PR TITLE
Add help output for CLI commands

### DIFF
--- a/crates/raven/src/cli/analysis_stats.rs
+++ b/crates/raven/src/cli/analysis_stats.rs
@@ -55,6 +55,7 @@ pub fn parse_args(args: &mut impl Iterator<Item = String>) -> Result<AnalysisSta
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
+            "--help" => return Err("HELP".to_string()),
             "--csv" => csv = true,
             "--only" => {
                 let phase = args
@@ -87,6 +88,24 @@ pub fn parse_args(args: &mut impl Iterator<Item = String>) -> Result<AnalysisSta
     }
 
     Ok(AnalysisStatsArgs { path, csv, only })
+}
+
+pub fn print_help() {
+    println!(
+        "raven analysis-stats {} — profile workspace analysis phases
+
+Usage: raven analysis-stats <path> [OPTIONS]
+
+Loads a workspace and reports timing metrics for each analysis phase:
+scan, parse, metadata, scope, and packages.
+
+Options:
+  --csv                      Output results in CSV format
+  --only PHASE               Run only one phase (scan, parse, metadata, scope, packages)
+  --help                     Print this help message
+",
+        env!("CARGO_PKG_VERSION")
+    );
 }
 
 /// Run the analysis-stats command and return phase results.

--- a/crates/raven/src/cli/mod.rs
+++ b/crates/raven/src/cli/mod.rs
@@ -43,11 +43,11 @@ mod tests {
     async fn packages_run_help_via_alias_argv_matches_nested() {
         // The alias `raven fetch --help` passes ["fetch", "--help"] to packages::run.
         // The nested `raven packages fetch --help` also passes ["fetch", "--help"] after skip(1).
-        // Both must return Err("HELP").
+        // Both must be handled directly by packages::run.
         let result = packages::run(["fetch", "--help"].into_iter().map(String::from)).await;
-        assert_eq!(result, Err("HELP".to_string()));
+        assert_eq!(result, Ok(()));
 
         let result = packages::run(["freeze", "--help"].into_iter().map(String::from)).await;
-        assert_eq!(result, Err("HELP".to_string()));
+        assert_eq!(result, Ok(()));
     }
 }

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -1480,29 +1480,69 @@ pub async fn run_build_embedded_base(args: BuildEmbeddedBaseArgs) -> Result<(), 
 /// Dispatch the `packages` subcommand group on its second token.
 pub async fn run(mut argv: impl Iterator<Item = String>) -> Result<(), String> {
     match argv.next().as_deref() {
+        Some("--help" | "help") => {
+            print_help();
+            Ok(())
+        }
         Some("update") => {
-            let args = parse_update_args(argv)?;
-            run_update(args).await
+            match parse_update_args(argv) {
+                Ok(args) => run_update(args).await,
+                Err(msg) if msg == "HELP" => {
+                    print_update_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some("freeze") => {
-            let args = parse_freeze_args(argv)?;
-            run_freeze(args).await
+            match parse_freeze_args(argv) {
+                Ok(args) => run_freeze(args).await,
+                Err(msg) if msg == "HELP" => {
+                    print_freeze_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some("fetch") => {
-            let args = parse_fetch_args(argv)?;
-            run_fetch(args).await
+            match parse_fetch_args(argv) {
+                Ok(args) => run_fetch(args).await,
+                Err(msg) if msg == "HELP" => {
+                    print_fetch_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some("build-shipped-db") => {
-            let args = parse_build_shipped_db_args(argv)?;
-            run_build_shipped_db(args).await
+            match parse_build_shipped_db_args(argv) {
+                Ok(args) => run_build_shipped_db(args).await,
+                Err(msg) if msg == "HELP" => {
+                    print_build_shipped_db_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some("build-embedded-base") => {
-            let args = parse_build_embedded_base_args(argv)?;
-            run_build_embedded_base(args).await
+            match parse_build_embedded_base_args(argv) {
+                Ok(args) => run_build_embedded_base(args).await,
+                Err(msg) if msg == "HELP" => {
+                    print_build_embedded_base_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some("validate-shipped-db") => {
-            let args = parse_validate_shipped_db_args(argv)?;
-            run_validate_shipped_db(args)
+            match parse_validate_shipped_db_args(argv) {
+                Ok(args) => run_validate_shipped_db(args),
+                Err(msg) if msg == "HELP" => {
+                    print_validate_shipped_db_help();
+                    Ok(())
+                }
+                Err(msg) => Err(msg),
+            }
         }
         Some(other) => Err(format!("unknown packages subcommand: {other}")),
         None => {
@@ -1523,7 +1563,105 @@ pub fn print_help() {
 [--runiverse-bioc DIR|dbdump.bson [--runiverse-bioc-min N]] [--seed names.db | --fresh] --output names.db \
 [--snapshot-date S] [--source S]\n  \
          raven packages build-embedded-base --reference-lib DIR [--output PATH]\n  \
-         raven packages validate-shipped-db names.db\n"
+         raven packages validate-shipped-db names.db\n\n\
+         Run `raven packages <subcommand> --help` for command-specific help.\n\
+         Docs: {}\n",
+        env!("CARGO_PKG_REPOSITORY")
+    );
+}
+
+pub fn print_fetch_help() {
+    println!(
+        "raven packages fetch — fetch package exports from r-universe\n\n\
+         Usage: raven packages fetch [OPTIONS]\n\n\
+         Produces .raven/packages.json from CRAN/Bioconductor r-universe metadata.\n\
+         Existing records are preserved and new records are added for packages the\n\
+         workspace uses but the file does not already cover.\n\n\
+         Options:\n  \
+         --missing-only              Skip packages already installed locally when R is available\n  \
+         --fail-on-missing           Exit non-zero if any used package cannot be resolved\n  \
+         --output PATH               Output path (default: .raven/packages.json)\n  \
+         --workspace DIR             Workspace root to scan (default: current directory)\n  \
+         --base-urls URL[,URL]       Ordered r-universe hosts\n  \
+         --help                      Print this help message\n\n\
+         Alias: raven fetch [OPTIONS]\n\
+         Docs: {}\n",
+        env!("CARGO_PKG_REPOSITORY")
+    );
+}
+
+pub fn print_freeze_help() {
+    println!(
+        "raven packages freeze — capture installed package exports\n\n\
+         Usage: raven packages freeze [OPTIONS]\n\n\
+         Writes .raven/packages.json from packages installed in the local R library.\n\
+         Commit this file when CI should use version-pinned package export metadata\n\
+         without downloading a broad database.\n\n\
+         Options:\n  \
+         --used                      Capture packages used by the workspace (default)\n  \
+         --installed, --all          Capture every installed package\n  \
+         --output PATH               Output path (default: .raven/packages.json)\n  \
+         --workspace DIR             Workspace root to scan (default: current directory)\n  \
+         --help                      Print this help message\n\n\
+         Alias: raven freeze [OPTIONS]\n\
+         Docs: {}\n",
+        env!("CARGO_PKG_REPOSITORY")
+    );
+}
+
+pub fn print_update_help() {
+    println!(
+        "raven packages update — download Raven's package symbol database\n\n\
+         Usage: raven packages update [YYYY-MM-DD | --base-url URL] [OPTIONS]\n\n\
+         Downloads names.db, Raven's broad CRAN/Bioconductor package symbol database.\n\
+         Use this in CI or local installs when R packages are not installed but Raven\n\
+         should still recognize exported package symbols.\n\n\
+         Options:\n  \
+         --base-url URL              Release asset base URL to download from\n  \
+         --dest-dir DIR              Destination directory for names.db\n  \
+         --help                      Print this help message\n\n\
+         Docs: {}\n",
+        env!("CARGO_PKG_REPOSITORY")
+    );
+}
+
+pub fn print_build_shipped_db_help() {
+    println!(
+        "raven packages build-shipped-db — maintainer package database builder\n\n\
+         Usage: raven packages build-shipped-db [OPTIONS] --output names.db\n\n\
+         Options:\n  \
+         --runiverse-cran PATH       CRAN r-universe dbdump BSON or package JSON directory\n  \
+         --runiverse-cran-min N      Minimum distinct CRAN packages required\n  \
+         --runiverse-bioc PATH       Bioconductor r-universe dbdump BSON or package JSON directory\n  \
+         --runiverse-bioc-min N      Minimum distinct Bioconductor packages required\n  \
+         --seed names.db             Prior database seed\n  \
+         --fresh, --no-seed          Build without a prior database seed\n  \
+         --output names.db           Output database path (required)\n  \
+         --snapshot-date S           Snapshot date recorded in provenance\n  \
+         --source S                  Source label recorded in provenance\n  \
+         --help                      Print this help message\n"
+    );
+}
+
+pub fn print_build_embedded_base_help() {
+    println!(
+        "raven packages build-embedded-base — maintainer embedded base table builder\n\n\
+         Usage: raven packages build-embedded-base --reference-lib DIR [OPTIONS]\n\n\
+         Options:\n  \
+         --reference-lib DIR         Reference R library containing base-priority packages (required)\n  \
+         --output PATH               Generated Rust source path\n  \
+         --help                      Print this help message\n"
+    );
+}
+
+pub fn print_validate_shipped_db_help() {
+    println!(
+        "raven packages validate-shipped-db — validate a names.db database\n\n\
+         Usage: raven packages validate-shipped-db names.db\n\n\
+         Opens and fully decodes a shipped database, checking container metadata,\n\
+         format compatibility, checksums, index bounds, and record count.\n\n\
+         Options:\n  \
+         --help                      Print this help message\n"
     );
 }
 

--- a/crates/raven/src/main.rs
+++ b/crates/raven/src/main.rs
@@ -54,6 +54,8 @@ freeze, fetch                Top-level aliases for raven packages freeze/fetch
 
 "#
     );
+    println!("Run `raven <command> --help` for command-specific help.");
+    println!("Docs: {}", env!("CARGO_PKG_REPOSITORY"));
 }
 
 #[tokio::main]
@@ -67,6 +69,10 @@ async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = argv.collect();
 
     match args.first().map(String::as_str) {
+        Some("help") => {
+            print_usage();
+            return Ok(());
+        }
         Some("analysis-stats") => {
             env_logger::init();
             let mut rest = args.into_iter().skip(1);
@@ -78,6 +84,10 @@ async fn main() -> anyhow::Result<()> {
                     } else {
                         cli::analysis_stats::print_results(&results);
                     }
+                    return Ok(());
+                }
+                Err(e) if e == "HELP" => {
+                    cli::analysis_stats::print_help();
                     return Ok(());
                 }
                 Err(e) => {

--- a/crates/raven/tests/cli_banner.rs
+++ b/crates/raven/tests/cli_banner.rs
@@ -1,10 +1,15 @@
 use std::process::Command;
 
+fn run_raven(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_raven"))
+        .args(args)
+        .output()
+        .expect("run raven")
+}
+
 #[test]
 fn no_args_describes_raven_as_static_analyzer_and_language_server() {
-    let output = Command::new(env!("CARGO_BIN_EXE_raven"))
-        .output()
-        .expect("run raven with no arguments");
+    let output = run_raven(&[]);
 
     assert!(output.status.success());
 
@@ -18,4 +23,93 @@ fn no_args_describes_raven_as_static_analyzer_and_language_server() {
             env!("CARGO_PKG_VERSION")
         )
     );
+}
+
+#[test]
+fn top_level_help_points_to_command_help_and_docs() {
+    let output = run_raven(&["--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("Run `raven <command> --help` for command-specific help."));
+    assert!(stdout.contains("Docs: https://github.com/jbearak/raven"));
+}
+
+#[test]
+fn help_alias_prints_top_level_help() {
+    let output = run_raven(&["help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("Usage: raven [OPTIONS]"));
+    assert!(stdout.contains("Docs: https://github.com/jbearak/raven"));
+}
+
+#[test]
+fn packages_group_help_is_available() {
+    let output = run_raven(&["packages", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven packages — package-database commands"));
+    assert!(stdout.contains("Usage:"));
+}
+
+#[test]
+fn packages_fetch_help_is_command_specific() {
+    let output = run_raven(&["packages", "fetch", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven packages fetch — fetch package exports from r-universe"));
+    assert!(stdout.contains("--missing-only"));
+    assert!(stdout.contains("--fail-on-missing"));
+}
+
+#[test]
+fn top_level_fetch_alias_help_is_command_specific() {
+    let output = run_raven(&["fetch", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven packages fetch — fetch package exports from r-universe"));
+}
+
+#[test]
+fn packages_freeze_help_is_command_specific() {
+    let output = run_raven(&["packages", "freeze", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven packages freeze — capture installed package exports"));
+    assert!(stdout.contains("--used"));
+    assert!(stdout.contains("--installed"));
+}
+
+#[test]
+fn packages_update_help_is_command_specific() {
+    let output = run_raven(&["packages", "update", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven packages update — download Raven's package symbol database"));
+    assert!(stdout.contains("--dest-dir"));
+}
+
+#[test]
+fn analysis_stats_help_is_available() {
+    let output = run_raven(&["analysis-stats", "--help"]);
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is valid UTF-8");
+    assert!(stdout.contains("raven analysis-stats"));
+    assert!(stdout.contains("Usage: raven analysis-stats <path>"));
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,6 +5,8 @@ Raven ships a single binary that serves the LSP via stdio *and* exposes subcomma
 - `raven check` — index a workspace and report the **full** diagnostic set (the same diagnostics the editor publishes).
 - `raven lint` — run the native **style** linter only.
 
+Run `raven`, `raven --help`, or `raven help` for top-level usage. Commands with options accept `--help`, including package-database commands such as `raven packages fetch --help` and the top-level aliases `raven fetch --help` / `raven freeze --help`.
+
 If your codebase imports any R packages — and it almost certainly does — Raven needs to know the symbols those packages export. Run `raven check` on the same machine where you run your R scripts and it reads them straight from your R installation.
 
 You may instead want to run Raven where R isn't installed — or where it is, but not all your packages are. The common case is an automated check on your pull requests: base images with R exist, but installing packages can take minutes or hours, expensive next to the moment `raven check` takes. So Raven can run without R: run `raven packages update && raven check`, where `raven packages update` downloads a database of known R packages. Or commit `raven packages freeze`, which writes your packages' exports — read from your local R install — into a `.raven/` file in your repository, so CI needs no download.


### PR DESCRIPTION
## Summary
- Add top-level `help` and `--help` support for the Raven CLI
- Print command-specific help for `packages` subcommands and `analysis-stats`
- Expand CLI tests to cover help paths and update user-facing CLI docs

## Testing
- Added integration coverage for top-level help, command aliases, and subcommand-specific help output
- Not run (not requested)