### PR TITLE
fix(data-viewer): clearer View() errors for lists and arrays

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -52,6 +52,8 @@ side-by-side.
   those appear in a leading `name` column — the same role the `rowname`
   column plays for a matrix. A standalone `factor` / `haven_labelled`
   vector keeps its labels, so the [Labels](#labels) toggle works on it.
+  A **1-D array** (`array(1:3)`) is rendered the same way as a vector;
+  its `dimnames` become the `name` column.
 - **Flat lists** — a list whose elements are all scalars/vectors. Each
   element becomes a column, padded with empty (`NA`) cells to the length
   of the longest element, and each column keeps its own type. Unnamed
@@ -59,14 +61,23 @@ side-by-side.
   scalars therefore render differently — `c(a = 1, b = 2)` is a two-row
   `name`/`values` table, while `list(a = 1, b = 2)` is a one-row,
   two-column table — matching `as.data.frame(list(a = 1, b = 2))`.
-- Other classes — including nested/recursive lists (an element that is
-  itself a list or `data.frame`), `raw` vectors, environments, and
-  functions — raise an error in R:
+- Other objects raise an error in R that explains *why*:
 
   ```r
   > View(sum)
   Error: Can't `View()` an object of class `function`
   ```
+
+  - A **nested/recursive list** (an element that is itself a list or
+    `data.frame`, or otherwise not a plain vector) names the offending
+    element rather than blaming the `list` class, e.g.
+    `` Can't `View()` this list: element `b` has class `list`. Only flat lists (every element a vector) are supported. ``
+    An empty list reports `` Can't `View()` an empty list. ``
+  - An **array with more than two dimensions** (a 3-D+ array or a
+    3-way+ `table`) reports its dimension count:
+    `` Can't `View()` an array with 3 dimensions; the data viewer shows 2-dimensional tables only. ``
+  - `raw` vectors, environments, functions, and other unsupported
+    classes keep the class-based message shown above.
 
 ## Triggering
 

--- a/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
@@ -1,4 +1,4 @@
-# Data viewer: clearer error message for un-`View()`-able lists
+# Data viewer: clearer error messages for un-`View()`-able lists and arrays
 
 **Date:** 2026-06-27
 **Status:** Approved (design)
@@ -23,27 +23,92 @@ it is empty. The class-based message is correct for genuinely
 unsupported classes (functions, environments, `NULL`, `raw`, S4) but
 wrong for lists.
 
+**The same defect affects arrays.** A 2-D array is a matrix
+(`is.matrix()` is true for any dim-length-2 object) and already renders.
+But an array whose `dim` length is **not** 2 falls through:
+
+```r
+> View(array(1:8, c(2, 2, 2)))
+Error: Can't `View()` an object of class `array`
+```
+
+The real reason is **dimensionality** — the data viewer shows
+2-dimensional tables, and a 3-D+ array has more dimensions than a table
+can hold. The class-based message hides that. A **1-D** array
+(`array(1:3)`) is rejected for the opposite reason: it is effectively a
+vector, but the vector branch's `is.null(dim(x))` guard excludes it for
+having a `dim` at all.
+
 ## Scope
 
-In scope: the list branch of the type-dispatch in `.raven_view`
-(`editors/vscode/src/plot/r-bootstrap-profile.ts`, currently the
-combined `else if (is.list(x) && length(x) > 0L && all(...))` condition
-at lines 405–411). Message wording only — what is and isn't
-`View()`-able does not change.
+In scope: the type-dispatch in `.raven_view`
+(`editors/vscode/src/plot/r-bootstrap-profile.ts`, lines ~393–411):
 
-Out of scope: the conversion logic (`.raven_list_elem_ok`,
-`.raven_list_to_df`, `.raven_vector_to_df`), the vector branch, and
-everything downstream (encode / Arrow write / POST / webview). The set
-of accepted/rejected objects is **identical** before and after — only
-the rejection *message* for lists changes.
+1. The **list branch** — split the combined
+   `else if (is.list(x) && length(x) > 0L && all(...))` into a dedicated
+   `is.list(x)` branch with tailored error messages. Message wording
+   only; the set of `View()`-able lists is unchanged.
+2. The **vector branch** — relax its `dim` guard so a **1-D array** is
+   accepted and rendered as a vector (a behavior change: `array(1:3)`
+   becomes `View()`-able).
+3. A new **`>2`-dimensional branch** — arrays/tables with a `dim` of
+   length ≥ 3 get a dimensionality-aware message instead of the
+   class-based one.
+
+Out of scope: the conversion-to-data.frame helpers themselves
+(`.raven_list_elem_ok`, `.raven_list_to_df`, `.raven_vector_to_df`) and
+everything downstream of `df` (encode / Arrow write / POST / webview).
+The webview renders any data.frame; nothing in its contract changes.
 
 ## Design
 
-All changes live in `.raven_view`. Replace the single combined list
-condition + shared `else` with a dedicated list branch that either
-produces `df` or stops with a tailored message. A `data.frame` is also a
-list, but it is caught by the earlier `is.data.frame(x)` branch, so this
-branch only ever sees **non-data.frame** lists.
+All changes live in `.raven_view`'s type-dispatch chain. The order is:
+`matrix` → `data.frame` → **vector (incl. 1-D array)** → **list** →
+**`>2`-D array** → generic `else`. Branch order is load-bearing:
+`matrix`/`data.frame` first (a data.frame is also a list), then the
+vector branch (so a 1-D array is treated as a vector before the array
+branch can see it), then the list branch, then the dimensionality branch
+catches the remaining dim-≥3 arrays/tables, and finally the generic
+`else`.
+
+### Vector branch — accept 1-D arrays
+
+Today the vector branch requires `is.null(dim(x))`, which rejects any
+object carrying a `dim` — including a 1-D array, which is effectively a
+vector. Relax the guard to `length(dim(x)) <= 1L` (true for a plain
+vector, whose `dim` is `NULL` → `length(NULL)` is `0`, **and** for a 1-D
+array, whose `dim` has length 1; false for a matrix's length-2 `dim` and
+a 3-D+ array's length-≥3 `dim`). The `!is.null(x)` guard stays — it must
+still come first because `is.atomic(NULL)` is `TRUE` on R < 4.4 and
+`length(dim(NULL))` is `0 <= 1`.
+
+A 1-D array's `dim`/`dimnames` must be stripped before it flows into
+`.raven_vector_to_df` (which calls `unname(x)` and reads `names(x)` —
+`unname` drops names but keeps `dim`, and a column with a `dim` attribute
+would break the data.frame construction). Setting `dim(x) <- NULL`
+removes `dim` **and** `dimnames` while preserving the underlying type and
+any non-dim attributes (e.g. a factor's `levels`/`class`). Carry the 1-D
+array's `dimnames[[1]]` over to `names(x)` first, so a named 1-D array
+keeps its names as the leading `name` column:
+
+```r
+} else if (!is.null(x) && length(dim(x)) <= 1L && !is.raw(x) &&
+           (is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled"))) {
+    if (length(dim(x)) == 1L) {
+        dn <- dimnames(x)
+        dim(x) <- NULL                       # also drops dimnames
+        if (!is.null(dn)) names(x) <- dn[[1L]]
+    }
+    .raven_vector_to_df(x)
+```
+
+### List branch
+
+Replace the single combined list condition + shared `else` with a
+dedicated list branch that either produces `df` or stops with a tailored
+message. A `data.frame` is also a list, but it is caught by the earlier
+`is.data.frame(x)` branch, so this branch only ever sees
+**non-data.frame** lists.
 
 ```r
 } else if (is.list(x)) {
@@ -65,6 +130,10 @@ branch only ever sees **non-data.frame** lists.
              call. = FALSE)
     }
     .raven_list_to_df(x)
+} else if (length(dim(x)) > 2L) {
+    stop("Can't `View()` an array with ", length(dim(x)),
+         " dimensions; the data viewer shows 2-dimensional tables only.",
+         call. = FALSE)
 } else {
     stop("Can't `View()` an object of class `",
          paste(class(x), collapse = "/"), "`", call. = FALSE)
@@ -80,9 +149,13 @@ branch only ever sees **non-data.frame** lists.
 - **Non-flat list**, unnamed / blank-named offender
   (`View(list(1, list(2)))`):
   `` Can't `View()` this list: element 2 has class `list`. Only flat lists (every element a vector) are supported. ``
-- **Everything else** (functions, environments, `NULL`, `raw`, S4,
-  multi-dim arrays): unchanged —
-  `` Can't `View()` an object of class `<class>` ``.
+- **`>2`-D array / table** (`View(array(1:8, c(2, 2, 2)))`):
+  `` Can't `View()` an array with 3 dimensions; the data viewer shows 2-dimensional tables only. ``
+  The dim count is interpolated, and is always ≥ 3 here (1-D arrays are
+  handled by the vector branch and 2-D arrays by the matrix branch), so
+  the noun is always plural — no singular/plural handling needed.
+- **Everything else** (functions, environments, `NULL`, `raw`, S4):
+  unchanged — `` Can't `View()` an object of class `<class>` ``.
 
 Wording notes:
 
@@ -124,28 +197,48 @@ list keeps its current behavior, including `View(NULL)` and
 - **Keep unchanged** `View(as.raw(1:3))` and `View(NULL)`: these hit the
   `else` branch, so they still contain
   `` Can't `View()` an object of class `` — these tests guard that the
-  list rewording did **not** leak into the generic path.
+  list/array rewording did **not** leak into the generic path.
+- **Add** 1-D array `View(array(1:3))`: posts `/view-data`; the resulting
+  Arrow file has a single `values` column with 3 rows (the array is
+  rendered as a vector, no error).
+- **Add** named 1-D array
+  `View(array(1:2, dimnames = list(c("a", "b"))))`: posts; the Arrow file
+  carries a leading `name` column (`a`, `b`) plus the value column —
+  guards the `dimnames[[1]]` → `names` carry-over.
+- **Add** 3-D array `View(array(1:8, c(2, 2, 2)))`: stderr contains
+  `` Can't `View()` an array with 3 dimensions ``; posts nothing.
 
 `tests/bun/data-viewer-bootstrap-content.test.ts` (string-level pin of
 the bootstrap source):
 
+- **Update** the "atomic vectors / scalars via a !is.null + !is.raw +
+  dim guard" test: the pinned `is.null(dim(x))` string becomes
+  `length(dim(x)) <= 1L` (the relaxed guard). Keep the `!is.null(x)`,
+  `!is.raw(x)`, and `is.atomic … is.factor … haven_labelled` assertions.
 - **Add** assertions that the source contains the new list strings:
   `` Can't `View()` an empty list. ``,
   `` Can't `View()` this list: ``, and
   `Only flat lists (every element a vector) are supported.`.
+- **Add** an assertion for the array message
+  (`the data viewer shows 2-dimensional tables only.`) and the
+  `length(dim(x)) > 2L` branch guard.
 - **Keep** the existing "Positron-style message for unsupported types"
   test — the `else` branch still contains
   `` Can't `View()` an object of class ``.
 
 ## Docs
 
-`docs/data-viewer.md` "Other classes" bullet: the example block uses
-`View(sum)` (a function), which is unaffected. Add a one-line note that
-nested/recursive lists report *which* element is unsupported rather than
-blaming the `list` class, so the doc matches the behavior.
+`docs/data-viewer.md`:
+
+- "What it shows" — note that a 1-D array renders like a vector.
+- "Other classes" bullet: the example block uses `View(sum)` (a
+  function), which is unaffected. Add a one-line note that
+  nested/recursive lists report *which* element is unsupported (rather
+  than blaming the `list` class) and that arrays with more than two
+  dimensions report their dimension count, so the doc matches behavior.
 
 ## Non-goals
 
-No change to which objects are `View()`-able. No enumerating every
-offending element. No change to the conversion helpers, the vector
-branch, or anything downstream of `df`.
+No nested/recursive list support. No flattening / slicing of `>2`-D
+arrays into 2-D pages. No enumerating every offending list element. No
+change to the conversion helpers or anything downstream of `df`.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
@@ -1,0 +1,151 @@
+# Data viewer: clearer error message for un-`View()`-able lists
+
+**Date:** 2026-06-27
+**Status:** Approved (design)
+
+## Problem
+
+Since the vectors/scalars/flat-lists feature
+(`58b38a61`, spec `2026-06-27-data-viewer-vectors-scalars-design.md`),
+a **flat** list — every element a scalar/vector — is `View()`-able. But a
+list that is empty or has a non-flat element still falls through to the
+generic type-dispatch error in `.raven_view`:
+
+```r
+> View(list(a = 1, b = list(2)))
+Error: Can't `View()` an object of class `list`
+```
+
+This message blames the **class** (`list`), which reads as "lists aren't
+supported" — yet most lists view fine. The real reason is the list's
+**contents** (a nested list / data.frame / matrix element, etc.) or that
+it is empty. The class-based message is correct for genuinely
+unsupported classes (functions, environments, `NULL`, `raw`, S4) but
+wrong for lists.
+
+## Scope
+
+In scope: the list branch of the type-dispatch in `.raven_view`
+(`editors/vscode/src/plot/r-bootstrap-profile.ts`, currently the
+combined `else if (is.list(x) && length(x) > 0L && all(...))` condition
+at lines 405–411). Message wording only — what is and isn't
+`View()`-able does not change.
+
+Out of scope: the conversion logic (`.raven_list_elem_ok`,
+`.raven_list_to_df`, `.raven_vector_to_df`), the vector branch, and
+everything downstream (encode / Arrow write / POST / webview). The set
+of accepted/rejected objects is **identical** before and after — only
+the rejection *message* for lists changes.
+
+## Design
+
+All changes live in `.raven_view`. Replace the single combined list
+condition + shared `else` with a dedicated list branch that either
+produces `df` or stops with a tailored message. A `data.frame` is also a
+list, but it is caught by the earlier `is.data.frame(x)` branch, so this
+branch only ever sees **non-data.frame** lists.
+
+```r
+} else if (is.list(x)) {
+    if (length(x) == 0L) {
+        stop("Can't `View()` an empty list.", call. = FALSE)
+    }
+    ok <- vapply(x, .raven_list_elem_ok, logical(1L))
+    if (!all(ok)) {
+        i <- which(!ok)[[1L]]                 # first offender
+        nm <- names(x)
+        label <- if (!is.null(nm) && !is.na(nm[[i]]) && nzchar(nm[[i]])) {
+            paste0("element `", nm[[i]], "`")
+        } else {
+            paste0("element ", i)
+        }
+        stop("Can't `View()` this list: ", label, " has class `",
+             paste(class(x[[i]]), collapse = "/"),
+             "`. Only flat lists (every element a vector) are supported.",
+             call. = FALSE)
+    }
+    .raven_list_to_df(x)
+} else {
+    stop("Can't `View()` an object of class `",
+         paste(class(x), collapse = "/"), "`", call. = FALSE)
+}
+```
+
+### Message wording
+
+- **Empty list** (`list()`):
+  `` Can't `View()` an empty list. ``
+- **Non-flat list**, named offender (`View(list(a = 1, b = list(2)))`):
+  `` Can't `View()` this list: element `b` has class `list`. Only flat lists (every element a vector) are supported. ``
+- **Non-flat list**, unnamed / blank-named offender
+  (`View(list(1, list(2)))`):
+  `` Can't `View()` this list: element 2 has class `list`. Only flat lists (every element a vector) are supported. ``
+- **Everything else** (functions, environments, `NULL`, `raw`, S4,
+  multi-dim arrays): unchanged —
+  `` Can't `View()` an object of class `<class>` ``.
+
+Wording notes:
+
+- **"has class `X`"** (not the brainstorm preview's "is a X"): keeps the
+  sentence grammatical for every offender type — "is a raw" / "is a
+  environment" / "is a matrix/array" are awkward or wrong, and the
+  backtick-quoted class matches the style of the rest of the message and
+  the trailing `else`.
+- **First offender only.** `which(!ok)[[1L]]` — reporting one concrete
+  element is enough to point the user at the problem; enumerating all is
+  noise.
+- **`names(x)` guard.** A fully unnamed list has `names(x) == NULL`;
+  `NULL[[i]]` errors, so the `!is.null(nm)` check must come first (it is
+  the left operand of `&&`, so `nm[[i]]` is never evaluated when `nm` is
+  `NULL`). A partially-named list has `""`/`NA` slots → fall to the
+  positional `element <i>` form.
+- **Offender class** uses `paste(class(x[[i]]), collapse = "/")` (mirrors
+  the trailing `else`), so e.g. a matrix element reads
+  `` has class `matrix/array` ``.
+
+The `else` (true non-list) branch is byte-for-byte the existing message,
+so any object that is not a matrix / data.frame / accepted vector /
+list keeps its current behavior, including `View(NULL)` and
+`View(as.raw(1:3))`.
+
+## Testing
+
+`tests/bun/data-viewer-bootstrap-r-integration.test.ts` (real R, gated on
+`HAS_R`/`HAS_ARROW`, captures the `/view-data` POST):
+
+- **Update** `View(nested list)` (`View(list(a = 1, b = list(1, 2)))`):
+  assert `r.stderr` contains the new
+  `` Can't `View()` this list: `` text **and** names the offender —
+  `` element `b` has class `list` ``; still posts nothing.
+- **Add** empty list `View(list())`: stderr contains
+  `` Can't `View()` an empty list. ``; posts nothing.
+- **Add** unnamed offender `View(list(1, list(2)))`: stderr contains
+  `element 2 has class `list``; posts nothing.
+- **Keep unchanged** `View(as.raw(1:3))` and `View(NULL)`: these hit the
+  `else` branch, so they still contain
+  `` Can't `View()` an object of class `` — these tests guard that the
+  list rewording did **not** leak into the generic path.
+
+`tests/bun/data-viewer-bootstrap-content.test.ts` (string-level pin of
+the bootstrap source):
+
+- **Add** assertions that the source contains the new list strings:
+  `` Can't `View()` an empty list. ``,
+  `` Can't `View()` this list: ``, and
+  `Only flat lists (every element a vector) are supported.`.
+- **Keep** the existing "Positron-style message for unsupported types"
+  test — the `else` branch still contains
+  `` Can't `View()` an object of class ``.
+
+## Docs
+
+`docs/data-viewer.md` "Other classes" bullet: the example block uses
+`View(sum)` (a function), which is unaffected. Add a one-line note that
+nested/recursive lists report *which* element is unsupported rather than
+blaming the `list` class, so the doc matches the behavior.
+
+## Non-goals
+
+No change to which objects are `View()`-able. No enumerating every
+offending element. No change to the conversion helpers, the vector
+branch, or anything downstream of `df`.

--- a/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md
@@ -24,8 +24,11 @@ unsupported classes (functions, environments, `NULL`, `raw`, S4) but
 wrong for lists.
 
 **The same defect affects arrays.** A 2-D array is a matrix
-(`is.matrix()` is true for any dim-length-2 object) and already renders.
-But an array whose `dim` length is **not** 2 falls through:
+(`is.matrix()` is true for any object with a length-2 `dim` **attribute**
+— a data.frame is not such an object, since its `dim` comes from a
+`dim.data.frame` method, not an attribute, and it is caught by the
+earlier `is.data.frame(x)` branch anyway) and already renders. But an
+array whose `dim` length is **not** 2 falls through:
 
 ```r
 > View(array(1:8, c(2, 2, 2)))
