### PR TITLE
feat(data-viewer): View() vectors, scalars, factors, labelled, and flat lists

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -45,11 +45,27 @@ side-by-side.
 - `matrix`. If the matrix has non-default rownames, they appear as a
   leading `rowname` column; auto-generated `1..N` rownames are dropped
   in favor of the viewer's row-number gutter.
-- Other classes raise an error in R:
+- **Atomic vectors and scalars** (`numeric`, `integer`, `character`,
+  `logical`, `complex`, `Date`, `POSIXct`), plus standalone `factor` and
+  `haven_labelled` vectors. A vector renders as a `values` column (a
+  `value` column when it has length 1). If the vector has `names()`,
+  those appear in a leading `name` column — the same role the `rowname`
+  column plays for a matrix. A standalone `factor` / `haven_labelled`
+  vector keeps its labels, so the [Labels](#labels) toggle works on it.
+- **Flat lists** — a list whose elements are all scalars/vectors. Each
+  element becomes a column, padded with empty (`NA`) cells to the length
+  of the longest element, and each column keeps its own type. Unnamed
+  elements get `V1`, `V2`, … headers. A named vector and a list of
+  scalars therefore render differently — `c(a = 1, b = 2)` is a two-row
+  `name`/`values` table, while `list(a = 1, b = 2)` is a one-row,
+  two-column table — matching `as.data.frame(list(a = 1, b = 2))`.
+- Other classes — including nested/recursive lists (an element that is
+  itself a list or `data.frame`), `raw` vectors, environments, and
+  functions — raise an error in R:
 
   ```r
-  > View(1)
-  Error: Can't `View()` an object of class `numeric`
+  > View(sum)
+  Error: Can't `View()` an object of class `function`
   ```
 
 ## Triggering

--- a/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
@@ -1,4 +1,4 @@
-# Data viewer: View() support for vectors and scalars
+# Data viewer: View() support for vectors, scalars, and flat lists
 
 **Date:** 2026-06-27
 **Status:** Approved (design)
@@ -13,140 +13,231 @@ Raven's `View()` override renders `data.frame` (incl. `tibble` /
 Error: Can't `View()` an object of class `numeric`
 ```
 
-Vectors and scalars are the most common objects users actually want to
-glance at — a single labelled column pulled from an import
-(`View(mydata$education)`), a factor (`View(iris$Species)`), or a plain
-result vector. They all error today.
+The objects users most often want to glance at — a scalar, a (named)
+vector, a single labelled column pulled from an import
+(`View(mydata$education)`), a factor (`View(iris$Species)`), or a flat
+list of columns — all error today.
 
-The fix is small and almost entirely R-side: the webview, Arrow reader,
+The fix is almost entirely R-side: the webview, Arrow reader,
 sort/filter/format, copy, and HTTP wire format already render any
-1-or-2-column frame. We only need to convert an accepted vector/scalar
-into such a frame on the R side, *before* the existing acceptance gate.
+data.frame. We only need to convert an accepted vector / scalar / flat
+list into a data.frame on the R side, in front of the existing pipeline.
+**No webview, wire-format, or Arrow-reader changes.**
 
 ## Scope
 
 In scope — newly `View()`-able:
 
-- Atomic vectors: `numeric` / `integer` / `double`, `character`,
-  `logical`, `complex`, `raw`.
-- Scalars (length-1 atomic vectors) — handled as the length-1 case of
-  the vector path, not special-cased.
-- Standalone `factor` vectors (e.g. `iris$Species`).
-- Standalone `haven_labelled` vectors (e.g. a single column extracted
-  from a `haven::read_dta` import).
+- **Atomic vectors**: `numeric` / `integer` / `double`, `character`,
+  `logical`, `complex`, `raw`. (`complex` / `raw` aren't Arrow-native;
+  the existing per-column fallback stringifies them, same as today for
+  unrecognized data.frame columns.)
+- **Scalars** — handled as the length-1 case of the vector path, not
+  special-cased.
+- **Standalone `factor` vectors** (e.g. `iris$Species`).
+- **Standalone `haven_labelled` vectors** (e.g. one column extracted from
+  a `haven::read_dta` import).
+- **Flat (non-recursive) lists** — a list whose every element is a
+  scalar/vector (atomic, factor, `haven_labelled`, or `NULL`), with no
+  element that is itself a list, data.frame, or multi-dimensional object.
 
 Out of scope — keep erroring with the existing message:
 
-- Lists (atomic-list / `list()`), S4 objects, environments, functions,
-  and anything else not in the accepted set.
-- Multi-dimensional objects (matrix/array) — already handled by the
-  matrix branch, or excluded by the `dim()` guard below.
+- Nested / recursive lists (any element is a list or data.frame).
+- List elements that are matrices/arrays (have a `dim`), S4 objects,
+  environments, functions, etc.
+- Bare S4 objects, environments, functions, `NULL` itself, and anything
+  else not in the accepted set.
 
 ## Design
 
-### Single new branch in `.raven_view`
-
 All changes live in `.raven_view` in
-`editors/vscode/src/plot/r-bootstrap-profile.ts`, inserted **between**
-the matrix branch and the existing
-`if (!is.data.frame(x) && !is.matrix(x)) stop(...)` gate.
+`editors/vscode/src/plot/r-bootstrap-profile.ts`. The current shape —
 
-### Acceptance gate
+```r
+if (!is.data.frame(x) && !is.matrix(x)) stop("Can't `View()` ...")
+df <- if (is.matrix(x)) { ...matrix... } else { x }
+```
 
-Accept `x` as a vector/scalar when **all** hold:
+becomes a single if/else-if chain that either produces `df` or stops:
 
-- `is.null(dim(x))` — excludes matrices and 1-D+ arrays, which must not
-  fall through to this branch.
-- `is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled")`.
+```r
+df <- if (is.matrix(x)) {
+    ...existing matrix handling...
+} else if (is.data.frame(x)) {
+    x
+} else if (<vector accepted>) {
+    <build name/value frame>          # see "Vectors / scalars"
+} else if (<list accepted>) {
+    <build element-as-column frame>   # see "Flat lists"
+} else {
+    stop("Can't `View()` an object of class `",
+         paste(class(x), collapse = "/"), "`", call. = FALSE)
+}
+```
 
-`is.factor` is called out explicitly because a factor is technically
-atomic in storage but we want it accepted regardless of how `is.atomic`
-treats it across R versions; `haven_labelled` likewise. Plain atomic
-vectors carry no labels, so for them this is identical to "atomic".
+Branch order matters: `matrix` and `data.frame` are tested first (a
+data.frame is also a list), then the vector branch, then the list
+branch. Everything that produces `df` then falls into the existing
+per-column `.raven_encode_col` loop and the existing Arrow-write + POST
+path, untouched.
 
-Anything that is not a `data.frame`, not a `matrix`, and not accepted
-here continues to hit the existing `stop("Can't `View()` ...")` path
-unchanged.
+### Vectors / scalars
 
-### Frame construction (preserve class/attributes)
+**Accept** when `is.null(dim(x))` and
+(`is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled")`). The
+`dim` guard keeps matrices/1-D arrays out of this branch. Plain atomic
+vectors carry no labels, so `factor` / `haven_labelled` are named
+explicitly only to admit those standalone classes.
 
-Build the frame as a **bare list given the `data.frame` class**, not via
-`data.frame(values = x)`. `data.frame()` can coerce or strip a factor's
-levels and a `haven_labelled`'s `labels` attribute; constructing the
-list directly keeps the values vector's class and attributes intact so
-the existing `.raven_encode_col` pass (which already understands factor
-and `haven_labelled`) and the webview's Labels toggle work with zero new
-code.
+**Shape — a leading `name` column (when named) + a value column:**
 
-Construction:
+| `names(x)` | Columns |
+| --- | --- |
+| non-NULL | `name` (character) + the value column |
+| NULL | the value column only |
 
