### PR TITLE
fix(check): clarify "R not found" note and suppress it when offline data covers

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -138,8 +138,10 @@ Options:
 
 R / packages:
   raven check auto-detects R on PATH to resolve installed-package exports and
-  base R symbols. If R is not found, package and base-symbol diagnostics are
-  limited and a note is printed to stderr; all other diagnostics still run.
+  base R symbols. If R is not found and no offline package data is present
+  (`raven packages update`/`freeze`), package symbol resolution is limited to
+  base R (still covered by the embedded database) and a note is printed to
+  stderr; all other diagnostics still run.
 
   --report-uninstalled        Report packages from library() calls that are not
                               present in the local library paths. Disabled by
@@ -382,7 +384,14 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
         footer.push(note);
     }
     if !footer.is_empty() {
-        let body = footer.join("\n");
+        // One `raven check:` header attributes the whole block, so the individual
+        // notes carry no per-line prefix (every note here is from `raven check` —
+        // repeating it on each line is noise). A leading blank line separates the
+        // block from the summary line `render` just wrote, and notes are joined by
+        // a blank line so stacked notes read as distinct paragraphs rather than
+        // running together. The header rides the same stream as the notes
+        // (`footer_stream`) so it can't be reordered away from them.
+        let body = format!("\nraven check:\n{}", footer.join("\n\n"));
         match footer_stream(args.format) {
             FooterStream::Stdout => {
                 use std::io::Write as _;
@@ -563,17 +572,21 @@ fn resolve_project_config_with_options(
 ///
 /// This function owns only the *caller policy*: it always installs the returned
 /// library, then uses `PackageLibraryOutcome::consumer_ready` for the diagnostic
-/// readiness gate. The three R-related degradations each print a one-line note
-/// to stderr so CI shows what was missing; `Disabled` (the user turned package
-/// awareness off in `raven.toml`) is silent, matching the editor.
+/// readiness gate. The three R-related degradations print a one-line note to
+/// stderr so CI shows what was missing — but only when no offline package data
+/// loaded (`!has_providers()`): a degraded R build whose coverage is served by
+/// an updated `names.db` or frozen `.raven/packages.json` is not actually
+/// degraded for package symbols, so warning (and recommending `raven packages
+/// update`, which already ran) would be a false alarm. `Disabled` (the user
+/// turned package awareness off in `raven.toml`) is silent, matching the editor.
 ///
 /// Returns `(shipped_db_load, load_notes)`:
 /// - the build's [`crate::package_library::ShippedDbLoad`] verdict, so the caller can tailor the
 ///   missing-export-metadata warning (absent / loaded / present-but-failed)
 ///   without re-stat-ing disk — the build already knows whether the shipped
 ///   `names.db` actually loaded, which a bare `Path::exists()` cannot tell;
-/// - the present-but-unusable package-DB load notes (each already prefixed
-///   `raven check: `). The caller folds these into the shared footer rather
+/// - the present-but-unusable package-DB load notes (unprefixed; the caller's
+///   footer carries one `raven check:` header for the whole block). The caller folds these into the shared footer rather
 ///   than this function printing them, so they ride the diagnostics' own stream
 ///   (stdout for `text`) instead of being reorderable against the findings on
 ///   stderr. See `footer_stream`.
@@ -605,17 +618,14 @@ async fn maybe_init_r(
     // `text`); printing to stderr inline would let a merged CI consumer reorder
     // them relative to the findings. Extract before the status match below
     // partially moves `outcome`.
-    let load_notes: Vec<String> = outcome
-        .load_notes
-        .iter()
-        .map(|note| format!("raven check: {note}"))
-        .collect();
+    // No `raven check: ` prefix: these ride the caller's shared footer, which
+    // carries one `raven check:` header for the whole block.
+    let load_notes: Vec<String> = outcome.load_notes.clone();
 
     // Always install the returned library: on a non-`Ready` status it may still
     // carry Tier 2/3 providers or bundled base exports, which are the whole
     // point of CI resolution without R. Dropping it here would send `raven
     // check` back to an empty library and lose the offline path.
-    use crate::package_library::PackageLibraryStatus::*;
     state.package_library_ready = outcome.consumer_ready();
     let status = outcome.status;
     let shipped_db_load = outcome.shipped_db_load;
@@ -630,19 +640,54 @@ async fn maybe_init_r(
     // internal as an undefined variable. Runs before `maybe_load_sysdata_fallback`,
     // which may refresh the overlay again after adding R-loaded sysdata names.
     state.refresh_local_dev_overlay();
-    match status {
-        Ready | Disabled => {}
-        RNotFound => eprintln!(
-            "raven check: R not found on PATH; package and base-symbol diagnostics will be limited"
-        ),
-        InitFailed(e) => eprintln!(
-            "raven check: R found but its package library failed to initialize ({e}); package and base-symbol diagnostics will be limited"
-        ),
-        NoLibraryPaths => eprintln!(
-            "raven check: R found but no library paths were discovered; package and base-symbol diagnostics will be limited"
-        ),
+    // The degraded-environment startup note's decision is factored into
+    // `degraded_env_note` (pure, hence unit-testable without an R environment —
+    // `RNotFound` is unreachable end-to-end on any machine with R installed,
+    // because `get_fallback_lib_paths()` finds the framework library and the
+    // build classifies `Ready`). `has_providers()` is the coverage gate: offline
+    // Tier 2/3 data resolves package symbols without R, so the note is suppressed.
+    if let Some(note) = degraded_env_note(&status, state.package_library.has_providers()) {
+        eprintln!("raven check: {note}");
     }
     (shipped_db_load, load_notes)
+}
+
+/// Shared tail of the degraded-environment startup notes: the consequence
+/// (coverage limited to base R, still covered by the embedded database) and the
+/// remedy. Identical across all three causes because the limitation and fix
+/// don't depend on *why* the live R library was unavailable.
+const DEGRADED_ENV_NOTE_TAIL: &str = "package symbol resolution is limited to base R (covered by the embedded database). Run `raven packages update` for broad CRAN/Bioconductor coverage";
+
+/// The degraded-environment startup note for a package-library build, or `None`
+/// when no note should print. (The caller prefixes `raven check: ` and writes it
+/// to stderr.)
+///
+/// `None` when the build is `Ready` (live R) or `Disabled` (package awareness
+/// off) — neither is degraded — or when `has_offline_packages`: an updated
+/// `names.db` or frozen `.raven/packages.json` resolves package symbols without
+/// R, so the warning would be a false alarm (and would tell a CI that already
+/// ran `raven packages update` to run it again). The gate is `has_providers()`,
+/// NOT `consumer_ready()`/`base_exports()`: base-only coverage is exactly the
+/// "limited to base R" case the note exists to flag. `build_package_library`
+/// does not wire a zero-package provider (an empty `names.db` /
+/// `.raven/packages.json`), so `has_providers()` means real package coverage
+/// exists — not merely that an offline file was present.
+fn degraded_env_note(
+    status: &crate::package_library::PackageLibraryStatus,
+    has_offline_packages: bool,
+) -> Option<String> {
+    use crate::package_library::PackageLibraryStatus::*;
+    match status {
+        Ready | Disabled => None,
+        _ if has_offline_packages => None,
+        RNotFound => Some(format!("R not found on PATH; {DEGRADED_ENV_NOTE_TAIL}")),
+        InitFailed(e) => Some(format!(
+            "R found but its package library failed to initialize ({e}); {DEGRADED_ENV_NOTE_TAIL}"
+        )),
+        NoLibraryPaths => Some(format!(
+            "R found but no library paths were discovered; {DEGRADED_ENV_NOTE_TAIL}"
+        )),
+    }
 }
 
 /// `raven check`'s counterpart of the LSP startup's sysdata R fallback (the
@@ -875,7 +920,7 @@ fn format_missing_export_metadata_warning(
     };
 
     let head = format!(
-        "raven check: couldn't load exported symbols for {names}.\n\
+        "couldn't load exported symbols for {names}.\n\
          Some \"Undefined variable\" warnings above may be inaccurate as a result.\n\
          To fix: install {noun} in your R library."
     );
@@ -950,7 +995,7 @@ fn format_traversal_budget_note(state: &crate::state::WorldState) -> Option<Stri
     if visited_trunc > 0 {
         let max_visited = state.cross_file_config.max_transitive_dependents_visited;
         lines.push(format!(
-            "raven check: a bounded cross-file neighborhood traversal was truncated \
+            "a bounded cross-file neighborhood traversal was truncated \
              (maxTransitiveDependentsVisited = {max_visited}); some source() edges were \
              not followed, so some \"Undefined variable\" warnings above may be false \
              positives. Raise `crossFile.maxTransitiveDependentsVisited` in raven.toml to \
@@ -960,13 +1005,15 @@ fn format_traversal_budget_note(state: &crate::state::WorldState) -> Option<Stri
     if depth_trunc > 0 {
         let max_chain_depth = state.cross_file_config.max_chain_depth;
         lines.push(format!(
-            "raven check: a cross-file traversal hit the depth limit \
+            "a cross-file traversal hit the depth limit \
              (maxChainDepth = {max_chain_depth}); some deeply-nested source() edges were \
              not followed. Raise `crossFile.maxChainDepth` in raven.toml to analyze deeper \
              dependency chains."
         ));
     }
-    Some(lines.join("\n"))
+    // Blank line between the two sub-notes so they read as distinct paragraphs
+    // under the footer's single `raven check:` header (no per-note prefix).
+    Some(lines.join("\n\n"))
 }
 
 /// Stable, public docs links for the NSE footer. raven has no hosted docs site
@@ -1033,7 +1080,7 @@ fn format_nse_hint_footer(diags: &[(PathBuf, Diagnostic)]) -> Option<String> {
         )
     };
     let mut out = format!(
-        "raven check: {count} undefined-variable {noun} above {verb} inside {obj}. If one is a \
+        "{count} undefined-variable {noun} above {verb} inside {obj}. If one is a \
          false positive, you can suppress it as with any \
          linter (`# raven: ignore`, `# nolint`, or `# raven: expect`). R has one extra cause: a \
          function that captures an argument via non-standard evaluation (NSE) — as \
@@ -1358,6 +1405,61 @@ mod tests {
 
     fn run_blocking(args: CheckArgs) -> i32 {
         tokio::runtime::Runtime::new().unwrap().block_on(run(args))
+    }
+
+    // ---- degraded_env_note (startup-note decision) ------------------------
+    //
+    // End-to-end coverage is impossible on a machine with R installed:
+    // `get_fallback_lib_paths()` finds the framework library, so the build
+    // classifies `Ready` and `RNotFound`/`NoLibraryPaths` are never reached.
+    // These pure-function tests pin the decision deterministically instead.
+    use crate::package_library::PackageLibraryStatus as S;
+
+    #[test]
+    fn degraded_env_note_silent_when_ready_or_disabled() {
+        // Live R / package awareness off: never degraded, regardless of providers.
+        assert!(degraded_env_note(&S::Ready, false).is_none());
+        assert!(degraded_env_note(&S::Ready, true).is_none());
+        assert!(degraded_env_note(&S::Disabled, false).is_none());
+    }
+
+    #[test]
+    fn degraded_env_note_suppressed_when_offline_packages_present() {
+        // The user's CI report: R absent but `raven packages update`/`freeze`
+        // already loaded offline coverage — the warning would be a false alarm,
+        // and would tell CI to re-run the command it already ran.
+        for status in [
+            S::RNotFound,
+            S::InitFailed("boom".into()),
+            S::NoLibraryPaths,
+        ] {
+            assert!(
+                degraded_env_note(&status, true).is_none(),
+                "note must be suppressed for {status:?} when offline packages loaded"
+            );
+        }
+    }
+
+    #[test]
+    fn degraded_env_note_fires_with_remedy_when_coverage_is_base_only() {
+        // No offline data: coverage really is base-R-only, so each cause names
+        // itself, the consequence (limited to base R), and the remedy.
+        let r_not_found = degraded_env_note(&S::RNotFound, false).expect("note");
+        assert!(r_not_found.starts_with("R not found on PATH;"));
+        assert!(r_not_found.contains("limited to base R"));
+        assert!(r_not_found.contains("raven packages update"));
+        // No `raven check:` prefix — the caller adds it (footer notes don't).
+        assert!(!r_not_found.starts_with("raven check:"));
+
+        let init_failed = degraded_env_note(&S::InitFailed("xyz".into()), false).expect("note");
+        assert!(
+            init_failed.starts_with("R found but its package library failed to initialize (xyz);")
+        );
+        assert!(init_failed.contains("raven packages update"));
+
+        let no_lib = degraded_env_note(&S::NoLibraryPaths, false).expect("note");
+        assert!(no_lib.starts_with("R found but no library paths were discovered;"));
+        assert!(no_lib.contains("raven packages update"));
     }
 
     fn run_with_cwd_blocking(args: CheckArgs, cwd: &Path) -> i32 {

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -384,14 +384,17 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
         footer.push(note);
     }
     if !footer.is_empty() {
-        // One `raven check:` header attributes the whole block, so the individual
-        // notes carry no per-line prefix (every note here is from `raven check` —
-        // repeating it on each line is noise). A leading blank line separates the
-        // block from the summary line `render` just wrote, and notes are joined by
-        // a blank line so stacked notes read as distinct paragraphs rather than
-        // running together. The header rides the same stream as the notes
-        // (`footer_stream`) so it can't be reordered away from them.
-        let body = format!("\nraven check:\n{}", footer.join("\n\n"));
+        // The notes carry no header and no per-line prefix: this is `raven
+        // check`'s own contiguous output, so labeling it `raven check:` mid-stream
+        // is redundant self-reference (cf. ESLint, which prints its trailing
+        // summary unlabeled). A leading blank line separates the block from the
+        // summary line `render` just wrote, and notes are joined by a blank line
+        // so stacked notes read as distinct paragraphs rather than running
+        // together. (The standalone degraded-environment startup note on stderr
+        // keeps a `raven check: ` prefix — there it is a lone line that can
+        // interleave with other programs' output, where the prefix earns its
+        // place; see `degraded_env_note`.)
+        let body = format!("\n{}", footer.join("\n\n"));
         match footer_stream(args.format) {
             FooterStream::Stdout => {
                 use std::io::Write as _;
@@ -586,7 +589,7 @@ fn resolve_project_config_with_options(
 ///   without re-stat-ing disk — the build already knows whether the shipped
 ///   `names.db` actually loaded, which a bare `Path::exists()` cannot tell;
 /// - the present-but-unusable package-DB load notes (unprefixed; the caller's
-///   footer carries one `raven check:` header for the whole block). The caller folds these into the shared footer rather
+///   footer prints the notes blank-line-separated with no header). The caller folds these into the shared footer rather
 ///   than this function printing them, so they ride the diagnostics' own stream
 ///   (stdout for `text`) instead of being reorderable against the findings on
 ///   stderr. See `footer_stream`.
@@ -619,7 +622,7 @@ async fn maybe_init_r(
     // them relative to the findings. Extract before the status match below
     // partially moves `outcome`.
     // No `raven check: ` prefix: these ride the caller's shared footer, which
-    // carries one `raven check:` header for the whole block.
+    // prints its notes blank-line-separated with no header.
     let load_notes: Vec<String> = outcome.load_notes.clone();
 
     // Always install the returned library: on a non-`Ready` status it may still
@@ -1012,7 +1015,7 @@ fn format_traversal_budget_note(state: &crate::state::WorldState) -> Option<Stri
         ));
     }
     // Blank line between the two sub-notes so they read as distinct paragraphs
-    // under the footer's single `raven check:` header (no per-note prefix).
+    // in the footer (which carries no header and no per-note prefix).
     Some(lines.join("\n\n"))
 }
 

--- a/crates/raven/src/package_db/binary_db.rs
+++ b/crates/raven/src/package_db/binary_db.rs
@@ -284,6 +284,14 @@ impl ShippedDb {
     pub fn provenance(&self) -> &ShippedDbProvenance {
         &self.provenance
     }
+
+    /// True when the DB carries no package records. A successfully-opened but
+    /// empty DB resolves nothing, so callers gating on "real package coverage"
+    /// (e.g. the degraded-environment note in `cli::check`) must treat it as no
+    /// coverage rather than as a usable provider.
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
 }
 
 /// Tier 3 provider over an opened `ShippedDb`.
@@ -305,6 +313,11 @@ impl ShippedDbProvider {
             Err(ShippedDbError::Absent) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// True when the underlying DB carries no packages — see [`ShippedDb::is_empty`].
+    pub fn is_empty(&self) -> bool {
+        self.db.is_empty()
     }
 }
 

--- a/crates/raven/src/package_db/json_db.rs
+++ b/crates/raven/src/package_db/json_db.rs
@@ -134,6 +134,15 @@ impl RepoDbProvider {
             Err(e) => Err(e),
         }
     }
+
+    /// True when the DB carries no package records. A valid-but-empty
+    /// `.raven/packages.json` (e.g. a `raven packages freeze` that matched no
+    /// external packages) parses to a zero-package provider that resolves
+    /// nothing, so callers gating on "real package coverage" must treat it as no
+    /// coverage rather than as a usable provider.
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
 }
 
 impl PackageMetadataProvider for RepoDbProvider {

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -2572,9 +2572,14 @@ impl PackageLibrary {
 /// failure text; this carries the structured verdict so callers don't parse strings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShippedDbLoad {
-    /// No shipped `names.db` candidate exists on disk.
+    /// No usable shipped `names.db`: either no candidate exists on disk, or a
+    /// candidate opened successfully but is empty (zero packages). An empty DB
+    /// is treated as `Absent` rather than `Loaded` because it provides no
+    /// coverage — steering the missing-metadata advice toward `raven packages
+    /// update` (download a real DB), not `raven packages freeze`.
     Absent,
-    /// A shipped `names.db` was found and loaded successfully (provider wired).
+    /// A non-empty shipped `names.db` was found and loaded successfully (provider
+    /// wired). An empty DB does not reach this state — see `Absent`.
     Loaded,
     /// A shipped `names.db` file is present but failed to load — `Corrupt` or
     /// `UnsupportedFormat`. The detail is also recorded in `load_notes`.
@@ -2717,26 +2722,40 @@ pub async fn build_package_library(
         let mut providers: Vec<Box<dyn crate::package_db::PackageMetadataProvider>> = Vec::new();
         let mut notes: Vec<String> = Vec::new();
         // Tier 2 first (repo DB), then Tier 3 (shipped DB).
+        //
+        // A valid-but-empty DB (zero packages) resolves nothing, so it is NOT
+        // wired as a provider: `has_providers()` must mean "real package
+        // coverage exists" (the degraded-environment note in `cli::check` gates
+        // on it), and an empty provider would also cost futile lookups. An empty
+        // Tier-2 file is thus treated exactly like an absent one.
         if let Some(path) = repo_db_path {
             match crate::package_db::json_db::RepoDbProvider::from_file(&path) {
-                Ok(Some(p)) => providers.push(Box::new(p)),
-                Ok(None) => {}                       // Absent -> silent
+                Ok(Some(p)) if !p.is_empty() => providers.push(Box::new(p)),
+                Ok(_) => {}                          // Absent or empty -> silent
                 Err(e) => notes.push(e.to_string()), // explain-and-continue
             }
         }
         // Track the Tier 3 verdict alongside the provider: `Absent` until a
-        // candidate proves otherwise. A successful load wins and stops the scan;
-        // a failed candidate records `Failed` but keeps looking, so a later
-        // working candidate still upgrades the verdict to `Loaded`.
+        // candidate proves otherwise. A non-empty load wins, is wired, and stops
+        // the scan; a failed candidate records `Failed` but keeps looking, so a
+        // later working candidate still upgrades the verdict to `Loaded`.
+        //
+        // An empty DB (zero packages) is treated as no coverage: it is neither
+        // wired (see the Tier-2 note above) nor recorded as `Loaded`, and the
+        // scan continues to lower-precedence candidates. Leaving the verdict
+        // `Absent` is deliberate — the missing-export footer then points at
+        // `raven packages update` (download a real DB), the correct remedy,
+        // rather than the `Loaded` branch's "the package is likely private / not
+        // on CRAN", which would misdescribe an empty database.
         let mut shipped_db_load = ShippedDbLoad::Absent;
         for path in shipped_db_candidates {
             match crate::package_db::binary_db::ShippedDbProvider::from_file(&path) {
-                Ok(Some(p)) => {
+                Ok(Some(p)) if !p.is_empty() => {
                     providers.push(Box::new(p));
                     shipped_db_load = ShippedDbLoad::Loaded;
                     break;
                 }
-                Ok(None) => {}
+                Ok(_) => {} // Absent (None) or empty -> not usable coverage; keep scanning
                 Err(e) => {
                     notes.push(format!("{}: {e}", path.display()));
                     shipped_db_load = ShippedDbLoad::Failed;

--- a/crates/raven/tests/package_db_consumer.rs
+++ b/crates/raven/tests/package_db_consumer.rs
@@ -44,6 +44,36 @@ impl Drop for NamesDbEnvGuard {
     }
 }
 
+/// Generic save/restore guard for an arbitrary env var, used to point
+/// `XDG_DATA_HOME` at an empty temp dir so the user-data `names.db` sidecar
+/// candidate is absent during a test. Same `ENV_LOCK` serialization contract as
+/// [`NamesDbEnvGuard`].
+struct EnvVarGuard {
+    key: &'static str,
+    prior: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &std::path::Path) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: caller holds `ENV_LOCK` for the whole test (see NamesDbEnvGuard).
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: dropped before the test's `ENV_LOCK` guard, still serialized.
+        unsafe {
+            match self.prior.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[tokio::test]
 async fn tier3_resolves_export_with_no_r() {
     let _guard = ENV_LOCK.lock().await;
@@ -85,6 +115,79 @@ async fn tier3_resolves_export_with_no_r() {
     );
     // And the package is NOT considered installed (install status stays Tier-1-only).
     assert!(!lib.package_exists(pkg));
+}
+
+/// Valid-but-empty offline DBs (zero packages — e.g. a `raven packages freeze`
+/// that matched nothing, or an empty `names.db`) must NOT be wired as providers:
+/// `has_providers()` is the "real package coverage exists" gate for the
+/// degraded-environment note in `cli::check`, so an empty offline file must read
+/// as no coverage, not as coverage. Regression for the false-negative where the
+/// note would be wrongly suppressed.
+///
+/// Both tiers are made empty: the Tier-3 env candidate points at a real but
+/// empty `names.db` (which opens-empty, is skipped, and the scan continues), and
+/// the user-data candidate is neutralized on every platform (`XDG_DATA_HOME` on
+/// unix, `LOCALAPPDATA` on Windows) so an ambient `names.db` can't mask the
+/// assertion. The Tier-2 `.raven/packages.json` carries zero packages.
+#[tokio::test]
+async fn empty_offline_dbs_are_not_wired_as_providers() {
+    use raven::package_db::json_db::{
+        REPO_DB_SCHEMA_VERSION, RepoDb, RepoDbProvenance, write_repo_db_file,
+    };
+
+    let _guard = ENV_LOCK.lock().await;
+
+    // Tier 3: a real but empty names.db as the highest-precedence candidate.
+    let names_dir = tempfile::tempdir().unwrap();
+    let empty_names_db = names_dir.path().join("names.db");
+    write_shipped_db(
+        &empty_names_db,
+        &[],
+        ShippedDbProvenance {
+            source: "test".into(),
+            snapshot_date: "2026-05-30".into(),
+            package_count: 0,
+            raven_version: "9.9.9".into(),
+        },
+    )
+    .unwrap();
+    let _db_guard = NamesDbEnvGuard::set(&empty_names_db);
+    // Neutralize the user-data candidate on every platform: `XDG_DATA_HOME`
+    // drives it on unix, `LOCALAPPDATA` (\Raven\names.db) on Windows. Setting
+    // both — each ignored on the other platform — keeps the test hermetic
+    // regardless of an ambient user-installed `names.db`.
+    let user_data_dir = tempfile::tempdir().unwrap();
+    let _xdg_guard = EnvVarGuard::set("XDG_DATA_HOME", user_data_dir.path());
+    let _localappdata_guard = EnvVarGuard::set("LOCALAPPDATA", user_data_dir.path());
+
+    // Tier 2: a valid but empty .raven/packages.json.
+    let workspace = tempfile::tempdir().unwrap();
+    write_repo_db_file(
+        &workspace.path().join(".raven").join("packages.json"),
+        &RepoDb {
+            schema_version: REPO_DB_SCHEMA_VERSION,
+            provenance: RepoDbProvenance {
+                raven_version: "test".into(),
+                r_version: "test".into(),
+                generated_unix: 0,
+            },
+            packages: vec![],
+        },
+    )
+    .unwrap();
+
+    // The third Tier-3 candidate is the executable-relative sidecar
+    // (`<test-binary-dir>/names.db`); like the other tests in this file we rely
+    // on it being absent under `cargo test` (a bundled `names.db` ships only in
+    // packaged releases, never next to the deps/ test binary). There is no env
+    // knob to relocate it, so it is left implicit.
+    let outcome =
+        build_package_library(None, &[], Some(workspace.path().to_path_buf()), true).await;
+    assert!(
+        !outcome.library.has_providers(),
+        "empty offline DBs must not be wired as providers (has_providers() must \
+         mean real coverage)"
+    );
 }
 
 /// R-gated: capture a Tier 2 record for an installed package and assert the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -309,7 +309,7 @@ Both `check` and `lint` share the same renderers:
 Diagnostics go to **stdout** for both commands. Beyond the diagnostics themselves, `raven check` may print a handful of **context notes** — short prose that explains *why* a result might be incomplete or how to act on it (`raven lint` prints none of these). They fall into two groups by *when* they appear:
 
 - **Startup notes** — printed once, *before* any diagnostics, to **stderr**. They report a degraded environment that affects the whole run.
-- **Footer notes** — printed once, *after* all diagnostics, as a footer. They annotate the findings above them. For `text` they go to **stdout** (the diagnostics' own stream); for `json` / `sarif` they go to **stderr** so they can't corrupt the machine document on stdout. The footer is set off from the summary line by a blank line and introduced by a single `raven check:` header; the individual notes carry no per-line prefix and, when more than one fires, are separated by a blank line.
+- **Footer notes** — printed once, *after* all diagnostics, as a footer. They annotate the findings above them. For `text` they go to **stdout** (the diagnostics' own stream); for `json` / `sarif` they go to **stderr** so they can't corrupt the machine document on stdout. The footer is set off from the summary line by a blank line and carries no header or per-line prefix (it is `raven check`'s own output, so labeling it as such mid-stream would be redundant); when more than one note fires, they are separated by a blank line.
 
 Footer notes share the diagnostics' stream for `text` deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave a multi-line note with the findings it describes. One stream keeps them grouped and in order — so a note never refers to another by position across streams.
 
@@ -338,7 +338,7 @@ All three variants share the same tail — ``package symbol resolution is limite
 
 When some undefined-variable findings sit inside call arguments that Raven cannot see into (a package function that *might* capture the argument via [non-standard evaluation](non-standard-evaluation.md)), the **`text`** report prints one footer after the findings — and **only** there. The footer is framed carefully so it never reads as Raven asserting the call *is* NSE: it leads with the universal false-positive escape hatches every linter has (`# raven: ignore`, `# nolint`, `# raven: expect`) and presents NSE as the *one R-specific* additional cause. It then lists the distinct, copy-pasteable per-function directives (one per function, however many findings it caused) and links [the directives reference](directives.md) and [handling false positives](diagnostics.md). The snippet is enough to apply without understanding the syntax; the links explain it — mirroring how ShellCheck and Clippy attach a docs URL rather than explaining suppression inline.
 
-It reads (with concrete callees filled in), under the footer's shared `raven check:` header:
+It reads (with concrete callees filled in), as a footer after the findings:
 
 ```
 3 undefined-variable findings above sit inside calls to package functions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -309,7 +309,7 @@ Both `check` and `lint` share the same renderers:
 Diagnostics go to **stdout** for both commands. Beyond the diagnostics themselves, `raven check` may print a handful of **context notes** — short prose that explains *why* a result might be incomplete or how to act on it (`raven lint` prints none of these). They fall into two groups by *when* they appear:
 
 - **Startup notes** — printed once, *before* any diagnostics, to **stderr**. They report a degraded environment that affects the whole run.
-- **Footer notes** — printed once, *after* all diagnostics, as a footer. They annotate the findings above them. For `text` they go to **stdout** (the diagnostics' own stream); for `json` / `sarif` they go to **stderr** so they can't corrupt the machine document on stdout.
+- **Footer notes** — printed once, *after* all diagnostics, as a footer. They annotate the findings above them. For `text` they go to **stdout** (the diagnostics' own stream); for `json` / `sarif` they go to **stderr** so they can't corrupt the machine document on stdout. The footer is set off from the summary line by a blank line and introduced by a single `raven check:` header; the individual notes carry no per-line prefix and, when more than one fires, are separated by a blank line.
 
 Footer notes share the diagnostics' stream for `text` deliberately: stdout and stderr are independent streams that a merged consumer (a terminal, `2>&1`, or a CI log viewer such as GitHub Actions, which timestamps each line as it reads it) can reorder, which would interleave a multi-line note with the findings it describes. One stream keeps them grouped and in order — so a note never refers to another by position across streams.
 
@@ -317,11 +317,15 @@ Footer notes share the diagnostics' stream for `text` deliberately: stdout and s
 
 Each note below is printed only when its condition holds; a clean run on a fully-resolved workspace prints just the diagnostics and the summary line.
 
-**Startup notes (stderr, before diagnostics)** — one fires when R-backed package resolution is degraded, so undefined-variable findings for package symbols may be unreliable. The text names the cause and the consequence:
+**Startup notes (stderr, before diagnostics)** — one fires when R-backed package resolution is degraded **and** no offline package data is available to cover for it, so undefined-variable findings for package symbols may be unreliable. The text names the cause and the consequence.
 
-- R not found on `PATH` — `R not found on PATH; package and base-symbol diagnostics will be limited`. (Base R-platform symbols are still covered by the embedded database; broad CRAN/Bioconductor coverage needs `raven packages update`.)
-- R found but its package library failed to initialize — `R found but its package library failed to initialize (…); …`.
-- R found but no library paths were discovered — `R found but no library paths were discovered; …`.
+**The note is keyed on actual coverage, not merely on R's absence.** It is suppressed when offline package data loaded — an updated `names.db` (Tier 3) or a frozen `.raven/packages.json` (Tier 2) — because that data resolves package symbols without a live R library, so the warning would be a false alarm (and would tell a CI that *already ran* `raven packages update` to run it again). It fires only when coverage falls back to base R alone.
+
+All three variants share the same tail — ``package symbol resolution is limited to base R (covered by the embedded database). Run `raven packages update` for broad CRAN/Bioconductor coverage`` — because the limitation and its remedy are identical regardless of *why* the live R library was unavailable.
+
+- R not found on `PATH` — ``R not found on PATH; package symbol resolution is limited to base R (covered by the embedded database). Run `raven packages update` for broad CRAN/Bioconductor coverage``.
+- R found but its package library failed to initialize — ``R found but its package library failed to initialize (…); package symbol resolution is limited to base R (…). Run `raven packages update` …``.
+- R found but no library paths were discovered — ``R found but no library paths were discovered; package symbol resolution is limited to base R (…). Run `raven packages update` …``.
 
 **Footer notes (stdout for `text`, stderr for `json`/`sarif`, after diagnostics)**, in the order printed:
 
@@ -334,10 +338,10 @@ Each note below is printed only when its condition holds; a clean run on a fully
 
 When some undefined-variable findings sit inside call arguments that Raven cannot see into (a package function that *might* capture the argument via [non-standard evaluation](non-standard-evaluation.md)), the **`text`** report prints one footer after the findings — and **only** there. The footer is framed carefully so it never reads as Raven asserting the call *is* NSE: it leads with the universal false-positive escape hatches every linter has (`# raven: ignore`, `# nolint`, `# raven: expect`) and presents NSE as the *one R-specific* additional cause. It then lists the distinct, copy-pasteable per-function directives (one per function, however many findings it caused) and links [the directives reference](directives.md) and [handling false positives](diagnostics.md). The snippet is enough to apply without understanding the syntax; the links explain it — mirroring how ShellCheck and Clippy attach a docs URL rather than explaining suppression inline.
 
-It reads (with concrete callees filled in):
+It reads (with concrete callees filled in), under the footer's shared `raven check:` header:
 
 ```
-raven check: 3 undefined-variable findings above sit inside calls to package functions
+3 undefined-variable findings above sit inside calls to package functions
 whose source raven can't see. If one is a false positive, you can suppress it as with any
 linter (`# raven: ignore`, `# nolint`, or `# raven: expect`).
 R has one extra cause: a function that captures an argument via non-standard


### PR DESCRIPTION
## Problem

`raven check` printed this when R was absent (e.g. in CI):

> `R not found on PATH; package and base-symbol diagnostics will be limited`

Confusing on two counts:

1. **It claimed base-symbol diagnostics were limited** — but base R symbols *are* covered by the embedded database even without R (the docs and `consumer_ready()` both say so). The note contradicted them.
2. **It fired purely on R's absence** — so a CI that had already run `raven packages update` (which downloads an offline `names.db` that `raven check` resolves without R) still got the note telling it to run the command it just ran.

A second, separate readability issue: the post-summary footer notes each repeated a `raven check: ` prefix.

## Changes

- **Reworded** the degraded-environment note: `package symbol resolution is limited to base R (covered by the embedded database). Run `raven packages update` for broad CRAN/Bioconductor coverage`.
- **Suppressed** the note when real offline package coverage exists, gated on `PackageLibrary::has_providers()`.
- **Root-caused the coverage signal** so `has_providers()` actually means "real coverage": zero-package offline DBs (an empty `.raven/packages.json` or `names.db`) are no longer wired as providers. An empty Tier-3 `names.db` no longer counts as `ShippedDbLoad::Loaded` — the candidate scan continues and the verdict stays `Absent`, so the missing-export footer steers to `raven packages update` (download a real DB) instead of "the package is likely private".
- **Footer presentation**: context-notes now print under a single `raven check:` header, blank-line separated, instead of a per-note prefix.
- Extracted the decision into the pure `degraded_env_note(status, has_offline_packages)` — unit-testable, since `RNotFound` is unreachable end-to-end on any host with R installed (`get_fallback_lib_paths()` finds the framework library → `Ready`).
- Added inherent `is_empty()` to `RepoDbProvider` / `ShippedDb` / `ShippedDbProvider`, and a regression test (`empty_offline_dbs_are_not_wired_as_providers`) that's hermetic across unix and Windows.
- Updated `docs/cli.md`.

## Verification

- Gates green: `cargo fmt --all --check`; `cargo clippy --workspace --all-targets --features test-support -- -D warnings`; `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items` in **both** the default and `--features test-support` configs.
- Tests green: new `degraded_env_note` unit tests, the empty-provider regression test, and the existing `check_footer_stream` / `package_db_consumer` suites.
- Reviewed: two consecutive clean rounds from codex and an independent finder pass; all earlier findings (base-symbol wording, empty-provider false-negative, empty-DB `Loaded` verdict, docs rendering, enum-doc accuracy, Windows test hermeticity) addressed.

https://claude.ai/code/session_01CVjPidHKDFBPj3dV3WCDj1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `raven check` output formatting with a single shared header for related footer notes.
  * Added clearer handling for empty offline package databases, so they are treated as unavailable coverage.

* **Bug Fixes**
  * Prevented empty package databases from being counted as provider coverage.
  * Refined startup and footer notes so messages are more accurate and no longer repeat prefixes.

* **Documentation**
  * Updated CLI help and output-stream documentation to match the revised behavior and wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->