### PR TITLE
Persist Knit Preview across window reload/restart

### DIFF
--- a/docs/knit.md
+++ b/docs/knit.md
@@ -16,6 +16,17 @@ intentionally narrow:
   in one keystroke. Re-rendering only on demand keeps the preview
   deterministic (you decide when it changes) and avoids spurious
   re-renders while you're mid-edit.
+- The preview **persists across window reload/restart**. If a preview
+  panel is open when you reload the window or quit and reopen VS Code,
+  Raven restores it automatically showing the **last rendered output** —
+  no re-knit, no R subprocess. The restored panel is a static snapshot
+  of the previous render; press **Knit again** to refresh it. This is
+  controlled by `raven.knit.persistPreview` (default on); disable it to
+  go back to the previous behavior, where the panel disappears on reload
+  and its temp files are removed immediately. Surviving a machine reboot
+  is out of scope — the OS may clear the temp directory. If a restored
+  preview's temp files are gone (swept, or cleaned up), the panel shows a
+  "press Knit again" placeholder.
 - The preview is saved to a per-session temp directory under
   `<os.tmpdir()>/raven-knit/<workspaceHash>/<sessionId>/preview/<sourceHash>/`,
   so the `.Rmd`'s own directory stays clean. Export commands write the
@@ -258,9 +269,26 @@ when an `.Rmd` file is open.
     `<sessionId>` is a UUID generated at extension activation so two
     VS Code windows on the same workspace are isolated, and
     `<sourceHash>` is a SHA-256 of the `.Rmd`'s absolute path. The
-    whole directory is removed when the panel is disposed; the entire
-    session subtree is removed when VS Code exits. Stale sibling
-    sessions (>7 days) are swept on activation.
+    whole `preview/<sourceHash>` directory is removed when its panel is
+    disposed (closed). What happens at window exit depends on
+    `raven.knit.persistPreview`:
+
+    - **On (default)** — the `preview/` artifacts of panels that are
+      still open are **kept** so they can be restored on the next launch
+      (only the throwaway `export/` subtree is removed). On restore,
+      Raven adopts that old-session `preview/<sourceHash>` directory into
+      the new session's tree, so a later **Knit again** is a normal
+      in-place update. Orphaned leftovers (a window closed and never
+      reopened) are reclaimed by the >7-day sweep and by **Raven: Clean
+      Up Knit Preview Cache**.
+    - **Off** — the entire session subtree is removed when VS Code exits,
+      as before.
+
+    Stale sibling sessions (>7 days) are swept on activation regardless.
+    **Raven: Clean Up Knit Preview Cache** reclaims orphaned session
+    directories on demand; it never touches the current session, nor any
+    session written within the last few minutes (so a preview open in a
+    concurrent window on the same workspace is spared).
 
 ## Exporting
 
@@ -333,6 +361,7 @@ template fidelity, run `rmarkdown::render(...)` in the R console.
 | `raven.rConsole.activation` | `auto` | Gates the knit command (and the R console / plot / data viewers / chunk run commands). |
 | `raven.knit.workingDirectory` | `document` | `document` / `project` / `current`. |
 | `raven.knit.timeoutMs` | `600000` | Hard timeout (ms) for the knit R subprocess. |
+| `raven.knit.persistPreview` | `true` | Keep the Knit Preview panel across window reload/restart (restores the last rendered output without re-knitting). Disable to drop previews and their temp files on window close. |
 | `raven.knit.export.timeoutMs` | `120000` | Hard timeout (ms) for the Pandoc subprocess during export. |
 | `raven.knit.fontFamily` | `""` | Body/prose font for the preview. Empty inherits `markdown.preview.fontFamily`. |
 | `raven.knit.monospaceFontFamily` | `""` | Monospace font for code chunks and output. Empty inherits `editor.fontFamily`. |

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -56,6 +56,7 @@ The **`raven.toml` path** column shows where to set a key in a project's `raven.
 | `raven.knit.export.timeoutMs` | `120000` | integer (≥5000) | — | [knit](knit.md) | Timeout (milliseconds) for the Pandoc subprocess used by Knit: Export to PDF / Word / HTML. |
 | `raven.knit.fontFamily` | `""` | string | — | [knit](knit.md) | Body/prose font for the Raven: Knit Preview output. |
 | `raven.knit.monospaceFontFamily` | `""` | string | — | [knit](knit.md) | Monospace font for both highlighted code chunks and bare output blocks in the Raven: Knit Preview output. |
+| `raven.knit.persistPreview` | `true` | boolean | — | [knit](knit.md) | Keep the Knit Preview panel across window reloads and VS Code restarts. |
 | `raven.knit.timeoutMs` | `600000` | integer (≥1000) | — | [knit](knit.md) | Hard timeout (milliseconds) for the Raven: Knit Preview subprocess. |
 | `raven.knit.workingDirectory` | `"document"` | `"document"` \| `"project"` \| `"current"` | — | [knit](knit.md) | Working directory used for knitr chunk evaluation (knitr::opts_knit$set(root.dir = ...)). |
 | `raven.linting.assignmentOperator` | `"<-"` | `"<-"` \| `"="` | `linting.assignmentOperator` | [linting](linting.md) | Preferred assignment operator. |

--- a/docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md
@@ -54,18 +54,25 @@ Register a `WebviewPanelSerializer` for `raven.knitOutput`, and on restore
 **adopt** the orphaned old-session preview dir into the *current* session's
 preview path for that source. Adoption keeps the path model consistent: a
 later "Knit again" is a normal in-place update (same `rootDir`), not a
-`rootDir` change that would dispose-and-recreate the panel and confuse the
-existing refcount/disposal logic. Per-session isolation (which protects
-concurrent windows) is preserved.
+`rootDir` change that dispose-and-recreates the panel — and it folds the
+orphaned old-`sessionId` dir back into the session tree so it isn't left for
+the 7-day sweep. Per-session isolation (which protects concurrent windows) is
+preserved.
+
+(Note: the dispose-and-recreate branch in `showOrUpdate` is not itself a
+data-loss risk today — the knit pipeline pins the preview dir before writing
+and cancels any stale deletion after a successful write, so a re-knit that
+changes `rootDir` does not delete fresh output. Adoption's value is therefore
+path-consistency and orphan-avoidance, not race-avoidance.)
 
 Rejected alternatives:
 
 - **Leave artifacts in place, restore pointing at the old path.** Simpler, but