-- `n <- length(x)`.
-- Determine headers (see below).
-- If `names(x)` is non-NULL: column 1 = the names header, holding
-  `as.character(names(x))`; column 2 = the values header, holding `x`
-  unchanged.
-- If `names(x)` is NULL: a single values-header column holding `x`
-  unchanged.
-- Assign `names()`, `class(df) <- "data.frame"`, and
-  `attr(df, "row.names") <- .set_row_names(n)`.
+- `name` column header is **always** `name` (singular), mirroring the
+  matrix `rowname` leading-column treatment — a named vector's names play
+  the same role as matrix rownames, so they render as a leading column,
+  not a tooltip.
+- Value column header: `value` when `length(x) == 1`, else `values`.
+- Row count = `length(x)`.
 
-Then fall into the existing per-column `.raven_encode_col` loop and the
-existing Arrow-write + POST path. No changes below this point.
+**Construction** uses a **bare list given the `data.frame` class** (not
+`data.frame(value = x)`), so the value vector's class/attributes —
+factor levels, `haven_labelled` `labels` — survive into the existing
+`.raven_encode_col` pass and the webview Labels toggle, with zero new
+code. Set `names()`, `class(df) <- "data.frame"`, and
+`attr(df, "row.names") <- .set_row_names(length(x))`.
 
-### Header naming
+**Rejected alternatives** (decided during brainstorming):
 
-Driven by length (`n`), per the approved rule:
+- *Expression-derived headers* (`names(x)` / `x` from
+  `deparse(substitute(x))`): clean for a bare symbol but ugly for
+  literals/calls (`View(c(1, 2, 3))` → a column headed `c(1, 2, 3)`),
+  duplicates the panel title, and the canvas header cell is sized for a
+  short name. Dropped in favor of the fixed generic `name` / `value(s)`.
+- *Names on cell hover instead of a column*: the grid is Glide Data Grid
+  (canvas — no DOM per-cell tooltip), so this would need a separate
+  side-channel to ship the full names vector to the webview (fighting the
+  stream-the-visible-window design) plus a custom tooltip overlay, and
+  names would not be copyable/sortable/filterable and would be hidden
+  until hovered. The column gives copy + sort + filter + visibility for
+  free and matches the matrix precedent.
 
-| Case | Names present | Names absent |
-| --- | --- | --- |
-| `n == 1` | `name`, `value` | `value` |
-| `n != 1` | `names`, `values` | `values` |
+### Flat lists
+
+**Accept** `x` when it is a list (data.frames are caught earlier),
+`length(x) > 0`, and **every** element `el` satisfies:
+
+```r
+is.null(el) ||
+((is.atomic(el) || is.factor(el) || inherits(el, "haven_labelled")) &&
+ is.null(dim(el)))
+```
+
+If any element is itself a list, a data.frame, or has a `dim`
+(matrix/array), or is otherwise unsupported, the list falls through to
+the existing `Can't `View()` ...` error — this is the "non-recursive"
+exclusion (`is.list(el)` catches both nested lists and data.frames).
+
+**Shape — element-as-column table, NA-padded to the longest element:**
+
+```r
+View(list(a = 1:3, b = c("x", "y"), c = TRUE))
+```
+
+| a | b | c    |
+| - | - | ---- |
+| 1 | x | TRUE |
+| 2 | y |      |
+| 3 |   |      |
+
+- One column per list element; row count `n = max(lengths(x))`
+  (`0` if every element is empty).
+- Each element keeps **its own type** — `a` integer, `b` character,
+  `c` logical — so per-column sort/filter/format and the Labels toggle
+  (for factor / `haven_labelled` elements) all work, exactly as for a
+  data.frame. No stringifying.
+
+**Per-column construction:**
+
+- Pad each element to `n` via **positional indexing**: `el[seq_len(n)]`.
+  Indexing past the end yields `NA` and preserves class — `factor[...]`
+  keeps levels, `[.haven_labelled` keeps its `labels`. This is why we
+  index rather than `length<-` (which can strip S3 attributes).
+- `NULL` or length-0 elements → an all-`NA` column (`rep(NA, n)`,
+  logical), since `NULL[seq_len(n)]` is `NULL`, not an NA vector.
+- Build the columns into a bare list given the `data.frame` class +
+  `.set_row_names(n)`, then fall into the existing `.raven_encode_col`
+  loop.
+
+**Column names:** from `names(x)`; any missing/`""` name is replaced by a
+position-based `V<i>` and the full set passed through `make.unique`,
+mirroring `as.data.frame(<unnamed list>)`.
+
+### Vector-vs-list shape divergence (intentional)
+
+A named vector and a list of scalars render differently, by design:
+
+- `c(a = 1, b = 2)` → **2-row** `name`/`values` table (one variable with
+  labelled entries).
+- `list(a = 1, b = 2)` → **1-row, 2-column** table `a | b` (a collection
+  of variables; matches `as.data.frame(list(a = 1, b = 2))`).
 
 ### Edge cases
 
-- **Length-0 vectors** (`integer(0)`, `character(0)`): allowed, not an
-  error. Renders an empty values column; the toolbar shows `rows: 0`.
-  Header uses the `n != 1` (plural) form.
-- **Partially-named vectors** (`c(a = 1, 2)`): `names()` is non-NULL with
-  `""` for the unnamed slots; the names column shows empty strings for
-  those rows. No special handling.
-- **Factor / `haven_labelled` standalone**: `names()` is typically NULL,
-  so these render as a single values column. The values column keeps its
-  class through construction, so the Labels toggle swaps codes for level
-  / value-label strings exactly as it does inside a data.frame. Plain
-  atomic vectors show no Labels button (nothing to label) — existing
-  toolbar logic already hides it when no column is affected.
-- **Panel name**: unchanged. `View(1)` deparses to panel name `1`;
-  `View(x)` to `x`; an explicit second arg still wins. No new logic.
+- **Length-0 vector** (`integer(0)`): allowed; empty `values` column,
+  `rows: 0`.
+- **Partially-named vector** (`c(a = 1, 2)`): `names()` has `""` for
+  unnamed slots → blank `name` cells.
+- **Factor / `haven_labelled` standalone**: `names()` is typically NULL →
+  single value column; class preserved → Labels toggle swaps codes for
+  labels. Plain atomic vectors show no Labels button (existing toolbar
+  logic hides it when no column is affected).
+- **Empty list** `list()`: `length(x) == 0` → falls through to the error.
+- **Panel name**: unchanged. `View(1)` → panel `1`; explicit second arg
+  still wins.
 
 ## Testing
 
 - `tests/bun/data-viewer-bootstrap-content.test.ts`: assert the bootstrap
-  source contains the new acceptance branch and the bare-list /
-  `.set_row_names` construction, and that the singular/plural header
-  selection is present (string-level checks, matching how this file
-  already pins the View() override).
+  source contains the new vector and list branches, the bare-list /
+  `.set_row_names` construction, the `name` + `value`/`values` header
+  selection, the `el[seq_len(n)]` padding, and `make.unique` column
+  naming (string-level checks, matching how this file already pins the
+  View() override).
 - `tests/bun/data-viewer-bootstrap-r-integration.test.ts` (runs the
-  profile against a real R, gated on `HAS_R` / `HAS_ARROW`, and captures
-  the `/view-data` POST): add cases that `View()` a named vector, an
-  unnamed vector, a scalar, a factor, and a `haven_labelled` vector, and
-  assert the resulting Arrow file's column names and row count match the
-  table above. Gate the `haven_labelled` case on `haven` availability
-  using the existing `r_with(...)` helper, consistent with how the suite
-  guards optional packages.
+  profile against a real R, gated on `HAS_R` / `HAS_ARROW`, capturing the
+  `/view-data` POST): add cases that `View()` —
+  - a named vector → columns `name`, `values`, `nrow == length`;
+  - an unnamed vector → single `values` column;
+  - a scalar → single `value` column, `nrow == 1`;
+  - a factor and a `haven_labelled` vector → single value column, labels
+    intact in the Arrow schema metadata (gate the `haven_labelled` case
+    on `haven` via the existing `r_with(...)` helper);
+  - a ragged flat list → element-as-column, `nrow == max(lengths)`, with
+    NA padding and per-column types preserved;
+  - a nested list → still errors.
+  Assert the resulting Arrow file's column names, types, and row count.
 - No webview/TS-grid test changes: the grid already renders arbitrary
