### PR TITLE
ci(release): harden Homebrew tap bump job

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -380,7 +380,10 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: jbearak/homebrew-raven
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Public repo: no token needed to clone, and persist-credentials:false
+          # keeps any credential out of tap/.git/config. The tap PAT is supplied
+          # only at push time (below), never persisted to disk.
+          persist-credentials: false
           path: tap
 
       - name: Bump formula
@@ -401,17 +404,30 @@ jobs:
           BRANCH="bump-raven-$VERSION"
           git config user.name "raven-release-bot"
           git config user.email "raven-release-bot@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          # Only this job ever writes bump-raven-*, so reset the branch from
+          # HEAD and force-push. No remote-tracking ref / pre-fetch needed, so
+          # reruns can't fail on a stale lease.
+          git checkout -B "$BRANCH"
           git add Formula/raven.rb
           git commit -m "raven $VERSION"
-          git push --force-with-lease -u origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
-            --title "raven $VERSION" \
-            --body "Automated formula bump for [raven $VERSION](https://github.com/jbearak/raven/releases/tag/v$VERSION). Checksum recomputed from the release artifact." \
-            || echo "PR for $BRANCH already exists; force-push updated it."
-          # Enable auto-merge: GitHub merges this PR once the tap's required
-          # `test` check passes. Because branch protection requires `test`, the
-          # PR is not immediately mergeable, so --auto is accepted (it waits)
-          # rather than merging instantly. A red check ⇒ it never merges.
+          # Authenticate the push with the tap token only here, via an HTTPS
+          # basic-auth header (the actions/checkout mechanism). The token is
+          # never written to .git/config.
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c http.extraheader="$AUTH_HEADER" push --force origin "HEAD:$BRANCH"
+          # Create the PR. Tolerate ONLY the "PR already exists" case (rerun);
+          # let auth/permission/API errors fail the job.
+          if ! gh pr create --base main --head "$BRANCH" \
+                --title "raven $VERSION" \
+                --body "Automated formula bump for [raven $VERSION](https://github.com/jbearak/raven/releases/tag/v$VERSION). Checksum recomputed from the release artifact."; then
+            if gh pr view "$BRANCH" --json url >/dev/null 2>&1; then
+              echo "PR for $BRANCH already exists; the force-push updated it."
+            else
+              echo "::error::gh pr create failed for $BRANCH" >&2
+              exit 1
+            fi
+          fi
+          # Auto-merge once the tap's required `test` check passes (branch
+          # protection makes it wait rather than merge immediately).
           gh pr merge "$BRANCH" --auto --squash \
-            || echo "Could not enable auto-merge; merge the PR manually."
+            || echo "::warning::could not enable auto-merge; merge $BRANCH manually."


### PR DESCRIPTION
Applies the same hardening CodeRabbit flagged on the sight tap bump job ([jbearak/sight#199](https://github.com/jbearak/sight/pull/199)) to raven's `bump-homebrew` job in `release-build.yml`.

## Changes
- **Don't persist the tap PAT.** Checkout the (public) tap with `persist-credentials: false` and **no** `token:`, so `HOMEBREW_TAP_TOKEN` is never written to `tap/.git/config`. The token is supplied only at push time via an HTTPS basic-auth header (the same mechanism `actions/checkout` uses) — addresses the zizmor `artipacked` finding.
- **Rerun-safe push.** `git checkout -B` + plain `--force` to the bot-only `bump-raven-*` branch, so a rerun can't fail on a stale `--force-with-lease` remote-tracking ref.
- **Don't swallow real errors.** `gh pr create` now fails the job on auth/permission/API errors; only a genuinely pre-existing PR (rerun) is treated as non-fatal.

No behavior change on the happy path; the bump PR still opens and auto-merges once the tap's `test` check passes.