### PR TITLE
fix(check): keep post-render context notes on the diagnostics' stream

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -292,8 +292,9 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
     // Auto-detect R for installed-package / base-symbol awareness. Any failure
     // (R absent, init error, no library paths) degrades gracefully and prints
     // its own one-line note to stderr. The returned verdict feeds the
-    // missing-export-metadata warning below.
-    let shipped_db_load = maybe_init_r(&mut state, &root).await;
+    // missing-export-metadata warning below; the returned load notes
+    // (present-but-unusable package DB) ride the shared footer.
+    let (shipped_db_load, db_load_notes) = maybe_init_r(&mut state, &root).await;
 
     // Resolve system.file() sources now that both package state AND library
     // paths are available (maybe_init_r populates lib_paths from R discovery
@@ -342,6 +343,10 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
     render(args.format, &all_diags, &root, args.quiet, use_color);
 
     // Post-render context notes that annotate the diagnostics above:
+    //   0. package-DB load notes (a present-but-unusable `names.db` /
+    //      `.raven/packages.json`), surfaced from `maybe_init_r`. They lead the
+    //      footer so the missing-export warning's "failed to load" wording reads
+    //      naturally after the specific load error.
     //   1. the missing-export-metadata warning (some attached packages' symbols
     //      couldn't be loaded, so undefined-variable findings may be inaccurate);
     //   2. the cross-file traversal-budget note (issue #473) — when a budget is
@@ -352,12 +357,12 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
     //      whole run. The editor surfaces the same via a throttled
     //      `window/showMessage`; `raven check` had no equivalent.
     //
-    // Both are emitted together so they share a stream and stay grouped:
+    // All are emitted together so they share a stream and stay grouped:
     // `route_footer_notes` keeps them on the diagnostics' own stream (stdout for
     // `text`, where a merged terminal/CI consumer would otherwise interleave
     // them with the findings; stderr for json/sarif, which reserve stdout for
     // the machine document). See `route_footer_notes`.