-  1-or-2-column frames; nothing in its contract changes.
+  frames; nothing in its contract changes.
 
 ## Docs
 
 - `docs/data-viewer.md` "What it shows": add atomic vectors, scalars,
-  standalone factors, and `haven_labelled` vectors, documenting the
-  names/values (and singular `name`/`value` for length-1) layout, the
-  drop of the names column when `names()` is NULL, and that the Labels
-  toggle applies to a standalone factor / labelled vector.
+  standalone factors, `haven_labelled` vectors, and flat lists.
+  Document: the leading `name` column + `value`/`values` data column for
+  vectors (and that the `name` column is dropped when `names()` is NULL);
+  that the `name` column mirrors the matrix `rowname` leading column;
+  the element-as-column, NA-padded table for lists; that nested/recursive
+  lists are unsupported; and the intentional named-vector-vs-list shape
+  divergence.
 
 ## Non-goals
 
-- No list support. No new settings. No webview, wire-format, Arrow-reader,
-  sort/filter/format/copy changes — this is purely a new R-side
-  conversion in front of the existing pipeline.
+- No nested/recursive list support. No names-on-hover. No
+  expression-derived headers. No new settings. No webview, wire-format,
+  Arrow-reader, or sort/filter/format/copy changes — this is purely a new
+  R-side conversion in front of the existing pipeline.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
@@ -1,0 +1,152 @@
+# Data viewer: View() support for vectors and scalars
+
+**Date:** 2026-06-27
+**Status:** Approved (design)
+
+## Problem
+
+Raven's `View()` override renders `data.frame` (incl. `tibble` /
+`data.table`) and `matrix`. Every other class raises:
+
+```r
+> View(1)
+Error: Can't `View()` an object of class `numeric`
+```
+
+Vectors and scalars are the most common objects users actually want to
+glance at — a single labelled column pulled from an import
+(`View(mydata$education)`), a factor (`View(iris$Species)`), or a plain
+result vector. They all error today.
+
+The fix is small and almost entirely R-side: the webview, Arrow reader,
+sort/filter/format, copy, and HTTP wire format already render any
+1-or-2-column frame. We only need to convert an accepted vector/scalar
+into such a frame on the R side, *before* the existing acceptance gate.
+
+## Scope
+
+In scope — newly `View()`-able:
+
+- Atomic vectors: `numeric` / `integer` / `double`, `character`,
+  `logical`, `complex`, `raw`.
+- Scalars (length-1 atomic vectors) — handled as the length-1 case of
+  the vector path, not special-cased.
+- Standalone `factor` vectors (e.g. `iris$Species`).
+- Standalone `haven_labelled` vectors (e.g. a single column extracted
+  from a `haven::read_dta` import).
+
+Out of scope — keep erroring with the existing message:
+
+- Lists (atomic-list / `list()`), S4 objects, environments, functions,
+  and anything else not in the accepted set.
+- Multi-dimensional objects (matrix/array) — already handled by the
+  matrix branch, or excluded by the `dim()` guard below.
+
+## Design
+
+### Single new branch in `.raven_view`
+
+All changes live in `.raven_view` in
+`editors/vscode/src/plot/r-bootstrap-profile.ts`, inserted **between**
+the matrix branch and the existing
+`if (!is.data.frame(x) && !is.matrix(x)) stop(...)` gate.
+
+### Acceptance gate
+
+Accept `x` as a vector/scalar when **all** hold:
+
+- `is.null(dim(x))` — excludes matrices and 1-D+ arrays, which must not
+  fall through to this branch.
+- `is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled")`.
+
+`is.factor` is called out explicitly because a factor is technically
+atomic in storage but we want it accepted regardless of how `is.atomic`
+treats it across R versions; `haven_labelled` likewise. Plain atomic
+vectors carry no labels, so for them this is identical to "atomic".
+
+Anything that is not a `data.frame`, not a `matrix`, and not accepted
+here continues to hit the existing `stop("Can't `View()` ...")` path
+unchanged.
+
+### Frame construction (preserve class/attributes)
+
+Build the frame as a **bare list given the `data.frame` class**, not via
+`data.frame(values = x)`. `data.frame()` can coerce or strip a factor's
+levels and a `haven_labelled`'s `labels` attribute; constructing the
+list directly keeps the values vector's class and attributes intact so
+the existing `.raven_encode_col` pass (which already understands factor
+and `haven_labelled`) and the webview's Labels toggle work with zero new
+code.
+
+Construction:
+
+- `n <- length(x)`.
+- Determine headers (see below).
+- If `names(x)` is non-NULL: column 1 = the names header, holding
+  `as.character(names(x))`; column 2 = the values header, holding `x`
+  unchanged.
+- If `names(x)` is NULL: a single values-header column holding `x`
+  unchanged.
+- Assign `names()`, `class(df) <- "data.frame"`, and
+  `attr(df, "row.names") <- .set_row_names(n)`.
+
+Then fall into the existing per-column `.raven_encode_col` loop and the
+existing Arrow-write + POST path. No changes below this point.
+
+### Header naming
+
+Driven by length (`n`), per the approved rule:
+
+| Case | Names present | Names absent |
+| --- | --- | --- |
+| `n == 1` | `name`, `value` | `value` |
+| `n != 1` | `names`, `values` | `values` |
+
+### Edge cases
+
+- **Length-0 vectors** (`integer(0)`, `character(0)`): allowed, not an
+  error. Renders an empty values column; the toolbar shows `rows: 0`.
+  Header uses the `n != 1` (plural) form.
+- **Partially-named vectors** (`c(a = 1, 2)`): `names()` is non-NULL with
+  `""` for the unnamed slots; the names column shows empty strings for
+  those rows. No special handling.
+- **Factor / `haven_labelled` standalone**: `names()` is typically NULL,
+  so these render as a single values column. The values column keeps its
+  class through construction, so the Labels toggle swaps codes for level
+  / value-label strings exactly as it does inside a data.frame. Plain
+  atomic vectors show no Labels button (nothing to label) — existing
+  toolbar logic already hides it when no column is affected.
+- **Panel name**: unchanged. `View(1)` deparses to panel name `1`;
+  `View(x)` to `x`; an explicit second arg still wins. No new logic.
+
+## Testing
+
+- `tests/bun/data-viewer-bootstrap-content.test.ts`: assert the bootstrap
+  source contains the new acceptance branch and the bare-list /
+  `.set_row_names` construction, and that the singular/plural header
+  selection is present (string-level checks, matching how this file
+  already pins the View() override).
+- `tests/bun/data-viewer-bootstrap-r-integration.test.ts` (runs the
+  profile against a real R, gated on `HAS_R` / `HAS_ARROW`, and captures
+  the `/view-data` POST): add cases that `View()` a named vector, an
+  unnamed vector, a scalar, a factor, and a `haven_labelled` vector, and
+  assert the resulting Arrow file's column names and row count match the
+  table above. Gate the `haven_labelled` case on `haven` availability
+  using the existing `r_with(...)` helper, consistent with how the suite
+  guards optional packages.
+- No webview/TS-grid test changes: the grid already renders arbitrary
+  1-or-2-column frames; nothing in its contract changes.
+
+## Docs
+
+- `docs/data-viewer.md` "What it shows": add atomic vectors, scalars,
+  standalone factors, and `haven_labelled` vectors, documenting the
+  names/values (and singular `name`/`value` for length-1) layout, the
+  drop of the names column when `names()` is NULL, and that the Labels
+  toggle applies to a standalone factor / labelled vector.
+
+## Non-goals
+
+- No list support. No new settings. No webview, wire-format, Arrow-reader,
+  sort/filter/format/copy changes — this is purely a new R-side
+  conversion in front of the existing pipeline.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
@@ -18,20 +18,29 @@ vector, a single labelled column pulled from an import
 (`View(mydata$education)`), a factor (`View(iris$Species)`), or a flat
 list of columns — all error today.
 
