### PR TITLE
feat(package-mode): resolve unqualified symbols from DESCRIPTION Depends:

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5975,6 +5975,23 @@ fn collect_in_play_packages(snapshot: &DiagnosticsSnapshot, uri: &Url) -> Vec<St
     for pkg in snapshot.scope_contribution.full_imports.iter() {
         packages.insert(pkg.clone());
     }
+    // DESCRIPTION `Depends:` packages are *attached* (R puts their exports on
+    // the bare search path when the package loads), so a meta-package in
+    // `Depends:` (e.g. `tidyverse`) must expand to its members — `filter`'s
+    // NSE policy comes from the member (dplyr), not the meta-package itself.
+    // This hardcoded expansion is independent of the package library, so it
+    // holds when the library is cold (CI / no R) and the owner-preserving
+    // fallback (issue #407, `table_verb_policy` step 3.5) can't recover the
+    // member. NAMESPACE `import(pkg)` / roxygen `@import` are deliberately NOT
+    // fed here: an `import()` is a selective namespace import, not an attach
+    // (`import(tidyverse)` does not put dplyr's `filter` on the search path),
+    // so meta-expanding it would falsely suppress a masked column. Non-meta
+    // packages expand to nothing (`meta_package_members` → `&[]`), so this is a
+    // safe no-op for the common concrete-`Depends:` case.
+    for pkg in snapshot.scope_contribution.depends_attached_packages.iter() {
+        packages.insert(pkg.clone());
+        attached_packages_for_meta.insert(pkg.clone());
+    }
     // `imported_symbols` is keyed by imported SYMBOL with the source PACKAGE(s)
     // in the values (`importFrom(dplyr, filter)` -> {"filter": {"dplyr"}}), so
     // the package names live in the values, not the keys.
@@ -26925,6 +26942,194 @@ clean_data <- function(x) {
                 "Depends: ggplot2 must suppress `{sym} is not defined` in R/ files; got: {messages:?}",
             );
         }
+    }
+
+    /// Issue #531 follow-up: a *meta-package* in `Depends:` (e.g. `tidyverse`)
+    /// must expand to its member packages (dplyr, …) for NSE argument-policy
+    /// resolution, so a data-masking verb like `filter(x > 5)` in the package's
+    /// own `R/` code does NOT flag the masked column `x`.
+    ///
+    /// This pins the behavior with a COLD package library — no installed
+    /// packages, no `names.db` — which is the case (CI / no R) where the
+    /// owner-preserving resolution fallback (issue #407) cannot resolve the
+    /// member owner. Without the hardcoded meta-expansion of
+    /// `depends_attached_packages`, only `tidyverse` is in play, `tidyverse`
+    /// carries no NSE policy, and `x` is wrongly flagged. A NAMESPACE
+    /// `import(tidyverse)` deliberately does NOT get this expansion (it is a
+    /// namespace import, not an attach) — see the scoping guard
+    /// `test_namespace_import_meta_package_does_not_expand_for_nse`.
+    #[tokio::test]
+    async fn test_depends_meta_package_expands_for_nse_cold_library() {
+        use crate::package_state::{
+            ContentDigest, DescriptionInput, PackageInputDelta, RFileInput, RFileKind,
+        };
+        use crate::state::{Document, WorldState};
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+        // Deliberately seed NOTHING into the package library — dplyr/tidyverse
+        // exports are unknown, so owner resolution cannot recover the member;
+        // suppression must come from hardcoded meta-expansion of
+        // `depends_attached_packages`.
+
+        state.package_inputs.workspace_root = Some(std::path::PathBuf::from("/work/pkg"));
+        state.package_inputs.package_mode = crate::cross_file::config::PackageMode::Auto;
+        state.package_inputs.description = Some(DescriptionInput {
+            text: "Package: tp\nVersion: 0.0.1\nDepends: tidyverse\n".into(),
+        });
+        let r_text: std::sync::Arc<str> =
+            "f <- function(df) df |> filter(x > 5)\nz <- genuine_undefined()\n".into();
+        state.package_inputs.r_files.insert(
+            std::path::PathBuf::from("/work/pkg/R/f.R"),
+            RFileInput {
+                kind: RFileKind::Source,
+                text: r_text.clone(),
+                content_digest: ContentDigest::of(&r_text),
+            },
+        );
+        state.apply_package_event(&PackageInputDelta::Initial);
+
+        let code = "f <- function(df) df |> filter(x > 5)\nz <- genuine_undefined()\n";
+        let uri = Url::parse("file:///work/pkg/R/f.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+            None,
+        );
+
+        let messages: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+        // Baseline: a genuinely-undefined symbol must still fire, else the
+        // pipeline isn't running and the test is vacuous.
+        assert!(
+            messages.contains(&"genuine_undefined is not defined"),
+            "baseline undefined symbol must be flagged; got: {messages:?}",
+        );
+        assert!(
+            !messages.iter().any(|m| m.contains("x is not defined")),
+            "Depends: tidyverse must meta-expand to dplyr so filter(x > 5) does \
+             not flag the masked column x (cold library); got: {messages:?}",
+        );
+    }
+
+    /// Issue #531 scoping guard (codex review): a NAMESPACE `import(meta_pkg)`
+    /// must NOT trigger hardcoded meta-package expansion. `import(tidyverse)` is
+    /// a selective namespace import, not an attach — in R it does not put
+    /// dplyr's `filter` on the search path — so meta-expanding it would falsely
+    /// suppress a masked column. With a COLD package library (so the issue #407
+    /// owner-preserving fallback can't intervene), `filter(x > 5)` in an `R/`
+    /// file with only `import(tidyverse)` MUST still flag `x`. (`Depends:
+    /// tidyverse`, a true attach, is the case that DOES expand — see
+    /// `test_depends_meta_package_expands_for_nse_cold_library`.)
+    #[tokio::test]
+    async fn test_namespace_import_meta_package_does_not_expand_for_nse() {
+        use crate::package_state::{
+            ContentDigest, DescriptionInput, NamespaceInput, PackageInputDelta, RFileInput,
+            RFileKind,
+        };
+        use crate::state::{Document, WorldState};
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+        // Cold library on purpose (see the Depends counterpart test).
+
+        state.package_inputs.workspace_root = Some(std::path::PathBuf::from("/work/pkg"));
+        state.package_inputs.package_mode = crate::cross_file::config::PackageMode::Auto;
+        state.package_inputs.description = Some(DescriptionInput {
+            text: "Package: tp\nVersion: 0.0.1\n".into(),
+        });
+        state.package_inputs.namespace = Some(NamespaceInput {
+            text: "import(tidyverse)\n".into(),
+        });
+        let r_text: std::sync::Arc<str> = "f <- function(df) df |> filter(x > 5)\n".into();
+        state.package_inputs.r_files.insert(
+            std::path::PathBuf::from("/work/pkg/R/f.R"),
+            RFileInput {
+                kind: RFileKind::Source,
+                text: r_text.clone(),
+                content_digest: ContentDigest::of(&r_text),
+            },
+        );
+        state.apply_package_event(&PackageInputDelta::Initial);
+
+        // `import(tidyverse)` populates `full_imports` but NOT
+        // `depends_attached_packages`, so meta-expansion does not apply.
+        assert!(
+            state
+                .package_state
+                .scope_contribution()
+                .full_imports
+                .contains("tidyverse"),
+            "import(tidyverse) should populate full_imports",
+        );
+        assert!(
+            state
+                .package_state
+                .scope_contribution()
+                .depends_attached_packages
+                .is_empty(),
+            "NAMESPACE import must NOT populate depends_attached_packages",
+        );
+
+        let code = "f <- function(df) df |> filter(x > 5)\n";
+        let uri = Url::parse("file:///work/pkg/R/f.R").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+            None,
+        );
+
+        let messages: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+        assert!(
+            messages.iter().any(|m| m.contains("x is not defined")),
+            "import(tidyverse) must NOT meta-expand to dplyr, so the masked column \
+             x stays flagged with a cold library; got: {messages:?}",
+        );
     }
 
     /// Workstream B negative test: a symbol NOT listed in any `importFrom`

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -26822,6 +26822,111 @@ clean_data <- function(x) {
         );
     }
 