-  the restored panel reads from an orphaned old-`sessionId` dir; the first
-  "Knit again" writes to the new session dir → `rootDir` changes →
-  dispose-and-recreate, and the disposal handler (which computes the *current*
-  session's preview dir) can race to delete the freshly-written dir. Adoption
-  avoids this entire class of bug.
+  the restored panel reads from an orphaned old-`sessionId` dir that the 7-day
+  sweep eventually reclaims out from under a long-lived restored panel, and the
+  first "Knit again" changes `rootDir` (old session → new session), forcing an
+  unnecessary dispose-and-recreate. Adoption keeps everything in one session
+  tree.
 - **Relocate previews to `context.storageUri`.** Durable across reboot, but
   reboot is out of scope and this is the heaviest option (relocating `figure/`
   images, larger persistent storage footprint).
@@ -85,20 +92,31 @@ vscode.window.registerWebviewPanelSerializer('raven.knitOutput', {
 });
 ```
 
+- **Activation event.** Add `"onWebviewPanel:raven.knitOutput"` to
+  `editors/vscode/package.json` `activationEvents`. Without it, VS Code does
+  not activate the extension to restore a serialized panel on a cold restart,
+  and the serializer is never registered — the feature silently no-ops on
+  restart (it would still work on in-window reload, masking the bug).
 - The webview shell script (`knit-output.ts` / `buildShellHtml`) calls
   `acquireVsCodeApi().setState({ sourceFsPath, outputPath })` once on load so
   VS Code persists enough to reconstruct. (The shell already acquires the VS
   Code API for its `postMessage` calls; this adds a single `setState`.)
+  `sourceFsPath` is **not currently threaded** into `buildShellHtml` — thread
+  it `updateContent → buildShellHtml → inline <script>` alongside the existing
+  `outputPath` arg.
 - `state` shape: `{ sourceFsPath: string; outputPath: string }`. Validate
-  defensively on deserialize — if either field is missing or not a string,
-  render the "no longer available" placeholder (see §3).
+  defensively on deserialize — if either field is missing/not a string, **or**
+  `outputPath` does not resolve inside the `<tmp>/raven-knit/` tree (see §2
+  containment check), render the "no longer available" placeholder (see §3).
 - New static `KnitOutputPanel.restore(context, panel, state, output)`:
-  - Sets `panel.webview.options` to match `create()`'s options
-    (`enableScripts`, `enableFindWidget`, `retainContextWhenHidden`,
-    `localResourceRoots: [Uri.file(rootDir)]` where `rootDir =
-    dirname(adoptedOutputPath)`). `localResourceRoots` **can** be set in
-    `deserializeWebviewPanel` because the panel is handed to us before first
-    paint.
+  - Sets `panel.webview.options = { enableScripts: true, localResourceRoots:
+    [Uri.file(rootDir)] }` where `rootDir = dirname(adoptedOutputPath)`. Only
+    the `WebviewOptions` are settable post-construction; `enableFindWidget` and
+    `retainContextWhenHidden` are `WebviewPanelOptions` fixed at creation and
+    restored by VS Code from the serialized panel — do **not** try to assign
+    them to `webview.options` (no-op / type error). If VS Code does not restore
+    `retainContextWhenHidden`, the only consequence is the hidden-tab DOM is
+    rebuilt from disk on reveal, which is harmless here.
   - Performs artifact adoption (§2) to compute the live `outputPath`.
   - Registers the instance in `KnitOutputPanel.instances` keyed by
     `sourceUri.fsPath`, wires the same theme/config/font listeners and
@@ -121,27 +139,38 @@ the `knit/index.ts` deactivation disposable):
   Closed panels already self-clean via the existing
   `onDidDispose → requestPreviewDirDeletion` path, so the only `preview/` dirs
   left at shutdown are those backing panels still open — exactly the set we
-  must keep for restore.
+  must keep for restore. **This applies to both branches of
+  `cleanupCurrentSession`**: the workspace branch (`workspaceHash !== null`,
+  removes `sessionRoot`) and the single-file branch (`workspaceHash === null`,
+  walks every `workspaceHash/<sessionId>` dir). Both must switch from
+  "remove session root" to "remove only `export/` + empty scaffolding" when the
+  flag is on.
 - When `persistPreview` is `false`: today's behavior — remove the whole session
-  root immediately.
+  root immediately (both branches unchanged).
 
-**Adoption on restore** (new pure-ish helper, e.g.
-`adoptPreviewArtifacts(sourceFsPath, persistedOutputPath)` in
-`raven-knit-paths.ts` or a small new module):
+**Adoption on restore** (new helper in a small new module, e.g.
+`preview-persistence.ts`, keeping `raven-knit-paths.ts` free of `fs`-heavy
+logic — `adoptPreviewArtifacts(sourceFsPath, persistedOutputPath)`):
 
-1. Compute the current-session paths via `previewArtifactPaths(sourceFsPath)`
+1. **Containment check.** Reject unless `persistedOutputPath` resolves (via
+   `realpath`, reusing `isUnderContainmentRoot`) inside
+   `<tmp>/raven-knit/`. A corrupted or crafted persisted state must never drive
+   a `rename`/`rm` on an arbitrary directory. On rejection → "missing"
+   sentinel.
+2. Compute current-session paths via `previewArtifactPaths(sourceFsPath)`
    → `{ previewDir: newDir, htmlPath: newHtml }`.
-2. If `newHtml` already exists, use it as-is (a knit already ran this session;
-   nothing to adopt).
-3. Else if `persistedOutputPath` exists on disk: ensure `newDir`'s parent
-   exists, then `fs.rename(oldPreviewDir, newDir)` (where `oldPreviewDir =
-   dirname(persistedOutputPath)`). On `EXDEV` or any rename failure, fall back
-   to a recursive copy then best-effort remove of the source. `touch` `newDir`
-   (update mtime) so the >7-day stale sweep clock resets for the adopted dir.
-   Return the adopted html path (basename preserved — the basename derives from
-   the `.Rmd` name, which is stable across sessions).
-4. Else (no live artifact anywhere): return a sentinel indicating "missing", so
-   the caller renders the placeholder.
+3. **Guard against an in-progress / completed current-session knit.** If
+   `newDir` already exists (a knit ran or is running this session — VS Code may
+   deserialize a hidden panel lazily, after a re-knit has started), do **not**
+   adopt: return `newHtml` if it exists, else "missing". Never `rename`/copy
+   into an existing destination, and never adopt while the source op is busy.
+4. Else if `persistedOutputPath` exists: ensure `newDir`'s parent exists, then
+   `fs.rename(oldPreviewDir, newDir)` (`oldPreviewDir =
+   dirname(persistedOutputPath)`). On `EXDEV`/rename failure, fall back to
+   recursive copy + best-effort remove of the source. `touch` `newDir` so the
+   >7-day sweep clock resets. Return the adopted html path (basename derives
+   from the stable `.Rmd` name).
+5. Else: return "missing" → caller renders the placeholder.
 
 The basename of the html under `newDir` is recomputed from `sourceFsPath` via
 the same `previewArtifactPaths` logic, so adoption does not depend on parsing
@@ -167,25 +196,26 @@ the restore case.)
 
 ### 4. New setting `raven.knit.persistPreview`
 
-- Boolean, default `true`, resource-scoped (matches the other `raven.knit.*`
-  settings so it can be overridden per-folder).
-- Read live via `vscode.workspace.getConfiguration('raven.knit').get(
-  'persistPreview', true)` at the two decision points: serializer deserialize
-  and deactivation cleanup. Reading live (not cached at activation) means
-  toggling it off mid-session takes effect at the next deactivation, and the
-  deserialize guard handles the "turned off between sessions" case by disposing
-  the restored panel.
+- Boolean, default `true`. **`window` scope, not resource scope.** It is a
+  behavior flag, not a per-document value like the font settings, and the
+  deactivation-cleanup decision point has no source URI to resolve a
+  resource-scoped value against — a `window`-scoped setting reads cleanly with
+  a bare `getConfiguration('raven.knit').get('persistPreview', true)`.
+- Read live (not cached at activation) at the two decision points: serializer
+  deserialize and deactivation cleanup. Toggling it off mid-session takes
+  effect at the next deactivation; the deserialize guard handles the "turned
+  off between sessions" case by disposing the restored panel.
 - Wiring: add to `editors/vscode/package.json` `configuration` schema →
   regenerate the alphabetical settings index with
   `bun editors/vscode/scripts/generate-settings-reference.mjs` (the drift test
   `tests/bun/settings-reference.test.ts` gates this) → document in
   `docs/knit.md` settings table and `docs/settings-reference.md`.
-- **LSP wiring check:** this is a TS-side knit-pipeline setting read directly
-  via `getConfiguration`, not consumed by the Rust backend. During
-  implementation, confirm no knit setting flows through
-  `editors/vscode/src/initializationOptions.ts` / `SETTINGS_MAPPING`; if none
-  do, the three-place LSP-setting wiring from CLAUDE.md does not apply and only
-  the package.json + settings-reference + docs touchpoints are needed.
+- **LSP wiring: not needed (confirmed).** No `raven.knit.*` setting flows
+  through `editors/vscode/src/initializationOptions.ts` / `SETTINGS_MAPPING`
+  (verified — none of the knit settings appear there; they are read directly
+  via `getConfiguration` on the TS side). So the three-place LSP-setting wiring
+  from CLAUDE.md does not apply: only the package.json + settings-reference +
+  docs touchpoints are needed.
 
 ### 5. New command `Raven: Clean Up Knit Preview Cache` (`raven.knit.cleanupCache`)
 
@@ -203,10 +233,20 @@ the restore case.)
 - On completion, show an information notification reporting how many dirs /
   roughly how much space was freed (best-effort byte count, or just a count if
   sizing is too slow).
-- Concurrency caveat documented: with two windows on the same workspace, the
-  age threshold — not session ownership — is what protects the *other* window's
-  files, because session ownership cannot be determined cross-process. The
-  threshold makes this safe in practice.
+- **Concurrency caveat (honestly documented).** Session ownership cannot be
+  determined cross-process, so the age threshold — not ownership — is what
+  spares another window's files. The residual gap: a preview open in another
+  window, idle for longer than the threshold, can have its temp dir removed.
+  The severity is limited because that window's panel uses
+  `retainContextWhenHidden`, so the *running* panel keeps its rendered DOM in
+  memory and is unaffected; only a *future* restore of that panel would fall
+  back to the "knit again" placeholder. We accept this for a manual,
+  user-invoked command and document it in `docs/knit.md`.
+- **Optional hardening (deferred, flagged for the user).** If cross-window
+  restore-survival turns out to matter, a per-preview lease file (touched by
+  open panels on render/restore and on a modest interval) would let cleanup
+  distinguish "live elsewhere" from "orphaned" without relying on age. This
+  adds a per-panel timer; not built in v1 unless requested.
 
 ### 6. Untouched
 
@@ -252,13 +292,25 @@ settings index; `cargo fmt`/`clippy` unaffected (no Rust changes expected).
   behavior), the settings table (new `raven.knit.persistPreview` row), and a
   short entry for the new cleanup command.
 - `docs/settings-reference.md`: regenerated.
-- `editors/vscode/package.json`: command + setting contributions.
+- `editors/vscode/package.json`: `activationEvents` (`onWebviewPanel:raven.knitOutput`),
+  command contribution (`raven.knit.cleanupCache`), and the
+  `raven.knit.persistPreview` setting.
 
 ## Open implementation questions (resolve during build, not blocking)
 
-- Exact module home for the adoption + cleanup-selector helpers (extend
-  `raven-knit-paths.ts` vs a new `preview-persistence.ts`). Lean toward a new
-  small module to keep `raven-knit-paths.ts` free of `fs`-heavy logic.
 - Whether `setState` belongs in the existing shell script or a tiny added
   inline script block — pick whichever keeps the CSP nonce handling simplest.
 - The cleanup command's space-reporting fidelity (count vs bytes).
+
+## Review
+
+This spec was adversarially reviewed by Codex (2026-06-22). Incorporated:
+the missing `onWebviewPanel:` activation event (§1), the
+`WebviewOptions`/`WebviewPanelOptions` split (§1), `window`-scope for the
+setting (§4), the adoption guard against an in-progress current-session knit
+and the path-containment check (§2), the single-file-mode cleanup branch (§2),
+and `sourceFsPath` threading (§1). The cleanup cross-window concern (§5) was
+calibrated — the running panel is unaffected (`retainContextWhenHidden`), so
+the age-threshold approach is kept with the limitation documented and a
+lease-file hardening flagged as deferred. The overstated adoption-vs-race
+rationale was softened (the knit pipeline already guards that race).

--- a/docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md
@@ -1,0 +1,264 @@
+# Knit Preview persistence across window reload/restart
+
+## Problem
+
+When a user knits an `.Rmd` in VS Code, the **Knit Preview** webview panel
+shows the rendered HTML. If the user reloads the window (`Developer: Reload
+Window`) or quits and reopens VS Code, the panel disappears and the user must
+re-knit. Knitting can be slow (it runs the R subprocess over every chunk), so
+losing the rendered output on every window reload is a recurring annoyance.
+
+The goal: a previously-open Knit Preview panel comes back automatically after a
+window reload or a full VS Code restart, showing the **last rendered output**,
+with **no R subprocess re-run** and no popup.
+
+Out of scope: surviving a machine reboot (the OS may clear `os.tmpdir()`); a
+"live"/auto-refresh preview; re-knitting on restore.
+
+## Why it doesn't persist today
+
+Two independent mechanisms each defeat persistence:
+
+1. **No webview serializer.** VS Code discards all webviews on reload/restart.
+   An extension must register a `WebviewPanelSerializer` for its view type to
+   get them back. Raven registers none — `knit-output-panel.ts` only ever
+   *creates* panels via `createWebviewPanel`. So the panel tab vanishes.
+
+2. **Ephemeral artifacts.** The rendered `.html` / `.md` / `figure/` live under
+   `<tmpdir>/raven-knit/<workspaceHash>/<sessionId>/preview/<sourceHash>/`. The
+   `sessionId` is a fresh UUID on every activation (`knit/index.ts`), and
+   `cleanupCurrentSession()` is wired as a deactivation disposable that
+   `rm -rf`s the whole session root on window close. So even if the panel came
+   back, the file it pointed at would be both gone and at an unreachable path.
+
+Persistence therefore requires both: re-create the panel **and** ensure the
+rendered artifact it reads still exists.
+
+## Decisions (settled during brainstorming)
+
+- **Scope:** survive `Reload Window` and a full quit-and-reopen. Both use the
+  serializer mechanism. Artifacts stay in `os.tmpdir()`; reboot survival is
+  explicitly out of scope.
+- **Restore behavior:** show the last rendered HTML statically and silently —
+  identical to how the panel looks right after a knit. No R subprocess.
+- **Disable setting:** `raven.knit.persistPreview`, boolean, default `true`
+  (the new behavior). Setting it `false` restores today's behavior.
+- **Manual cleanup command:** `Raven: Clean Up Knit Preview Cache` removes
+  *orphaned* dirs only — never a dir backing a panel open in this window, and
+  never a dir written within a short age threshold (so a concurrent window's
+  fresh files are spared).
+
+## Approach
+
+Register a `WebviewPanelSerializer` for `raven.knitOutput`, and on restore
+**adopt** the orphaned old-session preview dir into the *current* session's
+preview path for that source. Adoption keeps the path model consistent: a
+later "Knit again" is a normal in-place update (same `rootDir`), not a
+`rootDir` change that would dispose-and-recreate the panel and confuse the
+existing refcount/disposal logic. Per-session isolation (which protects
+concurrent windows) is preserved.
+
+Rejected alternatives:
+
+- **Leave artifacts in place, restore pointing at the old path.** Simpler, but
+  the restored panel reads from an orphaned old-`sessionId` dir; the first
+  "Knit again" writes to the new session dir → `rootDir` changes →
+  dispose-and-recreate, and the disposal handler (which computes the *current*
+  session's preview dir) can race to delete the freshly-written dir. Adoption
+  avoids this entire class of bug.
+- **Relocate previews to `context.storageUri`.** Durable across reboot, but
+  reboot is out of scope and this is the heaviest option (relocating `figure/`
+  images, larger persistent storage footprint).
+
+## Design
+
+### 1. Panel serializer
+
+Register in `registerKnit` (`knit/index.ts`):
+
+```ts
+vscode.window.registerWebviewPanelSerializer('raven.knitOutput', {
+  deserializeWebviewPanel: async (panel, state) => {
+    if (!persistPreviewEnabled()) { panel.dispose(); return; }
+    await KnitOutputPanel.restore(context, panel, state, knitOutput);
+  },
+});
+```
+
+- The webview shell script (`knit-output.ts` / `buildShellHtml`) calls
+  `acquireVsCodeApi().setState({ sourceFsPath, outputPath })` once on load so
+  VS Code persists enough to reconstruct. (The shell already acquires the VS
+  Code API for its `postMessage` calls; this adds a single `setState`.)
+- `state` shape: `{ sourceFsPath: string; outputPath: string }`. Validate
+  defensively on deserialize — if either field is missing or not a string,
+  render the "no longer available" placeholder (see §3).
+- New static `KnitOutputPanel.restore(context, panel, state, output)`:
+  - Sets `panel.webview.options` to match `create()`'s options
+    (`enableScripts`, `enableFindWidget`, `retainContextWhenHidden`,
+    `localResourceRoots: [Uri.file(rootDir)]` where `rootDir =
+    dirname(adoptedOutputPath)`). `localResourceRoots` **can** be set in
+    `deserializeWebviewPanel` because the panel is handed to us before first
+    paint.
+  - Performs artifact adoption (§2) to compute the live `outputPath`.
+  - Registers the instance in `KnitOutputPanel.instances` keyed by
+    `sourceUri.fsPath`, wires the same theme/config/font listeners and
+    `onDidDispose` handler as `create()`, applies the viewer tab icon, then
+    runs `updateContent(...)`.
+  - `create()` and `restore()` share a private helper for the
+    listener/registry wiring so the two paths cannot drift.
+
+`applyViewerTabIcon`, the `globalState` theme preference, and the live font
+resolution all attach unchanged, so a restored panel themes and fonts itself
+correctly with no extra work.
+
+### 2. Artifact survival + adoption (gated on the setting)
+
+**Deactivation cleanup** (`session-state.ts` `cleanupCurrentSession`, invoked by
+the `knit/index.ts` deactivation disposable):
+
+- When `persistPreview` is `true`: skip removal of `preview/` subdirs; still
+  remove `export/` throwaways and any otherwise-empty session scaffolding.
+  Closed panels already self-clean via the existing
+  `onDidDispose → requestPreviewDirDeletion` path, so the only `preview/` dirs
+  left at shutdown are those backing panels still open — exactly the set we
+  must keep for restore.
+- When `persistPreview` is `false`: today's behavior — remove the whole session
+  root immediately.
+
+**Adoption on restore** (new pure-ish helper, e.g.
+`adoptPreviewArtifacts(sourceFsPath, persistedOutputPath)` in
+`raven-knit-paths.ts` or a small new module):
+
+1. Compute the current-session paths via `previewArtifactPaths(sourceFsPath)`
+   → `{ previewDir: newDir, htmlPath: newHtml }`.
+2. If `newHtml` already exists, use it as-is (a knit already ran this session;
+   nothing to adopt).
+3. Else if `persistedOutputPath` exists on disk: ensure `newDir`'s parent
+   exists, then `fs.rename(oldPreviewDir, newDir)` (where `oldPreviewDir =
+   dirname(persistedOutputPath)`). On `EXDEV` or any rename failure, fall back
+   to a recursive copy then best-effort remove of the source. `touch` `newDir`
+   (update mtime) so the >7-day stale sweep clock resets for the adopted dir.
+   Return the adopted html path (basename preserved — the basename derives from
+   the `.Rmd` name, which is stable across sessions).
+4. Else (no live artifact anywhere): return a sentinel indicating "missing", so
+   the caller renders the placeholder.
+
+The basename of the html under `newDir` is recomputed from `sourceFsPath` via
+the same `previewArtifactPaths` logic, so adoption does not depend on parsing
+the persisted path beyond locating the old dir.
+
+**Orphan cleanup:** the existing `sweepStaleSessions` (>7 days, run at
+activation) remains the passive backstop for old-session dirs that were never
+adopted (window closed and never reopened). The new manual command (§4) gives
+an active reclaim path.
+
+### 3. Restore failure handling
+
+If adoption returns "missing" (persisted `outputPath` gone — tmp cleared,
+swept, or manually cleaned), `updateContent` renders a small in-iframe
+placeholder instead of a broken/blank webview:
+
+> This preview is no longer available. Press **Knit again** to regenerate it.
+
+The toolbar's **Knit again** button works immediately — it only needs
+`sourceUri`, which comes from the persisted `sourceFsPath`. (This reuses the
+existing read-failure fallback branch in `updateContent`, with copy tuned for
+the restore case.)
+
+### 4. New setting `raven.knit.persistPreview`
+
+- Boolean, default `true`, resource-scoped (matches the other `raven.knit.*`
+  settings so it can be overridden per-folder).
+- Read live via `vscode.workspace.getConfiguration('raven.knit').get(
+  'persistPreview', true)` at the two decision points: serializer deserialize
+  and deactivation cleanup. Reading live (not cached at activation) means
+  toggling it off mid-session takes effect at the next deactivation, and the
+  deserialize guard handles the "turned off between sessions" case by disposing
+  the restored panel.
+- Wiring: add to `editors/vscode/package.json` `configuration` schema →
+  regenerate the alphabetical settings index with
+  `bun editors/vscode/scripts/generate-settings-reference.mjs` (the drift test
+  `tests/bun/settings-reference.test.ts` gates this) → document in
+  `docs/knit.md` settings table and `docs/settings-reference.md`.
+- **LSP wiring check:** this is a TS-side knit-pipeline setting read directly
+  via `getConfiguration`, not consumed by the Rust backend. During
+  implementation, confirm no knit setting flows through
+  `editors/vscode/src/initializationOptions.ts` / `SETTINGS_MAPPING`; if none
+  do, the three-place LSP-setting wiring from CLAUDE.md does not apply and only
+  the package.json + settings-reference + docs touchpoints are needed.
+
+### 5. New command `Raven: Clean Up Knit Preview Cache` (`raven.knit.cleanupCache`)
+
+- Registered alongside the other knit commands; gated by the same
+  `raven.rConsole.activation` resolution. Title under the `Raven:` category.
+- Algorithm — walk `<tmpdir>/raven-knit/`:
+  - **Protect** any current-session `preview/<sourceHash>` dir that backs a
+    panel open in *this* window (derive the protected set from
+    `KnitOutputPanel.instances` keys → `previewArtifactPaths`).
+  - **Protect** any dir whose mtime is within a short threshold
+    (e.g. `5 * 60 * 1000` ms) so a concurrent window's just-written files are
+    not yanked away mid-knit.
+  - **Remove** everything else (`rm -rf`, best-effort, errors logged to the
+    Knit output channel).
+- On completion, show an information notification reporting how many dirs /
+  roughly how much space was freed (best-effort byte count, or just a count if
+  sizing is too slow).
+- Concurrency caveat documented: with two windows on the same workspace, the
+  age threshold — not session ownership — is what protects the *other* window's
+  files, because session ownership cannot be determined cross-process. The
+  threshold makes this safe in practice.
+
+### 6. Untouched
+
+- Theme toggle persistence (`globalState`) and font resolution (live config)
+  already survive reload; restored panels pick them up via the existing
+  listeners.
+- No R subprocess runs on restore.
+- Each previously-open `.Rmd` panel restores independently — VS Code calls
+  `deserializeWebviewPanel` once per persisted panel.
+- The per-source panel registry, in-flight export gate, preview-dir refcount
+  pinning, and the `>7-day` sweep all stay as-is.
+
+## Testing
+
+**Bun units:**
+
+- Adoption helper: new-empty + old-exists → moves dir, returns adopted html;
+  old-gone → returns "missing" sentinel; both-exist → returns existing new html
+  without clobbering; rename `EXDEV` → copy-then-remove fallback path.
+- Cleanup selector (pure function over a directory listing + protected set +
+  now): protect-by-open-set, protect-by-age-threshold, delete-rest. Keep the
+  filesystem walk and the selection predicate separate so the predicate is
+  unit-testable without touching disk.
+
+**`vscode-test` integration:**
+
+- Drive `deserializeWebviewPanel` with synthetic `{ sourceFsPath, outputPath }`
+  state pointing at a fixture html → assert a panel is registered in
+  `KnitOutputPanel.instances` and its content reflects the adopted file.
+- With `raven.knit.persistPreview: false` → assert the deserialize callback
+  disposes the panel and registers nothing.
+- Deactivation cleanup with `persistPreview: true` leaves an open panel's
+  `preview/` dir intact; with `false` removes the session root.
+
+**Drift/CI:** `tests/bun/settings-reference.test.ts` after regenerating the
+settings index; `cargo fmt`/`clippy` unaffected (no Rust changes expected).
+
+## Docs to update
+
+- `docs/knit.md`: the "static viewer" framing (note that the panel now
+  restores on reload/restart), the temp-dir lifecycle paragraph (currently
+  states the dir is removed on exit — qualify with the `persistPreview`
+  behavior), the settings table (new `raven.knit.persistPreview` row), and a
+  short entry for the new cleanup command.
+- `docs/settings-reference.md`: regenerated.
+- `editors/vscode/package.json`: command + setting contributions.
+
+## Open implementation questions (resolve during build, not blocking)
+
+- Exact module home for the adoption + cleanup-selector helpers (extend
+  `raven-knit-paths.ts` vs a new `preview-persistence.ts`). Lean toward a new
+  small module to keep `raven-knit-paths.ts` free of `fs`-heavy logic.
+- Whether `setState` belongs in the existing shell script or a tiny added
+  inline script block — pick whichever keeps the CSP nonce handling simplest.
+- The cleanup command's space-reporting fidelity (count vs bytes).

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,7 +29,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onTerminalProfile:raven.rTerminal"
+    "onTerminalProfile:raven.rTerminal",
+    "onWebviewPanel:raven.knitOutput"
   ],
   "main": "./dist/extension.js",
   "capabilities": {
@@ -249,6 +250,11 @@
         "category": "Raven"
       },
       {
+        "command": "raven.knit.cleanupCache",
+        "title": "Clean Up Knit Preview Cache",
+        "category": "Raven"
+      },
+      {
         "command": "raven.scaffold.gitignore",
         "title": "Create .gitignore",
         "category": "Raven"
@@ -449,6 +455,9 @@
         },
         {
           "command": "raven.knit.openOutputChannel"
+        },
+        {
+          "command": "raven.knit.cleanupCache"
         },
         {
           "command": "raven.openHelpPanel",
@@ -1393,6 +1402,12 @@
           "default": 600000,
           "minimum": 1000,
           "description": "Hard timeout (milliseconds) for the Raven: Knit Preview subprocess. After this elapses, Raven escalates the kill ladder (SIGINT → SIGTERM → SIGKILL) and surfaces a 'Knit timed out' message."
+        },
+        "raven.knit.persistPreview": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "description": "Keep the Knit Preview panel across window reloads and VS Code restarts. When enabled, a previously-open preview reopens automatically showing the last rendered output (no re-knit), and its rendered files are kept in the OS temp directory until the panel is closed. Disable to restore the previous behavior: previews are not reopened and their temp files are deleted as soon as the window closes. Run 'Raven: Clean Up Knit Preview Cache' to reclaim leftover temp files on demand."
         },
         "raven.knit.export.timeoutMs": {
           "type": "integer",

--- a/editors/vscode/src/knit/index.ts
+++ b/editors/vscode/src/knit/index.ts
@@ -19,6 +19,11 @@ import { OperationRegistry } from './operation-controller';
 import { registerExportCommands } from './export-commands';
 import { KnitOutputPanel } from './knit-output-panel';
 import { previewArtifactPaths } from './raven-knit-paths';
+import {
+    ravenKnitRoot,
+    selectStaleSessionDirs,
+    type SessionDirInfo,
+} from './preview-persistence';
 import { isPandocVersionOutput } from './pandoc-probe';
 
 export { disposeKnitGrammarRegistryForDeactivation };
@@ -75,7 +80,7 @@ export function registerKnit(
             ?? null;
         initSessionState({ sessionId: crypto.randomUUID(), workspaceUri });
         context.subscriptions.push({
-            dispose: () => { void cleanupCurrentSession(); },
+            dispose: () => { void cleanupCurrentSession(readPersistPreview()); },
         });
         // Non-blocking sweep of orphaned sibling sessions. Best effort —
         // errors are swallowed inside `sweepStaleSessions`.
@@ -136,6 +141,41 @@ export function registerKnit(
         },
     );
 
+    // Restore Knit Preview panels after a window reload/restart. VS Code
+    // calls `deserializeWebviewPanel` once per panel that was open when
+    // the window closed, handing back the `{ sourceFsPath, outputPath }`
+    // the shell persisted via `setState`. Gated live on
+    // `raven.knit.persistPreview`: when disabled we dispose the panel
+    // rather than restoring (covers "feature turned off between
+    // sessions"). Registered once per process — `registerKnit` is
+    // normally called once per activation, but the session-init guard
+    // above shows it can re-run in dev reloads, and a second serializer
+    // for the same view type would throw.
+    if (!knitSerializerRegistered) {
+        knitSerializerRegistered = true;
+        context.subscriptions.push(
+            vscode.window.registerWebviewPanelSerializer('raven.knitOutput', {
+                deserializeWebviewPanel: async (panel, state) => {
+                    if (!readPersistPreview()) {
+                        panel.dispose();
+                        return;
+                    }
+                    await KnitOutputPanel.restore(context, panel, state, knitOutput);
+                },
+            }),
+        );
+    }
+
+    // Manual cache reclaim. Removes orphaned per-session preview dirs
+    // left by prior windows/restarts. Safe with concurrent windows: it
+    // never touches the current session, nor any session touched within
+    // a short age threshold (a concurrent window may be live there).
+    context.subscriptions.push(
+        vscode.commands.registerCommand('raven.knit.cleanupCache', () =>
+            cleanupPreviewCache(knitOutput),
+        ),
+    );
+
     // Export commands (Pandoc-driven HTML/PDF/Word). The resolver is
     // shared across export invocations so the once-per-session probe is
     // amortized; settings changes invalidate the cache.
@@ -187,6 +227,128 @@ export function registerKnit(
             KnitOutputPanel.notifyExportBusy(rmdAbsPath, busy);
         },
     });
+}
+
+/**
+ * Set once the WebviewPanelSerializer has been registered this process.
+ * `registerKnit` normally runs once per activation, but the session-init
+ * guard shows it can re-run in dev reloads; re-registering a serializer
+ * for the same view type throws.
+ */
+let knitSerializerRegistered = false;
+
+/** Age below which a non-current session dir is spared by cleanup. */
+const CLEANUP_AGE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Read `raven.knit.persistPreview` live. Window-scoped (not resource-
+ * scoped) so it reads cleanly without a source URI — the deactivation
+ * cleanup path has no document to resolve a resource scope against.
+ */
+function readPersistPreview(): boolean {
+    return vscode.workspace
+        .getConfiguration('raven.knit')
+        .get<boolean>('persistPreview', true);
+}
+
+/**
+ * `Raven: Clean Up Knit Preview Cache` handler. Walks
+ * `<tmp>/raven-knit/<workspaceHash>/<sessionId>/`, computes each
+ * session's recency, and removes the stale orphans
+ * (`selectStaleSessionDirs`). The selection predicate is pure and
+ * unit-tested; this function owns only the impure walk + removal.
+ */
+async function cleanupPreviewCache(output: vscode.OutputChannel): Promise<void> {
+    const root = ravenKnitRoot();
+    const currentSessionId = maybeCurrentSession()?.sessionId ?? '';
+
+    let workspaceDirs: import('fs').Dirent[];
+    try {
+        workspaceDirs = await fs.promises.readdir(root, { withFileTypes: true });
+    } catch {
+        void vscode.window.showInformationMessage(
+            'Raven: Knit — no preview cache to clean up.',
+        );
+        return;
+    }
+
+    const sessions: SessionDirInfo[] = [];
+    for (const wd of workspaceDirs) {
+        if (!wd.isDirectory()) continue;
+        const wdPath = path.join(root, wd.name);
+        let sessDirs: import('fs').Dirent[];
+        try {
+            sessDirs = await fs.promises.readdir(wdPath, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const sd of sessDirs) {
+            if (!sd.isDirectory()) continue;
+            const sPath = path.join(wdPath, sd.name);
+            sessions.push({
+                path: sPath,
+                sessionId: sd.name,
+                recencyMs: await sessionRecencyMs(sPath),
+            });
+        }
+    }
+
+    const toRemove = selectStaleSessionDirs({
+        sessions,
+        currentSessionId,
+        nowMs: Date.now(),
+        ageThresholdMs: CLEANUP_AGE_THRESHOLD_MS,
+    });
+
+    let removed = 0;
+    for (const p of toRemove) {
+        try {
+            await fs.promises.rm(p, { recursive: true, force: true });
+            removed++;
+        } catch (err) {
+            output.appendLine(
+                `[cleanup] failed to remove ${p}: ${(err as Error).message}`,
+            );
+        }
+    }
+
+    void vscode.window.showInformationMessage(
+        removed === 0
+            ? 'Raven: Knit — no stale preview directories to clean up.'
+            : `Raven: Knit — cleaned up ${removed} stale preview ` +
+              `${removed === 1 ? 'directory' : 'directories'}.`,
+    );
+}
+
+/**
+ * Recency (max mtime, ms) of a session dir and its immediate `preview/`
+ * children — so a session actively rendering in another window reads as
+ * recent even though the top-level dir mtime can lag behind writes that
+ * land inside `preview/<sourceHash>/`.
+ */
+async function sessionRecencyMs(sessionPath: string): Promise<number> {
+    let max = 0;
+    try {
+        max = (await fs.promises.stat(sessionPath)).mtimeMs;
+    } catch {
+        /* ignore */
+    }
+    const previewDir = path.join(sessionPath, 'preview');
+    let entries: import('fs').Dirent[];
+    try {
+        entries = await fs.promises.readdir(previewDir, { withFileTypes: true });
+    } catch {
+        return max;
+    }
+    for (const e of entries) {
+        try {
+            const st = await fs.promises.stat(path.join(previewDir, e.name));
+            if (st.mtimeMs > max) max = st.mtimeMs;
+        } catch {
+            /* ignore */
+        }
+    }
+    return max;
 }
 
 /**

--- a/editors/vscode/src/knit/index.ts
+++ b/editors/vscode/src/knit/index.ts
@@ -1,8 +1,6 @@
 import * as child_process from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import type { LanguageClient } from 'vscode-languageclient/node';
 import { registerKnitCommands, runKnitWithExistingController } from './knit-commands';
@@ -20,9 +18,9 @@ import { registerExportCommands } from './export-commands';
 import { KnitOutputPanel } from './knit-output-panel';
 import { previewArtifactPaths } from './raven-knit-paths';
 import {
+    listSessionDirs,
     ravenKnitRoot,
     selectStaleSessionDirs,
-    type SessionDirInfo,
 } from './preview-persistence';
 import { isPandocVersionOutput } from './pandoc-probe';
 
@@ -84,7 +82,7 @@ export function registerKnit(
         });
         // Non-blocking sweep of orphaned sibling sessions. Best effort —
         // errors are swallowed inside `sweepStaleSessions`.
-        void sweepStaleSessions(path.join(os.tmpdir(), 'raven-knit'));
+        void sweepStaleSessions(ravenKnitRoot());
     }
 
     // One shared output channel for both knit and export. Two
@@ -259,40 +257,8 @@ function readPersistPreview(): boolean {
  * unit-tested; this function owns only the impure walk + removal.
  */
 async function cleanupPreviewCache(output: vscode.OutputChannel): Promise<void> {
-    const root = ravenKnitRoot();
     const currentSessionId = maybeCurrentSession()?.sessionId ?? '';
-
-    let workspaceDirs: import('fs').Dirent[];
-    try {
-        workspaceDirs = await fs.promises.readdir(root, { withFileTypes: true });
-    } catch {
-        void vscode.window.showInformationMessage(
-            'Raven: Knit — no preview cache to clean up.',
-        );
-        return;
-    }
-
-    const sessions: SessionDirInfo[] = [];
-    for (const wd of workspaceDirs) {
-        if (!wd.isDirectory()) continue;
-        const wdPath = path.join(root, wd.name);
-        let sessDirs: import('fs').Dirent[];
-        try {
-            sessDirs = await fs.promises.readdir(wdPath, { withFileTypes: true });
-        } catch {
-            continue;
-        }
-        for (const sd of sessDirs) {
-            if (!sd.isDirectory()) continue;
-            const sPath = path.join(wdPath, sd.name);
-            sessions.push({
-                path: sPath,
-                sessionId: sd.name,
-                recencyMs: await sessionRecencyMs(sPath),
-            });
-        }
-    }
-
+    const sessions = await listSessionDirs(ravenKnitRoot());
     const toRemove = selectStaleSessionDirs({
         sessions,
         currentSessionId,
@@ -318,37 +284,6 @@ async function cleanupPreviewCache(output: vscode.OutputChannel): Promise<void> 
             : `Raven: Knit — cleaned up ${removed} stale preview ` +
               `${removed === 1 ? 'directory' : 'directories'}.`,
     );
-}
-
-/**
- * Recency (max mtime, ms) of a session dir and its immediate `preview/`
- * children — so a session actively rendering in another window reads as
- * recent even though the top-level dir mtime can lag behind writes that
- * land inside `preview/<sourceHash>/`.
- */
-async function sessionRecencyMs(sessionPath: string): Promise<number> {
-    let max = 0;
-    try {
-        max = (await fs.promises.stat(sessionPath)).mtimeMs;
-    } catch {
-        /* ignore */
-    }
-    const previewDir = path.join(sessionPath, 'preview');
-    let entries: import('fs').Dirent[];
-    try {
-        entries = await fs.promises.readdir(previewDir, { withFileTypes: true });
-    } catch {
-        return max;
-    }
-    for (const e of entries) {
-        try {
-            const st = await fs.promises.stat(path.join(previewDir, e.name));
-            if (st.mtimeMs > max) max = st.mtimeMs;
-        } catch {
-            /* ignore */
-        }
-    }
-    return max;
 }
 
 /**

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -387,7 +387,6 @@ export class KnitOutputPanel {
                 localResourceRoots: [vscode.Uri.file(rootDir)],
             },
         );
-        applyViewerTabIcon(panel, 'book');
         return KnitOutputPanel.wireAndRegister(context, panel, args, rootDir);
     }
 
@@ -429,6 +428,22 @@ export class KnitOutputPanel {
         }
 
         const sourceUri = vscode.Uri.file(sourceFsPath);
+
+        // A live panel for this source may already exist when the
+        // serializer fires (a knit completed during activation, or
+        // "Developer: Reload Webviews"). Keep the existing one as
+        // authoritative and drop the duplicate VS Code just handed us —
+        // registering the new one would orphan the old panel and its
+        // dispose handler. (`create` never hits this because `showOrUpdate`
+        // resolves any existing instance before calling it.)
+        const existing = KnitOutputPanel.instances.get(sourceUri.fsPath);
+        if (existing && !existing.disposed) {
+            const col = existing.panel.viewColumn ?? existing.lastKnownColumn;
+            existing.panel.reveal(col, true);
+            panel.dispose();
+            return;
+        }
+
         let current: { previewDir: string; htmlPath: string };
         try {
             const paths = previewArtifactPaths(sourceFsPath);
@@ -448,7 +463,6 @@ export class KnitOutputPanel {
             enableScripts: true,
             localResourceRoots: [vscode.Uri.file(rootDir)],
         };
-        applyViewerTabIcon(panel, 'book');
         if (!adopt.available) {
             output.appendLine(
                 `[restore] ${sourceFsPath}: no rendered artifact to restore ` +
@@ -482,6 +496,9 @@ export class KnitOutputPanel {
         rootDir: string,
     ): KnitOutputPanel {
         const key = args.sourceUri.fsPath;
+        // Tab icon is set here (the shared path) so `create` and `restore`
+        // can't drift on it.
+        applyViewerTabIcon(panel, 'book');
         const instance = new KnitOutputPanel(context, panel, rootDir, args);
         KnitOutputPanel.instances.set(key, instance);
 

--- a/editors/vscode/src/knit/knit-output-panel.ts
+++ b/editors/vscode/src/knit/knit-output-panel.ts
@@ -15,6 +15,8 @@ import {
     type ResolvedFonts,
 } from './render-html';
 import { inlineLocalImagesAsDataUrls } from './inline-images';
+import { previewArtifactPaths } from './raven-knit-paths';
+import { adoptPreviewArtifacts } from './preview-persistence';
 import { getKnitGrammarRegistry } from './post-knit-renderer';
 import {
     resolveActiveThemePalette,
@@ -374,7 +376,6 @@ export class KnitOutputPanel {
         rootDir: string,
         column: vscode.ViewColumn,
     ): KnitOutputPanel {
-        const key = args.sourceUri.fsPath;
         const panel = vscode.window.createWebviewPanel(
             'raven.knitOutput',
             'Knit Preview',
@@ -387,6 +388,100 @@ export class KnitOutputPanel {
             },
         );
         applyViewerTabIcon(panel, 'book');
+        return KnitOutputPanel.wireAndRegister(context, panel, args, rootDir);
+    }
+
+    /**
+     * Rebuild a panel that VS Code is restoring after a window
+     * reload/restart, from the `{ sourceFsPath, outputPath }` record the
+     * shell's `setState` persisted. Called by the
+     * `WebviewPanelSerializer` registered in `knit/index.ts` (which has
+     * already confirmed `raven.knit.persistPreview` is enabled — when it
+     * isn't, the serializer disposes the panel instead of calling here).
+     *
+     * The orphaned old-session artifact is adopted into the current
+     * session's preview path (`adoptPreviewArtifacts`) so a later "Knit
+     * again" is a normal in-place update. When nothing is left to adopt
+     * the panel still rebuilds, showing the "knit again" placeholder
+     * (`updateContent`'s read-failure branch) — the toolbar's Knit-again
+     * button only needs the source URI.
+     *
+     * VS Code does NOT persist `webview.options`, so `enableScripts` and
+     * `localResourceRoots` must be re-applied here. `enableFindWidget` /
+     * `retainContextWhenHidden` are `WebviewPanelOptions` (fixed at
+     * creation) and are restored by VS Code from the serialized panel —
+     * they cannot be set post-construction and are intentionally not
+     * touched here.
+     */
+    static async restore(
+        context: vscode.ExtensionContext,
+        panel: vscode.WebviewPanel,
+        state: unknown,
+        output: vscode.OutputChannel,
+    ): Promise<void> {
+        const s = (state ?? {}) as { sourceFsPath?: unknown; outputPath?: unknown };
+        const sourceFsPath = typeof s.sourceFsPath === 'string' ? s.sourceFsPath : '';
+        const persistedOutputPath = typeof s.outputPath === 'string' ? s.outputPath : '';
+        if (sourceFsPath.length === 0) {
+            // No source recorded — nothing actionable to restore.
+            panel.dispose();
+            return;
+        }
+
+        const sourceUri = vscode.Uri.file(sourceFsPath);
+        let current: { previewDir: string; htmlPath: string };
+        try {
+            const paths = previewArtifactPaths(sourceFsPath);
+            current = { previewDir: paths.previewDir, htmlPath: paths.htmlPath };
+        } catch {
+            // Session state not initialized (shouldn't happen — registerKnit
+            // runs before the serializer can fire). Bail gracefully.
+            panel.dispose();
+            return;
+        }
+
+        const adopt = adoptPreviewArtifacts(current, persistedOutputPath);
+        const htmlPath = adopt.htmlPath;
+        const rootDir = path.dirname(htmlPath);
+        // Re-apply the WebviewOptions VS Code dropped on serialization.
+        panel.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [vscode.Uri.file(rootDir)],
+        };
+        applyViewerTabIcon(panel, 'book');
+        if (!adopt.available) {
+            output.appendLine(
+                `[restore] ${sourceFsPath}: no rendered artifact to restore ` +
+                `(${adopt.reason}); showing the knit-again placeholder.`,
+            );
+        }
+        KnitOutputPanel.wireAndRegister(
+            context,
+            panel,
+            { sourceUri, outputPath: htmlPath, output },
+            rootDir,
+        );
+    }
+
+    /**
+     * Shared post-creation wiring for both `create` (fresh panel) and
+     * `restore` (serializer-rebuilt panel): construct the instance,
+     * register it in the per-source map, anchor the preview column,
+     * attach the view-state / dispose / theme / config listeners, and
+     * render the initial content. Keeping this in one place means the two
+     * entry points cannot drift in their lifecycle handling.
+     */
+    private static wireAndRegister(
+        context: vscode.ExtensionContext,
+        panel: vscode.WebviewPanel,
+        args: {
+            sourceUri: vscode.Uri;
+            outputPath: string;
+            output: vscode.OutputChannel;
+        },
+        rootDir: string,
+    ): KnitOutputPanel {
+        const key = args.sourceUri.fsPath;
         const instance = new KnitOutputPanel(context, panel, rootDir, args);
         KnitOutputPanel.instances.set(key, instance);
 
@@ -599,8 +694,14 @@ export class KnitOutputPanel {
             this.output.appendLine(
                 `[panel] read failed: ${err instanceof Error ? err.message : String(err)}`,
             );
-            htmlContent = '<!doctype html><html><body><p>Raven: Knit Preview — '
-                + 'could not read the rendered output. Use Open in Browser instead.'
+            // Reached both when a live render's `.html` is unreadable and
+            // when a restored panel has no artifact left to show. The
+            // toolbar (including Knit again) is rendered by the
+            // surrounding shell regardless, so point the user at it.
+            htmlContent = '<!doctype html><html><body style="font-family: var(--vscode-font-family); '
+                + 'padding: 1rem; color: var(--vscode-foreground);"><p>'
+                + 'This preview is no longer available. Press <strong>Knit again</strong> '
+                + '(the refresh button above) to regenerate it.'
                 + '</p></body></html>';
         }
         // Subresources in the rendered HTML (CSS, images, fonts)
@@ -638,6 +739,8 @@ export class KnitOutputPanel {
             cspSource: this.panel.webview.cspSource,
             outputPath: args.outputPath,
             nonce,
+            // Persisted into webview state for the serializer restore path.
+            sourceFsPath: this.sourceUri.fsPath,
             initialThemeApplied: KnitOutputPanel.readThemePreference(this.context),
             // Resolved palette is delivered out-of-band via
             // postMessage from `pushVscodeThemePalette` — the

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -343,6 +343,16 @@ export function buildShellHtml(args: {
     outputPath: string;
     nonce: string;
     /**
+     * Absolute path of the source `.Rmd`. Persisted into the webview's
+     * `setState` (alongside `outputPath`) so the `WebviewPanelSerializer`
+     * can rebuild the panel after a window reload/restart: `outputPath`
+     * locates the (old-session) rendered artifact to adopt, and
+     * `sourceFsPath` is what "Knit again" and the current-session path
+     * computation need. Omitted/empty in unit tests that don't exercise
+     * persistence — `setState` is then skipped.
+     */
+    sourceFsPath?: string;
+    /**
      * Persisted theme-toggle state. Caller reads it from
      * `context.globalState` so the choice survives panel disposal /
      * recreation between knits.
@@ -390,6 +400,7 @@ export function buildShellHtml(args: {
         cspSource,
         outputPath,
         nonce,
+        sourceFsPath = '',
         initialThemeApplied,
         vscodeThemePaletteCss,
         vscodeFontFamiliesCss,
@@ -691,6 +702,20 @@ export function buildShellHtml(args: {
   <script nonce="${nonce}">
     (function () {
       const vscode = acquireVsCodeApi();
+      // Persist enough for the WebviewPanelSerializer to rebuild this
+      // panel after a window reload/restart: the source .Rmd path and
+      // the rendered HTML path. VS Code returns this object to
+      // \`deserializeWebviewPanel\` on the next launch. Empty
+      // sourceFsPath means a non-persistence caller (e.g. a unit test)
+      // built the shell — skip setState so we don't store a useless
+      // record.
+      var ravenRestoreState = {
+        sourceFsPath: ${JSON.stringify(sourceFsPath)},
+        outputPath: ${JSON.stringify(outputPath)},
+      };
+      if (ravenRestoreState.sourceFsPath) {
+        try { vscode.setState(ravenRestoreState); } catch (e) { /* setState unavailable */ }
+      }
       const iframe = document.getElementById('raven-knit-frame');
       const themeBtn = document.getElementById('raven-knit-theme');
       let loadFired = false;

--- a/editors/vscode/src/knit/knit-output.ts
+++ b/editors/vscode/src/knit/knit-output.ts
@@ -305,6 +305,19 @@ function escapeHtml(s: string): string {
 }
 
 /**
+ * Serialize a (possibly user-controlled) string to a JS literal safe to
+ * embed inside an inline `<script>`. `JSON.stringify` does not escape
+ * `<`, so a value containing `</script>` (legal in a filesystem path)
+ * would otherwise terminate the script element early — both a breakage
+ * and an HTML-injection vector. Replacing each `<` with its `<` JS
+ * unicode escape keeps the literal valid JS while neutralizing
+ * `</script>` and `<!--`.
+ */
+function jsonForScript(value: string): string {
+    return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+/**
  * Build the outer-shell HTML for the Knit Preview webview.
  *
  * The shell is Raven-controlled and owns the CSP in `<head>`; the
@@ -710,8 +723,8 @@ export function buildShellHtml(args: {
       // built the shell — skip setState so we don't store a useless
       // record.
       var ravenRestoreState = {
-        sourceFsPath: ${JSON.stringify(sourceFsPath)},
-        outputPath: ${JSON.stringify(outputPath)},
+        sourceFsPath: ${jsonForScript(sourceFsPath)},
+        outputPath: ${jsonForScript(outputPath)},
       };
       if (ravenRestoreState.sourceFsPath) {
         try { vscode.setState(ravenRestoreState); } catch (e) { /* setState unavailable */ }

--- a/editors/vscode/src/knit/preview-persistence.ts
+++ b/editors/vscode/src/knit/preview-persistence.ts
@@ -133,15 +133,12 @@ export function adoptPreviewArtifacts(
     }
 
     // (4) Adopt the old-session dir if its artifact is still on disk.
+    // (When the persisted dir already IS the current path — e.g. the
+    // session id was unchanged on an in-process reload — its HTML would
+    // exist and step 2 has already returned 'reused'; so here the source
+    // and destination are always distinct.)
     if (io.existsSync(persistedOutputPath)) {
         const oldPreviewDir = path.dirname(persistedOutputPath);
-        // No-op guard: if the persisted dir already IS the current path
-        // (e.g. session id unchanged), there is nothing to move.
-        if (path.resolve(oldPreviewDir) === path.resolve(current.previewDir)) {
-            return io.existsSync(htmlPath)
-                ? { htmlPath, available: true, reason: 'reused' }
-                : { htmlPath, available: false, reason: 'missing-source' };
-        }
         // Move the old dir into the current-session path. This must never
         // throw out of restore: any filesystem failure (EXDEV with a
         // failed copy, EACCES, ENOSPC, …) degrades to the placeholder,
@@ -260,7 +257,9 @@ export async function listSessionDirs(root: string): Promise<SessionDirInfo[]> {
     } catch {
         return [];
     }
-    const out: SessionDirInfo[] = [];
+    // Collect the session dirs first, then compute their recencies
+    // concurrently — the per-session stat walks are independent.
+    const found: Array<{ path: string; sessionId: string }> = [];
     for (const wd of workspaceDirs) {
         if (!wd.isDirectory()) continue;
         const wdPath = path.join(root, wd.name);
@@ -272,13 +271,14 @@ export async function listSessionDirs(root: string): Promise<SessionDirInfo[]> {
         }
         for (const sd of sessDirs) {
             if (!sd.isDirectory()) continue;
-            const sPath = path.join(wdPath, sd.name);
-            out.push({
-                path: sPath,
-                sessionId: sd.name,
-                recencyMs: await sessionRecencyMs(sPath),
-            });
+            found.push({ path: path.join(wdPath, sd.name), sessionId: sd.name });
         }
     }
-    return out;
+    return Promise.all(
+        found.map(async (f) => ({
+            path: f.path,
+            sessionId: f.sessionId,
+            recencyMs: await sessionRecencyMs(f.path),
+        })),
+    );
 }

--- a/editors/vscode/src/knit/preview-persistence.ts
+++ b/editors/vscode/src/knit/preview-persistence.ts
@@ -20,14 +20,12 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
-import { isUnderContainmentRoot } from './raven-knit-paths';
+import { isUnderContainmentRoot, ravenKnitRoot } from './raven-knit-paths';
 
-/** Root under which every per-session knit artifact lives. */
-export function ravenKnitRoot(): string {
-    return path.join(os.tmpdir(), 'raven-knit');
-}
+// Re-exported so persistence callers can reach the knit-temp root without
+// also importing the path module. `raven-knit-paths` is the single owner.
+export { ravenKnitRoot };
 
 /**
  * The pair of paths a restore targets for a given source: the
@@ -144,23 +142,32 @@ export function adoptPreviewArtifacts(
                 ? { htmlPath, available: true, reason: 'reused' }
                 : { htmlPath, available: false, reason: 'missing-source' };
         }
-        io.mkdirSync(path.dirname(current.previewDir));
+        // Move the old dir into the current-session path. This must never
+        // throw out of restore: any filesystem failure (EXDEV with a
+        // failed copy, EACCES, ENOSPC, …) degrades to the placeholder,
+        // detected by the existsSync check below.
         try {
-            io.renameSync(oldPreviewDir, current.previewDir);
-        } catch {
-            // Cross-device (EXDEV) or other rename failure: copy then
-            // best-effort remove the source.
-            io.cpSync(oldPreviewDir, current.previewDir);
+            io.mkdirSync(path.dirname(current.previewDir));
             try {
-                io.rmSync(oldPreviewDir);
+                io.renameSync(oldPreviewDir, current.previewDir);
             } catch {
-                /* best-effort — source left behind, swept later */
+                // Cross-device (EXDEV) or other rename failure: copy then
+                // best-effort remove the source.
+                io.cpSync(oldPreviewDir, current.previewDir);
+                try {
+                    io.rmSync(oldPreviewDir);
+                } catch {
+                    /* best-effort — source left behind, swept later */
+                }
             }
+        } catch {
+            /* fall through — existsSync(htmlPath) below decides the outcome */
         }
-        io.touch(current.previewDir);
-        return io.existsSync(htmlPath)
-            ? { htmlPath, available: true, reason: 'adopted' }
-            : { htmlPath, available: false, reason: 'missing-source' };
+        if (io.existsSync(htmlPath)) {
+            io.touch(current.previewDir);
+            return { htmlPath, available: true, reason: 'adopted' };
+        }
+        return { htmlPath, available: false, reason: 'missing-source' };
     }
 
     return { htmlPath, available: false, reason: 'missing-source' };
@@ -201,4 +208,77 @@ export function selectStaleSessionDirs(args: {
         .filter((s) => s.sessionId !== args.currentSessionId)
         .filter((s) => args.nowMs - s.recencyMs > args.ageThresholdMs)
         .map((s) => s.path);
+}
+
+/**
+ * Recency (max mtime, ms) of a session dir and its immediate `preview/`
+ * children — so a session actively rendering in another window reads as
+ * recent even though the top-level dir mtime can lag behind writes that
+ * land inside `preview/<sourceHash>/`. Returns 0 when the dir is gone.
+ */
+export async function sessionRecencyMs(sessionPath: string): Promise<number> {
+    let max = 0;
+    try {
+        max = (await fs.promises.stat(sessionPath)).mtimeMs;
+    } catch {
+        /* ignore */
+    }
+    const previewDir = path.join(sessionPath, 'preview');
+    let entries: fs.Dirent[];
+    try {
+        entries = await fs.promises.readdir(previewDir, { withFileTypes: true });
+    } catch {
+        return max;
+    }
+    const childMtimes = await Promise.all(
+        entries.map(async (e) => {
+            try {
+                return (await fs.promises.stat(path.join(previewDir, e.name))).mtimeMs;
+            } catch {
+                return 0;
+            }
+        }),
+    );
+    for (const m of childMtimes) {
+        if (m > max) max = m;
+    }
+    return max;
+}
+
+/**
+ * Walk `<root>/<workspaceHash>/<sessionId>/` and return one
+ * `SessionDirInfo` per discovered session directory (with its recency).
+ * Shared by both reclaimers — the activation-time `sweepStaleSessions`
+ * and the manual `Raven: Clean Up Knit Preview Cache` — so they observe
+ * the same tree shape and recency definition and cannot drift. Returns
+ * `[]` when the root does not exist.
+ */
+export async function listSessionDirs(root: string): Promise<SessionDirInfo[]> {
+    let workspaceDirs: fs.Dirent[];
+    try {
+        workspaceDirs = await fs.promises.readdir(root, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    const out: SessionDirInfo[] = [];
+    for (const wd of workspaceDirs) {
+        if (!wd.isDirectory()) continue;
+        const wdPath = path.join(root, wd.name);
+        let sessDirs: fs.Dirent[];
+        try {
+            sessDirs = await fs.promises.readdir(wdPath, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const sd of sessDirs) {
+            if (!sd.isDirectory()) continue;
+            const sPath = path.join(wdPath, sd.name);
+            out.push({
+                path: sPath,
+                sessionId: sd.name,
+                recencyMs: await sessionRecencyMs(sPath),
+            });
+        }
+    }
+    return out;
 }

--- a/editors/vscode/src/knit/preview-persistence.ts
+++ b/editors/vscode/src/knit/preview-persistence.ts
@@ -139,6 +139,16 @@ export function adoptPreviewArtifacts(
     // and destination are always distinct.)
     if (io.existsSync(persistedOutputPath)) {
         const oldPreviewDir = path.dirname(persistedOutputPath);
+        // Safety: only adopt a preview dir that belongs to THIS source.
+        // Its directory name is the source hash, which is identical to the
+        // current-session preview dir's name (same `.Rmd` → same hash,
+        // regardless of session/workspace). Containment alone would let a
+        // crafted or corrupt persisted path point at a whole session /
+        // workspace / other-source directory, which the move below would
+        // then relocate wholesale.
+        if (path.basename(oldPreviewDir) !== path.basename(current.previewDir)) {
+            return { htmlPath, available: false, reason: 'rejected-path' };
+        }
         // Move the old dir into the current-session path. This must never
         // throw out of restore: any filesystem failure (EXDEV with a
         // failed copy, EACCES, ENOSPC, …) degrades to the placeholder,
@@ -203,6 +213,12 @@ export function selectStaleSessionDirs(args: {
 }): string[] {
     return args.sessions
         .filter((s) => s.sessionId !== args.currentSessionId)
+        // Unknown recency (<= 0 — e.g. a stat that failed under fd
+        // pressure) means "don't know how old this is"; never delete it.
+        // Without this guard `nowMs - 0 > ageThresholdMs` is always true,
+        // so a transient stat failure on a live session would select it
+        // for removal.
+        .filter((s) => s.recencyMs > 0)
         .filter((s) => args.nowMs - s.recencyMs > args.ageThresholdMs)
         .map((s) => s.path);
 }
@@ -274,11 +290,21 @@ export async function listSessionDirs(root: string): Promise<SessionDirInfo[]> {
             found.push({ path: path.join(wdPath, sd.name), sessionId: sd.name });
         }
     }
-    return Promise.all(
-        found.map(async (f) => ({
-            path: f.path,
-            sessionId: f.sessionId,
-            recencyMs: await sessionRecencyMs(f.path),
-        })),
-    );
+    // Compute recencies in bounded batches: each session's stat walk
+    // opens several fds, so an unbounded fan-out over a large accumulated
+    // cache could exhaust the process fd limit (EMFILE).
+    const RECENCY_CONCURRENCY = 16;
+    const out: SessionDirInfo[] = [];
+    for (let i = 0; i < found.length; i += RECENCY_CONCURRENCY) {
+        const batch = found.slice(i, i + RECENCY_CONCURRENCY);
+        const resolved = await Promise.all(
+            batch.map(async (f) => ({
+                path: f.path,
+                sessionId: f.sessionId,
+                recencyMs: await sessionRecencyMs(f.path),
+            })),
+        );
+        out.push(...resolved);
+    }
+    return out;
 }

--- a/editors/vscode/src/knit/preview-persistence.ts
+++ b/editors/vscode/src/knit/preview-persistence.ts
@@ -1,0 +1,204 @@
+/**
+ * Filesystem helpers backing Knit Preview persistence across window
+ * reload/restart.
+ *
+ * Two concerns live here, deliberately kept apart from the `vscode`-aware
+ * panel code so they can be unit-tested under `bun test`:
+ *
+ *  - `adoptPreviewArtifacts` — on restore, fold the orphaned old-session
+ *    preview dir (recorded in the webview's persisted state) into the
+ *    *current* session's preview path for that source. Adoption keeps the
+ *    path model consistent: a later "Knit again" is then a normal in-place
+ *    update (same `rootDir`) rather than a `rootDir` change that would
+ *    dispose-and-recreate the panel.
+ *  - `selectStaleSessionDirs` — the pure selection predicate behind the
+ *    `Raven: Clean Up Knit Preview Cache` command. The impure directory
+ *    walk lives in the command handler; this predicate decides what to
+ *    remove given a listing, so it is testable without touching disk.
+ *
+ * See `docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md`.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isUnderContainmentRoot } from './raven-knit-paths';
+
+/** Root under which every per-session knit artifact lives. */
+export function ravenKnitRoot(): string {
+    return path.join(os.tmpdir(), 'raven-knit');
+}
+
+/**
+ * The pair of paths a restore targets for a given source: the
+ * current-session preview directory and the rendered HTML inside it.
+ * Callers compute this via `previewArtifactPaths(sourceFsPath)`.
+ */
+export interface CurrentPreviewPaths {
+    previewDir: string;
+    htmlPath: string;
+}
+
+export interface AdoptOutcome {
+    /**
+     * The HTML path the restored panel should point at — always the
+     * *current* session's preview HTML path, whether or not a usable
+     * artifact exists there. Pointing at the current-session path means a
+     * subsequent "Knit again" writes to the same dir (no `rootDir`
+     * change), and the panel updates in place.
+     */
+    htmlPath: string;
+    /**
+     * True when a readable rendered artifact now exists at `htmlPath`
+     * (either it already did, or we adopted the old-session dir into
+     * place). False means the caller should render the "knit again"
+     * placeholder — there was nothing to restore.
+     */
+    available: boolean;
+    /** Coarse reason, for logging/tests. */
+    reason: 'reused' | 'adopted' | 'in-progress' | 'rejected-path' | 'missing-source';
+}
+
+/**
+ * Injection seam so the EXDEV copy-fallback branch is unit-testable.
+ * Production omits it and the real `fs` module is used.
+ */
+export interface AdoptIo {
+    existsSync(p: string): boolean;
+    renameSync(src: string, dst: string): void;
+    cpSync(src: string, dst: string): void;
+    rmSync(p: string): void;
+    mkdirSync(p: string): void;
+    /** Best-effort touch (reset mtime) so the stale sweep clock restarts. */
+    touch(p: string): void;
+}
+
+const realIo: AdoptIo = {
+    existsSync: (p) => fs.existsSync(p),
+    renameSync: (src, dst) => fs.renameSync(src, dst),
+    cpSync: (src, dst) => fs.cpSync(src, dst, { recursive: true }),
+    rmSync: (p) => fs.rmSync(p, { recursive: true, force: true }),
+    mkdirSync: (p) => { fs.mkdirSync(p, { recursive: true }); },
+    touch: (p) => {
+        try {
+            const now = new Date();
+            fs.utimesSync(p, now, now);
+        } catch {
+            /* best-effort */
+        }
+    },
+};
+
+/**
+ * Decide what a restoring panel should display, adopting the orphaned
+ * old-session preview dir into the current session when appropriate.
+ *
+ * Order of checks (each falls through to "render placeholder"):
+ *  1. **Containment.** `persistedOutputPath` must resolve inside
+ *     `<tmp>/raven-knit/`. Persisted webview state crosses a trust
+ *     boundary; never drive a `rename`/`rm` from a path outside the tree.
+ *  2. **Already present.** If the current-session HTML already exists, use
+ *     it — a knit ran this session; nothing to adopt.
+ *  3. **In-progress / partial.** If the current-session preview *dir*
+ *     exists but its HTML does not, a knit is mid-flight (knit-commands
+ *     `mkdir`s the dir before writing). Do not clobber it; show the
+ *     placeholder and let that knit update the panel in place when done.
+ *  4. **Adopt.** If the persisted HTML exists on disk, move its parent dir
+ *     into the current-session preview path (rename, falling back to
+ *     recursive copy + remove on EXDEV), reset mtime, and use it.
+ *  5. Otherwise the source artifact is gone → placeholder.
+ */
+export function adoptPreviewArtifacts(
+    current: CurrentPreviewPaths,
+    persistedOutputPath: string,
+    io: AdoptIo = realIo,
+): AdoptOutcome {
+    const htmlPath = current.htmlPath;
+
+    // (1) Containment — reject anything outside the knit temp tree.
+    if (
+        typeof persistedOutputPath !== 'string'
+        || persistedOutputPath.length === 0
+        || !isUnderContainmentRoot(persistedOutputPath, ravenKnitRoot())
+    ) {
+        return { htmlPath, available: false, reason: 'rejected-path' };
+    }
+
+    // (2) Current-session output already present.
+    if (io.existsSync(htmlPath)) {
+        return { htmlPath, available: true, reason: 'reused' };
+    }
+
+    // (3) Current-session dir exists without its HTML → knit in progress.
+    if (io.existsSync(current.previewDir)) {
+        return { htmlPath, available: false, reason: 'in-progress' };
+    }
+
+    // (4) Adopt the old-session dir if its artifact is still on disk.
+    if (io.existsSync(persistedOutputPath)) {
+        const oldPreviewDir = path.dirname(persistedOutputPath);
+        // No-op guard: if the persisted dir already IS the current path
+        // (e.g. session id unchanged), there is nothing to move.
+        if (path.resolve(oldPreviewDir) === path.resolve(current.previewDir)) {
+            return io.existsSync(htmlPath)
+                ? { htmlPath, available: true, reason: 'reused' }
+                : { htmlPath, available: false, reason: 'missing-source' };
+        }
+        io.mkdirSync(path.dirname(current.previewDir));
+        try {
+            io.renameSync(oldPreviewDir, current.previewDir);
+        } catch {
+            // Cross-device (EXDEV) or other rename failure: copy then
+            // best-effort remove the source.
+            io.cpSync(oldPreviewDir, current.previewDir);
+            try {
+                io.rmSync(oldPreviewDir);
+            } catch {
+                /* best-effort — source left behind, swept later */
+            }
+        }
+        io.touch(current.previewDir);
+        return io.existsSync(htmlPath)
+            ? { htmlPath, available: true, reason: 'adopted' }
+            : { htmlPath, available: false, reason: 'missing-source' };
+    }
+
+    return { htmlPath, available: false, reason: 'missing-source' };
+}
+
+/** One discovered `<workspaceHash>/<sessionId>` session directory. */
+export interface SessionDirInfo {
+    /** Absolute path to the session directory. */
+    path: string;
+    /** The `<sessionId>` segment (directory name). */
+    sessionId: string;
+    /**
+     * Most recent activity timestamp (ms) observed for this session —
+     * the max mtime of the session dir and its immediate `preview/`
+     * children, so an actively-rendering session in another window reads
+     * as recent even though the top-level dir mtime may lag.
+     */
+    recencyMs: number;
+}
+
+/**
+ * Pure selection predicate for `Raven: Clean Up Knit Preview Cache`.
+ *
+ * Removes only *orphaned* session dirs: never the current session (its
+ * open panels — and any in-flight knit — live there), and never a session
+ * touched within `ageThresholdMs` (a concurrent window may be actively
+ * using it; session ownership cannot be determined cross-process, so
+ * recency is the only safe cross-window signal). Everything else is
+ * reclaimable.
+ */
+export function selectStaleSessionDirs(args: {
+    sessions: readonly SessionDirInfo[];
+    currentSessionId: string;
+    nowMs: number;
+    ageThresholdMs: number;
+}): string[] {
+    return args.sessions
+        .filter((s) => s.sessionId !== args.currentSessionId)
+        .filter((s) => args.nowMs - s.recencyMs > args.ageThresholdMs)
+        .map((s) => s.path);
+}

--- a/editors/vscode/src/knit/raven-knit-paths.ts
+++ b/editors/vscode/src/knit/raven-knit-paths.ts
@@ -82,9 +82,19 @@ export function isUnderContainmentRoot(absPath: string, root: string): boolean {
     return !rel.startsWith('..') && !path.isAbsolute(rel);
 }
 
+/**
+ * Root under which every per-session knit artifact lives:
+ * `<os.tmpdir()>/raven-knit`. The single source of truth for this path —
+ * `sessionRoot`, the activation sweep, the deactivation cleanup, and the
+ * persistence helpers all derive from it.
+ */
+export function ravenKnitRoot(): string {
+    return path.join(os.tmpdir(), 'raven-knit');
+}
+
 /** Root of all per-session artifacts: `<tmp>/raven-knit/<workspaceHash>/<sessionId>/`. */
 export function sessionRoot(workspaceHash: string, sessionId: string): string {
-    return path.join(os.tmpdir(), 'raven-knit', workspaceHash, sessionId);
+    return path.join(ravenKnitRoot(), workspaceHash, sessionId);
 }
 
 /** `<sessionRoot>/preview/<sourceHash>/`. Stable per `.Rmd` for the session. */

--- a/editors/vscode/src/knit/session-state.ts
+++ b/editors/vscode/src/knit/session-state.ts
@@ -16,7 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { computeSourceHash, computeWorkspaceHash, sessionRoot } from './raven-knit-paths';
+import { computeSourceHash, computeWorkspaceHash, ravenKnitRoot, sessionRoot } from './raven-knit-paths';
+import { listSessionDirs, selectStaleSessionDirs } from './preview-persistence';
 
 export interface SessionInfo {
     sessionId: string;
@@ -93,14 +94,14 @@ export function __resetSessionStateForTests(): void {
  * `sweepStaleSessions` (>7 days) and the `Raven: Clean Up Knit Preview
  * Cache` command.
  */
-export async function cleanupCurrentSession(persistPreview: boolean = false): Promise<void> {
+export async function cleanupCurrentSession(persistPreview: boolean): Promise<void> {
     if (!state) return;
     if (state.workspaceHash === null) {
         // Single-file mode — per-`.Rmd` parent-dir hashes were used.
         // We can't enumerate them at cleanup without keeping a registry,
         // so we sweep the whole sessionId by walking every workspaceHash
         // directory that contains our sessionId subdir. Best effort.
-        const knitRoot = path.join(require('os').tmpdir(), 'raven-knit');
+        const knitRoot = ravenKnitRoot();
         let workspaceDirs: string[];
         try { workspaceDirs = await fs.promises.readdir(knitRoot); } catch { return; }
         for (const wd of workspaceDirs) {
@@ -120,38 +121,33 @@ export async function cleanupCurrentSession(persistPreview: boolean = false): Pr
 }
 
 /**
- * Remove stale `<workspaceHash>/<sessionId>/` directories whose mtime is
- * older than `maxAgeMs`. Runs in the background at activation.
+ * Remove stale `<workspaceHash>/<sessionId>/` directories whose recency
+ * is older than `maxAgeMs`. Runs in the background at activation.
+ *
+ * Shares the `listSessionDirs` walk and the `selectStaleSessionDirs`
+ * predicate with the manual `Raven: Clean Up Knit Preview Cache` command
+ * so the two reclaimers observe the same tree shape and recency
+ * definition. The only differences are the threshold (7 days here vs a
+ * few minutes for the manual command) and that the sweep does not exclude
+ * a "current" session — at a 7-day threshold the freshly-created current
+ * session is never stale, so passing an empty current id is sufficient.
  */
 export async function sweepStaleSessions(
-    ravenKnitRoot: string,
+    knitRoot: string,
     maxAgeMs = 7 * 24 * 60 * 60 * 1000,
 ): Promise<void> {
-    let workspaceDirs: string[];
-    try {
-        workspaceDirs = await fs.promises.readdir(ravenKnitRoot);
-    } catch {
-        return;
-    }
-    const now = Date.now();
-    for (const wd of workspaceDirs) {
-        const wdPath = path.join(ravenKnitRoot, wd);
-        let sessions: string[];
+    const sessions = await listSessionDirs(knitRoot);
+    const stale = selectStaleSessionDirs({
+        sessions,
+        currentSessionId: '',
+        nowMs: Date.now(),
+        ageThresholdMs: maxAgeMs,
+    });
+    for (const p of stale) {
         try {
-            sessions = await fs.promises.readdir(wdPath);
+            await fs.promises.rm(p, { recursive: true, force: true });
         } catch {
-            continue;
-        }
-        for (const session of sessions) {
-            const sPath = path.join(wdPath, session);
-            try {
-                const stat = await fs.promises.stat(sPath);
-                if (now - stat.mtimeMs > maxAgeMs) {
-                    await fs.promises.rm(sPath, { recursive: true, force: true });
-                }
-            } catch {
-                /* ignore */
-            }
+            /* ignore */
         }
     }
 }

--- a/editors/vscode/src/knit/session-state.ts
+++ b/editors/vscode/src/knit/session-state.ts
@@ -76,7 +76,24 @@ export function __resetSessionStateForTests(): void {
     state = null;
 }
 
-export async function cleanupCurrentSession(): Promise<void> {
+/**
+ * Remove this session's temp artifacts at deactivation.
+ *
+ * When `persistPreview` is false (the feature is disabled) this removes
+ * the entire session root immediately — the historical behavior.
+ *
+ * When `persistPreview` is true, the open Knit Preview panels are about
+ * to be serialized by VS Code and restored on the next launch, so their
+ * `preview/<sourceHash>/` artifacts MUST survive. We therefore remove
+ * only the throwaway `export/` subtree and leave `preview/` in place.
+ * (Closed panels already self-clean their own `preview/<sourceHash>` dir
+ * via `KnitOutputPanel.onDidDispose → requestPreviewDirDeletion`, so the
+ * only preview dirs left at shutdown back panels that are still open —
+ * exactly the set restore needs.) Orphaned leftovers are reclaimed by
+ * `sweepStaleSessions` (>7 days) and the `Raven: Clean Up Knit Preview
+ * Cache` command.
+ */
+export async function cleanupCurrentSession(persistPreview: boolean = false): Promise<void> {
     if (!state) return;
     if (state.workspaceHash === null) {
         // Single-file mode — per-`.Rmd` parent-dir hashes were used.
@@ -88,13 +105,15 @@ export async function cleanupCurrentSession(): Promise<void> {
         try { workspaceDirs = await fs.promises.readdir(knitRoot); } catch { return; }
         for (const wd of workspaceDirs) {
             const sessionPath = path.join(knitRoot, wd, state.sessionId);
-            try { await fs.promises.rm(sessionPath, { recursive: true, force: true }); } catch { /* ignore */ }
+            const target = persistPreview ? path.join(sessionPath, 'export') : sessionPath;
+            try { await fs.promises.rm(target, { recursive: true, force: true }); } catch { /* ignore */ }
         }
         return;
     }
     const root = sessionRoot(state.workspaceHash, state.sessionId);
+    const target = persistPreview ? path.join(root, 'export') : root;
     try {
-        await fs.promises.rm(root, { recursive: true, force: true });
+        await fs.promises.rm(target, { recursive: true, force: true });
     } catch {
         /* ignore — best effort */
     }

--- a/editors/vscode/src/test/knit-preview-restore.test.ts
+++ b/editors/vscode/src/test/knit-preview-restore.test.ts
@@ -108,9 +108,12 @@ suite('KnitOutputPanel.restore (serializer rebuild)', () => {
 
             const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
             assert.ok(inst, 'instance still registered so Knit again works');
+            // Assert the placeholder-UNIQUE copy, not the toolbar's
+            // always-present "Knit again" button, so this discriminates the
+            // placeholder branch from a (wrongly) rendered content branch.
             assert.ok(
-                panel.webview.html.includes('Knit again'),
-                'placeholder points the user at the Knit again button',
+                panel.webview.html.includes('This preview is no longer available'),
+                'the knit-again placeholder body is shown',
             );
         } finally {
             output.dispose();

--- a/editors/vscode/src/test/knit-preview-restore.test.ts
+++ b/editors/vscode/src/test/knit-preview-restore.test.ts
@@ -52,8 +52,11 @@ suite('KnitOutputPanel.restore (serializer rebuild)', () => {
             createdPreviewDirs.push(current.previewDir);
             assert.ok(!fs.existsSync(current.htmlPath), 'precondition: no current artifact');
 
-            // Old-session dir with the same basename the current path expects.
-            const oldDir = fs.mkdtempSync(path.join(ravenKnitRoot(), 'restore-old-'));
+            // Old-session dir: its dir name must equal the current preview
+            // dir's name (the source hash) for the adopt guard to accept it.
+            const oldParent = fs.mkdtempSync(path.join(ravenKnitRoot(), 'restore-old-'));
+            const oldDir = path.join(oldParent, path.basename(current.previewDir));
+            fs.mkdirSync(oldDir, { recursive: true });
             const oldHtml = path.join(oldDir, path.basename(current.htmlPath));
             fs.writeFileSync(oldHtml, '<html><body>RESTORED-MARKER-7Q</body></html>', 'utf-8');
 

--- a/editors/vscode/src/test/knit-preview-restore.test.ts
+++ b/editors/vscode/src/test/knit-preview-restore.test.ts
@@ -1,0 +1,140 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activate } from './helper';
+import { KnitOutputPanel } from '../knit/knit-output-panel';
+import { previewArtifactPaths } from '../knit/raven-knit-paths';
+import { ravenKnitRoot } from '../knit/preview-persistence';
+
+/**
+ * Integration coverage for `KnitOutputPanel.restore` — the
+ * `WebviewPanelSerializer` entry point that rebuilds a Knit Preview
+ * panel after a window reload/restart.
+ *
+ * See `docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md`.
+ */
+suite('KnitOutputPanel.restore (serializer rebuild)', () => {
+    let tmp: string;
+    const createdPreviewDirs: string[] = [];
+
+    setup(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'raven-knit-restore-'));
+        fs.mkdirSync(ravenKnitRoot(), { recursive: true });
+    });
+
+    teardown(() => {
+        KnitOutputPanel.disposeAllForTesting();
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+        for (const d of createdPreviewDirs) {
+            try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* noop */ }
+        }
+        createdPreviewDirs.length = 0;
+    });
+
+    function makePanel(): vscode.WebviewPanel {
+        return vscode.window.createWebviewPanel(
+            'raven.knitOutput',
+            'Knit Preview',
+            vscode.ViewColumn.One,
+            { enableScripts: true },
+        );
+    }
+
+    test('adopts the old-session artifact into the current session and rebuilds', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Restore Test');
+        const panel = makePanel();
+        try {
+            const src = vscode.Uri.file(path.join(tmp, 'doc.Rmd'));
+            const current = previewArtifactPaths(src.fsPath);
+            createdPreviewDirs.push(current.previewDir);
+            assert.ok(!fs.existsSync(current.htmlPath), 'precondition: no current artifact');
+
+            // Old-session dir with the same basename the current path expects.
+            const oldDir = fs.mkdtempSync(path.join(ravenKnitRoot(), 'restore-old-'));
+            const oldHtml = path.join(oldDir, path.basename(current.htmlPath));
+            fs.writeFileSync(oldHtml, '<html><body>RESTORED-MARKER-7Q</body></html>', 'utf-8');
+
+            await KnitOutputPanel.restore(
+                {} as vscode.ExtensionContext,
+                panel,
+                { sourceFsPath: src.fsPath, outputPath: oldHtml },
+                output,
+            );
+
+            const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
+            assert.ok(inst, 'a panel instance is registered for the source');
+            assert.ok(
+                fs.existsSync(current.htmlPath),
+                'artifact was adopted into the current-session path',
+            );
+            assert.ok(
+                panel.webview.html.includes('RESTORED-MARKER-7Q'),
+                'rebuilt panel renders the adopted content',
+            );
+            // localResourceRoots re-applied to the adopted dir.
+            const roots = panel.webview.options.localResourceRoots!;
+            assert.strictEqual(roots[0].fsPath, current.previewDir);
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('shows the knit-again placeholder when nothing is left to restore', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Restore Test');
+        const panel = makePanel();
+        try {
+            const src = vscode.Uri.file(path.join(tmp, 'gone.Rmd'));
+            const current = previewArtifactPaths(src.fsPath);
+            createdPreviewDirs.push(current.previewDir);
+
+            // Persisted path is under the knit tree (containment ok) but the
+            // file is gone — parent exists so containment resolves cleanly.
+            const oldDir = fs.mkdtempSync(path.join(ravenKnitRoot(), 'restore-gone-'));
+            const goneHtml = path.join(oldDir, path.basename(current.htmlPath));
+
+            await KnitOutputPanel.restore(
+                {} as vscode.ExtensionContext,
+                panel,
+                { sourceFsPath: src.fsPath, outputPath: goneHtml },
+                output,
+            );
+
+            const inst = KnitOutputPanel.getInstancesForTesting().get(src.fsPath);
+            assert.ok(inst, 'instance still registered so Knit again works');
+            assert.ok(
+                panel.webview.html.includes('Knit again'),
+                'placeholder points the user at the Knit again button',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+
+    test('disposes the panel and registers nothing when state has no source', async () => {
+        await activate();
+        const output = vscode.window.createOutputChannel('Knit Restore Test');
+        const panel = makePanel();
+        let disposed = false;
+        panel.onDidDispose(() => { disposed = true; });
+        try {
+            await KnitOutputPanel.restore(
+                {} as vscode.ExtensionContext,
+                panel,
+                { outputPath: '/whatever' },
+                output,
+            );
+            assert.strictEqual(disposed, true, 'panel was disposed');
+            assert.strictEqual(
+                KnitOutputPanel.getInstancesForTesting().size,
+                0,
+                'no instance registered for a sourceless restore',
+            );
+        } finally {
+            output.dispose();
+        }
+    });
+});

--- a/tests/bun/export-commands.test.ts
+++ b/tests/bun/export-commands.test.ts
@@ -108,7 +108,8 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-    await cleanupCurrentSession();
+    // Full teardown of the session root (persistPreview=false → remove all).
+    await cleanupCurrentSession(false);
     __resetSessionStateForTests();
 });
 

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -93,6 +93,18 @@ describe('buildShellHtml', () => {
         expect(html).toContain('outputPath: "/work/report.html"');
     });
 
+    test('escapes < in the setState path so a </script> in a path cannot break out', () => {
+        const html = buildShellHtml({
+            ...args('/work/weird</script><x>.html'),
+            sourceFsPath: '/work/weird</script><x>.Rmd',
+        });
+        // The raw closing-tag sequence must NOT appear inside the inline script.
+        const scriptStart = html.indexOf('<script nonce');
+        const script = html.slice(scriptStart);
+        expect(script).toContain('\\u003c/script>');
+        expect(script).not.toContain('</script><x>');
+    });
+
     test('skips setState when sourceFsPath is absent', () => {
         // Non-persistence callers (unit tests) omit sourceFsPath; the
         // guard means no useless restore record is stored.

--- a/tests/bun/knit-output-shell.test.ts
+++ b/tests/bun/knit-output-shell.test.ts
@@ -82,6 +82,26 @@ describe('buildShellHtml', () => {
         expect(html).toContain('id="raven-knit-theme"');
     });
 
+    test('persists restore state via setState when sourceFsPath is given', () => {
+        const html = buildShellHtml({
+            ...args('/work/report.html'),
+            sourceFsPath: '/work/report.Rmd',
+        });
+        // The serializer-restore record must carry both fields.
+        expect(html).toContain('vscode.setState(ravenRestoreState)');
+        expect(html).toContain('sourceFsPath: "/work/report.Rmd"');
+        expect(html).toContain('outputPath: "/work/report.html"');
+    });
+
+    test('skips setState when sourceFsPath is absent', () => {
+        // Non-persistence callers (unit tests) omit sourceFsPath; the
+        // guard means no useless restore record is stored.
+        const html = buildShellHtml(args('/work/report.html'));
+        expect(html).toContain('sourceFsPath: ""');
+        // The guard `if (ravenRestoreState.sourceFsPath)` gates the call.
+        expect(html).toContain('if (ravenRestoreState.sourceFsPath)');
+    });
+
     test('open-in-browser renders visible in a local workspace', () => {
         // `isRemoteWorkspace` defaults to false; both the toolbar
         // button (icon-only after the icon-toolbar redesign) and the
@@ -620,14 +640,18 @@ describe('buildShellHtml', () => {
         expect(html).toContain("execCommand('copy')");
     });
 
-    test('theme toggle posts themeChanged message instead of using setState', () => {
-        // Persistence lives in the extension's globalState so the
-        // choice survives panel disposal/recreation across knits.
-        // The webview only posts a message; the extension writes.
+    test('theme toggle posts themeChanged message (persistence is host-side globalState)', () => {
+        // The theme-toggle choice lives in the extension's globalState so
+        // it survives panel disposal/recreation across knits; the webview
+        // only posts a message and the extension writes. (Note: the shell
+        // DOES use vscode.setState — but only to persist the
+        // serializer-restore record {sourceFsPath, outputPath}, never the
+        // theme choice. Those are separate concerns.)
         const html = buildShellHtml(args('/work/report.html'));
         expect(html).toContain("type: 'themeChanged'");
         expect(html).toMatch(/postMessage\(\s*\{\s*type:\s*['"]themeChanged['"]/);
-        expect(html).not.toContain('vscode.setState');
+        // The only setState call is the restore-record one.
+        expect(html).toContain('vscode.setState(ravenRestoreState)');
     });
 
     test('filename does not appear in the toolbar (panel title already shows it)', () => {

--- a/tests/bun/knit-preview-persistence.test.ts
+++ b/tests/bun/knit-preview-persistence.test.ts
@@ -56,26 +56,65 @@ describe('adoptPreviewArtifacts', () => {
         expect(fs.existsSync(old.htmlPath)).toBe(true);
     });
 
+    // The adopt move requires the old and current preview dirs to share a
+    // base name (the source hash). Build a realistic
+    // `<root>/preview/<hash>` pair for both sides.
+    function matchedPair(label: string): {
+        hash: string;
+        cur: { previewDir: string; htmlPath: string };
+        oldDir: string;
+        oldHtml: string;
+    } {
+        const hash = `h-${label}-${process.pid}-${Math.floor(performance.now())}`;
+        const curRoot = fs.mkdtempSync(path.join(KNIT_ROOT, `cur-${label}-`));
+        const oldRoot = fs.mkdtempSync(path.join(KNIT_ROOT, `old-${label}-`));
+        fixtures.push(curRoot, oldRoot);
+        const curDir = path.join(curRoot, 'preview', hash);
+        const oldDir = path.join(oldRoot, 'preview', hash);
+        fs.mkdirSync(oldDir, { recursive: true });
+        return {
+            hash,
+            cur: { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') },
+            oldDir,
+            oldHtml: path.join(oldDir, 'doc.html'),
+        };
+    }
+
     it('adopts the old dir when the current session has no output yet', () => {
-        // Current preview dir does NOT exist yet.
-        const curDir = path.join(KNIT_ROOT, `test-adopt-new-${process.pid}-${Math.floor(performance.now())}`);
-        const cur = { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') };
-        fixtures.push(curDir);
+        const { cur, oldDir, oldHtml } = matchedPair('adopt');
+        fs.writeFileSync(oldHtml, '<html>old</html>');
+        fs.mkdirSync(path.join(oldDir, 'figure'), { recursive: true });
+        fs.writeFileSync(path.join(oldDir, 'figure', 'p.png'), 'x');
 
-        const old = freshPreviewDir('adopt-old');
-        fs.writeFileSync(old.htmlPath, '<html>old</html>');
-        fs.mkdirSync(path.join(old.previewDir, 'figure'), { recursive: true });
-        fs.writeFileSync(path.join(old.previewDir, 'figure', 'p.png'), 'x');
-
-        const out = adoptPreviewArtifacts(cur, old.htmlPath);
+        const out = adoptPreviewArtifacts(cur, oldHtml);
         expect(out.reason).toBe('adopted');
         expect(out.available).toBe(true);
         expect(out.htmlPath).toBe(cur.htmlPath);
         // Artifacts now live at the current path, including figures.
         expect(fs.readFileSync(cur.htmlPath, 'utf-8')).toBe('<html>old</html>');
-        expect(fs.existsSync(path.join(curDir, 'figure', 'p.png'))).toBe(true);
+        expect(fs.existsSync(path.join(cur.previewDir, 'figure', 'p.png'))).toBe(true);
         // Old dir moved away.
-        expect(fs.existsSync(old.previewDir)).toBe(false);
+        expect(fs.existsSync(oldDir)).toBe(false);
+    });
+
+    it('rejects adopting a preview dir whose hash does not match this source', () => {
+        // Old artifact exists and is under the knit tree, but its preview
+        // dir name differs from the current source hash (a crafted/corrupt
+        // record, or another source's dir). Must NOT be moved.
+        const { cur } = matchedPair('mismatch-cur');
+        const otherRoot = fs.mkdtempSync(path.join(KNIT_ROOT, 'other-'));
+        fixtures.push(otherRoot);
+        const otherDir = path.join(otherRoot, 'preview', 'DIFFERENT-HASH');
+        fs.mkdirSync(otherDir, { recursive: true });
+        const otherHtml = path.join(otherDir, 'doc.html');
+        fs.writeFileSync(otherHtml, '<html>other</html>');
+
+        const out = adoptPreviewArtifacts(cur, otherHtml);
+        expect(out.reason).toBe('rejected-path');
+        expect(out.available).toBe(false);
+        // The other source's dir is untouched.
+        expect(fs.existsSync(otherHtml)).toBe(true);
+        expect(fs.existsSync(cur.previewDir)).toBe(false);
     });
 
     it('reports missing-source when the persisted artifact is gone', () => {
@@ -122,11 +161,8 @@ describe('adoptPreviewArtifacts', () => {
     });
 
     it('falls back to copy+remove when rename fails (EXDEV)', () => {
-        const curDir = path.join(KNIT_ROOT, `test-exdev-${process.pid}-${Math.floor(performance.now())}`);
-        const cur = { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') };
-        fixtures.push(curDir);
-        const old = freshPreviewDir('exdev-old');
-        fs.writeFileSync(old.htmlPath, '<html>old</html>');
+        const { cur, oldDir, oldHtml } = matchedPair('exdev');
+        fs.writeFileSync(oldHtml, '<html>old</html>');
 
         let renameCalled = false;
         let cpCalled = false;
@@ -144,13 +180,13 @@ describe('adoptPreviewArtifacts', () => {
             touch: () => { /* noop */ },
         };
 
-        const out = adoptPreviewArtifacts(cur, old.htmlPath, io);
+        const out = adoptPreviewArtifacts(cur, oldHtml, io);
         expect(renameCalled).toBe(true);
         expect(cpCalled).toBe(true);
         expect(out.reason).toBe('adopted');
         expect(out.available).toBe(true);
         expect(fs.readFileSync(cur.htmlPath, 'utf-8')).toBe('<html>old</html>');
-        expect(fs.existsSync(old.previewDir)).toBe(false);
+        expect(fs.existsSync(oldDir)).toBe(false);
     });
 });
 
@@ -176,6 +212,21 @@ describe('selectStaleSessionDirs', () => {
 
     it('protects sessions touched within the age threshold', () => {
         const sessions = [mk('other', 60 * 1000)]; // 1 min ago < 5 min
+        const out = selectStaleSessionDirs({
+            sessions,
+            currentSessionId: 'cur',
+            nowMs: now,
+            ageThresholdMs: threshold,
+        });
+        expect(out).toEqual([]);
+    });
+
+    it('spares sessions whose recency is unknown (<= 0)', () => {
+        // A stat that failed (e.g. EMFILE) yields recencyMs 0; that must
+        // never be read as "ancient" and deleted.
+        const sessions: SessionDirInfo[] = [
+            { path: '/tmp/raven-knit/wh/unknown', sessionId: 'unknown', recencyMs: 0 },
+        ];
         const out = selectStaleSessionDirs({
             sessions,
             currentSessionId: 'cur',

--- a/tests/bun/knit-preview-persistence.test.ts
+++ b/tests/bun/knit-preview-persistence.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, afterAll } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    adoptPreviewArtifacts,
+    selectStaleSessionDirs,
+    ravenKnitRoot,
+    type AdoptIo,
+    type SessionDirInfo,
+} from '../../editors/vscode/src/knit/preview-persistence';
+import {
+    initSessionState,
+    cleanupCurrentSession,
+    __resetSessionStateForTests,
+} from '../../editors/vscode/src/knit/session-state';
+import {
+    computeWorkspaceHash,
+    sessionRoot,
+    previewDirFor,
+    exportDirFor,
+} from '../../editors/vscode/src/knit/raven-knit-paths';
+
+// All adoption tests operate inside the real raven-knit root so the
+// containment check passes for legitimately-placed fixtures.
+const KNIT_ROOT = ravenKnitRoot();
+fs.mkdirSync(KNIT_ROOT, { recursive: true });
+const fixtures: string[] = [];
+
+function freshPreviewDir(label: string): { previewDir: string; htmlPath: string } {
+    const dir = fs.mkdtempSync(path.join(KNIT_ROOT, `test-${label}-`));
+    fixtures.push(dir);
+    return { previewDir: dir, htmlPath: path.join(dir, 'doc.html') };
+}
+
+afterAll(() => {
+    for (const f of fixtures) {
+        try { fs.rmSync(f, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});
+
+describe('adoptPreviewArtifacts', () => {
+    it('reuses the current-session HTML when it already exists', () => {
+        const cur = freshPreviewDir('reuse');
+        fs.writeFileSync(cur.htmlPath, '<html>current</html>');
+        // Persisted path is some other (existing) location, but reuse wins.
+        const old = freshPreviewDir('reuse-old');
+        fs.writeFileSync(old.htmlPath, '<html>old</html>');
+
+        const out = adoptPreviewArtifacts(cur, old.htmlPath);
+        expect(out.reason).toBe('reused');
+        expect(out.available).toBe(true);
+        expect(out.htmlPath).toBe(cur.htmlPath);
+        // Old dir untouched.
+        expect(fs.existsSync(old.htmlPath)).toBe(true);
+    });
+
+    it('adopts the old dir when the current session has no output yet', () => {
+        // Current preview dir does NOT exist yet.
+        const curDir = path.join(KNIT_ROOT, `test-adopt-new-${process.pid}-${Math.floor(performance.now())}`);
+        const cur = { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') };
+        fixtures.push(curDir);
+
+        const old = freshPreviewDir('adopt-old');
+        fs.writeFileSync(old.htmlPath, '<html>old</html>');
+        fs.mkdirSync(path.join(old.previewDir, 'figure'), { recursive: true });
+        fs.writeFileSync(path.join(old.previewDir, 'figure', 'p.png'), 'x');
+
+        const out = adoptPreviewArtifacts(cur, old.htmlPath);
+        expect(out.reason).toBe('adopted');
+        expect(out.available).toBe(true);
+        expect(out.htmlPath).toBe(cur.htmlPath);
+        // Artifacts now live at the current path, including figures.
+        expect(fs.readFileSync(cur.htmlPath, 'utf-8')).toBe('<html>old</html>');
+        expect(fs.existsSync(path.join(curDir, 'figure', 'p.png'))).toBe(true);
+        // Old dir moved away.
+        expect(fs.existsSync(old.previewDir)).toBe(false);
+    });
+
+    it('reports missing-source when the persisted artifact is gone', () => {
+        const curDir = path.join(KNIT_ROOT, `test-missing-${process.pid}-${Math.floor(performance.now())}`);
+        const cur = { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') };
+        // Old preview dir survived but its HTML was swept — parent exists so
+        // the containment check resolves deterministically; the file does not.
+        const oldDir = freshPreviewDir('gone-old').previewDir;
+        const goneOld = path.join(oldDir, 'doc.html');
+
+        const out = adoptPreviewArtifacts(cur, goneOld);
+        expect(out.reason).toBe('missing-source');
+        expect(out.available).toBe(false);
+        expect(out.htmlPath).toBe(cur.htmlPath);
+        expect(fs.existsSync(curDir)).toBe(false);
+    });
+
+    it('rejects a persisted path outside the raven-knit tree', () => {
+        const cur = freshPreviewDir('reject');
+        const outside = path.join(os.tmpdir(), 'definitely-not-raven-knit', 'evil.html');
+        const out = adoptPreviewArtifacts(cur, outside);
+        expect(out.reason).toBe('rejected-path');
+        expect(out.available).toBe(false);
+    });
+
+    it('rejects an empty persisted path', () => {
+        const cur = freshPreviewDir('reject-empty');
+        const out = adoptPreviewArtifacts(cur, '');
+        expect(out.reason).toBe('rejected-path');
+        expect(out.available).toBe(false);
+    });
+
+    it('does not clobber a current dir that exists without HTML (knit in progress)', () => {
+        const cur = freshPreviewDir('inprogress'); // dir exists, no html
+        const old = freshPreviewDir('inprogress-old');
+        fs.writeFileSync(old.htmlPath, '<html>old</html>');
+
+        const out = adoptPreviewArtifacts(cur, old.htmlPath);
+        expect(out.reason).toBe('in-progress');
+        expect(out.available).toBe(false);
+        // Old dir left intact (not moved into the live dir).
+        expect(fs.existsSync(old.htmlPath)).toBe(true);
+        expect(fs.existsSync(cur.htmlPath)).toBe(false);
+    });
+
+    it('falls back to copy+remove when rename fails (EXDEV)', () => {
+        const curDir = path.join(KNIT_ROOT, `test-exdev-${process.pid}-${Math.floor(performance.now())}`);
+        const cur = { previewDir: curDir, htmlPath: path.join(curDir, 'doc.html') };
+        fixtures.push(curDir);
+        const old = freshPreviewDir('exdev-old');
+        fs.writeFileSync(old.htmlPath, '<html>old</html>');
+
+        let renameCalled = false;
+        let cpCalled = false;
+        const io: AdoptIo = {
+            existsSync: (p) => fs.existsSync(p),
+            renameSync: () => {
+                renameCalled = true;
+                const e = new Error('cross-device link') as NodeJS.ErrnoException;
+                e.code = 'EXDEV';
+                throw e;
+            },
+            cpSync: (src, dst) => { cpCalled = true; fs.cpSync(src, dst, { recursive: true }); },
+            rmSync: (p) => fs.rmSync(p, { recursive: true, force: true }),
+            mkdirSync: (p) => { fs.mkdirSync(p, { recursive: true }); },
+            touch: () => { /* noop */ },
+        };
+
+        const out = adoptPreviewArtifacts(cur, old.htmlPath, io);
+        expect(renameCalled).toBe(true);
+        expect(cpCalled).toBe(true);
+        expect(out.reason).toBe('adopted');
+        expect(out.available).toBe(true);
+        expect(fs.readFileSync(cur.htmlPath, 'utf-8')).toBe('<html>old</html>');
+        expect(fs.existsSync(old.previewDir)).toBe(false);
+    });
+});
+
+describe('selectStaleSessionDirs', () => {
+    const now = 1_000_000_000;
+    const threshold = 5 * 60 * 1000; // 5 minutes
+    const mk = (sessionId: string, ageMs: number): SessionDirInfo => ({
+        path: `/tmp/raven-knit/wh/${sessionId}`,
+        sessionId,
+        recencyMs: now - ageMs,
+    });
+
+    it('never removes the current session', () => {
+        const sessions = [mk('cur', 99 * 60 * 1000)]; // very old, but current
+        const out = selectStaleSessionDirs({
+            sessions,
+            currentSessionId: 'cur',
+            nowMs: now,
+            ageThresholdMs: threshold,
+        });
+        expect(out).toEqual([]);
+    });
+
+    it('protects sessions touched within the age threshold', () => {
+        const sessions = [mk('other', 60 * 1000)]; // 1 min ago < 5 min
+        const out = selectStaleSessionDirs({
+            sessions,
+            currentSessionId: 'cur',
+            nowMs: now,
+            ageThresholdMs: threshold,
+        });
+        expect(out).toEqual([]);
+    });
+
+    it('removes other sessions older than the threshold', () => {
+        const sessions = [mk('stale', 10 * 60 * 1000)]; // 10 min ago
+        const out = selectStaleSessionDirs({
+            sessions,
+            currentSessionId: 'cur',
+            nowMs: now,
+            ageThresholdMs: threshold,
+        });
+        expect(out).toEqual(['/tmp/raven-knit/wh/stale']);
+    });
+
+    it('mixes the rules correctly', () => {
+        const sessions = [
+            mk('cur', 99 * 60 * 1000),   // current → keep
+            mk('fresh', 60 * 1000),      // recent → keep
+            mk('stale1', 6 * 60 * 1000), // old → remove
+            mk('stale2', 8 * 60 * 1000), // old → remove
+        ];
+        const out = selectStaleSessionDirs({
+            sessions,
+            currentSessionId: 'cur',
+            nowMs: now,
+            ageThresholdMs: threshold,
+        });
+        expect(out.sort()).toEqual(
+            ['/tmp/raven-knit/wh/stale1', '/tmp/raven-knit/wh/stale2'].sort(),
+        );
+    });
+});
+
+describe('cleanupCurrentSession persistPreview gating', () => {
+    const wsUri = `file:///tmp/raven-persist-test-${process.pid}`;
+    const sessionId = `sess-${process.pid}-${Math.floor(performance.now())}`;
+    const wh = computeWorkspaceHash(wsUri);
+    const root = sessionRoot(wh, sessionId);
+
+    afterAll(() => {
+        __resetSessionStateForTests();
+        try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    function seed(): { previewHtml: string; exportFile: string } {
+        const previewDir = previewDirFor(wh, sessionId, 'srchash');
+        const exportDir = exportDirFor(wh, sessionId, 'expuuid');
+        fs.mkdirSync(previewDir, { recursive: true });
+        fs.mkdirSync(exportDir, { recursive: true });
+        const previewHtml = path.join(previewDir, 'doc.html');
+        const exportFile = path.join(exportDir, 'out.html');
+        fs.writeFileSync(previewHtml, '<html></html>');
+        fs.writeFileSync(exportFile, '<html></html>');
+        return { previewHtml, exportFile };
+    }
+
+    it('keeps preview dirs but removes export when persistPreview=true', async () => {
+        __resetSessionStateForTests();
+        initSessionState({ sessionId, workspaceUri: wsUri });
+        const { previewHtml, exportFile } = seed();
+
+        await cleanupCurrentSession(true);
+
+        expect(fs.existsSync(previewHtml)).toBe(true);
+        expect(fs.existsSync(path.join(root, 'export'))).toBe(false);
+        expect(fs.existsSync(exportFile)).toBe(false);
+    });
+
+    it('removes the whole session root when persistPreview=false', async () => {
+        __resetSessionStateForTests();
+        initSessionState({ sessionId, workspaceUri: wsUri });
+        seed();
+
+        await cleanupCurrentSession(false);
+
+        expect(fs.existsSync(root)).toBe(false);
+    });
+});

--- a/tests/bun/knit-preview-persistence.test.ts
+++ b/tests/bun/knit-preview-persistence.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import {
     adoptPreviewArtifacts,
     selectStaleSessionDirs,
+    listSessionDirs,
     ravenKnitRoot,
     type AdoptIo,
     type SessionDirInfo,
@@ -211,6 +212,35 @@ describe('selectStaleSessionDirs', () => {
         expect(out.sort()).toEqual(
             ['/tmp/raven-knit/wh/stale1', '/tmp/raven-knit/wh/stale2'].sort(),
         );
+    });
+});
+
+describe('listSessionDirs', () => {
+    it('returns one entry per <workspaceHash>/<sessionId> dir with recency', async () => {
+        const root = fs.mkdtempSync(path.join(KNIT_ROOT, 'list-'));
+        fixtures.push(root);
+        // <root>/wh1/sessA/preview/h, <root>/wh1/sessB, <root>/wh2/sessC
+        const a = path.join(root, 'wh1', 'sessA', 'preview', 'h');
+        const b = path.join(root, 'wh1', 'sessB');
+        const c = path.join(root, 'wh2', 'sessC');
+        fs.mkdirSync(a, { recursive: true });
+        fs.writeFileSync(path.join(a, 'doc.html'), 'x');
+        fs.mkdirSync(b, { recursive: true });
+        fs.mkdirSync(c, { recursive: true });
+        // A stray file at the workspace level must be ignored.
+        fs.writeFileSync(path.join(root, 'wh1', 'stray.txt'), 'x');
+
+        const out = await listSessionDirs(root);
+        const ids = out.map((s) => s.sessionId).sort();
+        expect(ids).toEqual(['sessA', 'sessB', 'sessC']);
+        for (const s of out) {
+            expect(s.recencyMs).toBeGreaterThan(0);
+        }
+    });
+
+    it('returns [] when the root does not exist', async () => {
+        const out = await listSessionDirs(path.join(KNIT_ROOT, 'does-not-exist-xyz'));
+        expect(out).toEqual([]);
     });
 });
 