-The fix is almost entirely R-side: the webview, Arrow reader,
-sort/filter/format, copy, and HTTP wire format already render any
-data.frame. We only need to convert an accepted vector / scalar / flat
-list into a data.frame on the R side, in front of the existing pipeline.
-**No webview, wire-format, or Arrow-reader changes.**
+The fix is R-side only, in one place: the type-dispatch in `.raven_view`.
+Today a hard gate (`r-bootstrap-profile.ts:303`) rejects everything that
+is not a data.frame/matrix before any conversion can run; we replace
+that gate with a conversion chain that turns an accepted vector / scalar
+/ flat list into a data.frame. Everything downstream —
+`.raven_encode_col`, `.raven_write_arrow`, the `/view-data` POST, and the
+entire webview / wire-format / Arrow-reader path — is **untouched**,
+because it already renders any data.frame.
 
 ## Scope
 
 In scope — newly `View()`-able:
 
 - **Atomic vectors**: `numeric` / `integer` / `double`, `character`,
-  `logical`, `complex`, `raw`. (`complex` / `raw` aren't Arrow-native;
-  the existing per-column fallback stringifies them, same as today for
+  `logical`, `complex`, plus classed atomic vectors the existing encoder
+  already handles — `Date`, `POSIXct`. (`complex` isn't Arrow-native; the
+  existing per-column fallback stringifies it, same as today for
   unrecognized data.frame columns.)
+- **`raw` is excluded.** A raw vector has no `NA`, so out-of-bounds
+  indexing during ragged-list padding yields `00` bytes rather than a
+  missing cell — a silent-wrong result. To keep one rule across the
+  vector and list branches, `raw` is rejected in both; `View(raw_vec)`
+  keeps erroring.
 - **Scalars** — handled as the length-1 case of the vector path, not
   special-cased.
 - **Standalone `factor` vectors** (e.g. `iris$Species`).
@@ -84,11 +93,13 @@ path, untouched.
 
 ### Vectors / scalars
 
-**Accept** when `is.null(dim(x))` and
+**Accept** when `is.null(dim(x))` and `!is.raw(x)` and
 (`is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled")`). The
-`dim` guard keeps matrices/1-D arrays out of this branch. Plain atomic
-vectors carry no labels, so `factor` / `haven_labelled` are named
-explicitly only to admit those standalone classes.
+`dim` guard keeps matrices/1-D arrays out of this branch; `!is.raw(x)`
+enforces the raw exclusion above. Plain atomic vectors carry no labels,
+so `factor` / `haven_labelled` are named explicitly only to admit those
+standalone classes. `Date` / `POSIXct` are atomic with no `dim`, so they
+are admitted here and rendered by the existing encoder.
 
 **Shape — a leading `name` column (when named) + a value column:**
 
@@ -134,7 +145,7 @@ code. Set `names()`, `class(df) <- "data.frame"`, and
 ```r
 is.null(el) ||
 ((is.atomic(el) || is.factor(el) || inherits(el, "haven_labelled")) &&
- is.null(dim(el)))
+ is.null(dim(el)) && !is.raw(el))
 ```
 
 If any element is itself a list, a data.frame, or has a `dim`
@@ -163,19 +174,27 @@ View(list(a = 1:3, b = c("x", "y"), c = TRUE))
 
 **Per-column construction:**
 
-- Pad each element to `n` via **positional indexing**: `el[seq_len(n)]`.
-  Indexing past the end yields `NA` and preserves class — `factor[...]`
-  keeps levels, `[.haven_labelled` keeps its `labels`. This is why we
-  index rather than `length<-` (which can strip S3 attributes).
-- `NULL` or length-0 elements → an all-`NA` column (`rep(NA, n)`,
-  logical), since `NULL[seq_len(n)]` is `NULL`, not an NA vector.
+- Pad each **non-NULL** element to `n` via **positional indexing**:
+  `el[seq_len(n)]`. Indexing past the end yields `NA` and **preserves
+  class** — `factor[...]` keeps levels, `[.haven_labelled` keeps its
+  `labels`. Crucially this also covers length-0 *typed* elements: a
+  `factor(character(), levels = "a")` or `integer(0)` element indexed to
+  `n` becomes a class-preserving NA column (or a zero-row class-preserving
+  column when `n == 0`), so its levels/labels survive into
+  `.raven_encode_col`. We index rather than `length<-` (which can strip
+  S3 attributes) or `rep(NA, n)` (which would erase type).
+- **Only a literal `NULL` element** → `rep(NA, n)` (logical). `NULL` has
+  no type to preserve, and `NULL[seq_len(n)]` is `NULL`, not an NA vector.
 - Build the columns into a bare list given the `data.frame` class +
   `.set_row_names(n)`, then fall into the existing `.raven_encode_col`
   loop.
 
-**Column names:** from `names(x)`; any missing/`""` name is replaced by a
-position-based `V<i>` and the full set passed through `make.unique`,
-mirroring `as.data.frame(<unnamed list>)`.
+**Column names:** start from `names(x)`, or — when `names(x)` is `NULL`
+(a fully unnamed list, not a character vector with empty slots) — a
+length-`length(x)` vector of `""`. Replace every `""` / `NA` slot with a
+position-based `V<i>`, then pass the whole vector through `make.unique`.
+This mirrors `as.data.frame(<unnamed list>)`. (Column count is
+`length(x)`, independent of the row count `n`.)
 
 ### Vector-vs-list shape divergence (intentional)
 
@@ -219,7 +238,20 @@ A named vector and a list of scalars render differently, by design:
     on `haven` via the existing `r_with(...)` helper);
   - a ragged flat list → element-as-column, `nrow == max(lengths)`, with
     NA padding and per-column types preserved;
-  - a nested list → still errors.
+  - a flat list with a **length-0 typed element** (e.g.
+    `list(a = 1:3, f = factor(character(), levels = "a"))`) → the `f`
+    column is still a factor (levels intact), all-NA, not a logical
+    column — guards finding #2;
+  - an **all-empty** typed list (e.g.
+    `list(f = factor(character(), levels = "a"))`) → a zero-row factor
+    column, levels intact — guards finding #3;
+  - a list with a **`NULL` element** → an all-NA column, no crash;
+  - a fully **unnamed** list → synthesized `V1..Vk` column names;
+  - a `raw` vector and a flat list containing a `raw` element → both
+    **error** (raw is excluded);
+  - a factor with a literal **`NA` level** (`factor(x, exclude = NULL)`)
+    vs. a factor with `NA` *values* → the level/value distinction
+    round-trips correctly through the schema metadata.
   Assert the resulting Arrow file's column names, types, and row count.
 - No webview/TS-grid test changes: the grid already renders arbitrary
   frames; nothing in its contract changes.
@@ -232,12 +264,14 @@ A named vector and a list of scalars render differently, by design:
   vectors (and that the `name` column is dropped when `names()` is NULL);
   that the `name` column mirrors the matrix `rowname` leading column;
   the element-as-column, NA-padded table for lists; that nested/recursive
-  lists are unsupported; and the intentional named-vector-vs-list shape
-  divergence.
+  lists and `raw` vectors are unsupported; and the intentional
+  named-vector-vs-list shape divergence.
 
 ## Non-goals
 
-- No nested/recursive list support. No names-on-hover. No
-  expression-derived headers. No new settings. No webview, wire-format,
-  Arrow-reader, or sort/filter/format/copy changes — this is purely a new
-  R-side conversion in front of the existing pipeline.
+- No nested/recursive list support. No `raw`-vector support. No
+  names-on-hover. No expression-derived headers. No new settings. The
+  only change is the `.raven_view` type-dispatch gate; `.raven_encode_col`,
+  the Arrow write, the `/view-data` POST, and the entire webview /
+  wire-format / Arrow-reader / sort / filter / format / copy path are
+  untouched.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
@@ -93,8 +93,11 @@ path, untouched.
 
 ### Vectors / scalars
 
