### PR TITLE
ci(release): arm64-only Homebrew bump + auto-merge

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -344,11 +344,11 @@ jobs:
 
   # ── Homebrew tap bump ───────────────────────────────────────────────
   # After the GitHub Release is published, open a PR against the Homebrew
-  # tap (jbearak/homebrew-raven) bumping the formula to this version with
-  # macOS checksums recomputed from the in-workflow release artifacts (no
+  # tap (jbearak/homebrew-raven) bumping the formula to this version with the
+  # Apple Silicon checksum recomputed from the in-workflow release artifact (no
   # dependence on release-CDN propagation). The tap's own CI (brew audit /
   # install / test) gates that PR before it can merge, so a broken formula
-  # never reaches the fleet. The formula edit lives in the tap repo
+  # never reaches users. The formula edit lives in the tap repo
   # (bin/update-formula.sh) — single source of truth shared with the tap's
   # bootstrap script.
   #
@@ -369,10 +369,10 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
-      - name: Download macOS LSP artifacts
+      - name: Download macOS arm64 LSP artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          pattern: lsp-macos-*
+          pattern: lsp-macos-arm64
           path: lsp
           merge-multiple: true
 
@@ -386,7 +386,7 @@ jobs:
       - name: Bump formula
         run: |
           tap/bin/update-formula.sh "${{ steps.version.outputs.version }}" \
-            lsp/raven-macos-arm64.zip lsp/raven-macos-x64.zip
+            lsp/raven-macos-arm64.zip
 
       - name: Open bump PR
         working-directory: tap

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -407,5 +407,11 @@ jobs:
           git push --force-with-lease -u origin "$BRANCH"
           gh pr create --base main --head "$BRANCH" \
             --title "raven $VERSION" \
-            --body "Automated formula bump for [raven $VERSION](https://github.com/jbearak/raven/releases/tag/v$VERSION). Checksums recomputed from the release artifacts." \
+            --body "Automated formula bump for [raven $VERSION](https://github.com/jbearak/raven/releases/tag/v$VERSION). Checksum recomputed from the release artifact." \
             || echo "PR for $BRANCH already exists; force-push updated it."
+          # Enable auto-merge: GitHub merges this PR once the tap's required
+          # `test` check passes. Because branch protection requires `test`, the
+          # PR is not immediately mergeable, so --auto is accepted (it waits)
+          # rather than merging instantly. A red check ⇒ it never merges.
+          gh pr merge "$BRANCH" --auto --squash \
+            || echo "Could not enable auto-merge; merge the PR manually."


### PR DESCRIPTION
Follow-up to #534 (which merged the initial bump job). Two changes:

- **arm64-only**: the tap formula is Apple Silicon only, so the bump job fetches just `lsp-macos-arm64` and passes one zip to the tap's `update-formula.sh`.
- **auto-merge**: after opening the bump PR, enable GitHub auto-merge (squash). The tap's required `test` check gates it — merges hands-off only once CI is green, never if the formula fails to install.

The tap repo (`jbearak/homebrew-raven`) is already arm64-only with branch protection + auto-merge enabled; this aligns the raven-side bump job with it.