### PR DESCRIPTION
## Summary

Knit Preview panels now **persist across window reload and full VS Code restart**. Previously, reloading the window (or quitting and reopening) discarded the preview webview and deleted its rendered files, forcing a re-knit — annoying when knitting is slow.

Now an open preview is restored automatically, showing the **last rendered output with no re-knit and no R subprocess** — a static snapshot, exactly as it looked after the last knit. Press **Knit again** to refresh.

Spec: `docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md` (brainstormed, then adversarially reviewed by Codex before implementation).

## How it works

Two mechanisms previously defeated persistence; both are addressed:

1. **No webview serializer** → register a `WebviewPanelSerializer` for `raven.knitOutput` (plus the `onWebviewPanel:raven.knitOutput` activation event). The shell persists `{ sourceFsPath, outputPath }` via `setState`; `KnitOutputPanel.restore` rebuilds the panel.
2. **Ephemeral temp files** → on restore, the orphaned old-session preview dir is **adopted** into the current session's path (so a later Knit again is a normal in-place update). Deactivation cleanup keeps open-panel `preview/` dirs when persistence is enabled, removing only throwaway `export/`.

If the temp files are gone (swept/cleaned), the panel shows a "press Knit again" placeholder rather than a broken view.

## New surfaces

- **Setting** `raven.knit.persistPreview` (default `true`, `window` scope) — disable to restore the previous behavior (no restore; temp files removed on window close).
- **Command** `Raven: Clean Up Knit Preview Cache` — on-demand reclaim of orphaned session temp dirs. Never touches the current session nor any session written in the last few minutes (spares concurrent windows).