+    /// Issue #531 end-to-end: a package in `DESCRIPTION` `Depends:` is attached
+    /// at load time, so its exports resolve unqualified in the package's own
+    /// `R/` code — equivalent to a NAMESPACE `import(pkg)`, but with no
+    /// NAMESPACE present (the issue's exact repro). Drives the FULL path
+    /// (DESCRIPTION text → `derive_package_state` → `full_imports` →
+    /// `is_package_export` suppression).
+    #[tokio::test]
+    async fn test_depends_resolves_unqualified_symbols_in_package_file() {
+        use crate::package_library::PackageInfo;
+        use crate::package_state::{
+            ContentDigest, DescriptionInput, PackageInputDelta, RFileInput, RFileKind,
+        };
+        use crate::state::{Document, WorldState};
+
+        let workspace_root = Url::parse("file:///work/pkg").unwrap();
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![workspace_root.clone()];
+        state.workspace_scan_complete = true;
+        state.cross_file_config.packages_enabled = true;
+        state.package_library_ready = true;
+
+        // ggplot2 exports must be known to the library so the whole-package
+        // (`full_imports`) resolution can confirm the symbols.
+        let mut ggplot2_exports = std::collections::HashSet::new();
+        ggplot2_exports.insert("ggplot".to_string());
+        ggplot2_exports.insert("aes".to_string());
+        ggplot2_exports.insert("theme_bw".to_string());
+        state
+            .package_library
+            .insert_package(PackageInfo::new("ggplot2".to_string(), ggplot2_exports))
+            .await;
+
+        // The issue's repro: a package with `Depends: ggplot2` and NO NAMESPACE.
+        state.package_inputs.workspace_root = Some(std::path::PathBuf::from("/work/pkg"));
+        state.package_inputs.package_mode = crate::cross_file::config::PackageMode::Auto;
+        state.package_inputs.description = Some(DescriptionInput {
+            text: "Package: tp\nVersion: 0.0.1\nDepends: ggplot2\n".into(),
+        });
+        let r_text: std::sync::Arc<str> =
+            "myplot <- function(d) ggplot(d, aes(x, y)) + theme_bw()\nz <- genuine_undefined()\n"
+                .into();
+        state.package_inputs.r_files.insert(
+            std::path::PathBuf::from("/work/pkg/R/p.r"),
+            RFileInput {
+                kind: RFileKind::Source,
+                text: r_text.clone(),
+                content_digest: ContentDigest::of(&r_text),
+            },
+        );
+        state.apply_package_event(&PackageInputDelta::Initial);
+
+        // Derivation must have placed ggplot2 in full_imports (no NAMESPACE).
+        assert!(
+            state
+                .package_state
+                .scope_contribution()
+                .full_imports
+                .contains("ggplot2"),
+            "Depends: ggplot2 must populate full_imports: {:?}",
+            state.package_state.scope_contribution().full_imports,
+        );
+
+        let code =
+            "myplot <- function(d) ggplot(d, aes(x, y)) + theme_bw()\nz <- genuine_undefined()\n";
+        let uri = Url::parse("file:///work/pkg/R/p.r").unwrap();
+        state
+            .documents
+            .insert(uri.clone(), Document::new(code, None));
+        let tree = {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_r::LANGUAGE.into())
+                .unwrap();
+            parser.parse(code, None).unwrap()
+        };
+
+        let mut diagnostics = Vec::new();
+        let snapshot = DiagnosticsSnapshot::build(&state, &uri).expect("snapshot built");
+        collect_undefined_variables_from_snapshot(
+            &snapshot,
+            &uri,
+            tree.root_node(),
+            code,
+            DiagnosticSeverity::WARNING,
+            &mut diagnostics,
+            &mut std::collections::HashMap::new(),
+            &DiagCancelToken::never(),
+            None,
+        );
+
+        let messages: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+        // Baseline: a genuinely-undefined symbol must still fire, else the
+        // pipeline isn't running and the test is vacuous.
+        assert!(
+            messages.contains(&"genuine_undefined is not defined"),
+            "baseline undefined symbol must be flagged; got: {messages:?}",
+        );
+        for sym in ["ggplot", "aes", "theme_bw"] {
+            assert!(
+                !messages.iter().any(|m| m.contains(sym)),
+                "Depends: ggplot2 must suppress `{sym} is not defined` in R/ files; got: {messages:?}",
+            );
+        }
+    }
+
     /// Workstream B negative test: a symbol NOT listed in any `importFrom`
     /// directive must still be flagged as undefined even when other symbols
     /// from the same package ARE imported. Ensures no leak of unnamed imports.

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -170,9 +170,17 @@ fn build_scope_contribution(
     // never self-depends, but a malformed one mid-edit could, and self-name in
     // `full_imports` would query a possibly-stale installed package of the same
     // name.
+    //
+    // The same names are also collected into `depends_attached_packages` (a
+    // subset of `full_imports`) so the NSE meta-package expansion can treat
+    // `Depends:` as an attach WITHOUT meta-expanding NAMESPACE `import()` /
+    // `@import` (which share `full_imports` but are not attaches). See the field
+    // doc on `PackageScopeContribution::depends_attached_packages`.
+    let mut depends_attached_packages: BTreeSet<String> = BTreeSet::new();
     if let Some(desc) = description {
         for pkg in crate::namespace_parser::parse_description_field_pub(&desc.text, "Depends") {
             if pkg != ws.name {
+                depends_attached_packages.insert(pkg.clone());
                 full_imports.insert(pkg);
             }
         }
@@ -184,6 +192,7 @@ fn build_scope_contribution(
         r_internal_symbols: Arc::new(r_internal_symbols),
         imported_symbols: Arc::new(imported_symbols),
         full_imports: Arc::new(full_imports),
+        depends_attached_packages: Arc::new(depends_attached_packages),
         test_attached_packages: Arc::new(test_attached_packages),
         test_helper_symbols: Arc::new(test_helper_symbols),
         test_helper_attached_packages: Arc::new(test_helper_attached_packages),
@@ -556,6 +565,47 @@ mod tests {
             .filter(|p| p.as_str() == "rlang")
             .count();
         assert_eq!(count, 1, "rlang should appear exactly once");
+    }
+
+    /// `Depends:` packages populate `depends_attached_packages` (the
+    /// meta-expansion subset), while NAMESPACE `import(pkg)` does NOT — only
+    /// `Depends:` is a true attach. Both still land in `full_imports`.
+    #[test]
+    fn depends_populates_attached_subset_but_namespace_import_does_not() {
+        let mut inputs = with_description(PackageMode::Auto, "Package: tp\nDepends: tidyverse\n");
+        inputs.namespace = Some(NamespaceInput {
+            text: "import(rlang)\n".into(),
+        });
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        let attached = &s.scope_contribution.depends_attached_packages;
+        assert!(
+            attached.contains("tidyverse"),
+            "Depends entry must be attached"
+        );
+        assert!(
+            !attached.contains("rlang"),
+            "NAMESPACE import(rlang) must NOT be in depends_attached_packages"
+        );
+        // Both still resolve unqualified via full_imports.
+        let full = &s.scope_contribution.full_imports;
+        assert!(full.contains("tidyverse") && full.contains("rlang"));
+    }
+
+    /// The self-name filter applies to `depends_attached_packages` too.
+    #[test]
+    fn depends_attached_excludes_own_package_name() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: tp\nDepends: tp, ggplot2\n"),
+            &PackageInputDelta::Initial,
+        );
+        let attached = &s.scope_contribution.depends_attached_packages;
+        assert!(attached.contains("ggplot2"));
+        assert!(!attached.contains("tp"), "own name must be excluded");
     }
 
     /// A malformed self-dependency (`Depends:` listing the package's own name)

--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -145,7 +145,7 @@ fn build_scope_contribution(
             }
         }
     }