-    let mut footer = Vec::new();
+    let mut footer = db_load_notes;
     if !missing_export_metadata_packages.is_empty() {
         footer.push(format_missing_export_metadata_warning(
             &missing_export_metadata_packages,
@@ -560,7 +565,7 @@ fn resolve_project_config_with_options(
 async fn maybe_init_r(
     state: &mut crate::state::WorldState,
     root: &Path,
-) -> crate::package_library::ShippedDbLoad {
+) -> (crate::package_library::ShippedDbLoad, Vec<String>) {
     // Snapshot config into locals before the call so the later `state`
     // mutation doesn't conflict with the borrow.
     let r_path = state.cross_file_config.packages_r_path.clone();
@@ -578,13 +583,18 @@ async fn maybe_init_r(
     )
     .await;
 
-    // Surface present-but-unusable package-DB notes (e.g. a `.raven/packages.json`
-    // from a newer Raven, or a corrupt/incompatible `names.db`). These are
-    // build-time events carried on the outcome; print them before the status
-    // match below partially moves `outcome.library`.
-    for note in &outcome.load_notes {
-        eprintln!("raven check: {note}");
-    }
+    // Present-but-unusable package-DB notes (e.g. a `.raven/packages.json` from a
+    // newer Raven, or a corrupt/incompatible `names.db`) are build-time events
+    // carried on the outcome. Return them to the caller rather than printing here
+    // so they ride the shared footer on the diagnostics' own stream (stdout for
+    // `text`); printing to stderr inline would let a merged CI consumer reorder
+    // them relative to the findings. Extract before the status match below
+    // partially moves `outcome`.
+    let load_notes: Vec<String> = outcome
+        .load_notes
+        .iter()
+        .map(|note| format!("raven check: {note}"))
+        .collect();
 
     // Always install the returned library: on a non-`Ready` status it may still
     // carry Tier 2/3 providers or bundled base exports, which are the whole
@@ -617,7 +627,7 @@ async fn maybe_init_r(
             "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
         ),
     }
-    shipped_db_load
+    (shipped_db_load, load_notes)
 }
 
 /// `raven check`'s counterpart of the LSP startup's sysdata R fallback (the
@@ -868,7 +878,7 @@ fn format_missing_export_metadata_warning(
         ),
         Failed => format!(
             "{head}\n\
-             Raven's package symbol database is present but failed to load (corrupt or unsupported format), so it was not searched — see the load note above.\n\
+             Raven's package symbol database is present but failed to load (corrupt or unsupported format), so it was not searched.\n\
              Run `raven packages update` to re-download a working database."
         ),
     }
@@ -1354,6 +1364,16 @@ mod tests {
         assert!(
             !msg.contains("raven packages freeze"),
             "freeze is wrong advice when the DB merely failed to load: {msg}"
+        );
+        // Self-contained: must not cross-reference the separately-emitted load
+        // note by position. The load note and this footer can land on different
+        // streams a CI consumer reorders, so "see the load note above" can't be
+        // relied on; the load-note detail rides the same footer instead.
+        // (The shared head's "Undefined variable warnings above" is fine — those
+        // diagnostics share this footer's stream for `text`.)
+        assert!(
+            !msg.contains("load note above") && !msg.contains("see the load note"),
+            "warning must not reference the load note by position: {msg}"
         );
     }
 

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -341,26 +341,45 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
     let use_color = resolve_color_from_env(args.color);
     render(args.format, &all_diags, &root, args.quiet, use_color);
 
+    // Post-render context notes that annotate the diagnostics above:
+    //   1. the missing-export-metadata warning (some attached packages' symbols
+    //      couldn't be loaded, so undefined-variable findings may be inaccurate);
+    //   2. the cross-file traversal-budget note (issue #473) — when a budget is
+    //      hit the resolver silently stops following `source()` edges, so some
+    //      "Undefined variable" warnings above may be false positives. The owned
+    //      `state.cross_file_graph` accumulates these counters across every
+    //      target's diagnostic pass, so reading them after the loop reflects the
+    //      whole run. The editor surfaces the same via a throttled
+    //      `window/showMessage`; `raven check` had no equivalent.
+    //
+    // Both are emitted together so they share a stream and stay grouped:
+    // `route_footer_notes` keeps them on the diagnostics' own stream (stdout for
+    // `text`, where a merged terminal/CI consumer would otherwise interleave
+    // them with the findings; stderr for json/sarif, which reserve stdout for
+    // the machine document). See `route_footer_notes`.
+    let mut footer = Vec::new();
     if !missing_export_metadata_packages.is_empty() {
-        eprintln!(
-            "{}",
-            format_missing_export_metadata_warning(
-                &missing_export_metadata_packages,
-                shipped_db_load
-            )
-        );
+        footer.push(format_missing_export_metadata_warning(
+            &missing_export_metadata_packages,
+            shipped_db_load,
+        ));
     }
-
-    // Surface cross-file traversal-budget exhaustion (issue #473). The owned
-    // `state.cross_file_graph` accumulates these counters across every target's
-    // diagnostic pass (neighborhood collection records on the full graph), so
-    // reading them after the loop reflects the whole run. When a budget is hit
-    // the resolver silently stops following `source()` edges, so some
-    // "Undefined variable" warnings above may be false positives — say so, on
-    // stderr, so CI output is not misleading. The editor surfaces the same via
-    // a throttled `window/showMessage`; `raven check` had no equivalent.
     if let Some(note) = format_traversal_budget_note(&state) {
-        eprintln!("{note}");
+        footer.push(note);
+    }
+    if !footer.is_empty() {
+        let (to_stdout, to_stderr) = route_footer_notes(args.format, &footer);
+        if !to_stdout.is_empty() {
+            use std::io::Write as _;
+            // Lock + flush so the footer lands after the diagnostics already
+            // written by `render` and is fully drained before the process exits.
+            let mut out = std::io::stdout().lock();
+            let _ = writeln!(out, "{}", to_stdout.join("\n"));
+            let _ = out.flush();
+        }
+        if !to_stderr.is_empty() {
+            eprintln!("{}", to_stderr.join("\n"));
+        }
     }
 
     // Operator error takes priority over a threshold breach: a half-read run
@@ -855,6 +874,28 @@ fn format_missing_export_metadata_warning(
     }
 }
 
+/// Decide which stream each post-render context note goes to, given the output
+/// format. Pure (no I/O) so the routing rule is unit-testable without spawning
+/// the binary or an R subprocess; the caller does the actual writing.
+///
+/// The notes (missing-export-metadata warning, traversal-budget note) annotate
+/// the diagnostics, so for the human-readable `text` format they MUST share the
+/// diagnostics' stream — stdout. stdout and stderr are independent OS pipes that
+/// a merged consumer (a terminal, `2>&1`, or GitHub Actions — which timestamps
+/// each line at *read* time across two reader threads) reorders freely, so
+/// splitting a logically-grouped report across both streams interleaves the
+/// notes with the findings they describe. Same stream ⇒ a single reader
+/// preserves order. For the machine formats (`json`/`sarif`) stdout carries the
+/// parsed document, so notes stay on stderr where they can't corrupt it.
+///
+/// Returns `(to_stdout, to_stderr)`; exactly one is non-empty for a given format.
+fn route_footer_notes(format: OutputFormat, notes: &[String]) -> (Vec<String>, Vec<String>) {
+    match format {
+        OutputFormat::Text => (notes.to_vec(), Vec::new()),
+        OutputFormat::Json | OutputFormat::Sarif => (Vec::new(), notes.to_vec()),
+    }
+}
+
 /// Build the cross-file traversal-budget note for `raven check`, or `None` if
 /// no traversal was truncated (issue #473).
 ///
@@ -1198,6 +1239,30 @@ mod tests {
 
         let default = parse_args(std::iter::empty()).unwrap();
         assert!(!default.report_uninstalled);
+    }
+
+    #[test]
+    fn footer_notes_go_to_stdout_for_text_format() {
+        // Text output is human-readable and shares the terminal/CI stream with
+        // the diagnostics, so context notes must ride the SAME stream (stdout)
+        // — otherwise a merged consumer (GitHub Actions, `2>&1`) interleaves
+        // them with the findings they annotate. See issue: check footer stream.
+        let notes = vec!["note A".to_string(), "note B".to_string()];
+        let (to_stdout, to_stderr) = super::route_footer_notes(OutputFormat::Text, &notes);
+        assert_eq!(to_stdout, notes);
+        assert!(to_stderr.is_empty());
+    }
+
+    #[test]
+    fn footer_notes_go_to_stderr_for_machine_formats() {
+        // json/sarif reserve stdout for the machine document, so notes stay on
+        // stderr where they cannot corrupt the parsed output.
+        let notes = vec!["note A".to_string()];
+        for fmt in [OutputFormat::Json, OutputFormat::Sarif] {
+            let (to_stdout, to_stderr) = super::route_footer_notes(fmt, &notes);
+            assert!(to_stdout.is_empty());
+            assert_eq!(to_stderr, notes);
+        }
     }
 
     #[test]

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -358,10 +358,10 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
     //      `window/showMessage`; `raven check` had no equivalent.
     //
     // All are emitted together so they share a stream and stay grouped:
-    // `route_footer_notes` keeps them on the diagnostics' own stream (stdout for
+    // `footer_stream` keeps them on the diagnostics' own stream (stdout for
     // `text`, where a merged terminal/CI consumer would otherwise interleave
     // them with the findings; stderr for json/sarif, which reserve stdout for
-    // the machine document). See `route_footer_notes`.
+    // the machine document). See `footer_stream`.
     let mut footer = db_load_notes;
     if !missing_export_metadata_packages.is_empty() {
         footer.push(format_missing_export_metadata_warning(
@@ -373,17 +373,17 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
         footer.push(note);
     }
     if !footer.is_empty() {
-        let (to_stdout, to_stderr) = route_footer_notes(args.format, &footer);
-        if !to_stdout.is_empty() {
-            use std::io::Write as _;
-            // Lock + flush so the footer lands after the diagnostics already
-            // written by `render` and is fully drained before the process exits.
-            let mut out = std::io::stdout().lock();
-            let _ = writeln!(out, "{}", to_stdout.join("\n"));
-            let _ = out.flush();
-        }
-        if !to_stderr.is_empty() {
-            eprintln!("{}", to_stderr.join("\n"));
+        let body = footer.join("\n");
+        match footer_stream(args.format) {
+            FooterStream::Stdout => {
+                use std::io::Write as _;
+                // Lock + flush so the footer lands after the diagnostics already
+                // written by `render` and is fully drained before process exit.
+                let mut out = std::io::stdout().lock();
+                let _ = writeln!(out, "{body}");
+                let _ = out.flush();
+            }
+            FooterStream::Stderr => eprintln!("{body}"),
         }
     }
 
@@ -558,10 +558,16 @@ fn resolve_project_config_with_options(
 /// to stderr so CI shows what was missing; `Disabled` (the user turned package
 /// awareness off in `raven.toml`) is silent, matching the editor.
 ///
-/// Returns the build's [`ShippedDbLoad`] verdict so the caller can tailor the
-/// missing-export-metadata warning (absent / loaded / present-but-failed)
-/// without re-stat-ing disk — the build already knows whether the shipped
-/// `names.db` actually loaded, which a bare `Path::exists()` cannot tell.
+/// Returns `(shipped_db_load, load_notes)`:
+/// - the build's [`ShippedDbLoad`] verdict, so the caller can tailor the
+///   missing-export-metadata warning (absent / loaded / present-but-failed)
+///   without re-stat-ing disk — the build already knows whether the shipped
+///   `names.db` actually loaded, which a bare `Path::exists()` cannot tell;
+/// - the present-but-unusable package-DB load notes (each already prefixed
+///   `raven check: `). The caller folds these into the shared footer rather
+///   than this function printing them, so they ride the diagnostics' own stream
+///   (stdout for `text`) instead of being reorderable against the findings on
+///   stderr. See `footer_stream`.
 async fn maybe_init_r(
     state: &mut crate::state::WorldState,
     root: &Path,
@@ -884,25 +890,32 @@ fn format_missing_export_metadata_warning(
     }
 }
 
-/// Decide which stream each post-render context note goes to, given the output
-/// format. Pure (no I/O) so the routing rule is unit-testable without spawning
-/// the binary or an R subprocess; the caller does the actual writing.
+/// Which stream the post-render context-note footer goes to.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum FooterStream {
+    Stdout,
+    Stderr,
+}
+
+/// Decide which stream the post-render context-note footer goes to, given the
+/// output format. Pure (no I/O) so the routing rule is unit-testable without
+/// spawning the binary or an R subprocess; the caller owns the footer `Vec` and
+/// does the actual writing (no copy here).
 ///
-/// The notes (missing-export-metadata warning, traversal-budget note) annotate
-/// the diagnostics, so for the human-readable `text` format they MUST share the
-/// diagnostics' stream — stdout. stdout and stderr are independent OS pipes that
-/// a merged consumer (a terminal, `2>&1`, or GitHub Actions — which timestamps
-/// each line at *read* time across two reader threads) reorders freely, so
-/// splitting a logically-grouped report across both streams interleaves the
-/// notes with the findings they describe. Same stream ⇒ a single reader
-/// preserves order. For the machine formats (`json`/`sarif`) stdout carries the
-/// parsed document, so notes stay on stderr where they can't corrupt it.
-///
-/// Returns `(to_stdout, to_stderr)`; exactly one is non-empty for a given format.
-fn route_footer_notes(format: OutputFormat, notes: &[String]) -> (Vec<String>, Vec<String>) {
+/// The footer notes (package-DB load note, missing-export-metadata warning,
+/// traversal-budget note) annotate the diagnostics, so for the human-readable
+/// `text` format they MUST share the diagnostics' stream — stdout. stdout and
+/// stderr are independent OS pipes that a merged consumer (a terminal, `2>&1`,
+/// or GitHub Actions — which timestamps each line at *read* time across two
+/// reader threads) reorders freely, so splitting a logically-grouped report
+/// across both streams interleaves the notes with the findings they describe.
+/// Same stream ⇒ a single reader preserves order. For the machine formats
+/// (`json`/`sarif`) stdout carries the parsed document, so the footer goes to
+/// stderr where it can't corrupt it.
+fn footer_stream(format: OutputFormat) -> FooterStream {
     match format {
-        OutputFormat::Text => (notes.to_vec(), Vec::new()),
-        OutputFormat::Json | OutputFormat::Sarif => (Vec::new(), notes.to_vec()),
+        OutputFormat::Text => FooterStream::Stdout,
+        OutputFormat::Json | OutputFormat::Sarif => FooterStream::Stderr,
     }
 }
 
@@ -1252,26 +1265,23 @@ mod tests {
     }
 
     #[test]
-    fn footer_notes_go_to_stdout_for_text_format() {
+    fn footer_goes_to_stdout_for_text_format() {
         // Text output is human-readable and shares the terminal/CI stream with
-        // the diagnostics, so context notes must ride the SAME stream (stdout)
-        // — otherwise a merged consumer (GitHub Actions, `2>&1`) interleaves
-        // them with the findings they annotate. See issue: check footer stream.
-        let notes = vec!["note A".to_string(), "note B".to_string()];
-        let (to_stdout, to_stderr) = super::route_footer_notes(OutputFormat::Text, &notes);
-        assert_eq!(to_stdout, notes);
-        assert!(to_stderr.is_empty());
+        // the diagnostics, so the context-note footer must ride the SAME stream
+        // (stdout) — otherwise a merged consumer (GitHub Actions, `2>&1`)
+        // interleaves it with the findings it annotates.
+        assert_eq!(
+            super::footer_stream(OutputFormat::Text),
+            super::FooterStream::Stdout
+        );
     }
 
     #[test]
-    fn footer_notes_go_to_stderr_for_machine_formats() {
-        // json/sarif reserve stdout for the machine document, so notes stay on
-        // stderr where they cannot corrupt the parsed output.
-        let notes = vec!["note A".to_string()];
+    fn footer_goes_to_stderr_for_machine_formats() {
+        // json/sarif reserve stdout for the machine document, so the footer
+        // stays on stderr where it cannot corrupt the parsed output.
         for fmt in [OutputFormat::Json, OutputFormat::Sarif] {
-            let (to_stdout, to_stderr) = super::route_footer_notes(fmt, &notes);
-            assert!(to_stdout.is_empty());
-            assert_eq!(to_stderr, notes);
+            assert_eq!(super::footer_stream(fmt), super::FooterStream::Stderr);
         }
     }
 

--- a/crates/raven/tests/check_footer_stream.rs
+++ b/crates/raven/tests/check_footer_stream.rs
@@ -9,9 +9,13 @@
 //! (`json`/`sarif`) stdout is reserved for the parsed document, so the note
 //! stays on stderr.
 //!
-//! This drives the traversal-budget note (issue #473), which needs no R
-//! subprocess: a `maxTransitiveDependentsVisited = 1` budget over a short
-//! `source()` chain truncates the neighborhood walk and emits the note.
+//! Two footer paths are driven, both without an R subprocess:
+//! - the traversal-budget note (issue #473): a `maxTransitiveDependentsVisited = 1`
+//!   budget over a short `source()` chain truncates the neighborhood walk;
+//! - the package-DB load note: a corrupt `.raven/packages.json` makes the
+//!   package library report an unreadable Tier-2 DB. This is the only footer
+//!   entry in that case, so it proves a lone load note still surfaces on the
+//!   right stream.
 //!
 //! Run with: `cargo test -p raven --test check_footer_stream`
 
@@ -110,5 +114,65 @@ fn json_format_keeps_traversal_note_on_stderr() {
     assert!(
         stderr.contains(TRUNCATION_NOTE),
         "the note must be on stderr for json format; stderr was:\n{stderr}"
+    );
+}
+
+const LOAD_NOTE: &str = ".raven/packages.json is unreadable";
+
+/// A workspace whose committed Tier-2 package DB (`.raven/packages.json`) is
+/// corrupt, so `maybe_init_r` emits a package-DB load note. No R subprocess and
+/// no `names.db` required — this drives the load-note footer path that
+/// `route_footer_notes` must keep on the diagnostics' stream. `a.R` is
+/// diagnostic-free so the load note is the ONLY footer entry, proving it
+/// surfaces on its own (a regression that reverted `maybe_init_r` to print it
+/// inline on stderr would fail this).
+fn corrupt_package_db_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path();
+    std::fs::create_dir(p.join(".raven")).unwrap();
+    std::fs::write(
+        p.join(".raven/packages.json"),
+        "this is not valid json {{{\n",
+    )
+    .unwrap();
+    std::fs::write(p.join("a.R"), "x <- 1\n").unwrap();
+    dir
+}
+
+#[test]
+fn text_format_emits_load_note_on_stdout_not_stderr() {
+    let ws = corrupt_package_db_workspace();
+    let out = run_check(ws.path(), &[]);
+    let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
+
+    assert!(
+        stdout.contains(LOAD_NOTE),
+        "package-DB load note must be on stdout for text format; stdout was:\n{stdout}"
+    );
+    assert!(
+        !stderr.contains(LOAD_NOTE),
+        "package-DB load note must NOT be on stderr for text format; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn json_format_keeps_load_note_on_stderr() {
+    let ws = corrupt_package_db_workspace();
+    let out = run_check(ws.path(), &["--format", "json"]);
+    let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
+
+    assert!(
+        !stdout.contains(LOAD_NOTE),
+        "the load note must not pollute the json document on stdout; stdout was:\n{stdout}"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(stdout.trim()).is_ok(),
+        "stdout must be valid JSON; got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains(LOAD_NOTE),
+        "the load note must be on stderr for json format; stderr was:\n{stderr}"
     );
 }

--- a/crates/raven/tests/check_footer_stream.rs
+++ b/crates/raven/tests/check_footer_stream.rs
@@ -63,6 +63,12 @@ fn run_check(workspace: &std::path::Path, extra: &[&str]) -> Output {
     args.push("a.R");
     Command::new(raven_binary())
         .args(&args)
+        // Pin the logger to `error` so an inherited `RUST_LOG=warn`+ in the test
+        // environment can't make `env_logger` mirror the package-DB load note
+        // (logged at `warn` in `build_package_library`) onto stderr — which
+        // would defeat these tests' "note is absent from stderr for text"
+        // assertions. We are testing footer-stream routing, not logger config.
+        .env("RUST_LOG", "error")
         .output()
         .expect("run raven check")
 }

--- a/crates/raven/tests/check_footer_stream.rs
+++ b/crates/raven/tests/check_footer_stream.rs
@@ -1,0 +1,114 @@
+//! End-to-end test for `raven check`'s post-render context-note stream routing.
+//!
+//! The traversal-budget and missing-export-metadata notes annotate the
+//! diagnostics above them, so for the human-readable `text` format they must
+//! ride the diagnostics' own stream (stdout). Otherwise a merged consumer (a
+//! terminal, `2>&1`, or GitHub Actions — which timestamps each line at read
+//! time across two independent pipe readers) interleaves the note lines with
+//! the findings, splitting the multi-line block apart. For the machine formats
+//! (`json`/`sarif`) stdout is reserved for the parsed document, so the note
+//! stays on stderr.
+//!
+//! This drives the traversal-budget note (issue #473), which needs no R
+//! subprocess: a `maxTransitiveDependentsVisited = 1` budget over a short
+//! `source()` chain truncates the neighborhood walk and emits the note.
+//!
+//! Run with: `cargo test -p raven --test check_footer_stream`
+
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const TRUNCATION_NOTE: &str = "a bounded cross-file neighborhood traversal was truncated";
+
+fn raven_binary() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // remove test binary name
+    path.pop(); // remove `deps`
+    path.push("raven");
+    path
+}
+
+/// A workspace whose `a.R` → `b.R` → `c.R` chain truncates under a
+/// visited-budget of 1, so checking `a.R` emits the traversal-budget note.
+fn truncating_workspace() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let p = dir.path();
+    std::fs::write(
+        p.join("raven.toml"),
+        "[crossFile]\nmaxTransitiveDependentsVisited = 1\n",
+    )
+    .unwrap();
+    std::fs::write(p.join("a.R"), "source(\"b.R\")\nx <- helper_b()\n").unwrap();
+    std::fs::write(
+        p.join("b.R"),
+        "source(\"c.R\")\nhelper_b <- function() helper_c()\n",
+    )
+    .unwrap();
+    std::fs::write(p.join("c.R"), "helper_c <- function() 1\n").unwrap();
+    dir
+}
+
+fn run_check(workspace: &std::path::Path, extra: &[&str]) -> Output {
+    let mut args = vec![
+        "check",
+        "--workspace",
+        workspace.to_str().unwrap(),
+        "--no-color",
+    ];
+    args.extend_from_slice(extra);
+    args.push("a.R");
+    Command::new(raven_binary())
+        .args(&args)
+        .output()
+        .expect("run raven check")
+}
+
+#[test]
+fn text_format_emits_traversal_note_on_stdout_not_stderr() {
+    let ws = truncating_workspace();
+    let out = run_check(ws.path(), &[]);
+    let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
+
+    // The note rides the diagnostics' stream (stdout) so a merged consumer
+    // can't interleave it with the findings it annotates.
+    assert!(
+        stdout.contains(TRUNCATION_NOTE),
+        "traversal note must be on stdout for text format; stdout was:\n{stdout}"
+    );
+    assert!(
+        !stderr.contains(TRUNCATION_NOTE),
+        "traversal note must NOT be on stderr for text format; stderr was:\n{stderr}"
+    );
+    // It is a footer: the diagnostic line precedes it on the same stream.
+    let diag = stdout
+        .find("undefined-variable")
+        .expect("expected an undefined-variable diagnostic on stdout");
+    let note = stdout.find(TRUNCATION_NOTE).unwrap();
+    assert!(
+        diag < note,
+        "the note must follow the diagnostics it annotates"
+    );
+}
+
+#[test]
+fn json_format_keeps_traversal_note_on_stderr() {
+    let ws = truncating_workspace();
+    let out = run_check(ws.path(), &["--format", "json"]);
+    let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
+
+    // stdout must remain a parseable JSON document — no prose note in it.
+    assert!(
+        !stdout.contains(TRUNCATION_NOTE),
+        "the note must not pollute the json document on stdout; stdout was:\n{stdout}"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(stdout.trim()).is_ok(),
+        "stdout must be valid JSON; got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains(TRUNCATION_NOTE),
+        "the note must be on stderr for json format; stderr was:\n{stderr}"
+    );
+}

--- a/crates/raven/tests/check_footer_stream.rs
+++ b/crates/raven/tests/check_footer_stream.rs
@@ -67,10 +67,23 @@ fn run_check(workspace: &std::path::Path, extra: &[&str]) -> Output {
         .expect("run raven check")
 }
 
+/// `raven check` must finish with a findings-based exit code — `0` (nothing over
+/// threshold) or `1` (some) — never the operator-error code `2`. Asserting this
+/// guards the footer tests against an exit-code regression that still happened
+/// to emit the note on the expected stream (Codex review).
+fn assert_findings_exit(out: &Output) {
+    assert!(
+        matches!(out.status.code(), Some(0) | Some(1)),
+        "raven check exited with an unexpected (operator-error) status: {:?}",
+        out.status.code()
+    );
+}
+
 #[test]
 fn text_format_emits_traversal_note_on_stdout_not_stderr() {
     let ws = truncating_workspace();
     let out = run_check(ws.path(), &[]);
+    assert_findings_exit(&out);
     let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
     let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
 
@@ -99,6 +112,7 @@ fn text_format_emits_traversal_note_on_stdout_not_stderr() {
 fn json_format_keeps_traversal_note_on_stderr() {
     let ws = truncating_workspace();
     let out = run_check(ws.path(), &["--format", "json"]);
+    assert_findings_exit(&out);
     let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
     let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
 
@@ -122,7 +136,7 @@ const LOAD_NOTE: &str = ".raven/packages.json is unreadable";
 /// A workspace whose committed Tier-2 package DB (`.raven/packages.json`) is
 /// corrupt, so `maybe_init_r` emits a package-DB load note. No R subprocess and
 /// no `names.db` required — this drives the load-note footer path that
-/// `route_footer_notes` must keep on the diagnostics' stream. `a.R` is
+/// `footer_stream` must keep on the diagnostics' stream. `a.R` is
 /// diagnostic-free so the load note is the ONLY footer entry, proving it
 /// surfaces on its own (a regression that reverted `maybe_init_r` to print it
 /// inline on stderr would fail this).
@@ -143,6 +157,7 @@ fn corrupt_package_db_workspace() -> TempDir {
 fn text_format_emits_load_note_on_stdout_not_stderr() {
     let ws = corrupt_package_db_workspace();
     let out = run_check(ws.path(), &[]);
+    assert_findings_exit(&out);
     let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
     let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
 
@@ -160,6 +175,7 @@ fn text_format_emits_load_note_on_stdout_not_stderr() {
 fn json_format_keeps_load_note_on_stderr() {
     let ws = corrupt_package_db_workspace();
     let out = run_check(ws.path(), &["--format", "json"]);
+    assert_findings_exit(&out);
     let stdout = String::from_utf8(out.stdout).expect("stdout utf-8");
     let stderr = String::from_utf8(out.stderr).expect("stderr utf-8");
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -306,12 +306,12 @@ Both `check` and `lint` share the same renderers:
 
 ### Output streams
 
-Diagnostics go to **stdout**. Context notes that *follow* and annotate them — the "couldn't load exported symbols … warnings above may be inaccurate" warning and the cross-file traversal-budget note — are routed to keep the report readable:
+Diagnostics go to **stdout**. Context notes that *follow* and annotate them — a package-database load note (a present-but-unusable `names.db` / `.raven/packages.json`), the "couldn't load exported symbols … warnings above may be inaccurate" warning, and the cross-file traversal-budget note — are routed together to keep the report readable:
 
-- For `text`, the notes are written to **stdout** too, as a footer after the diagnostics. They share the diagnostics' stream deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave the multi-line note with the findings it describes. One stream keeps them grouped and in order.
+- For `text`, the notes are written to **stdout** too, as a footer after the diagnostics. They share the diagnostics' stream deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave the multi-line note with the findings it describes. One stream keeps them grouped and in order — so a note never refers to another by position across streams.
 - For `json` / `sarif`, stdout carries only the machine document, so those notes go to **stderr** instead (where they can't corrupt the parsed output).
 
-The one-line note printed when R is absent is emitted earlier (before any diagnostics) and always goes to stderr.
+The one-line note printed when R is absent (or its library fails to initialize) is emitted earlier (before any diagnostics) and always goes to stderr.
 
 ## Color output
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -306,7 +306,7 @@ Both `check` and `lint` share the same renderers:
 
 ### Output streams
 
-Diagnostics go to **stdout**. Context notes that *follow* and annotate them — a package-database load note (a present-but-unusable `names.db` / `.raven/packages.json`), the "couldn't load exported symbols … warnings above may be inaccurate" warning, and the cross-file traversal-budget note — are routed together to keep the report readable:
+Diagnostics go to **stdout** for both commands. For `raven check`, context notes that *follow* and annotate the diagnostics — a package-database load note (a present-but-unusable `names.db` / `.raven/packages.json`), the "couldn't load exported symbols … warnings above may be inaccurate" warning, and the cross-file traversal-budget note — are routed together to keep the report readable (`raven lint` has no such notes):
 
 - For `text`, the notes are written to **stdout** too, as a footer after the diagnostics. They share the diagnostics' stream deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave the multi-line note with the findings it describes. One stream keeps them grouped and in order — so a note never refers to another by position across streams.
 - For `json` / `sarif`, stdout carries only the machine document, so those notes go to **stderr** instead (where they can't corrupt the parsed output).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -304,6 +304,15 @@ Both `check` and `lint` share the same renderers:
 - `json` — array of `{ path, diagnostic }` objects (`diagnostic` is a verbatim LSP `Diagnostic`).
 - `sarif` — SARIF 2.1.0 envelope. Tool name `raven`; `ruleId` from `Diagnostic.code`.
 
+### Output streams
+
+Diagnostics go to **stdout**. Context notes that *follow* and annotate them — the "couldn't load exported symbols … warnings above may be inaccurate" warning and the cross-file traversal-budget note — are routed to keep the report readable:
+
+- For `text`, the notes are written to **stdout** too, as a footer after the diagnostics. They share the diagnostics' stream deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave the multi-line note with the findings it describes. One stream keeps them grouped and in order.
+- For `json` / `sarif`, stdout carries only the machine document, so those notes go to **stderr** instead (where they can't corrupt the parsed output).
+
+The one-line note printed when R is absent is emitted earlier (before any diagnostics) and always goes to stderr.
+
 ## Color output
 
 Both `check` and `lint` colorize the **severity word** (`error`, `warning`, `info`, `hint`) in `text` output — the rest of the line stays uncolored so it remains easy to grep. The `json` and `sarif` formats are machine-readable and are **never** colorized regardless of the flag or environment.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ Package-affecting changes (toggling `[packages].enabled`, `packageMode`, `rprofi
 | `raven.crossFile.maxBackwardDepth` | `10` | Maximum depth for backward directive traversal |
 | `raven.crossFile.maxForwardDepth` | `10` | Maximum depth for forward source() traversal |
 | `raven.crossFile.maxChainDepth` | `64` | Maximum total chain depth (emits diagnostic when exceeded). Also bounds the bidirectional neighborhood-walk depth. |
-| `raven.crossFile.maxTransitiveDependentsVisited` | `50000` | Maximum files visited while traversing the cross-file dependency graph. When this budget truncates analysis, dropped `source()` edges can surface as false-positive `undefined-variable` warnings; the editor shows a throttled warning and `raven check` prints a one-line note to stderr. Raise this for very large workspaces. |
+| `raven.crossFile.maxTransitiveDependentsVisited` | `50000` | Maximum files visited while traversing the cross-file dependency graph. When this budget truncates analysis, dropped `source()` edges can surface as false-positive `undefined-variable` warnings; the editor shows a throttled warning and `raven check` prints a one-line note (on stdout with the diagnostics for `text`, on stderr for `json`/`sarif`). Raise this for very large workspaces. |
 | `raven.crossFile.maxRevalidationsPerTrigger` | `10` | Max open documents to revalidate per change |
 | `raven.crossFile.revalidationDebounceMs` | `200` | Debounce delay for dependent file diagnostics (ms) |
 | `raven.crossFile.editedFileDebounceMs` | `50` | Debounce delay for the actively-edited file (ms). *LSP init-only — not exposed in the VS Code Settings UI.* |

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -308,7 +308,7 @@ Cross-file resolution walks the `source()` dependency graph under two safety bud
 The defaults are sized so realistic workspaces never reach them (the neighborhood is naturally bounded by the workspace's file count). If a workspace is large and dense enough to exhaust a budget, Raven stops following some `source()` edges, and the symbols those files define can surface as **false-positive `undefined-variable` warnings**. When that happens:
 
 - In the editor, Raven shows a throttled warning naming the setting to raise.
-- `raven check` prints a one-line note to stderr (so budget-induced drops are distinguishable from genuine undefined variables in CI).
+- `raven check` prints a one-line note (grouped with the diagnostics on stdout for the default `text` output, or on stderr for `json`/`sarif` — see [Output streams](cli.md#output-streams)), so budget-induced drops are distinguishable from genuine undefined variables in CI.
 
 Raise the relevant setting in `raven.toml` to analyze more of the graph. See [Configuration](configuration.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -377,7 +377,9 @@ the seam.
   returns `Absent` (normal, silent) vs `UnsupportedSchema { found, supported }` /
   `UnsupportedFormat` vs `Corrupt`. A present-but-unusable file (e.g. a
   `.raven/packages.json` written by a newer Raven) is **explained and the surface
-  continues**: `raven check` prints a specific stderr note, the language server
+  continues**: `raven check` prints a specific note (on stdout with the
+  diagnostics for `text` output, on stderr for `json`/`sarif` — it rides the
+  shared footer; see `footer_stream` in `cli/check.rs`), the language server
   raises `window/showMessage`, then resolution degrades to the next tier. A
   missing or unreadable database never hard-fails the LSP or the build.
 - **Tier 3 locator order:** environment overrides still win, then the user-data

--- a/docs/package-database.md
+++ b/docs/package-database.md
@@ -86,7 +86,7 @@ See [`raven packages fetch`](cli.md#raven-packages-fetch) and [Four ways to run 
 
 ### Version skew is explained, not silently dropped
 
-If a committed `.raven/packages.json` was written by a **newer** Raven than the one reading it (an incompatible schema), Raven does not silently ignore it. It **explains and continues**: `raven check` prints a specific note to stderr, the language server raises a notification, and resolution degrades to Tier 3 when a usable database is available. The message tells you to upgrade Raven here or regenerate the file with `raven packages freeze`. An unreadable or corrupt file is reported the same way. A missing file is normal and silent.
+If a committed `.raven/packages.json` was written by a **newer** Raven than the one reading it (an incompatible schema), Raven does not silently ignore it. It **explains and continues**: `raven check` prints a specific note (grouped with the diagnostics on stdout for the default `text` output, or on stderr for `json`/`sarif` — see [Output streams](cli.md#output-streams)), the language server raises a notification, and resolution degrades to Tier 3 when a usable database is available. The message tells you to upgrade Raven here or regenerate the file with `raven packages freeze`. An unreadable or corrupt file is reported the same way. A missing file is normal and silent.
 
 ## Tier 3 — `names.db` database
 


### PR DESCRIPTION
## Problem

In CI, `raven check`'s context notes get interspersed with the diagnostics they annotate. From a [worldwide CI run](https://github.com/Guttmacher/worldwide/actions/runs/28067891887/job/83096097475?pr=20), the five-line "couldn't load exported symbols for maptools, rgdal, rgeos…" warning was split apart by `undefined-variable` lines:

```
…6181  raven check: couldn't load exported symbols for maptools, rgdal, rgeos.   ← stderr
…6182  scripts/Paper/paperfigures.R:138:14 warning: Undefined variable: area …   ← stdout
…6184  Some "Undefined variable" warnings above may be inaccurate as a result.   ← stderr
…6185  scripts/analysis/Leaflet tutorial.R:29:15 warning: Undefined variable …   ← stdout
…6186  To fix: install these packages in your R library.                         ← stderr
…6187  scripts/analysis/appendix_table_1.r:3:1 warning: File not found …         ← stdout
```

## Root cause

Diagnostics print to **stdout** (`print_text` → `println!`); the two post-render notes — the missing-export-metadata warning and the cross-file traversal-budget note (#473) — printed to **stderr** via `eprintln!`. stdout and stderr are independent OS pipes. GitHub Actions reads each on its own thread and timestamps lines **at read time, not write time**, so a small stderr block and a large stdout backlog that become readable in the same window get merged in scrambled order. The single multi-line `eprintln!` is read line-by-line and interspersed. This is the same interleaving you get from `2>&1` or a terminal, and it can't be fixed by flushing — once bytes are in two separate pipes, the consumer chooses the order.

## Fix

Route the post-render notes onto the **same stream as the diagnostics they annotate**, so a single reader preserves order:

- **`text`** → notes to **stdout**, as a footer after the findings (single stream ⇒ no interleaving anywhere).
- **`json` / `sarif`** → notes stay on **stderr**, since stdout carries the machine document.

The pre-render "R not found" note is unchanged (it's emitted before any diagnostic and stays on stderr).

A pure `route_footer_notes(format, notes)` holds the routing rule (unit-tested without R). An end-to-end test drives the traversal-budget note — which needs no R subprocess — and asserts it lands on stdout (after the diagnostic) for `text` and on stderr for `json`. `docs/cli.md` gains an "Output streams" subsection.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` ✓
- New unit + integration tests pass; existing check-related integration suites unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `raven check` now routes explanatory context notes more consistently based on output format, keeping machine-readable output clean.
  * Added end-to-end coverage for footer note routing and exit-code behavior.

* **Bug Fixes**
  * Prevented context notes from appearing inline with diagnostics, reducing output reordering in CI.
  * Adjusted the missing-export warning wording to avoid referring to note placement.

* **Documentation**
  * Clarified how `stdout` and `stderr` are used for command output in the CLI docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->