@@ -130,7 +133,7 @@ message. A `data.frame` is also a list, but it is caught by the earlier
              call. = FALSE)
     }
     .raven_list_to_df(x)
-} else if (length(dim(x)) > 2L) {
+} else if (is.array(x) && length(dim(x)) > 2L) {
     stop("Can't `View()` an array with ", length(dim(x)),
          " dimensions; the data viewer shows 2-dimensional tables only.",
          call. = FALSE)
@@ -153,7 +156,12 @@ message. A `data.frame` is also a list, but it is caught by the earlier
   `` Can't `View()` an array with 3 dimensions; the data viewer shows 2-dimensional tables only. ``
   The dim count is interpolated, and is always ≥ 3 here (1-D arrays are
   handled by the vector branch and 2-D arrays by the matrix branch), so
-  the noun is always plural — no singular/plural handling needed.
+  the noun is always plural — no singular/plural handling needed. The
+  branch is gated on **`is.array(x)`** (not bare `length(dim(x)) > 2L`):
+  `is.array` tests the `dim` **attribute**, so it matches base arrays and
+  `table`s (a 3-way table is an array) but **not** an S4 object whose
+  `dim()` *method* returns a length-≥3 vector with no `dim` attribute —
+  that S4 object must fall through to the generic `else`, as promised.
 - **Everything else** (functions, environments, `NULL`, `raw`, S4):
   unchanged — `` Can't `View()` an object of class `<class>` ``.
 
@@ -178,8 +186,17 @@ Wording notes:
 
 The `else` (true non-list) branch is byte-for-byte the existing message,
 so any object that is not a matrix / data.frame / accepted vector /
-list keeps its current behavior, including `View(NULL)` and
+list / array keeps its current behavior, including `View(NULL)` and
 `View(as.raw(1:3))`.
+
+**List-array edge case (intentional):** a list carrying a `dim`
+attribute (e.g. `array(list(1, 2), dim = c(1, 1, 2))`) is still a list,
+so `is.list(x)` catches it in the list branch **before** the array
+branch. It is therefore handled as a (non-flat) list — its elements run
+through `.raven_list_elem_ok` and it gets the list message, never the
+dimension message. This is acceptable: list-arrays are exotic, and the
+list branch's message is still more informative than the old generic
+one. The array branch deliberately handles only **atomic** arrays.
 
 ## Testing
 
@@ -194,6 +211,11 @@ list keeps its current behavior, including `View(NULL)` and
   `` Can't `View()` an empty list. ``; posts nothing.
 - **Add** unnamed offender `View(list(1, list(2)))`: stderr contains
   `element 2 has class `list``; posts nothing.
+- **Add** blank/`NA`-named offender
+  (`View(setNames(list(1, list(2)), c("a", "")))` and an `NA`-name
+  variant): stderr reports the positional `element 2` form — **not**
+  `` element `` `` / `element `NA` `` — guarding the
+  `nzchar`/`!is.na` fall-through to the positional label.
 - **Keep unchanged** `View(as.raw(1:3))` and `View(NULL)`: these hit the
   `else` branch, so they still contain
   `` Can't `View()` an object of class `` — these tests guard that the
@@ -207,6 +229,17 @@ list keeps its current behavior, including `View(NULL)` and
   guards the `dimnames[[1]]` → `names` carry-over.
 - **Add** 3-D array `View(array(1:8, c(2, 2, 2)))`: stderr contains
   `` Can't `View()` an array with 3 dimensions ``; posts nothing.
+- **Add** 3-way table
+  (`View(table(sample(letters[1:2], 8, TRUE), sample(1:2, 8, TRUE), sample(1:2, 8, TRUE)))`
+  or a deterministic equivalent): a 3-way table has `class == "table"`
+  and `length(dim) == 3`; assert it hits the same
+  `` an array with 3 dimensions `` message (guards that the `is.array(x)`
+  gate admits tables); posts nothing.
+- **Non-regression (kept coverage, already exercised but call out
+  explicitly):** the existing accepted set must still post `/view-data`
+  — a `data.frame`, a `matrix`, a flat list, and an atomic / `factor` /
+  `haven_labelled` vector. The 1-D-array additions above must not change
+  any of these.
 
 `tests/bun/data-viewer-bootstrap-content.test.ts` (string-level pin of
 the bootstrap source):

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -386,10 +386,16 @@ local({
 
         # Type dispatch: matrix and data.frame are tested first (a
         # data.frame is also a list). Then an atomic / factor /
-        # haven_labelled vector — the !is.null(x) guard matters because
-        # is.atomic(NULL) is TRUE on R < 4.4, and !is.raw(x) excludes raw
-        # (no NA for ragged-list padding). Finally a flat list. Anything
-        # else errors with the Positron-style message.
+        # haven_labelled vector OR a 1-D array — the !is.null(x) guard
+        # matters because is.atomic(NULL) is TRUE on R < 4.4; the
+        # length(dim(x)) <= 1L guard admits plain vectors (dim NULL ->
+        # length 0) and 1-D arrays (dim length 1) while excluding the
+        # length-2 dim of a matrix and the length->=3 dim of a higher
+        # array; and !is.raw(x) excludes raw (no NA for ragged-list
+        # padding). Then a list (flat -> rendered; empty or non-flat ->
+        # a content-specific error naming the offending element). Then a
+        # >2-D array (a dimensionality error). Anything else errors with
+        # the Positron-style class message.
         df <- if (is.matrix(x)) {
             d <- as.data.frame(x, stringsAsFactors = FALSE)
             if (.raven_meaningful_rownames(x)) {
@@ -399,12 +405,50 @@ local({
             d
         } else if (is.data.frame(x)) {
             x
-        } else if (!is.null(x) && is.null(dim(x)) && !is.raw(x) &&
+        } else if (!is.null(x) && length(dim(x)) <= 1L && !is.raw(x) &&
                    (is.atomic(x) || is.factor(x) || inherits(x, "haven_labelled"))) {
+            if (length(dim(x)) == 1L) {
+                # 1-D array: render it as a vector. Carry dimnames[[1]]
+                # over to names() first, then drop dim (which also drops
+                # dimnames) -- this preserves the underlying type and any
+                # non-dim attributes (factor levels, haven_labelled
+                # labels), unlike as.vector(). unname()/names() in
+                # .raven_vector_to_df otherwise trips over a leftover dim.
+                dn <- dimnames(x)
+                dim(x) <- NULL
+                if (!is.null(dn)) names(x) <- dn[[1L]]
+            }
             .raven_vector_to_df(x)
-        } else if (is.list(x) && length(x) > 0L &&
-                   all(vapply(x, .raven_list_elem_ok, logical(1L)))) {
+        } else if (is.list(x)) {
+            # data.frames are caught above, so this is a non-data.frame
+            # list. A flat list renders; otherwise stop with a reason.
+            if (length(x) == 0L) {
+                stop("Can't \`View()\` an empty list.", call. = FALSE)
+            }
+            ok <- vapply(x, .raven_list_elem_ok, logical(1L))
+            if (!all(ok)) {
+                i <- which(!ok)[[1L]]
+                nm <- names(x)
+                # !is.null(nm) must come first: nm[[i]] errors on a
+                # fully-unnamed list (names() is NULL). A blank or NA
+                # name falls through to the positional "element <i>".
+                label <- if (!is.null(nm) && !is.na(nm[[i]]) && nzchar(nm[[i]])) {
+                    paste0("element \`", nm[[i]], "\`")
+                } else {
+                    paste0("element ", i)
+                }
+                stop("Can't \`View()\` this list: ", label, " has class \`",
+                     paste(class(x[[i]]), collapse = "/"),
+                     "\`. Only flat lists (every element a vector) are supported.",
+                     call. = FALSE)
+            }
             .raven_list_to_df(x)
+        } else if (is.array(x) && length(dim(x)) > 2L) {
+            # is.array tests the dim attribute (admits base arrays and
+            # tables, excludes S4 objects whose dim() is only a method).
+            stop("Can't \`View()\` an array with ", length(dim(x)),
+                 " dimensions; the data viewer shows 2-dimensional tables only.",
+                 call. = FALSE)
         } else {
             stop("Can't \`View()\` an object of class \`",
                  paste(class(x), collapse = "/"), "\`", call. = FALSE)

--- a/editors/vscode/src/plot/r-bootstrap-profile.ts
+++ b/editors/vscode/src/plot/r-bootstrap-profile.ts
@@ -430,9 +430,12 @@ local({
                 i <- which(!ok)[[1L]]
                 nm <- names(x)
                 # !is.null(nm) must come first: nm[[i]] errors on a
-                # fully-unnamed list (names() is NULL). A blank or NA
-                # name falls through to the positional "element <i>".
-                label <- if (!is.null(nm) && !is.na(nm[[i]]) && nzchar(nm[[i]])) {
+                # fully-unnamed list (names() is NULL). A blank, NA, or
+                # backtick-containing name (which would break the
+                # backtick quoting below) falls through to the
+                # unambiguous positional "element <i>".
+                label <- if (!is.null(nm) && !is.na(nm[[i]]) && nzchar(nm[[i]]) &&
+                             !grepl("\`", nm[[i]], fixed = TRUE)) {
                     paste0("element \`", nm[[i]], "\`")
                 } else {
                     paste0("element ", i)

--- a/tests/bun/data-viewer-bootstrap-content.test.ts
+++ b/tests/bun/data-viewer-bootstrap-content.test.ts
@@ -58,16 +58,32 @@ describe('bootstrap profile: data viewer block', () => {
         expect(src).toContain("Can't `View()` an object of class");
     });
 
-    test('accepts atomic vectors / scalars via a !is.null + !is.raw + dim guard', () => {
+    test('accepts atomic vectors / scalars / 1-D arrays via a !is.null + !is.raw + dim guard', () => {
         const dvIdx = src.indexOf('# Raven data viewer block');
         const slice = src.slice(dvIdx);
         // The vector branch must guard bare NULL (is.atomic(NULL) is TRUE on
-        // R < 4.4) and raw (no NA for ragged padding), and exclude
-        // multi-dimensional objects.
+        // R < 4.4) and raw (no NA for ragged padding). The dim guard admits
+        // plain vectors (dim NULL) and 1-D arrays (dim length 1) but excludes
+        // matrices and higher arrays.
         expect(slice).toContain('!is.null(x)');
         expect(slice).toContain('!is.raw(x)');
-        expect(slice).toContain('is.null(dim(x))');
+        expect(slice).toContain('length(dim(x)) <= 1L');
         expect(slice).toMatch(/is\.atomic\(x\).*is\.factor\(x\).*haven_labelled/s);
+        // 1-D array normalization: carry dimnames to names, drop dim.
+        expect(slice).toContain('dim(x) <- NULL');
+    });
+
+    test('lists report a content-specific reason; >2-D arrays report dimensions', () => {
+        const dvIdx = src.indexOf('# Raven data viewer block');
+        const slice = src.slice(dvIdx);
+        // Empty and non-flat lists name the reason rather than the class.
+        expect(slice).toContain("Can't `View()` an empty list.");
+        expect(slice).toContain("Can't `View()` this list:");
+        expect(slice).toContain('Only flat lists (every element a vector) are supported.');
+        // Higher-dimensional arrays report their dimensionality, gated on
+        // is.array so S4 dim() methods fall through to the generic message.
+        expect(slice).toContain('the data viewer shows 2-dimensional tables only.');
+        expect(slice).toMatch(/is\.array\(x\)\s*&&\s*length\(dim\(x\)\)\s*>\s*2L/);
     });
 
     test('names vector columns name + value(s); drops name column when unnamed', () => {

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -459,10 +459,14 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
     );
 
     test.skipIf(!HAS_R || !HAS_ARROW)(
-        'View(list with blank/NA-named offender) reports the positional element',
+        'View(list offender: unnamed / blank / NA) reports the positional element',
         async () => {
             const cap = await start_capture_server();
             try {
+                // Fully-unnamed list: names(x) is NULL — exercises the
+                // !is.null(nm) short-circuit (nm[[i]] would error otherwise).
+                const unnamed = await spawnR(cap, viewExpectError('View(list(1, list(2)))'));
+                expect(unnamed.stderr).toContain('element 2 has class `list`');
                 // Blank name and NA name must both fall through to "element <i>"
                 // rather than "element ``" / "element `NA`".
                 const blank = await spawnR(cap, viewExpectError(

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -427,12 +427,120 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
     );
 
     test.skipIf(!HAS_R || !HAS_ARROW)(
-        'View(nested list) errors and posts nothing',
+        'View(nested list) errors naming the offending element and posts nothing',
         async () => {
             const cap = await start_capture_server();
             try {
                 const r = await spawnR(cap, viewExpectError('View(list(a = 1, b = list(1, 2)))'));
-                expect(r.stderr).toContain("Can't `View()` an object of class");
+                expect(r.stderr).toContain("Can't `View()` this list:");
+                expect(r.stderr).toContain('element `b` has class `list`');
+                expect(r.stderr).toContain('Only flat lists (every element a vector) are supported.');
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(empty list) errors with an empty-list message and posts nothing',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewExpectError('View(list())'));
+                expect(r.stderr).toContain("Can't `View()` an empty list.");
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(list with blank/NA-named offender) reports the positional element',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                // Blank name and NA name must both fall through to "element <i>"
+                // rather than "element ``" / "element `NA`".
+                const blank = await spawnR(cap, viewExpectError(
+                    'View(setNames(list(1, list(2)), c("a", "")))',
+                ));
+                expect(blank.stderr).toContain('element 2 has class `list`');
+                expect(blank.stderr).not.toContain('element ``');
+                const na = await spawnR(cap, viewExpectError(
+                    'View(setNames(list(1, list(2)), c("a", NA)))',
+                ));
+                expect(na.stderr).toContain('element 2 has class `list`');
+                expect(na.stderr).not.toContain('element `NA`');
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(1-D array) renders as a vector (single values column)',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback('View(array(1:3))'));
+                expect(r.stdout).toContain('RAVEN_COLS=values');
+                expect(r.stdout).toContain('RAVEN_NROW=3');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(named 1-D array) carries dimnames into a leading name column',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewAndReadback(
+                    'View(array(1:2, dimnames = list(c("a", "b"))))',
+                ));
+                expect(r.stdout).toContain('RAVEN_COLS=name,values');
+                expect(r.stdout).toContain('RAVEN_NROW=2');
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(3-D array) errors with the dimensionality message and posts nothing',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                const r = await spawnR(cap, viewExpectError('View(array(1:8, c(2, 2, 2)))'));
+                expect(r.stderr).toContain("Can't `View()` an array with 3 dimensions");
+                expect(r.stderr).toContain('the data viewer shows 2-dimensional tables only.');
+                expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
+            } finally {
+                await cap.close();
+            }
+        },
+        30_000,
+    );
+
+    test.skipIf(!HAS_R || !HAS_ARROW)(
+        'View(3-way table) hits the dimensionality message (is.array admits tables)',
+        async () => {
+            const cap = await start_capture_server();
+            try {
+                // A deterministic 3-way table: dim c(2,2,2), class "table".
+                const r = await spawnR(cap, viewExpectError(
+                    'View(table(c(1,1,2,2), c(1,2,1,2), c(1,1,2,2)))',
+                ));
+                expect(r.stderr).toContain("Can't `View()` an array with 3 dimensions");
                 expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
             } finally {
                 await cap.close();

--- a/tests/bun/data-viewer-bootstrap-r-integration.test.ts
+++ b/tests/bun/data-viewer-bootstrap-r-integration.test.ts
@@ -479,6 +479,12 @@ describe('Data viewer bootstrap (real R subprocess)', () => {
                 ));
                 expect(na.stderr).toContain('element 2 has class `list`');
                 expect(na.stderr).not.toContain('element `NA`');
+                // A backtick in the name would break the backtick quoting,
+                // so it also falls through to the positional form.
+                const tick = await spawnR(cap, viewExpectError(
+                    'View(setNames(list(list(2)), "a`b"))',
+                ));
+                expect(tick.stderr).toContain('element 1 has class `list`');
                 expect(cap.requests.filter(req => req.headers.includes('POST /view-data')).length).toBe(0);
             } finally {
                 await cap.close();


### PR DESCRIPTION
## Summary

The `View()` override's type-dispatch reported `` Error: Can't `View()` an object of class `list` `` for any list it couldn't render — misleading, since most lists view fine. The real reason is the list's *contents* (or that it's empty). The same defect hit arrays: a `>2`-D array reported `` class `array` `` rather than its real problem (dimensionality).

This makes the errors say *why*, and makes 1-D arrays viewable:

- **Empty list** → `` Can't `View()` an empty list. ``
- **Non-flat list** → names the first offending element, e.g. `` Can't `View()` this list: element `b` has class `list`. Only flat lists (every element a vector) are supported. `` (positional `element <i>` fallback when the name is unnamed/blank/`NA`/contains a backtick).
- **1-D array** (`array(1:3)`) → now rendered as a vector; its `dimnames` become the leading `name` column.
- **`>2`-D array / table** → `` Can't `View()` an array with 3 dimensions; the data viewer shows 2-dimensional tables only. `` (gated on `is.array()` so S4 objects with a `dim()` method fall through).
- **Everything else** (functions, environments, `NULL`, `raw`, S4) — unchanged class-based message.

No change to the set of currently-`View()`-able objects beyond adding 1-D arrays; conversion helpers and everything downstream of the data.frame are untouched.

## Design

Spec: `docs/superpowers/specs/2026-06-27-data-viewer-list-error-message-design.md`. Dispatch order is load-bearing: `matrix → data.frame → vector (incl. 1-D array) → list → >2-D array → generic else`.

## Testing

- `bun test tests/bun/data-viewer-bootstrap-content.test.ts` (source pins) and `...-r-integration.test.ts` (real R subprocess, gated on `HAS_R`/`HAS_ARROW`): **42 pass**. New cases cover empty/nested/unnamed/blank/`NA`/backtick-named list offenders, 1-D and named 1-D arrays, 3-D arrays, and 3-way tables; existing accepted-set cases unchanged.
- Docs updated: `docs/data-viewer.md`.

## Review

Spec and implementation each went through adversarial Codex review plus `/code-review`; two consecutive fully-clean rounds before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)