-    let (imported_symbols, full_imports) = match namespace_model {
+    let (imported_symbols, mut full_imports) = match namespace_model {
         Some(m) => {
             let mut imp: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
             for (pkg, sym) in &m.imports {
@@ -156,6 +156,27 @@ fn build_scope_contribution(
         }
         None => (BTreeMap::new(), BTreeSet::new()),
     };
+    // Issue #531: `DESCRIPTION` `Depends:` packages are *attached* when the
+    // package is loaded (R puts their exports on the search path), so their
+    // exports resolve unqualified inside the package's own code — exactly like
+    // a NAMESPACE `import(pkg)`. Union them into `full_imports` (runs after the
+    // match, so it applies whether or not a NAMESPACE exists; the `BTreeSet`
+    // dedupes a package that is both imported and depended-on).
+    //
+    // `Imports:` is deliberately excluded: it is loaded but not attached, so it
+    // stays `::`/`importFrom`-only (matches R). Version constraints and the
+    // special `R` entry are stripped by `parse_description_field_pub`. The
+    // package's own name is filtered (`pkg != ws.name`): a valid DESCRIPTION
+    // never self-depends, but a malformed one mid-edit could, and self-name in
+    // `full_imports` would query a possibly-stale installed package of the same
+    // name.
+    if let Some(desc) = description {
+        for pkg in crate::namespace_parser::parse_description_field_pub(&desc.text, "Depends") {
+            if pkg != ws.name {
+                full_imports.insert(pkg);
+            }
+        }
+    }
     let test_attached_packages = compute_test_attached_packages(description);
     PackageScopeContribution {
         workspace_root: Some(ws.root.clone()),
@@ -440,6 +461,119 @@ mod tests {
             &PackageInputDelta::Initial,
         );
         assert_eq!(s.workspace.as_ref().unwrap().name, "unknown");
+    }
+
+    /// Issue #531: a package in `DESCRIPTION` `Depends:` is attached at load
+    /// time, so its exports resolve unqualified in the package's own code —
+    /// equivalent to a NAMESPACE `import(pkg)`. It must land in `full_imports`
+    /// even with no NAMESPACE present (the issue's repro has no NAMESPACE).
+    #[test]
+    fn depends_packages_added_to_full_imports() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: tp\nDepends: ggplot2\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(
+            s.scope_contribution.full_imports.contains("ggplot2"),
+            "Depends: ggplot2 should contribute to full_imports"
+        );
+    }
+
+    /// `Imports:` keeps the stricter R semantics (loaded, not attached → needs
+    /// `::`/`importFrom`), so it must NOT contribute to the unqualified set.
+    #[test]
+    fn imports_not_added_to_full_imports() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: tp\nImports: dplyr\n"),
+            &PackageInputDelta::Initial,
+        );
+        assert!(
+            !s.scope_contribution.full_imports.contains("dplyr"),
+            "Imports: dplyr must not contribute to full_imports"
+        );
+    }
+
+    /// `Depends:` unions with NAMESPACE `import(pkg)` — both populate the same
+    /// unqualified-export set.
+    #[test]
+    fn depends_unions_with_namespace_full_imports() {
+        let mut inputs = with_description(PackageMode::Auto, "Package: tp\nDepends: ggplot2\n");
+        inputs.namespace = Some(NamespaceInput {
+            text: "import(rlang)\n".into(),
+        });
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        let full = &s.scope_contribution.full_imports;
+        assert!(full.contains("ggplot2"), "Depends entry missing");
+        assert!(full.contains("rlang"), "NAMESPACE import entry missing");
+    }
+
+    /// Version constraints are stripped and the special `R` entry is dropped.
+    #[test]
+    fn depends_strips_version_and_drops_r() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(
+                PackageMode::Auto,
+                "Package: tp\nDepends: R (>= 3.5), ggplot2 (>= 3.0)\n",
+            ),
+            &PackageInputDelta::Initial,
+        );
+        let full = &s.scope_contribution.full_imports;
+        assert!(full.contains("ggplot2"), "ggplot2 should be present");
+        assert!(
+            !full.contains("R"),
+            "R version requirement is not a package"
+        );
+        assert!(
+            !full.iter().any(|p| p.contains('(')),
+            "version constraints must be stripped"
+        );
+    }
+
+    /// A package both depended-on and NAMESPACE-imported collapses to one entry
+    /// (the `BTreeSet` dedupes).
+    #[test]
+    fn depends_dedupes_with_namespace() {
+        let mut inputs = with_description(PackageMode::Auto, "Package: tp\nDepends: rlang\n");
+        inputs.namespace = Some(NamespaceInput {
+            text: "import(rlang)\n".into(),
+        });
+        let s = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        let count = s
+            .scope_contribution
+            .full_imports
+            .iter()
+            .filter(|p| p.as_str() == "rlang")
+            .count();
+        assert_eq!(count, 1, "rlang should appear exactly once");
+    }
+
+    /// A malformed self-dependency (`Depends:` listing the package's own name)
+    /// is filtered out so we never query a stale installed package of the same
+    /// name.
+    #[test]
+    fn depends_filters_own_package_name() {
+        let s = derive_package_state(
+            &PackageState::default(),
+            &with_description(PackageMode::Auto, "Package: tp\nDepends: tp, ggplot2\n"),
+            &PackageInputDelta::Initial,
+        );
+        let full = &s.scope_contribution.full_imports;
+        assert!(full.contains("ggplot2"), "ggplot2 should be present");
+        assert!(
+            !full.contains("tp"),
+            "own package name must be filtered from full_imports"
+        );
     }
 
     #[test]