-**Accept** when `is.null(dim(x))` and `!is.raw(x)` and
+**Accept** when `!is.null(x)` and `is.null(dim(x))` and `!is.raw(x)` and
 (`is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled")`). The
+`!is.null(x)` guard is required because `is.atomic(NULL)` is `TRUE` on
+R < 4.4 (it became `FALSE` in 4.4.0), so without it `View(NULL)` would
+wrongly enter this branch; instead it must fall through to the error. The
 `dim` guard keeps matrices/1-D arrays out of this branch; `!is.raw(x)`
 enforces the raw exclusion above. Plain atomic vectors carry no labels,
 so `factor` / `haven_labelled` are named explicitly only to admit those
@@ -249,6 +252,8 @@ A named vector and a list of scalars render differently, by design:
   - a fully **unnamed** list → synthesized `V1..Vk` column names;
   - a `raw` vector and a flat list containing a `raw` element → both
     **error** (raw is excluded);
+  - `View(NULL)` → **errors** (must not enter the vector branch on
+    R < 4.4 where `is.atomic(NULL)` is `TRUE`);
   - a factor with a literal **`NA` level** (`factor(x, exclude = NULL)`)
     vs. a factor with `NA` *values* → the level/value distinction
     round-trips correctly through the schema metadata.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md
@@ -177,17 +177,28 @@ View(list(a = 1:3, b = c("x", "y"), c = TRUE))
 
 **Per-column construction:**
 
