### PR TITLE
Surface R Markdown / Quarto headings in the document outline

### DIFF
--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -501,6 +501,167 @@ pub fn position_in_r_chunk_body(text: &str, line: u32) -> bool {
     false
 }
 
+/// A prose Markdown heading detected in an R Markdown / Quarto document.
+///
+/// Surfaced in the document outline (see `SymbolExtractor::extract_markdown_headings`)
+/// so the rendered document's heading structure — the same structure the Knit
+/// Preview shows — appears in VS Code's Outline view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownHeading {
+    /// 0-based line index of the heading.
+    pub line: u32,
+    /// ATX heading level: 1 (`#`) through 6 (`######`).
+    pub level: u32,
+    /// Heading text, with the leading `#` run, any closing `#` sequence, and
+    /// surrounding whitespace removed. Never empty (empty-title headings are
+    /// dropped).
+    pub title: String,
+}
+
+/// Detect prose (ATX) Markdown headings in raw R Markdown / Quarto text.
+///
+/// Only headings in *prose* are returned: lines inside leading YAML front
+/// matter and inside fenced code blocks (both ` ```{r} ` chunks and generic
+/// ` ``` ` / `~~~` blocks) are skipped, so a `#` comment inside code never
+/// becomes a phantom heading. This intentionally complements [`mask_to_r`],
+/// which keeps R chunk bodies and blanks prose; here we keep prose headings and
+/// skip code.
+///
+/// Heading recognition follows CommonMark ATX rules: 1–6 leading `#` (after up
+/// to 3 spaces of indentation) must be followed by a space/tab or end of line
+/// (so `#hashtag` is not a heading), an optional trailing `#` closing sequence
+/// is stripped only when preceded by whitespace, and empty-title headings are
+/// dropped. Setext (underline) headings are not recognized.
+///
+/// Fence tracking mirrors [`detect_rmd_chunks`]'s close rules — a closing fence
+/// must use the same character as its opener, be at least as long, and carry no
+/// info string — so the two stay aligned on tilde/backtick and unclosed-to-EOF
+/// behavior. An unclosed fence runs to end of document.
+pub fn detect_markdown_headings(text: &str) -> Vec<MarkdownHeading> {
+    // BOM-tolerant, column-0 scan: matching anchors at column 0 (after ≤3
+    // spaces). Reported positions are line numbers only, so the stripped
+    // first line is safe here. #346.
+    let lines = crate::utf16::lines_for_column0_scan(text);
+    let n = lines.len();
+
+    // Skip a leading YAML frontmatter block, mirroring the contract in
+    // `frontmatter_declares_params`: the first non-empty line must be exactly
+    // `---`, and the block ends at the next `---`/`...`. An unterminated block
+    // is not treated as frontmatter (scan from the top), matching that sniff.
+    let mut scan_start = 0usize;
+    let mut first_non_empty = 0usize;
+    while first_non_empty < n && lines[first_non_empty].trim().is_empty() {
+        first_non_empty += 1;
+    }
+    if first_non_empty < n && lines[first_non_empty].trim() == "---" {
+        for (j, line) in lines.iter().enumerate().skip(first_non_empty + 1) {
+            let t = line.trim();
+            if t == "---" || t == "..." {
+                scan_start = j + 1;
+                break;
+            }
+        }
+    }
+
+    let mut headings = Vec::new();
+    let mut fence: Option<(char, usize)> = None; // (fence char, opening length)
+
+    for (idx, &line) in lines.iter().enumerate().skip(scan_start) {
+        if let Some((ch, len, has_info)) = fence_marker(line) {
+            match fence {
+                // A closing fence: same character, at least as long, no info string.
+                Some((open_ch, open_len)) if ch == open_ch && len >= open_len && !has_info => {
+                    fence = None;
+                }
+                Some(_) => {} // a fence-looking line inside a different fence stays content
+                None => fence = Some((ch, len)),
+            }
+            continue; // fence lines are never headings
+        }
+        if fence.is_some() {
+            continue;
+        }
+        if let Some((level, title)) = parse_atx_heading(line) {
+            headings.push(MarkdownHeading {
+                line: idx as u32,
+                level,
+                title,
+            });
+        }
+    }
+
+    headings
+}
+
+/// Classify a line as a Markdown code-fence marker: a run of ≥3 backticks or
+/// tildes at column 0. Returns the fence character, the run length, and whether
+/// a non-whitespace info string follows (a closing fence must have none).
+///
+/// Fences are recognized only at column 0, matching [`detect_rmd_chunks`]
+/// (`fence_header_re`/`fence_close_re` both anchor at column 0). Keeping the two
+/// detectors aligned means heading detection and chunk-range detection never
+/// disagree about where a fenced block opens or closes — e.g. an indented ```
+/// closes neither, so both let the fence run on rather than one treating the
+/// following text as prose and the other as code.
+fn fence_marker(line: &str) -> Option<(char, usize, bool)> {
+    let first = line.chars().next()?;
+    if first != '`' && first != '~' {
+        return None;
+    }
+    let run = line.chars().take_while(|&c| c == first).count();
+    if run < 3 {
+        return None;
+    }
+    // `first` is a single-byte ASCII char, so `run` bytes index the rest safely.
+    let has_info = !line[run..].trim().is_empty();
+    Some((first, run, has_info))
+}
+
+/// Parse a line as an ATX Markdown heading, returning `(level, title)` when it
+/// is one with a non-empty title. Follows CommonMark: ≤3 spaces of indentation,
+/// 1–6 `#`, a required space/tab (or end of line) after the `#` run, and an
+/// optional trailing `#` closing sequence stripped only when whitespace-separated.
+fn parse_atx_heading(line: &str) -> Option<(u32, String)> {
+    let trimmed = line.trim_start_matches(' ');
+    let indent = line.len() - trimmed.len();
+    if indent > 3 {
+        return None; // 4+ spaces is an indented code block, not a heading
+    }
+    let hashes = trimmed.chars().take_while(|&c| c == '#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    let after = &trimmed[hashes..]; // '#' is single-byte ASCII
+    // The `#` run must be followed by whitespace or end of line.
+    if !after.is_empty() && !after.starts_with([' ', '\t']) {
+        return None;
+    }
+    let content = after.trim_matches([' ', '\t']);
+    let title = strip_closing_hashes(content).trim_matches([' ', '\t']);
+    if title.is_empty() {
+        return None;
+    }
+    Some((hashes as u32, title.to_string()))
+}
+
+/// Strip a trailing ATX closing sequence (`#`s) from heading content. The
+/// closing sequence is removed only when it is whitespace-separated from the
+/// content or constitutes the entire content; otherwise the `#`s are content
+/// (e.g. `bar#`).
+fn strip_closing_hashes(content: &str) -> &str {
+    let without = content.trim_end_matches('#');
+    if without.len() == content.len() {
+        return content; // no trailing '#'
+    }
+    if without.is_empty() {
+        return ""; // content was only '#'s
+    }
+    if without.ends_with([' ', '\t']) {
+        return without.trim_end_matches([' ', '\t']);
+    }
+    content // trailing '#' not whitespace-separated → part of the content
+}
+
 /// Regex for the in-chunk `# raven: ignore-chunk` directive (F2 Step 4),
 /// optionally with a `[code]` selector. Anchored to the start of a (possibly
 /// indented) line; a trailing comment-only directive.
@@ -1537,5 +1698,163 @@ mod tests {
         append_chunk_suppressions(&mut meta, src);
         assert_eq!(meta.ignored_ranges.len(), 1);
         assert_eq!(meta.ignored_ranges[0].what, LineSuppression::All);
+    }
+
+    // ---- detect_markdown_headings -----------------------------------------
+
+    fn headings(text: &str) -> Vec<(u32, u32, String)> {
+        detect_markdown_headings(text)
+            .into_iter()
+            .map(|h| (h.line, h.level, h.title))
+            .collect()
+    }
+
+    #[test]
+    fn markdown_headings_basic_levels() {
+        let src = "# One\n\n## Two\n\n### Three\n";
+        assert_eq!(
+            headings(src),
+            vec![
+                (0, 1, "One".to_string()),
+                (2, 2, "Two".to_string()),
+                (4, 3, "Three".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_levels_one_through_six() {
+        let src = "# a\n## b\n### c\n#### d\n##### e\n###### f\n####### g\n";
+        // 7 hashes is not a heading.
+        assert_eq!(
+            headings(src),
+            vec![
+                (0, 1, "a".to_string()),
+                (1, 2, "b".to_string()),
+                (2, 3, "c".to_string()),
+                (3, 4, "d".to_string()),
+                (4, 5, "e".to_string()),
+                (5, 6, "f".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_skip_yaml_frontmatter() {
+        // The `# comment` and `## title` lines inside frontmatter are not headings.
+        let src = "---\ntitle: Doc\n# yaml comment\n---\n\n# Real Heading\n";
+        assert_eq!(headings(src), vec![(5, 1, "Real Heading".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_skip_unterminated_frontmatter_is_not_frontmatter() {
+        // An unterminated leading `---` block is not valid frontmatter; the
+        // heading after it is still detected (the `---`/`title:` lines are not
+        // ATX headings, so they simply don't match).
+        let src = "---\ntitle: Doc\n\n# Heading\n";
+        assert_eq!(headings(src), vec![(3, 1, "Heading".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_skip_generic_fenced_code() {
+        let src = "# Before\n\n```\n# not a heading\n```\n\n# After\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 1, "Before".to_string()), (6, 1, "After".to_string()),]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_skip_r_chunk_bodies() {
+        let src = "# Before\n\n```{r}\n# an R comment\nx <- 1\n```\n\n## After\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 1, "Before".to_string()), (7, 2, "After".to_string()),]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_skip_tilde_fenced_code() {
+        let src = "# Before\n\n~~~\n# not a heading\n~~~\n\n# After\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 1, "Before".to_string()), (6, 1, "After".to_string()),]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_unclosed_fence_runs_to_eof() {
+        // The fence is never closed, so the `# heading` after it is code.
+        let src = "# Before\n\n```\n# swallowed\n\n# also swallowed\n";
+        assert_eq!(headings(src), vec![(0, 1, "Before".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_shorter_close_does_not_close_fence() {
+        // Open fence of 4 backticks; a 3-backtick line does not close it, so
+        // the `#` line stays inside the fence.
+        let src = "````\n# inside\n```\n# still inside\n````\n# outside\n";
+        assert_eq!(headings(src), vec![(5, 1, "outside".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_indented_close_does_not_close_fence() {
+        // Fences are recognized only at column 0, matching the Rmd chunk
+        // detector (`detect_rmd_chunks`). An indented ``` does not close the
+        // fence, so the heading between it and the real close stays code.
+        let src = "```\n# inside\n   ```\n# still inside\n```\n# outside\n";
+        assert_eq!(headings(src), vec![(5, 1, "outside".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_reject_hashtag_without_space() {
+        let src = "#hashtag\n# real\n";
+        assert_eq!(headings(src), vec![(1, 1, "real".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_reject_indented_code_block() {
+        // 4 spaces of indentation makes it an indented code block, not a heading.
+        let src = "    # indented code\n  ## up to three spaces ok\n";
+        assert_eq!(
+            headings(src),
+            vec![(1, 2, "up to three spaces ok".to_string())]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_strip_closing_hash_sequence() {
+        // `## foo ##` -> "foo" (closing sequence preceded by space).
+        // `# bar#`    -> "bar#" (no space before '#', so it is content).
+        let src = "## foo ##\n# bar#\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 2, "foo".to_string()), (1, 1, "bar#".to_string()),]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_drop_empty_titles() {
+        // `#`, `###`, and `# ###` are all empty headings and are dropped.
+        let src = "#\n###\n# ###\n# kept\n";
+        assert_eq!(headings(src), vec![(3, 1, "kept".to_string())]);
+    }
+
+    #[test]
+    fn markdown_headings_crlf() {
+        let src = "# One\r\n\r\n## Two\r\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 1, "One".to_string()), (2, 2, "Two".to_string()),]
+        );
+    }
+
+    #[test]
+    fn markdown_headings_bom_first_line() {
+        let src = "\u{FEFF}# Title\n## Sub\n";
+        assert_eq!(
+            headings(src),
+            vec![(0, 1, "Title".to_string()), (1, 2, "Sub".to_string()),]
+        );
     }
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -1477,6 +1477,14 @@ pub enum DocumentSymbolKind {
     /// symbol kinds to icons) can include or exclude chunks separately from
     /// section headers.
     Chunk,
+    /// Prose Markdown heading in an `.Rmd`/`.qmd` document (SymbolKind::STRING).
+    ///
+    /// Maps to `STRING` to match VS Code's native Markdown outline, and is kept
+    /// distinct from `Module` (R `# Section ----` dividers) so the outline
+    /// filter can treat document headings and code sections separately. Like
+    /// `Module`, it carries a `section_level` and forms the section spine of the
+    /// outline (see `HierarchyBuilder::is_section_symbol`).
+    Heading,
 }
 
 impl DocumentSymbolKind {
@@ -1512,6 +1520,7 @@ impl DocumentSymbolKind {
             Self::Interface => SymbolKind::INTERFACE,
             Self::Module => SymbolKind::MODULE,
             Self::Chunk => SymbolKind::OBJECT,
+            Self::Heading => SymbolKind::STRING,
         }
     }
 }
@@ -2601,6 +2610,55 @@ impl<'a> SymbolExtractor<'a> {
         symbols
     }
 
+    /// Extract prose Markdown headings (`.Rmd`/`.qmd` only) as outline sections.
+    ///
+    /// Each heading becomes a [`DocumentSymbolKind::Heading`] `RawSymbol` with a
+    /// `section_level` (1–6), so the [`HierarchyBuilder`] treats it as part of
+    /// the section spine: chunks and chunk-body R symbols nest beneath the
+    /// heading whose section contains them, mirroring the rendered document and
+    /// the Knit Preview. Detection (see [`crate::chunks::detect_markdown_headings`])
+    /// scans the RAW text — the masked analysis text blanks prose — and skips
+    /// front matter and fenced code, so a `#` comment inside a chunk never
+    /// produces a phantom heading.
+    ///
+    /// `range`/`selection_range` span the heading line; the range is later
+    /// extended to the section's extent by `HierarchyBuilder::compute_section_ranges`.
+    pub fn extract_markdown_headings(&self) -> Vec<RawSymbol> {
+        let headings = crate::chunks::detect_markdown_headings(self.text);
+        if headings.is_empty() {
+            return Vec::new();
+        }
+        // Measure end columns from the raw (un-stripped) lines so a first-line
+        // BOM doesn't shorten the reported range; line indices match the
+        // detector's column-0 scan (both come from `str::lines`).
+        let lines: Vec<&str> = self.text.lines().collect();
+        headings
+            .into_iter()
+            .map(|h| {
+                let line_text = lines.get(h.line as usize).copied().unwrap_or("");
+                let range = Range {
+                    start: Position {
+                        line: h.line,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: h.line,
+                        character: utf16_len(line_text),
+                    },
+                };
+                RawSymbol {
+                    name: h.title,
+                    kind: DocumentSymbolKind::Heading,
+                    range,
+                    selection_range: range,
+                    detail: None,
+                    section_level: Some(h.level),
+                    children: Vec::new(),
+                }
+            })
+            .collect()
+    }
+
     /// Extract decorative banner and inline headings for JAGS and Stan files.
     fn extract_decorative_sections(&self, style: ModelCommentStyle) -> Vec<RawSymbol> {
         let mut sections = Vec::new();
@@ -2825,6 +2883,18 @@ impl HierarchyBuilder {
         ) || (matches!(symbol.kind, DocumentSymbolKind::Module) && symbol.section_level == Some(0))
     }
 
+    /// Whether a symbol forms part of the outline's section spine — an R
+    /// comment section (`Module`) or a Markdown heading (`Heading`) carrying a
+    /// `section_level`. "Section" throughout the `HierarchyBuilder` means
+    /// `section_level.is_some()` for these kinds; level-0 Stan/JAGS blocks are
+    /// `Module` and so are sections too.
+    fn is_section_symbol(symbol: &RawSymbol) -> bool {
+        matches!(
+            symbol.kind,
+            DocumentSymbolKind::Module | DocumentSymbolKind::Heading
+        ) && symbol.section_level.is_some()
+    }
+
     /// Creates a new HierarchyBuilder with the given symbols and line count.
     ///
     /// # Arguments
@@ -2844,9 +2914,11 @@ impl HierarchyBuilder {
 
     /// Compute section ranges (from section comment to next section or EOF).
     ///
-    /// This method updates the `range` field of section symbols (those with `kind == Module`
-    /// and `section_level` set) to span from the section comment line to the line before
-    /// the next section, or to the end of the document if this is the last section.
+    /// This method updates the `range` field of section symbols (those for which
+    /// [`Self::is_section_symbol`] holds — a `Module` or `Heading` with a
+    /// `section_level`) to span from the section comment/heading line to the line
+    /// before the next section, or to the end of the document if this is the last
+    /// section.
     ///
     /// The `selection_range` is NOT modified - it remains the comment line only, as set
     /// during extraction.
@@ -2867,14 +2939,12 @@ impl HierarchyBuilder {
     /// - THE section symbol's `selectionRange` SHALL be the section comment line only
     ///   - Requirement 4.3 (already satisfied by extract_sections)
     pub fn compute_section_ranges(&mut self) {
-        // Collect indices of section symbols (kind == Module with section_level set)
+        // Collect indices of section symbols (Module or Heading with a level)
         let mut section_indices: Vec<usize> = self
             .symbols
             .iter()
             .enumerate()
-            .filter(|(_, sym)| {
-                matches!(sym.kind, DocumentSymbolKind::Module) && sym.section_level.is_some()
-            })
+            .filter(|(_, sym)| Self::is_section_symbol(sym))
             .map(|(idx, _)| idx)
             .collect();
 
@@ -3222,7 +3292,7 @@ impl HierarchyBuilder {
                         continue;
                     }
                     let container = &symbols[container_idx];
-                    if Self::symbol_is_inside_container(sym, container) {
+                    if Self::can_contain(container, sym) {
                         nested_indices.push(i);
                         break;
                     }
@@ -3251,9 +3321,7 @@ impl HierarchyBuilder {
             for sym in to_nest {
                 let mut inserted = false;
                 for container in remaining.iter_mut() {
-                    if Self::is_container_symbol(container)
-                        && Self::symbol_is_inside_container(&sym, container)
-                    {
+                    if Self::can_contain(container, &sym) {
                         Self::insert_into_innermost_container(&mut container.children, sym.clone());
                         inserted = true;
                         break;
@@ -3271,10 +3339,38 @@ impl HierarchyBuilder {
     }
 
     fn is_container_symbol(symbol: &RawSymbol) -> bool {
+        // Chunks (and `.R` `# %%` cells) contain the R symbols defined in their
+        // body, the same way functions and loops contain theirs. Treating them
+        // as containers here nests chunk-body symbols under their chunk at every
+        // level of the tree — including when the chunk itself is nested under a
+        // Markdown heading — rather than relying on a root-level positional
+        // accident in `nest_in_sections`.
         matches!(
             symbol.kind,
-            DocumentSymbolKind::Function | DocumentSymbolKind::Loop
+            DocumentSymbolKind::Function | DocumentSymbolKind::Loop | DocumentSymbolKind::Chunk
         )
+    }
+
+    /// Whether `container` may adopt `sym` as a child during function/loop/chunk
+    /// nesting: `container` is a container, `sym` falls inside its range, and the
+    /// pairing is allowed.
+    ///
+    /// A chunk/cell never adopts a section-spine entry (a Markdown `Heading` or
+    /// an R `# Section ----` `Module`). A `.R` `# %%` cell's range extends up to
+    /// and including a following section divider (see `detect_r_cells`), so
+    /// without this guard the divider — which must stay a top-level section —
+    /// would be swallowed as a child of the cell once chunks became containers.
+    ///
+    /// The guard is deliberately scoped to chunks. Functions and loops have
+    /// always been able to adopt a section that falls inside their body, and
+    /// Stan/JAGS rely on it: a decorative `// --- ... ---` section nests under
+    /// its enclosing `for` loop (see `test_stan_section_inside_loop_is_clamped_to_loop_end`).
+    /// Broadening the exclusion to all containers would regress that.
+    fn can_contain(container: &RawSymbol, sym: &RawSymbol) -> bool {
+        Self::is_container_symbol(container)
+            && Self::symbol_is_inside_container(sym, container)
+            && !(matches!(container.kind, DocumentSymbolKind::Chunk)
+                && Self::is_section_symbol(sym))
     }
 
     /// Check if a symbol is inside a container's range.
@@ -3296,8 +3392,7 @@ impl HierarchyBuilder {
     /// allowing for arbitrary nesting depth.
     fn insert_into_innermost_container(children: &mut Vec<RawSymbol>, symbol: RawSymbol) {
         for child in children.iter_mut() {
-            if Self::is_container_symbol(child) && Self::symbol_is_inside_container(&symbol, child)
-            {
+            if Self::can_contain(child, &symbol) {
                 Self::insert_into_innermost_container(&mut child.children, symbol);
                 return;
             }
@@ -4057,6 +4152,21 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             // Rmd docs this surfaces real R symbols defined inside chunk bodies.
             let ast_extractor = SymbolExtractor::new(&analysis_text, tree.root_node());
             let mut raw_symbols = ast_extractor.extract_all();
+            // In an Rmd/Quarto outline, Markdown headings (added below) are the
+            // section spine. The `Module` sections `extract_all` finds here come
+            // only from R `# X ----` dividers inside chunk bodies (prose is
+            // masked), and their numeric levels are unrelated to Markdown heading
+            // levels — letting them share the section stack would mis-close
+            // headings. Demote them to plain positioned entries so they still
+            // appear, nested by position, without competing as section
+            // boundaries. (Plain `.R` files keep their dividers as sections.)
+            if doc.is_rmd_document() {
+                for sym in &mut raw_symbols {
+                    if matches!(sym.kind, DocumentSymbolKind::Module) {
+                        sym.section_level = None;
+                    }
+                }
+            }
             // Chunk detection (R Markdown / Quarto fences and `.R` `# %%` cells)
             // must scan the RAW text: an Rmd doc's masked analysis text has its
             // fence and prose lines blanked. For plain R the raw text equals
@@ -4070,6 +4180,12 @@ pub fn document_symbol(state: &WorldState, uri: &Url) -> Option<DocumentSymbolRe
             let raw_text = rmd_raw_text.as_deref().unwrap_or(&analysis_text);
             let chunk_extractor = SymbolExtractor::new(raw_text, tree.root_node());
             raw_symbols.extend(chunk_extractor.extract_chunks(doc.chunk_kind));
+            // Prose Markdown headings form the outline's section spine for
+            // Rmd/Quarto only — detected from the raw text (prose is masked away
+            // in the analysis text).
+            if doc.is_rmd_document() {
+                raw_symbols.extend(chunk_extractor.extract_markdown_headings());
+            }
             raw_symbols
         }
     };
@@ -34600,6 +34716,192 @@ result <- data %>% filter(x > 0)
     fn test_chunk_lsp_kind_is_object() {
         // Distinct from sections (MODULE) so clients can filter independently.
         assert_eq!(DocumentSymbolKind::Chunk.to_lsp_kind(), SymbolKind::OBJECT);
+    }
+
+    #[test]
+    fn test_heading_lsp_kind_is_string() {
+        // Markdown headings map to STRING — VS Code's native Markdown-outline
+        // kind — so they read as headings and filter apart from chunks (OBJECT)
+        // and R sections (MODULE).
+        assert_eq!(
+            DocumentSymbolKind::Heading.to_lsp_kind(),
+            SymbolKind::STRING
+        );
+    }
+
+    #[test]
+    fn test_extract_markdown_headings_basic() {
+        let code = "# Title\n\nProse.\n\n## Section\n";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let headings = extractor.extract_markdown_headings();
+        assert_eq!(headings.len(), 2);
+        assert_eq!(headings[0].name, "Title");
+        assert!(matches!(headings[0].kind, DocumentSymbolKind::Heading));
+        assert_eq!(headings[0].section_level, Some(1));
+        assert_eq!(headings[0].range.start.line, 0);
+        assert_eq!(headings[0].range.start.character, 0);
+        // Selection range spans the heading line.
+        assert_eq!(
+            headings[0].selection_range.end.character,
+            utf16_len("# Title")
+        );
+        assert_eq!(headings[1].name, "Section");
+        assert_eq!(headings[1].section_level, Some(2));
+        assert_eq!(headings[1].range.start.line, 4);
+    }
+
+    #[test]
+    fn test_extract_markdown_headings_bom_first_line_columns() {
+        // Open documents keep a leading BOM verbatim (position-aligned with the
+        // client). The detector strips it only to anchor the column-0 match, but
+        // the LSP range columns must be measured against the RAW document line,
+        // so the end column is the real end-of-line (BOM + "# Title" = 8 UTF-16
+        // units), not the BOM-stripped width (7) — which would land one unit
+        // short of the heading's end.
+        let code = "\u{FEFF}# Title\n";
+        let tree = parse_r_code(code);
+        let extractor = SymbolExtractor::new(code, tree.root_node());
+        let headings = extractor.extract_markdown_headings();
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].name, "Title");
+        assert_eq!(headings[0].range.start.line, 0);
+        assert_eq!(
+            headings[0].selection_range.end.character,
+            utf16_len("\u{FEFF}# Title"),
+            "range end is measured on the raw (BOM-inclusive) line"
+        );
+    }
+
+    #[test]
+    fn test_document_symbol_nests_chunk_and_symbol_under_markdown_heading() {
+        // The outline mirrors the rendered document: Markdown headings form the
+        // top-level spine; a chunk nests under its heading, and an R symbol
+        // defined in the chunk nests under the chunk.
+        use crate::state::{Document, WorldState};
+
+        // 0 "# Analysis"
+        // 4 "```{r demo}"
+        // 5 "my_fun <- function(a) a + 1"
+        // 6 "```"
+        // 8 "## Details"
+        let code = "# Analysis\n\nIntro prose.\n\n```{r demo}\nmy_fun <- function(a) a + 1\n```\n\n## Details\n\nMore.\n";
+        let uri = Url::parse("file:///report.Rmd").unwrap();
+        let mut state = WorldState::new();
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        // One top-level H1; the H2 nests beneath it.
+        assert_eq!(symbols.len(), 1, "single top-level heading");
+        let h1 = &symbols[0];
+        assert_eq!(h1.kind, SymbolKind::STRING);
+        assert_eq!(h1.name, "Analysis");
+
+        let kids = h1.children.as_ref().expect("H1 has children");
+        let chunk = kids
+            .iter()
+            .find(|s| s.kind == SymbolKind::OBJECT && s.name == "demo")
+            .expect("chunk nested under H1");
+        let my_fun = chunk
+            .children
+            .as_ref()
+            .and_then(|k| k.iter().find(|s| s.name == "my_fun"))
+            .expect("my_fun nested under the chunk");
+        assert_eq!(my_fun.kind, SymbolKind::FUNCTION);
+        assert_eq!(my_fun.range.start.line, 5);
+
+        let h2 = kids
+            .iter()
+            .find(|s| s.kind == SymbolKind::STRING && s.name == "Details")
+            .expect("H2 nested under H1");
+        assert_eq!(h2.range.start.line, 8);
+    }
+
+    #[test]
+    fn test_document_symbol_r_cell_divider_stays_top_level_section() {
+        // Regression guard: chunks/cells are containers, but they must never
+        // adopt section-spine entries. In a `.R` file a `# Section ----` divider
+        // falls inside the preceding `# %%` cell's range, yet it must remain a
+        // top-level MODULE section, not become a child of the cell.
+        use crate::state::{Document, WorldState};
+
+        let code = "# %% Setup\nlibrary(x)\n# Analysis ----\ny <- 1\n";
+        let uri = Url::parse("file:///cells.R").unwrap();
+        let mut state = WorldState::new();
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        assert!(
+            symbols
+                .iter()
+                .any(|s| s.kind == SymbolKind::MODULE && s.name == "Analysis"),
+            "the divider must stay a top-level section, got: {:?}",
+            symbols
+                .iter()
+                .map(|s| (s.name.clone(), s.kind))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_document_symbol_rmd_demotes_chunk_r_divider() {
+        // An R section divider (`# X ----`) inside a chunk body must NOT act as
+        // a document-level section competing with Markdown headings, or it would
+        // mis-close the heading hierarchy (its numeric level is unrelated to the
+        // Markdown heading levels). The heading hierarchy must stay intact.
+        use crate::state::{Document, WorldState};
+
+        // 0 "# Heading One"
+        // 2 "```{r}"
+        // 3 "# Inner Divider ----"
+        // 4 "x <- 1"
+        // 5 "```"
+        // 7 "## Heading Two"
+        let code = "# Heading One\n\n```{r}\n# Inner Divider ----\nx <- 1\n```\n\n## Heading Two\n";
+        let uri = Url::parse("file:///divider.Rmd").unwrap();
+        let mut state = WorldState::new();
+        state.symbol_config.hierarchical_document_symbol_support = true;
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let response = super::document_symbol(&state, &uri).expect("response");
+        let symbols = match response {
+            DocumentSymbolResponse::Nested(s) => s,
+            DocumentSymbolResponse::Flat(_) => panic!("expected nested"),
+        };
+
+        // Exactly one top-level heading; the R divider is not a top-level section.
+        assert_eq!(symbols.len(), 1, "only the H1 is top-level");
+        assert_eq!(symbols[0].name, "Heading One");
+        assert!(
+            symbols.iter().all(|s| s.kind != SymbolKind::MODULE),
+            "no R-divider MODULE section competes at the top level"
+        );
+
+        // "Heading Two" (H2) nests under H1.
+        let kids = symbols[0].children.as_ref().expect("H1 has children");
+        assert!(
+            kids.iter()
+                .any(|s| s.kind == SymbolKind::STRING && s.name == "Heading Two"),
+            "H2 nests under H1"
+        );
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -34902,6 +34902,24 @@ result <- data %>% filter(x > 0)
                 .any(|s| s.kind == SymbolKind::STRING && s.name == "Heading Two"),
             "H2 nests under H1"
         );
+
+        // The divider is demoted, not removed: it still appears somewhere in the
+        // tree as an entry (per docs/document-outline.md).
+        let mut stack: Vec<&DocumentSymbol> = symbols.iter().collect();
+        let mut found_divider = false;
+        while let Some(sym) = stack.pop() {
+            if sym.name == "Inner Divider" {
+                found_divider = true;
+                break;
+            }
+            if let Some(children) = sym.children.as_ref() {
+                stack.extend(children.iter());
+            }
+        }
+        assert!(
+            found_divider,
+            "the divider is demoted but still present in the tree"
+        );
     }
 
     #[test]

--- a/docs/document-outline.md
+++ b/docs/document-outline.md
@@ -8,6 +8,7 @@ The document outline appears in VS Code's **Outline** view (usually in the Explo
 
 - **Hierarchical symbol tree** - See nested functions, variables within sections, and class methods
 - **R code sections** - Organize your code with collapsible section headers (`# Section ----`)
+- **R Markdown / Quarto headings** - Prose Markdown headings (`# Title`, `## Section`) form the document outline, mirroring the structure you see in the Knit Preview
 - **R Markdown / Quarto chunks** - Each ```` ```{r ...} ```` block (and `# %%` cell in plain `.R` files) appears as its own outline entry, distinct from section headers
 - **Rich symbol types** - Distinguish functions, constants, classes, and methods with distinct icons
 - **Quick navigation** - Click any symbol to jump to its definition
@@ -128,6 +129,48 @@ Chunk #3        {python}
 Chunks use a distinct symbol kind (`OBJECT`) so the outline filter can include or exclude them separately from section headers.
 
 R symbols defined *inside* an R chunk body — functions, variable assignments, S4/R6 classes — also appear in the outline, nested under their chunk, at their real document line. Prose, YAML front matter, and non-R chunk bodies are ignored, so a `library(...)` call in prose or a Python chunk never produces a phantom outline entry. (For non-R chunks only the chunk entry itself is shown.)
+
+## R Markdown / Quarto Headings
+
+For `.Rmd` and `.qmd` files, prose Markdown headings form the document outline — the same heading structure the Knit Preview renders. Opening the Outline view (or breadcrumbs) while editing the source therefore mirrors the rendered document.
+
+```rmd
+---
+title: "My Report"
+---
+
+# Introduction
+
+Some prose.
+
+```{r setup}
+library(dplyr)
+```
+
+## Methods
+
+```{r model}
+fit <- lm(y ~ x, data = df)
+```
+```
+
+Outline view shows:
+
+```text
+▼ Introduction
+  ▼ setup
+  ▼ Methods
+    ▼ model
+        fit
+```
+
+Details:
+
+- **Levels nest by depth.** `#` is level 1, `##` is level 2, and so on through `######`; deeper headings nest under shallower ones, just like R code sections.
+- **Chunks and chunk-body symbols nest under their heading.** A chunk appears under the heading whose section contains it, and the R symbols defined in that chunk nest under the chunk.
+- **Only prose headings count.** Headings inside YAML front matter, fenced code blocks, and R chunk bodies are ignored, so a `#` comment in code never becomes a phantom heading. A `# Section ----` divider inside a chunk body still appears as an entry, but it does not compete with Markdown headings for the document's section structure.
+- **Distinct icon.** Headings use the heading (string) symbol kind, so the outline filter can show or hide them separately from code chunks (object) and R sections (module).
+- **ATX headings only.** Setext (underline-style) headings — text underlined with `===` or `---` — are not recognized; use `#`-prefixed (ATX) headings.
 
 ### `# %%` cells in `.R` files
 

--- a/docs/document-outline.md
+++ b/docs/document-outline.md
@@ -8,7 +8,7 @@ The document outline appears in VS Code's **Outline** view (usually in the Explo
 
 - **Hierarchical symbol tree** - See nested functions, variables within sections, and class methods
 - **R code sections** - Organize your code with collapsible section headers (`# Section ----`)
-- **R Markdown / Quarto headings** - Prose Markdown headings (`# Title`, `## Section`) form the document outline, mirroring the structure you see in the Knit Preview
+- **R Markdown / Quarto headings** - Prose Markdown headings (`# Title`, `## Section`) form the document outline
 - **R Markdown / Quarto chunks** - Each ```` ```{r ...} ```` block (and `# %%` cell in plain `.R` files) appears as its own outline entry, distinct from section headers
 - **Rich symbol types** - Distinguish functions, constants, classes, and methods with distinct icons
 - **Quick navigation** - Click any symbol to jump to its definition
@@ -132,7 +132,7 @@ R symbols defined *inside* an R chunk body — functions, variable assignments, 
 
 ## R Markdown / Quarto Headings
 
-For `.Rmd` and `.qmd` files, prose Markdown headings form the document outline — the same heading structure the Knit Preview renders. Opening the Outline view (or breadcrumbs) while editing the source therefore mirrors the rendered document.
+For `.Rmd` and `.qmd` files, prose Markdown headings (`#`, `##`, …) form the document outline, so the Outline view and breadcrumbs reflect the document's section structure as you edit the source.
 
 ```rmd
 ---

--- a/docs/knit.md
+++ b/docs/knit.md
@@ -47,6 +47,11 @@ using whichever R / Python / SQL / Bash grammar your installed VS
 Code extensions contribute, with Raven's `function` semantic-token
 overlay layered on top of R blocks.
 
+While you edit the source `.Rmd` (or `.qmd`), VS Code's **Outline**
+view and breadcrumbs reflect the document's Markdown heading structure —
+the same structure the preview renders — so you can navigate the document
+as you preview it. See [docs/document-outline.md](document-outline.md).
+
 See [docs/coexistence.md](coexistence.md) for the surfaces Raven
 defers to other extensions (most notably `quarto.quarto`). The R and
 R Markdown grammars are vendored from REditorSupport upstream and ship


### PR DESCRIPTION
## What & why

When you open Raven's Knit Preview, it would be nice if the document's heading structure were navigable. VS Code's **Outline** view can't be populated for a webview panel, but it *is* fed by the LSP `textDocument/documentSymbol` response for the active source editor. So this teaches Raven's outline to include the prose **Markdown headings** (`# Title`, `## Section`) of `.Rmd`/`.qmd` files — the same structure the preview renders. Open the source alongside the preview and the Outline mirrors the rendered document.

Previously the outline for an `.Rmd` showed only code chunks, chunk-body R symbols, and R `# Section ----` dividers — never the prose headings (prose is masked before symbol extraction).

## Behavior

- Markdown headings form the top-level section spine; deeper headings nest under shallower ones.
- A chunk nests under the heading whose section contains it; R symbols defined in a chunk nest under the chunk.
- Only prose headings count — headings inside YAML front matter, fenced code, and chunk bodies are ignored. A `# X ----` divider inside a chunk still appears, but no longer competes with Markdown headings for the document's section structure (it's demoted in Rmd/Quarto).
- Headings use a distinct kind (`SymbolKind::STRING`, matching VS Code's native Markdown outline) so the outline filter can separate them from chunks (object) and R sections (module).
- ATX headings only; Setext (underline) headings are not recognized.

## Implementation

- `chunks.rs`: `detect_markdown_headings` — a column-0 scanner (aligned with `detect_rmd_chunks`' fence rules) that skips front matter and fenced code and recognizes CommonMark ATX headings.
- `handlers.rs`: new `DocumentSymbolKind::Heading`; `extract_markdown_headings`; headings join the hierarchy via `is_section_symbol` (`Module | Heading`); chunks become containers with `can_contain` guarding them from adopting section-spine entries; Rmd chunk-body dividers are demoted.
- Docs: `document-outline.md` (new subsection) and a `knit.md` cross-reference.

## Testing

- 27 unit/integration tests covering ATX edge cases (levels, trailing-`#` stripping, `#hashtag` rejection, empty titles, indentation), frontmatter/fence skipping (generic + tilde + `{r}`, shorter/indented closes, unclosed-to-EOF), CRLF and BOM handling, heading→chunk→symbol nesting, the Rmd divider demotion, and the `.R` cell/divider regression guard.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, and the `raven` lib suite all pass (the only failures are pre-existing `cli::packages::tests` that require network, blocked by the sandbox and failing identically on `main`).
- Reviewed by Codex (verdict: ship) and two consecutive clean `/code-review` passes.

https://claude.ai/code/session_01H1PCqchsNWr5iMzwhcJadR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown prose headings (ATX-style `#`, `##`, etc.) are now detected and integrated into the document outline for R Markdown and Quarto files
  * Headings appear in VS Code's outline view and breadcrumbs, reflecting the Markdown structure

* **Documentation**
  * Added documentation on how Markdown headings are recognized, nested with code chunks, and displayed in the document outline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->