### PR TITLE
ci(release): open Homebrew tap bump PR on each release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -341,3 +341,71 @@ jobs:
         with:
           version: ${{ github.ref_name }}
       - run: raven --version
+
+  # ── Homebrew tap bump ───────────────────────────────────────────────
+  # After the GitHub Release is published, open a PR against the Homebrew
+  # tap (jbearak/homebrew-raven) bumping the formula to this version with
+  # macOS checksums recomputed from the in-workflow release artifacts (no
+  # dependence on release-CDN propagation). The tap's own CI (brew audit /
+  # install / test) gates that PR before it can merge, so a broken formula
+  # never reaches the fleet. The formula edit lives in the tap repo
+  # (bin/update-formula.sh) — single source of truth shared with the tap's
+  # bootstrap script.
+  #
+  # Setup (one-time), then this job activates itself:
+  #   gh secret   set HOMEBREW_TAP_TOKEN   -R jbearak/raven   # paste token
+  #   gh variable set ENABLE_HOMEBREW_BUMP -R jbearak/raven --body true
+  # HOMEBREW_TAP_TOKEN: a GitHub App installation token or fine-grained PAT
+  # scoped to jbearak/homebrew-raven with Contents:write + Pull requests:write.
+  # The `if` guard keeps this job from failing on releases cut before setup.
+  bump-homebrew:
+    needs: github-release
+    if: vars.ENABLE_HOMEBREW_BUMP == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download macOS LSP artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: lsp-macos-*
+          path: lsp
+          merge-multiple: true
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          repository: jbearak/homebrew-raven
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Bump formula
+        run: |
+          tap/bin/update-formula.sh "${{ steps.version.outputs.version }}" \
+            lsp/raven-macos-arm64.zip lsp/raven-macos-x64.zip
+
+      - name: Open bump PR
+        working-directory: tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git diff --quiet; then
+            echo "Formula already at $VERSION — nothing to do."
+            exit 0
+          fi
+          BRANCH="bump-raven-$VERSION"
+          git config user.name "raven-release-bot"
+          git config user.email "raven-release-bot@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Formula/raven.rb
+          git commit -m "raven $VERSION"
+          git push --force-with-lease -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "raven $VERSION" \
+            --body "Automated formula bump for [raven $VERSION](https://github.com/jbearak/raven/releases/tag/v$VERSION). Checksums recomputed from the release artifacts." \
+            || echo "PR for $BRANCH already exists; force-push updated it."


### PR DESCRIPTION
## What

Adds a `bump-homebrew` job to `release-build.yml`. After the GitHub Release is published, it recomputes the macOS sha256s from the in-workflow release artifacts and opens a PR against the `jbearak/homebrew-raven` tap bumping the formula.

## Why

Distribute + auto-update the `raven` CLI across a fleet of Macs via `brew install jbearak/raven/raven` (fully-qualified — homebrew/core already ships a different `raven`).

## Design notes
- **PR, not direct push** — the tap's own CI (`brew audit`/`install`/`test` on arm64 + intel) gates every bump, so a broken formula never reaches the fleet.
- **Checksums from in-workflow artifacts** — no dependence on release-CDN propagation.
- **Single source of truth** — the formula edit lives in the tap repo (`bin/update-formula.sh`), shared with the tap's bootstrap script.
- **Self-gating** — `if: vars.ENABLE_HOMEBREW_BUMP == 'true'`, so releases cut before the tap + `HOMEBREW_TAP_TOKEN` secret exist won't fail.

## Activation (after the tap repo exists)
```
gh secret   set HOMEBREW_TAP_TOKEN   -R jbearak/raven
gh variable set ENABLE_HOMEBREW_BUMP -R jbearak/raven --body true
```

The tap scaffold (formula, README, tap CI, bootstrap) is staged separately and not part of this PR.