-- Pad each **non-NULL** element to `n` via **positional indexing**:
-  `el[seq_len(n)]`. Indexing past the end yields `NA` and **preserves
-  class** — `factor[...]` keeps levels, `[.haven_labelled` keeps its
-  `labels`. Crucially this also covers length-0 *typed* elements: a
-  `factor(character(), levels = "a")` or `integer(0)` element indexed to
+- Pad each **non-NULL** element to `n` by indexing with an **NA-filled
+  index** — *not* by over-indexing with `el[seq_len(n)]`. Build
+  `idx <- seq_len(n)` and set `idx[idx > length(el)] <- NA`, then take
+  `el[idx]`. Indexing existing positions plus `NA` **preserves class**
+  for base vectors, factors, *and* vctrs-backed `haven_labelled`:
+  `factor[...]` keeps levels and `[.haven_labelled` keeps its `labels`.
+
+  > ⚠️ Over-indexing (`el[seq_len(n)]`) is **wrong** here even though it
+  > NA-pads base vectors and factors: a `vctrs`/`haven_labelled` element's
+  > `[` method **errors** on out-of-bounds subscripts ("Can't subset
+  > elements past the end"), aborting `View()`. The NA-index form avoids
+  > the out-of-bounds access entirely, which is the whole reason it is
+  > used. Do not "simplify" it back to `el[seq_len(n)]`.
+
+  This also covers length-0 *typed* elements: a
+  `factor(character(), levels = "a")` or `integer(0)` element padded to
   `n` becomes a class-preserving NA column (or a zero-row class-preserving
   column when `n == 0`), so its levels/labels survive into
-  `.raven_encode_col`. We index rather than `length<-` (which can strip
-  S3 attributes) or `rep(NA, n)` (which would erase type).
+  `.raven_encode_col`. We index this way rather than `length<-` (which
+  can strip S3 attributes) or `rep(NA, n)` (which would erase type).
 - **Only a literal `NULL` element** → `rep(NA, n)` (logical). `NULL` has
-  no type to preserve, and `NULL[seq_len(n)]` is `NULL`, not an NA vector.
+  no type to preserve, and is excluded before any indexing.
 - Build the columns into a bare list given the `data.frame` class +
   `.set_row_names(n)`, then fall into the existing `.raven_encode_col`
   loop.
@@ -227,9 +238,9 @@ A named vector and a list of scalars render differently, by design:
 - `tests/bun/data-viewer-bootstrap-content.test.ts`: assert the bootstrap
   source contains the new vector and list branches, the bare-list /
   `.set_row_names` construction, the `name` + `value`/`values` header
-  selection, the `el[seq_len(n)]` padding, and `make.unique` column
-  naming (string-level checks, matching how this file already pins the
-  View() override).
+  selection, the NA-index padding, and `make.unique` column naming
+  (string-level checks, matching how this file already pins the View()
+  override).
 - `tests/bun/data-viewer-bootstrap-r-integration.test.ts` (runs the
   profile against a real R, gated on `HAS_R` / `HAS_ARROW`, capturing the
   `/view-data` POST): add cases that `View()` —

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -174,6 +174,57 @@ local({
         any(rn != as.character(seq_len(n)))
     }
 
+    # Build a 1- or 2-column data.frame from an atomic / factor /
+    # haven_labelled vector: a leading "name" column when names() is
+    # non-NULL, plus a "value" (length 1) / "values" column. Built as a
+    # bare list given the data.frame class — not data.frame() — so the
+    # value vector's class/attributes (factor levels, haven_labelled
+    # labels) survive into .raven_encode_col.
+    .raven_vector_to_df <- function(x) {
+        n <- length(x)
+        cols <- list()
+        nm <- names(x)
+        if (!is.null(nm)) cols[["name"]] <- as.character(nm)
+        cols[[if (n == 1L) "value" else "values"]] <- unname(x)
+        class(cols) <- "data.frame"
+        attr(cols, "row.names") <- .set_row_names(n)
+        cols
+    }
+
+    # Is a list element a plain scalar/vector (so a flat list can become a
+    # table)? NULL is allowed (→ an all-NA column). Nested lists,
+    # data.frames, multi-dimensional objects, and raw are rejected.
+    .raven_list_elem_ok <- function(el) {
+        is.null(el) ||
+            ((is.atomic(el) || is.factor(el) || inherits(el, "haven_labelled")) &&
+             is.null(dim(el)) && !is.raw(el))
+    }
+
+    # Build a data.frame from a flat (non-recursive) list: one column per
+    # element, NA-padded to the longest element. Positional indexing
+    # (el[seq_len(n)]) preserves each element's class — even length-0
+    # typed elements keep their levels/labels; a literal NULL element has
+    # no type and becomes a logical NA column. Column names come from
+    # names(); blank/NA names are filled "V<i>" then make.unique'd.
+    .raven_list_to_df <- function(x) {
+        k <- length(x)
+        n <- max(c(0L, lengths(x)))
+        nm <- names(x)
+        if (is.null(nm)) nm <- rep("", k)
+        blank <- is.na(nm) | !nzchar(nm)
+        nm[blank] <- paste0("V", seq_len(k))[blank]
+        nm <- make.unique(nm)
+        cols <- vector("list", k)
+        for (i in seq_len(k)) {
+            el <- x[[i]]
+            cols[[i]] <- if (is.null(el)) rep(NA, n) else unname(el[seq_len(n)])
+        }
+        names(cols) <- nm
+        class(cols) <- "data.frame"
+        attr(cols, "row.names") <- .set_row_names(n)
+        cols
+    }
+
     # Pre-encode one column for arrow:
     # - factor: keep as-is (arrow handles dictionary)
     # - haven_labelled: strip class, keep underlying numeric/character
@@ -185,7 +236,10 @@ local({
         if (is.factor(col)) return(col)
         if ("haven_labelled" %in% cls) {
             x <- unclass(col)
-            attr(x, "label") <- attr(col, "label")
+            # exact = TRUE: a bare attr(col, "label") partial-matches the
+            # "labels" attribute when there is no variable label, which
+            # would stamp a bogus length-2 "label" onto the encoded column.
+            attr(x, "label") <- attr(col, "label", exact = TRUE)
             attr(x, "labels") <- attr(col, "labels")
             return(x)
         }
@@ -223,7 +277,11 @@ local({
 
     .raven_field_metadata <- function(name, col) {
         md <- list()
-        lbl <- attr(col, "label")
+        # exact = TRUE: without it, attr(col, "label") partial-matches the
+        # "labels" (value-label) attribute on a haven_labelled column that
+        # has no variable label, returning a length-2 vector that then
+        # breaks the && below.
+        lbl <- attr(col, "label", exact = TRUE)
         if (!is.null(lbl) && nzchar(as.character(lbl))) {
             md[["raven.variable_label"]] <- as.character(lbl)
         }
@@ -300,11 +358,12 @@ local({
             s
         }
 
-        if (!is.data.frame(x) && !is.matrix(x)) {
-            stop("Can't \`View()\` an object of class \`",
-                 paste(class(x), collapse = "/"), "\`", call. = FALSE)
-        }
-
+        # Type dispatch: matrix and data.frame are tested first (a
+        # data.frame is also a list). Then an atomic / factor /
+        # haven_labelled vector — the !is.null(x) guard matters because
+        # is.atomic(NULL) is TRUE on R < 4.4, and !is.raw(x) excludes raw
+        # (no NA for ragged-list padding). Finally a flat list. Anything
+        # else errors with the Positron-style message.
         df <- if (is.matrix(x)) {
             d <- as.data.frame(x, stringsAsFactors = FALSE)
             if (.raven_meaningful_rownames(x)) {
@@ -312,8 +371,17 @@ local({
             }
             rownames(d) <- NULL
             d
-        } else {
+        } else if (is.data.frame(x)) {
             x
+        } else if (!is.null(x) && is.null(dim(x)) && !is.raw(x) &&
+                   (is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled"))) {
+            .raven_vector_to_df(x)
+        } else if (is.list(x) && length(x) > 0L &&
+                   all(vapply(x, .raven_list_elem_ok, logical(1L)))) {
+            .raven_list_to_df(x)
+        } else {
+            stop("Can't \`View()\` an object of class \`",
+                 paste(class(x), collapse = "/"), "\`", call. = FALSE)
         }
         # Pre-encode every column.
         for (nm in names(df)) df[[nm]] <- .raven_encode_col(df[[nm]])

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -174,21 +174,27 @@ local({
         any(rn != as.character(seq_len(n)))
     }
 
+    # Stamp a named list of equal-length columns as an n-row data.frame
+    # WITHOUT data.frame() — a bare class assignment preserves each
+    # column's class/attributes (factor levels, haven_labelled labels) so
+    # they survive into .raven_encode_col, which data.frame() would coerce
+    # away.
+    .raven_bare_df <- function(cols, n) {
+        class(cols) <- "data.frame"
+        attr(cols, "row.names") <- .set_row_names(n)
+        cols
+    }
+
     # Build a 1- or 2-column data.frame from an atomic / factor /
     # haven_labelled vector: a leading "name" column when names() is
-    # non-NULL, plus a "value" (length 1) / "values" column. Built as a
-    # bare list given the data.frame class — not data.frame() — so the
-    # value vector's class/attributes (factor levels, haven_labelled
-    # labels) survive into .raven_encode_col.
+    # non-NULL, plus a "value" (length 1) / "values" column.
     .raven_vector_to_df <- function(x) {
         n <- length(x)
         cols <- list()
         nm <- names(x)
         if (!is.null(nm)) cols[["name"]] <- as.character(nm)
         cols[[if (n == 1L) "value" else "values"]] <- unname(x)
-        class(cols) <- "data.frame"
-        attr(cols, "row.names") <- .set_row_names(n)
-        cols
+        .raven_bare_df(cols, n)
     }
 
     # Is a list element a plain scalar/vector (so a flat list can become a
@@ -200,12 +206,24 @@ local({
              is.null(dim(el)) && !is.raw(el))
     }
 
+    # Pad a single scalar/vector element to length n, preserving class.
+    # We index with NA for the out-of-range positions rather than
+    # over-indexing (el[seq_len(n)]): base vectors and factors NA-pad on
+    # over-index, but vctrs/haven_labelled's [ method ERRORS on
+    # out-of-bounds subscripts. Indexing existing positions plus NA works
+    # for all three and keeps factor levels / haven_labelled labels.
+    .raven_pad_to <- function(el, n) {
+        if (is.null(el)) return(rep(NA, n))
+        idx <- seq_len(n)
+        idx[idx > length(el)] <- NA_integer_
+        unname(el[idx])
+    }
+
     # Build a data.frame from a flat (non-recursive) list: one column per
-    # element, NA-padded to the longest element. Positional indexing
-    # (el[seq_len(n)]) preserves each element's class — even length-0
-    # typed elements keep their levels/labels; a literal NULL element has
-    # no type and becomes a logical NA column. Column names come from
-    # names(); blank/NA names are filled "V<i>" then make.unique'd.
+    # element, NA-padded to the longest element (see .raven_pad_to). A
+    # literal NULL element has no type and becomes a logical NA column.
+    # Column names come from names(); blank/NA names are filled "V<i>"
+    # then make.unique'd.
     .raven_list_to_df <- function(x) {
         k <- length(x)
         n <- max(c(0L, lengths(x)))
@@ -215,14 +233,9 @@ local({
         nm[blank] <- paste0("V", seq_len(k))[blank]
         nm <- make.unique(nm)
         cols <- vector("list", k)
-        for (i in seq_len(k)) {
-            el <- x[[i]]
-            cols[[i]] <- if (is.null(el)) rep(NA, n) else unname(el[seq_len(n)])
-        }
+        for (i in seq_len(k)) cols[[i]] <- .raven_pad_to(x[[i]], n)
         names(cols) <- nm
-        class(cols) <- "data.frame"
-        attr(cols, "row.names") <- .set_row_names(n)
-        cols
+        .raven_bare_df(cols, n)
     }
 
     # Pre-encode one column for arrow:
@@ -240,7 +253,7 @@ local({
             # "labels" attribute when there is no variable label, which
             # would stamp a bogus length-2 "label" onto the encoded column.
             attr(x, "label") <- attr(col, "label", exact = TRUE)
-            attr(x, "labels") <- attr(col, "labels")
+            attr(x, "labels") <- attr(col, "labels", exact = TRUE)
             return(x)
         }
         if (is.integer(col) || is.double(col) || is.logical(col) ||
@@ -265,8 +278,10 @@ local({
             }, character(1L))
             return(paste0("{", paste(entries, collapse = ","), "}"))
         }
-        labs <- attr(col, "labels")
-        if (is.null(labs)) labs <- attr(col, "value.labels")
+        # exact = TRUE so a "label" / "labelsomething" attribute can't
+        # partial-match where an exact "labels" is absent.
+        labs <- attr(col, "labels", exact = TRUE)
+        if (is.null(labs)) labs <- attr(col, "value.labels", exact = TRUE)
         if (is.null(labs) || is.null(names(labs))) return("")
         entries <- vapply(seq_along(labs), function(i) {
             key <- as.character(labs[[i]])

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -300,9 +300,11 @@ local({
         # exact = TRUE: without it, attr(col, "label") partial-matches the
         # "labels" (value-label) attribute on a haven_labelled column that
         # has no variable label, returning a length-2 vector that then
-        # breaks the && below.
+        # breaks the && below. The length(lbl) == 1L guard is belt-and-
+        # suspenders against a non-standard multi-element "label" attribute
+        # (same hazard guarded in the format.* loop below).
         lbl <- attr(col, "label", exact = TRUE)
-        if (!is.null(lbl) && nzchar(as.character(lbl))) {
+        if (!is.null(lbl) && length(lbl) == 1L && nzchar(as.character(lbl))) {
             md[["raven.variable_label"]] <- as.character(lbl)
         }
         vlj <- .raven_value_labels_json(col)

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -222,15 +222,20 @@ local({
     # Build a data.frame from a flat (non-recursive) list: one column per
     # element, NA-padded to the longest element (see .raven_pad_to). A
     # literal NULL element has no type and becomes a logical NA column.
-    # Column names come from names(); blank/NA names are filled "V<i>"
-    # then make.unique'd.
+    # Column names come from names(); blank/NA names are filled "V<i>".
+    # Explicit names are authoritative: the "V<i>" placeholders are made
+    # unique against them first, so a user's real column named e.g. "V1"
+    # keeps its name and the placeholder yields (not the reverse).
     .raven_list_to_df <- function(x) {
         k <- length(x)
         n <- max(c(0L, lengths(x)))
         nm <- names(x)
         if (is.null(nm)) nm <- rep("", k)
         blank <- is.na(nm) | !nzchar(nm)
-        nm[blank] <- paste0("V", seq_len(k))[blank]
+        if (any(blank)) {
+            fill <- make.unique(c(nm[!blank], paste0("V", seq_len(k))))
+            nm[blank] <- tail(fill, k)[blank]
+        }
         nm <- make.unique(nm)
         cols <- vector("list", k)
         for (i in seq_len(k)) cols[[i]] <- .raven_pad_to(x[[i]], n)
@@ -309,8 +314,12 @@ local({
         # Used downstream to detect integer-formatted Float columns
         # (e.g. SAS "F8.0" — stored as double, intended as integer).
         for (attr_nm in c("format.stata", "format.sas", "format.spss")) {
-            fmt <- attr(col, attr_nm)
-            if (!is.null(fmt) && nzchar(as.character(fmt))) {
+            # exact = TRUE + the length(fmt) == 1L guard: attr_nm is a
+            # variable, so partial matching is live; a partial match could
+            # return a length>1 vector and turn the nzchar() check into a
+            # length>1 condition (a hard error in the && on R >= 4.4).
+            fmt <- attr(col, attr_nm, exact = TRUE)
+            if (!is.null(fmt) && length(fmt) == 1L && nzchar(as.character(fmt))) {
                 md[["raven.format"]] <- as.character(fmt)
                 break
             }

--- a/tests/bun/data-viewer-bootstrap-content.test.ts
+++ b/tests/bun/data-viewer-bootstrap-content.test.ts
@@ -58,6 +58,42 @@ describe('bootstrap profile: data viewer block', () => {
         expect(src).toContain("Can't `View()` an object of class");
     });
 
+    test('accepts atomic vectors / scalars via a !is.null + !is.raw + dim guard', () => {
+        const dvIdx = src.indexOf('# Raven data viewer block');
+        const slice = src.slice(dvIdx);
+        // The vector branch must guard bare NULL (is.atomic(NULL) is TRUE on
+        // R < 4.4) and raw (no NA for ragged padding), and exclude
+        // multi-dimensional objects.
+        expect(slice).toContain('!is.null(x)');
+        expect(slice).toContain('!is.raw(x)');
+        expect(slice).toContain('is.null(dim(x))');
+        expect(slice).toMatch(/is\.atomic\(x\).*is\.factor\(x\).*haven_labelled/s);
+    });
+
+    test('names vector columns name + value(s); drops name column when unnamed', () => {
+        const dvIdx = src.indexOf('# Raven data viewer block');
+        const slice = src.slice(dvIdx);
+        // Singular value header when length 1, else plural.
+        expect(slice).toContain('"value"');
+        expect(slice).toContain('"values"');
+        // Leading names column headed "name".
+        expect(slice).toContain('"name"');
+        // The names column is conditional on names() being non-NULL.
+        expect(slice).toMatch(/is\.null\(nm\)|is\.null\(names\(/);
+    });
+
+    test('accepts flat lists, excludes nested/recursive and raw elements', () => {
+        const dvIdx = src.indexOf('# Raven data viewer block');
+        const slice = src.slice(dvIdx);
+        // Per-element acceptance check rejects list/data.frame/dim/raw.
+        expect(slice).toMatch(/is\.list\(/);
+        expect(slice).toContain('!is.raw(');
+        // NA-padding via positional indexing (preserves class); make.unique
+        // for column names.
+        expect(slice).toMatch(/seq_len\(/);
+        expect(slice).toContain('make.unique');
+    });
+
     test('truncates panelName to 256 chars with ellipsis', () => {
         const dvIdx = src.indexOf('# Raven data viewer block');
         const slice = src.slice(dvIdx);

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -406,6 +406,27 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
     );
 
     test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(df with a non-scalar "label" attr) does not crash on the && length check',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                // A malformed length-2 "label" attribute must not blow up the
+                // `&&` in the metadata writer (length>1 → error on R >= 4.4).
+                const r = spawnR(cap,
+                    'df <- data.frame(a = 1:2); attr(df$a, "label") <- c("x", "y"); View(df); Sys.sleep(0.2)');
+                const got = await cap.waitForRequest(
+                    req => req.headers.includes('POST /view-data'), 20_000);
+                const done = await r;
+                expect(got.body).toContain('"nrow":2');
+                expect(done.stderr).not.toContain('length = 2');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
         'View(nested list) errors and posts nothing',
         async () => {
             const cap = await start_capture_server();

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -361,6 +361,30 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
         30_000,
     );
 
+    test.skipIf(!HAS_HAVEN || !HAS_ARROW)(
+        'View(ragged list with a short haven_labelled element) NA-pads without crashing',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                // vctrs [ rejects out-of-bounds indices, so over-indexing a
+                // short labelled element to pad it would crash. The values
+                // column must NA-pad to nrow = 4 and keep the labels.
+                const r = await spawnR(cap, viewAndReadback(
+                    'View(list(g = haven::labelled(c(1, 2), c(Male = 1, Female = 2)), n = 1:4))',
+                    'cat("RAVEN_G3_NA=", is.na(.df$g[[3L]]), "\\n", sep = "")',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=g,n');
+                expect(r.stdout).toContain('RAVEN_NROW=4');
+                expect(r.stdout).toContain('RAVEN_G3_NA=TRUE');
+                expect(r.stdout).toMatch(/Male/);
+                expect(r.stderr).not.toContain('past the end');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
     test.skipIf(!HAS_R || !HAS_ARROW)(
         'View(nested list) errors and posts nothing',
         async () => {

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -341,6 +341,26 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
         30_000,
     );
 
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(list) — a synthesized V<i> name never steals a real column name',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                // Element 1 is unnamed → would be filled "V1"; element 2 is
+                // the user's explicit "V1". The user's V1 (value 20) must
+                // survive; the placeholder yields.
+                const r = await spawnR(cap, viewAndReadback(
+                    'View(list(10, V1 = 20))',
+                    'cat("RAVEN_V1=", .df[["V1"]][[1L]], "\\n", sep = "")',
+                ));
+                expect(r.stdout).toContain('RAVEN_V1=20');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
     test.skipIf(!HAS_HAVEN || !HAS_ARROW)(
         'View(haven_labelled) → single value column, labels in schema metadata',
         async () => {

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -45,6 +45,39 @@ async function has_R(): Promise<boolean> {
 
 const HAS_R = await has_R();
 const HAS_ARROW = HAS_R && (await r_with('arrow'));
+const HAS_HAVEN = HAS_R && (await r_with('haven'));
+
+/**
+ * R code that runs `viewCall`, then reads back the single Arrow file the
+ * View() override wrote into RAVEN_DATA_VIEWER_DIR and prints a structured
+ * summary to stdout (RAVEN_COLS / RAVEN_TYPES / RAVEN_NROW / per-factor
+ * RAVEN_LEVELS / RAVEN_FIELDS schema metadata), plus any `extra` asserts.
+ * No file is written when View() errors, so the readback is skipped.
+ */
+function viewAndReadback(viewCall: string, extra = ''): string {
+    return [
+        viewCall,
+        '.dir <- Sys.getenv("RAVEN_DATA_VIEWER_DIR")',
+        '.f <- list.files(.dir, pattern = "[.]arrow$", full.names = TRUE)',
+        'if (length(.f) >= 1L) {',
+        '  .t <- arrow::read_feather(.f[[1L]], as_data_frame = FALSE)',
+        '  .df <- as.data.frame(.t)',
+        '  cat("RAVEN_COLS=", paste(names(.df), collapse = ","), "\\n", sep = "")',
+        '  cat("RAVEN_TYPES=", paste(vapply(.df, function(c) class(c)[[1L]], character(1L)), collapse = ","), "\\n", sep = "")',
+        '  cat("RAVEN_NROW=", nrow(.df), "\\n", sep = "")',
+        '  for (.nm in names(.df)) if (is.factor(.df[[.nm]])) cat("RAVEN_LEVELS[", .nm, "]=", paste(levels(.df[[.nm]]), collapse = "|"), "\\n", sep = "")',
+        '  .md <- .t$schema$metadata[["raven.fields"]]',
+        '  if (!is.null(.md)) cat("RAVEN_FIELDS=", .md, "\\n", sep = "")',
+        '}',
+        extra,
+        'Sys.sleep(0.2)',
+    ].join('\n');
+}
+
+/** R code that swallows an expected View() error, printing it to stderr. */
+function viewExpectError(viewCall: string): string {
+    return `tryCatch(${viewCall}, error = function(e) cat(conditionMessage(e), file = stderr())); Sys.sleep(0.2)`;
+}
 
 type CapturedRequest = { headers: string; body: string };
 
@@ -170,15 +203,202 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
     );
 
     test.skipIf(!HAS_R || !HAS_ARROW)(
-        'View(1) errors with the Positron-style message and posts nothing',
+        'View(environment) errors with the Positron-style message and posts nothing',
         async () => {
             const cap = await start_capture_server();
             try {
-                const r = await spawnR(cap, 'tryCatch(View(1), error = function(e) cat(conditionMessage(e), file = stderr())); Sys.sleep(0.2)');
+                const r = await spawnR(cap, viewExpectError('View(new.env())'));
                 expect(r.stderr).toContain("Can't `View()` an object of class");
                 // No /view-data POST should have arrived.
                 const dataPosts = cap.requests.filter(req => req.headers.includes('POST /view-data'));
                 expect(dataPosts.length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(named vector) → name + values columns',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback(
+                    'x <- c(a = 1, b = 2, c = 3); View(x)',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=name,values');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+                const got = cap.requests.find(req => req.headers.includes('POST /view-data'));
+                expect(got?.body).toContain('"nrow":3');
+                expect(got?.body).toContain('"panelName":"x"');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(unnamed vector) → single values column',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback('View(c(10, 20, 30))'));
+                expect(r.stdout).toContain('RAVEN_COLS=values');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(scalar) → single value column, one row',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback('View(42L)'));
+                expect(r.stdout).toContain('RAVEN_COLS=value');
+                expect(r.stdout).toContain('RAVEN_NROW=1');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(factor) → single value column, factor round-trips with levels',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback('View(factor(c("b", "a", "b")))'));
+                expect(r.stdout).toContain('RAVEN_COLS=values');
+                expect(r.stdout).toContain('RAVEN_TYPES=factor');
+                expect(r.stdout).toContain('RAVEN_LEVELS[values]=a|b');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(ragged flat list) → element-as-column, NA-padded, types preserved',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback(
+                    'View(list(a = 1:3, b = c("x", "y"), c = TRUE))',
+                    'cat("RAVEN_B3_NA=", is.na(.df$b[[3L]]), "\\n", sep = "")',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=a,b,c');
+                expect(r.stdout).toContain('RAVEN_TYPES=integer,character,logical');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+                expect(r.stdout).toContain('RAVEN_B3_NA=TRUE');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(list with length-0 typed element) keeps the factor column (finding #2)',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback(
+                    'View(list(a = 1:3, f = factor(character(), levels = c("a", "b"))))',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=a,f');
+                // f must remain a factor with its levels, NOT degrade to logical.
+                expect(r.stdout).toContain('RAVEN_TYPES=integer,factor');
+                expect(r.stdout).toContain('RAVEN_LEVELS[f]=a|b');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(unnamed list) → synthesized V1.. column names',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback('View(list(1:2, 3:4))'));
+                expect(r.stdout).toContain('RAVEN_COLS=V1,V2');
+                expect(r.stdout).toContain('RAVEN_NROW=2');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_HAVEN || !HAS_ARROW)(
+        'View(haven_labelled) → single value column, labels in schema metadata',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback(
+                    'x <- haven::labelled(c(1, 2, 1), c(Male = 1, Female = 2)); View(x)',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=values');
+                expect(r.stdout).toContain('RAVEN_FIELDS=');
+                expect(r.stdout).toMatch(/Male/);
+                expect(r.stdout).toMatch(/Female/);
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(nested list) errors and posts nothing',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewExpectError('View(list(a = 1, b = list(1, 2)))'));
+                expect(r.stderr).toContain("Can't `View()` an object of class");
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(raw vector) errors and posts nothing (raw excluded)',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewExpectError('View(as.raw(1:3))'));
+                expect(r.stderr).toContain("Can't `View()` an object of class");
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(NULL) errors and posts nothing (is.atomic(NULL) guard)',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewExpectError('View(NULL)'));
+                expect(r.stderr).toContain("Can't `View()` an object of class");
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
             } finally {
                 await cap.close();
             }


### PR DESCRIPTION
## Summary

Extends Raven's `View()` override so it accepts more than `data.frame` and `matrix`. Everything new is converted to a `data.frame` in front of the existing Arrow pipeline — the webview, Arrow reader, sort/filter/format/copy, and wire format are untouched. The only change is the type-dispatch in `.raven_view`.

Newly `View()`-able:
- **Atomic vectors / scalars** (`numeric`, `integer`, `character`, `logical`, `complex`, `Date`, `POSIXct`) → a `values` column (`value` when length 1). When the vector has `names()`, they appear in a leading `name` column — the same role the matrix `rowname` column plays.
- **Standalone `factor` and `haven_labelled` vectors** (e.g. `View(iris$Species)`, `View(stata_df$education)`) — labels preserved, so the Labels toggle works.
- **Flat (non-recursive) lists** → one column per element, NA-padded to the longest element, each column keeping its own type. Unnamed elements get `V1`, `V2`, … headers.

Out of scope (still error): nested/recursive lists, `raw` vectors, environments, functions, and other unsupported classes.

A named vector and a list of scalars intentionally render differently — `c(a=1, b=2)` is a two-row `name`/`values` table; `list(a=1, b=2)` is a one-row, two-column table (matching `as.data.frame(list(a=1, b=2))`).

## Notable correctness work

While making `haven_labelled` vectors View-able, this surfaced and fixed three latent R hazards in the metadata path:
- `attr(col, "label")` **partial-matched** the `"labels"` value-label attribute when a column had value labels but no variable label, returning a length-2 vector that crashed the downstream `&&` (`'length = 2' in coercion to 'logical(1)'` on R ≥ 4.4). All metadata `attr()` reads now use `exact = TRUE`, and the variable-label / format-string branches are length-guarded.
- Ragged-list padding via over-indexing (`el[seq_len(n)]`) crashed on `vctrs`/`haven_labelled` elements, whose `[` rejects out-of-bounds subscripts. Padding now uses an NA-index, which NA-pads base vectors, factors, and vctrs alike while preserving class.
- Synthesized `V<i>` list-column names are now made unique against explicit names first, so a user's real `V1` column is never silently renamed.

## Design & review

Design spec: `docs/superpowers/specs/2026-06-27-data-viewer-vectors-scalars-design.md` (reviewed by Codex before implementation). The implementation went through repeated Codex + `/code-review` rounds until two consecutive came back clean.

## Testing

- 18 bootstrap-content assertions + 17 real-R integration cases (gated on R / `arrow` / `haven` availability): named/unnamed vectors, scalar, factor, `haven_labelled`, ragged list, length-0 typed element, ragged list with a short labelled element, unnamed list, the `V<i>`-vs-real-name collision, a non-scalar `label` attr, plus `raw` / nested-list / `NULL` / environment error cases.
- Full bun suite (1368 tests) green; VS Code mocha suite green.

## Docs

`docs/data-viewer.md` "What it shows" updated for the new behavior.

https://claude.ai/code/session_01NxZqX9xLYDntvAxNw4hSp9