--- a/crates/raven/src/package_state/mod.rs
+++ b/crates/raven/src/package_state/mod.rs
@@ -858,6 +858,21 @@ pub struct PackageScopeContribution {
     pub imported_symbols: Arc<BTreeMap<String, BTreeSet<String>>>,
     pub full_imports: Arc<BTreeSet<String>>,
 
+    /// Packages from `DESCRIPTION` `Depends:` — a *subset* of `full_imports`
+    /// (issue #531). `Depends:` is a true attach (R puts the package's exports
+    /// on the bare search path when this package loads), so these are also fed
+    /// to the NSE meta-package expansion in `collect_in_play_packages`: a
+    /// meta-package here (e.g. `tidyverse`) expands to its members so a bare
+    /// data-masking verb resolves to the member's policy.
+    ///
+    /// Tracked separately from `full_imports` precisely so this hardcoded
+    /// meta-expansion does NOT also apply to NAMESPACE `import(pkg)` / roxygen
+    /// `@import` entries (which also live in `full_imports` but are selective
+    /// namespace imports, not attaches — `import(tidyverse)` does not put
+    /// dplyr's `filter` on the search path, so expanding it would falsely
+    /// suppress a masked column). The package's own name is excluded.
+    pub depends_attached_packages: Arc<BTreeSet<String>>,
+
     /// Packages that should be treated as if attached (via `library(...)`)
     /// when resolving scope for any file under `<root>/tests/testthat/`.
     ///

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -8,7 +8,7 @@ Raven activates **package mode** when the workspace root contains a `DESCRIPTION
 
 1. **Mutual visibility** — All `R/*.R` files see each other's top-level symbols, matching `devtools::load_all()` semantics. A function defined in `R/utils.R` is available in `R/analysis.R` without any `source()` call.
 
-2. **Import resolution** — Symbols imported via `NAMESPACE` or roxygen annotations (`@import`, `@importFrom`) suppress undefined-variable diagnostics.
+2. **Import resolution** — Symbols imported via `NAMESPACE` or roxygen annotations (`@import`, `@importFrom`) suppress undefined-variable diagnostics. Packages listed in `DESCRIPTION` `Depends:` are also treated as attached — their exports resolve unqualified, equivalent to a NAMESPACE `import(pkg)` of each — because R puts a `Depends:` package's exports on the search path when your package loads. `Imports:` keeps the stricter R semantics (loaded but not attached), so an `Imports:`-only package still requires `pkg::fn` or an explicit `@importFrom`/`importFrom(...)`.
 
 3. **Roxygen + NAMESPACE merge** — Raven unions imports and exports parsed from the generated `NAMESPACE` file with roxygen tags (`@import`, `@importFrom`, `@export`) parsed from `R/*.R` files. Imports visible to your code are the combined set from both sources, so you get correct import resolution whether you edit `NAMESPACE` directly, rely on `devtools::document()` to regenerate it from roxygen, or are mid-edit between the two.
 
@@ -421,6 +421,19 @@ and roxygen are deduped. This means roxygen-annotated imports are
 visible to diagnostics and completions even before you run
 `devtools::document()` to regenerate `NAMESPACE`, and NAMESPACE-only
 imports remain visible if some `R/*.R` files don't carry roxygen tags.
+
+`DESCRIPTION` `Depends:` packages are folded into this same set as
+whole-package imports: each `Depends:` entry is treated exactly like a
+NAMESPACE `import(pkg)`, because R attaches `Depends:` packages onto the
+search path when your package loads, making their exports available
+unqualified. Version constraints (`pkg (>= 1.0)`) and the special `R`
+entry are ignored. `Imports:` is deliberately *not* folded in — an
+`Imports:`-only package is loaded but not attached, so it still requires
+`pkg::fn` or an explicit `importFrom`/`@importFrom`, matching R. (One
+narrow case is not yet modeled: a *meta-package* in `Depends:` such as
+`Depends: tidyverse` resolves the meta-package's own exports but does not
+expand to member packages' NSE argument policies — the same limitation
+that `import(tidyverse)` has today. Concrete packages are unaffected.)
 
 ### data.table `[` detection in package mode
 

--- a/docs/r-package-dev.md
+++ b/docs/r-package-dev.md
@@ -429,11 +429,21 @@ search path when your package loads, making their exports available
 unqualified. Version constraints (`pkg (>= 1.0)`) and the special `R`
 entry are ignored. `Imports:` is deliberately *not* folded in — an
 `Imports:`-only package is loaded but not attached, so it still requires
-`pkg::fn` or an explicit `importFrom`/`@importFrom`, matching R. (One
-narrow case is not yet modeled: a *meta-package* in `Depends:` such as
-`Depends: tidyverse` resolves the meta-package's own exports but does not
-expand to member packages' NSE argument policies — the same limitation
-that `import(tidyverse)` has today. Concrete packages are unaffected.)
+`pkg::fn` or an explicit `importFrom`/`@importFrom`, matching R.
+
+A meta-package in `Depends:` also expands to its members for
+non-standard-evaluation. `Depends: tidyverse` contributes dplyr, tidyr,
+ggplot2, … to the set of packages whose NSE argument policies are in
+play, so a data-masking verb like `filter(x > 5)` in your `R/` code does
+not flag the masked column `x`. This expansion is built in and does not
+depend on the member packages being installed, so it holds in CI without
+R. This applies to `Depends:` (and `library()`/`require()` attaches)
+because those *attach* the meta-package — putting its members on the
+search path. A NAMESPACE `import(tidyverse)` / `@import tidyverse` does
+**not** get this expansion: an `import()` is a selective namespace import,
+not an attach, so it does not bring the members' exports into scope (a
+bare member verb there is still resolved only if the member is genuinely
+re-exported and known to Raven's package database).
 
 ### data.table `[` detection in package mode
 

--- a/docs/superpowers/specs/2026-06-25-issue-531-depends-attached-unqualified-symbols-design.md
+++ b/docs/superpowers/specs/2026-06-25-issue-531-depends-attached-unqualified-symbols-design.md
@@ -149,37 +149,59 @@ visible to any code evaluated with the package loaded — broader than a namespa
 not a regression, and is exactly what the issue requests ("equivalent to a
 NAMESPACE `import()` of each"). No new file-kind scoping mechanism is introduced.
 
-### Meta-package NSE expansion: intentional asymmetry (review finding 3)
+### Meta-package NSE expansion (review finding 3 — now implemented)
 
-`collect_in_play_packages` adds `full_imports` to the in-play `packages` set but
-**not** to `attached_packages_for_meta` (`handlers.rs:5975` vs `:5984`). Only
-`library()`/`require()` attaches and `test_attached_packages` feed
-`attached_packages_for_meta`, which expands meta-packages (e.g. `tidyverse`) to
-their members so a bare verb like `filter` resolves to dplyr's NSE policy.
+`collect_in_play_packages` originally added `full_imports` to the in-play
+`packages` set but **not** to `attached_packages_for_meta` (`handlers.rs`). Only
+`library()`/`require()` attaches and `test_attached_packages` fed
+`attached_packages_for_meta`, which expands a meta-package (e.g. `tidyverse`) to
+its members so a bare verb like `filter` resolves to dplyr's NSE policy.
 
-Routing `Depends:` through `full_imports` therefore does **not** trigger
-meta-package member expansion. We accept this deliberately:
+The first cut accepted the asymmetry as a documented limitation. On review it
+was upgraded to **fix now**, scoped to `Depends:` (a true attach), because:
 
-- It is **identical to the existing `import(pkg)` behavior** — `import(tidyverse)`
-  in NAMESPACE doesn't meta-expand today either — so `Depends:` stays consistent
-  with the mechanism the issue asked it to mirror.
-- The only affected case is a *meta-package* in `Depends:` (e.g.
-  `Depends: tidyverse`), which is rare and a discouraged anti-pattern. A concrete
-  package in `Depends:` (`ggplot2`, `data.table`, `dplyr`, `R6`, …) is itself a
-  member, so its own NSE policy resolves directly via the in-play `packages` set
-  — no meta-expansion needed. The motivating issue and all realistic cases are
-  concrete packages.
-- The worst-case symptom for a meta-package in `Depends:` is a *false positive*
-  (a mask argument flagged), never a false negative, and it is fixable by the
-  user with an explicit `library(member_pkg)` — the same escape hatch that exists
-  for `import(tidyverse)` today.
+- `Depends:` puts a whole package's exports on the bare search path when the
+  package loads — semantically an attach, exactly like `library()`. A
+  meta-package attached this way attaches its members, so their NSE policies
+  apply. It therefore belongs in the meta-expansion set.
+- The owner-preserving fallback (issue #407, `table_verb_policy` step 3.5)
+  already covers the meta-package case **when the package library is warm**
+  (installed deps or `names.db` let it resolve `filter`'s true owner, dplyr).
+  But when the library is **cold** (CI / no R / deps not installed), step 3.5
+  returns `None`, only the meta-package is in play, it carries no NSE policy, and
+  the masked column is wrongly flagged. Hardcoded meta-expansion closes exactly
+  that gap, independent of the library.
 
-Adding `Depends:`-specific meta-expansion would require tracking the `Depends:`
-subset separately from `full_imports` (since `import()` entries must *not* be
-meta-expanded, to preserve current behavior) and a new consumer in
-`collect_in_play_packages`. That cost is not justified by the rare anti-pattern
-case. If a real report surfaces, the follow-up is a separate
-`depends_attached_packages` field consumed there — explicitly out of scope here.
+**NAMESPACE `import()` / `@import` is deliberately excluded** (codex review).
+An `import(pkg)` is a *selective namespace import*, not an attach: in R,
+`import(tidyverse)` imports only tidyverse's own exports into the namespace and
+does **not** put dplyr's `filter` on the search path. Meta-expanding it would
+falsely suppress a masked column for code where the verb isn't actually
+available. The `attached_packages_for_meta` set is documented as "limited to
+true attach contexts," so feeding NAMESPACE imports into it would also violate
+that intent. (For the rare case where a meta-package genuinely re-exports a
+member verb, the warm-library owner-preserving fallback still covers it.)
+
+**Implementation.** `Depends:` packages are tracked in a dedicated
+`PackageScopeContribution::depends_attached_packages` set (a subset of
+`full_imports`, populated in `build_scope_contribution` alongside the
+`full_imports` union, same `pkg != ws.name` filter). `collect_in_play_packages`
+feeds **only that set** into `attached_packages_for_meta`; `full_imports` itself
+is left feeding only the in-play `packages` set as before. Non-meta `Depends:`
+packages expand to nothing (`meta_package_members` → `&[]`), so this is a safe
+no-op for the common concrete-`Depends:` case.
+
+**Tests.**
+- `test_depends_meta_package_expands_for_nse_cold_library` (`handlers.rs`) pins
+  the positive case with a deliberately **empty** package library (the cold case
+  the fallback can't cover): `Depends: tidyverse` + `filter(x > 5)` in `R/` must
+  not flag `x`, while a genuine undefined still fires. Fails without the
+  expansion, passes with it.
+- `test_namespace_import_meta_package_does_not_expand_for_nse` is the scoping
+  guard: `import(tidyverse)` with a cold library must **still** flag `x` (no
+  hardcoded expansion), and asserts `depends_attached_packages` stays empty.
+- Derive tests assert `Depends:` populates `depends_attached_packages` while
+  `import()` does not, and the self-name filter applies to both sets.
 
 ### Both-paths coverage (NAMESPACE present and absent)
 

--- a/docs/superpowers/specs/2026-06-25-issue-531-depends-attached-unqualified-symbols-design.md
+++ b/docs/superpowers/specs/2026-06-25-issue-531-depends-attached-unqualified-symbols-design.md
@@ -1,0 +1,273 @@
+# Issue #531 — Resolve unqualified symbols from `Depends:` packages in package mode
+
+Date: 2026-06-25
+Status: Approved for implementation (codex round 2: "no blockers"; spec-text
+precision corrections applied)
+
+## Problem
+
+In package mode (workspace root has `DESCRIPTION` with a non-empty `Package:`
+field), raven resolves unqualified symbols from a package listed in
+`NAMESPACE: import(pkg)` but **not** from a package listed in `Depends:` in
+`DESCRIPTION`. Because R *attaches* `Depends:` packages when the package is
+loaded (`library()` / `pkgload::load_all()`), their exports are available
+unqualified to the package's own code at runtime, and `R CMD check` does not
+flag them. raven's static analysis diverges from R here, producing false
+`undefined-variable` warnings.
+
+Reproduction (raven 0.11.1): a package with `Depends: ggplot2` and
+`R/p.r` = `myplot <- function(d) ggplot(d, aes(x, y)) + theme_bw()` flags
+`ggplot` and `theme_bw` as undefined. Adding `NAMESPACE` with `import(ggplot2)`
+(and nothing else) fixes both — so the export data is available; only the
+`Depends:`-based resolution path is missing.
+
+## Goal / non-goals
+
+**Goal.** Treat each package in `DESCRIPTION` `Depends:` as a source of
+unqualified exported symbols for the package's own code — exactly equivalent to
+a `NAMESPACE` `import(pkg)` of each. This suppresses `undefined-variable` for
+those packages' exports and feeds completion / NSE-in-play the same way
+`import(pkg)` does today.
+
+**Non-goals.**
+- `Imports:` keeps its current stricter semantics (loaded, not attached →
+  requires `pkg::sym` or `importFrom`). We do **not** add `Imports:` packages to
+  the unqualified set. This matches R.
+- `Suggests:` is unaffected.
+- We do not change how a package's exports are *looked up* (the package
+  library / names-db three-tier path is untouched).
+- We do not add `useDynLib` or any other resolution that doesn't exist today.
+
+## Background: how `import(pkg)` resolves today
+
+(All paths under `crates/raven/src/`.)
+
+1. **NAMESPACE → model.** `package_namespace.rs` parses `import(pkg)` into
+   `PackageNamespaceModel.full_imports: Vec<String>` and `importFrom(pkg, sym)`
+   into `imports: Vec<(String, String)>`.
+2. **Model + roxygen → contribution.** `package_state/derive.rs`
+   `build_scope_contribution` (lines ~148-176) folds the namespace model into a
+   `PackageScopeContribution`: `full_imports: Arc<BTreeSet<String>>` (whole-
+   package imports) and `imported_symbols: Arc<BTreeMap<sym, {pkg}>>` (specific
+   symbols). `merge_namespace_model` first unions roxygen `@import`/`@importFrom`
+   from `R/*.R` Source files into the model.
+3. **Consumption.** `full_imports` is **not** injected as concrete symbols into
+   scope (`scope.rs` `append_package_contribution` deliberately skips it — the
+   comment explains the package library enumerates them). Instead three
+   consumers read `scope_contribution.full_imports`:
+   - completion (`handlers.rs` ~18079): offer those packages' exports;
+   - NSE "in-play packages" (`handlers.rs` `collect_in_play_packages` ~5975):
+     determine which packages' NSE policies apply;
+   - undefined-variable diagnostics (`handlers.rs` ~5803, ~6700): an undefined
+     identifier that is an export of a `full_imports` package is suppressed.
+
+`Depends:` is already *parsed* — `namespace_parser::parse_description_field_pub`
+(strips `(>= x)` version constraints, drops the special `R` entry) — but is used
+only by `compute_test_attached_packages` (the `tests/testthat/` implicit-attach
+gate for testthat). It never reaches `full_imports`.
+
+## Design
+
+**Single change site: `build_scope_contribution` in
+`package_state/derive.rs`.** After computing `full_imports` from the namespace
+model, union in the `Depends:` package names from `DESCRIPTION`.
+
+Current (lines ~148-158):
+
+```rust
+let (imported_symbols, full_imports) = match namespace_model {
+    Some(m) => {
+        let mut imp: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for (pkg, sym) in &m.imports {
+            imp.entry(sym.clone()).or_default().insert(pkg.clone());
+        }
+        let full: BTreeSet<String> = m.full_imports.iter().cloned().collect();
+        (imp, full)
+    }
+    None => (BTreeMap::new(), BTreeSet::new()),
+};
+```
+
+Proposed:
+
+```rust
+let (imported_symbols, mut full_imports) = match namespace_model {
+    Some(m) => { /* unchanged */ }
+    None => (BTreeMap::new(), BTreeSet::new()),
+};
+// `Depends:` packages are attached when the package is loaded (R puts their
+// exports on the search path), so their exports resolve unqualified inside the
+// package's own code — exactly like a NAMESPACE `import(pkg)`. Union them into
+// `full_imports`. `Imports:` is deliberately excluded: it is loaded but not
+// attached, so it stays `::`/`importFrom`-only (matches R). Version
+// constraints and the special `R` entry are stripped by the parser. The
+// package's own name is filtered out (`pkg != ws.name`): a valid DESCRIPTION
+// never self-depends, but a malformed one mid-edit could, and self-name in
+// `full_imports` would query a possibly-stale installed package of the same
+// name.
+if let Some(desc) = description {
+    for pkg in crate::namespace_parser::parse_description_field_pub(&desc.text, "Depends") {
+        if pkg != ws.name {
+            full_imports.insert(pkg);
+        }
+    }
+}
+```
+
+`ws` (the `PackageWorkspace`) is already in scope at this point (it is used a
+few lines down for `package_name: Some(ws.name.clone())`), so `ws.name` is
+available for the self-name guard.
+
+### Why merge into `full_imports` rather than add a new field
+
+The issue asks for behavior "equivalent to a `NAMESPACE` `import()` of each."
+`full_imports` *is* the "whole package available unqualified" set, and all three
+consumers (completion, NSE-in-play, undefined-variable) already read it. Merging
+gets correct behavior in all three with one change and no new plumbing, no new
+interface-hash field, no new scope-injection branch. A separate field would
+duplicate three consumer sites for no semantic gain.
+
+### Visibility / consumer scope (review finding 1)
+
+`full_imports` is read from `scope_contribution` — a single package-wide value —
+by three consumers, *none* gated on the queried file's path (gating differs per
+consumer, so do not assume a single uniform gate):
+
+- undefined-variable suppression (`handlers.rs:5803`, `:6700`/`:6726`) — gated on
+  `cross_file_config.packages_enabled && package_library_ready`;
+- NSE in-play set (`handlers.rs:5975`, via `collect_in_play_packages`) — adds
+  `full_imports` with no direct packages-ready gate of its own;
+- completion (`handlers.rs:18086`) — gated on `packages_enabled`.
+
+So in package mode `full_imports` already applies workspace-wide, regardless of
+whether the queried file is under `R/`. This is the **existing** behavior of
+NAMESPACE `import(pkg)`; the spec does not change it. It is also *correct* for
+`Depends:`: R attaches `Depends:` packages onto the global search path whenever
+the package is loaded (including when its test suite runs), so their exports are
+visible to any code evaluated with the package loaded — broader than a namespace
+`import()`, never narrower. Matching `import()`'s scope is therefore faithful,
+not a regression, and is exactly what the issue requests ("equivalent to a
+NAMESPACE `import()` of each"). No new file-kind scoping mechanism is introduced.
+
+### Meta-package NSE expansion: intentional asymmetry (review finding 3)
+
+`collect_in_play_packages` adds `full_imports` to the in-play `packages` set but
+**not** to `attached_packages_for_meta` (`handlers.rs:5975` vs `:5984`). Only
+`library()`/`require()` attaches and `test_attached_packages` feed
+`attached_packages_for_meta`, which expands meta-packages (e.g. `tidyverse`) to
+their members so a bare verb like `filter` resolves to dplyr's NSE policy.
+
+Routing `Depends:` through `full_imports` therefore does **not** trigger
+meta-package member expansion. We accept this deliberately:
+
+- It is **identical to the existing `import(pkg)` behavior** — `import(tidyverse)`
+  in NAMESPACE doesn't meta-expand today either — so `Depends:` stays consistent
+  with the mechanism the issue asked it to mirror.
+- The only affected case is a *meta-package* in `Depends:` (e.g.
+  `Depends: tidyverse`), which is rare and a discouraged anti-pattern. A concrete
+  package in `Depends:` (`ggplot2`, `data.table`, `dplyr`, `R6`, …) is itself a
+  member, so its own NSE policy resolves directly via the in-play `packages` set
+  — no meta-expansion needed. The motivating issue and all realistic cases are
+  concrete packages.
+- The worst-case symptom for a meta-package in `Depends:` is a *false positive*
+  (a mask argument flagged), never a false negative, and it is fixable by the
+  user with an explicit `library(member_pkg)` — the same escape hatch that exists
+  for `import(tidyverse)` today.
+
+Adding `Depends:`-specific meta-expansion would require tracking the `Depends:`
+subset separately from `full_imports` (since `import()` entries must *not* be
+meta-expanded, to preserve current behavior) and a new consumer in
+`collect_in_play_packages`. That cost is not justified by the rare anti-pattern
+case. If a real report surfaces, the follow-up is a separate
+`depends_attached_packages` field consumed there — explicitly out of scope here.
+
+### Both-paths coverage (NAMESPACE present and absent)
+
+The union runs **after** the `match`, so it applies whether or not a NAMESPACE
+exists. The repro has no NAMESPACE (`namespace_model` is `None` → `full_imports`
+starts empty), and `Depends:` still populates it. A package with both a
+`NAMESPACE import(x)` and `Depends: y` ends with `{x, y}` (de-duped by the
+`BTreeSet`; a package both imported and depended-on collapses to one entry).
+
+### Revalidation / caching (review finding 2)
+
+Revalidation here is **not** driven by per-file `interface_hash`
+(`compute_interface_hash` carries no `PackageScopeContribution`). It is driven by
+the package-state change path in `backend.rs`:
+
+- `DESCRIPTION` is in the package-input gate — `path == root.join("DESCRIPTION")`
+  (`backend.rs:4796`) — so editing it re-runs `derive_package_state`.
+- The backend compares the old vs new contribution and sets
+  `package_visibility_changed = ... || scope_contribution() != &old_contribution`
+  (`backend.rs:4818`). Populating `full_imports` from `Depends:` changes the
+  contribution, so a `Depends:` edit flips this flag.
+- When set, the fanout (`backend.rs:4895`) adds every open `is_r_source_path`
+  file to the affected set and re-publishes their diagnostics. `is_r_source_path`
+  covers `R/` **and** package test files (`tests/`, installed test dirs), but
+  **excludes** dev-context paths (`vignettes/`, `demo/`, `data-raw/`, `man/`).
+
+That fanout covers `R/` + test files — which includes the issue's target — and
+is the same path a NAMESPACE `import()` edit already takes, so `Depends:` edits
+revalidate identically to NAMESPACE edits. `PackageScopeContribution` derives
+`PartialEq, Eq` (`mod.rs:834`), so the equality comparison above includes
+`full_imports` automatically; no interface-hash field changes. (Dev-context
+files — vignettes etc. — are outside this fanout's eager refresh, identical to
+the existing NAMESPACE-change behavior; they still pick up the new contribution
+on their next edit. Out of scope for this issue.)
+
+## Tests
+
+Add to `package_state/derive.rs` tests (which already construct `PackageInputs`
+with a `DESCRIPTION`):
+
+1. **`depends_packages_added_to_full_imports`** — `Depends: ggplot2` with no
+   NAMESPACE → `scope_contribution.full_imports` contains `"ggplot2"`.
+2. **`imports_not_added_to_full_imports`** — `Imports: dplyr` (no `Depends:`, no
+   NAMESPACE) → `full_imports` does **not** contain `"dplyr"`.
+3. **`depends_unions_with_namespace_full_imports`** — `Depends: ggplot2` +
+   NAMESPACE `import(rlang)` → `full_imports == {ggplot2, rlang}`.
+4. **`depends_strips_version_and_drops_R`** —
+   `Depends: R (>= 3.5), ggplot2 (>= 3.0)` → `full_imports == {ggplot2}` (no
+   `R`, no version text).
+5. **`depends_dedupes_with_namespace`** — `Depends: rlang` + NAMESPACE
+   `import(rlang)` → `full_imports == {rlang}` (single entry).
+5b. **`depends_filters_own_package_name`** — package `tp` with
+   `Depends: tp, ggplot2` (malformed self-dep) → `full_imports == {ggplot2}`
+   (own name dropped by the `pkg != ws.name` guard).
+6. **End-to-end diagnostic** (in `handlers.rs`, mirroring
+   `test_completion_includes_full_imports_packages` /
+   `test_diagnostic_suppresses_importFrom_in_package_file`): a package file using
+   `ggplot`/`theme_bw` with `Depends: ggplot2` (and ggplot2 exports seeded into
+   the package library the way existing tests do) produces no
+   `undefined-variable` for those symbols. This is the issue's actual repro and
+   the regression guard.
+
+## Docs
+
+Update `docs/r-package-dev.md`:
+- In the import-resolution section, state that `DESCRIPTION` `Depends:` packages
+  are treated as attached (their exports resolve unqualified), equivalent to a
+  NAMESPACE `import()`, while `Imports:` remains `::`/`importFrom`-only.
+
+(No README change needed; this is a package-mode detail.)
+
+## Risk / edge cases considered
+
+- **Over-suppression.** Only `Depends:` is added, never `Imports:`/`Suggests:`,
+  so we do not silence diagnostics for packages R itself wouldn't attach. The
+  worst case for a mis-declared `Depends:` is a suppressed diagnostic for a real
+  typo that happens to match a depended-package export — identical to the
+  existing `import(pkg)` exposure, and the user explicitly declared the
+  dependency.
+- **Self-reference.** A valid DESCRIPTION cannot `Depends:` on itself, but a
+  malformed one mid-edit could. The `pkg != ws.name` guard drops it so we never
+  query a stale installed package of the package's own name. `R` is filtered and
+  empty/blank fields yield no entries (`parse_depends_value`).
+- **Base packages in `Depends:`** (e.g. `methods`, `utils`, `stats`). These are
+  attached at runtime, so treating them as unqualified-export sources is correct
+  and harmless — their exports (e.g. `setClass`, `head`) are genuinely available.
+  This is the same as listing them in `import()`.
+- **Exports unavailable.** If the depended package's exports can't be resolved
+  (not installed, not in repo-db / names-db), the diagnostic behavior is
+  unchanged from `import(pkg)` of an unresolvable package — raven can only
+  suppress symbols it can enumerate. Out of scope.


### PR DESCRIPTION
## Summary

In package mode (a directory with `DESCRIPTION` + `R/`), raven resolved unqualified symbols from a package listed in `NAMESPACE: import(pkg)` but **not** from a package listed in `Depends:` in `DESCRIPTION`. Because R *attaches* `Depends:` packages when the package is loaded (`library()` / `pkgload::load_all()`) — putting their exports on the search path, available unqualified to the package's own code — raven flagged valid code as `undefined-variable`.

Repro (from #531): a package with `Depends: ggplot2` and `R/p.r` = `myplot <- function(d) ggplot(d, aes(x, y)) + theme_bw()` flagged `ggplot` and `theme_bw`. Adding a `NAMESPACE` with `import(ggplot2)` fixed both — proving the export data was available; only the `Depends:`-based path was missing.

## Change

**1. Unqualified resolution.** `build_scope_contribution` (`crates/raven/src/package_state/derive.rs`) now unions each `DESCRIPTION` `Depends:` package into `full_imports`, equivalent to a NAMESPACE `import(pkg)` of each. Runs after the namespace-model match, so it applies whether or not a `NAMESPACE` exists.

- `Imports:` is **deliberately excluded** — loaded but not attached → still requires `pkg::fn` / `importFrom` (matches R).
- Version constraints (`pkg (>= 1.0)`) and the special `R` entry are stripped by the existing parser.
- The package's own name is filtered (`pkg != ws.name`) so a malformed mid-edit DESCRIPTION can't query a stale installed package of the same name.

**2. NSE meta-package expansion (Depends: only).** `Depends:` is a true *attach*, so a meta-package in `Depends:` (e.g. `tidyverse`) must expand to its members for non-standard-evaluation argument policies — otherwise a data-masking verb like `filter(x > 5)` in `R/` code falsely flags the masked column `x`. The issue #407 owner-preserving fallback already covers this when the package library is warm, but **not** when it's cold (CI / no R / deps not installed). A new `PackageScopeContribution::depends_attached_packages` set (a subset of `full_imports`) feeds the existing meta-expansion in `collect_in_play_packages`, independent of the library.

  NAMESPACE `import(pkg)` / roxygen `@import` is **excluded** from meta-expansion: an `import()` is a selective namespace import, not an attach (`import(tidyverse)` does not put dplyr's `filter` on the search path), so meta-expanding it would falsely suppress a masked column. Tracking the `Depends:` subset separately is what keeps the two apart.

## Tests

- Derive unit tests: Depends→`full_imports`; `Imports:` excluded; union with NAMESPACE `import()`; version/`R` stripping; dedup; self-name filter; `Depends:` populates `depends_attached_packages` while `import()` does not.
- End-to-end (`handlers.rs`): the issue's exact repro (`Depends: ggplot2` suppresses `ggplot`/`aes`/`theme_bw`); a **cold-library** positive test (`Depends: tidyverse` meta-expands → `filter(x>5)` doesn't flag `x`); a **scoping guard** (`import(tidyverse)` cold-library still flags `x`). All include a genuine-undefined baseline so they can't pass vacuously.

## Docs

`docs/r-package-dev.md` updated: `Depends:` is attached (exports resolve unqualified; meta-packages expand for NSE), `Imports:` is not, `import()` does not meta-expand. Design spec under `docs/superpowers/specs/`.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` clean
- `cargo test -p raven --lib` passes (the only failures are `cli::packages::tests::*fetch*`, sandbox-only local-socket binding failures, confirmed passing unsandboxed and unrelated to this change)

Adversarially reviewed by Codex and `/code-review` across the spec and implementation; the meta-package scoping (Depends-only, excluding `import()`) was a direct result of a Codex finding. Both reviewers came back clean twice consecutively on the final state.

Closes #531.

https://claude.ai/code/session_01RdQxCF4UPXpvC6ggddycuS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package-mode diagnostics by suppressing false “undefined” reports for unqualified symbols exported from `DESCRIPTION` `Depends:` packages.
  * Preserved existing `Imports:` behavior so it still doesn’t become fully attached for unqualified resolution.

* **New Features**
  * Improved scope handling so `Depends:` behaves like whole-package attachment for analysis, including better NSE handling for meta-package cold-library scenarios.

* **Documentation**
  * Documented updated semantics for `Depends:` vs `Imports:`, and noted that `NAMESPACE`/roxygen namespace imports (e.g., `import(tidyverse)`) do not trigger the meta-expansion behavior.

* **Tests**
  * Added end-to-end coverage for Issue `#531`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->