Reboot survival is out of scope (the OS may clear the temp dir). The cross-window cleanup-vs-long-running-knit recency gap is a documented, accepted limitation (lease-file hardening deferred).

## Testing

- **Bun units**: adoption (reuse/adopt/in-progress/containment/source-hash guard/EXDEV fallback/missing), cleanup selection (current-session/age-threshold/unknown-recency sparing), `listSessionDirs`, the deactivation-cleanup gating, and `</script>`-escaping in the shell.
- **vscode-test**: `deserializeWebviewPanel` rebuilds and adopts; placeholder when nothing to restore; sourceless state disposes. All 32 Knit suites pass.
- Compile clean; settings-reference regenerated (no drift). No Rust changes.

## Review

Implementation went through several adversarial `/code-review` passes (robust/total adopt move, source-hash adopt guard, unknown-recency sparing, bounded fs fan-out, shared dir-walk dedup, script-injection escaping), converging to two consecutive clean passes.

https://claude.ai/code/session_01R5DHCptTLyLtbMRSLkh8D2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knit Preview panel now persists and automatically restores across VS Code window reloads and restarts
  * Added "Clean Up Knit Preview Cache" command to manually remove stale preview artifacts
  * Added configurable `raven.knit.persistPreview` setting (enabled by default)

* **Documentation**
  * Updated Knit Preview documentation with persistence details and cache lifecycle information
  * Added design specification for the preview persistence feature
  * Updated settings reference with the new persistence setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->