### PR TITLE
data-viewer: explain & let users cancel the saved sort/filter restore (#519)

### DIFF
--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -256,6 +256,27 @@ row values (column names and types can match while values differ).
 Set `raven.dataViewer.persistSort` to `false` to make every panel
 open unsorted.
 
+### Reopening with a saved sort or filter
+
+The grid itself paints instantly because it is virtualized — only the
+visible window of rows is read at a time. Restoring a saved **sort** or
+**filter**, however, requires reading the relevant column(s) in full to
+recompute the permutation / survivor set, which on a multi-million-row
+frame can take a few seconds. During that time the toolbar shows
+**"Applying your saved sort & filter…"** (worded for whichever applies)
+with a **Cancel** button, instead of a bare `Loading…`. The message only
+appears if the restore takes longer than ~200 ms, so small datasets never
+flash it. Rows still appear only in their final order — there is no
+unsorted-then-sorted "jump".
+
+**Cancel** abandons the restore, **forgets** the saved sort/filter for
+that panel (clears the persisted entries), and shows the data in its
+natural, unsorted/unfiltered order. This is distinct from a genuine read
+failure: if reapplying the saved sort/filter fails for a real reason (a
+corrupt or unreadable column), the panel opens in natural order, a notice
+explains that the saved sort/filter could not be reapplied, and the saved
+preferences are **kept** so the next reopen can retry.
+
 ### Sort indicator
 
 The active sort keys appear as chips in the toolbar — one per key, in

--- a/docs/data-viewer.md
+++ b/docs/data-viewer.md
@@ -275,18 +275,16 @@ visible window of rows is read at a time. Restoring a saved **sort** or
 recompute the permutation / survivor set, which on a multi-million-row
 frame can take a few seconds. During that time the toolbar shows
 **"Applying your saved sort & filter…"** (worded for whichever applies)
-with a **Cancel** button, instead of a bare `Loading…`. The message only
-appears if the restore takes longer than ~200 ms, so small datasets never
-flash it. Rows still appear only in their final order — there is no
-unsorted-then-sorted "jump".
+with a **Skip and show data now** link below it. The message only appears
+if the restore takes longer than ~200 ms, so small datasets never flash it.
 
-**Cancel** abandons the restore, **forgets** the saved sort/filter for
-that panel (clears the persisted entries), and shows the data in its
-natural, unsorted/unfiltered order. This is distinct from a genuine read
-failure: if reapplying the saved sort/filter fails for a real reason (a
-corrupt or unreadable column), the panel opens in natural order, a notice
-explains that the saved sort/filter could not be reapplied, and the saved
-preferences are **kept** so the next reopen can retry.
+**Skip and show data now** abandons the restore, **forgets** the saved
+sort/filter for that panel (clears the persisted entries), and shows the
+data in its natural, unsorted/unfiltered order. This is distinct from a
+genuine read failure: if reapplying the saved sort/filter fails for a real
+reason (a corrupt or unreadable column), the panel opens in natural order,
+a notice explains that the saved sort/filter could not be reapplied, and
+the saved preferences are **kept** so the next reopen can retry.
 
 ### Sort indicator
 

--- a/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
@@ -3,8 +3,8 @@
 Port of [sight#228](https://github.com/jbearak/sight/pull/228) into raven's
 data viewer, adapted to raven's architecture.
 
-> **Revision 2** — folds in the adversarial spec review (codex). The key
-> corrections: `restoreId` is a dedicated monotonic counter, **not** the
+> **Revision 3** — folds in two rounds of adversarial spec review (codex). The
+> key corrections: `restoreId` is a dedicated monotonic counter, **not** the
 > generation (raven's `webviewReady` does not bump `generation`, so reusing it
 > would alias restores across reloads); reload/refresh paths **bump generation
 > AND abort** so the in-flight send bails as *stale* (keeping prefs) rather than
@@ -256,7 +256,18 @@ private restoring = false;
 private restoreId = -1;          // -1 === no active cancellable restore
 private restoreSeq = 0;          // monotonic source of restoreId
 private sendChain: Promise<void> = Promise.resolve();
+// Last active toolbar posted to the webview, captured so the late
+// clear-and-forget path can rebuild a `replace` without an async store
+// load. (Raven has no persistent host-side toolbar field today; the
+// toolbar is otherwise a local in sendInit/sendReplace, panel.ts:217,281.)
+private lastToolbar: ToolbarState | undefined;
 ```
+
+`sendInitImpl` / `sendReplaceImpl` set `this.lastToolbar = activeToolbar` just
+before posting `init` / `replace`. A small `currentSchemaHash()` helper returns
+`schemaHash(this.reader.schema.columns)` for the forget/late-cancel paths (raven
+recomputes the hash from the live reader rather than threading the `layoutHash`
+local out of the send methods).
 
 ### Serialization without self-deadlock
 
@@ -355,10 +366,16 @@ path, because raven's `webviewReady` does not bump it today.
   - applicable sort ⟺ `persistSort` && `savedSort.keys.length > 0` && every
     `key.columnIndex` is in `[0, columns.length)` (matches `restoreSort`'s
     early-returns);
-  - applicable filter ⟺ `persistFilters` && `savedFilter` has ≥1 **enabled**
-    entry whose `columnIndex` is in range (matches `restoreFilter` +
-    `computeFilteredIndices`, which filters to enabled entries and throws on an
-    unknown column index, `filter.ts:48,69`).
+  - applicable filter ⟺ `persistFilters` && `savedFilter.entries.length > 0` &&
+    **every** entry's `columnIndex` is in range && **at least one** entry is
+    `enabled`. The "every entry in range" clause matches `restoreFilter`, which
+    rejects the *entire* saved filter if **any** entry — enabled or not — is out
+    of range (`panel.ts:380-382`); the "≥1 enabled" clause matches
+    `computeFilteredIndices`, which filters to enabled entries and does the heavy
+    read only if at least one survives (`filter.ts:48-49`). Together they make
+    the banner appear iff a heavy filter read will actually run — no false
+    positive for an all-disabled or any-out-of-range saved filter (which
+    `restoreFilter` would silently drop before reading).
 
   If neither applies, return false. Otherwise arm a fresh `AbortController`, set
   `restoreId = ++this.restoreSeq`, `restoring = true`, post `restorePending {
@@ -374,10 +391,12 @@ path, because raven's `webviewReady` does not bump it today.
   hash)` and `if persistFilters: filterStore.clear(panelName, hash)`. Raven's
   stores delete the entry on `clear`; that is "forget entirely."
 - `postReplaceNaturalOrder(generation)` — builds and posts a `replace` from
-  in-memory `this.columns` / `this.layout` / `this.dictionaries` / active toolbar
-  with `EMPTY_SORT` / `EMPTY_FILTER` at the given (already-bumped) generation,
-  used by the late clear-and-forget so the webview adopts the new generation and
-  drops chips coherently.
+  in-memory `this.columns` / `this.layout` / `this.dictionaries` /
+  `this.lastToolbar ?? this.defaultToolbar()` / `currentSchemaHash()` with
+  `EMPTY_SORT` / `EMPTY_FILTER` at the given (already-bumped) generation, used by
+  the late clear-and-forget so the webview adopts the new generation and drops
+  chips coherently. (Requires `webviewInitialized`, always true on the late path
+  since the restore already posted `init`/`replace`.)
 
 ### Message handling
 
@@ -390,17 +409,21 @@ path, because raven's `webviewReady` does not bump it today.
   - else (the restore already completed and posted `init`/`replace` in the
     cross-window race): honor the click as an explicit **clear-and-forget** so it
     is never silently dropped. In order: `resetRestoredPrefs(); this.generation++;
-    this.rowCache?.clear?.(); recompute effective;
     postReplaceNaturalOrder(this.generation);` (a full natural-order `replace`,
     so the webview adopts the bumped generation — a bare `sortApplied`/
     `filterApplied` would leave the webview on the old generation and its
     subsequent messages would be dropped by `panel.ts:540`); **then** `await
-    this.forgetPersistedPrefs(layoutHash)`. Invalidate (bump generation + clear
-    cache) **before** awaiting the store writes so no in-flight `getRows` lands
-    stale sorted/filtered rows after the cancel.
+    this.forgetPersistedPrefs(currentSchemaHash())`. The `generation++` (before
+    the await) is the invalidation: any in-flight `getRows` reply computed under
+    the old effective permutation is captured at the old generation and dropped
+    by `panel.ts:540` / by the webview (which adopts the new generation from the
+    `replace`). Raven has **no host-side row cache** (the row cache is
+    webview-side, `App.tsx:311`, and is cleared when the webview applies
+    `replace`), so there is nothing host-side to clear — only the generation bump
+    and the `replace` are needed.
 - **`webviewReady`** (`panel.ts:442`): if `this.restoring`, treat as a
-  lifecycle interruption — `this.generation++; this.rowCache?.clear?.();
-  abortAndClearRestore();` **before** `await this.sendInit()`. The generation
+  lifecycle interruption — `this.generation++; abortAndClearRestore();`
+  **before** `await this.sendInit()`. The generation
   bump makes the abandoned in-flight restore bail *stale* (prefs kept); the abort
   frees the serialized chain so the re-send (which re-reads from the store and
   re-restores, since raven has no one-shot flags) can post its own
@@ -525,8 +548,9 @@ Extension-side cases:
    no popup, prefs forgotten.
 10. **handleCancelRestore** — ignores stale/mismatched `restoreId`; aborts
     in-flight on match; late cancel after completion = clear-and-forget that
-    bumps generation, posts a natural-order `replace`, clears cache before
-    awaiting store writes, and is a no-op on a duplicate (id consumed).
+    bumps generation **before** awaiting the store writes, posts a natural-order
+    `replace` (asserts the posted `replace` carries the bumped generation and
+    EMPTY sort/filter), and is a no-op on a duplicate (id consumed).
 11. **handleSetSort / handleSetFilters** consume `restoreId` (a later stale
     cancel cannot clear manual prefs) and are no-ops while restoring.
 12. **Stale restore state does not leak** — a later `sendInit` that begins no
@@ -605,4 +629,19 @@ Findings from the round-1 spec review and how this revision resolves them:
 9. **Checkpoint ordering underspecified** (Med) — pinned to top-of-iteration
    `throwIfAborted`, bottom-of-iteration `yieldToEventLoop` (signal only), and a
    post-loop `throwIfAborted`.
+
+Round-2 review (after Revision 2) confirmed findings 1–4 resolved and raised
+three more, all addressed in Revision 3:
+
+10. **`maybeBeginRestore` filter guard still mismatched** (High) — the guard now
+    requires *every* entry in range (matching `restoreFilter`'s all-or-nothing
+    reject, `panel.ts:380-382`) **and** ≥1 enabled (matching the actual heavy
+    read), so the banner cannot false-positive on a saved filter that
+    `restoreFilter` would silently drop.
+11. **`postReplaceNaturalOrder` toolbar/schemaHash source unspecified** (Med) —
+    added a `lastToolbar` field (set before each post) and a `currentSchemaHash()`
+    helper; the helper now names exact sources.
+12. **Phantom host-side `rowCache`** (Low) — removed; raven's row cache is
+    webview-side and self-clears on `replace`. The generation bump alone is the
+    host-side invalidation.
 ```

--- a/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
@@ -1,0 +1,460 @@
+# Data viewer: explain (and let users cancel) the saved sort/filter restore (#519)
+
+Port of [sight#228](https://github.com/jbearak/sight/pull/228) into raven's
+data viewer, adapted to raven's architecture.
+
+## Problem
+
+Raven's data viewer opens instantly because the grid is virtualized: only the
+visible window of rows is read from the Arrow file at any moment. Sort and
+filter break that frugality — to apply either, the host must read the relevant
+column(s) **in their entirety** to compute a sort permutation or a filter
+survivor set.
+
+Sort and filter preferences are persisted per `panelName × schemaHash` and
+**re-applied automatically on reopen**. On reopen of a panel with saved
+preferences, `DataViewerPanel.sendInit` (and `sendReplace`) does the heavy
+column reads *before* it posts the `init` / `replace` message:
+
+```
+webviewReady → sendInit():
+    load stores (layout, toolbar, sort, filter)
+    restoreSort(savedSort)      // computePermutation: reads sort column(s) fully
+    restoreFilter(savedFilter)  // computeFilteredIndices: scans filter column(s) fully
+    postMessage(init)           // only now does the grid populate
+    postMessage(filterApplied)  // if a filter was restored
+```
+
+Until `init` arrives the webview has no schema, so the toolbar shows a bare
+`Loading…` (`describeVisibleRows(..., loading=true)` in `grid-model.ts`).
+
+This is the same shape of regression #518 fixed (O(nrow) work awaited before the
+paint-enabling message), but gated on **persisted sort/filter** rather than
+always-on. A fresh `View()` with no persisted state short-circuits both restores
+and is unaffected (that is why #518 alone made the smoke demo instant). On a
+multi-million-row frame, reopening a panel that has a saved sort or filter shows
+seconds of empty grid with:
+
+1. **No explanation.** No hint that the wait exists *because* raven is reapplying
+   the remembered sort/filter and reading whole columns to do it. (There is
+   already a `Sorting…` / `Filtering…` progress pill, but it is wired only to
+   *interactive* sort/filter changes made after the grid is up — never to this
+   initial restore.)
+2. **No escape hatch.** No way to say "skip it, just show me the data."
+
+## Goal
+
+On reopen with saved preferences:
+
+1. Replace the bare `Loading…` with an explanation — e.g. *"Applying your saved
+   sort & filter…"* — so the wait is self-explanatory.
+2. Offer a **Cancel** control. Cancelling abandons the restore, **forgets** the
+   saved preferences for this panel (clears the persisted sort/filter), and shows
+   the data in its natural (unsorted, unfiltered) order.
+3. Keep today's "no visible reorder" property: rows must never appear in the
+   wrong order and then jump. Data appears only once its final order is known
+   (or, on cancel, in natural order).
+
+For Cancel to be meaningful, the column read it interrupts must yield the event
+loop so the abort message is observed.
+
+## Non-goals
+
+- **Showing the grid in natural order first, then re-sorting** (the issue's
+  "option 1"). Rejected: it causes a visible reorder "jump," which goal #3
+  forbids. This matches sight's rejection of the same alternative.
+- **Cancel for interactive sort/filter** (`handleSetSort` / `handleSetFilters`,
+  applied after the grid is up). Out of scope; those keep their single-shot
+  reads. Possible follow-up.
+- **Interruptible permutation/index computation.** Cancel interrupts the
+  *column-reading* phase (the dominant cost). The final synchronous
+  `permutation.sort()` and the filter `compact()` scan over nrow remain
+  uninterruptible; they are comparatively cheap. Acceptable, documented
+  limitation.
+- **"Remember but don't auto-apply" semantics.** Cancel means *forget entirely*.
+- **A dependency/library bump.** Unlike sight (whose `@jbearak/dta-parser`
+  `read_rows` was synchronous `fs.readSync` and had to be made chunked in the
+  library), raven's reader is in-repo and its restore reads already iterate Arrow
+  record batches via `await getBatch(i)`. Interruptibility is added directly in
+  raven's `sort.ts` / `filter.ts`. There is no "Part 1" here.
+
+## Why Cancel works without a library change
+
+Sight needed a library change because `DtaFile.read_rows` ran to completion
+synchronously (`fs.readSync`), blocking the host event loop so a `cancelRestore`
+message sat unprocessed until the read it targeted had already finished.
+
+Raven differs. `computePermutation` (`sort.ts`) iterates batches with
+`for await (const batch of iterateBatches(reader))`, and `computeFilteredIndices`
+(`filter.ts`) calls `await reader.getBatch(bi)` per batch. Each `getBatch`
+awaits `AsyncRecordBatchFileReader.readRecordBatch(i)` — genuine async I/O on a
+cold cache (the restore-on-open case). So the loop already yields between
+batches. To make cancellation robust even on a warm batch cache (where the
+`await` resolves on a microtask and would not drain the macrotask IPC queue), we
+add an explicit `await setImmediate` yield **between batches, only when a signal
+is present**. `setImmediate` runs in the check phase after the poll phase, so a
+pending webview→host IPC message (the Cancel) is delivered and its handler runs
+`controller.abort()` before the next batch's `signal.aborted` check.
+
+## Part 1 — interruptible restore reads (`sort.ts`, `filter.ts`)
+
+### API
+
+```ts
+// sort.ts
+export function computePermutation(
+    reader: ArrowSliceReader,
+    keys: readonly SortKey[],
+    ctx: SortContext,
+    opts?: { signal?: AbortSignal },
+): Promise<Uint32Array>;
+
+// filter.ts
+export function computeFilteredIndices(
+    reader: ArrowSliceReader,
+    state: FilterState,
+    ctx: FilterContext,
+    opts?: { signal?: AbortSignal },
+): Promise<Uint32Array | undefined>;
+```
+
+The `signal` threads down into every full-column read:
+
+- `sort.ts`: `computePermutation` → `buildSortColumn` →
+  `buildNumericSortColumn` / the string/bool variants → the `iterateBatches`
+  loop. `iterateBatches` gains an optional signal and performs the per-batch
+  check + yield.
+- `filter.ts`: `computeFilteredIndices` → `applyEntry` →
+  `acceptorFor` / `missingMaskFor` → `loadNumeric` / `loadString` / `loadBool`.
+  Each load helper performs the per-batch check + yield.
+
+### Behavior
+
+- **No `signal` (default / existing callers, incl. the viewport `getRows`
+  path):** unchanged — no per-batch checks, no yields, byte-identical results.
+  This is the critical backward-compat guarantee; all existing sort/filter perf
+  and tests are untouched.
+- **With `signal`:** at each batch boundary, in order:
+  1. If `signal.aborted`, throw `new DOMException('The restore was aborted',
+     'AbortError')` (Node provides global `DOMException`).
+  2. Process the batch as today.
+  3. `await new Promise<void>(resolve => setImmediate(resolve))` to release the
+     event loop so a queued abort is observed on the next batch's check.
+
+  A final `signal.aborted` check after the loop, before returning, throws if the
+  abort landed on the last batch.
+
+A small shared helper keeps the two files consistent:
+
+```ts
+// A single source of truth for "throw if aborted, else yield the loop."
+export function checkpoint(signal?: AbortSignal): Promise<void> {
+    if (!signal) return Promise.resolve();
+    if (signal.aborted) {
+        return Promise.reject(
+            new DOMException('The restore was aborted', 'AbortError'),
+        );
+    }
+    return new Promise<void>(resolve => setImmediate(resolve));
+}
+```
+
+`isAbortError(err)` matches on `name === 'AbortError'` (the abort is a
+`DOMException`, not an `Error` subclass on every runtime), used by the panel to
+distinguish a cancel from a genuine read failure.
+
+### Tests (Part 1)
+
+- **Signal-less equivalence:** `computePermutation` / `computeFilteredIndices`
+  with no signal returns identical output to before (covers the fast path).
+- **Abort before first batch:** an already-aborted signal rejects with
+  `AbortError` having read nothing observable.
+- **Abort mid-read:** aborting after the first yield rejects with `AbortError`.
+- **Completion with signal but no abort:** identical result to the signal-less
+  call (signal presence alone must not change output).
+
+## Part 2 — panel state machine (`panel.ts`)
+
+### Protocol (`messages.ts`)
+
+```ts
+// Extension → Webview
+| { type: 'restorePending'; panelGeneration: number; restoreId: number;
+    sort: boolean; filter: boolean }
+
+// Webview → Extension
+| { type: 'cancelRestore'; panelGeneration: number; restoreId: number }
+```
+
+`restoreId` is the panel's `generation` captured when `restorePending` is
+posted. It is the dedicated handshake key (distinct from the per-message
+`panelGeneration`) so a stale or crossed cancel from a prior lifecycle is
+dropped at the protocol level. `sort` / `filter` say which prefs are being
+applied (for the wording). `restorePending` is posted whenever an applicable
+stored pref **exists** for this `panelName × schemaHash` — gated on existence,
+not on whether the filter ultimately yields a non-empty survivor set (unknowable
+without the read the UI exists to explain).
+
+### State
+
+```ts
+private restoreAbort: AbortController | null = null;
+private restoring = false;
+private restoreId = -1;                       // -1 === no cancellable restore
+private sendChain: Promise<void> = Promise.resolve();
+```
+
+`sendChain` serializes **both** `sendInit` and `sendReplace` (raven's two
+paint-enabling entry points; sight had one `send_metadata`). Without it, a
+webview reload during a slow restore starts a concurrent send that overwrites
+the shared `restoreAbort`, so a Cancel could abort the wrong restore.
+
+```ts
+private sendInit(): Promise<boolean> {
+    const next = this.sendChain.catch(() => {}).then(() => this.sendInitImpl());
+    // Coerce to void for the chain; callers still get the boolean from `next`.
+    this.sendChain = next.then(() => {}, () => {});
+    return next;
+}
+// sendReplace wraps sendReplaceImpl identically, sharing the same chain.
+```
+
+### `sendInitImpl` / `sendReplaceImpl` flow
+
+Both share one restore helper. Structure (init shown; replace identical except
+the message `type` and the existing `webviewInitialized` guard):
+
+1. Capture `const generation = this.generation; const reader = this.reader;`
+2. Load stores (layout, toolbar, sort, filter) as today; bail on
+   generation/reader change.
+3. `const began = this.maybeBeginRestore(generation, savedSort, savedFilter);`
+   — posts `restorePending` before the reads if an applicable pref exists; arms
+   `restoreAbort`/`restoreId`/`restoring`; returns whether begun.
+4. `const myAbort = began ? this.restoreAbort : null;`
+   `const isCancelled = () => myAbort?.signal.aborted === true;`
+   (Read cancellation from the **captured** controller, not `this.restoreAbort`,
+   which a concurrent send could reassign.)
+5. `try { ... } finally { if (began && this.restoreAbort === myAbort) {
+   this.restoring = false; this.restoreAbort = null; } }`
+   The ownership guard keeps a superseded call from clobbering a restore a
+   concurrent refresh started; the `finally` guarantees an early throw cannot
+   strand `restoring`.
+6. Inside the try:
+   - `const sortFailed = await this.restoreSort(savedSort, toolbar, generation,
+     reader, myAbort?.signal);`
+   - bail if `generation !== this.generation || reader !== this.reader` (a
+     refresh/reload supersedes this attempt — leave prefs intact for the queued
+     re-send).
+   - `let filterFailed = false; if (!isCancelled()) { filterFailed = await
+     this.restoreFilter(savedFilter, toolbar, generation, reader,
+     myAbort?.signal); bail-if-stale; }`
+     (Skip the filter read entirely if the sort read was cancelled.)
+   - `if (isCancelled()) this.resetRestoredPrefs();` — undo a sort that
+     completed before the cancel landed during the filter read.
+   - `this.recomputeEffective();` (or raven's equivalent recompute; see note).
+   - Post `init`/`replace` with `sort`/`filter` reflecting current in-memory
+     state (EMPTY after a cancel → no chips).
+   - `if (!isCancelled() && this.filteredIndices) postFilterApplied(...)`
+     (`fromPersistence: true`, as today).
+   - `if (!isCancelled() && (sortFailed || filterFailed))` →
+     `vscode.window.showWarningMessage("Could not reapply the saved <what> for
+     this dataset; it was not applied.")` where `<what>` names only what failed.
+   - `if (isCancelled()) await this.forgetPersistedPrefs(generation-derived
+     schemaHash);` — persist the forget **after** the post, so a store-write
+     failure cannot strand the webview waiting on an `init` it never receives.
+
+### `restoreSort` / `restoreFilter` changes
+
+Today both `catch { return EMPTY }`, silently swallowing every error. They now:
+
+- take an optional `signal` and thread it into `computePermutation` /
+  `computeFilteredIndices`;
+- return `boolean` — `true` iff a **genuine (non-abort)** failure occurred:
+
+```ts
+} catch (err) {
+    // Abort → silent natural order. Real failure → natural order, but report
+    // so the caller can warn and KEEP the saved pref for next time.
+    return !isAbortError(err);
+}
+```
+
+On a generation/reader change after the await they return `false` (stale, not a
+failure). The success path is unchanged except for returning `false`.
+
+### Helpers
+
+- `maybeBeginRestore(generation, savedSort, savedFilter): boolean` — returns
+  false if neither an applicable stored sort (keys.length > 0, columns in range)
+  nor an applicable stored filter (≥1 entry whose predicate still fits its
+  column's current kind, mirroring `restoreFilter`'s keep logic) exists, or if
+  persistence is disabled for both. Otherwise arms a fresh `AbortController`,
+  sets `restoreId = generation`, `restoring = true`, posts `restorePending`,
+  returns true.
+- `resetRestoredPrefs()` — synchronous: `restoreId = -1; sort = EMPTY_SORT;
+  permutation = undefined; filter = EMPTY_FILTER; filteredIndices = undefined`.
+- `consumeRestoreHandshake()` — `restoreId = -1` only (no sort/filter reset).
+  Deliberately distinct from `resetRestoredPrefs` (which shares the `-1` line but
+  must also clear sort/filter); the two must not be merged.
+- `abortAndClearRestore()` — `restoreAbort?.abort(); restoreAbort = null;
+  restoring = false; restoreId = -1`. Used by lifecycle-interruption paths.
+- `forgetPersistedPrefs(schemaHash)` — `if persistSort:
+  sortStore.clear(panelName, hash)` and `if persistFilters:
+  filterStore.clear(panelName, hash)`. Raven's stores delete the entry on
+  `clear`; that is "forget entirely."
+
+### Message handling
+
+- **`cancelRestore`** → `handleCancelRestore(msg)`:
+  - `if (msg.restoreId !== this.restoreId) return;` (stale/consumed id).
+  - `if (this.restoring) { this.restoreAbort?.abort(); return; }` — the
+    in-flight reads observe the aborted signal and `sendInitImpl` takes its
+    cancelled path (forget + natural-order `init`).
+  - else (the restore already completed and posted `init` in the cross-window
+    race): honor the click as an explicit **clear-and-forget** so it is never
+    silently dropped. Synchronously: `resetRestoredPrefs(); generation++;
+    rowCache.clear(); recomputeEffective(); postSortApplied(); postFilterApplied()`
+    (and an updated `init`/`replace` only if chips must disappear and
+    `*Applied` does not already drop them), **then** `await
+    forgetPersistedPrefs(...)`. Invalidate (bump generation + clear cache)
+    **before** awaiting the store writes so no in-flight `getRows` lands stale
+    sorted/filtered rows after the cancel.
+- **`webviewReady`** while `this.restoring` → `abortAndClearRestore()` before
+  the queued `sendInit` re-runs. Raven re-loads sort/filter from the store on
+  every `sendInit`, so there are no one-shot flags to re-arm — the re-send
+  re-restores naturally; the abort just lets the serialized chain advance at once
+  instead of waiting behind the dropped read.
+- **`replace` / refresh to a new dataset** → `abortAndClearRestore()` after the
+  generation bump (the bump makes the abandoned restore bail before
+  posting/forgetting, so prefs survive; the abort frees the chain).
+- **`handleSetSort` / `handleSetFilters`** → `if (this.restoring) return;` (a
+  generation bump here would strand the restore with no `init` posted). When not
+  restoring, call `consumeRestoreHandshake()` so a delayed `cancelRestore`
+  carrying the old id cannot wipe a manually-applied sort/filter.
+
+> Note on raven specifics: raven uses `permutation` / `filteredIndices`
+> (undefined === identity) and `EMPTY_SORT` / `EMPTY_FILTER`. The "recompute
+> effective" step is whatever raven already does to combine sort+filter for the
+> reader (it does not maintain a single `effective_perm` field the way sight
+> does; the implementer follows the existing `restoreSort`/`restoreFilter`
+> assignment pattern). `postSortApplied` is a new tiny helper mirroring the
+> existing `filterApplied` post; if the existing code updates chips purely via
+> `init`/`replace`, the late-cancel branch posts a fresh `replace` instead of a
+> `sortApplied`/`filterApplied` pair — the implementer picks whichever matches
+> the webview's existing chip-update path.
+
+## Part 3 — webview (`webview/App.tsx`, `webview/grid-model.ts`, `styles.css`)
+
+Raven's webview keeps message handling and state in `App.tsx` (no
+`use-row-loader.ts` hook). Add:
+
+- State `restorePending: { restoreId: number; sort: boolean; filter: boolean } |
+  null` and `restoreCancelling: boolean`, plus a `restoreTimer` ref and a
+  `restoreIdRef`.
+- On `restorePending`: record `restoreId`; clear `restoreCancelling`; (re)start a
+  `RESTORE_DEBOUNCE_MS = 200` timer that sets `restorePending`. **Debounce:**
+  only reveal the UI if the signal persists past ~200 ms, so fast files never
+  flash it. If a banner is already visible, swap its wording immediately.
+- On `init` / `replace`: clear the timer, `restorePending = null`,
+  `restoreCancelling = false`, `restoreIdRef = null` (both the normal and
+  cancelled paths end by posting `init`/`replace`).
+- `cancelRestore()` handler: post `{ type: 'cancelRestore', panelGeneration,
+  restoreId }`, set `restoreCancelling = true` (optimistic *"Cancelling…"*).
+- Render: while `restorePending` is set and the grid is not yet showing, render —
+  in place of the bare `Loading…`, reusing the `toolbar-progress` styling — an
+  explanatory line plus an inline **Cancel** button:
+  - both → *"Applying your saved sort & filter…"*
+  - sort only → *"Applying your saved sort…"*
+  - filter only → *"Applying your saved filter…"*
+  - while cancelling → *"Cancelling…"* (no button).
+- Suppress the bare `Loading…` row-count while the banner is up so it does not
+  stack above the explanation.
+
+`grid-model.ts` gains two pure, unit-testable helpers:
+
+```ts
+export function describeRestoreMessage(sort: boolean, filter: boolean): string;
+// 'Applying your saved sort & filter…' | '…sort…' | '…filter…'
+
+// Returns '' while a restore banner is showing, else the normal row count.
+export function describeToolbarRowCount(
+    nrow: number, range: VisibleRange, loading: boolean, restoreActive: boolean,
+): string;
+```
+
+`styles.css` gains `.toolbar-restore` (flex row, `min-width: 0`, ellipsis on the
+message span) and `.restore-cancel` (secondary button), matching sight's CSS
+adapted to raven's existing toolbar variables.
+
+## Tests
+
+Ported from sight's `restore-cancel.test.ts` (19 tests) and the `grid-model`
+helper tests, adapted to raven method/field names. Headless: construct a
+`DataViewerPanel` via `Object.create(DataViewerPanel.prototype)` with stubbed
+`reader`, stores, and `panel.webview.postMessage`, then drive the private
+methods (the sight suite does exactly this).
+
+Extension-side cases:
+1. **maybeBeginRestore** posts `restorePending` + arms when prefs apply; no-op
+   when none stored; sort-only vs filter-only flags.
+2. **Completed sort + cancelled filter** ends fully natural — `permutation`
+   undefined, `filteredIndices` undefined, `init` carries no chips, no
+   `filterApplied`, stores cleared. (Guards against the naive "only omit
+   stored_sort" bug.)
+3. **Normal completion** applies + ships saved prefs; `restorePending` precedes
+   `init`; nothing forgotten; `filterApplied` posted when filtered.
+4. **Throws before posting `init`** → `restoring` cleared, `restoreAbort` nulled
+   (the `finally`).
+5. **Serialization** — two overlapping sends post exactly one `restorePending`.
+6. **Generation bump mid-restore** → no `init` posted, prefs intact.
+7. **Real read error vs cancel** — non-`AbortError` failure opens natural order,
+   warns (naming only what failed), and **keeps** stores; cancel **clears**
+   them.
+8. **Cancel suppresses the failure warning** — a real failure before a cancel →
+   no popup, prefs forgotten.
+9. **handleCancelRestore** — ignores stale id; aborts in-flight on match; late
+   cancel after completion = clear-and-forget (+ duplicate late cancel ignored,
+   id consumed).
+10. **Late-cancel ordering** — generation bumped + cache cleared **before**
+    awaiting store writes.
+11. **webviewReady during restore** aborts the in-flight restore so the chain
+    advances; **refresh during restore** aborts before discarding the
+    controller.
+12. **handleSetSort / handleSetFilters** consume `restoreId` (a later stale
+    cancel cannot clear manual prefs) and are no-ops while restoring.
+13. **Stale restore state does not leak** — a later `sendInit` with no restore
+    begun does not forget manually-applied prefs.
+
+Part-1 cases: the four `sort.ts` / `filter.ts` signal cases above.
+
+Webview-side: `describeRestoreMessage` wording per flag combo;
+`describeToolbarRowCount` returns '' while restore active, else the normal label.
+
+## Docs
+
+- `docs/data-viewer.md` — describe the restore banner + Cancel behavior, the
+  forget-on-cancel semantics, and the keep-prefs-on-genuine-error distinction.
+- This spec under `docs/superpowers/specs/`.
+
+## Sequence summary
+
+Normal reopen with saved prefs:
+
+```
+webview: webviewReady
+host:    restorePending {restoreId, sort, filter}   ← webview shows explanation after 200ms
+host:    [chunked, cancellable column reads]
+host:    init (sort/filter set)                      ← webview clears banner, renders sorted
+host:    filterApplied (if filtered)
+```
+
+Cancelled reopen:
+
+```
+webview: webviewReady
+host:    restorePending {restoreId, sort, filter}
+webview: [Cancel] → cancelRestore {restoreId}
+host:    restoreId matches & restoring → controller.abort()
+host:      reads reject AbortError → reset in-memory sort+filter, recompute, prefs forgotten
+host:    init (no sort/filter)                       ← webview renders natural order, no chips
+```

--- a/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
@@ -3,6 +3,19 @@
 Port of [sight#228](https://github.com/jbearak/sight/pull/228) into raven's
 data viewer, adapted to raven's architecture.
 
+> **Revision 2** — folds in the adversarial spec review (codex). The key
+> corrections: `restoreId` is a dedicated monotonic counter, **not** the
+> generation (raven's `webviewReady` does not bump `generation`, so reusing it
+> would alias restores across reloads); reload/refresh paths **bump generation
+> AND abort** so the in-flight send bails as *stale* (keeping prefs) rather than
+> as *cancelled* (forgetting them); the `sendInit`/`sendReplace` serialization
+> wraps only the public entry points while internal delegation calls the *impl*
+> (no self-deadlock); the late clear-and-forget posts a full natural-order
+> `replace` so the webview adopts the bumped generation; `maybeBeginRestore`'s
+> applicability mirrors raven's *actual* restore guards (column-in-range +
+> non-empty), not sight's predicate-fits-kind logic. See "Review notes" at the
+> end for the finding-by-finding mapping.
+
 ## Problem
 
 Raven's data viewer opens instantly because the grid is virtualized: only the
@@ -66,11 +79,19 @@ loop so the abort message is observed.
 - **Cancel for interactive sort/filter** (`handleSetSort` / `handleSetFilters`,
   applied after the grid is up). Out of scope; those keep their single-shot
   reads. Possible follow-up.
-- **Interruptible permutation/index computation.** Cancel interrupts the
-  *column-reading* phase (the dominant cost). The final synchronous
-  `permutation.sort()` and the filter `compact()` scan over nrow remain
-  uninterruptible; they are comparatively cheap. Acceptable, documented
-  limitation.
+- **Fully interruptible restore.** Cancel interrupts the *column-loading* phase
+  at **Arrow record-batch granularity** (the dominant cost). The following
+  remain synchronous and uninterruptible once entered, and are accepted,
+  documented limitations:
+  - a single oversized record batch (cancel is observed only at its end);
+  - `filter.ts` `applyEntry`'s per-row mask scan and regex/string predicate
+    evaluation over the loaded column;
+  - the dictionary-code set building after the batch loop in both files;
+  - the final `permutation.sort()` (sort) and `compact()` (filter) over nrow.
+
+  These are comparatively cheap relative to the column I/O; cancel latency is
+  bounded by "the rest of the current column read + the synchronous tail," not
+  "the whole restore."
 - **"Remember but don't auto-apply" semantics.** Cancel means *forget entirely*.
 - **A dependency/library bump.** Unlike sight (whose `@jbearak/dta-parser`
   `read_rows` was synchronous `fs.readSync` and had to be made chunked in the
@@ -86,15 +107,23 @@ message sat unprocessed until the read it targeted had already finished.
 
 Raven differs. `computePermutation` (`sort.ts`) iterates batches with
 `for await (const batch of iterateBatches(reader))`, and `computeFilteredIndices`
-(`filter.ts`) calls `await reader.getBatch(bi)` per batch. Each `getBatch`
-awaits `AsyncRecordBatchFileReader.readRecordBatch(i)` — genuine async I/O on a
-cold cache (the restore-on-open case). So the loop already yields between
-batches. To make cancellation robust even on a warm batch cache (where the
-`await` resolves on a microtask and would not drain the macrotask IPC queue), we
-add an explicit `await setImmediate` yield **between batches, only when a signal
-is present**. `setImmediate` runs in the check phase after the poll phase, so a
-pending webview→host IPC message (the Cancel) is delivered and its handler runs
-`controller.abort()` before the next batch's `signal.aborted` check.
+(`filter.ts`) loops `for (let bi = 0; bi < numBatches; bi++) { await
+reader.getBatch(bi) }`. On a **cold** batch cache (the restore-on-open case)
+`getBatch` awaits `AsyncRecordBatchFileReader.readRecordBatch(i)` — genuine async
+I/O — so the loop already yields between batches. On a **warm** cache `getBatch`
+returns synchronously (`arrow-reader.ts` LRU), so the `await` only drains a
+microtask and would *not* deliver a macrotask IPC message. To make cancellation
+robust in both cases we add an explicit `await setImmediate` yield **between
+batches, only when a signal is present**. `setImmediate` schedules a check-phase
+callback that runs after the poll phase, so a pending webview→host IPC message
+(the Cancel) is delivered and its handler runs `controller.abort()` before the
+next batch's abort check.
+
+> The IPC-ordering reasoning is a claim about Node's event-loop phases, not
+> something unit tests can prove. The test plan therefore includes a real
+> extension-host integration test (open a panel with a persisted sort on a large
+> frame, click Cancel, assert natural-order `init` + forgotten prefs) in
+> addition to the unit tests.
 
 ## Part 1 — interruptible restore reads (`sort.ts`, `filter.ts`)
 
@@ -122,56 +151,77 @@ The `signal` threads down into every full-column read:
 
 - `sort.ts`: `computePermutation` → `buildSortColumn` →
   `buildNumericSortColumn` / the string/bool variants → the `iterateBatches`
-  loop. `iterateBatches` gains an optional signal and performs the per-batch
-  check + yield.
+  loop.
 - `filter.ts`: `computeFilteredIndices` → `applyEntry` →
   `acceptorFor` / `missingMaskFor` → `loadNumeric` / `loadString` / `loadBool`.
-  Each load helper performs the per-batch check + yield.
 
-### Behavior
+### Behavior and checkpoint placement
 
-- **No `signal` (default / existing callers, incl. the viewport `getRows`
-  path):** unchanged — no per-batch checks, no yields, byte-identical results.
-  This is the critical backward-compat guarantee; all existing sort/filter perf
-  and tests are untouched.
-- **With `signal`:** at each batch boundary, in order:
-  1. If `signal.aborted`, throw `new DOMException('The restore was aborted',
-     'AbortError')` (Node provides global `DOMException`).
-  2. Process the batch as today.
-  3. `await new Promise<void>(resolve => setImmediate(resolve))` to release the
-     event loop so a queued abort is observed on the next batch's check.
-
-  A final `signal.aborted` check after the loop, before returning, throws if the
-  abort landed on the last batch.
-
-A small shared helper keeps the two files consistent:
+Two tiny shared helpers are the single source of truth:
 
 ```ts
-// A single source of truth for "throw if aborted, else yield the loop."
-export function checkpoint(signal?: AbortSignal): Promise<void> {
-    if (!signal) return Promise.resolve();
-    if (signal.aborted) {
-        return Promise.reject(
-            new DOMException('The restore was aborted', 'AbortError'),
-        );
+export function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw new DOMException('The restore was aborted', 'AbortError');
     }
+}
+
+export function yieldToEventLoop(): Promise<void> {
     return new Promise<void>(resolve => setImmediate(resolve));
 }
 ```
 
-`isAbortError(err)` matches on `name === 'AbortError'` (the abort is a
-`DOMException`, not an `Error` subclass on every runtime), used by the panel to
-distinguish a cancel from a genuine read failure.
+Each batch loop is instrumented as:
+
+```
+for (each record batch) {
+    throwIfAborted(signal);          // (a) catch an abort raised since last yield
+    ...process this batch...
+    if (signal) await yieldToEventLoop();   // (b) release the loop so a Cancel lands
+}
+throwIfAborted(signal);              // (c) catch an abort during the final batch
+```
+
+- **(a) at the top of each iteration** catches an already-aborted signal *before*
+  any read (so an abort before the first batch reads nothing) and an abort that
+  landed during the previous batch's processing/yield.
+- **(b) at the bottom, only when `signal` is set** keeps the no-signal path
+  byte-identical (no extra turns) and releases the loop exactly once per batch on
+  the restore path.
+- **(c) after the loop** catches an abort that landed during the last batch.
+
+The `iterateBatches` generator in `sort.ts` is the natural home for the sort-side
+instrumentation; the filter-side load helpers (`loadNumeric` etc.) instrument
+their own `for (bi …)` loops. Throwing propagates up through
+`computePermutation` / `computeFilteredIndices` to the panel, which classifies it
+with:
+
+```ts
+export function isAbortError(err: unknown): boolean {
+    return typeof err === 'object' && err !== null
+        && (err as { name?: unknown }).name === 'AbortError';
+}
+```
+
+(Matched on `name` because the abort is a `DOMException`, not an `Error`
+subclass on every runtime.)
+
+### Backward-compat invariant
+
+With no `signal` there are **no** `throwIfAborted` effects (the guard is cheap
+and never throws) and **no** yields. The viewport `getRows` path passes no
+signal and is byte-identical. All existing sort/filter perf and tests are
+untouched.
 
 ### Tests (Part 1)
 
 - **Signal-less equivalence:** `computePermutation` / `computeFilteredIndices`
   with no signal returns identical output to before (covers the fast path).
+- **Signal-but-no-abort equivalence:** completion with a never-aborted signal
+  returns identical output (signal presence alone must not change results).
 - **Abort before first batch:** an already-aborted signal rejects with
-  `AbortError` having read nothing observable.
+  `AbortError`.
 - **Abort mid-read:** aborting after the first yield rejects with `AbortError`.
-- **Completion with signal but no abort:** identical result to the signal-less
-  call (signal presence alone must not change output).
 
 ## Part 2 — panel state machine (`panel.ts`)
 
@@ -186,89 +236,201 @@ distinguish a cancel from a genuine read failure.
 | { type: 'cancelRestore'; panelGeneration: number; restoreId: number }
 ```
 
-`restoreId` is the panel's `generation` captured when `restorePending` is
-posted. It is the dedicated handshake key (distinct from the per-message
-`panelGeneration`) so a stale or crossed cancel from a prior lifecycle is
-dropped at the protocol level. `sort` / `filter` say which prefs are being
-applied (for the wording). `restorePending` is posted whenever an applicable
-stored pref **exists** for this `panelName × schemaHash` — gated on existence,
-not on whether the filter ultimately yields a non-empty survivor set (unknowable
-without the read the UI exists to explain).
+`restoreId` is a **dedicated monotonic counter** (`++this.restoreSeq`), assigned
+when `restorePending` is posted. It is *not* the `generation`: raven bumps
+`generation` only on dataset `replace()` (`panel.ts:159`), **not** on a
+`webviewReady` reload (`panel.ts:442`), so reusing `generation` would alias two
+different restore attempts across a reload and let a stale `cancelRestore` abort
+or clear the wrong one. The counter is monotonic and unique per restore, so a
+crossed/stale cancel never matches a newer restore. `sort` / `filter` say which
+prefs are being applied (for the wording). `restorePending` is posted whenever an
+applicable stored pref **exists** for this `panelName × schemaHash` — gated on
+existence, not on whether the filter ultimately yields a non-empty survivor set
+(unknowable without the read the UI exists to explain).
 
 ### State
 
 ```ts
 private restoreAbort: AbortController | null = null;
 private restoring = false;
-private restoreId = -1;                       // -1 === no cancellable restore
+private restoreId = -1;          // -1 === no active cancellable restore
+private restoreSeq = 0;          // monotonic source of restoreId
 private sendChain: Promise<void> = Promise.resolve();
 ```
 
-`sendChain` serializes **both** `sendInit` and `sendReplace` (raven's two
-paint-enabling entry points; sight had one `send_metadata`). Without it, a
-webview reload during a slow restore starts a concurrent send that overwrites
-the shared `restoreAbort`, so a Cancel could abort the wrong restore.
+### Serialization without self-deadlock
+
+`sendChain` serializes the two paint-enabling entry points so two restores never
+overlap (a webview reload during a slow restore must not start a concurrent send
+that overwrites `restoreAbort`). The wrapping is applied to the **public** methods
+only; the existing internal delegation in `sendReplace` (which calls `sendInit`
+when uninitialized, `panel.ts:259`) is rewritten to call the **impl** directly so
+it does not await a job queued behind itself:
 
 ```ts
 private sendInit(): Promise<boolean> {
     const next = this.sendChain.catch(() => {}).then(() => this.sendInitImpl());
-    // Coerce to void for the chain; callers still get the boolean from `next`.
     this.sendChain = next.then(() => {}, () => {});
     return next;
 }
-// sendReplace wraps sendReplaceImpl identically, sharing the same chain.
+private sendReplace(): Promise<void> {
+    const next = this.sendChain.catch(() => {}).then(() => this.sendReplaceImpl());
+    this.sendChain = next.then(() => {}, () => {});
+    return next;
+}
+// inside sendReplaceImpl: if (!this.webviewInitialized) { await this.sendInitImpl(); return; }
 ```
 
 ### `sendInitImpl` / `sendReplaceImpl` flow
 
 Both share one restore helper. Structure (init shown; replace identical except
-the message `type` and the existing `webviewInitialized` guard):
+the message `type` and the `webviewInitialized` guard above):
 
-1. Capture `const generation = this.generation; const reader = this.reader;`
+1. `const generation = this.generation; const reader = this.reader;`
 2. Load stores (layout, toolbar, sort, filter) as today; bail on
    generation/reader change.
-3. `const began = this.maybeBeginRestore(generation, savedSort, savedFilter);`
-   — posts `restorePending` before the reads if an applicable pref exists; arms
-   `restoreAbort`/`restoreId`/`restoring`; returns whether begun.
+3. `const began = this.maybeBeginRestore(savedSort, savedFilter);` — posts
+   `restorePending` before the reads if an applicable pref exists; arms
+   `restoreAbort` / `restoreId` / `restoring`; returns whether begun.
 4. `const myAbort = began ? this.restoreAbort : null;`
    `const isCancelled = () => myAbort?.signal.aborted === true;`
-   (Read cancellation from the **captured** controller, not `this.restoreAbort`,
-   which a concurrent send could reassign.)
-5. `try { ... } finally { if (began && this.restoreAbort === myAbort) {
+   (Cancellation is read from the **captured** controller, not
+   `this.restoreAbort`, which a concurrent send could reassign.)
+5. `try { … } finally { if (began && this.restoreAbort === myAbort) {
    this.restoring = false; this.restoreAbort = null; } }`
    The ownership guard keeps a superseded call from clobbering a restore a
    concurrent refresh started; the `finally` guarantees an early throw cannot
    strand `restoring`.
-6. Inside the try:
+6. Inside the try, **generation check before cancel handling** (this ordering is
+   load-bearing — see below):
    - `const sortFailed = await this.restoreSort(savedSort, toolbar, generation,
      reader, myAbort?.signal);`
-   - bail if `generation !== this.generation || reader !== this.reader` (a
-     refresh/reload supersedes this attempt — leave prefs intact for the queued
-     re-send).
-   - `let filterFailed = false; if (!isCancelled()) { filterFailed = await
-     this.restoreFilter(savedFilter, toolbar, generation, reader,
-     myAbort?.signal); bail-if-stale; }`
+   - `if (generation !== this.generation || reader !== this.reader) return;`
+     (a refresh/reload superseded this attempt — bail *stale*, leaving prefs
+     intact for the queued re-send).
+   - `let filterFailed = false;`
+     `if (!isCancelled()) { filterFailed = await this.restoreFilter(savedFilter,
+     toolbar, generation, reader, myAbort?.signal);
+     if (generation !== this.generation || reader !== this.reader) return; }`
      (Skip the filter read entirely if the sort read was cancelled.)
-   - `if (isCancelled()) this.resetRestoredPrefs();` — undo a sort that
-     completed before the cancel landed during the filter read.
-   - `this.recomputeEffective();` (or raven's equivalent recompute; see note).
-   - Post `init`/`replace` with `sort`/`filter` reflecting current in-memory
-     state (EMPTY after a cancel → no chips).
+   - `if (isCancelled()) this.resetRestoredPrefs();` — undo a sort that completed
+     before the cancel landed during the filter read.
+   - recompute the effective order (raven's existing combine step; see note).
+   - Post `init` / `replace`. **The message's `sort` / `filter` come from the
+     in-memory `this.sort` / `this.filter`** (which `restoreSort` / `restoreFilter`
+     assign on success and `resetRestoredPrefs` clears) — *not* from a returned
+     `SortState`. After a cancel/failure they are `EMPTY_SORT` / `EMPTY_FILTER`,
+     so no chips render. (This is the wiring change implied by `restoreSort` /
+     `restoreFilter` now returning a boolean instead of the state.)
    - `if (!isCancelled() && this.filteredIndices) postFilterApplied(...)`
-     (`fromPersistence: true`, as today).
+     (`fromPersistence: true`, exactly as today).
    - `if (!isCancelled() && (sortFailed || filterFailed))` →
      `vscode.window.showWarningMessage("Could not reapply the saved <what> for
-     this dataset; it was not applied.")` where `<what>` names only what failed.
-   - `if (isCancelled()) await this.forgetPersistedPrefs(generation-derived
-     schemaHash);` — persist the forget **after** the post, so a store-write
-     failure cannot strand the webview waiting on an `init` it never receives.
+     this dataset; it was not applied.")` where `<what>` is `"sort"`,
+     `"filter"`, or `"sort and filter"` — naming only what actually failed.
+   - `if (isCancelled()) await this.forgetPersistedPrefs(layoutHash);` — persist
+     the forget **after** the post, so a store-write failure cannot strand the
+     webview waiting on an `init` it never receives.
+
+#### Why the generation check must precede the cancel check
+
+A user Cancel and a reload/refresh **both** abort `restoreAbort`, so
+`isCancelled()` is true in both. The *only* discriminator is `generation`:
+
+- **User Cancel** does not bump generation → the generation check passes → the
+  cancelled path runs → prefs forgotten. (Intended.)
+- **Reload/refresh** bumps generation (see Message handling) → the generation
+  check fails first → the send bails *stale* before the cancel path → prefs
+  **kept**. (Intended — a reload must not forget the user's prefs.)
+
+This mirrors sight, whose `ready` path bumped generation for the same reason. The
+correction for raven is that we must *add* the generation bump on the reload
+path, because raven's `webviewReady` does not bump it today.
+
+### Helpers
+
+- `maybeBeginRestore(savedSort, savedFilter): boolean` — returns false unless an
+  **applicable** stored pref exists, gating on raven's *actual* restore guards
+  (not sight's predicate-fits-kind logic, which raven's restore does not do):
+  - applicable sort ⟺ `persistSort` && `savedSort.keys.length > 0` && every
+    `key.columnIndex` is in `[0, columns.length)` (matches `restoreSort`'s
+    early-returns);
+  - applicable filter ⟺ `persistFilters` && `savedFilter` has ≥1 **enabled**
+    entry whose `columnIndex` is in range (matches `restoreFilter` +
+    `computeFilteredIndices`, which filters to enabled entries and throws on an
+    unknown column index, `filter.ts:48,69`).
+
+  If neither applies, return false. Otherwise arm a fresh `AbortController`, set
+  `restoreId = ++this.restoreSeq`, `restoring = true`, post `restorePending {
+  panelGeneration: generation, restoreId, sort, filter }`, return true.
+- `resetRestoredPrefs()` — synchronous: `restoreId = -1; sort = EMPTY_SORT;
+  permutation = undefined; filter = EMPTY_FILTER; filteredIndices = undefined`.
+- `consumeRestoreHandshake()` — `restoreId = -1` only (no sort/filter reset).
+  Deliberately distinct from `resetRestoredPrefs` (shares the `-1` line but must
+  also clear sort/filter); the two must not be merged.
+- `abortAndClearRestore()` — `restoreAbort?.abort(); restoreAbort = null;
+  restoring = false; restoreId = -1`. Used by lifecycle-interruption paths.
+- `forgetPersistedPrefs(hash)` — `if persistSort: sortStore.clear(panelName,
+  hash)` and `if persistFilters: filterStore.clear(panelName, hash)`. Raven's
+  stores delete the entry on `clear`; that is "forget entirely."
+- `postReplaceNaturalOrder(generation)` — builds and posts a `replace` from
+  in-memory `this.columns` / `this.layout` / `this.dictionaries` / active toolbar
+  with `EMPTY_SORT` / `EMPTY_FILTER` at the given (already-bumped) generation,
+  used by the late clear-and-forget so the webview adopts the new generation and
+  drops chips coherently.
+
+### Message handling
+
+- **`cancelRestore`** → `handleCancelRestore(msg)`:
+  - `if (msg.restoreId !== this.restoreId) return;` (stale/consumed id).
+  - `if (this.restoring) { this.restoreAbort?.abort(); return; }` — the in-flight
+    reads observe the aborted signal and `sendInitImpl` takes its cancelled path
+    (forget + natural-order `init`). Generation is *not* bumped here, so the
+    in-flight send does **not** bail stale and correctly runs the cancel path.
+  - else (the restore already completed and posted `init`/`replace` in the
+    cross-window race): honor the click as an explicit **clear-and-forget** so it
+    is never silently dropped. In order: `resetRestoredPrefs(); this.generation++;
+    this.rowCache?.clear?.(); recompute effective;
+    postReplaceNaturalOrder(this.generation);` (a full natural-order `replace`,
+    so the webview adopts the bumped generation — a bare `sortApplied`/
+    `filterApplied` would leave the webview on the old generation and its
+    subsequent messages would be dropped by `panel.ts:540`); **then** `await
+    this.forgetPersistedPrefs(layoutHash)`. Invalidate (bump generation + clear
+    cache) **before** awaiting the store writes so no in-flight `getRows` lands
+    stale sorted/filtered rows after the cancel.
+- **`webviewReady`** (`panel.ts:442`): if `this.restoring`, treat as a
+  lifecycle interruption — `this.generation++; this.rowCache?.clear?.();
+  abortAndClearRestore();` **before** `await this.sendInit()`. The generation
+  bump makes the abandoned in-flight restore bail *stale* (prefs kept); the abort
+  frees the serialized chain so the re-send (which re-reads from the store and
+  re-restores, since raven has no one-shot flags) can post its own
+  `restorePending` immediately instead of waiting behind the dropped read.
+- **`replace()`** (`panel.ts:153`) already bumps generation at line 159; add
+  `this.abortAndClearRestore();` right after the bump so any in-flight restore
+  from the previous dataset bails stale and the chain advances before
+  `sendReplace()`.
+- **`handleSetSort` / `handleSetFilters`** → `if (this.restoring) return;` (a
+  generation bump here would strand the restore with no `init` posted). When not
+  restoring, call `consumeRestoreHandshake()` so a delayed `cancelRestore`
+  carrying the old id cannot wipe a manually-applied sort/filter.
+
+> Note on raven specifics: raven uses `permutation` / `filteredIndices`
+> (undefined === identity) and `EMPTY_SORT` / `EMPTY_FILTER`. "Recompute
+> effective" is raven's existing `composeEffective()` path (`panel.ts:558`);
+> there is no single `effective_perm` field as in sight. `restoreSort` /
+> `restoreFilter` already assign `this.sort` / `this.permutation` /
+> `this.filter` / `this.filteredIndices`; the only behavioral change is they now
+> additionally return a genuine-failure boolean and accept a `signal`.
 
 ### `restoreSort` / `restoreFilter` changes
 
 Today both `catch { return EMPTY }`, silently swallowing every error. They now:
 
 - take an optional `signal` and thread it into `computePermutation` /
-  `computeFilteredIndices`;
+  `computeFilteredIndices` (as `{ signal }`);
+- still set `this.sort` / `this.permutation` (resp. `this.filter` /
+  `this.filteredIndices`) exactly as today on success, and reset them to EMPTY at
+  the top (unchanged);
 - return `boolean` — `true` iff a **genuine (non-abort)** failure occurred:
 
 ```ts
@@ -280,68 +442,8 @@ Today both `catch { return EMPTY }`, silently swallowing every error. They now:
 ```
 
 On a generation/reader change after the await they return `false` (stale, not a
-failure). The success path is unchanged except for returning `false`.
-
-### Helpers
-
-- `maybeBeginRestore(generation, savedSort, savedFilter): boolean` — returns
-  false if neither an applicable stored sort (keys.length > 0, columns in range)
-  nor an applicable stored filter (≥1 entry whose predicate still fits its
-  column's current kind, mirroring `restoreFilter`'s keep logic) exists, or if
-  persistence is disabled for both. Otherwise arms a fresh `AbortController`,
-  sets `restoreId = generation`, `restoring = true`, posts `restorePending`,
-  returns true.
-- `resetRestoredPrefs()` — synchronous: `restoreId = -1; sort = EMPTY_SORT;
-  permutation = undefined; filter = EMPTY_FILTER; filteredIndices = undefined`.
-- `consumeRestoreHandshake()` — `restoreId = -1` only (no sort/filter reset).
-  Deliberately distinct from `resetRestoredPrefs` (which shares the `-1` line but
-  must also clear sort/filter); the two must not be merged.
-- `abortAndClearRestore()` — `restoreAbort?.abort(); restoreAbort = null;
-  restoring = false; restoreId = -1`. Used by lifecycle-interruption paths.
-- `forgetPersistedPrefs(schemaHash)` — `if persistSort:
-  sortStore.clear(panelName, hash)` and `if persistFilters:
-  filterStore.clear(panelName, hash)`. Raven's stores delete the entry on
-  `clear`; that is "forget entirely."
-
-### Message handling
-
-- **`cancelRestore`** → `handleCancelRestore(msg)`:
-  - `if (msg.restoreId !== this.restoreId) return;` (stale/consumed id).
-  - `if (this.restoring) { this.restoreAbort?.abort(); return; }` — the
-    in-flight reads observe the aborted signal and `sendInitImpl` takes its
-    cancelled path (forget + natural-order `init`).
-  - else (the restore already completed and posted `init` in the cross-window
-    race): honor the click as an explicit **clear-and-forget** so it is never
-    silently dropped. Synchronously: `resetRestoredPrefs(); generation++;
-    rowCache.clear(); recomputeEffective(); postSortApplied(); postFilterApplied()`
-    (and an updated `init`/`replace` only if chips must disappear and
-    `*Applied` does not already drop them), **then** `await
-    forgetPersistedPrefs(...)`. Invalidate (bump generation + clear cache)
-    **before** awaiting the store writes so no in-flight `getRows` lands stale
-    sorted/filtered rows after the cancel.
-- **`webviewReady`** while `this.restoring` → `abortAndClearRestore()` before
-  the queued `sendInit` re-runs. Raven re-loads sort/filter from the store on
-  every `sendInit`, so there are no one-shot flags to re-arm — the re-send
-  re-restores naturally; the abort just lets the serialized chain advance at once
-  instead of waiting behind the dropped read.
-- **`replace` / refresh to a new dataset** → `abortAndClearRestore()` after the
-  generation bump (the bump makes the abandoned restore bail before
-  posting/forgetting, so prefs survive; the abort frees the chain).
-- **`handleSetSort` / `handleSetFilters`** → `if (this.restoring) return;` (a
-  generation bump here would strand the restore with no `init` posted). When not
-  restoring, call `consumeRestoreHandshake()` so a delayed `cancelRestore`
-  carrying the old id cannot wipe a manually-applied sort/filter.
-
-> Note on raven specifics: raven uses `permutation` / `filteredIndices`
-> (undefined === identity) and `EMPTY_SORT` / `EMPTY_FILTER`. The "recompute
-> effective" step is whatever raven already does to combine sort+filter for the
-> reader (it does not maintain a single `effective_perm` field the way sight
-> does; the implementer follows the existing `restoreSort`/`restoreFilter`
-> assignment pattern). `postSortApplied` is a new tiny helper mirroring the
-> existing `filterApplied` post; if the existing code updates chips purely via
-> `init`/`replace`, the late-cancel branch posts a fresh `replace` instead of a
-> `sortApplied`/`filterApplied` pair — the implementer picks whichever matches
-> the webview's existing chip-update path.
+failure) and leave state as-is for the caller's stale check to discard. The
+success path returns `false`.
 
 ## Part 3 — webview (`webview/App.tsx`, `webview/grid-model.ts`, `styles.css`)
 
@@ -349,24 +451,27 @@ Raven's webview keeps message handling and state in `App.tsx` (no
 `use-row-loader.ts` hook). Add:
 
 - State `restorePending: { restoreId: number; sort: boolean; filter: boolean } |
-  null` and `restoreCancelling: boolean`, plus a `restoreTimer` ref and a
+  null`, `restoreCancelling: boolean`, plus a `restoreTimer` ref and a
   `restoreIdRef`.
-- On `restorePending`: record `restoreId`; clear `restoreCancelling`; (re)start a
-  `RESTORE_DEBOUNCE_MS = 200` timer that sets `restorePending`. **Debounce:**
-  only reveal the UI if the signal persists past ~200 ms, so fast files never
-  flash it. If a banner is already visible, swap its wording immediately.
+- On `restorePending`: record `restoreId` in the ref; clear `restoreCancelling`;
+  (re)start a `RESTORE_DEBOUNCE_MS = 200` timer that sets `restorePending`.
+  **Debounce:** only reveal the UI if the signal persists past ~200 ms, so fast
+  files never flash it. If a banner is already visible (a prior restore whose
+  debounce elapsed), swap its wording immediately.
 - On `init` / `replace`: clear the timer, `restorePending = null`,
   `restoreCancelling = false`, `restoreIdRef = null` (both the normal and
-  cancelled paths end by posting `init`/`replace`).
-- `cancelRestore()` handler: post `{ type: 'cancelRestore', panelGeneration,
-  restoreId }`, set `restoreCancelling = true` (optimistic *"Cancelling…"*).
-- Render: while `restorePending` is set and the grid is not yet showing, render —
-  in place of the bare `Loading…`, reusing the `toolbar-progress` styling — an
-  explanatory line plus an inline **Cancel** button:
+  cancelled/late-cancel paths end by posting `init`/`replace`).
+- `cancelRestore()` handler: if `restoreIdRef` is null, no-op; else post
+  `{ type: 'cancelRestore', panelGeneration, restoreId }` and set
+  `restoreCancelling = true` (optimistic *"Cancelling…"*).
+- Cleanup: clear the debounce timer on unmount.
+- Render: while `restorePending` is set, render — in place of the bare
+  `Loading…`, reusing the existing toolbar-progress styling — an explanatory line
+  plus an inline **Cancel** button:
   - both → *"Applying your saved sort & filter…"*
   - sort only → *"Applying your saved sort…"*
   - filter only → *"Applying your saved filter…"*
-  - while cancelling → *"Cancelling…"* (no button).
+  - while `restoreCancelling` → *"Cancelling…"* (no button).
 - Suppress the bare `Loading…` row-count while the banner is up so it does not
   stack above the explanation.
 
@@ -388,47 +493,58 @@ adapted to raven's existing toolbar variables.
 
 ## Tests
 
-Ported from sight's `restore-cancel.test.ts` (19 tests) and the `grid-model`
-helper tests, adapted to raven method/field names. Headless: construct a
-`DataViewerPanel` via `Object.create(DataViewerPanel.prototype)` with stubbed
-`reader`, stores, and `panel.webview.postMessage`, then drive the private
-methods (the sight suite does exactly this).
+Ported from sight's `restore-cancel.test.ts` and the `grid-model` helper tests,
+adapted to raven method/field names. Headless: construct a `DataViewerPanel` via
+`Object.create(DataViewerPanel.prototype)` with stubbed `reader`, stores, and
+`webviewPanel.webview.postMessage`, then drive the private methods.
 
 Extension-side cases:
 1. **maybeBeginRestore** posts `restorePending` + arms when prefs apply; no-op
-   when none stored; sort-only vs filter-only flags.
+   when none stored / persistence disabled / columns out of range; sort-only vs
+   filter-only flags; `restoreId` increments per call.
 2. **Completed sort + cancelled filter** ends fully natural — `permutation`
-   undefined, `filteredIndices` undefined, `init` carries no chips, no
+   undefined, `filteredIndices` undefined, `init` carries `EMPTY` sort/filter, no
    `filterApplied`, stores cleared. (Guards against the naive "only omit
    stored_sort" bug.)
 3. **Normal completion** applies + ships saved prefs; `restorePending` precedes
    `init`; nothing forgotten; `filterApplied` posted when filtered.
 4. **Throws before posting `init`** → `restoring` cleared, `restoreAbort` nulled
    (the `finally`).
-5. **Serialization** — two overlapping sends post exactly one `restorePending`.
-6. **Generation bump mid-restore** → no `init` posted, prefs intact.
-7. **Real read error vs cancel** — non-`AbortError` failure opens natural order,
-   warns (naming only what failed), and **keeps** stores; cancel **clears**
-   them.
-8. **Cancel suppresses the failure warning** — a real failure before a cancel →
+5. **Serialization** — two overlapping sends post exactly one `restorePending`;
+   `sendReplaceImpl` delegating to `sendInitImpl` when uninitialized does not
+   deadlock.
+6. **Reload bumps generation → keeps prefs (not forgotten).** A `webviewReady`
+   during an in-flight restore bumps generation + aborts; the in-flight send
+   bails stale; stores are **unchanged** (contrast with user-cancel). This is the
+   raven-specific regression codex flagged.
+7. **Generation bump mid-restore** (refresh) → no `init` posted, prefs intact,
+   in-flight controller aborted before discard.
+8. **Real read error vs cancel** — non-`AbortError` failure opens natural order,
+   warns (naming only what failed), and **keeps** stores; cancel **clears** them.
+9. **Cancel suppresses the failure warning** — a real failure before a cancel →
    no popup, prefs forgotten.
-9. **handleCancelRestore** — ignores stale id; aborts in-flight on match; late
-   cancel after completion = clear-and-forget (+ duplicate late cancel ignored,
-   id consumed).
-10. **Late-cancel ordering** — generation bumped + cache cleared **before**
-    awaiting store writes.
-11. **webviewReady during restore** aborts the in-flight restore so the chain
-    advances; **refresh during restore** aborts before discarding the
-    controller.
-12. **handleSetSort / handleSetFilters** consume `restoreId` (a later stale
+10. **handleCancelRestore** — ignores stale/mismatched `restoreId`; aborts
+    in-flight on match; late cancel after completion = clear-and-forget that
+    bumps generation, posts a natural-order `replace`, clears cache before
+    awaiting store writes, and is a no-op on a duplicate (id consumed).
+11. **handleSetSort / handleSetFilters** consume `restoreId` (a later stale
     cancel cannot clear manual prefs) and are no-ops while restoring.
-13. **Stale restore state does not leak** — a later `sendInit` with no restore
-    begun does not forget manually-applied prefs.
+12. **Stale restore state does not leak** — a later `sendInit` that begins no
+    restore does not forget manually-applied prefs (the captured `myAbort` is
+    null, so `isCancelled()` is false even if a stale aborted controller lingers
+    on the instance).
 
 Part-1 cases: the four `sort.ts` / `filter.ts` signal cases above.
 
 Webview-side: `describeRestoreMessage` wording per flag combo;
 `describeToolbarRowCount` returns '' while restore active, else the normal label.
+
+Integration (vscode test harness, `editors/vscode/src/test`): open a panel with a
+persisted sort on a large frame; assert `restorePending` precedes `init` and,
+without cancel, the restored order is applied; then a second panel where a
+`cancelRestore` posted during the restore yields a natural-order `init` with no
+chips and forgotten prefs. This is the only test that exercises the real
+event-loop/IPC ordering the "Why Cancel works" section relies on.
 
 ## Docs
 
@@ -456,5 +572,37 @@ host:    restorePending {restoreId, sort, filter}
 webview: [Cancel] → cancelRestore {restoreId}
 host:    restoreId matches & restoring → controller.abort()
 host:      reads reject AbortError → reset in-memory sort+filter, recompute, prefs forgotten
-host:    init (no sort/filter)                       ← webview renders natural order, no chips
+host:    init (EMPTY sort/filter)                    ← webview renders natural order, no chips
+```
+
+## Review notes (adversarial review — codex)
+
+Findings from the round-1 spec review and how this revision resolves them:
+
+1. **`webviewReady` mistaken for user Cancel** (High) — reload now bumps
+   generation; the in-flight send bails *stale* before the cancel path (generation
+   check precedes the cancel check). Prefs kept. Test #6.
+2. **`restoreId = generation` not unique** (High) — `restoreId` is now a
+   dedicated monotonic `restoreSeq`, independent of generation. Protocol section.
+3. **`sendChain` self-deadlock via `sendReplace → sendInit`** (High) — wrapping
+   is on the public methods only; internal delegation calls `sendInitImpl`
+   directly. Serialization section + test #5.
+4. **Late clear-and-forget strands the webview on an old generation** (High) —
+   the late path posts a full natural-order `replace` (`postReplaceNaturalOrder`)
+   so the webview adopts the bumped generation. Message handling + test #10.
+5. **`maybeBeginRestore` applicability diverges from real restore** (High) —
+   gating now mirrors raven's actual guards (column-in-range + non-empty +
+   enabled), not sight's predicate-fits-kind logic. Helpers section.
+6. **Interruptibility granularity overstated** (Med-High) — non-goals now
+   enumerate the synchronous tails (single large batch, per-row mask scan, regex,
+   dictionary-set building, final sort/compact) as accepted limitations.
+7. **IPC-ordering claim unprovable by unit tests** (Med-High) — added an
+   extension-host integration test; the claim is scoped as event-loop-phase
+   reasoning, not a unit-test assertion.
+8. **Return-shape wiring underspecified** (Med) — the `init`/`replace` message
+   now explicitly reads `sort`/`filter` from in-memory `this.sort`/`this.filter`;
+   `restoreSort`/`restoreFilter` return only the failure boolean.
+9. **Checkpoint ordering underspecified** (Med) — pinned to top-of-iteration
+   `throwIfAborted`, bottom-of-iteration `yieldToEventLoop` (signal only), and a
+   post-loop `throwIfAborted`.
 ```

--- a/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
@@ -29,7 +29,7 @@ Sort and filter preferences are persisted per `panelName × schemaHash` and
 preferences, `DataViewerPanel.sendInit` (and `sendReplace`) does the heavy
 column reads *before* it posts the `init` / `replace` message:
 
-```
+```text
 webviewReady → sendInit():
     load stores (layout, toolbar, sort, filter)
     restoreSort(savedSort)      // computePermutation: reads sort column(s) fully
@@ -173,7 +173,7 @@ export function yieldToEventLoop(): Promise<void> {
 
 Each batch loop is instrumented as:
 
-```
+```text
 for (each record batch) {
     throwIfAborted(signal);          // (a) catch an abort raised since last yield
     ...process this batch...
@@ -586,7 +586,7 @@ event-loop/IPC ordering the "Why Cancel works" section relies on.
 
 Normal reopen with saved prefs:
 
-```
+```text
 webview: webviewReady
 host:    restorePending {restoreId, sort, filter}   ← webview shows explanation after 200ms
 host:    [chunked, cancellable column reads]
@@ -596,7 +596,7 @@ host:    filterApplied (if filtered)
 
 Cancelled reopen:
 
-```
+```text
 webview: webviewReady
 host:    restorePending {restoreId, sort, filter}
 webview: [Cancel] → cancelRestore {restoreId}

--- a/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md
@@ -264,10 +264,16 @@ private lastToolbar: ToolbarState | undefined;
 ```
 
 `sendInitImpl` / `sendReplaceImpl` set `this.lastToolbar = activeToolbar` just
-before posting `init` / `replace`. A small `currentSchemaHash()` helper returns
-`schemaHash(this.reader.schema.columns)` for the forget/late-cancel paths (raven
-recomputes the hash from the live reader rather than threading the `layoutHash`
-local out of the send methods).
+before posting `init` / `replace`. The two forget paths obtain the schema hash
+differently, by context:
+
+- the **in-flight cancelled path** runs *inside* `sendInitImpl` /
+  `sendReplaceImpl`, where the `layoutHash` local is already in scope, so it
+  calls `forgetPersistedPrefs(layoutHash)` directly;
+- the **late clear-and-forget path** runs in `handleCancelRestore`, *outside* any
+  send method, so it uses a small `currentSchemaHash()` helper returning
+  `schemaHash(this.reader.schema.columns)` (same computation as the send methods'
+  local, `panel.ts:202,266`) rather than threading the local out.
 
 ### Serialization without self-deadlock
 

--- a/editors/vscode/src/data-viewer/abort.ts
+++ b/editors/vscode/src/data-viewer/abort.ts
@@ -1,0 +1,49 @@
+/**
+ * Cooperative-cancellation helpers for the saved-sort/filter restore on
+ * open (#519). The restore reads whole columns to compute a permutation
+ * / survivor set; threading an {@link AbortSignal} through those reads,
+ * and yielding the event loop between Arrow record batches, lets a
+ * webview Cancel actually interrupt the wait.
+ *
+ * These are host-side only (the column reads run on the extension host,
+ * not in the webview). The no-signal path of every consumer stays
+ * byte-identical: {@link throwIfAborted} is a cheap guard that never
+ * throws without a signal, and the yield is only inserted when a signal
+ * is present.
+ */
+
+/**
+ * Throw an `AbortError` if `signal` is aborted; otherwise no-op. Called
+ * at each Arrow record-batch boundary so an abort raised since the last
+ * yield interrupts the read. The error is a `DOMException` (not an
+ * `Error` subclass on every runtime), matched by {@link isAbortError}.
+ */
+export function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw new DOMException('The restore was aborted', 'AbortError');
+    }
+}
+
+/**
+ * Release the event loop so a queued webview→host message (the Cancel)
+ * is delivered before the next batch is read. `setImmediate` schedules a
+ * check-phase callback that runs after the poll phase where incoming IPC
+ * is handled, so the abort is observed on the next {@link throwIfAborted}.
+ * Only inserted on the restore (signal-bearing) path.
+ */
+export function yieldToEventLoop(): Promise<void> {
+    return new Promise<void>(resolve => {
+        setImmediate(resolve);
+    });
+}
+
+/**
+ * Whether `err` is an abort (a user Cancel) rather than a genuine read
+ * failure. Matched on `name` because the abort is thrown as a
+ * `DOMException`, which is not an `Error` subclass on every runtime.
+ */
+export function isAbortError(err: unknown): boolean {
+    return typeof err === 'object'
+        && err !== null
+        && (err as { name?: unknown }).name === 'AbortError';
+}

--- a/editors/vscode/src/data-viewer/abort.ts
+++ b/editors/vscode/src/data-viewer/abort.ts
@@ -1,9 +1,10 @@
 /**
- * Cooperative-cancellation helpers for the saved-sort/filter restore on
- * open (#519). The restore reads whole columns to compute a permutation
- * / survivor set; threading an {@link AbortSignal} through those reads,
- * and yielding the event loop between Arrow record batches, lets a
- * webview Cancel actually interrupt the wait.
+ * Cooperative-cancellation helpers for data-viewer full-column scans.
+ * Saved sort/filter restore and interactive sort/filter changes read
+ * whole columns to compute a permutation / survivor set; threading an
+ * {@link AbortSignal} through those reads, and yielding the event loop
+ * between Arrow record batches, lets a webview Cancel or superseding
+ * user action interrupt the wait.
  *
  * These are host-side only (the column reads run on the extension host,
  * not in the webview). The no-signal path of every consumer stays
@@ -20,16 +21,16 @@
  */
 export function throwIfAborted(signal?: AbortSignal): void {
     if (signal?.aborted) {
-        throw new DOMException('The restore was aborted', 'AbortError');
+        throw new DOMException('The data-viewer operation was aborted', 'AbortError');
     }
 }
 
 /**
- * Release the event loop so a queued webview→host message (the Cancel)
- * is delivered before the next batch is read. `setImmediate` schedules a
- * check-phase callback that runs after the poll phase where incoming IPC
- * is handled, so the abort is observed on the next {@link throwIfAborted}.
- * Only inserted on the restore (signal-bearing) path.
+ * Release the event loop so a queued webview→host message (Cancel or a
+ * superseding sort/filter) is delivered before the next batch is read.
+ * `setImmediate` schedules a check-phase callback that runs after the poll
+ * phase where incoming IPC is handled, so the abort is observed on the
+ * next {@link throwIfAborted}. Only inserted on signal-bearing paths.
  */
 export function yieldToEventLoop(): Promise<void> {
     return new Promise<void>(resolve => {

--- a/editors/vscode/src/data-viewer/batch-iter.ts
+++ b/editors/vscode/src/data-viewer/batch-iter.ts
@@ -7,8 +7,10 @@
  * (the saved-sort/filter restore on open), the iteration throws an
  * `AbortError` before each batch if aborted and yields the event loop
  * after each batch so a queued webview Cancel is delivered before the
- * next read. With no `signal` (the viewport `getRows` path) it is
- * byte-identical to a plain batch loop — no checks, no yields.
+ * next read. With no `signal` (interactive setSort/setFilters, which read
+ * whole columns but are not cancellable) it is byte-identical to a plain
+ * batch loop — no checks, no yields. The virtualized viewport `getRows`
+ * path does not walk batches through here at all.
  */
 import type { ArrowSliceReader } from './arrow-reader';
 import { throwIfAborted, yieldToEventLoop } from './abort';

--- a/editors/vscode/src/data-viewer/batch-iter.ts
+++ b/editors/vscode/src/data-viewer/batch-iter.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared record-batch iteration for the sort and filter engines.
+ *
+ * Both engines read whole columns by walking the reader's record
+ * batches. Centralizing the walk here gives one place for the
+ * cooperative-cancellation checkpoint (#519): when a `signal` is passed
+ * (the saved-sort/filter restore on open), the iteration throws an
+ * `AbortError` before each batch if aborted and yields the event loop
+ * after each batch so a queued webview Cancel is delivered before the
+ * next read. With no `signal` (the viewport `getRows` path) it is
+ * byte-identical to a plain batch loop — no checks, no yields.
+ */
+import type { ArrowSliceReader } from './arrow-reader';
+import { throwIfAborted, yieldToEventLoop } from './abort';
+
+/** One record batch plus its row range in the full dataset. */
+export type BatchSlice = { batch: any; start: number; length: number };
+
+/** Async iterator over a reader's record batches with their starting
+ *  row index. See the module doc for the `signal` semantics. */
+export async function* iterateBatches(
+    reader: ArrowSliceReader,
+    signal?: AbortSignal,
+): AsyncGenerator<BatchSlice> {
+    const numBatches = reader.batchStarts.length - 1;
+    for (let bi = 0; bi < numBatches; bi++) {
+        throwIfAborted(signal);
+        const batch = await readerGetBatch(reader, bi);
+        const start = reader.batchStarts[bi];
+        const length = reader.batchStarts[bi + 1] - start;
+        yield { batch, start, length };
+        if (signal) await yieldToEventLoop();
+    }
+    throwIfAborted(signal);
+}
+
+/** Bridge into the reader's private batch loader. The reader caches
+ *  decoded batches with an LRU, so repeated reads here are cheap and
+ *  warm the cache for the subsequent `getRows()` window. */
+export function readerGetBatch(reader: ArrowSliceReader, i: number): Promise<any> {
+    return (reader as any).getBatch(i);
+}

--- a/editors/vscode/src/data-viewer/batch-iter.ts
+++ b/editors/vscode/src/data-viewer/batch-iter.ts
@@ -1,16 +1,15 @@
 /**
- * Shared record-batch iteration for the sort and filter engines.
+ * Shared record-batch iteration for full-column data-viewer scans.
  *
- * Both engines read whole columns by walking the reader's record
- * batches. Centralizing the walk here gives one place for the
- * cooperative-cancellation checkpoint (#519): when a `signal` is passed
- * (the saved-sort/filter restore on open), the iteration throws an
- * `AbortError` before each batch if aborted and yields the event loop
- * after each batch so a queued webview Cancel is delivered before the
- * next read. With no `signal` (interactive setSort/setFilters, which read
- * whole columns but are not cancellable) it is byte-identical to a plain
- * batch loop — no checks, no yields. The virtualized viewport `getRows`
- * path does not walk batches through here at all.
+ * Sort, filter, and histogram code read whole columns by walking the
+ * reader's record batches. Centralizing the walk here gives one place for the
+ * cooperative-cancellation checkpoint (#519): when a `signal` is passed,
+ * the iteration throws an `AbortError` before each batch if aborted and
+ * yields the event loop after each batch so a queued webview Cancel or
+ * superseding sort/filter is delivered before the next read. With no
+ * `signal` it is byte-identical to a plain batch loop — no checks, no
+ * yields. The virtualized viewport `getRows` path does not walk batches
+ * through here at all.
  */
 import type { ArrowSliceReader } from './arrow-reader';
 import { throwIfAborted, yieldToEventLoop } from './abort';

--- a/editors/vscode/src/data-viewer/batch-iter.ts
+++ b/editors/vscode/src/data-viewer/batch-iter.ts
@@ -38,7 +38,9 @@ export async function* iterateBatches(
 
 /** Bridge into the reader's private batch loader. The reader caches
  *  decoded batches with an LRU, so repeated reads here are cheap and
- *  warm the cache for the subsequent `getRows()` window. */
-export function readerGetBatch(reader: ArrowSliceReader, i: number): Promise<any> {
+ *  warm the cache for the subsequent `getRows()` window. Module-private:
+ *  callers go through {@link iterateBatches} so the cancellation checkpoint
+ *  is never bypassed. */
+function readerGetBatch(reader: ArrowSliceReader, i: number): Promise<any> {
     return (reader as any).getBatch(i);
 }

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -61,6 +61,7 @@ export async function computeFilteredIndices(
         await applyEntry(reader, e, ctx, mask, signal);
         if (allZero(mask)) break;
     }
+    throwIfAborted(signal);
     return compact(mask);
 }
 
@@ -82,6 +83,7 @@ async function applyEntry(
     const include = p.kind === 'isEmpty' ? true : entry.includeMissing;
     const missing = await missingMaskFor(reader, entry.columnIndex, schema, signal);
 
+    throwIfAborted(signal);
     for (let i = 0; i < mask.length; i++) {
         if (mask[i] === 0) continue;
         if (missing[i]) {
@@ -90,6 +92,7 @@ async function applyEntry(
         }
         mask[i] = accept(i) ? 1 : 0;
     }
+    throwIfAborted(signal);
 }
 
 /** Returns a fn `(rowIndex) => boolean` whose domain is **non-missing**

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -61,6 +61,10 @@ export async function computeFilteredIndices(
         await applyEntry(reader, e, ctx, mask, signal);
         if (allZero(mask)) break;
     }
+    // Yield once more before the synchronous compaction tail so a Cancel
+    // queued during the final entry's mask scan is delivered and honored here,
+    // leaving the data unfiltered rather than publishing compacted indices.
+    if (signal) await yieldToEventLoop();
     throwIfAborted(signal);
     return compact(mask);
 }

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -34,7 +34,7 @@
 import type { ArrowSliceReader, ColumnSchema } from './arrow-reader';
 import type { FilterEntry, FilterState } from './messages';
 import { iterateBatches } from './batch-iter';
-import { throwIfAborted } from './abort';
+import { throwIfAborted, yieldToEventLoop } from './abort';
 
 export type FilterContext = {
     labelsOn: boolean;
@@ -83,7 +83,16 @@ async function applyEntry(
     const include = p.kind === 'isEmpty' ? true : entry.includeMissing;
     const missing = await missingMaskFor(reader, entry.columnIndex, schema, signal);
 
-    throwIfAborted(signal);
+    // Yield once more before the synchronous mask scan so a Cancel queued
+    // during the acceptor/missing-mask reads is delivered and observed here,
+    // leaving the data unfiltered rather than publishing filtered indices.
+    // Only the cancellable restore passes a signal.
+    if (signal) {
+        await yieldToEventLoop();
+        throwIfAborted(signal);
+    } else {
+        throwIfAborted(signal);
+    }
     for (let i = 0; i < mask.length; i++) {
         if (mask[i] === 0) continue;
         if (missing[i]) {

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -312,8 +312,7 @@ async function missingMaskFor(
     const isFloat = schema.arrowType.startsWith('Float');
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const n = length;
-        for (let r = 0; r < n; r++) {
+        for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) m[start + r] = 1;
             else if (isFloat && typeof v === 'number' && Number.isNaN(v)) m[start + r] = 1;
@@ -327,8 +326,7 @@ async function loadBool(reader: ArrowSliceReader, columnIndex: number, signal?: 
     const values = new Uint8Array(nrow);
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const n = length;
-        for (let r = 0; r < n; r++) {
+        for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
             values[start + r] = v ? 1 : 0;
@@ -342,8 +340,7 @@ async function loadNumeric(reader: ArrowSliceReader, columnIndex: number, signal
     const out = new Float64Array(nrow);
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const n = length;
-        for (let r = 0; r < n; r++) {
+        for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
             // bigint columns (Int64 / Uint64) lossily coerce to Number;
@@ -362,8 +359,7 @@ async function loadString(reader: ArrowSliceReader, columnIndex: number, signal?
     const out: string[] = new Array(nrow).fill('');
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const n = length;
-        for (let r = 0; r < n; r++) {
+        for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v !== null && v !== undefined) out[start + r] = String(v);
         }
@@ -377,8 +373,7 @@ async function loadFactorCodes(reader: ArrowSliceReader, columnIndex: number, si
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
         const data = child.data[0];
-        const n = length;
-        for (let r = 0; r < n; r++) codes[start + r] = data.values[r] as number;
+        for (let r = 0; r < length; r++) codes[start + r] = data.values[r] as number;
     }
     return codes;
 }
@@ -412,8 +407,7 @@ async function loadValueLabelled(
     const labels = schema.valueLabels ?? {};
     for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const n = length;
-        for (let r = 0; r < n; r++) {
+        for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
             const key = typeof v === 'bigint' ? v.toString() : String(v);

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -33,6 +33,8 @@
 
 import type { ArrowSliceReader, ColumnSchema } from './arrow-reader';
 import type { FilterEntry, FilterState } from './messages';
+import { iterateBatches } from './batch-iter';
+import { throwIfAborted } from './abort';
 
 export type FilterContext = {
     labelsOn: boolean;
@@ -44,7 +46,9 @@ export async function computeFilteredIndices(
     reader: ArrowSliceReader,
     state: FilterState,
     ctx: FilterContext,
+    opts?: { signal?: AbortSignal },
 ): Promise<Uint32Array | undefined> {
+    const signal = opts?.signal;
     const active = state.entries.filter(e => e.enabled);
     if (active.length === 0) return undefined;
 
@@ -53,7 +57,8 @@ export async function computeFilteredIndices(
     mask.fill(1);
 
     for (const e of active) {
-        await applyEntry(reader, e, ctx, mask);
+        throwIfAborted(signal);
+        await applyEntry(reader, e, ctx, mask, signal);
         if (allZero(mask)) break;
     }
     return compact(mask);
@@ -64,17 +69,18 @@ async function applyEntry(
     entry: FilterEntry,
     ctx: FilterContext,
     mask: Uint8Array,
+    signal?: AbortSignal,
 ): Promise<void> {
     const schema = reader.schema.columns[entry.columnIndex];
     if (!schema) {
         throw new Error(`computeFilteredIndices: unknown columnIndex ${entry.columnIndex}`);
     }
     const p = entry.predicate;
-    const accept = await acceptorFor(reader, entry.columnIndex, schema, p, ctx);
+    const accept = await acceptorFor(reader, entry.columnIndex, schema, p, ctx, signal);
     // isEmpty targets missing values — they always pass regardless of includeMissing.
     // All other predicates use the entry's includeMissing flag.
     const include = p.kind === 'isEmpty' ? true : entry.includeMissing;
-    const missing = await missingMaskFor(reader, entry.columnIndex, schema);
+    const missing = await missingMaskFor(reader, entry.columnIndex, schema, signal);
 
     for (let i = 0; i < mask.length; i++) {
         if (mask[i] === 0) continue;
@@ -95,18 +101,19 @@ async function acceptorFor(
     schema: ColumnSchema,
     predicate: FilterEntry['predicate'],
     ctx: FilterContext,
+    signal?: AbortSignal,
 ): Promise<(row: number) => boolean> {
     if (predicate.kind === 'isEmpty') return () => false;
     if (predicate.kind === 'isNotEmpty') return () => true;
 
     if (predicate.kind === 'bool') {
-        const values = await loadBool(reader, columnIndex);
+        const values = await loadBool(reader, columnIndex, signal);
         const want = predicate.value ? 1 : 0;
         return (i) => values[i] === want;
     }
 
     if (predicate.kind === 'numCompare') {
-        const values = await loadNumeric(reader, columnIndex);
+        const values = await loadNumeric(reader, columnIndex, signal);
         const v = predicate.value;
         switch (predicate.op) {
             case '=': return (i) => values[i] === v;
@@ -118,14 +125,14 @@ async function acceptorFor(
         }
     }
     if (predicate.kind === 'numBetween') {
-        const values = await loadNumeric(reader, columnIndex);
+        const values = await loadNumeric(reader, columnIndex, signal);
         const lo = predicate.lo, hi = predicate.hi, incl = predicate.inclusive;
         return incl
             ? (i) => values[i] >= lo && values[i] <= hi
             : (i) => values[i] > lo && values[i] < hi;
     }
     if (predicate.kind === 'numNotBetween') {
-        const values = await loadNumeric(reader, columnIndex);
+        const values = await loadNumeric(reader, columnIndex, signal);
         const lo = predicate.lo, hi = predicate.hi, incl = predicate.inclusive;
         return incl
             ? (i) => values[i] < lo || values[i] > hi
@@ -137,7 +144,7 @@ async function acceptorFor(
         || predicate.kind === 'strStartsWith'
         || predicate.kind === 'strEndsWith'
         || predicate.kind === 'strRegex') {
-        const values = await loadString(reader, columnIndex);
+        const values = await loadString(reader, columnIndex, signal);
         const cs = predicate.caseSensitive;
         switch (predicate.kind) {
             case 'strCompare': {
@@ -202,7 +209,7 @@ async function acceptorFor(
         // Timestamp columns (bigint microseconds) coerce to Number ms * 1000
         // via loadNumeric's bigint path, which loses sub-ms precision but is
         // fine for user-typed ISO strings.
-        const values = await loadNumeric(reader, columnIndex);
+        const values = await loadNumeric(reader, columnIndex, signal);
         const isTs = schema.arrowType.startsWith('Timestamp');
         const toUnit = (iso: string): number => {
             const ms = Date.parse(iso);
@@ -248,7 +255,7 @@ async function acceptorFor(
         const hasValueLabels = !!schema.valueLabels;
 
         if (isFactor) {
-            const codes = await loadFactorCodes(reader, columnIndex);
+            const codes = await loadFactorCodes(reader, columnIndex, signal);
             if (ctx.labelsOn) {
                 const labels: string[] = Array.isArray(schema.dictionary)
                     ? schema.dictionary
@@ -271,20 +278,20 @@ async function acceptorFor(
             && (t.startsWith('Int') || t.startsWith('Uint') || t.startsWith('Float'));
         if (isNumericLabelled) {
             const want = new Set(predicate.values.map(Number));
-            const values = await loadNumeric(reader, columnIndex);
+            const values = await loadNumeric(reader, columnIndex, signal);
             return predicate.kind === 'setIn'
                 ? (i) => want.has(values[i])
                 : (i) => !want.has(values[i]);
         }
 
         if (hasValueLabels && ctx.labelsOn) {
-            const displayed = await loadValueLabelled(reader, columnIndex, schema);
+            const displayed = await loadValueLabelled(reader, columnIndex, schema, signal);
             return predicate.kind === 'setIn'
                 ? (i) => wantStr.has(displayed[i])
                 : (i) => !wantStr.has(displayed[i]);
         }
 
-        const values = await loadString(reader, columnIndex);
+        const values = await loadString(reader, columnIndex, signal);
         return predicate.kind === 'setIn'
             ? (i) => wantStr.has(values[i])
             : (i) => !wantStr.has(values[i]);
@@ -298,16 +305,14 @@ async function missingMaskFor(
     reader: ArrowSliceReader,
     columnIndex: number,
     schema: ColumnSchema,
+    signal?: AbortSignal,
 ): Promise<Uint8Array> {
     const nrow = reader.nrow;
     const m = new Uint8Array(nrow);
     const isFloat = schema.arrowType.startsWith('Float');
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const start = reader.batchStarts[bi];
-        const n = (reader.batchStarts[bi + 1] - start);
+        const n = length;
         for (let r = 0; r < n; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) m[start + r] = 1;
@@ -317,15 +322,12 @@ async function missingMaskFor(
     return m;
 }
 
-async function loadBool(reader: ArrowSliceReader, columnIndex: number): Promise<Uint8Array> {
+async function loadBool(reader: ArrowSliceReader, columnIndex: number, signal?: AbortSignal): Promise<Uint8Array> {
     const nrow = reader.nrow;
     const values = new Uint8Array(nrow);
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const start = reader.batchStarts[bi];
-        const n = (reader.batchStarts[bi + 1] - start);
+        const n = length;
         for (let r = 0; r < n; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -335,15 +337,12 @@ async function loadBool(reader: ArrowSliceReader, columnIndex: number): Promise<
     return values;
 }
 
-async function loadNumeric(reader: ArrowSliceReader, columnIndex: number): Promise<Float64Array> {
+async function loadNumeric(reader: ArrowSliceReader, columnIndex: number, signal?: AbortSignal): Promise<Float64Array> {
     const nrow = reader.nrow;
     const out = new Float64Array(nrow);
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const start = reader.batchStarts[bi];
-        const n = reader.batchStarts[bi + 1] - start;
+        const n = length;
         for (let r = 0; r < n; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -358,15 +357,12 @@ async function loadNumeric(reader: ArrowSliceReader, columnIndex: number): Promi
     return out;
 }
 
-async function loadString(reader: ArrowSliceReader, columnIndex: number): Promise<string[]> {
+async function loadString(reader: ArrowSliceReader, columnIndex: number, signal?: AbortSignal): Promise<string[]> {
     const nrow = reader.nrow;
     const out: string[] = new Array(nrow).fill('');
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const start = reader.batchStarts[bi];
-        const n = reader.batchStarts[bi + 1] - start;
+        const n = length;
         for (let r = 0; r < n; r++) {
             const v = child.get(r);
             if (v !== null && v !== undefined) out[start + r] = String(v);
@@ -375,16 +371,13 @@ async function loadString(reader: ArrowSliceReader, columnIndex: number): Promis
     return out;
 }
 
-async function loadFactorCodes(reader: ArrowSliceReader, columnIndex: number): Promise<Int32Array> {
+async function loadFactorCodes(reader: ArrowSliceReader, columnIndex: number, signal?: AbortSignal): Promise<Int32Array> {
     const nrow = reader.nrow;
     const codes = new Int32Array(nrow);
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
         const data = child.data[0];
-        const start = reader.batchStarts[bi];
-        const n = reader.batchStarts[bi + 1] - start;
+        const n = length;
         for (let r = 0; r < n; r++) codes[start + r] = data.values[r] as number;
     }
     return codes;
@@ -408,16 +401,14 @@ async function loadValueLabelled(
     reader: ArrowSliceReader,
     columnIndex: number,
     schema: ColumnSchema,
+    signal?: AbortSignal,
 ): Promise<string[]> {
     const nrow = reader.nrow;
     const out: string[] = new Array(nrow).fill('');
     const labels = schema.valueLabels ?? {};
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, start, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const start = reader.batchStarts[bi];
-        const n = reader.batchStarts[bi + 1] - start;
+        const n = length;
         for (let r = 0; r < n; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -259,7 +259,7 @@ async function acceptorFor(
             if (ctx.labelsOn) {
                 const labels: string[] = Array.isArray(schema.dictionary)
                     ? schema.dictionary
-                    : await dictFromGetLabels(reader, columnIndex, codes);
+                    : await dictFromGetLabels(reader, columnIndex, codes, signal);
                 return predicate.kind === 'setIn'
                     ? (i) => wantStr.has(labels[codes[i]])
                     : (i) => !wantStr.has(labels[codes[i]]);
@@ -387,10 +387,14 @@ async function dictFromGetLabels(
     reader: ArrowSliceReader,
     columnIndex: number,
     codes: Int32Array,
+    signal?: AbortSignal,
 ): Promise<string[]> {
     const seen = new Set<number>();
     for (let i = 0; i < codes.length; i++) seen.add(codes[i]);
     const labels = await reader.getLabels(columnIndex, [...seen]);
+    // getLabels is an extra async hop after the cancellable column load;
+    // check the signal so a Cancel during it is observed promptly.
+    throwIfAborted(signal);
     const max = [...seen].reduce((a, b) => Math.max(a, b), -1);
     const out: string[] = new Array(max + 1).fill('');
     for (const [k, v] of Object.entries(labels)) out[Number(k)] = v;

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -86,13 +86,10 @@ async function applyEntry(
     // Yield once more before the synchronous mask scan so a Cancel queued
     // during the acceptor/missing-mask reads is delivered and observed here,
     // leaving the data unfiltered rather than publishing filtered indices.
-    // Only the cancellable restore passes a signal.
-    if (signal) {
-        await yieldToEventLoop();
-        throwIfAborted(signal);
-    } else {
-        throwIfAborted(signal);
-    }
+    // Only the cancellable restore passes a signal; throwIfAborted(undefined)
+    // is a no-op on the interactive path.
+    if (signal) await yieldToEventLoop();
+    throwIfAborted(signal);
     for (let i = 0; i < mask.length; i++) {
         if (mask[i] === 0) continue;
         if (missing[i]) {

--- a/editors/vscode/src/data-viewer/histograms.ts
+++ b/editors/vscode/src/data-viewer/histograms.ts
@@ -25,6 +25,8 @@
 
 import type { ArrowSliceReader } from './arrow-reader';
 import type { HistogramBin } from './messages';
+import { iterateBatches } from './batch-iter';
+import { throwIfAborted } from './abort';
 
 const BIN_COUNT = 50;
 
@@ -40,12 +42,13 @@ export function isNumericArrowType(arrowType: string): boolean {
 
 export async function computeNumericHistograms(
     reader: ArrowSliceReader,
+    opts?: { signal?: AbortSignal },
 ): Promise<Record<number, HistogramBin[]>> {
     const out: Record<number, HistogramBin[]> = {};
     const schema = reader.schema.columns;
     for (let ci = 0; ci < schema.length; ci++) {
         if (!isNumericArrowType(schema[ci].arrowType)) continue;
-        out[ci] = await computeHistogramForColumn(reader, ci);
+        out[ci] = await computeHistogramForColumn(reader, ci, opts);
     }
     return out;
 }
@@ -59,16 +62,15 @@ export async function computeNumericHistograms(
 export async function computeHistogramForColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
+    opts?: { signal?: AbortSignal },
 ): Promise<HistogramBin[]> {
+    const signal = opts?.signal;
     let min = Number.POSITIVE_INFINITY;
     let max = Number.NEGATIVE_INFINITY;
     let count = 0;
-    const numBatches = reader.batchStarts.length - 1;
 
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const length = reader.batchStarts[bi + 1] - reader.batchStarts[bi];
         for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -80,6 +82,7 @@ export async function computeHistogramForColumn(
         }
     }
 
+    throwIfAborted(signal);
     if (count === 0) return [];
     if (min === max) {
         return [{ lo: min, hi: max, count }];
@@ -92,10 +95,8 @@ export async function computeHistogramForColumn(
     }
     bins[BIN_COUNT - 1].hi = max;
 
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const length = reader.batchStarts[bi + 1] - reader.batchStarts[bi];
         for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -107,5 +108,6 @@ export async function computeHistogramForColumn(
             bins[idx].count++;
         }
     }
+    throwIfAborted(signal);
     return bins;
 }

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -232,7 +232,7 @@ export type ExtensionToWebview =
     | {
         /** Sent before the host reads columns to reapply a saved
          *  sort/filter on open (#519), so the webview can explain the wait
-         *  (instead of a bare "Loading…") and offer a Cancel control.
+         *  (instead of a bare "Loading…") and offer a skip action.
          *  `restoreId` is a monotonic id (NOT `panelGeneration`, which the
          *  host bumps only on dataset replace) identifying this restore so
          *  a `cancelRestore` can be matched to it. `sort` / `filter` say

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -230,6 +230,20 @@ export type ExtensionToWebview =
         state: 'pending' | 'idle';
     }
     | {
+        /** Sent before the host reads columns to reapply a saved
+         *  sort/filter on open (#519), so the webview can explain the wait
+         *  (instead of a bare "Loading…") and offer a Cancel control.
+         *  `restoreId` is a monotonic id (NOT `panelGeneration`, which the
+         *  host bumps only on dataset replace) identifying this restore so
+         *  a `cancelRestore` can be matched to it. `sort` / `filter` say
+         *  which preferences are being applied (for the wording). */
+        type: 'restorePending';
+        panelGeneration: number;
+        restoreId: number;
+        sort: boolean;
+        filter: boolean;
+    }
+    | {
         type: 'copyDone';
         panelGeneration: number;
         requestId: number;
@@ -390,6 +404,16 @@ export type WebviewToExtension =
         panelGeneration: number;
         schemaHash: string;
         filter: FilterState;
+    }
+    | {
+        /** Asks the host to abandon the in-progress restore of a saved
+         *  sort/filter (#519) and show the data unsorted/unfiltered,
+         *  forgetting the saved preferences. `restoreId` echoes the value
+         *  from the `restorePending` being cancelled, so a stale cancel
+         *  from a prior lifecycle is ignored by the host. */
+        type: 'cancelRestore';
+        panelGeneration: number;
+        restoreId: number;
     };
 
 /** Hard cap on the number of cells the extension will materialize for a

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -2,9 +2,10 @@
  * Protocol types for the data-viewer postMessage channel.
  *
  * Every message after the initial `webviewReady` handshake carries the
- * panel's monotonic `panelGeneration`. Receivers drop messages tagged with
- * an older generation than the receiver's current one — this is how stale
- * `getRows` / `copy` / `labels` responses are filtered out after a `replace`.
+ * panel's monotonic `panelGeneration`. The host bumps it on webview reload
+ * and dataset replacement; receivers drop messages from older generations
+ * so stale `getRows` / `copy` / `labels` / transform responses cannot leak
+ * across those lifecycle boundaries.
  */
 
 import type { Cell } from './wire-format';
@@ -204,12 +205,20 @@ export type ExtensionToWebview =
         requestId: number;
         sort: SortState;
         fromPersistence: boolean;
+        /** True when this is an authoritative rollback after a failed
+         *  interactive setSort request. The webview should update display
+         *  state but must not persist the rolled-back state as a new user
+         *  preference. */
+        rollback?: boolean;
+        /** Optional failure text carried by a rollback response. */
+        error?: string;
     }
     | {
         /** Lifecycle ping driving the toolbar "Sorting…" progress pill.
          *  `state: 'pending'` shows it; `'idle'` clears it. */
         type: 'sortStatus';
         panelGeneration: number;
+        requestId: number;
         state: 'pending' | 'idle';
     }
     | {
@@ -223,20 +232,28 @@ export type ExtensionToWebview =
         filter: FilterState;
         nrowFiltered: number;
         fromPersistence: boolean;
+        /** True when this is an authoritative rollback after a failed
+         *  interactive setFilters request. The webview should clear pending
+         *  intent but must not persist the rolled-back state as a new user
+         *  preference. */
+        rollback?: boolean;
+        /** Optional failure text carried by a rollback response. */
+        error?: string;
     }
     | {
         type: 'filterStatus';
         panelGeneration: number;
+        requestId: number;
         state: 'pending' | 'idle';
     }
     | {
         /** Sent before the host reads columns to reapply a saved
          *  sort/filter on open (#519), so the webview can explain the wait
          *  (instead of a bare "Loading…") and offer a skip action.
-         *  `restoreId` is a monotonic id (NOT `panelGeneration`, which the
-         *  host bumps only on dataset replace) identifying this restore so
-         *  a `cancelRestore` can be matched to it. `sort` / `filter` say
-         *  which preferences are being applied (for the wording). */
+         *  `restoreId` is a monotonic id identifying this restore so a
+         *  `cancelRestore` can be matched to it independently of lifecycle
+         *  generation bumps. `sort` / `filter` say which preferences are
+         *  being applied (for the wording). */
         type: 'restorePending';
         panelGeneration: number;
         restoreId: number;
@@ -374,6 +391,10 @@ export type WebviewToExtension =
         type: 'setSort';
         panelGeneration: number;
         requestId: number;
+        /** Request id of the sort state the webview has actually accepted
+         *  and wants restored if this request fails. Older direct callers may
+         *  omit it; the host then falls back to its current state. */
+        rollbackBaseRequestId?: number;
         keys: SortKey[];
         labelsOn: boolean;
         formatOn: boolean;
@@ -396,6 +417,10 @@ export type WebviewToExtension =
         type: 'setFilters';
         panelGeneration: number;
         requestId: number;
+        /** Request id of the filter state the webview has actually accepted
+         *  and wants restored if this request fails. Older direct callers may
+         *  omit it; the host then falls back to its current state. */
+        rollbackBaseRequestId?: number;
         entries: FilterEntry[];
         labelsOn: boolean;
     }

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -103,6 +103,11 @@ export class DataViewerPanel {
     private restoreId = -1;
     /** Source of {@link restoreId}; bumped per restore begun. */
     private restoreSeq = 0;
+    /** True when the user clicked Cancel on an in-flight restore but the
+     *  abort has not yet been observed by paintWithRestore. Lets a webview
+     *  reload that races into that window honor the cancel (forget the
+     *  prefs) instead of bailing stale and re-restoring them. */
+    private restoreCancelRequested = false;
     /** Active toolbar last shipped to the webview, captured so the late
      *  clear-and-forget can rebuild a `replace` without re-loading the
      *  store. */
@@ -230,16 +235,18 @@ export class DataViewerPanel {
     // restores never overlap. The chain wraps only these public entry
     // points; internal delegation (an uninitialized replace) calls the
     // *impl* directly so it never awaits a job queued behind itself.
-    private sendInit(): Promise<boolean> {
-        const next = this.sendChain.catch(() => {}).then(() => this.sendInitImpl());
+    private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+        const next = this.sendChain.catch(() => {}).then(fn);
         this.sendChain = next.then(() => {}, () => {});
         return next;
     }
 
+    private sendInit(): Promise<boolean> {
+        return this.enqueue(() => this.sendInitImpl());
+    }
+
     private sendReplace(): Promise<void> {
-        const next = this.sendChain.catch(() => {}).then(() => this.sendReplaceImpl());
-        this.sendChain = next.then(() => {}, () => {});
-        return next;
+        return this.enqueue(() => this.sendReplaceImpl());
     }
 
     private sendInitImpl(): Promise<boolean> {
@@ -433,6 +440,7 @@ export class DataViewerPanel {
         this.restoreAbort = new AbortController();
         this.restoreId = ++this.restoreSeq;
         this.restoring = true;
+        this.restoreCancelRequested = false;
         void this.webviewPanel.webview.postMessage({
             type: 'restorePending',
             panelGeneration: generation,
@@ -447,6 +455,7 @@ export class DataViewerPanel {
      *  (synchronous). The caller persists the forget separately. */
     private resetRestoredPrefs(): void {
         this.restoreId = -1;
+        this.restoreCancelRequested = false;
         this.sort = EMPTY_SORT;
         this.permutation = undefined;
         this.sortGeneration += 1;
@@ -472,6 +481,7 @@ export class DataViewerPanel {
         this.restoreAbort = null;
         this.restoring = false;
         this.restoreId = -1;
+        this.restoreCancelRequested = false;
     }
 
     /** Schema hash of the live reader — used by the late clear-and-forget
@@ -516,6 +526,10 @@ export class DataViewerPanel {
     ): Promise<void> {
         if (msg.restoreId !== this.restoreId) return;
         if (this.restoring) {
+            // Record the cancel intent so a webview reload that races the
+            // abort (and bumps generation, making paintWithRestore bail
+            // stale) still forgets the prefs rather than re-restoring them.
+            this.restoreCancelRequested = true;
             this.restoreAbort?.abort();
             return;
         }
@@ -677,8 +691,15 @@ export class DataViewerPanel {
             // The queued sendInit re-reads from the store and re-restores
             // (raven has no one-shot restored flags).
             if (this.restoring) {
+                // If the user had clicked Cancel on this restore, honor it:
+                // forget the prefs durably before re-arming, so the queued
+                // re-send shows natural order instead of re-restoring. A pure
+                // reload (no pending cancel) keeps the prefs.
+                const cancelled = this.restoreCancelRequested;
+                const hash = this.currentSchemaHash();
                 this.generation += 1;
                 this.abortAndClearRestore();
+                if (cancelled) await this.forgetPersistedPrefs(hash);
             }
             await this.sendInit();
             return;

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -191,7 +191,13 @@ export class DataViewerPanel {
         // Abort any in-flight restore from the previous dataset. The
         // generation bump above makes it bail *stale* (prefs intact); the
         // abort frees the serialized send chain so sendReplace below isn't
-        // stuck behind the dropped read.
+        // stuck behind the dropped read. But if the user had clicked Cancel
+        // on that restore, honor it (forget the prev dataset's prefs) before
+        // re-arming — abortAndClearRestore clears the flag, so capture it
+        // (and the prev schema hash, while this.reader is still the old one)
+        // first. Mirrors the webviewReady reload path.
+        const restoreCancelled = this.restoreCancelRequested;
+        const prevSchemaHash = this.currentSchemaHash();
         this.abortAndClearRestore();
         // Clear cached visible range so a stale range from the previous
         // dataset is never returned for the new one. The next lifecycle
@@ -216,6 +222,10 @@ export class DataViewerPanel {
         this.reader = reader;
         this.filePath = filePath;
         this.trace('replace', { filePath, nrow: reader.nrow, columns: reader.schema.columns.length });
+        // Honor a cancel of the previous dataset's restore by forgetting its
+        // prefs before sendReplace re-reads the store (so a same-schema reopen
+        // does not silently re-apply what the user cancelled).
+        if (restoreCancelled) await this.forgetPersistedPrefs(prevSchemaHash);
         if (this.webviewReady) await this.sendReplace();
         await prevReader.close().catch(() => undefined);
         try { await fs.unlink(prevPath); } catch { /* ignore */ }
@@ -319,41 +329,53 @@ export class DataViewerPanel {
                 );
                 if (generation !== this.generation || reader !== this.reader) return false;
             }
-            // Undo a sort that completed before the cancel landed during the
-            // filter read, so chips and effective order agree on natural.
-            if (isCancelled()) this.resetRestoredPrefs();
+            // Snapshot the cancel decision ONCE before the paint. The reads
+            // are done; using a single snapshot for resetRestoredPrefs (below)
+            // keeps the post/forget/filterApplied branches internally
+            // consistent — re-reading the live isCancelled() across the
+            // `await postPaint` could split-brain (e.g. suppress filterApplied
+            // while leaving filteredIndices applied). A cancel that lands
+            // *during* the paint is handled by the cancelledNow branch.
+            const cancelledBeforePaint = isCancelled();
+            if (cancelledBeforePaint) this.resetRestoredPrefs();
 
             await this.postPaint(kind, generation, layoutHash, activeToolbar);
             if (kind === 'init') this.webviewInitialized = true;
 
-            // A restored filter changes the visible row count; the webview
-            // learns the effective count from filterApplied.
-            if (!isCancelled() && this.filteredIndices) {
-                await this.webviewPanel.webview.postMessage({
-                    type: 'filterApplied',
-                    panelGeneration: generation,
-                    requestId: -1,
-                    filter: this.filter,
-                    nrowFiltered: this.filteredIndices.length,
-                    fromPersistence: true,
-                } satisfies ExtensionToWebview);
+            if (cancelledBeforePaint) {
+                // Persist the forget only after the paint, so a store-write
+                // failure cannot strand the webview waiting on a message it
+                // never receives.
+                await this.forgetPersistedPrefs(layoutHash);
+            } else if (isCancelled()) {
+                // The user cancelled during the paint (after the reads, before
+                // the finally). The chips were already posted; honor the cancel
+                // as a clear-and-forget so the grid ends in natural order.
+                await this.clearAndForgetNaturalOrder(layoutHash);
+            } else {
+                // Normal completion. A restored filter changes the visible row
+                // count; the webview learns the effective count from
+                // filterApplied (metadata.nrow stays the full dataset size).
+                if (this.filteredIndices) {
+                    await this.webviewPanel.webview.postMessage({
+                        type: 'filterApplied',
+                        panelGeneration: generation,
+                        requestId: -1,
+                        filter: this.filter,
+                        nrowFiltered: this.filteredIndices.length,
+                        fromPersistence: true,
+                    } satisfies ExtensionToWebview);
+                }
+                if (sortFailed || filterFailed) {
+                    const what = sortFailed && filterFailed
+                        ? 'sort and filter'
+                        : sortFailed ? 'sort' : 'filter';
+                    vscode.window.showWarningMessage(
+                        `Could not reapply the saved ${what} for this dataset; `
+                        + 'it was not applied.',
+                    );
+                }
             }
-            // Suppress the failure warning on cancel: a read may have
-            // genuinely failed before the cancel landed, but the user chose
-            // natural order, so a "couldn't reapply" popup would be noise.
-            if (!isCancelled() && (sortFailed || filterFailed)) {
-                const what = sortFailed && filterFailed
-                    ? 'sort and filter'
-                    : sortFailed ? 'sort' : 'filter';
-                vscode.window.showWarningMessage(
-                    `Could not reapply the saved ${what} for this dataset; `
-                    + 'it was not applied.',
-                );
-            }
-            // Persist the forget only after the paint, so a store-write
-            // failure cannot strand the webview waiting on a message it
-            // never receives.
-            if (isCancelled()) await this.forgetPersistedPrefs(layoutHash);
             return true;
         } finally {
             // Only the call that began this restore clears its state, and
@@ -533,11 +555,21 @@ export class DataViewerPanel {
             this.restoreAbort?.abort();
             return;
         }
-        // Invalidate synchronously (bump generation) BEFORE awaiting the
-        // store writes, so an in-flight getRows reply under the old
-        // effective permutation is dropped (panel.ts generation gate) and
-        // the natural-order replace adopts the new generation.
-        const hash = this.currentSchemaHash();
+        // The restore already completed (the cross-window race): honor the
+        // click as a clear-and-forget so it is never silently dropped.
+        await this.clearAndForgetNaturalOrder(this.currentSchemaHash());
+    }
+
+    /**
+     * Drop the restored sort/filter to natural order and forget the
+     * persisted prefs. Bumps the generation and clears the row state
+     * synchronously (BEFORE awaiting the store writes) so an in-flight
+     * getRows reply under the old effective permutation is dropped by the
+     * generation gate, then posts a natural-order `replace` so the webview
+     * adopts the new generation and drops the chips. Shared by the
+     * late-cancel path and the cancel-during-paint path.
+     */
+    private async clearAndForgetNaturalOrder(hash: string): Promise<void> {
         this.resetRestoredPrefs();
         this.generation += 1;
         await this.postReplaceNaturalOrder(this.generation);

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -377,6 +377,19 @@ export class DataViewerPanel {
                         nrowFiltered: this.filteredIndices.length,
                         fromPersistence: true,
                     } satisfies ExtensionToWebview);
+                    // The filterApplied post is the second (and last)
+                    // post-decision await window. A cancel/lifecycle abort can
+                    // land during it: a lifecycle abort bumped generation →
+                    // bail stale (prefs intact); a user Cancel (no bump) →
+                    // honor as clear-and-forget. Only one cancelRestore is ever
+                    // sent, so this single recheck closes the window.
+                    if (generation !== this.generation || reader !== this.reader) {
+                        return false;
+                    }
+                    if (isCancelled()) {
+                        await this.clearAndForgetNaturalOrder(layoutHash);
+                        return true;
+                    }
                 }
                 if (sortFailed || filterFailed) {
                     const what = sortFailed && filterFailed

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -26,6 +26,7 @@ import {
 } from './messages';
 import { computePermutation } from './sort';
 import { computeFilteredIndices } from './filter';
+import { isAbortError } from './abort';
 import { computeHistogramForColumn, isNumericArrowType } from './histograms';
 import { LayoutStore, schemaHash } from './layout-state';
 import { ToolbarState, ToolbarStateStore } from './toolbar-state';
@@ -85,6 +86,31 @@ export class DataViewerPanel {
     private lastViewportRange: { start: number; end: number } | undefined;
     /** Latest selected focus cell observed via lifecycle events. */
     private lastFocusCell: { row: number; col: number } | undefined;
+    // --- Saved-sort/filter restore on open (#519) ---
+    /** Controls the in-flight restore's column reads. A webview Cancel
+     *  aborts it; cancellation is read from the captured signal, not a
+     *  shared boolean, so a concurrent send can't erase an in-flight
+     *  cancel. */
+    private restoreAbort: AbortController | null = null;
+    /** True while a cancellable restore is reading columns. Gates the
+     *  in-flight vs. already-completed cancel paths and makes interactive
+     *  setSort/setFilters no-op so a generation bump can't strand it. */
+    private restoring = false;
+    /** Monotonic id of the active restore (-1 ⇔ none). The
+     *  restorePending/cancelRestore handshake key. NOT `generation` —
+     *  webviewReady reloads do not bump generation, so reusing it would
+     *  alias restores across a reload. */
+    private restoreId = -1;
+    /** Source of {@link restoreId}; bumped per restore begun. */
+    private restoreSeq = 0;
+    /** Active toolbar last shipped to the webview, captured so the late
+     *  clear-and-forget can rebuild a `replace` without re-loading the
+     *  store. */
+    private lastToolbar: ToolbarState | undefined;
+    /** Serializes sendInit/sendReplace so two restores never overlap (a
+     *  reload mid-restore must not start a concurrent send that overwrites
+     *  {@link restoreAbort}). */
+    private sendChain: Promise<void> = Promise.resolve();
 
     private constructor(
         panelName: string,
@@ -157,6 +183,11 @@ export class DataViewerPanel {
             return;
         }
         this.generation += 1;
+        // Abort any in-flight restore from the previous dataset. The
+        // generation bump above makes it bail *stale* (prefs intact); the
+        // abort frees the serialized send chain so sendReplace below isn't
+        // stuck behind the dropped read.
+        this.abortAndClearRestore();
         // Clear cached visible range so a stale range from the previous
         // dataset is never returned for the new one. The next lifecycle
         // event from the webview will repopulate it.
@@ -195,7 +226,46 @@ export class DataViewerPanel {
         };
     }
 
-    private async sendInit(): Promise<boolean> {
+    // sendInit / sendReplace are serialized through `sendChain` so two
+    // restores never overlap. The chain wraps only these public entry
+    // points; internal delegation (an uninitialized replace) calls the
+    // *impl* directly so it never awaits a job queued behind itself.
+    private sendInit(): Promise<boolean> {
+        const next = this.sendChain.catch(() => {}).then(() => this.sendInitImpl());
+        this.sendChain = next.then(() => {}, () => {});
+        return next;
+    }
+
+    private sendReplace(): Promise<void> {
+        const next = this.sendChain.catch(() => {}).then(() => this.sendReplaceImpl());
+        this.sendChain = next.then(() => {}, () => {});
+        return next;
+    }
+
+    private sendInitImpl(): Promise<boolean> {
+        return this.paintWithRestore('init');
+    }
+
+    private async sendReplaceImpl(): Promise<void> {
+        if (!this.webviewInitialized) {
+            await this.sendInitImpl();
+            return;
+        }
+        await this.paintWithRestore('replace');
+    }
+
+    /**
+     * Load persisted state, (re)apply any saved sort/filter against the
+     * current reader, and post the paint-enabling `init`/`replace`. When
+     * a saved pref applies, a cancellable restore is begun first: a
+     * `restorePending` precedes the (potentially long) column reads so the
+     * webview can explain the wait and offer Cancel (#519).
+     *
+     * On Cancel the restore is abandoned, the in-memory sort/filter reset,
+     * the persisted prefs forgotten, and the grid shown in natural order.
+     * A genuine (non-abort) read failure instead keeps the prefs and warns.
+     */
+    private async paintWithRestore(kind: 'init' | 'replace'): Promise<boolean> {
         const generation = this.generation;
         const reader = this.reader;
         const columns = reader.schema.columns;
@@ -215,184 +285,342 @@ export class DataViewerPanel {
         this.layout = layout ?? { columnWidths: {}, hiddenColumns: [] };
         this.dictionaries = this.collectDictionaries();
         const activeToolbar = toolbar ?? this.defaultToolbar();
-        const restored = await this.restoreSort(savedSort, activeToolbar, generation, reader);
-        if (generation !== this.generation || reader !== this.reader) return false;
-        const restoredFilter = await this.restoreFilter(savedFilter, activeToolbar, generation, reader);
-        if (generation !== this.generation || reader !== this.reader) return false;
-        const msg: ExtensionToWebview = {
-            type: 'init',
+        this.lastToolbar = activeToolbar;
+
+        // Begin a cancellable restore if saved prefs apply. `myAbort`
+        // identifies this restore's controller; cancellation is read from
+        // its own signal so a concurrent send reassigning this.restoreAbort
+        // can't change what THIS call sees.
+        const began = this.maybeBeginRestore(generation, savedSort, savedFilter);
+        const myAbort = began ? this.restoreAbort : null;
+        const isCancelled = () => myAbort?.signal.aborted === true;
+        try {
+            // restoreSort/restoreFilter set this.sort/permutation/filter/
+            // filteredIndices as a side effect and return true only on a
+            // genuine (non-abort) failure.
+            const sortFailed = await this.restoreSort(
+                savedSort, activeToolbar, generation, reader, myAbort?.signal,
+            );
+            // A refresh/reload during the read supersedes this attempt; bail
+            // *stale* (prefs intact) before the cancel path. A user Cancel
+            // does NOT bump generation, so it falls through to forget below.
+            if (generation !== this.generation || reader !== this.reader) return false;
+            let filterFailed = false;
+            if (!isCancelled()) {
+                filterFailed = await this.restoreFilter(
+                    savedFilter, activeToolbar, generation, reader, myAbort?.signal,
+                );
+                if (generation !== this.generation || reader !== this.reader) return false;
+            }
+            // Undo a sort that completed before the cancel landed during the
+            // filter read, so chips and effective order agree on natural.
+            if (isCancelled()) this.resetRestoredPrefs();
+
+            await this.postPaint(kind, generation, layoutHash, activeToolbar);
+            if (kind === 'init') this.webviewInitialized = true;
+
+            // A restored filter changes the visible row count; the webview
+            // learns the effective count from filterApplied.
+            if (!isCancelled() && this.filteredIndices) {
+                await this.webviewPanel.webview.postMessage({
+                    type: 'filterApplied',
+                    panelGeneration: generation,
+                    requestId: -1,
+                    filter: this.filter,
+                    nrowFiltered: this.filteredIndices.length,
+                    fromPersistence: true,
+                } satisfies ExtensionToWebview);
+            }
+            // Suppress the failure warning on cancel: a read may have
+            // genuinely failed before the cancel landed, but the user chose
+            // natural order, so a "couldn't reapply" popup would be noise.
+            if (!isCancelled() && (sortFailed || filterFailed)) {
+                const what = sortFailed && filterFailed
+                    ? 'sort and filter'
+                    : sortFailed ? 'sort' : 'filter';
+                vscode.window.showWarningMessage(
+                    `Could not reapply the saved ${what} for this dataset; `
+                    + 'it was not applied.',
+                );
+            }
+            // Persist the forget only after the paint, so a store-write
+            // failure cannot strand the webview waiting on a message it
+            // never receives.
+            if (isCancelled()) await this.forgetPersistedPrefs(layoutHash);
+            return true;
+        } finally {
+            // Only the call that began this restore clears its state, and
+            // only if a concurrent refresh hasn't swapped in a newer one.
+            if (began && this.restoreAbort === myAbort) {
+                this.restoring = false;
+                this.restoreAbort = null;
+            }
+        }
+    }
+
+    /** Build and post the paint-enabling init/replace message from the
+     *  current in-memory state (sort/filter are EMPTY after a cancel, so
+     *  no chips render). */
+    private async postPaint(
+        kind: 'init' | 'replace',
+        generation: number,
+        layoutHash: string,
+        activeToolbar: ToolbarState,
+    ): Promise<void> {
+        const common = {
             panelGeneration: generation,
-            nrow: reader.nrow,
+            nrow: this.reader.nrow,
             columns: this.columns,
             layout: this.layout,
             toolbar: activeToolbar,
-            settings: this.settings,
             dictionaries: this.dictionaries,
             schemaHash: layoutHash,
-            sort: restored,
-            filter: restoredFilter,
+            sort: this.sort,
+            filter: this.filter,
         };
-        this.trace('post-init', {
+        const msg: ExtensionToWebview = kind === 'init'
+            ? { type: 'init', ...common, settings: this.settings }
+            : { type: 'replace', ...common };
+        this.trace(`post-${kind}`, {
             generation,
-            nrow: reader.nrow,
+            nrow: this.reader.nrow,
             columns: this.columns.length,
             schemaHash: layoutHash,
             loadedLayoutHidden: this.layout.hiddenColumns,
-            loadedToolbar: toolbar ?? null,
+            loadedToolbar: activeToolbar,
         });
         await this.webviewPanel.webview.postMessage(msg);
-        this.webviewInitialized = true;
-        if (this.filteredIndices) {
-            await this.webviewPanel.webview.postMessage({
-                type: 'filterApplied',
-                panelGeneration: generation,
-                requestId: -1,
-                filter: this.filter,
-                nrowFiltered: this.filteredIndices.length,
-                fromPersistence: true,
-            } satisfies ExtensionToWebview);
-        }
+    }
+
+    // -------------------------------------------------------
+    // Saved-preference restore handshake (#519)
+    // -------------------------------------------------------
+
+    /** Whether `saved` references only columns that still exist. */
+    private columnsInRange(indices: number[]): boolean {
+        const max = this.columns.length - 1;
+        return indices.every(i => i >= 0 && i <= max);
+    }
+
+    /**
+     * If a saved sort and/or filter applies to the current dataset, arm a
+     * cancellable restore (fresh AbortController, fresh restoreId) and post
+     * `restorePending` before the column reads. Returns whether one began.
+     *
+     * Applicability mirrors the real restore guards: a sort is applicable
+     * iff it has keys all in range (restoreSort drops it otherwise); a
+     * filter iff it has an in-range, enabled entry (restoreFilter rejects
+     * any out-of-range entry, and computeFilteredIndices only reads when an
+     * enabled entry survives) — so the banner appears iff a heavy read will
+     * actually run.
+     */
+    private maybeBeginRestore(
+        generation: number,
+        savedSort: SortState | undefined,
+        savedFilter: FilterState | undefined,
+    ): boolean {
+        const hasSort = this.settings.persistSort
+            && !!savedSort
+            && savedSort.keys.length > 0
+            && this.columnsInRange(savedSort.keys.map(k => k.columnIndex));
+        const hasFilter = this.settings.persistFilters
+            && !!savedFilter
+            && savedFilter.entries.length > 0
+            && this.columnsInRange(savedFilter.entries.map(e => e.columnIndex))
+            && savedFilter.entries.some(e => e.enabled);
+        if (!hasSort && !hasFilter) return false;
+
+        this.restoreAbort = new AbortController();
+        this.restoreId = ++this.restoreSeq;
+        this.restoring = true;
+        void this.webviewPanel.webview.postMessage({
+            type: 'restorePending',
+            panelGeneration: generation,
+            restoreId: this.restoreId,
+            sort: hasSort,
+            filter: hasFilter,
+        } satisfies ExtensionToWebview);
         return true;
     }
 
-    private async sendReplace(): Promise<void> {
-        if (!this.webviewInitialized) {
-            await this.sendInit();
-            return;
+    /** Drop the restored sort/filter from memory and consume the handshake
+     *  (synchronous). The caller persists the forget separately. */
+    private resetRestoredPrefs(): void {
+        this.restoreId = -1;
+        this.sort = EMPTY_SORT;
+        this.permutation = undefined;
+        this.sortGeneration += 1;
+        this.filter = EMPTY_FILTER;
+        this.filteredIndices = undefined;
+        this.filterGeneration += 1;
+    }
+
+    /** Consume the restore handshake because the user superseded the
+     *  restored prefs (a new sort/filter), so a later cancelRestore with
+     *  the old id can no longer reach the clear-and-forget branch. */
+    private consumeRestoreHandshake(): void {
+        this.restoreId = -1;
+    }
+
+    /** Abort the in-flight restore's reads and clear the handshake. Used by
+     *  the lifecycle-interruption paths (a webview reload and replace()):
+     *  both bump generation first, which makes the aborted restore bail
+     *  *stale* (prefs intact), while the abort lets the serialized chain
+     *  advance at once instead of waiting on the dropped read. */
+    private abortAndClearRestore(): void {
+        this.restoreAbort?.abort();
+        this.restoreAbort = null;
+        this.restoring = false;
+        this.restoreId = -1;
+    }
+
+    /** Schema hash of the live reader — used by the late clear-and-forget
+     *  path, which runs outside the send methods (where `layoutHash` is a
+     *  local). */
+    private currentSchemaHash(): string {
+        return schemaHash(this.reader.schema.columns);
+    }
+
+    /** Forget the persisted sort/filter for this dataset × schema. */
+    private async forgetPersistedPrefs(hash: string): Promise<void> {
+        if (this.settings.persistSort) {
+            await this.sortStore.clear(this.panelName, hash);
         }
-        const generation = this.generation;
-        const reader = this.reader;
-        const columns = reader.schema.columns;
-        const layoutHash = schemaHash(columns);
-        const [layout, toolbar, savedSort, savedFilter] = await Promise.all([
-            this.store.load(this.panelName, layoutHash),
-            this.toolbarStore.load(this.panelName, layoutHash),
-            this.settings.persistSort
-                ? this.sortStore.load(this.panelName, layoutHash)
-                : Promise.resolve(undefined),
-            this.settings.persistFilters
-                ? this.filterStore.load(this.panelName, layoutHash)
-                : Promise.resolve(undefined),
-        ]);
-        if (generation !== this.generation || reader !== this.reader) return;
-        this.columns = columns;
-        this.layout = layout ?? { columnWidths: {}, hiddenColumns: [] };
-        this.dictionaries = this.collectDictionaries();
-        const activeToolbar = toolbar ?? this.defaultToolbar();
-        const restored = await this.restoreSort(savedSort, activeToolbar, generation, reader);
-        if (generation !== this.generation || reader !== this.reader) return;
-        const restoredFilter = await this.restoreFilter(savedFilter, activeToolbar, generation, reader);
-        if (generation !== this.generation || reader !== this.reader) return;
-        const msg: ExtensionToWebview = {
-            type: 'replace',
-            panelGeneration: generation,
-            nrow: reader.nrow,
-            columns: this.columns,
-            layout: this.layout,
-            toolbar: activeToolbar,
-            dictionaries: this.dictionaries,
-            schemaHash: layoutHash,
-            sort: restored,
-            filter: restoredFilter,
-        };
-        this.trace('post-replace', {
-            generation,
-            nrow: reader.nrow,
-            columns: this.columns.length,
-            schemaHash: layoutHash,
-            loadedLayoutHidden: this.layout.hiddenColumns,
-            loadedToolbar: toolbar ?? null,
-        });
-        await this.webviewPanel.webview.postMessage(msg);
-        if (this.filteredIndices) {
-            await this.webviewPanel.webview.postMessage({
-                type: 'filterApplied',
-                panelGeneration: generation,
-                requestId: -1,
-                filter: this.filter,
-                nrowFiltered: this.filteredIndices.length,
-                fromPersistence: true,
-            } satisfies ExtensionToWebview);
+        if (this.settings.persistFilters) {
+            await this.filterStore.clear(this.panelName, hash);
         }
     }
 
-    /** Attempt to restore a persisted sort. Returns the SortState to ship
-     *  to the webview, and as a side effect updates `this.sort` and
-     *  `this.permutation`. Always recomputes the permutation against the
-     *  current reader — schema-hash equality is not evidence that two
-     *  datasets share row values, so the only persisted truth is the
-     *  list of sort keys. The state is dropped when:
+    /** Post a natural-order `replace` from in-memory state at the given
+     *  (already-bumped) generation, so the webview adopts the new
+     *  generation and drops chips. Used by the late clear-and-forget. */
+    private async postReplaceNaturalOrder(generation: number): Promise<void> {
+        await this.postPaint(
+            'replace',
+            generation,
+            this.currentSchemaHash(),
+            this.lastToolbar ?? this.defaultToolbar(),
+        );
+    }
+
+    /**
+     * Handle a webview Cancel of the saved-preference restore. Ignores a
+     * stale/consumed id. While the restore is in flight, aborts the column
+     * reads (paintWithRestore's cancelled path forgets + posts natural
+     * order). If the restore already completed (the cross-window race),
+     * honors the click as an explicit clear-and-forget so it is never
+     * silently dropped.
+     */
+    private async handleCancelRestore(
+        msg: Extract<WebviewToExtension, { type: 'cancelRestore' }>,
+    ): Promise<void> {
+        if (msg.restoreId !== this.restoreId) return;
+        if (this.restoring) {
+            this.restoreAbort?.abort();
+            return;
+        }
+        // Invalidate synchronously (bump generation) BEFORE awaiting the
+        // store writes, so an in-flight getRows reply under the old
+        // effective permutation is dropped (panel.ts generation gate) and
+        // the natural-order replace adopts the new generation.
+        const hash = this.currentSchemaHash();
+        this.resetRestoredPrefs();
+        this.generation += 1;
+        await this.postReplaceNaturalOrder(this.generation);
+        await this.forgetPersistedPrefs(hash);
+    }
+
+    /** Attempt to restore a persisted sort, updating `this.sort` and
+     *  `this.permutation` as a side effect (the caller reads them when
+     *  building the paint message). Returns true iff a genuine (non-abort)
+     *  read failure occurred, so the caller can warn and keep the saved
+     *  pref; a user-Cancel abort returns false (silent natural order).
+     *  Always recomputes the permutation against the current reader —
+     *  schema-hash equality is not evidence that two datasets share row
+     *  values, so the only persisted truth is the list of sort keys. The
+     *  sort is dropped (no failure) when:
      *    - persistSort is off,
      *    - no saved state exists,
      *    - the saved state had no keys (already empty), or
      *    - any key references a column that no longer exists.
+     *  An optional `signal` makes the column reads cancellable (#519).
      *  Caller is responsible for the post-await generation check. */
     private async restoreSort(
         saved: SortState | undefined,
         toolbar: ToolbarState,
         generation: number,
         reader: ArrowSliceReader,
-    ): Promise<SortState> {
+        signal?: AbortSignal,
+    ): Promise<boolean> {
         this.sort = EMPTY_SORT;
         this.permutation = undefined;
-        if (!saved || saved.keys.length === 0) return EMPTY_SORT;
+        if (!saved || saved.keys.length === 0) return false;
         const maxColIndex = this.columns.length - 1;
         for (const k of saved.keys) {
-            if (k.columnIndex < 0 || k.columnIndex > maxColIndex) return EMPTY_SORT;
+            if (k.columnIndex < 0 || k.columnIndex > maxColIndex) return false;
         }
         try {
             const perm = await computePermutation(reader, saved.keys, {
                 labelsOn: toolbar.labelsOn,
                 formatOn: toolbar.formatOn,
                 digits: toolbar.digits,
-            });
-            if (generation !== this.generation || reader !== this.reader) return EMPTY_SORT;
+            }, { signal });
+            if (generation !== this.generation || reader !== this.reader) return false;
             this.sort = {
                 keys: saved.keys,
                 labelsOnWhenSorted: toolbar.labelsOn,
             };
             this.permutation = perm;
             this.sortGeneration += 1;
-            return this.sort;
-        } catch {
-            return EMPTY_SORT;
+            return false;
+        } catch (err) {
+            // A user Cancel aborts the read → natural order, silent. A
+            // genuine read failure → natural order, but report so the
+            // caller can warn and keep the saved pref for next time.
+            return !isAbortError(err);
         }
     }
 
-    /** Attempt to restore a persisted filter. Returns the FilterState to
-     *  ship to the webview, and as a side effect updates `this.filter` and
-     *  `this.filteredIndices`. The state is dropped when:
+    /** Attempt to restore a persisted filter, updating `this.filter` and
+     *  `this.filteredIndices` as a side effect. Returns true iff a genuine
+     *  (non-abort) read failure occurred (see {@link restoreSort}); a
+     *  user-Cancel abort returns false. The filter is dropped (no failure)
+     *  when:
      *    - persistFilters is off,
      *    - no saved state exists,
      *    - the saved state had no entries (already empty), or
      *    - any entry references a column that no longer exists.
+     *  An optional `signal` makes the column reads cancellable (#519).
      *  Caller is responsible for the post-await generation check. */
     private async restoreFilter(
         saved: FilterState | undefined,
         toolbar: ToolbarState,
         generation: number,
         reader: ArrowSliceReader,
-    ): Promise<FilterState> {
+        signal?: AbortSignal,
+    ): Promise<boolean> {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
-        if (!saved || saved.entries.length === 0) return EMPTY_FILTER;
+        if (!saved || saved.entries.length === 0) return false;
         const maxColIndex = this.columns.length - 1;
         for (const e of saved.entries) {
-            if (e.columnIndex < 0 || e.columnIndex > maxColIndex) return EMPTY_FILTER;
+            if (e.columnIndex < 0 || e.columnIndex > maxColIndex) return false;
         }
         try {
             const indices = await computeFilteredIndices(reader, saved, {
                 labelsOn: toolbar.labelsOn,
                 formatOn: toolbar.formatOn,
                 digits: toolbar.digits,
-            });
-            if (generation !== this.generation || reader !== this.reader) return EMPTY_FILTER;
+            }, { signal });
+            if (generation !== this.generation || reader !== this.reader) return false;
             this.filter = { entries: saved.entries, labelsOnWhenFiltered: toolbar.labelsOn };
             this.filteredIndices = indices;
             this.filterGeneration += 1;
-            return this.filter;
-        } catch {
-            return EMPTY_FILTER;
+            return false;
+        } catch (err) {
+            // Cancel → natural order silently; genuine failure → natural
+            // order, reported so the caller can warn and keep the filter.
+            return !isAbortError(err);
         }
     }
 
@@ -442,7 +670,21 @@ export class DataViewerPanel {
         if (m.type === 'webviewReady') {
             this.trace('webview-ready', { generation: this.generation });
             this.webviewReady = true;
+            // A webview reload mid-restore is a lifecycle interruption, not
+            // a user Cancel: bump generation so the abandoned restore bails
+            // *stale* (prefs intact) rather than taking the cancel/forget
+            // path, then abort it so the serialized chain advances at once.
+            // The queued sendInit re-reads from the store and re-restores
+            // (raven has no one-shot restored flags).
+            if (this.restoring) {
+                this.generation += 1;
+                this.abortAndClearRestore();
+            }
             await this.sendInit();
+            return;
+        }
+        if (m.type === 'cancelRestore') {
+            await this.handleCancelRestore(m);
             return;
         }
         if (m.type === 'lifecycle') {
@@ -675,6 +917,16 @@ export class DataViewerPanel {
         m: Extract<WebviewToExtension, { type: 'setSort' }>,
         gen: number,
     ): Promise<void> {
+        // Ignore interactive sort while a saved-preference restore is in
+        // flight: a generation bump here would make the restore discard its
+        // result without posting init/replace, stranding the panel. The
+        // restore posts authoritative state momentarily.
+        if (this.restoring) return;
+        // The user is superseding the restored prefs, so the restore
+        // handshake is over — a delayed cancelRestore with the old id must
+        // not reach the clear-and-forget branch and wipe this.
+        this.consumeRestoreHandshake();
+
         // Clear the current permutation and let the webview render a
         // "Sorting…" indicator while we work. For empty `keys`, this is
         // also the final state (no apply pass needed).
@@ -765,6 +1017,11 @@ export class DataViewerPanel {
         m: Extract<WebviewToExtension, { type: 'setFilters' }>,
         gen: number,
     ): Promise<void> {
+        // Ignore interactive filter while a restore is in flight (see
+        // handleSetSort), then consume the handshake when superseding.
+        if (this.restoring) return;
+        this.consumeRestoreHandshake();
+
         this.filterGeneration += 1;
         const myFilterGen = this.filterGeneration;
         const next: FilterState = { entries: m.entries, labelsOnWhenFiltered: m.labelsOn };

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -308,7 +308,7 @@ export class DataViewerPanel {
         // cleanup below and strand the webview, so swallow it (worst case the
         // cancelled pref survives — same as the genuine-error "keep" path).
         if (restoreCancelled && prevSchemaHash !== undefined) {
-            await this.forgetPersistedPrefs(prevSchemaHash).catch(() => undefined);
+            await this.forgetPersistedPrefsGuarded(prevSchemaHash).catch(() => undefined);
         }
         if (this.webviewReady) await this.sendReplace();
         await prevReader.close().catch(() => undefined);
@@ -543,8 +543,9 @@ export class DataViewerPanel {
             if (cancelledBeforePaint) {
                 // Persist the forget only after the paint, so a store-write
                 // failure cannot strand the webview waiting on a message it
-                // never receives.
-                await this.forgetPersistedPrefs(layoutHash);
+                // never receives. Guarded so a concurrent reload's re-read
+                // cannot re-restore these prefs mid-clear.
+                await this.forgetPersistedPrefsGuarded(layoutHash);
                 // Cancel durably honored; clear the intent so it cannot linger
                 // into a later replace()/reload (which would forget again).
                 this.restoreCancelRequested = false;
@@ -774,6 +775,22 @@ export class DataViewerPanel {
             clears.push(this.filterStore.clear(this.panelName, hash));
         }
         await Promise.allSettled(clears);
+    }
+
+    /** {@link forgetPersistedPrefs} wrapped in the {@link pendingForgetHashes}
+     *  guard so a `webviewReady`/`replace()` whose `sendInit`/`sendReplace`
+     *  re-reads the store while this clear is still in flight cannot load and
+     *  re-restore the prefs being forgotten. Used by the lifecycle cancel
+     *  paths (replace, webviewReady, cancel-before-paint), which forget
+     *  outside `clearAndForgetNaturalOrder` (that path manages the marker
+     *  itself because its window also spans a natural-order paint). */
+    private async forgetPersistedPrefsGuarded(hash: string): Promise<void> {
+        this.pendingForgetHashes.add(hash);
+        try {
+            await this.forgetPersistedPrefs(hash);
+        } finally {
+            this.pendingForgetHashes.delete(hash);
+        }
     }
 
     /** Post a natural-order `replace` from in-memory state at the given
@@ -1023,7 +1040,7 @@ export class DataViewerPanel {
                 // Swallow a store-write failure so it cannot skip the sendInit
                 // below and strand the reloaded webview on a permanent
                 // Loading… (worst case the cancelled pref survives the reload).
-                if (cancelled) await this.forgetPersistedPrefs(hash).catch(() => undefined);
+                if (cancelled) await this.forgetPersistedPrefsGuarded(hash).catch(() => undefined);
             }
             this.abortInteractiveTransforms();
             await this.sendInit();

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -197,7 +197,10 @@ export class DataViewerPanel {
         // (and the prev schema hash, while this.reader is still the old one)
         // first. Mirrors the webviewReady reload path.
         const restoreCancelled = this.restoreCancelRequested;
-        const prevSchemaHash = this.currentSchemaHash();
+        // Hash the PREVIOUS dataset's schema now, while this.reader is still
+        // the old one (the swap below makes currentSchemaHash() return the new
+        // schema). Only needed when honoring a cancel, so skip it otherwise.
+        const prevSchemaHash = restoreCancelled ? this.currentSchemaHash() : undefined;
         this.abortAndClearRestore();
         // Clear cached visible range so a stale range from the previous
         // dataset is never returned for the new one. The next lifecycle
@@ -225,7 +228,12 @@ export class DataViewerPanel {
         // Honor a cancel of the previous dataset's restore by forgetting its
         // prefs before sendReplace re-reads the store (so a same-schema reopen
         // does not silently re-apply what the user cancelled).
-        if (restoreCancelled) await this.forgetPersistedPrefs(prevSchemaHash);
+        // A store-write failure here must not skip the sendReplace / reader
+        // cleanup below and strand the webview, so swallow it (worst case the
+        // cancelled pref survives — same as the genuine-error "keep" path).
+        if (restoreCancelled && prevSchemaHash !== undefined) {
+            await this.forgetPersistedPrefs(prevSchemaHash).catch(() => undefined);
+        }
         if (this.webviewReady) await this.sendReplace();
         await prevReader.close().catch(() => undefined);
         try { await fs.unlink(prevPath); } catch { /* ignore */ }
@@ -491,13 +499,18 @@ export class DataViewerPanel {
         this.restoreId = ++this.restoreSeq;
         this.restoring = true;
         this.restoreCancelRequested = false;
+        // Fire-and-forget so the (potentially long) column reads start at
+        // once; ordering before init/replace is preserved by the transport's
+        // FIFO queue. Catch so a post to an already-disposed webview cannot
+        // surface as an unhandled rejection (every other restore post is
+        // awaited inside paintWithRestore's try).
         void this.webviewPanel.webview.postMessage({
             type: 'restorePending',
             panelGeneration: generation,
             restoreId: this.restoreId,
             sort: hasSort,
             filter: hasFilter,
-        } satisfies ExtensionToWebview);
+        } satisfies ExtensionToWebview).then(undefined, () => undefined);
         return true;
     }
 
@@ -766,7 +779,10 @@ export class DataViewerPanel {
                 const hash = this.currentSchemaHash();
                 this.generation += 1;
                 this.abortAndClearRestore();
-                if (cancelled) await this.forgetPersistedPrefs(hash);
+                // Swallow a store-write failure so it cannot skip the sendInit
+                // below and strand the reloaded webview on a permanent
+                // Loading… (worst case the cancelled pref survives the reload).
+                if (cancelled) await this.forgetPersistedPrefs(hash).catch(() => undefined);
             }
             await this.sendInit();
             return;

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -359,6 +359,9 @@ export class DataViewerPanel {
                 // failure cannot strand the webview waiting on a message it
                 // never receives.
                 await this.forgetPersistedPrefs(layoutHash);
+                // Cancel durably honored; clear the intent so it cannot linger
+                // into a later replace()/reload (which would forget again).
+                this.restoreCancelRequested = false;
             } else if (isCancelled()) {
                 // The user cancelled during the paint (after the reads, before
                 // the finally). The chips were already posted; honor the cancel
@@ -603,6 +606,9 @@ export class DataViewerPanel {
         this.generation += 1;
         await this.postReplaceNaturalOrder(this.generation);
         await this.forgetPersistedPrefs(hash);
+        // The cancel is now durably honored; clear the intent so it cannot
+        // linger and cause a later replace()/reload to forget again.
+        this.restoreCancelRequested = false;
     }
 
     /** Attempt to restore a persisted sort, updating `this.sort` and

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -158,6 +158,14 @@ export class DataViewerPanel {
      *  reload that races into that window honor the cancel (forget the
      *  prefs) instead of bailing stale and re-restoring them. */
     private restoreCancelRequested = false;
+    /** Schema hash whose persisted prefs a late clear-and-forget is
+     *  durably clearing. Set before the natural-order post and the store
+     *  writes, cleared once they finish. A `webviewReady`/`replace()` that
+     *  re-reads the store inside that window would otherwise load the
+     *  still-saved prefs and re-restore exactly what the user cancelled;
+     *  `paintWithRestore` honors this marker and drops those prefs. `null`
+     *  when no forget is in flight. */
+    private pendingForgetHash: string | null = null;
     /** Active toolbar last shipped to the webview, captured so the late
      *  clear-and-forget can rebuild a `replace` without re-loading the
      *  store. */
@@ -472,11 +480,20 @@ export class DataViewerPanel {
         const activeToolbar = toolbar ?? this.defaultToolbar();
         this.lastToolbar = activeToolbar;
 
+        // If a late clear-and-forget is durably forgetting this schema's
+        // prefs, the load above may have raced ahead of the store clears and
+        // returned the cancelled prefs. Drop them so this paint shows natural
+        // order instead of re-restoring what the user just cancelled; the
+        // in-flight forget completes the durable clear.
+        const forgetting = this.pendingForgetHash === layoutHash;
+        const sortToRestore = forgetting ? undefined : savedSort;
+        const filterToRestore = forgetting ? undefined : savedFilter;
+
         // Begin a cancellable restore if saved prefs apply. `myAbort`
         // identifies this restore's controller; cancellation is read from
         // its own signal so a concurrent send reassigning this.restoreAbort
         // can't change what THIS call sees.
-        const began = this.maybeBeginRestore(generation, savedSort, savedFilter);
+        const began = this.maybeBeginRestore(generation, sortToRestore, filterToRestore);
         const myAbort = began ? this.restoreAbort : null;
         const isCancelled = () => myAbort?.signal.aborted === true;
         try {
@@ -484,7 +501,7 @@ export class DataViewerPanel {
             // filteredIndices as a side effect and return true only on a
             // genuine (non-abort) failure.
             const sortFailed = await this.restoreSort(
-                savedSort, activeToolbar, generation, reader, myAbort?.signal,
+                sortToRestore, activeToolbar, generation, reader, myAbort?.signal,
             );
             // A refresh/reload during the read supersedes this attempt; bail
             // *stale* (prefs intact) before the cancel path. A user Cancel
@@ -493,7 +510,7 @@ export class DataViewerPanel {
             let filterFailed = false;
             if (!isCancelled()) {
                 filterFailed = await this.restoreFilter(
-                    savedFilter, activeToolbar, generation, reader, myAbort?.signal,
+                    filterToRestore, activeToolbar, generation, reader, myAbort?.signal,
                 );
                 if (generation !== this.generation || reader !== this.reader) return false;
             }
@@ -807,8 +824,14 @@ export class DataViewerPanel {
     private async clearAndForgetNaturalOrder(hash: string): Promise<void> {
         this.resetRestoredPrefs();
         this.generation += 1;
+        // Mark the forget as in flight BEFORE the awaits: a webviewReady or
+        // replace() landing between the natural-order post and the store
+        // clears completing would otherwise re-read the still-saved prefs and
+        // re-restore the cancelled sort/filter. paintWithRestore honors this.
+        this.pendingForgetHash = hash;
         await this.postReplaceNaturalOrder(this.generation);
         await this.forgetPersistedPrefs(hash);
+        if (this.pendingForgetHash === hash) this.pendingForgetHash = null;
         // The cancel is now durably honored; clear the intent so it cannot
         // linger and cause a later replace()/reload to forget again.
         this.restoreCancelRequested = false;

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -737,14 +737,25 @@ export class DataViewerPanel {
         return schemaHash(this.reader.schema.columns);
     }
 
-    /** Forget the persisted sort/filter for this dataset × schema. */
+    /** Forget the persisted sort/filter for this dataset × schema.
+     *
+     *  The two clears are attempted independently via `allSettled`: a
+     *  rejection from one store must not skip the other, or honoring a
+     *  Cancel that had both a saved sort AND filter could durably forget
+     *  only one of them, leaving the survivor to re-trigger a restore on
+     *  the next reload despite the user having already declined it. Writes
+     *  are best-effort — every caller already tolerates a forget that
+     *  cannot be persisted (the UI paint is posted first, so a write
+     *  failure never strands the webview). */
     private async forgetPersistedPrefs(hash: string): Promise<void> {
+        const clears: Promise<void>[] = [];
         if (this.settings.persistSort) {
-            await this.sortStore.clear(this.panelName, hash);
+            clears.push(this.sortStore.clear(this.panelName, hash));
         }
         if (this.settings.persistFilters) {
-            await this.filterStore.clear(this.panelName, hash);
+            clears.push(this.filterStore.clear(this.panelName, hash));
         }
+        await Promise.allSettled(clears);
     }
 
     /** Post a natural-order `replace` from in-memory state at the given

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -1,11 +1,11 @@
 /**
  * DataViewerPanel — owns one webview tab keyed by panel name.
  *
- * Generations: every replace() increments `generation`. The handle()
- * method captures the current generation before any await, and drops
- * the reply if a replace landed in the meantime. The webview also tags
- * its requests with the generation it last received and silently
- * ignores responses tagged with an older one.
+ * Generations: every dataset replace and webviewReady lifecycle increments
+ * `generation`. The handle() method captures the current generation before
+ * any await, and drops the reply if a replace or reload landed in the
+ * meantime. The webview also tags its requests with the generation it last
+ * received and silently ignores responses tagged with an older one.
  */
 
 import * as vscode from 'vscode';
@@ -17,6 +17,7 @@ import {
     EMPTY_FILTER,
     EMPTY_SORT,
     ExtensionToWebview,
+    FilterEntry,
     FilterState,
     HistogramBin,
     Layout,
@@ -38,6 +39,46 @@ import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 let dataViewerTraceOutput: vscode.OutputChannel | undefined;
 
+type SortSnapshot = {
+    sort: SortState;
+    permutation?: Uint32Array;
+};
+
+type FilterSnapshot = {
+    filter: FilterState;
+    filteredIndices?: Uint32Array;
+};
+
+function cloneSortState(sort: SortState): SortState {
+    if (sort.keys.length === 0) return EMPTY_SORT;
+    return {
+        keys: sort.keys.map(k => ({ ...k })),
+        labelsOnWhenSorted: sort.labelsOnWhenSorted,
+    };
+}
+
+function cloneFilterEntry(entry: FilterEntry): FilterEntry {
+    const predicate = entry.predicate.kind === 'setIn' || entry.predicate.kind === 'setNotIn'
+        ? { ...entry.predicate, values: [...entry.predicate.values] }
+        : { ...entry.predicate };
+    return {
+        ...entry,
+        predicate: predicate as FilterEntry['predicate'],
+    };
+}
+
+function cloneFilterState(filter: FilterState): FilterState {
+    if (filter.entries.length === 0) return EMPTY_FILTER;
+    return {
+        entries: filter.entries.map(cloneFilterEntry),
+        labelsOnWhenFiltered: filter.labelsOnWhenFiltered,
+    };
+}
+
+function cloneIndices(indices: Uint32Array | undefined): Uint32Array | undefined {
+    return indices === undefined ? undefined : new Uint32Array(indices);
+}
+
 export class DataViewerPanel {
     readonly panelName: string;
     private readonly webviewPanel: vscode.WebviewPanel;
@@ -57,10 +98,14 @@ export class DataViewerPanel {
     /** Permutation backing the current sort. `undefined` ↔ identity
      *  ordering. Plumbed into every reader.getRows call below. */
     private permutation: Uint32Array | undefined;
-    /** Monotonic counter — every setSort that produces a new permutation
-     *  bumps it. Late-landing `sortApplied` responses tagged with an
-     *  older value are dropped. */
+    /** Monotonic request token — bumped for every setSort and lifecycle
+     *  abort so stale async sort work can be detected and dropped. */
     private sortGeneration = 0;
+    /** Generation-local rollback snapshots keyed by request id. The webview
+     *  tells us which accepted id to roll back to on a later failure; keeping
+     *  this host-side preserves the already-built permutation. Key 0 is the
+     *  current init/replace baseline. */
+    private sortSnapshots = new Map<number, SortSnapshot>([[0, { sort: EMPTY_SORT }]]);
     /** Current filter state. Mirrors what the webview shows in the chip
      *  strip. Updated by `setFilters` and by init/replace's restore path. */
     private filter: FilterState = EMPTY_FILTER;
@@ -70,6 +115,11 @@ export class DataViewerPanel {
     /** Monotonic counter — bumped on every setFilters call so stale
      *  async results can be detected and dropped. */
     private filterGeneration = 0;
+    /** Generation-local rollback snapshots keyed by request id. The webview
+     *  tells us which accepted id to roll back to on a later failure; keeping
+     *  this host-side preserves the already-built filtered index. Key 0 is
+     *  the current init/replace baseline. */
+    private filterSnapshots = new Map<number, FilterSnapshot>([[0, { filter: EMPTY_FILTER }]]);
     /** Per-column numeric histogram cache, keyed by column index, for the
      *  current reader. Populated lazily by the `getHistogram` handler (a
      *  histogram costs two full column scans, so we never recompute one).
@@ -97,9 +147,9 @@ export class DataViewerPanel {
      *  setSort/setFilters no-op so a generation bump can't strand it. */
     private restoring = false;
     /** Monotonic id of the active restore (-1 ⇔ none). The
-     *  restorePending/cancelRestore handshake key. NOT `generation` —
-     *  webviewReady reloads do not bump generation, so reusing it would
-     *  alias restores across a reload. */
+     *  restorePending/cancelRestore handshake key. Kept distinct from
+     *  `generation`, which invalidates stale webview messages across reloads
+     *  and dataset replacement rather than identifying a specific restore. */
     private restoreId = -1;
     /** Source of {@link restoreId}; bumped per restore begun. */
     private restoreSeq = 0;
@@ -116,6 +166,21 @@ export class DataViewerPanel {
      *  reload mid-restore must not start a concurrent send that overwrites
      *  {@link restoreAbort}). */
     private sendChain: Promise<void> = Promise.resolve();
+    /** FIFO queue for full-column scans (saved restore, sort/filter, and
+     *  histogram). The Arrow IPC reader must not service two batch streams
+     *  concurrently; preserving request order is preferable to letting a
+     *  later transform observe a partially-aborted earlier one. Interactive
+     *  sort/filter still post their pending status before entering the queue. */
+    private transformChain: Promise<void> = Promise.resolve();
+    /** Abort controller for the active or queued interactive sort. A newer
+     *  sort supersedes it; filters do not, because sort+filter compose. */
+    private sortAbort: AbortController | null = null;
+    /** Abort controller for the active or queued interactive filter. A newer
+     *  filter supersedes it; sorts do not, because sort+filter compose. */
+    private filterAbort: AbortController | null = null;
+    /** Abort controllers for active or queued histogram scans. Histograms are
+     *  on-demand full-column scans and are stale after reload/replace/close. */
+    private histogramAborts = new Set<AbortController>();
 
     private constructor(
         panelName: string,
@@ -210,6 +275,7 @@ export class DataViewerPanel {
         this.lastFocusCell = undefined;
         // Old permutation cannot be reused — sendReplace below will
         // attempt to restore a saved sort against the new reader.
+        this.abortInteractiveTransforms();
         this.sort = EMPTY_SORT;
         this.permutation = undefined;
         this.sortGeneration += 1;
@@ -218,6 +284,7 @@ export class DataViewerPanel {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
         this.filterGeneration += 1;
+        this.resetRollbackSnapshots();
         // Histograms are reader-scoped; the new reader is a different dataset.
         this.histogramCache.clear();
         const prevReader = this.reader;
@@ -249,6 +316,93 @@ export class DataViewerPanel {
         };
     }
 
+    private currentSortSnapshot(): SortSnapshot {
+        return {
+            sort: cloneSortState(this.sort),
+            permutation: cloneIndices(this.permutation),
+        };
+    }
+
+    private applySortSnapshot(snapshot: SortSnapshot): void {
+        this.sort = cloneSortState(snapshot.sort);
+        this.permutation = cloneIndices(snapshot.permutation);
+    }
+
+    private rollbackSortSnapshot(baseRequestId: number | undefined): SortSnapshot {
+        if (baseRequestId !== undefined) {
+            const snapshot = this.sortSnapshots.get(baseRequestId);
+            if (snapshot) {
+                return {
+                    sort: cloneSortState(snapshot.sort),
+                    permutation: cloneIndices(snapshot.permutation),
+                };
+            }
+        }
+        return this.currentSortSnapshot();
+    }
+
+    private recordSortSnapshot(
+        requestId: number,
+        snapshot: SortSnapshot = this.currentSortSnapshot(),
+        keepBaseRequestId?: number,
+    ): void {
+        this.sortSnapshots.set(requestId, {
+            sort: cloneSortState(snapshot.sort),
+            permutation: cloneIndices(snapshot.permutation),
+        });
+        for (const key of this.sortSnapshots.keys()) {
+            if (key !== 0 && key !== requestId && key !== keepBaseRequestId) {
+                this.sortSnapshots.delete(key);
+            }
+        }
+    }
+
+    private currentFilterSnapshot(): FilterSnapshot {
+        return {
+            filter: cloneFilterState(this.filter),
+            filteredIndices: cloneIndices(this.filteredIndices),
+        };
+    }
+
+    private applyFilterSnapshot(snapshot: FilterSnapshot): void {
+        this.filter = cloneFilterState(snapshot.filter);
+        this.filteredIndices = cloneIndices(snapshot.filteredIndices);
+    }
+
+    private rollbackFilterSnapshot(baseRequestId: number | undefined): FilterSnapshot {
+        if (baseRequestId !== undefined) {
+            const snapshot = this.filterSnapshots.get(baseRequestId);
+            if (snapshot) {
+                return {
+                    filter: cloneFilterState(snapshot.filter),
+                    filteredIndices: cloneIndices(snapshot.filteredIndices),
+                };
+            }
+        }
+        return this.currentFilterSnapshot();
+    }
+
+    private recordFilterSnapshot(
+        requestId: number,
+        snapshot: FilterSnapshot = this.currentFilterSnapshot(),
+        keepBaseRequestId?: number,
+    ): void {
+        this.filterSnapshots.set(requestId, {
+            filter: cloneFilterState(snapshot.filter),
+            filteredIndices: cloneIndices(snapshot.filteredIndices),
+        });
+        for (const key of this.filterSnapshots.keys()) {
+            if (key !== 0 && key !== requestId && key !== keepBaseRequestId) {
+                this.filterSnapshots.delete(key);
+            }
+        }
+    }
+
+    private resetRollbackSnapshots(): void {
+        this.sortSnapshots = new Map([[0, this.currentSortSnapshot()]]);
+        this.filterSnapshots = new Map([[0, this.currentFilterSnapshot()]]);
+    }
+
     // sendInit / sendReplace are serialized through `sendChain` so two
     // restores never overlap. The chain wraps only these public entry
     // points; internal delegation (an uninitialized replace) calls the
@@ -256,6 +410,12 @@ export class DataViewerPanel {
     private enqueue<T>(fn: () => Promise<T>): Promise<T> {
         const next = this.sendChain.catch(() => {}).then(fn);
         this.sendChain = next.then(() => {}, () => {});
+        return next;
+    }
+
+    private enqueueTransform<T>(fn: () => Promise<T>): Promise<T> {
+        const next = this.transformChain.catch(() => {}).then(fn);
+        this.transformChain = next.then(() => {}, () => {});
         return next;
     }
 
@@ -388,6 +548,7 @@ export class DataViewerPanel {
                         nrowFiltered: this.filteredIndices.length,
                         fromPersistence: true,
                     } satisfies ExtensionToWebview);
+                    this.recordFilterSnapshot(-1, undefined, 0);
                     // The filterApplied post is the second (and last)
                     // post-decision await window. A cancel/lifecycle abort can
                     // land during it: a lifecycle abort bumped generation →
@@ -455,6 +616,8 @@ export class DataViewerPanel {
             loadedToolbar: activeToolbar,
         });
         await this.webviewPanel.webview.postMessage(msg);
+        this.recordSortSnapshot(0);
+        this.recordFilterSnapshot(0);
     }
 
     // -------------------------------------------------------
@@ -529,6 +692,7 @@ export class DataViewerPanel {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
         this.filterGeneration += 1;
+        this.resetRollbackSnapshots();
     }
 
     /** Consume the restore handshake because the user superseded the
@@ -549,6 +713,21 @@ export class DataViewerPanel {
         this.restoring = false;
         this.restoreId = -1;
         this.restoreCancelRequested = false;
+    }
+
+    /** Abort active or queued interactive transforms when the webview
+     *  reloads/replaces/closes. The next init/replace is authoritative for
+     *  display state; stale interactive acks from the old webview must not
+     *  race into the new one. */
+    private abortInteractiveTransforms(): void {
+        this.sortAbort?.abort();
+        this.sortAbort = null;
+        this.sortGeneration += 1;
+        this.filterAbort?.abort();
+        this.filterAbort = null;
+        this.filterGeneration += 1;
+        for (const abort of this.histogramAborts) abort.abort();
+        this.histogramAborts.clear();
     }
 
     /** Schema hash of the live reader — used by the late clear-and-forget
@@ -654,11 +833,19 @@ export class DataViewerPanel {
             if (k.columnIndex < 0 || k.columnIndex > maxColIndex) return false;
         }
         try {
-            const perm = await computePermutation(reader, saved.keys, {
-                labelsOn: toolbar.labelsOn,
-                formatOn: toolbar.formatOn,
-                digits: toolbar.digits,
-            }, { signal });
+            const perm = await this.enqueueTransform(async () => {
+                if (generation !== this.generation
+                    || reader !== this.reader
+                    || signal?.aborted) {
+                    return undefined;
+                }
+                return computePermutation(reader, saved.keys, {
+                    labelsOn: toolbar.labelsOn,
+                    formatOn: toolbar.formatOn,
+                    digits: toolbar.digits,
+                }, { signal });
+            });
+            if (!perm) return false;
             if (generation !== this.generation || reader !== this.reader) return false;
             this.sort = {
                 keys: saved.keys,
@@ -701,14 +888,26 @@ export class DataViewerPanel {
             if (e.columnIndex < 0 || e.columnIndex > maxColIndex) return false;
         }
         try {
-            const indices = await computeFilteredIndices(reader, saved, {
-                labelsOn: toolbar.labelsOn,
-                formatOn: toolbar.formatOn,
-                digits: toolbar.digits,
-            }, { signal });
+            const result = await this.enqueueTransform(async (): Promise<
+                | { stale: true }
+                | { stale: false; indices: Uint32Array | undefined }
+            > => {
+                if (generation !== this.generation
+                    || reader !== this.reader
+                    || signal?.aborted) {
+                    return { stale: true };
+                }
+                const indices = await computeFilteredIndices(reader, saved, {
+                    labelsOn: toolbar.labelsOn,
+                    formatOn: toolbar.formatOn,
+                    digits: toolbar.digits,
+                }, { signal });
+                return { stale: false, indices };
+            });
+            if (result.stale) return false;
             if (generation !== this.generation || reader !== this.reader) return false;
             this.filter = { entries: saved.entries, labelsOnWhenFiltered: toolbar.labelsOn };
-            this.filteredIndices = indices;
+            this.filteredIndices = result.indices;
             this.filterGeneration += 1;
             return false;
         } catch (err) {
@@ -762,6 +961,7 @@ export class DataViewerPanel {
 
     private async handleInner(m: WebviewToExtension): Promise<void> {
         if (m.type === 'webviewReady') {
+            this.generation += 1;
             this.trace('webview-ready', { generation: this.generation });
             this.webviewReady = true;
             // A webview reload mid-restore is a lifecycle interruption, not
@@ -777,13 +977,13 @@ export class DataViewerPanel {
                 // reload (no pending cancel) keeps the prefs.
                 const cancelled = this.restoreCancelRequested;
                 const hash = this.currentSchemaHash();
-                this.generation += 1;
                 this.abortAndClearRestore();
                 // Swallow a store-write failure so it cannot skip the sendInit
                 // below and strand the reloaded webview on a permanent
                 // Loading… (worst case the cancelled pref survives the reload).
                 if (cancelled) await this.forgetPersistedPrefs(hash).catch(() => undefined);
             }
+            this.abortInteractiveTransforms();
             await this.sendInit();
             return;
         }
@@ -965,32 +1165,65 @@ export class DataViewerPanel {
                     // brush stays blank forever with no retry (unlike getRows,
                     // a missing histogram reply is unrecoverable). All degrade
                     // to "no brush". The whole-grid getRows path would also be
-                    // failing if a batch genuinely can't decode, and a decode
+                    // failing if a batch genuinely can't decode. A decode
                     // failure on a fixed Arrow file is deterministic, so the
-                    // empty result is cached below rather than re-scanning on
-                    // every popover reopen.
+                    // empty result from a failed scannable column is cached
+                    // below rather than re-scanning on every popover reopen.
                     const cols = reader.schema.columns;
                     const scannable = Number.isInteger(ci) && ci >= 0 && ci < cols.length
                         && isNumericArrowType(cols[ci].arrowType);
                     if (!scannable) {
                         bins = [];
                     } else {
-                        try {
-                            bins = await computeHistogramForColumn(reader, ci);
-                        } catch {
-                            bins = [];
-                        }
+                        const abort = new AbortController();
+                        this.histogramAborts.add(abort);
+                        bins = await this.enqueueTransform(async () => {
+                            if (this.disposed
+                                || gen !== this.generation
+                                || reader !== this.reader
+                                || abort.signal.aborted) {
+                                this.histogramAborts.delete(abort);
+                                return undefined;
+                            }
+                            const cached = this.histogramCache.get(ci);
+                            if (cached) {
+                                this.histogramAborts.delete(abort);
+                                return cached;
+                            }
+                            let computed: HistogramBin[];
+                            try {
+                                computed = await computeHistogramForColumn(reader, ci, {
+                                    signal: abort.signal,
+                                });
+                            } catch (err) {
+                                if (abort.signal.aborted || isAbortError(err)) {
+                                    this.histogramAborts.delete(abort);
+                                    return undefined;
+                                }
+                                computed = [];
+                            }
+                            // After the await: drop if the panel was disposed
+                            // or the dataset was swapped (mirrors getRows) —
+                            // no reply is owed, the new generation's webview
+                            // already cleared its in-flight marker.
+                            if (this.disposed
+                                || gen !== this.generation
+                                || reader !== this.reader
+                                || abort.signal.aborted) {
+                                this.histogramAborts.delete(abort);
+                                return undefined;
+                            }
+                            const existing = this.histogramCache.get(ci);
+                            if (existing) {
+                                this.histogramAborts.delete(abort);
+                                return existing;
+                            }
+                            this.histogramCache.set(ci, computed);
+                            this.histogramAborts.delete(abort);
+                            return computed;
+                        });
+                        if (bins === undefined) return;
                     }
-                    // After the await: drop if the panel was disposed or the
-                    // dataset was swapped (mirrors the getRows handler) — no
-                    // reply is owed, the new generation's webview already
-                    // cleared its in-flight marker. A concurrent request for
-                    // the same column may have cached a result meanwhile;
-                    // first writer wins so a late error-[] never clobbers it.
-                    if (this.disposed || gen !== this.generation || reader !== this.reader) return;
-                    const existing = this.histogramCache.get(ci);
-                    if (existing) bins = existing;
-                    else this.histogramCache.set(ci, bins);
                 }
                 const reply: ExtensionToWebview = {
                     type: 'histogram',
@@ -1031,14 +1264,20 @@ export class DataViewerPanel {
         // not reach the clear-and-forget branch and wipe this.
         this.consumeRestoreHandshake();
 
-        // Clear the current permutation and let the webview render a
-        // "Sorting…" indicator while we work. For empty `keys`, this is
-        // also the final state (no apply pass needed).
+        // Let the webview render a "Sorting..." indicator while non-empty
+        // sorts compute. The old authoritative permutation stays in place as
+        // the rollback baseline until the new result is ready to publish.
+        // For empty `keys`, clearing is immediate and final.
         this.sortGeneration += 1;
         const mySortGen = this.sortGeneration;
+        this.sortAbort?.abort();
+        const abort = new AbortController();
+        this.sortAbort = abort;
         if (m.keys.length === 0) {
             this.sort = EMPTY_SORT;
             this.permutation = undefined;
+            this.recordSortSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+            if (this.sortAbort === abort) this.sortAbort = null;
             const ack: ExtensionToWebview = {
                 type: 'sortApplied',
                 panelGeneration: gen,
@@ -1046,16 +1285,34 @@ export class DataViewerPanel {
                 sort: EMPTY_SORT,
                 fromPersistence: false,
             };
-            await this.webviewPanel.webview.postMessage(ack);
+            void this.webviewPanel.webview.postMessage(ack).then(undefined, () => undefined);
             return;
         }
 
         const pending: ExtensionToWebview = {
             type: 'sortStatus',
             panelGeneration: gen,
+            requestId: m.requestId,
             state: 'pending',
         };
         await this.webviewPanel.webview.postMessage(pending);
+
+        await this.enqueueTransform(() => this.runSetSort(m, gen, mySortGen, abort));
+    }
+
+    private async runSetSort(
+        m: Extract<WebviewToExtension, { type: 'setSort' }>,
+        gen: number,
+        mySortGen: number,
+        abort: AbortController,
+    ): Promise<void> {
+        if (gen !== this.generation
+            || mySortGen !== this.sortGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
 
         let perm: Uint32Array;
         try {
@@ -1063,7 +1320,7 @@ export class DataViewerPanel {
                 labelsOn: m.labelsOn,
                 formatOn: m.formatOn,
                 digits: m.digits,
-            });
+            }, { signal: abort.signal });
         } catch (err) {
             // Drop the failure entirely if a newer setSort or a panel
             // replace landed while computePermutation was in flight —
@@ -1072,27 +1329,63 @@ export class DataViewerPanel {
             // an error that's no longer relevant.
             if (gen !== this.generation
                 || mySortGen !== this.sortGeneration
-                || this.disposed) {
+                || this.disposed
+                || isAbortError(err)) {
+                if (this.sortAbort === abort) this.sortAbort = null;
                 return;
             }
             const idle: ExtensionToWebview = {
                 type: 'sortStatus',
                 panelGeneration: gen,
+                requestId: m.requestId,
                 state: 'idle',
             };
             await this.webviewPanel.webview.postMessage(idle);
-            const errMsg: ExtensionToWebview = {
-                type: 'error',
+            if (gen !== this.generation
+                || mySortGen !== this.sortGeneration
+                || this.disposed
+                || abort.signal.aborted) {
+                if (this.sortAbort === abort) this.sortAbort = null;
+                return;
+            }
+            const rollbackSnapshot = this.rollbackSortSnapshot(m.rollbackBaseRequestId);
+            this.applySortSnapshot(rollbackSnapshot);
+            this.recordSortSnapshot(m.requestId, rollbackSnapshot, m.rollbackBaseRequestId);
+            const rollback: ExtensionToWebview = {
+                type: 'sortApplied',
                 panelGeneration: gen,
-                message: err instanceof Error ? err.message : String(err),
+                requestId: m.requestId,
+                sort: cloneSortState(this.sort),
+                fromPersistence: false,
+                rollback: true,
+                error: err instanceof Error ? err.message : String(err),
             };
-            await this.webviewPanel.webview.postMessage(errMsg);
+            void this.webviewPanel.webview.postMessage(rollback).then(undefined, () => undefined);
+            if (this.sortAbort === abort) this.sortAbort = null;
             return;
         }
 
         // If another setSort raced in front, or the panel was replaced,
         // discard our result without publishing.
-        if (gen !== this.generation || mySortGen !== this.sortGeneration) return;
+        if (gen !== this.generation || mySortGen !== this.sortGeneration) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
+
+        const idle: ExtensionToWebview = {
+            type: 'sortStatus',
+            panelGeneration: gen,
+            requestId: m.requestId,
+            state: 'idle',
+        };
+        await this.webviewPanel.webview.postMessage(idle);
+        if (gen !== this.generation
+            || mySortGen !== this.sortGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
 
         const next: SortState = {
             keys: m.keys,
@@ -1100,13 +1393,7 @@ export class DataViewerPanel {
         };
         this.sort = next;
         this.permutation = perm;
-
-        const idle: ExtensionToWebview = {
-            type: 'sortStatus',
-            panelGeneration: gen,
-            state: 'idle',
-        };
-        await this.webviewPanel.webview.postMessage(idle);
+        this.recordSortSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
         const ack: ExtensionToWebview = {
             type: 'sortApplied',
             panelGeneration: gen,
@@ -1114,7 +1401,8 @@ export class DataViewerPanel {
             sort: next,
             fromPersistence: false,
         };
-        await this.webviewPanel.webview.postMessage(ack);
+        void this.webviewPanel.webview.postMessage(ack).then(undefined, () => undefined);
+        if (this.sortAbort === abort) this.sortAbort = null;
     }
 
     private async handleSetFilters(
@@ -1128,21 +1416,45 @@ export class DataViewerPanel {
 
         this.filterGeneration += 1;
         const myFilterGen = this.filterGeneration;
+        this.filterAbort?.abort();
+        const abort = new AbortController();
+        this.filterAbort = abort;
         const next: FilterState = { entries: m.entries, labelsOnWhenFiltered: m.labelsOn };
 
         if (m.entries.length === 0 || m.entries.every(e => !e.enabled)) {
             this.filter = next;
             this.filteredIndices = undefined;
-            await this.webviewPanel.webview.postMessage({
+            this.recordFilterSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+            if (this.filterAbort === abort) this.filterAbort = null;
+            void this.webviewPanel.webview.postMessage({
                 type: 'filterApplied', panelGeneration: gen, requestId: m.requestId,
                 filter: next, nrowFiltered: this.reader.nrow, fromPersistence: false,
-            } satisfies ExtensionToWebview);
+            } satisfies ExtensionToWebview).then(undefined, () => undefined);
             return;
         }
 
         await this.webviewPanel.webview.postMessage({
-            type: 'filterStatus', panelGeneration: gen, state: 'pending',
+            type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'pending',
         } satisfies ExtensionToWebview);
+
+        await this.enqueueTransform(() =>
+            this.runSetFilters(m, gen, myFilterGen, abort, next));
+    }
+
+    private async runSetFilters(
+        m: Extract<WebviewToExtension, { type: 'setFilters' }>,
+        gen: number,
+        myFilterGen: number,
+        abort: AbortController,
+        next: FilterState,
+    ): Promise<void> {
+        if (gen !== this.generation
+            || myFilterGen !== this.filterGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
 
         let indices: Uint32Array | undefined;
         try {
@@ -1150,29 +1462,65 @@ export class DataViewerPanel {
                 labelsOn: m.labelsOn,
                 formatOn: true,
                 digits: this.settings.defaultDigits,
-            });
+            }, { signal: abort.signal });
         } catch (err) {
-            if (gen !== this.generation || myFilterGen !== this.filterGeneration || this.disposed) return;
+            if (gen !== this.generation
+                || myFilterGen !== this.filterGeneration
+                || this.disposed
+                || isAbortError(err)) {
+                if (this.filterAbort === abort) this.filterAbort = null;
+                return;
+            }
             await this.webviewPanel.webview.postMessage({
-                type: 'filterStatus', panelGeneration: gen, state: 'idle',
+                type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'idle',
             } satisfies ExtensionToWebview);
-            await this.webviewPanel.webview.postMessage({
-                type: 'error', panelGeneration: gen,
-                message: err instanceof Error ? err.message : String(err),
-            } satisfies ExtensionToWebview);
+            if (gen !== this.generation
+                || myFilterGen !== this.filterGeneration
+                || this.disposed
+                || abort.signal.aborted) {
+                if (this.filterAbort === abort) this.filterAbort = null;
+                return;
+            }
+            const rollbackSnapshot = this.rollbackFilterSnapshot(m.rollbackBaseRequestId);
+            this.applyFilterSnapshot(rollbackSnapshot);
+            this.recordFilterSnapshot(m.requestId, rollbackSnapshot, m.rollbackBaseRequestId);
+            void this.webviewPanel.webview.postMessage({
+                type: 'filterApplied',
+                panelGeneration: gen,
+                requestId: m.requestId,
+                filter: cloneFilterState(this.filter),
+                nrowFiltered: this.filteredIndices?.length ?? this.reader.nrow,
+                fromPersistence: false,
+                rollback: true,
+                error: err instanceof Error ? err.message : String(err),
+            } satisfies ExtensionToWebview).then(undefined, () => undefined);
+            if (this.filterAbort === abort) this.filterAbort = null;
             return;
         }
 
-        if (gen !== this.generation || myFilterGen !== this.filterGeneration) return;
+        if (gen !== this.generation || myFilterGen !== this.filterGeneration) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
+        await this.webviewPanel.webview.postMessage({
+            type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'idle',
+        } satisfies ExtensionToWebview);
+        if (gen !== this.generation
+            || myFilterGen !== this.filterGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
+
         this.filter = next;
         this.filteredIndices = indices;
-        await this.webviewPanel.webview.postMessage({
-            type: 'filterStatus', panelGeneration: gen, state: 'idle',
-        } satisfies ExtensionToWebview);
-        await this.webviewPanel.webview.postMessage({
+        this.recordFilterSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+        void this.webviewPanel.webview.postMessage({
             type: 'filterApplied', panelGeneration: gen, requestId: m.requestId,
             filter: next, nrowFiltered: indices?.length ?? this.reader.nrow, fromPersistence: false,
-        } satisfies ExtensionToWebview);
+        } satisfies ExtensionToWebview).then(undefined, () => undefined);
+        if (this.filterAbort === abort) this.filterAbort = null;
     }
 
     private async handleCopy(
@@ -1305,6 +1653,8 @@ export class DataViewerPanel {
     private async dispose(): Promise<void> {
         if (this.disposed) return;
         this.disposed = true;
+        this.abortInteractiveTransforms();
+        this.abortAndClearRestore();
         this.trace('dispose', {});
         await this.reader.close().catch(() => undefined);
         try { await fs.unlink(this.filePath); } catch { /* ignore */ }

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -1123,6 +1123,11 @@ export class DataViewerPanel {
                 schemaHash: m.schemaHash,
                 keys: m.sort.keys,
             });
+            // Drop a save whose schema is being durably forgotten: an
+            // interactive saveSort issued before a restore-cancel can otherwise
+            // interleave its store write after the forget's clear and resurrect
+            // the pref the user just cancelled (handle() is not serialized).
+            if (this.pendingForgetHashes.has(m.schemaHash)) return;
             if (m.schemaHash && this.settings.persistSort) {
                 if (m.sort.keys.length === 0) {
                     await this.sortStore.clear(this.panelName, m.schemaHash);
@@ -1133,6 +1138,10 @@ export class DataViewerPanel {
             return;
         }
         if (m.type === 'saveFilter') {
+            // See saveSort: drop a save for a schema whose prefs are being
+            // durably forgotten so a stale interactive write cannot resurrect
+            // a cancelled filter.
+            if (this.pendingForgetHashes.has(m.schemaHash)) return;
             if (m.schemaHash && this.settings.persistFilters) {
                 if (m.filter.entries.length === 0) {
                     await this.filterStore.clear(this.panelName, m.schemaHash);

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -342,6 +342,18 @@ export class DataViewerPanel {
             await this.postPaint(kind, generation, layoutHash, activeToolbar);
             if (kind === 'init') this.webviewInitialized = true;
 
+            // A lifecycle interruption (webview reload / replace()) during the
+            // paint bumps generation and aborts our controller. That abort is
+            // NOT a user Cancel, so bail *stale* here — before the cancel
+            // branch below would misread the aborted signal as a Cancel and
+            // wrongly forget the prefs. The interrupting path keeps the prefs
+            // (or forgets them itself if the user had actually cancelled) and
+            // the queued re-send re-restores. A genuine user Cancel never
+            // bumps generation, so it falls through to the branches below.
+            if (generation !== this.generation || reader !== this.reader) {
+                return false;
+            }
+
             if (cancelledBeforePaint) {
                 // Persist the forget only after the paint, so a store-write
                 // failure cannot strand the webview waiting on a message it
@@ -477,7 +489,11 @@ export class DataViewerPanel {
      *  (synchronous). The caller persists the forget separately. */
     private resetRestoredPrefs(): void {
         this.restoreId = -1;
-        this.restoreCancelRequested = false;
+        // NB: deliberately does NOT clear restoreCancelRequested. That flag is
+        // the user's "forget" intent and is consumed only by maybeBeginRestore
+        // (a fresh restore) or abortAndClearRestore (a lifecycle path reads it
+        // first). Clearing it here would let a lifecycle interruption that
+        // races the paint lose a cancel the user already requested.
         this.sort = EMPTY_SORT;
         this.permutation = undefined;
         this.sortGeneration += 1;

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -158,14 +158,15 @@ export class DataViewerPanel {
      *  reload that races into that window honor the cancel (forget the
      *  prefs) instead of bailing stale and re-restoring them. */
     private restoreCancelRequested = false;
-    /** Schema hash whose persisted prefs a late clear-and-forget is
-     *  durably clearing. Set before the natural-order post and the store
-     *  writes, cleared once they finish. A `webviewReady`/`replace()` that
-     *  re-reads the store inside that window would otherwise load the
-     *  still-saved prefs and re-restore exactly what the user cancelled;
-     *  `paintWithRestore` honors this marker and drops those prefs. `null`
-     *  when no forget is in flight. */
-    private pendingForgetHash: string | null = null;
+    /** Schema hashes whose persisted prefs a late clear-and-forget is
+     *  durably clearing. A hash is added before the natural-order post and
+     *  the store writes, and removed once they finish. A `webviewReady`/
+     *  `replace()` that re-reads the store inside that window would otherwise
+     *  load the still-saved prefs and re-restore exactly what the user
+     *  cancelled; `paintWithRestore` honors this set and drops those prefs.
+     *  A `Set` (not a single hash) so overlapping forgets for two different
+     *  schemas cannot clobber each other's suppression. */
+    private readonly pendingForgetHashes = new Set<string>();
     /** Active toolbar last shipped to the webview, captured so the late
      *  clear-and-forget can rebuild a `replace` without re-loading the
      *  store. */
@@ -485,7 +486,7 @@ export class DataViewerPanel {
         // returned the cancelled prefs. Drop them so this paint shows natural
         // order instead of re-restoring what the user just cancelled; the
         // in-flight forget completes the durable clear.
-        const forgetting = this.pendingForgetHash === layoutHash;
+        const forgetting = this.pendingForgetHashes.has(layoutHash);
         const sortToRestore = forgetting ? undefined : savedSort;
         const filterToRestore = forgetting ? undefined : savedFilter;
 
@@ -828,13 +829,20 @@ export class DataViewerPanel {
         // replace() landing between the natural-order post and the store
         // clears completing would otherwise re-read the still-saved prefs and
         // re-restore the cancelled sort/filter. paintWithRestore honors this.
-        this.pendingForgetHash = hash;
-        await this.postReplaceNaturalOrder(this.generation);
-        await this.forgetPersistedPrefs(hash);
-        if (this.pendingForgetHash === hash) this.pendingForgetHash = null;
-        // The cancel is now durably honored; clear the intent so it cannot
-        // linger and cause a later replace()/reload to forget again.
-        this.restoreCancelRequested = false;
+        this.pendingForgetHashes.add(hash);
+        try {
+            await this.postReplaceNaturalOrder(this.generation);
+            await this.forgetPersistedPrefs(hash);
+        } finally {
+            // Always release the marker, even if the natural-order post rejects
+            // (e.g. a disposed webview): a stuck entry would suppress every
+            // future restore for this schema. Deleting only this call's own
+            // hash leaves a concurrent forget for a different schema intact.
+            this.pendingForgetHashes.delete(hash);
+            // The cancel is now durably honored; clear the intent so it cannot
+            // linger and cause a later replace()/reload to forget again.
+            this.restoreCancelRequested = false;
+        }
     }
 
     /** Attempt to restore a persisted sort, updating `this.sort` and

--- a/editors/vscode/src/data-viewer/sort.ts
+++ b/editors/vscode/src/data-viewer/sort.ts
@@ -37,6 +37,7 @@
 import type { ArrowSliceReader, ColumnSchema } from './arrow-reader';
 import type { SortKey } from './messages';
 import { iterateBatches } from './batch-iter';
+import { throwIfAborted } from './abort';
 
 /** Toolbar snapshot used to derive sort keys WYSIWYG. */
 export type SortContext = {
@@ -373,6 +374,10 @@ async function buildDictionarySortColumn(
             if (!missing[i]) need.add(codes[i]);
         }
         const fetched = await reader.getLabels(columnIndex, [...need]);
+        // getLabels is an extra async hop after the cancellable batch scan;
+        // check the signal so a Cancel delivered during it is observed
+        // promptly rather than only after the (cheap) compare step.
+        throwIfAborted(signal);
         for (const [k, v] of Object.entries(fetched)) {
             labelByCode.set(Number(k), v);
         }

--- a/editors/vscode/src/data-viewer/sort.ts
+++ b/editors/vscode/src/data-viewer/sort.ts
@@ -37,7 +37,7 @@
 import type { ArrowSliceReader, ColumnSchema } from './arrow-reader';
 import type { SortKey } from './messages';
 import { iterateBatches } from './batch-iter';
-import { throwIfAborted } from './abort';
+import { throwIfAborted, yieldToEventLoop } from './abort';
 
 /** Toolbar snapshot used to derive sort keys WYSIWYG. */
 export type SortContext = {
@@ -94,8 +94,15 @@ export async function computePermutation(
     // Materialize the permutation as a plain number[] for sort(), then
     // copy back. Uint32Array.sort exists but lacks the stability guarantee
     // and the comparator signature isn't well-typed.
-    throwIfAborted(signal);
     const idx: number[] = Array.from(perm);
+    // Yield once more before the (synchronous, potentially expensive) sort so
+    // a Cancel queued during the final column read is delivered and observed
+    // here, leaving the data in natural order rather than running the full
+    // sort first. Only the cancellable restore passes a signal.
+    if (signal) {
+        await yieldToEventLoop();
+        throwIfAborted(signal);
+    }
     idx.sort((a, b) => compareRows(a, b, cols, directions));
     throwIfAborted(signal);
     for (let i = 0; i < nrow; i++) perm[i] = idx[i];

--- a/editors/vscode/src/data-viewer/sort.ts
+++ b/editors/vscode/src/data-viewer/sort.ts
@@ -36,6 +36,7 @@
 
 import type { ArrowSliceReader, ColumnSchema } from './arrow-reader';
 import type { SortKey } from './messages';
+import { iterateBatches } from './batch-iter';
 
 /** Toolbar snapshot used to derive sort keys WYSIWYG. */
 export type SortContext = {
@@ -68,7 +69,9 @@ export async function computePermutation(
     reader: ArrowSliceReader,
     keys: readonly SortKey[],
     ctx: SortContext,
+    opts?: { signal?: AbortSignal },
 ): Promise<Uint32Array> {
+    const signal = opts?.signal;
     const nrow = reader.nrow;
     const perm = new Uint32Array(nrow);
     for (let i = 0; i < nrow; i++) perm[i] = i;
@@ -83,7 +86,7 @@ export async function computePermutation(
                 `computePermutation: unknown columnIndex ${k.columnIndex}`,
             );
         }
-        cols.push(await buildSortColumn(reader, k.columnIndex, schema, ctx));
+        cols.push(await buildSortColumn(reader, k.columnIndex, schema, ctx, signal));
         directions.push(k.direction === 'desc' ? -1 : 1);
     }
 
@@ -123,11 +126,12 @@ async function buildSortColumn(
     columnIndex: number,
     schema: ColumnSchema,
     ctx: SortContext,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const arrowType = schema.arrowType;
 
     if (arrowType.startsWith('Dictionary')) {
-        return buildDictionarySortColumn(reader, columnIndex, schema, ctx);
+        return buildDictionarySortColumn(reader, columnIndex, schema, ctx, signal);
     }
     // Value-labelled columns (haven_labelled, foreign::value.labels,
     // readstata13) can be backed by any Arrow type whose `.get()`
@@ -142,33 +146,33 @@ async function buildSortColumn(
             || arrowType.startsWith('Float')
             || arrowType === 'Utf8'
             || arrowType === 'LargeUtf8')) {
-        return buildValueLabelledSortColumn(reader, columnIndex, schema);
+        return buildValueLabelledSortColumn(reader, columnIndex, schema, signal);
     }
     if (arrowType === 'Int64') {
         // 64-bit integers exceed Number's 2^53 safe range; use signed
         // BigInt storage + bigint comparator so the order stays exact.
-        return buildBigIntSortColumn(reader, columnIndex, false);
+        return buildBigIntSortColumn(reader, columnIndex, false, signal);
     }
     if (arrowType === 'Uint64') {
         // Same reasoning, but unsigned storage — BigInt64Array would
         // wrap any value above 2^63-1 to a negative two's-complement
         // bigint and corrupt ascending order.
-        return buildBigIntSortColumn(reader, columnIndex, true);
+        return buildBigIntSortColumn(reader, columnIndex, true, signal);
     }
     if (arrowType.startsWith('Int') || arrowType === 'Bool') {
-        return buildNumericSortColumn(reader, columnIndex, false);
+        return buildNumericSortColumn(reader, columnIndex, false, signal);
     }
     if (arrowType.startsWith('Float')) {
-        return buildNumericSortColumn(reader, columnIndex, true);
+        return buildNumericSortColumn(reader, columnIndex, true, signal);
     }
     if (arrowType.startsWith('Date')) {
-        return buildNumericSortColumn(reader, columnIndex, false);
+        return buildNumericSortColumn(reader, columnIndex, false, signal);
     }
     if (arrowType.startsWith('Timestamp')) {
-        return buildTimestampSortColumn(reader, columnIndex);
+        return buildTimestampSortColumn(reader, columnIndex, signal);
     }
     // Utf8 / LargeUtf8 / fallback.
-    return buildStringSortColumn(reader, columnIndex);
+    return buildStringSortColumn(reader, columnIndex, signal);
 }
 
 /** Numeric sort column from Int8/16/32, Bool, Float, or Date columns.
@@ -183,12 +187,13 @@ async function buildNumericSortColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
     floatNaNMissing: boolean,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const values = new Float64Array(nrow);
     const missing = new Uint8Array(nrow);
     let written = 0;
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         for (let r = 0; r < batch.length; r++) {
             const v = child.get(r);
@@ -228,13 +233,14 @@ async function buildBigIntSortColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
     unsigned: boolean,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const values: BigInt64Array | BigUint64Array = unsigned
         ? new BigUint64Array(nrow)
         : new BigInt64Array(nrow);
     const missing = new Uint8Array(nrow);
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         for (let r = 0; r < batch.length; r++) {
             const v = child.get(r);
@@ -264,11 +270,12 @@ async function buildBigIntSortColumn(
 async function buildTimestampSortColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const values = new BigInt64Array(nrow);
     const missing = new Uint8Array(nrow);
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         const data = child.data[0];
         for (let r = 0; r < batch.length; r++) {
@@ -293,11 +300,12 @@ async function buildTimestampSortColumn(
 async function buildStringSortColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const values: string[] = new Array(nrow);
     const missing = new Uint8Array(nrow);
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         for (let r = 0; r < batch.length; r++) {
             const i = batch.start + r;
@@ -325,11 +333,12 @@ async function buildDictionarySortColumn(
     columnIndex: number,
     schema: ColumnSchema,
     ctx: SortContext,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const codes = new Int32Array(nrow);
     const missing = new Uint8Array(nrow);
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         const data = child.data[0];
         for (let r = 0; r < batch.length; r++) {
@@ -391,12 +400,13 @@ async function buildValueLabelledSortColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
     schema: ColumnSchema,
+    signal?: AbortSignal,
 ): Promise<SortColumn> {
     const nrow = reader.nrow;
     const display: string[] = new Array(nrow);
     const missing = new Uint8Array(nrow);
     const valueLabels = schema.valueLabels ?? {};
-    for await (const batch of iterateBatches(reader)) {
+    for await (const batch of iterateBatches(reader, signal)) {
         const child = batch.batch.getChildAt(columnIndex);
         for (let r = 0; r < batch.length; r++) {
             const i = batch.start + r;
@@ -420,27 +430,6 @@ async function buildValueLabelledSortColumn(
         missing,
         compare: (a, b) => COLLATOR.compare(display[a], display[b]),
     };
-}
-
-/** Async iterator over a reader's record batches with their starting
- *  row index. */
-async function* iterateBatches(
-    reader: ArrowSliceReader,
-): AsyncGenerator<{ batch: any; start: number; length: number }> {
-    const numBatches = reader.batchStarts.length - 1;
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await readerGetBatch(reader, bi);
-        const start = reader.batchStarts[bi];
-        const length = reader.batchStarts[bi + 1] - start;
-        yield { batch, start, length };
-    }
-}
-
-/** Bridge into the reader's private batch loader. The reader caches
- *  decoded batches with an LRU, so repeated reads here are cheap and
- *  warm the cache for the subsequent `getRows()` window. */
-function readerGetBatch(reader: ArrowSliceReader, i: number): Promise<any> {
-    return (reader as any).getBatch(i);
 }
 
 function isNullAt(data: any, row: number): boolean {

--- a/editors/vscode/src/data-viewer/sort.ts
+++ b/editors/vscode/src/data-viewer/sort.ts
@@ -94,8 +94,10 @@ export async function computePermutation(
     // Materialize the permutation as a plain number[] for sort(), then
     // copy back. Uint32Array.sort exists but lacks the stability guarantee
     // and the comparator signature isn't well-typed.
+    throwIfAborted(signal);
     const idx: number[] = Array.from(perm);
     idx.sort((a, b) => compareRows(a, b, cols, directions));
+    throwIfAborted(signal);
     for (let i = 0; i < nrow; i++) perm[i] = idx[i];
     return perm;
 }

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -1161,8 +1161,14 @@ export function App({
                     // showing stale text until the timer fires.
                     setRestorePending(prev => (prev ? info : prev));
                     restoreTimerRef.current = setTimeout(() => {
-                        setRestorePending(info);
                         restoreTimerRef.current = null;
+                        // If the restore finished (init/replace cleared
+                        // restoreIdRef) or a newer restore superseded this one
+                        // between scheduling and firing, this banner is stale.
+                        // clearTimeout cannot cancel an already-queued callback,
+                        // so guard here too rather than flashing a dead banner.
+                        if (restoreIdRef.current !== info.restoreId) return;
+                        setRestorePending(info);
                     }, RESTORE_DEBOUNCE_MS);
                     return;
                 }

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -1081,13 +1081,7 @@ export function App({
             }
         };
         window.addEventListener('message', onMessage);
-        return () => {
-            window.removeEventListener('message', onMessage);
-            if (restoreTimerRef.current !== null) {
-                clearTimeout(restoreTimerRef.current);
-                restoreTimerRef.current = null;
-            }
-        };
+        return () => window.removeEventListener('message', onMessage);
     }, [
         applyCopyDone,
         applyFilterApplied,
@@ -1103,6 +1097,19 @@ export function App({
         scrollToFraction,
         vscode,
     ]);
+
+    // Clear the restore-banner debounce timer on UNMOUNT only. This must not
+    // live in the message-handler effect's cleanup: that effect re-runs on
+    // every dep change (e.g. a scroll updates visibleRange → applyInitOrReplace
+    // identity changes), which would clear a pending timer and prevent the
+    // banner from ever appearing during a slow restore while the old grid is
+    // still interactive.
+    useEffect(() => () => {
+        if (restoreTimerRef.current !== null) {
+            clearTimeout(restoreTimerRef.current);
+            restoreTimerRef.current = null;
+        }
+    }, []);
 
     useEffect(() => {
         if (!toolbarBootstrappedRef.current || !schemaHash) return;

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -108,7 +108,7 @@ const DEFAULT_SETTINGS: Settings = { missingValueStyle: 'foreground', defaultDig
 
 /** Delay before the saved-sort/filter restore banner appears (#519). A
  *  restore that finishes faster than this never flashes the message; only a
- *  genuinely slow restore reveals it (and its Cancel). */
+ *  genuinely slow restore reveals it and its skip action. */
 const RESTORE_DEBOUNCE_MS = 200;
 // Glide's renderer type is invariant, but dispatch is by each renderer's `kind`.
 const DATA_VIEWER_RENDERERS = [
@@ -365,7 +365,7 @@ export function App({
     const [loading, setLoading] = useState<boolean>(!(restored?.columns && restored.columns.length > 0));
     // Saved-sort/filter restore banner (#519). `restorePending` is set only
     // after the debounce timer fires, so a fast restore never flashes it;
-    // `restoreCancelling` shows the optimistic "Cancelling…" until init/replace
+    // `restoreCancelling` shows the optimistic "Loading…" until init/replace
     // lands. The refs hold the live restoreId (echoed on cancelRestore) and the
     // debounce timer so it can be cleared when the restore completes.
     const [restorePending, setRestorePending] =
@@ -415,16 +415,17 @@ export function App({
      *  All grid-coordinate math must use this count so row indices never
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
-    // On open, explain (and let the user cancel) the wait while saved
-    // sort/filter preferences are reapplied (#519). While the banner is up it
-    // explains the wait, so the bare "Loading…" row-count is suppressed.
+    // On open, explain the background wait while saved sort/filter
+    // preferences are reapplied (#519). The grid already shows natural-order
+    // data, so the toolbar keeps its row-count while the banner offers a
+    // clearer "skip and show data now" affordance below it.
     const restoreMessage = restorePending
         ? (restoreCancelling
-            ? 'Cancelling…'
+            ? 'Loading…'
             : describeRestoreMessage(restorePending.sort, restorePending.filter))
         : null;
     const rowCountText = describeToolbarRowCount(
-        effectiveNrow, visibleRange, loading, restoreMessage !== null,
+        effectiveNrow, visibleRange, loading, false,
     );
     /** Whether the chip group must wrap onto its own second row. `layout.hiddenColumns.length`
      *  is in the deps because the Columns count badge widens the action buttons without
@@ -1008,9 +1009,9 @@ export function App({
         vscode.postMessage({ type: 'webviewReady' });
     }, [vscode]);
 
-    /** Cancel the in-flight saved-sort/filter restore (#519). Posts the
+    /** Skip the in-flight saved-sort/filter restore (#519). Posts the
      *  echoed restoreId so a stale cancel from a prior lifecycle is ignored
-     *  by the host, and optimistically shows "Cancelling…" until the
+     *  by the host, and optimistically shows "Loading…" until the
      *  natural-order init/replace lands. */
     const cancelRestore = useCallback(() => {
         const id = restoreIdRef.current;
@@ -1526,20 +1527,6 @@ export function App({
                 ref={toolbarRef}
             >
                 <span className="row-count" ref={rowCountRef}>{rowCountText}</span>
-                {restoreMessage && (
-                    <div className="toolbar-restore" role="status" aria-live="polite">
-                        <span>{restoreMessage}</span>
-                        {!restoreCancelling && (
-                            <button
-                                type="button"
-                                className="restore-cancel"
-                                onClick={cancelRestore}
-                            >
-                                Cancel
-                            </button>
-                        )}
-                    </div>
-                )}
                 <div className="toolbar-chips" ref={toolbarChipsRef}>
                     <ToolbarSortStrip
                         sort={sort}
@@ -1630,6 +1617,20 @@ export function App({
                     </div>
                 </div>
             </div>
+            {restoreMessage && (
+                <div className="toolbar-restore" role="status" aria-live="polite">
+                    <span>{restoreMessage}</span>
+                    {!restoreCancelling && (
+                        <button
+                            type="button"
+                            className="restore-skip"
+                            onClick={cancelRestore}
+                        >
+                            Skip and show data now
+                        </button>
+                    )}
+                </div>
+            )}
             <div className="grid-shell" ref={gridShellRef}>
                 <DataEditor
                     ref={gridRef}

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -43,7 +43,8 @@ import { hasFormatEffect, hasLabelsEffect } from './toolbar-effects';
 import {
     buildGridColumns,
     buildVisibleGridColumns,
-    describeVisibleRows,
+    describeRestoreMessage,
+    describeToolbarRowCount,
     fitLeadingText,
     HEADER_HEIGHT_PX,
     OVERSCAN_ROWS,
@@ -104,6 +105,11 @@ type HeaderTooltipState = {
 const EMPTY_LAYOUT: Layout = { columnWidths: {}, hiddenColumns: [] };
 const EMPTY_TOOLBAR: ToolbarState = { labelsOn: true, formatOn: true, digits: 3 };
 const DEFAULT_SETTINGS: Settings = { missingValueStyle: 'foreground', defaultDigits: 3, persistSort: true, persistFilters: true };
+
+/** Delay before the saved-sort/filter restore banner appears (#519). A
+ *  restore that finishes faster than this never flashes the message; only a
+ *  genuinely slow restore reveals it (and its Cancel). */
+const RESTORE_DEBOUNCE_MS = 200;
 // Glide's renderer type is invariant, but dispatch is by each renderer's `kind`.
 const DATA_VIEWER_RENDERERS = [
     markerCellRenderer,
@@ -357,6 +363,16 @@ export function App({
      *  restored a non-empty schema from getState (we already have something
      *  to show). */
     const [loading, setLoading] = useState<boolean>(!(restored?.columns && restored.columns.length > 0));
+    // Saved-sort/filter restore banner (#519). `restorePending` is set only
+    // after the debounce timer fires, so a fast restore never flashes it;
+    // `restoreCancelling` shows the optimistic "Cancelling…" until init/replace
+    // lands. The refs hold the live restoreId (echoed on cancelRestore) and the
+    // debounce timer so it can be cleared when the restore completes.
+    const [restorePending, setRestorePending] =
+        useState<{ restoreId: number; sort: boolean; filter: boolean } | null>(null);
+    const [restoreCancelling, setRestoreCancelling] = useState(false);
+    const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const restoreIdRef = useRef<number | null>(null);
     const [filterEditor, setFilterEditor] = useState<{
         entry?: FilterEntry;
         columnIndex?: number;
@@ -389,7 +405,17 @@ export function App({
      *  All grid-coordinate math must use this count so row indices never
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
-    const rowCountText = describeVisibleRows(effectiveNrow, visibleRange, loading);
+    // On open, explain (and let the user cancel) the wait while saved
+    // sort/filter preferences are reapplied (#519). While the banner is up it
+    // explains the wait, so the bare "Loading…" row-count is suppressed.
+    const restoreMessage = restorePending
+        ? (restoreCancelling
+            ? 'Cancelling…'
+            : describeRestoreMessage(restorePending.sort, restorePending.filter))
+        : null;
+    const rowCountText = describeToolbarRowCount(
+        effectiveNrow, visibleRange, loading, restoreMessage !== null,
+    );
     /** Whether the chip group must wrap onto its own second row. `layout.hiddenColumns.length`
      *  is in the deps because the Columns count badge widens the action buttons without
      *  changing the toolbar width — without that the wrap state can be stale.
@@ -964,14 +990,58 @@ export function App({
         vscode.postMessage({ type: 'webviewReady' });
     }, [vscode]);
 
+    /** Cancel the in-flight saved-sort/filter restore (#519). Posts the
+     *  echoed restoreId so a stale cancel from a prior lifecycle is ignored
+     *  by the host, and optimistically shows "Cancelling…" until the
+     *  natural-order init/replace lands. */
+    const cancelRestore = useCallback(() => {
+        const id = restoreIdRef.current;
+        if (id === null) return;
+        setRestoreCancelling(true);
+        vscode.postMessage({
+            type: 'cancelRestore',
+            panelGeneration,
+            restoreId: id,
+        });
+    }, [vscode, panelGeneration]);
+
     useEffect(() => {
         const onMessage = (event: MessageEvent<ExtensionToWebview>) => {
             const m = event.data;
             if (!m || typeof m !== 'object') return;
             if ('panelGeneration' in m && m.panelGeneration < panelGeneration) return;
             switch (m.type) {
+                case 'restorePending': {
+                    // Defer showing the banner until the debounce elapses; a
+                    // restore that completes sooner clears the timer on
+                    // init/replace below and never flashes the message.
+                    restoreIdRef.current = m.restoreId;
+                    setRestoreCancelling(false);
+                    if (restoreTimerRef.current !== null) {
+                        clearTimeout(restoreTimerRef.current);
+                    }
+                    const info = { restoreId: m.restoreId, sort: m.sort, filter: m.filter };
+                    // If a banner is already visible (a prior restore whose
+                    // debounce elapsed), swap its wording at once rather than
+                    // showing stale text until the timer fires.
+                    setRestorePending(prev => (prev ? info : prev));
+                    restoreTimerRef.current = setTimeout(() => {
+                        setRestorePending(info);
+                        restoreTimerRef.current = null;
+                    }, RESTORE_DEBOUNCE_MS);
+                    return;
+                }
                 case 'init':
                 case 'replace':
+                    // Both the normal and cancelled/late-cancel restore paths
+                    // end by posting init/replace, so clear the banner here.
+                    if (restoreTimerRef.current !== null) {
+                        clearTimeout(restoreTimerRef.current);
+                        restoreTimerRef.current = null;
+                    }
+                    setRestorePending(null);
+                    setRestoreCancelling(false);
+                    restoreIdRef.current = null;
                     applyInitOrReplace(m);
                     return;
                 case 'rows':
@@ -1011,7 +1081,13 @@ export function App({
             }
         };
         window.addEventListener('message', onMessage);
-        return () => window.removeEventListener('message', onMessage);
+        return () => {
+            window.removeEventListener('message', onMessage);
+            if (restoreTimerRef.current !== null) {
+                clearTimeout(restoreTimerRef.current);
+                restoreTimerRef.current = null;
+            }
+        };
     }, [
         applyCopyDone,
         applyFilterApplied,
@@ -1419,6 +1495,20 @@ export function App({
                 ref={toolbarRef}
             >
                 <span className="row-count" ref={rowCountRef}>{rowCountText}</span>
+                {restoreMessage && (
+                    <div className="toolbar-restore" role="status" aria-live="polite">
+                        <span>{restoreMessage}</span>
+                        {!restoreCancelling && (
+                            <button
+                                type="button"
+                                className="restore-cancel"
+                                onClick={cancelRestore}
+                            >
+                                Cancel
+                            </button>
+                        )}
+                    </div>
+                )}
                 <div className="toolbar-chips" ref={toolbarChipsRef}>
                     <ToolbarSortStrip
                         sort={sort}

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -652,15 +652,16 @@ export function App({
         lastHostFilterRef.current = m.filter;
         // Histograms are fetched lazily per column (getHistogram) the first
         // time a numeric filter popover opens — not shipped in init/replace.
-        // Drop any cached bins + in-flight request markers whenever the
-        // dataset changes (always on replace; on init unless this is the same
-        // dataset being restored from getState, e.g. after a tab hide/show),
-        // since bins are keyed by column index and would be wrong for a
-        // different schema. A same-dataset init keeps the restored cache.
-        if (m.type === 'replace' || !sameDataset) {
-            setHistograms({});
-            histogramRequestedRef.current.clear();
-        }
+        // Drop any cached bins + in-flight request markers on every init AND
+        // replace. Bins are value-derived but keyed only by column index, and
+        // `sameDataset` compares row count + column shape only — it cannot tell
+        // a genuine same-dataset reload (tab hide/show) apart from a different
+        // dataset that happens to share that shape, so keeping the cache risked
+        // showing stale bins from a previous frame after a same-shape swap. The
+        // host treats histograms as reader-scoped and clears them on every
+        // replace; the webview now matches that, refetching lazily on demand.
+        setHistograms({});
+        histogramRequestedRef.current.clear();
         setFilterPending(false);
         setNrowFiltered(undefined);
         setLoading(false);
@@ -1149,8 +1150,15 @@ export function App({
                     // Defer showing the banner until the debounce elapses; a
                     // restore that completes sooner clears the timer on
                     // init/replace below and never flashes the message.
+                    const previousRestoreId = restoreIdRef.current;
                     restoreIdRef.current = m.restoreId;
-                    setRestoreCancelling(false);
+                    // Only reset the canceling state for a genuinely new restore.
+                    // A same-id refresh while a Skip is already in flight must
+                    // not flip the banner back from "Loading…" and re-enable the
+                    // button.
+                    if (previousRestoreId !== m.restoreId) {
+                        setRestoreCancelling(false);
+                    }
                     if (restoreTimerRef.current !== null) {
                         clearTimeout(restoreTimerRef.current);
                     }

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -373,6 +373,16 @@ export function App({
     const [restoreCancelling, setRestoreCancelling] = useState(false);
     const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const restoreIdRef = useRef<number | null>(null);
+    // The exact filter object the host last sent authoritatively (via
+    // init/replace, or a fromPersistence filterApplied). The debounced
+    // saveFilter effect skips when `filter` is still this object, so the
+    // webview never echoes host-owned state back to the store. This matters
+    // on a genuine restore-filter read failure: the host keeps the saved
+    // filter but sends EMPTY for display; without this guard the webview
+    // would saveFilter(EMPTY) and destroy the very pref the host preserved.
+    // A real user change replaces `filter` with a new object (≠ this ref),
+    // so it still persists normally. (#519)
+    const lastHostFilterRef = useRef<FilterState | null>(null);
     const [filterEditor, setFilterEditor] = useState<{
         entry?: FilterEntry;
         columnIndex?: number;
@@ -592,6 +602,9 @@ export function App({
         setSort(m.sort);
         setSortPending(false);
         setFilter(m.filter);
+        // init/replace carries the host's authoritative filter; don't echo it
+        // back via saveFilter (see lastHostFilterRef).
+        lastHostFilterRef.current = m.filter;
         // Histograms are fetched lazily per column (getHistogram) the first
         // time a numeric filter popover opens — not shipped in init/replace.
         // Drop any cached bins + in-flight request markers whenever the
@@ -716,6 +729,11 @@ export function App({
     const applyFilterApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'filterApplied' }>) => {
         if (m.panelGeneration !== panelGeneration) return;
         setFilter(m.filter);
+        // A restore echo (fromPersistence) is host-owned state already in the
+        // store — suppress its redundant save-back. A user-initiated
+        // filterApplied (fromPersistence false) must still persist, so leave
+        // the ref alone in that case.
+        if (m.fromPersistence) lastHostFilterRef.current = m.filter;
         const activeNrowFiltered = m.filter.entries.some(e => e.enabled) ? m.nrowFiltered : undefined;
         setNrowFiltered(activeNrowFiltered);
         setFilterPending(false);
@@ -1156,6 +1174,12 @@ export function App({
         // and saving it would clobber a host-persisted filter before the
         // restore round-trip completes.
         if (!toolbarBootstrappedRef.current || !schemaHash) return;
+        // Don't echo a host-owned filter back to the store. On a genuine
+        // restore-filter read failure the host keeps the saved filter but
+        // sends EMPTY for display; echoing that would destroy the pref the
+        // host preserved. A real user change replaces `filter` with a new
+        // object, so it still persists. (#519)
+        if (filter === lastHostFilterRef.current) return;
         const id = window.setTimeout(() => {
             vscode.postMessage({
                 type: 'saveFilter',

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -67,6 +67,17 @@ import { FilterStrip } from './filter-strip';
 import { FilterPopover } from './filter-popover';
 import { colKind } from './filter-column-kind';
 import { useToolbarWrap } from './use-toolbar-wrap';
+import {
+    filterEntriesForNextRequest,
+    nextSortKeysForColumn,
+    sortKeysForNextRequest,
+    createIntentRequestState,
+    requestFilterIntent,
+    requestSortIntent,
+    shouldAcceptAppliedResponse,
+    shouldAcceptInteractiveResponse,
+    shouldAcceptSortResponse,
+} from './transform-intent';
 
 type VscodeApi = {
     postMessage(msg: WebviewToExtension): void;
@@ -318,10 +329,20 @@ export function App({
     const inflightRef = useRef(new Map<number, string>());
     const pendingKeysRef = useRef(new Set<string>());
     const nextRequestIdRef = useRef(0);
+    const intentRequestStateRef = useRef(createIntentRequestState());
+    const panelGenerationRef = useRef(restored?.panelGeneration ?? 0);
     /** Column indices whose histogram has been requested from the host but
      *  not yet received, so the lazy-fetch effect fires at most one
      *  getHistogram per column. Cleared on replace (new dataset). */
-    const histogramRequestedRef = useRef(new Set<number>());
+    const histogramRequestedRef = useRef(new Map<number, number>());
+    const bootstrappingRef = useRef(true);
+    const latestSortRequestIdRef = useRef<number | null>(null);
+    const latestSortIntentRef = useRef<SortState | null>(null);
+    const acceptedSortRequestIdRef = useRef(0);
+    const latestFilterRequestIdRef = useRef<number | null>(null);
+    const latestFilterIntentRef = useRef<FilterState | null>(null);
+    const acceptedFilterRequestIdRef = useRef(0);
+    const restoreInteractionBlockRef = useRef<{ sort: boolean; filter: boolean } | null>(null);
     const viewportGenerationRef = useRef(0);
     const toolbarBootstrappedRef = useRef(false);
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
@@ -354,6 +375,7 @@ export function App({
     const [sort, setSort] = useState<SortState>(restored?.sort ?? EMPTY_SORT);
     const [sortPending, setSortPending] = useState(false);
     const [filter, setFilter] = useState<FilterState>(restored?.filter ?? EMPTY_FILTER);
+    const [pendingFilterIntent, setPendingFilterIntent] = useState<FilterState | null>(null);
     const [filterPending, setFilterPending] = useState(false);
     const [nrowFiltered, setNrowFiltered] = useState<number | undefined>(restored?.nrowFiltered);
     const [histograms, setHistograms] = useState<Record<number, HistogramBin[]>>(restored?.histograms ?? {});
@@ -390,6 +412,12 @@ export function App({
         topPx?: number;
     } | null>(null);
 
+    const nextRequestId = useCallback(() => {
+        const requestId = ++nextRequestIdRef.current;
+        intentRequestStateRef.current.nextRequestId = requestId;
+        return requestId;
+    }, []);
+
     const visibleCols = useMemo(
         () => visibleColumnIndices(columns, layout.hiddenColumns),
         [columns, layout.hiddenColumns],
@@ -415,6 +443,7 @@ export function App({
      *  All grid-coordinate math must use this count so row indices never
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
+    const displayedFilter = pendingFilterIntent ?? filter;
     // On open, explain the background wait while saved sort/filter
     // preferences are reapplied (#519). The grid already shows natural-order
     // data, so the toolbar keeps its row-count while the banner offers a
@@ -442,7 +471,7 @@ export function App({
         },
         // sortPending/filterPending are deps because the progress pills they
         // drive widen the chip group, which can change whether it must wrap.
-        [sort.keys, filter.entries, rowCountText, layout.hiddenColumns.length, sortPending, filterPending, labelsHaveEffect, formatHasEffect],
+        [sort.keys, displayedFilter.entries, rowCountText, layout.hiddenColumns.length, sortPending, filterPending, labelsHaveEffect, formatHasEffect],
     );
     /** Transient progress pills for the toolbar chip group. The data viewer
      *  has no bottom status bar: the sort/filter chip strips carry the full
@@ -498,11 +527,16 @@ export function App({
         return { row: Math.min(effectiveNrow - 1, visibleRange.start), col: visibleCols[0] };
     }, [effectiveNrow, gridSelection, visibleCols, visibleRange.start]);
 
-    const postLifecycle = useCallback((event: string, range: VisibleRange = visibleRange, selection = gridSelection) => {
+    const postLifecycle = useCallback((
+        event: string,
+        range: VisibleRange = visibleRange,
+        selection = gridSelection,
+        generation = panelGeneration,
+    ) => {
         vscode.postMessage({
             type: 'lifecycle',
             event,
-            panelGeneration,
+            panelGeneration: generation,
             nrow,
             columns: columns.length,
             visibleRows: Math.max(0, range.end - range.start),
@@ -541,6 +575,7 @@ export function App({
     }, []);
 
     const requestRows = useCallback((range: VisibleRange) => {
+        if (bootstrappingRef.current) return;
         if (range.end <= range.start || visibleCols.length === 0) return;
         if (rowCacheRef.current.hasRange(range.start, range.end)) return;
         const columnsKey = visibleCols.join(',');
@@ -548,7 +583,7 @@ export function App({
         if (pendingKeysRef.current.has(key)) return;
 
         viewportGenerationRef.current += 1;
-        const requestId = ++nextRequestIdRef.current;
+        const requestId = nextRequestId();
         pendingKeysRef.current.add(key);
         inflightRef.current.set(requestId, key);
         vscode.postMessage({
@@ -560,7 +595,7 @@ export function App({
             end: range.end,
             columns: visibleCols,
         });
-    }, [panelGeneration, visibleCols, vscode]);
+    }, [nextRequestId, panelGeneration, visibleCols, vscode]);
 
     const scheduleMissingRowRequest = useCallback((row: number) => {
         if (effectiveNrow <= 0 || visibleCols.length === 0) return;
@@ -589,9 +624,9 @@ export function App({
     }, []);
 
     const applyInitOrReplace = useCallback((m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>) => {
-        const sameDataset = m.panelGeneration === panelGeneration
-            && m.nrow === nrow
+        const sameDataset = m.nrow === nrow
             && sameColumns(m.columns, columns);
+        panelGenerationRef.current = m.panelGeneration;
         setPanelGeneration(m.panelGeneration);
         setNrow(m.nrow);
         setColumns(m.columns);
@@ -600,6 +635,15 @@ export function App({
         setSchemaHash(m.schemaHash);
         if (m.type === 'init') setSettings(m.settings);
         setToolbar(m.toolbar);
+        latestSortRequestIdRef.current = null;
+        latestSortIntentRef.current = null;
+        acceptedSortRequestIdRef.current = 0;
+        latestFilterRequestIdRef.current = null;
+        latestFilterIntentRef.current = null;
+        acceptedFilterRequestIdRef.current = 0;
+        intentRequestStateRef.current.latestSortIntent = null;
+        intentRequestStateRef.current.latestFilterIntent = null;
+        setPendingFilterIntent(null);
         setSort(m.sort);
         setSortPending(false);
         setFilter(m.filter);
@@ -618,19 +662,24 @@ export function App({
             histogramRequestedRef.current.clear();
         }
         setFilterPending(false);
-        if (m.filter.entries.length === 0) setNrowFiltered(undefined);
+        setNrowFiltered(undefined);
         setLoading(false);
         toolbarBootstrappedRef.current = true;
         clearRows();
         setResolvedLabels({});
         setGridSelection(createEmptySelection());
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
-        postLifecycle(m.type, sameDataset ? visibleRange : { start: 0, end: 0 }, createEmptySelection());
+        postLifecycle(
+            m.type,
+            sameDataset ? visibleRange : { start: 0, end: 0 },
+            createEmptySelection(),
+            m.panelGeneration,
+        );
         window.setTimeout(() => gridRef.current?.scrollTo(0, 0, 'both'), 0);
     }, [clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
 
     const applyRows = useCallback((m: Extract<ExtensionToWebview, { type: 'rows' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         const key = inflightRef.current.get(m.requestId);
         if (!key) {
             return;
@@ -652,10 +701,10 @@ export function App({
             gridRef.current?.updateCells(damageList);
         }
         postLifecycle('rows');
-    }, [panelGeneration, postLifecycle, visibleCols.length]);
+    }, [postLifecycle, visibleCols.length]);
 
     const applyLabels = useCallback((m: Extract<ExtensionToWebview, { type: 'labels' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         setResolvedLabels(previous => ({
             ...previous,
             [m.columnIndex]: {
@@ -672,16 +721,25 @@ export function App({
         if (damageList.length > 0) {
             gridRef.current?.updateCells(damageList);
         }
-    }, [panelGeneration, visibleCols, visibleRange.end, visibleRange.start]);
+    }, [visibleCols, visibleRange.end, visibleRange.start]);
 
     const applyHistogram = useCallback((m: Extract<ExtensionToWebview, { type: 'histogram' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (histogramRequestedRef.current.get(m.columnIndex) !== m.requestId) return;
         histogramRequestedRef.current.delete(m.columnIndex);
         setHistograms(prev => ({ ...prev, [m.columnIndex]: m.bins }));
-    }, [panelGeneration]);
+    }, []);
 
     const applySortApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'sortApplied' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptSortResponse(
+            latestSortRequestIdRef.current,
+            m.requestId,
+            m.fromPersistence,
+        )) return;
+        latestSortRequestIdRef.current = null;
+        latestSortIntentRef.current = null;
+        acceptedSortRequestIdRef.current = m.requestId;
         setSort(m.sort);
         setSortPending(false);
         // Permutation just changed — every cached row window is now in
@@ -701,9 +759,14 @@ export function App({
                 OVERSCAN_ROWS,
             ));
         }
+        if (m.error) {
+            setCopyStatus('error');
+            setCopyStatusMsg(m.error);
+        }
         // Persist the latest sort. Cleared (empty keys) saves are also
-        // valid — the host treats an empty SortState as a clear.
-        if (schemaHash) {
+        // valid — the host treats an empty SortState as a clear. Rollbacks
+        // are failure recovery, not a new user preference.
+        if (schemaHash && !m.rollback) {
             vscode.postMessage({
                 type: 'saveSort',
                 panelGeneration: m.panelGeneration,
@@ -714,7 +777,6 @@ export function App({
     }, [
         clearRows,
         effectiveNrow,
-        panelGeneration,
         requestRows,
         schemaHash,
         visibleCols.length,
@@ -723,18 +785,50 @@ export function App({
     ]);
 
     const applySortStatus = useCallback((m: Extract<ExtensionToWebview, { type: 'sortStatus' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptSortResponse(latestSortRequestIdRef.current, m.requestId, false)) return;
         setSortPending(m.state === 'pending');
-    }, [panelGeneration]);
+    }, []);
 
     const applyFilterApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'filterApplied' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptAppliedResponse(
+            latestFilterRequestIdRef.current,
+            m.requestId,
+            m.fromPersistence,
+        )) {
+            if (m.fromPersistence) restoreInteractionBlockRef.current = null;
+            return;
+        }
+        latestFilterRequestIdRef.current = null;
+        latestFilterIntentRef.current = null;
+        acceptedFilterRequestIdRef.current = m.requestId;
+        setPendingFilterIntent(null);
+        if (m.error) {
+            setCopyStatus('error');
+            setCopyStatusMsg(m.error);
+        }
         setFilter(m.filter);
-        // A restore echo (fromPersistence) is host-owned state already in the
-        // store — suppress its redundant save-back. A user-initiated
-        // filterApplied (fromPersistence false) must still persist, so leave
-        // the ref alone in that case.
-        if (m.fromPersistence) lastHostFilterRef.current = m.filter;
+        // Host-owned state and rollback recovery are not new user
+        // preferences. Successful user filter applies are persisted
+        // immediately (like sort applies), then marked as handled so the
+        // debounced saveFilter effect does not duplicate the write. Persisting
+        // on acknowledgement avoids losing an accepted filter if a later
+        // pending filter cancels the debounce and then rolls back.
+        if (m.fromPersistence) {
+            lastHostFilterRef.current = m.filter;
+            restoreInteractionBlockRef.current = null;
+        } else if (m.rollback) {
+            lastHostFilterRef.current = m.filter;
+        } else if (schemaHash) {
+            vscode.postMessage({
+                type: 'saveFilter',
+                panelGeneration: m.panelGeneration,
+                schemaHash,
+                filter: m.filter,
+            });
+            lastHostFilterRef.current = m.filter;
+        }
         const activeNrowFiltered = m.filter.entries.some(e => e.enabled) ? m.nrowFiltered : undefined;
         setNrowFiltered(activeNrowFiltered);
         setFilterPending(false);
@@ -754,30 +848,47 @@ export function App({
     }, [
         clearRows,
         nrow,
-        panelGeneration,
         requestRows,
+        schemaHash,
         visibleCols.length,
         visibleRange,
+        vscode,
     ]);
 
     const applyFilterStatus = useCallback((m: Extract<ExtensionToWebview, { type: 'filterStatus' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptInteractiveResponse(latestFilterRequestIdRef.current, m.requestId)) return;
         setFilterPending(m.state === 'pending');
-    }, [panelGeneration]);
+    }, []);
 
     /** Send a setFilters request. Empty `entries` clears the filter. The host
      *  replies with `filterApplied` which drives state updates. */
     const applyFilters = useCallback((entries: FilterEntry[]) => {
-        setFilterPending(entries.some(e => e.enabled));
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current || restoreInteractionBlockRef.current !== null) return;
+        const request = requestFilterIntent(
+            intentRequestStateRef.current,
+            entries,
+            toolbar.labelsOn,
+        );
+        nextRequestIdRef.current = intentRequestStateRef.current.nextRequestId;
+        const next = request.filter;
+        latestFilterIntentRef.current = next;
+        setPendingFilterIntent(next);
+        setFilterPending(next.entries.some(e => e.enabled));
+        latestFilterRequestIdRef.current = request.requestId;
         vscode.postMessage({
             type: 'setFilters',
             panelGeneration,
-            requestId,
-            entries,
-            labelsOn: toolbar.labelsOn,
+            requestId: request.requestId,
+            rollbackBaseRequestId: acceptedFilterRequestIdRef.current,
+            entries: request.entries,
+            labelsOn: next.labelsOnWhenFiltered,
         });
     }, [panelGeneration, toolbar.labelsOn, vscode]);
+
+    const filterEntriesForRequest = useCallback(() => {
+        return filterEntriesForNextRequest(filter.entries, latestFilterIntentRef.current);
+    }, [filter.entries]);
 
     const onEditFilter = useCallback((entry: FilterEntry) => {
         setFilterEditor({ entry });
@@ -786,47 +897,63 @@ export function App({
     /** Open the filter popover for a column, pre-seeded with its active filter
      *  (one-filter-per-column invariant) so editing reflects the live settings.
      *  When the column is unfiltered, `existing` is undefined and the popover
-     *  opens blank — the "add new" path. Keyed on `filter.entries` so callers
-     *  inside effects (e.g. the keyboard handler) never read a stale snapshot. */
+     *  opens blank — the "add new" path. Reads through
+     *  `filterEntriesForRequest` so rapid edits compose from the latest pending
+     *  request rather than the last host acknowledgement. */
     const openFilterEditor = useCallback(
         (columnIndex: number, leftPx: number, topPx: number) => {
-            const existing = filter.entries.find(e => e.columnIndex === columnIndex);
+            const existing = filterEntriesForRequest().find(e => e.columnIndex === columnIndex);
             setFilterEditor({ entry: existing, columnIndex, leftPx, topPx });
         },
-        [filter.entries],
+        [filterEntriesForRequest],
     );
 
     const onToggleFilterEnabled = useCallback((id: string) => {
-        applyFilters(filter.entries.map(e => e.id === id ? { ...e, enabled: !e.enabled } : e));
-    }, [applyFilters, filter.entries]);
+        applyFilters(filterEntriesForRequest().map(e => e.id === id ? { ...e, enabled: !e.enabled } : e));
+    }, [applyFilters, filterEntriesForRequest]);
 
     const onRemoveFilter = useCallback((id: string) => {
-        applyFilters(filter.entries.filter(e => e.id !== id));
-    }, [applyFilters, filter.entries]);
+        applyFilters(filterEntriesForRequest().filter(e => e.id !== id));
+    }, [applyFilters, filterEntriesForRequest]);
 
     const onClearAllFilters = useCallback(() => {
         applyFilters([]);
     }, [applyFilters]);
 
     const clearFilterOnColumn = useCallback((columnIndex: number) => {
-        applyFilters(filter.entries.filter(e => e.columnIndex !== columnIndex));
-    }, [filter, applyFilters]);
+        applyFilters(filterEntriesForRequest().filter(e => e.columnIndex !== columnIndex));
+    }, [filterEntriesForRequest, applyFilters]);
 
     /** Send a setSort request. Empty `keys` clears the sort. The host
      *  replies with `sortApplied` which drives state updates. */
     const applySort = useCallback((keys: SortKey[]) => {
-        setSortPending(true);
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current || restoreInteractionBlockRef.current !== null) return;
+        const request = requestSortIntent(
+            intentRequestStateRef.current,
+            keys,
+            toolbar.labelsOn,
+        );
+        nextRequestIdRef.current = intentRequestStateRef.current.nextRequestId;
+        const next = request.sort;
+        latestSortIntentRef.current = next;
+        setSort(next);
+        setSortPending(keys.length > 0);
+        latestSortRequestIdRef.current = request.requestId;
         vscode.postMessage({
             type: 'setSort',
             panelGeneration,
-            requestId,
-            keys,
+            requestId: request.requestId,
+            rollbackBaseRequestId: acceptedSortRequestIdRef.current,
+            keys: request.keys,
             labelsOn: toolbar.labelsOn,
             formatOn: toolbar.formatOn,
             digits: toolbar.digits,
         });
     }, [panelGeneration, toolbar, vscode]);
+
+    const sortKeysForRequest = useCallback(() => {
+        return sortKeysForNextRequest(sort.keys, latestSortIntentRef.current);
+    }, [sort.keys]);
 
     /** Pick a direction for `sourceIndex`. When `append` is true, merge
      *  into the existing sort (flipping the column's direction in place
@@ -837,50 +964,32 @@ export function App({
         direction: 'asc' | 'desc',
         append: boolean,
     ) => {
-        const existing = sort.keys.findIndex(k => k.columnIndex === sourceIndex);
-        let next: SortKey[];
-        if (!append) {
-            // Plain pick: this column becomes the sort. If user picks the
-            // same column/direction that's already active, no-op.
-            if (existing >= 0
-                && sort.keys.length === 1
-                && sort.keys[0].direction === direction) {
-                return;
-            }
-            next = [{ columnIndex: sourceIndex, direction }];
-        } else if (existing >= 0) {
-            // Shift+pick on an existing key: flip direction in place,
-            // priority preserved.
-            if (sort.keys[existing].direction === direction) return;
-            next = sort.keys.map((k, i) =>
-                i === existing ? { ...k, direction } : k);
-        } else {
-            // Shift+pick on a new column: append at the end.
-            next = [...sort.keys, { columnIndex: sourceIndex, direction }];
-        }
+        const next = nextSortKeysForColumn(sortKeysForRequest(), sourceIndex, direction, append);
+        if (!next) return;
         applySort(next);
-    }, [applySort, sort.keys]);
+    }, [applySort, sortKeysForRequest]);
 
     const clearSortOnColumn = useCallback((sourceIndex: number) => {
-        const next = sort.keys.filter(k => k.columnIndex !== sourceIndex);
-        if (next.length === sort.keys.length) return;
+        const current = sortKeysForRequest();
+        const next = current.filter(k => k.columnIndex !== sourceIndex);
+        if (next.length === current.length) return;
         applySort(next);
-    }, [applySort, sort.keys]);
+    }, [applySort, sortKeysForRequest]);
 
     const clearAllSorts = useCallback(() => {
-        if (sort.keys.length === 0) return;
+        if (sortKeysForRequest().length === 0) return;
         applySort([]);
-    }, [applySort, sort.keys.length]);
+    }, [applySort, sortKeysForRequest]);
 
     const applyCopyDone = useCallback((m: Extract<ExtensionToWebview, { type: 'copyDone' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         setCopyStatus(m.ok ? 'copied' : 'error');
         setCopyStatusMsg(m.ok ? 'Copied' : (m.error ?? 'Copy failed'));
         window.setTimeout(() => {
             setCopyStatus('');
             setCopyStatusMsg('');
         }, 2500);
-    }, [panelGeneration]);
+    }, []);
 
     const estimatedViewportRowCount = useCallback((): number => {
         const current = visibleRange.end - visibleRange.start;
@@ -1006,6 +1115,7 @@ export function App({
     ]);
 
     useEffect(() => {
+        bootstrappingRef.current = true;
         vscode.postMessage({ type: 'webviewReady' });
     }, [vscode]);
 
@@ -1028,7 +1138,12 @@ export function App({
         const onMessage = (event: MessageEvent<ExtensionToWebview>) => {
             const m = event.data;
             if (!m || typeof m !== 'object') return;
-            if ('panelGeneration' in m && m.panelGeneration < panelGeneration) return;
+            const currentGeneration = panelGenerationRef.current;
+            if ('panelGeneration' in m && m.panelGeneration < currentGeneration) return;
+            if ('panelGeneration' in m && bootstrappingRef.current) {
+                if (m.type !== 'init' && m.type !== 'replace' && m.type !== 'restorePending') return;
+                if (m.panelGeneration <= currentGeneration) return;
+            }
             switch (m.type) {
                 case 'restorePending': {
                     // Defer showing the banner until the debounce elapses; a
@@ -1040,6 +1155,7 @@ export function App({
                         clearTimeout(restoreTimerRef.current);
                     }
                     const info = { restoreId: m.restoreId, sort: m.sort, filter: m.filter };
+                    restoreInteractionBlockRef.current = { sort: m.sort, filter: m.filter };
                     // If a banner is already visible (a prior restore whose
                     // debounce elapsed), swap its wording at once rather than
                     // showing stale text until the timer fires.
@@ -1052,6 +1168,7 @@ export function App({
                 }
                 case 'init':
                 case 'replace':
+                    bootstrappingRef.current = false;
                     // Both the normal and cancelled/late-cancel restore paths
                     // end by posting init/replace, so clear the banner here.
                     if (restoreTimerRef.current !== null) {
@@ -1060,6 +1177,10 @@ export function App({
                     }
                     setRestorePending(null);
                     setRestoreCancelling(false);
+                    if (!(restoreInteractionBlockRef.current?.filter
+                        && m.filter.entries.some(e => e.enabled))) {
+                        restoreInteractionBlockRef.current = null;
+                    }
                     restoreIdRef.current = null;
                     applyInitOrReplace(m);
                     return;
@@ -1159,15 +1280,16 @@ export function App({
         if (kind !== 'numeric' && kind !== 'labelledNumeric') return;
         if (histograms[ci] !== undefined) return;          // already cached
         if (histogramRequestedRef.current.has(ci)) return;  // request in flight
-        histogramRequestedRef.current.add(ci);
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current) return;
+        const requestId = nextRequestId();
+        histogramRequestedRef.current.set(ci, requestId);
         vscode.postMessage({
             type: 'getHistogram',
             panelGeneration,
             requestId,
             columnIndex: ci,
         });
-    }, [filterEditor, columns, histograms, panelGeneration, vscode]);
+    }, [filterEditor, columns, histograms, nextRequestId, panelGeneration, vscode]);
 
     useEffect(() => {
         // Guard on the same bootstrap flag as saveToolbar: until the first
@@ -1175,6 +1297,7 @@ export function App({
         // and saving it would clobber a host-persisted filter before the
         // restore round-trip completes.
         if (!toolbarBootstrappedRef.current || !schemaHash) return;
+        if (pendingFilterIntent !== null || latestFilterRequestIdRef.current !== null) return;
         // Don't echo a host-owned filter back to the store. On a genuine
         // restore-filter read failure the host keeps the saved filter but
         // sends EMPTY for display; echoing that would destroy the pref the
@@ -1190,7 +1313,7 @@ export function App({
             });
         }, 300);
         return () => window.clearTimeout(id);
-    }, [filter, panelGeneration, schemaHash, vscode]);
+    }, [filter, panelGeneration, pendingFilterIntent, schemaHash, vscode]);
 
     /** Labels-toggle invalidates sort keys derived from displayed text.
      *  When the active sort touches a factor or value-labelled column
@@ -1218,16 +1341,16 @@ export function App({
      *  filter.labelsOnWhenFiltered = toolbar.labelsOn, making the guard true
      *  on the next render and preventing an infinite re-fire loop. */
     useEffect(() => {
-        if (filter.entries.length === 0) return;
-        if (filter.labelsOnWhenFiltered === toolbar.labelsOn) return;
-        const touchesLabelled = filter.entries.some(e => {
+        if (displayedFilter.entries.length === 0) return;
+        if (displayedFilter.labelsOnWhenFiltered === toolbar.labelsOn) return;
+        const touchesLabelled = displayedFilter.entries.some(e => {
             const col = columns[e.columnIndex];
             if (!col) return false;
             return e.predicate.kind === 'setIn' || e.predicate.kind === 'setNotIn';
         });
         if (!touchesLabelled) return;
-        applyFilters(filter.entries);
-    }, [applyFilters, columns, filter, toolbar.labelsOn]);
+        applyFilters(filterEntriesForRequest());
+    }, [applyFilters, columns, displayedFilter, filterEntriesForRequest, toolbar.labelsOn]);
 
     useEffect(() => {
         if (!toolbar.labelsOn) return;
@@ -1246,7 +1369,7 @@ export function App({
         }
         for (const [colIndexRaw, indices] of Object.entries(wantByColumn)) {
             if (indices.size === 0) continue;
-            const requestId = ++nextRequestIdRef.current;
+            const requestId = nextRequestId();
             vscode.postMessage({
                 type: 'getLabels',
                 panelGeneration,
@@ -1296,7 +1419,7 @@ export function App({
         }
 
         if (rowEnd <= rowStart || colIndices.length === 0) return;
-        const requestId = ++nextRequestIdRef.current;
+        const requestId = nextRequestId();
         setCopyStatus('copying');
         setCopyStatusMsg('Copying...');
         vscode.postMessage({
@@ -1309,7 +1432,7 @@ export function App({
             digits: toolbar.digits,
             includeHeader,
         });
-    }, [effectiveNrow, gridSelection, panelGeneration, toolbar, visibleCols, vscode]);
+    }, [effectiveNrow, gridSelection, nextRequestId, panelGeneration, toolbar, visibleCols, vscode]);
 
     useEffect(() => {
         const onCopy = (event: ClipboardEvent) => {
@@ -1535,7 +1658,7 @@ export function App({
                         onClearAll={clearAllSorts}
                     />
                     <FilterStrip
-                        filter={filter}
+                        filter={displayedFilter}
                         columns={columns}
                         onEdit={onEditFilter}
                         onToggleEnabled={onToggleFilterEnabled}
@@ -1818,10 +1941,10 @@ export function App({
                             : undefined}
                         filter={contextMenu.kind === 'column' && contextMenu.columnIndex !== undefined
                             ? {
-                                hasFilter: filter.entries.some(
+                                hasFilter: displayedFilter.entries.some(
                                     e => e.columnIndex === contextMenu.columnIndex,
                                 ),
-                                anyFiltered: filter.entries.length > 0,
+                                anyFiltered: displayedFilter.entries.length > 0,
                                 onAddFilter: () => {
                                     openFilterEditor(
                                         contextMenu.columnIndex!,
@@ -1831,7 +1954,7 @@ export function App({
                                     setContextMenu(null);
                                 },
                                 onClearColumn: () => {
-                                    applyFilters(filter.entries.filter(
+                                    applyFilters(filterEntriesForRequest().filter(
                                         e => e.columnIndex !== contextMenu.columnIndex,
                                     ));
                                     setContextMenu(null);
@@ -1868,13 +1991,13 @@ export function App({
                                 const next = (() => {
                                     if (filterEditor.entry) {
                                         // Editing existing: replace by id, also enforce one-per-column.
-                                        const withoutSameCol = filter.entries.filter(
+                                        const withoutSameCol = filterEntriesForRequest().filter(
                                             e => e.id !== entry.id && e.columnIndex !== entry.columnIndex,
                                         );
                                         return [...withoutSameCol, entry];
                                     }
                                     // New: replace any existing entry for this column.
-                                    const withoutCol = filter.entries.filter(
+                                    const withoutCol = filterEntriesForRequest().filter(
                                         e => e.columnIndex !== entry.columnIndex,
                                     );
                                     return [...withoutCol, entry];

--- a/editors/vscode/src/data-viewer/webview/grid-model.ts
+++ b/editors/vscode/src/data-viewer/webview/grid-model.ts
@@ -90,18 +90,17 @@ export function describeVisibleRows(nrow: number, range: VisibleRange, loading =
 }
 
 /**
- * The toolbar row-count text, suppressed while a saved-sort/filter restore
- * banner is showing (#519). The banner's explanation ("Applying your saved
- * sort…") replaces the unexplained "Loading…" rather than stacking above it,
- * so this returns '' when `restoreActive`; otherwise the normal label.
+ * The toolbar row-count text. `restoreActive` is accepted for call sites that
+ * already know about the saved-sort/filter restore lifecycle, but the restore
+ * banner sits below the toolbar, so the count remains visible while prefs
+ * reapply in the background.
  */
 export function describeToolbarRowCount(
     nrow: number,
     range: VisibleRange,
     loading: boolean,
-    restoreActive: boolean,
+    _restoreActive: boolean,
 ): string {
-    if (restoreActive) return '';
     return describeVisibleRows(nrow, range, loading);
 }
 

--- a/editors/vscode/src/data-viewer/webview/grid-model.ts
+++ b/editors/vscode/src/data-viewer/webview/grid-model.ts
@@ -89,6 +89,32 @@ export function describeVisibleRows(nrow: number, range: VisibleRange, loading =
     return `Showing ${start.toLocaleString()}-${end.toLocaleString()} of ${nrow.toLocaleString()}`;
 }
 
+/**
+ * The toolbar row-count text, suppressed while a saved-sort/filter restore
+ * banner is showing (#519). The banner's explanation ("Applying your saved
+ * sort…") replaces the unexplained "Loading…" rather than stacking above it,
+ * so this returns '' when `restoreActive`; otherwise the normal label.
+ */
+export function describeToolbarRowCount(
+    nrow: number,
+    range: VisibleRange,
+    loading: boolean,
+    restoreActive: boolean,
+): string {
+    if (restoreActive) return '';
+    return describeVisibleRows(nrow, range, loading);
+}
+
+/**
+ * Explains the saved-sort/filter restore wait on open (#519). `sort` /
+ * `filter` say which preferences are being reapplied; at least one is true.
+ */
+export function describeRestoreMessage(sort: boolean, filter: boolean): string {
+    if (sort && filter) return 'Applying your saved sort & filter…';
+    if (sort) return 'Applying your saved sort…';
+    return 'Applying your saved filter…';
+}
+
 /** Labels for the host operations currently in progress, shown as transient
  *  pills in the toolbar chip group. The data viewer has no bottom status bar;
  *  this is the only progress cue for a multi-second sort/filter on a large

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -286,6 +286,52 @@ body,
     animation: toolbar-progress-pulse 1.2s ease-in-out infinite;
 }
 
+/* Saved sort/filter is being reapplied on open (#519): explains the wait and
+   offers a Cancel that abandons it and shows the data in natural order. Sits
+   in the toolbar flex row in place of the suppressed row-count. */
+.toolbar-restore {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    /* A flex item defaults to min-width:auto; allow it to shrink so the
+       message truncates instead of pushing the Cancel button off-screen. */
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground, var(--vscode-foreground, #cccccc));
+}
+
+.toolbar-restore > span {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    animation: toolbar-progress-pulse 1.2s ease-in-out infinite;
+}
+
+.restore-cancel {
+    flex: 0 0 auto;
+    padding: 1px 8px;
+    font-size: 12px;
+    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+}
+
+.restore-cancel:hover {
+    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .toolbar-restore > span {
+        animation: none;
+        opacity: 0.85;
+    }
+}
+
 @keyframes toolbar-progress-pulse {
     0%, 100% { opacity: 0.55; }
     50% { opacity: 1; }

--- a/editors/vscode/src/data-viewer/webview/styles.css
+++ b/editors/vscode/src/data-viewer/webview/styles.css
@@ -21,8 +21,8 @@ body,
 }
 
 .data-viewer-root {
-    display: grid;
-    grid-template-rows: auto 1fr;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
     min-width: 0;
@@ -251,6 +251,7 @@ body,
 
 .grid-shell {
     position: relative;
+    flex: 1 1 0;
     min-width: 0;
     min-height: 0;
     overflow: hidden;
@@ -287,42 +288,44 @@ body,
 }
 
 /* Saved sort/filter is being reapplied on open (#519): explains the wait and
-   offers a Cancel that abandons it and shows the data in natural order. Sits
-   in the toolbar flex row in place of the suppressed row-count. */
+   offers a "Skip and show data now" link that abandons it and shows the data
+   in natural order. */
 .toolbar-restore {
+    /* Stack the message and the skip link so the link reads as the message's
+       own follow-up action rather than a detached control floating at the far
+       right of the toolbar row. */
     display: flex;
-    align-items: center;
-    gap: 8px;
-    /* A flex item defaults to min-width:auto; allow it to shrink so the
-       message truncates instead of pushing the Cancel button off-screen. */
-    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.35));
+    background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background, #1e1e1e));
     min-width: 0;
     font-size: 12px;
     color: var(--vscode-descriptionForeground, var(--vscode-foreground, #cccccc));
 }
 
 .toolbar-restore > span {
-    flex: 1 1 auto;
-    min-width: 0;
+    max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     animation: toolbar-progress-pulse 1.2s ease-in-out infinite;
 }
 
-.restore-cancel {
-    flex: 0 0 auto;
-    padding: 1px 8px;
+.restore-skip {
+    padding: 0;
     font-size: 12px;
-    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
-    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    color: var(--vscode-textLink-foreground, inherit);
+    background: none;
     border: none;
-    border-radius: 2px;
+    text-decoration: underline;
     cursor: pointer;
 }
 
-.restore-cancel:hover {
-    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+.restore-skip:hover {
+    color: var(--vscode-textLink-activeForeground, inherit);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/editors/vscode/src/data-viewer/webview/transform-intent.ts
+++ b/editors/vscode/src/data-viewer/webview/transform-intent.ts
@@ -1,0 +1,144 @@
+import {
+    EMPTY_FILTER,
+    EMPTY_SORT,
+    type FilterEntry,
+    type FilterState,
+    type SortKey,
+    type SortState,
+} from '../messages';
+
+function cloneFilterEntry(entry: FilterEntry): FilterEntry {
+    const predicate = entry.predicate.kind === 'setIn' || entry.predicate.kind === 'setNotIn'
+        ? { ...entry.predicate, values: [...entry.predicate.values] }
+        : { ...entry.predicate };
+    return {
+        ...entry,
+        predicate: predicate as FilterEntry['predicate'],
+    };
+}
+
+export function sortStateForRequestedKeys(
+    keys: readonly SortKey[],
+    labelsOn: boolean,
+): SortState {
+    if (keys.length === 0) return EMPTY_SORT;
+    return {
+        keys: keys.map(k => ({ ...k })),
+        labelsOnWhenSorted: labelsOn,
+    };
+}
+
+export function nextSortKeysForColumn(
+    currentKeys: readonly SortKey[],
+    sourceIndex: number,
+    direction: 'asc' | 'desc',
+    append: boolean,
+): SortKey[] | undefined {
+    const existing = currentKeys.findIndex(k => k.columnIndex === sourceIndex);
+    if (!append) {
+        if (existing >= 0
+            && currentKeys.length === 1
+            && currentKeys[0].direction === direction) {
+            return undefined;
+        }
+        return [{ columnIndex: sourceIndex, direction }];
+    }
+    if (existing >= 0) {
+        if (currentKeys[existing].direction === direction) return undefined;
+        return currentKeys.map((k, i) =>
+            i === existing ? { ...k, direction } : { ...k });
+    }
+    return [...currentKeys.map(k => ({ ...k })), { columnIndex: sourceIndex, direction }];
+}
+
+export function sortKeysForNextRequest(
+    currentKeys: readonly SortKey[],
+    latestRequestedSort: SortState | null,
+): SortKey[] {
+    return (latestRequestedSort?.keys ?? currentKeys).map(k => ({ ...k }));
+}
+
+export function filterStateForRequestedEntries(
+    entries: readonly FilterEntry[],
+    labelsOn: boolean,
+): FilterState {
+    if (entries.length === 0) return EMPTY_FILTER;
+    return {
+        entries: entries.map(cloneFilterEntry),
+        labelsOnWhenFiltered: labelsOn,
+    };
+}
+
+export function filterEntriesForNextRequest(
+    currentEntries: readonly FilterEntry[],
+    latestRequestedFilter: FilterState | null,
+): FilterEntry[] {
+    return (latestRequestedFilter?.entries ?? currentEntries).map(cloneFilterEntry);
+}
+
+export function shouldAcceptAppliedResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+    fromPersistence: boolean,
+): boolean {
+    return fromPersistence
+        ? latestRequestId === null
+        : shouldAcceptInteractiveResponse(latestRequestId, responseRequestId);
+}
+
+export function shouldAcceptSortResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+    fromPersistence: boolean,
+): boolean {
+    return shouldAcceptAppliedResponse(latestRequestId, responseRequestId, fromPersistence);
+}
+
+export function shouldAcceptInteractiveResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+): boolean {
+    return latestRequestId !== null && responseRequestId === latestRequestId;
+}
+
+export type IntentRequestState = {
+    nextRequestId: number;
+    latestSortIntent: SortState | null;
+    latestFilterIntent: FilterState | null;
+};
+
+export function createIntentRequestState(): IntentRequestState {
+    return {
+        nextRequestId: 0,
+        latestSortIntent: null,
+        latestFilterIntent: null,
+    };
+}
+
+export function requestSortIntent(
+    state: IntentRequestState,
+    keys: readonly SortKey[],
+    labelsOn: boolean,
+): { requestId: number; keys: SortKey[]; sort: SortState } {
+    const sort = sortStateForRequestedKeys(keys, labelsOn);
+    state.latestSortIntent = sort;
+    return {
+        requestId: ++state.nextRequestId,
+        keys: sort.keys.map(k => ({ ...k })),
+        sort,
+    };
+}
+
+export function requestFilterIntent(
+    state: IntentRequestState,
+    entries: readonly FilterEntry[],
+    labelsOn: boolean,
+): { requestId: number; entries: FilterEntry[]; filter: FilterState } {
+    const filter = filterStateForRequestedEntries(entries, labelsOn);
+    state.latestFilterIntent = filter;
+    return {
+        requestId: ++state.nextRequestId,
+        entries: filter.entries.map(cloneFilterEntry),
+        filter,
+    };
+}

--- a/tests/bun/data-viewer-abort.test.ts
+++ b/tests/bun/data-viewer-abort.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Abort helpers shared by the cancellable saved-sort/filter restore
+ * (#519): throwIfAborted / yieldToEventLoop / isAbortError.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+    isAbortError,
+    throwIfAborted,
+    yieldToEventLoop,
+} from '../../editors/vscode/src/data-viewer/abort';
+
+describe('throwIfAborted', () => {
+    test('no signal is a no-op', () => {
+        expect(() => throwIfAborted(undefined)).not.toThrow();
+    });
+
+    test('un-aborted signal is a no-op', () => {
+        const c = new AbortController();
+        expect(() => throwIfAborted(c.signal)).not.toThrow();
+    });
+
+    test('aborted signal throws an AbortError DOMException', () => {
+        const c = new AbortController();
+        c.abort();
+        let err: unknown;
+        try {
+            throwIfAborted(c.signal);
+        } catch (e) {
+            err = e;
+        }
+        expect(err).toBeInstanceOf(DOMException);
+        expect((err as DOMException).name).toBe('AbortError');
+    });
+});
+
+describe('isAbortError', () => {
+    test('true for an AbortError DOMException', () => {
+        expect(isAbortError(new DOMException('x', 'AbortError'))).toBe(true);
+    });
+
+    test('false for a plain Error', () => {
+        expect(isAbortError(new Error('decode failed'))).toBe(false);
+    });
+
+    test('false for non-objects', () => {
+        expect(isAbortError(undefined)).toBe(false);
+        expect(isAbortError('AbortError')).toBe(false);
+        expect(isAbortError(null)).toBe(false);
+    });
+});
+
+describe('yieldToEventLoop', () => {
+    test('defers to a later macrotask (does not resolve synchronously)', async () => {
+        let resolved = false;
+        const p = yieldToEventLoop().then(() => { resolved = true; });
+        // The yield must not have completed during synchronous execution;
+        // that macrotask boundary is what lets a queued IPC message land.
+        expect(resolved).toBe(false);
+        await p;
+        expect(resolved).toBe(true);
+    });
+});

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -254,11 +254,12 @@ describe('saved sort/filter restore messaging (#519)', () => {
             .toBe('Applying your saved filter…');
     });
 
-    test('describeToolbarRowCount suppresses the row count while a restore banner shows', () => {
-        // The banner already explains the wait, so the bare "Loading…"
-        // must not stack above it.
-        expect(describeToolbarRowCount(0, { start: 0, end: 0 }, true, true)).toBe('');
-        expect(describeToolbarRowCount(1000, { start: 0, end: 50 }, false, true)).toBe('');
+    test('describeToolbarRowCount keeps the row count visible while a restore banner shows', () => {
+        // The restore banner sits below the toolbar, so the row-count
+        // readout remains useful context while the saved prefs reapply.
+        expect(describeToolbarRowCount(0, { start: 0, end: 0 }, true, true)).toBe('Loading…');
+        expect(describeToolbarRowCount(1000, { start: 0, end: 50 }, false, true))
+            .toBe('Showing 1-50 of 1,000');
     });
 
     test('describeToolbarRowCount falls through to the normal label when no restore', () => {

--- a/tests/bun/data-viewer-grid-model.test.ts
+++ b/tests/bun/data-viewer-grid-model.test.ts
@@ -3,6 +3,8 @@ import {
     buildGridColumns,
     buildVisibleGridColumns,
     clampColumnWidth,
+    describeRestoreMessage,
+    describeToolbarRowCount,
     describeVisibleRows,
     fitLeadingText,
     MAX_COLUMN_WIDTH_PX,
@@ -239,5 +241,29 @@ describe('formatCell', () => {
             .toEqual({ text: '2024-01-15', missing: false });
         expect(formatCell({ _: 'trunc', v: 'long...' }, undefined, undefined, false, false, 3))
             .toEqual({ text: 'long...', missing: false });
+    });
+});
+
+describe('saved sort/filter restore messaging (#519)', () => {
+    test('describeRestoreMessage words by which prefs apply', () => {
+        expect(describeRestoreMessage(true, true))
+            .toBe('Applying your saved sort & filter…');
+        expect(describeRestoreMessage(true, false))
+            .toBe('Applying your saved sort…');
+        expect(describeRestoreMessage(false, true))
+            .toBe('Applying your saved filter…');
+    });
+
+    test('describeToolbarRowCount suppresses the row count while a restore banner shows', () => {
+        // The banner already explains the wait, so the bare "Loading…"
+        // must not stack above it.
+        expect(describeToolbarRowCount(0, { start: 0, end: 0 }, true, true)).toBe('');
+        expect(describeToolbarRowCount(1000, { start: 0, end: 50 }, false, true)).toBe('');
+    });
+
+    test('describeToolbarRowCount falls through to the normal label when no restore', () => {
+        expect(describeToolbarRowCount(0, { start: 0, end: 0 }, true, false)).toBe('Loading…');
+        expect(describeToolbarRowCount(1000, { start: 0, end: 50 }, false, false))
+            .toBe('Showing 1-50 of 1,000');
     });
 });

--- a/tests/bun/data-viewer-panel-filter.test.ts
+++ b/tests/bun/data-viewer-panel-filter.test.ts
@@ -328,6 +328,178 @@ describe('DataViewerPanel: filter round-trips', () => {
         expect(getBatchCalls).toBe(0);
     });
 
+    test('getHistogram and setSort do not read batches concurrently', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 50,
+            columnIndex: 0,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 51,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 50,
+        ) as any;
+        expect(hist).toBeDefined();
+        const sortAck = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 51,
+        ) as any;
+        expect(sortAck).toBeDefined();
+        expect(sortAck.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+    });
+
+    test('webview reload aborts an active histogram without replying to the stale request', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let triggeredReload = false;
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount > 1) throw new Error('histogram read after abort');
+            if (!triggeredReload) {
+                triggeredReload = true;
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+            }
+            return origGetBatch(i);
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 52,
+            columnIndex: 0,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'histogram' && m.requestId === 52))
+            .toEqual([]);
+        expect(readCount).toBe(1);
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        expect(initMessages.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('webview reload aborts an active filter before the next batch read', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount === 1) {
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+                return await origGetBatch(i);
+            }
+            throw new Error('filter read after abort');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: init.panelGeneration,
+            requestId: 54,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'filterApplied' && m.requestId === 54))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(readCount).toBe(1);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted histogram', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let rejectRead!: (err: Error) => void;
+        const readPromise = new Promise<never>((_resolve, reject) => { rejectRead = reject; });
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                return await readPromise;
+            }
+            return await origGetBatch(i);
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 53,
+            columnIndex: 0,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        rejectRead(new Error('decode failed after abort'));
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'histogram' && m.requestId === 53))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+    });
+
     test('setFilters round-trip: filterStatus pending → filterApplied, then getRows returns matching rows', async () => {
         const { fakeWebview } = await setupPanel();
 
@@ -433,6 +605,466 @@ describe('DataViewerPanel: filter round-trips', () => {
         ) as any;
         expect(rows).toBeDefined();
         expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('overlapping setFilter and setSort serialize and compose', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 80,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 81,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 80,
+        )).toBeDefined();
+        expect(fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 81,
+        )).toBeDefined();
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 82,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 82,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('overlapping setFilters requests do not read batches concurrently and latest wins', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 1,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 2,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const applied = fakeWebview.posted.filter(m => m.type === 'filterApplied') as any[];
+        expect(applied.map(m => m.requestId)).toEqual([2]);
+        expect(applied[0].filter.entries).toEqual([{
+            id: 'e2',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare', op: '<', value: 4 },
+            enabled: true,
+            includeMissing: false,
+        }]);
+        expect(applied[0].nrowFiltered).toBe(3);
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 3,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 3,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3]);
+    });
+
+    test('setFilters read failure rolls back pending state to the authoritative filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+        const previousEntry = {
+            id: 'e1',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare' as const, op: '>' as const, value: 2 },
+            enabled: true,
+            includeMissing: false,
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 70,
+            entries: [previousEntry],
+            labelsOn: true,
+        });
+        await flush();
+        const previousApplied = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 70,
+        ) as any;
+        expect(previousApplied.nrowFiltered).toBe(3);
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('filter decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 71,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 71,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([previousEntry]);
+        expect(rollback.nrowFiltered).toBe(3);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 72,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 72,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([3, 4, 5]);
+    });
+
+    test('failed newer filter does not roll back to an unpublished superseded filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstIdleReached!: () => void;
+        const firstIdleReachedPromise = new Promise<void>(resolve => { firstIdleReached = resolve; });
+        let releaseFirstIdle!: () => void;
+        const releaseFirstIdlePromise = new Promise<void>(resolve => { releaseFirstIdle = resolve; });
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'filterStatus' && msg.requestId === 73 && msg.state === 'idle') {
+                firstIdleReached();
+                return releaseFirstIdlePromise.then(() => true);
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 73,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstIdleReachedPromise;
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('second filter decode boom');
+        };
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 74,
+            rollbackBaseRequestId: 0,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+        releaseFirstIdle();
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 74,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([]);
+        expect(rollback.nrowFiltered).toBe(5);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 75,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 75,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('failed newer filter does not roll back to an applied ack the webview ignored', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'filterApplied' && msg.requestId === 76) {
+                return new Promise<boolean>(() => {});
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 76,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('third filter decode boom');
+        };
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 77,
+            rollbackBaseRequestId: 0,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 77,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([]);
+        expect(rollback.nrowFiltered).toBe(5);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('third filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 78,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 78,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted interactive filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let firstRead = true;
+        (reader as any).getBatch = async () => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                await releaseFirstPromise;
+            }
+            throw new Error('late filter decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 60,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'filterApplied' && m.requestId === 60))
+            .toEqual([]);
     });
 
     test('saveFilter persists and restore on panel recreate sends filterApplied(fromPersistence:true)', async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -222,6 +222,48 @@ describe('sendInit restore', () => {
         expect(panel.restoreAbort).toBeNull();
     });
 
+    it('honors a cancel that lands during the paint, with no split-brain', async () => {
+        const { panel, posted, sortSet, filterSet } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async () => {
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        panel.restoreFilter = async () => {
+            panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); return false;
+        };
+        // The cancelRestore is dispatched exactly as the chips init is posted
+        // (during paintWithRestore's `await postPaint`), after both reads
+        // already completed — the racy window between reads-done and the
+        // restore's finally.
+        const origPost = panel.webviewPanel.webview.postMessage;
+        let fired = false;
+        panel.webviewPanel.webview.postMessage = (m: any) => {
+            if (!fired && (m.type === 'init' || m.type === 'replace')) {
+                fired = true;
+                void panel.handleCancelRestore({
+                    type: 'cancelRestore', panelGeneration: 0, restoreId: panel.restoreId,
+                });
+            }
+            return origPost(m);
+        };
+
+        await panel.sendInit();
+
+        // Cancel honored: prefs forgotten, in-memory state fully natural.
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.permutation).toBeUndefined();
+        expect(panel.filteredIndices).toBeUndefined();
+        // No split-brain: no stale filterApplied leaks, and a natural-order
+        // replace lands after the (already-posted) chips init.
+        const last = posted[posted.length - 1];
+        expect(last.type).toBe('replace');
+        expect(last.sort).toEqual(EMPTY_SORT);
+        expect(last.filter).toEqual(EMPTY_FILTER);
+    });
+
     it('clears restoring even if it throws before posting init (finding #3)', async () => {
         const { panel } = await makePanel({ storedSort: STORED_SORT });
         panel.restoreSort = async () => {
@@ -384,6 +426,28 @@ describe('lifecycle interruptions', () => {
         await p;
         void realSendInit;
         expect(sortSet).toEqual(['cleared']);
+    });
+
+    it('replace honors a pending cancel by forgetting the prev dataset prefs', async () => {
+        const { panel, sortSet } = await makePanel({ storedSort: STORED_SORT });
+        panel.filePath = '/tmp/raven-does-not-exist-a.arrow';
+        panel.reader.close = async () => {};
+        panel.webviewReady = false; // skip sendReplace (isolate replace())
+        panel.restoring = true;
+        panel.restoreAbort = new AbortController();
+        panel.restoreId = 1;
+        panel.restoreCancelRequested = true;
+
+        const reader2 = {
+            nrow: 5, batchStarts: [0, 5],
+            schema: { columns: COLUMNS }, close: async () => {},
+        };
+        await panel.replace(reader2, '/tmp/raven-does-not-exist-b.arrow');
+
+        // The cancelled restore's prefs are forgotten before the new dataset
+        // could re-apply them.
+        expect(sortSet).toEqual(['cleared']);
+        expect(panel.restoreCancelRequested).toBe(false);
     });
 
     it('webviewReady during restore bumps generation + aborts so prefs survive', async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -290,6 +290,38 @@ describe('sendInit restore', () => {
         expect(sortSet).toEqual([]);
     });
 
+    it('honors a cancel that lands during the filterApplied post', async () => {
+        const { panel, posted, filterSet } = await makePanel({
+            storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async () => false;
+        panel.restoreFilter = async () => {
+            panel.filter = STORED_FILTER;
+            panel.filteredIndices = new Uint32Array([0, 1, 2]);
+            return false;
+        };
+        // The cancel lands during the (second) post-decision await: the
+        // filterApplied post, after the chips init was already posted.
+        const origPost = panel.webviewPanel.webview.postMessage;
+        panel.webviewPanel.webview.postMessage = (m: any) => {
+            if (m.type === 'filterApplied') {
+                void panel.handleCancelRestore({
+                    type: 'cancelRestore', panelGeneration: 0, restoreId: panel.restoreId,
+                });
+            }
+            return origPost(m);
+        };
+
+        await panel.sendInit();
+
+        // Cancel honored: prefs forgotten, grid ends in natural order.
+        expect(filterSet).toEqual(['cleared']);
+        expect(panel.filteredIndices).toBeUndefined();
+        const last = posted[posted.length - 1];
+        expect(last.type).toBe('replace');
+        expect(last.filter).toEqual(EMPTY_FILTER);
+    });
+
     it('clears restoring even if it throws before posting init (finding #3)', async () => {
         const { panel } = await makePanel({ storedSort: STORED_SORT });
         panel.restoreSort = async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -358,6 +358,34 @@ describe('handleCancelRestore', () => {
 });
 
 describe('lifecycle interruptions', () => {
+    it('honors a user cancel even when a webview reload races the abort', async () => {
+        const { panel, posted, sortSet } = await makePanel({ storedSort: STORED_SORT });
+        // An in-flight restore whose read blocks on a gate (the abort is not
+        // observed until released).
+        let release: (() => void) | null = null;
+        const gate = new Promise<void>(r => { release = r; });
+        panel.restoreSort = async () => { await gate; return false; };
+        const p = panel.sendInit();
+        await new Promise(r => setTimeout(r, 0));
+        const rp = posted.find((m: any) => m.type === 'restorePending');
+        expect(rp).toBeDefined();
+        // User clicks Cancel (in-flight): aborts + records the intent.
+        await panel.handleCancelRestore({
+            type: 'cancelRestore', panelGeneration: 0, restoreId: rp.restoreId,
+        });
+        expect(sortSet).toEqual([]); // not forgotten yet (delegated)
+        // A webview reload races in before paintWithRestore observes the abort.
+        // The reload must honor the pending cancel and forget the prefs, not
+        // bail stale and re-restore them.
+        const realSendInit = panel.sendInit.bind(panel);
+        panel.sendInit = async () => {}; // isolate the re-send
+        await panel.handleInner({ type: 'webviewReady' });
+        release!();
+        await p;
+        void realSendInit;
+        expect(sortSet).toEqual(['cleared']);
+    });
+
     it('webviewReady during restore bumps generation + aborts so prefs survive', async () => {
         const { panel } = await makePanel();
         panel.restoring = true;

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -80,16 +80,20 @@ async function makePanel(opts: {
     panel.sort = EMPTY_SORT;
     panel.permutation = undefined;
     panel.sortGeneration = 0;
+    panel.sortSnapshots = new Map([[0, { sort: EMPTY_SORT }]]);
     panel.filter = EMPTY_FILTER;
     panel.filteredIndices = undefined;
     panel.filterGeneration = 0;
+    panel.filterSnapshots = new Map([[0, { filter: EMPTY_FILTER }]]);
     panel.histogramCache = new Map();
+    panel.histogramAborts = new Set();
     panel.restoreAbort = null;
     panel.restoring = false;
     panel.restoreId = -1;
     panel.restoreSeq = 0;
     panel.lastToolbar = undefined;
     panel.sendChain = Promise.resolve();
+    panel.transformChain = Promise.resolve();
     panel.settings = { persistSort: true, persistFilters: true, defaultDigits: 3 };
     panel.panelName = 'p';
 

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -322,6 +322,26 @@ describe('sendInit restore', () => {
         expect(last.filter).toEqual(EMPTY_FILTER);
     });
 
+    it('does not let a fully-honored cancel linger (no spurious forget later)', async () => {
+        const { panel, sortSet } = await makePanel({ storedSort: STORED_SORT });
+        // User cancels during the read (via handleCancelRestore in-flight),
+        // which sets restoreCancelRequested.
+        panel.restoreSort = async () => {
+            await panel.handleCancelRestore({
+                type: 'cancelRestore', panelGeneration: 0, restoreId: panel.restoreId,
+            });
+            return false;
+        };
+
+        await panel.sendInit();
+
+        // The cancel was fully honored (prefs forgotten) AND the intent flag
+        // is cleared — so a later replace() cannot mistake it for a fresh
+        // pending cancel and wrongly forget re-saved prefs.
+        expect(sortSet).toEqual(['cleared']);
+        expect(panel.restoreCancelRequested).toBe(false);
+    });
+
     it('clears restoring even if it throws before posting init (finding #3)', async () => {
         const { panel } = await makePanel({ storedSort: STORED_SORT });
         panel.restoreSort = async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -264,6 +264,32 @@ describe('sendInit restore', () => {
         expect(last.filter).toEqual(EMPTY_FILTER);
     });
 
+    it('a webview reload during the paint keeps prefs (lifecycle abort, not a cancel)', async () => {
+        const { panel, sortSet } = await makePanel({ storedSort: STORED_SORT });
+        panel.restoreSort = async () => {
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        // Prevent the reload's re-send from recursing in this isolated test.
+        panel.sendInit = async () => {};
+        // A webview reload lands during the paint (after the reads completed).
+        // It bumps generation + aborts — but it is NOT a user Cancel, so the
+        // prefs must survive (the queued re-send re-restores them).
+        const origPost = panel.webviewPanel.webview.postMessage;
+        let fired = false;
+        panel.webviewPanel.webview.postMessage = (m: any) => {
+            if (!fired && m.type === 'init') {
+                fired = true;
+                void panel.handleInner({ type: 'webviewReady' });
+            }
+            return origPost(m);
+        };
+
+        await panel.paintWithRestore('init');
+
+        // The reload bailed paintWithRestore stale; prefs were NOT forgotten.
+        expect(sortSet).toEqual([]);
+    });
+
     it('clears restoring even if it throws before posting init (finding #3)', async () => {
         const { panel } = await makePanel({ storedSort: STORED_SORT });
         panel.restoreSort = async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -602,4 +602,30 @@ describe('helpers', () => {
         expect(sortSet).toEqual(['cleared']);
         expect(filterSet).toEqual(['cleared']);
     });
+
+    it('forgetPersistedPrefs still clears the filter when the sort clear rejects (#548 review)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        panel.sortStore.clear = async () => { throw new Error('sort clear boom'); };
+        // Must not reject, and must still attempt the filter clear — otherwise a
+        // cancelled restore would forget only the sort and re-restore the filter.
+        await panel.forgetPersistedPrefs('h');
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual(['cleared']);
+    });
+
+    it('forgetPersistedPrefs still clears the sort when the filter clear rejects (#548 review)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        panel.filterStore.clear = async () => { throw new Error('filter clear boom'); };
+        await panel.forgetPersistedPrefs('h');
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual([]);
+    });
+
+    it('forgetPersistedPrefs honors the persist-* settings (skips disabled stores)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        panel.settings = { persistSort: false, persistFilters: true, defaultDigits: 3 };
+        await panel.forgetPersistedPrefs('h');
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual(['cleared']);
+    });
 });

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -709,4 +709,31 @@ describe('helpers', () => {
         expect(sortSet).toEqual([]);
         expect(filterSet).toEqual(['cleared']);
     });
+
+    it('drops a saveSort/saveFilter for a schema being forgotten (#548 codex write-race)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        // A late clear-and-forget for schema "h" is in flight.
+        panel.pendingForgetHashes.add('h');
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+        });
+        await panel.handleInner({
+            type: 'saveFilter', panelGeneration: 0, schemaHash: 'h', filter: STORED_FILTER,
+        });
+        // Stale interactive writes must not resurrect the cancelled prefs.
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
+    });
+
+    it('saves a sort/filter normally when no forget is pending for its schema (control)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+        });
+        await panel.handleInner({
+            type: 'saveFilter', panelGeneration: 0, schemaHash: 'h', filter: STORED_FILTER,
+        });
+        expect(sortSet).toEqual([STORED_SORT]);
+        expect(filterSet).toEqual([STORED_FILTER]);
+    });
 });

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -91,6 +91,7 @@ async function makePanel(opts: {
     panel.restoring = false;
     panel.restoreId = -1;
     panel.restoreSeq = 0;
+    panel.pendingForgetHashes = new Set();
     panel.lastToolbar = undefined;
     panel.sendChain = Promise.resolve();
     panel.transformChain = Promise.resolve();
@@ -214,7 +215,7 @@ describe('sendInit restore', () => {
             return false;
         };
         // Simulate the in-flight forget window for this schema.
-        panel.pendingForgetHash = panel.currentSchemaHash();
+        panel.pendingForgetHashes.add(panel.currentSchemaHash());
 
         await panel.sendInit();
 
@@ -240,13 +241,41 @@ describe('sendInit restore', () => {
             if (saved) { panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); }
             return false;
         };
-        panel.pendingForgetHash = null; // forget already finished
+        // pendingForgetHashes is empty: no forget in flight.
 
         await panel.sendInit();
 
         expect(posted.filter((m: any) => m.type === 'restorePending').length).toBe(1);
         expect(panel.sort.keys.length).toBe(1);
         expect(panel.filter.entries.length).toBe(1);
+    });
+
+    it('tracks overlapping forgets per-schema so they cannot clobber each other (#548 codex)', async () => {
+        // Two late clear-and-forgets for different schemas can be in flight at
+        // once; a single marker would let the second overwrite the first and
+        // un-suppress its restore. The Set keeps them independent.
+        const { panel, posted } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async (saved: SortState | undefined) => {
+            if (saved) { panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); }
+            return false;
+        };
+        panel.restoreFilter = async (saved: FilterState | undefined) => {
+            if (saved) { panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); }
+            return false;
+        };
+        const hashA = panel.currentSchemaHash();
+        panel.pendingForgetHashes.add(hashA);
+        panel.pendingForgetHashes.add('schema-B-hash');
+        // A forget for the OTHER schema completing must not un-suppress schema A.
+        panel.pendingForgetHashes.delete('schema-B-hash');
+
+        await panel.sendInit();
+
+        expect(posted.filter((m: any) => m.type === 'restorePending')).toEqual([]);
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.filter.entries.length).toBe(0);
     });
 
     it('completed sort + cancelled filter ends in natural order (finding #1)', async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Panel state machine for the saved-sort/filter restore banner + Cancel
+ * (#519, part 2). Port of sight#228's restore-cancel suite, adapted to
+ * raven (DataViewerPanel, init/replace, restoreSort/restoreFilter,
+ * SortStateStore/FilterStateStore, permutation/filteredIndices).
+ *
+ * Uses Object.create(DataViewerPanel.prototype) with stubbed reader,
+ * stores and webview so the private methods can be driven headlessly and
+ * deterministically (restoreSort/restoreFilter are stubbed to simulate
+ * completion / abort / genuine failure without real column reads).
+ */
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+
+let warnings: string[] = [];
+mock.module('vscode', () => ({
+    window: {
+        showErrorMessage: () => undefined,
+        showWarningMessage: (msg: string) => { warnings.push(msg); return undefined; },
+    },
+    workspace: {
+        getConfiguration: () => ({ get: (_k: string, d?: unknown) => d }),
+    },
+}));
+
+import {
+    EMPTY_SORT,
+    EMPTY_FILTER,
+    type SortState,
+    type FilterState,
+} from '../../editors/vscode/src/data-viewer/messages';
+import type { ColumnSchema } from '../../editors/vscode/src/data-viewer/arrow-reader';
+
+const COLUMNS: ColumnSchema[] = [
+    { name: 'a', arrowType: 'Int32', isInteger: true, dictionaryShipped: false },
+    { name: 'b', arrowType: 'Utf8', isInteger: false, dictionaryShipped: false },
+];
+
+const STORED_SORT: SortState = {
+    keys: [{ columnIndex: 0, direction: 'asc' }],
+    labelsOnWhenSorted: true,
+};
+const STORED_FILTER: FilterState = {
+    entries: [{
+        id: 'f1', columnIndex: 1, predicate: { kind: 'isNotEmpty' },
+        enabled: true, includeMissing: false,
+    }],
+    labelsOnWhenFiltered: true,
+};
+
+interface Harness {
+    panel: any;
+    posted: any[];
+    sortSet: (SortState | 'cleared')[];
+    filterSet: (FilterState | 'cleared')[];
+}
+
+async function makePanel(opts: {
+    storedSort?: SortState;
+    storedFilter?: FilterState;
+} = {}): Promise<Harness> {
+    const { DataViewerPanel } = await import(
+        '../../editors/vscode/src/data-viewer/panel'
+    );
+    const posted: any[] = [];
+    const sortSet: (SortState | 'cleared')[] = [];
+    const filterSet: (FilterState | 'cleared')[] = [];
+    const panel: any = Object.create(DataViewerPanel.prototype);
+
+    panel.reader = {
+        nrow: 5,
+        batchStarts: [0, 5],
+        schema: { columns: COLUMNS },
+    };
+    panel.columns = COLUMNS;
+    panel.layout = { columnWidths: {}, hiddenColumns: [] };
+    panel.dictionaries = {};
+    panel.generation = 0;
+    panel.webviewInitialized = true;
+    panel.disposed = false;
+    panel.sort = EMPTY_SORT;
+    panel.permutation = undefined;
+    panel.sortGeneration = 0;
+    panel.filter = EMPTY_FILTER;
+    panel.filteredIndices = undefined;
+    panel.filterGeneration = 0;
+    panel.histogramCache = new Map();
+    panel.restoreAbort = null;
+    panel.restoring = false;
+    panel.restoreId = -1;
+    panel.restoreSeq = 0;
+    panel.lastToolbar = undefined;
+    panel.sendChain = Promise.resolve();
+    panel.settings = { persistSort: true, persistFilters: true, defaultDigits: 3 };
+    panel.panelName = 'p';
+
+    panel.webviewPanel = {
+        webview: { postMessage: (m: any) => { posted.push(m); return Promise.resolve(true); } },
+    };
+    const noStore = { load: async () => undefined };
+    panel.store = noStore;
+    panel.toolbarStore = noStore;
+    panel.sortStore = {
+        load: async () => opts.storedSort,
+        save: async (_p: string, _h: string, s: SortState) => { sortSet.push(s); },
+        clear: async () => { sortSet.push('cleared'); },
+    };
+    panel.filterStore = {
+        load: async () => opts.storedFilter,
+        save: async (_p: string, _h: string, f: FilterState) => { filterSet.push(f); },
+        clear: async () => { filterSet.push('cleared'); },
+    };
+    return { panel, posted, sortSet, filterSet };
+}
+
+beforeEach(() => { warnings = []; });
+
+describe('maybeBeginRestore', () => {
+    it('arms a restore and posts restorePending when prefs apply', async () => {
+        const { panel, posted } = await makePanel();
+        const began = panel.maybeBeginRestore(0, STORED_SORT, STORED_FILTER);
+        expect(began).toBe(true);
+        expect(panel.restoring).toBe(true);
+        expect(panel.restoreAbort).not.toBeNull();
+        expect(panel.restoreId).toBe(1);
+        expect(posted[0]).toEqual({
+            type: 'restorePending', panelGeneration: 0, restoreId: 1,
+            sort: true, filter: true,
+        });
+    });
+
+    it('does not begin when no prefs apply', async () => {
+        const { panel, posted } = await makePanel();
+        expect(panel.maybeBeginRestore(0, undefined, undefined)).toBe(false);
+        expect(panel.restoring).toBe(false);
+        expect(posted).toEqual([]);
+    });
+
+    it('does not begin for an out-of-range sort key', async () => {
+        const { panel } = await makePanel();
+        const bad: SortState = { keys: [{ columnIndex: 9, direction: 'asc' }], labelsOnWhenSorted: true };
+        expect(panel.maybeBeginRestore(0, bad, undefined)).toBe(false);
+    });
+
+    it('does not begin for an all-disabled filter', async () => {
+        const { panel } = await makePanel();
+        const off: FilterState = {
+            entries: [{ ...STORED_FILTER.entries[0], enabled: false }],
+            labelsOnWhenFiltered: true,
+        };
+        expect(panel.maybeBeginRestore(0, undefined, off)).toBe(false);
+    });
+
+    it('increments restoreId monotonically', async () => {
+        const { panel } = await makePanel();
+        panel.maybeBeginRestore(0, STORED_SORT, undefined);
+        expect(panel.restoreId).toBe(1);
+        panel.maybeBeginRestore(0, STORED_SORT, undefined);
+        expect(panel.restoreId).toBe(2);
+    });
+
+    it('flags sort-only vs filter-only', async () => {
+        const { panel, posted } = await makePanel();
+        panel.maybeBeginRestore(0, undefined, STORED_FILTER);
+        expect(posted[0].sort).toBe(false);
+        expect(posted[0].filter).toBe(true);
+    });
+});
+
+describe('sendInit restore', () => {
+    it('normal completion applies and ships the saved prefs', async () => {
+        const { panel, posted, sortSet, filterSet } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async () => {
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        panel.restoreFilter = async () => {
+            panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); return false;
+        };
+
+        await panel.sendInit();
+
+        expect(panel.sort.keys.length).toBe(1);
+        expect(panel.filter.entries.length).toBe(1);
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
+        expect(posted[0].type).toBe('restorePending');
+        const init = posted.find((m: any) => m.type === 'init');
+        expect(init.sort).toEqual(STORED_SORT);
+        expect(init.filter).toEqual(STORED_FILTER);
+        expect(posted.some((m: any) => m.type === 'filterApplied')).toBe(true);
+        expect(panel.restoring).toBe(false);
+        expect(panel.restoreAbort).toBeNull();
+    });
+
+    it('completed sort + cancelled filter ends in natural order (finding #1)', async () => {
+        const { panel, posted, sortSet, filterSet } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async () => {
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        panel.restoreFilter = async () => {
+            panel.restoreAbort?.abort();
+            panel.filter = EMPTY_FILTER; panel.filteredIndices = undefined;
+            return false;
+        };
+
+        await panel.sendInit();
+
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.permutation).toBeUndefined();
+        expect(panel.filter.entries.length).toBe(0);
+        expect(panel.filteredIndices).toBeUndefined();
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+        const init = posted.find((m: any) => m.type === 'init');
+        expect(init.sort).toEqual(EMPTY_SORT);
+        expect(init.filter).toEqual(EMPTY_FILTER);
+        expect(posted.some((m: any) => m.type === 'filterApplied')).toBe(false);
+        expect(panel.restoring).toBe(false);
+        expect(panel.restoreAbort).toBeNull();
+    });
+
+    it('clears restoring even if it throws before posting init (finding #3)', async () => {
+        const { panel } = await makePanel({ storedSort: STORED_SORT });
+        panel.restoreSort = async () => {
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        // Throw on the real path (the paint postMessage), after the restore
+        // began but before it completes — the impl's finally must still run.
+        panel.webviewPanel.webview.postMessage = (m: any) => {
+            if (m.type === 'init') throw new Error('boom');
+            return Promise.resolve(true);
+        };
+        await panel.sendInit().catch(() => {});
+        expect(panel.restoring).toBe(false);
+        expect(panel.restoreAbort).toBeNull();
+    });
+
+    it('serializes sends so a second restore cannot start until the first finishes', async () => {
+        const { panel, posted } = await makePanel({ storedSort: STORED_SORT });
+        let release: (() => void) | null = null;
+        const gate = new Promise<void>(r => { release = r; });
+        let calls = 0;
+        panel.restoreSort = async () => {
+            if (calls++ === 0) await gate;
+            panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); return false;
+        };
+        const p1 = panel.sendInit();
+        const p2 = panel.sendInit();
+        // Let p1 reach its gated restoreSort. Serialization means p2 has not
+        // begun its own restore yet, so only p1's restorePending exists.
+        await new Promise(r => setTimeout(r, 0));
+        const pendingCount = () =>
+            posted.filter((m: any) => m.type === 'restorePending').length;
+        expect(pendingCount()).toBe(1);
+        release!();
+        await Promise.all([p1, p2]);
+        // p2 ran only after p1 finished — both restored, but never overlapped.
+        expect(pendingCount()).toBe(2);
+    });
+
+    it('real read error keeps prefs and warns (finding #7)', async () => {
+        const { panel, posted, sortSet, filterSet } = await makePanel({ storedSort: STORED_SORT });
+        panel.restoreSort = async () => true; // genuine (non-abort) failure
+        await panel.sendInit();
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain('sort');
+        expect(warnings[0]).not.toContain('filter');
+        expect(panel.sort.keys.length).toBe(0);
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
+        const init = posted.find((m: any) => m.type === 'init');
+        expect(init.sort).toEqual(EMPTY_SORT);
+    });
+
+    it('cancel suppresses the failure warning (finding #9)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async () => true; // would warn...
+        panel.restoreFilter = async () => { panel.restoreAbort?.abort(); return false; };
+        await panel.sendInit();
+        expect(warnings).toEqual([]);
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+    });
+
+    it('bails without posting or forgetting if generation changes mid-restore', async () => {
+        const { panel, posted, sortSet } = await makePanel({ storedSort: STORED_SORT });
+        panel.restoreSort = async () => { panel.generation++; return false; };
+        await panel.sendInit();
+        expect(posted.some((m: any) => m.type === 'init')).toBe(false);
+        expect(sortSet).toEqual([]);
+    });
+});
+
+describe('handleCancelRestore', () => {
+    it('ignores a stale restoreId', async () => {
+        const { panel } = await makePanel();
+        panel.restoreId = 5; panel.restoring = true;
+        let aborted = false;
+        panel.restoreAbort = { abort: () => { aborted = true; } };
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 4 });
+        expect(aborted).toBe(false);
+    });
+
+    it('aborts an in-flight restore on a matching id', async () => {
+        const { panel } = await makePanel();
+        panel.restoreId = 7; panel.restoring = true;
+        let aborted = false;
+        panel.restoreAbort = { abort: () => { aborted = true; } };
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 7 });
+        expect(aborted).toBe(true);
+    });
+
+    it('honors a late cancel as clear-and-forget (finding #5)', async () => {
+        const { panel, posted, sortSet, filterSet } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreId = 3; panel.restoring = false;
+        panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5);
+        const genBefore = panel.generation;
+
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 3 });
+
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.permutation).toBeUndefined();
+        expect(panel.generation).toBe(genBefore + 1);
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+        expect(panel.restoreId).toBe(-1);
+        const replace = posted.find((m: any) => m.type === 'replace');
+        expect(replace).toBeDefined();
+        expect(replace.panelGeneration).toBe(genBefore + 1);
+        expect(replace.sort).toEqual(EMPTY_SORT);
+        expect(replace.filter).toEqual(EMPTY_FILTER);
+
+        // Duplicate late cancel is now ignored (id consumed).
+        const before = sortSet.length;
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 3 });
+        expect(sortSet.length).toBe(before);
+    });
+
+    it('bumps generation before awaiting the forget writes (ordering)', async () => {
+        const { panel } = await makePanel({ storedSort: STORED_SORT });
+        panel.restoreId = 2; panel.restoring = false;
+        panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5);
+        let order = 0;
+        let persistedAt: number | null = null;
+        panel.sortStore.clear = async () => { persistedAt = order++; };
+        const genBefore = panel.generation;
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 2 });
+        expect(panel.generation).toBe(genBefore + 1);
+        expect(persistedAt).not.toBeNull();
+    });
+});
+
+describe('lifecycle interruptions', () => {
+    it('webviewReady during restore bumps generation + aborts so prefs survive', async () => {
+        const { panel } = await makePanel();
+        panel.restoring = true;
+        const ctrl = new AbortController();
+        panel.restoreAbort = ctrl;
+        panel.restoreId = 1;
+        let resend = false;
+        panel.sendInit = async () => { resend = true; };
+        const genBefore = panel.generation;
+
+        await panel.handleInner({ type: 'webviewReady' });
+
+        expect(panel.generation).toBe(genBefore + 1);
+        expect(ctrl.signal.aborted).toBe(true);
+        expect(panel.restoring).toBe(false);
+        expect(panel.restoreId).toBe(-1);
+        expect(resend).toBe(true);
+    });
+});
+
+describe('sort/filter ignored while restoring', () => {
+    it('handleSetSort is a no-op while a restore is in flight', async () => {
+        const { panel, posted } = await makePanel();
+        panel.restoring = true;
+        const genBefore = panel.generation;
+        await panel.handleSetSort(
+            { type: 'setSort', panelGeneration: 0, requestId: 1, keys: [{ columnIndex: 0, direction: 'asc' }], labelsOn: true, formatOn: true, digits: 3 },
+            panel.generation,
+        );
+        expect(panel.generation).toBe(genBefore);
+        expect(posted).toEqual([]);
+    });
+
+    it('handleSetSort consumes restoreId so a later stale cancel cannot clear it', async () => {
+        const { panel, sortSet } = await makePanel();
+        panel.restoring = false;
+        panel.restoreId = 4;
+        await panel.handleSetSort(
+            { type: 'setSort', panelGeneration: 0, requestId: 1, keys: [], labelsOn: true, formatOn: true, digits: 3 },
+            panel.generation,
+        );
+        expect(panel.restoreId).toBe(-1);
+        const before = sortSet.length;
+        await panel.handleCancelRestore({ type: 'cancelRestore', panelGeneration: 0, restoreId: 4 });
+        expect(sortSet.length).toBe(before);
+    });
+});
+
+describe('helpers', () => {
+    it('resetRestoredPrefs clears memory + consumes id synchronously', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        panel.sort = STORED_SORT; panel.permutation = new Uint32Array(3);
+        panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array(2);
+        panel.restoreId = 9;
+        panel.resetRestoredPrefs();
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.permutation).toBeUndefined();
+        expect(panel.filter.entries.length).toBe(0);
+        expect(panel.filteredIndices).toBeUndefined();
+        expect(panel.restoreId).toBe(-1);
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
+    });
+
+    it('forgetPersistedPrefs clears both stores', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        await panel.forgetPersistedPrefs('h');
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+    });
+});

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -197,6 +197,58 @@ describe('sendInit restore', () => {
         expect(panel.restoreAbort).toBeNull();
     });
 
+    it('drops prefs while a late clear-and-forget is in flight (#548 review)', async () => {
+        // A late clear-and-forget marks pendingForgetHash before awaiting the
+        // store clears. A webviewReady/replace that re-reads the store inside
+        // that window must NOT re-restore the prefs the user just cancelled.
+        const { panel, posted } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        // Mirror the real restoreSort/restoreFilter: act only when given prefs.
+        panel.restoreSort = async (saved: SortState | undefined) => {
+            if (saved) { panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); }
+            return false;
+        };
+        panel.restoreFilter = async (saved: FilterState | undefined) => {
+            if (saved) { panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); }
+            return false;
+        };
+        // Simulate the in-flight forget window for this schema.
+        panel.pendingForgetHash = panel.currentSchemaHash();
+
+        await panel.sendInit();
+
+        // No restore begins; the paint shows natural order.
+        expect(posted.filter((m: any) => m.type === 'restorePending')).toEqual([]);
+        expect(panel.restoring).toBe(false);
+        expect(panel.sort.keys.length).toBe(0);
+        expect(panel.filter.entries.length).toBe(0);
+        const init = posted.find((m: any) => m.type === 'init');
+        expect(init.sort).toEqual(EMPTY_SORT);
+        expect(init.filter).toEqual(EMPTY_FILTER);
+    });
+
+    it('restores normally once the forget completes and clears the marker (control)', async () => {
+        const { panel, posted } = await makePanel({
+            storedSort: STORED_SORT, storedFilter: STORED_FILTER,
+        });
+        panel.restoreSort = async (saved: SortState | undefined) => {
+            if (saved) { panel.sort = STORED_SORT; panel.permutation = new Uint32Array(5); }
+            return false;
+        };
+        panel.restoreFilter = async (saved: FilterState | undefined) => {
+            if (saved) { panel.filter = STORED_FILTER; panel.filteredIndices = new Uint32Array([0, 1, 2]); }
+            return false;
+        };
+        panel.pendingForgetHash = null; // forget already finished
+
+        await panel.sendInit();
+
+        expect(posted.filter((m: any) => m.type === 'restorePending').length).toBe(1);
+        expect(panel.sort.keys.length).toBe(1);
+        expect(panel.filter.entries.length).toBe(1);
+    });
+
     it('completed sort + cancelled filter ends in natural order (finding #1)', async () => {
         const { panel, posted, sortSet, filterSet } = await makePanel({
             storedSort: STORED_SORT, storedFilter: STORED_FILTER,

--- a/tests/bun/data-viewer-panel-sort.test.ts
+++ b/tests/bun/data-viewer-panel-sort.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from 'node:os';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIX_SRC = (n: string) =>
     join(HERE, '..', '..', 'editors/vscode/test-fixtures/data-viewer', n);
+let warnings: string[] = [];
 
 function tempCopyOf(name: string): string {
     const dir = mkdtempSync(join(tmpdir(), 'raven-panel-sort-'));
@@ -73,6 +74,10 @@ async function loadPanel() {
         window: {
             createWebviewPanel: () => new FakeWebviewPanel(),
             createOutputChannel: () => ({ appendLine: () => {}, dispose: () => {} }),
+            showWarningMessage: (msg: string) => {
+                warnings.push(msg);
+                return Promise.resolve(undefined);
+            },
         },
         workspace: {
             getConfiguration: () => ({
@@ -121,6 +126,7 @@ afterEach(async () => {
     for (const c of list) {
         try { await c(); } catch { /* swallow — best effort */ }
     }
+    warnings = [];
     mock.restore();
 });
 
@@ -170,6 +176,21 @@ async function setupPanel(settingsOverride?: Partial<typeof TEST_SETTINGS>): Pro
 }
 
 describe('DataViewerPanel: setSort → sortApplied round-trip', () => {
+    test('webview reload bumps panelGeneration so stale request ids cannot collide', async () => {
+        const { fakeWebview } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const firstInit = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        const secondInit = initMessages[initMessages.length - 1];
+
+        expect(secondInit.panelGeneration).toBeGreaterThan(firstInit.panelGeneration);
+    });
+
     test('setSort builds a permutation and broadcasts sortApplied', async () => {
         const { fakeWebview } = await setupPanel();
 
@@ -327,6 +348,452 @@ describe('DataViewerPanel: setSort → sortApplied round-trip', () => {
         const rows = fakeWebview.posted.find(m => m.type === 'rows' && m.requestId === 3) as any;
         expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
         expect(rows.originalRowIndices).toBeUndefined();
+    });
+
+    test('overlapping setSort requests do not read batches concurrently and latest wins', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 1,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 2,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const acks = fakeWebview.posted.filter(m => m.type === 'sortApplied') as any[];
+        expect(acks.map(m => m.requestId)).toEqual([2]);
+        expect(acks[0].sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: init.panelGeneration,
+            requestId: 3,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 3,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('setSort read failure rolls back optimistic state with authoritative sortApplied', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        (reader as any).getBatch = () => { throw new Error('sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 10,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 10,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+    });
+
+    test('setSort read failure rolls back to the previous non-empty sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 11,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        const previousAck = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 11,
+        ) as any;
+        expect(previousAck.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('second sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 12,
+            keys: [{ columnIndex: 1, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 12,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second sort decode boom');
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 13,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 13,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('failed newer sort does not roll back to an unpublished superseded sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstIdleReached!: () => void;
+        const firstIdleReachedPromise = new Promise<void>(resolve => { firstIdleReached = resolve; });
+        let releaseFirstIdle!: () => void;
+        const releaseFirstIdlePromise = new Promise<void>(resolve => { releaseFirstIdle = resolve; });
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'sortStatus' && msg.requestId === 40 && msg.state === 'idle') {
+                firstIdleReached();
+                return releaseFirstIdlePromise.then(() => true);
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 40,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstIdleReachedPromise;
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('second sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 41,
+            rollbackBaseRequestId: 0,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirstIdle();
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 41,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 42,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 42,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('failed newer sort does not roll back to an applied ack the webview ignored', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'sortApplied' && msg.requestId === 43) {
+                return new Promise<boolean>(() => {});
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 43,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('third sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 44,
+            rollbackBaseRequestId: 0,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 44,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('third sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 45,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 45,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('webview reload saved-sort restore does not overlap an active interactive sort read', async () => {
+        const { fakeWebview, sortStore, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        await sortStore.save('tiny', init.schemaHash, {
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOnWhenSorted: true,
+        });
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 20,
+            keys: [{ columnIndex: 1, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(warnings).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 20))
+            .toEqual([]);
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        expect(initMessages.at(-1).sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted interactive sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let firstRead = true;
+        (reader as any).getBatch = async () => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                await releaseFirstPromise;
+            }
+            throw new Error('late sort decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 30,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 30))
+            .toEqual([]);
+    });
+
+    test('webview reload aborts an active sort before the next batch read', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount === 1) {
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+                return await origGetBatch(i);
+            }
+            throw new Error('sort read after abort');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 31,
+            keys: [
+                { columnIndex: 0, direction: 'desc' },
+                { columnIndex: 1, direction: 'asc' },
+            ],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 31))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(readCount).toBe(1);
     });
 
     test('persistSort=false skips sortStore writes', async () => {

--- a/tests/bun/data-viewer-restore-affordance.test.ts
+++ b/tests/bun/data-viewer-restore-affordance.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(import.meta.dir, '..', '..');
+const appSource = readFileSync(
+    join(root, 'editors/vscode/src/data-viewer/webview/App.tsx'),
+    'utf-8',
+);
+const stylesSource = readFileSync(
+    join(root, 'editors/vscode/src/data-viewer/webview/styles.css'),
+    'utf-8',
+);
+
+describe('data viewer restore skip affordance', () => {
+    test('restore action is explanatory skip text, not a detached Cancel button', () => {
+        expect(appSource).toContain('Loading…');
+        expect(appSource).toContain('className="restore-skip"');
+        expect(appSource).toContain('Skip and show data now');
+        expect(appSource).not.toContain('className="restore-cancel"');
+        expect(appSource).not.toContain('>Cancel</button>');
+    });
+
+    test('restore banner stacks the skip link under its message', () => {
+        expect(stylesSource).toContain('.toolbar-restore');
+        expect(stylesSource).toContain('flex-direction: column');
+        expect(stylesSource).toContain('align-items: flex-start');
+        expect(stylesSource).toContain('.restore-skip');
+        expect(stylesSource).not.toContain('.restore-cancel');
+    });
+});

--- a/tests/bun/data-viewer-sort-filter-cancel.test.ts
+++ b/tests/bun/data-viewer-sort-filter-cancel.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Part 1 of #519: computePermutation / computeFilteredIndices accept an
+ * optional AbortSignal and reject with an AbortError when cancelled,
+ * while the signal-less path stays byte-identical. The panel uses this
+ * to make the saved sort/filter restore on open interruptible.
+ */
+import { describe, test, expect } from 'bun:test';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ArrowSliceReader } from '../../editors/vscode/src/data-viewer/arrow-reader';
+import { computePermutation } from '../../editors/vscode/src/data-viewer/sort';
+import { computeFilteredIndices } from '../../editors/vscode/src/data-viewer/filter';
+import { isAbortError } from '../../editors/vscode/src/data-viewer/abort';
+import type { FilterState } from '../../editors/vscode/src/data-viewer/messages';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIX = (n: string) =>
+    join(HERE, '..', '..', 'editors/vscode/test-fixtures/data-viewer', n);
+const CTX = { labelsOn: true, formatOn: true, digits: 3 };
+
+async function rejectsAbort(p: Promise<unknown>): Promise<void> {
+    let err: unknown;
+    try { await p; } catch (e) { err = e; }
+    expect(err).toBeDefined();
+    expect(isAbortError(err)).toBe(true);
+}
+
+describe('computePermutation with AbortSignal', () => {
+    test('signal that never aborts yields the same result as no signal', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const keys = [{ columnIndex: 0, direction: 'desc' as const }];
+        const baseline = await computePermutation(r, keys, CTX);
+        const withSignal = await computePermutation(r, keys, CTX, {
+            signal: new AbortController().signal,
+        });
+        expect(Array.from(withSignal)).toEqual(Array.from(baseline));
+        await r.close();
+    });
+
+    test('already-aborted signal rejects with AbortError', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const c = new AbortController();
+        c.abort();
+        await rejectsAbort(computePermutation(
+            r, [{ columnIndex: 0, direction: 'asc' }], CTX, { signal: c.signal },
+        ));
+        await r.close();
+    });
+
+    test('aborting during the read rejects with AbortError', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const c = new AbortController();
+        const p = computePermutation(
+            r, [{ columnIndex: 0, direction: 'asc' }], CTX, { signal: c.signal },
+        );
+        // computePermutation has already suspended at its first column-read
+        // await; aborting now is observed at the next checkpoint.
+        c.abort();
+        await rejectsAbort(p);
+        await r.close();
+    });
+});
+
+const NOT_EMPTY: FilterState = {
+    entries: [{
+        id: 'f1',
+        columnIndex: 0,
+        predicate: { kind: 'isNotEmpty' },
+        enabled: true,
+        includeMissing: false,
+    }],
+    labelsOnWhenFiltered: true,
+};
+
+describe('computeFilteredIndices with AbortSignal', () => {
+    test('signal that never aborts yields the same result as no signal', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const baseline = await computeFilteredIndices(r, NOT_EMPTY, CTX);
+        const withSignal = await computeFilteredIndices(r, NOT_EMPTY, CTX, {
+            signal: new AbortController().signal,
+        });
+        expect(withSignal && Array.from(withSignal))
+            .toEqual(baseline ? Array.from(baseline) : undefined);
+        await r.close();
+    });
+
+    test('already-aborted signal rejects with AbortError', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const c = new AbortController();
+        c.abort();
+        await rejectsAbort(computeFilteredIndices(r, NOT_EMPTY, CTX, {
+            signal: c.signal,
+        }));
+        await r.close();
+    });
+
+    test('aborting during the read rejects with AbortError', async () => {
+        const r = await ArrowSliceReader.open(FIX('tiny.arrow'));
+        const c = new AbortController();
+        const p = computeFilteredIndices(r, NOT_EMPTY, CTX, { signal: c.signal });
+        c.abort();
+        await rejectsAbort(p);
+        await r.close();
+    });
+});

--- a/tests/bun/data-viewer-transform-intent.test.ts
+++ b/tests/bun/data-viewer-transform-intent.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    createIntentRequestState,
+    filterEntriesForNextRequest,
+    filterStateForRequestedEntries,
+    sortKeysForNextRequest,
+    nextSortKeysForColumn,
+    requestFilterIntent,
+    requestSortIntent,
+    shouldAcceptAppliedResponse,
+    shouldAcceptInteractiveResponse,
+    shouldAcceptSortResponse,
+    sortStateForRequestedKeys,
+} from '../../editors/vscode/src/data-viewer/webview/transform-intent';
+import type { FilterEntry } from '../../editors/vscode/src/data-viewer/messages';
+
+describe('data viewer webview transform intent', () => {
+    test('plain sort replaces the current keys', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            1,
+            'desc',
+            false,
+        )).toEqual([{ columnIndex: 1, direction: 'desc' }]);
+    });
+
+    test('append sort adds a new column after the pending key', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            1,
+            'desc',
+            true,
+        )).toEqual([
+            { columnIndex: 0, direction: 'asc' },
+            { columnIndex: 1, direction: 'desc' },
+        ]);
+    });
+
+    test('rapid sort requests compose from the latest pending keys', () => {
+        const state = createIntentRequestState();
+        const first = requestSortIntent(
+            state,
+            [{ columnIndex: 0, direction: 'asc' }],
+            true,
+        );
+        expect(nextSortKeysForColumn(
+            sortKeysForNextRequest([], state.latestSortIntent),
+            1,
+            'desc',
+            true,
+        )).toEqual([
+            { columnIndex: 0, direction: 'asc' },
+            { columnIndex: 1, direction: 'desc' },
+        ]);
+        expect(first.requestId).toBe(1);
+    });
+
+    test('repeating the current single-column sort is a no-op', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            0,
+            'asc',
+            false,
+        )).toBeUndefined();
+    });
+
+    test('requested keys become optimistic sort state immediately', () => {
+        expect(sortStateForRequestedKeys(
+            [{ columnIndex: 1, direction: 'desc' }],
+            false,
+        )).toEqual({
+            keys: [{ columnIndex: 1, direction: 'desc' }],
+            labelsOnWhenSorted: false,
+        });
+    });
+
+    test('sort host responses older than the latest optimistic request are stale', () => {
+        expect(shouldAcceptSortResponse(8, 7, false)).toBe(false);
+        expect(shouldAcceptSortResponse(8, 8, false)).toBe(true);
+        expect(shouldAcceptSortResponse(8, 9, false)).toBe(false);
+        expect(shouldAcceptSortResponse(null, 7, false)).toBe(false);
+        expect(shouldAcceptSortResponse(null, -1, true)).toBe(true);
+        expect(shouldAcceptSortResponse(8, -1, true)).toBe(false);
+    });
+
+    test('interactive status responses require the latest request id exactly', () => {
+        expect(shouldAcceptInteractiveResponse(8, 7)).toBe(false);
+        expect(shouldAcceptInteractiveResponse(8, 8)).toBe(true);
+        expect(shouldAcceptInteractiveResponse(8, 9)).toBe(false);
+        expect(shouldAcceptInteractiveResponse(null, 8)).toBe(false);
+    });
+
+    test('applied responses from persistence are stale while an interactive request is pending', () => {
+        expect(shouldAcceptAppliedResponse(null, -1, true)).toBe(true);
+        expect(shouldAcceptAppliedResponse(9, -1, true)).toBe(false);
+        expect(shouldAcceptAppliedResponse(9, 9, false)).toBe(true);
+        expect(shouldAcceptAppliedResponse(9, 8, false)).toBe(false);
+    });
+
+    test('rapid filter requests compose from the latest pending entries', () => {
+        const state = createIntentRequestState();
+        const first: FilterEntry = {
+            id: 'a',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare', op: '>', value: 2 },
+            enabled: true,
+            includeMissing: false,
+        };
+        const second: FilterEntry = {
+            id: 'b',
+            columnIndex: 1,
+            predicate: { kind: 'strContains', value: 'x', caseSensitive: false, negate: false },
+            enabled: true,
+            includeMissing: false,
+        };
+
+        const firstRequest = requestFilterIntent(state, [first], true);
+        const nextBase = filterEntriesForNextRequest([], state.latestFilterIntent);
+        const secondRequest = requestFilterIntent(state, [...nextBase, second], true);
+        const next = secondRequest.filter;
+
+        expect(firstRequest.requestId).toBe(1);
+        expect(secondRequest.requestId).toBe(2);
+        expect(next.entries.map(e => e.id)).toEqual(['a', 'b']);
+        expect(next.labelsOnWhenFiltered).toBe(true);
+    });
+
+    test('pending set-membership filter values are cloned for request composition', () => {
+        const values = [1, 2];
+        const first: FilterEntry = {
+            id: 'a',
+            columnIndex: 0,
+            predicate: { kind: 'setIn', values },
+            enabled: true,
+            includeMissing: false,
+        };
+        const pending = filterStateForRequestedEntries([first], true);
+        values.push(3);
+        const base = filterEntriesForNextRequest([], pending);
+        expect((base[0].predicate as any).values).toEqual([1, 2]);
+        (base[0].predicate as any).values.push(4);
+        expect((pending.entries[0].predicate as any).values).toEqual([1, 2]);
+    });
+});

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -187,3 +187,50 @@ describe('data viewer App filter persistence', () => {
         }]);
     });
 });
+
+describe('data viewer App restore banner debounce', () => {
+    function restorePendingMessage(restoreId: number) {
+        return {
+            type: 'restorePending' as const,
+            panelGeneration: 1,
+            restoreId,
+            sort: true,
+            filter: true,
+        };
+    }
+
+    test('shows the restore banner after the debounce, then clears it on completion', async () => {
+        await renderApp();
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', { data: restorePendingMessage(1) }));
+        });
+        // Debounced: nothing is shown immediately.
+        expect(document.body.textContent).not.toContain('Skip and show data now');
+
+        await act(async () => { await new Promise(resolve => setTimeout(resolve, 350)); });
+        expect(document.body.textContent).toContain('Skip and show data now');
+
+        // The restore completing (replace) clears the banner.
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', { data: { ...initMessage(), type: 'replace' } }));
+        });
+        expect(document.body.textContent).not.toContain('Skip and show data now');
+    });
+
+    test('a restore completing before the debounce never flashes a stale banner', async () => {
+        await renderApp();
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', { data: restorePendingMessage(1) }));
+        });
+        // Completes immediately, before the 200ms debounce elapses.
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', { data: { ...initMessage(), type: 'replace' } }));
+        });
+        // Even after the debounce window passes, the superseded timer must not
+        // surface the banner (clearTimeout plus the restoreId staleness guard).
+        await act(async () => { await new Promise(resolve => setTimeout(resolve, 350)); });
+        expect(document.body.textContent).not.toContain('Skip and show data now');
+    });
+});

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    pretendToBeVisual: true,
+});
+const g = globalThis as Record<string, unknown>;
+g.window = dom.window;
+g.document = dom.window.document;
+g.navigator = dom.window.navigator;
+g.HTMLElement = dom.window.HTMLElement;
+g.MutationObserver = dom.window.MutationObserver;
+g.MouseEvent = dom.window.MouseEvent;
+g.MessageEvent = dom.window.MessageEvent;
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+
+class ResizeObserverStub {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    observe(target: Element) {
+        this.callback([{ target, contentRect: { width: 800, height: 500 } as DOMRectReadOnly }] as ResizeObserverEntry[], this as unknown as ResizeObserver);
+    }
+    unobserve() {}
+    disconnect() {}
+}
+g.ResizeObserver = ResizeObserverStub;
+(dom.window as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
+
+const canvasContext = new Proxy({
+    canvas: undefined,
+    measureText: (text: string) => ({ width: String(text).length * 8 }),
+    createLinearGradient: () => ({ addColorStop: () => undefined }),
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+}, {
+    get(target, prop) {
+        if (prop in target) return target[prop as keyof typeof target];
+        return () => undefined;
+    },
+    set(target, prop, value) {
+        (target as Record<PropertyKey, unknown>)[prop] = value;
+        return true;
+    },
+});
+(dom.window.HTMLCanvasElement.prototype as unknown as {
+    getContext: () => unknown;
+}).getContext = function getContext(this: HTMLCanvasElement) {
+    canvasContext.canvas = this;
+    return canvasContext;
+};
+
+const { App } = await import('../../editors/vscode/src/data-viewer/webview/App');
+
+const column = {
+    name: 'x',
+    arrowType: 'Int32',
+    dictionaryShipped: false,
+    isInteger: true,
+};
+
+const activeFilter = {
+    entries: [{
+        id: 'e1',
+        columnIndex: 0,
+        predicate: { kind: 'numCompare' as const, op: '>' as const, value: 2 },
+        enabled: true,
+        includeMissing: false,
+    }],
+    labelsOnWhenFiltered: true,
+};
+
+const emptyFilter = {
+    entries: [],
+    labelsOnWhenFiltered: true,
+};
+
+let roots: Root[] = [];
+
+afterEach(() => {
+    for (const root of roots) {
+        act(() => root.unmount());
+    }
+    roots = [];
+    document.body.innerHTML = '';
+});
+
+function initMessage() {
+    return {
+        type: 'init' as const,
+        panelGeneration: 1,
+        nrow: 5,
+        columns: [column],
+        layout: { columnWidths: {}, hiddenColumns: [] },
+        toolbar: { labelsOn: true, formatOn: true, digits: 3 },
+        settings: { missingValueStyle: 'foreground' as const, defaultDigits: 3, persistSort: true, persistFilters: true },
+        dictionaries: {},
+        schemaHash: 'schema-1',
+        sort: { keys: [], labelsOnWhenSorted: true },
+        filter: activeFilter,
+    };
+}
+
+async function renderApp() {
+    const posted: any[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const vscode = {
+        postMessage: (msg: any) => { posted.push(msg); },
+        setState: () => undefined,
+    };
+
+    await act(async () => {
+        root.render(<App vscode={vscode} />);
+    });
+    await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', { data: initMessage() }));
+    });
+    posted.length = 0;
+    return { posted };
+}
+
+async function clickClearAllFilters() {
+    const clear = document.querySelector<HTMLButtonElement>('button[aria-label="Clear all filters"]');
+    expect(clear).not.toBeNull();
+    await act(async () => {
+        clear!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+}
+
+describe('data viewer App filter persistence', () => {
+    test('does not save a rollback filterApplied response', async () => {
+        const { posted } = await renderApp();
+
+        await clickClearAllFilters();
+        const request = posted.find(m => m.type === 'setFilters');
+        expect(request).toBeDefined();
+        posted.length = 0;
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: {
+                    type: 'filterApplied',
+                    panelGeneration: 1,
+                    requestId: request.requestId,
+                    filter: activeFilter,
+                    nrowFiltered: 3,
+                    fromPersistence: false,
+                    rollback: true,
+                    error: 'filter failed',
+                },
+            }));
+        });
+        await new Promise(resolve => setTimeout(resolve, 350));
+
+        expect(posted.filter(m => m.type === 'saveFilter')).toEqual([]);
+    });
+
+    test('saves a successful user filterApplied response immediately', async () => {
+        const { posted } = await renderApp();
+
+        await clickClearAllFilters();
+        const request = posted.find(m => m.type === 'setFilters');
+        expect(request).toBeDefined();
+        posted.length = 0;
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: {
+                    type: 'filterApplied',
+                    panelGeneration: 1,
+                    requestId: request.requestId,
+                    filter: emptyFilter,
+                    nrowFiltered: 5,
+                    fromPersistence: false,
+                },
+            }));
+        });
+
+        expect(posted.filter(m => m.type === 'saveFilter')).toEqual([{
+            type: 'saveFilter',
+            panelGeneration: 1,
+            schemaHash: 'schema-1',
+            filter: emptyFilter,
+        }]);
+    });
+});

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -45,6 +45,9 @@
     "plot-share-popover-position.test.ts",
     "data-viewer-build-bundle.test.ts",
     "data-viewer-filter-popover-seed.test.ts",
+    "data-viewer-abort.test.ts",
+    "data-viewer-sort-filter-cancel.test.ts",
+    "data-viewer-panel-restore-cancel.test.ts",
     "help-command-palette-gating.test.ts"
   ]
 }

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -44,6 +44,7 @@
     "plot-webview-inline-icons.test.ts",
     "plot-share-popover-position.test.ts",
     "data-viewer-build-bundle.test.ts",
+    "data-viewer-restore-affordance.test.ts",
     "data-viewer-filter-popover-seed.test.ts",
     "data-viewer-abort.test.ts",
     "data-viewer-sort-filter-cancel.test.ts",


### PR DESCRIPTION
## Summary

Resolves #519 — a port of [sight#228](https://github.com/jbearak/sight/pull/228) to raven's data viewer.

The grid paints instantly (virtualized), but restoring a **persisted sort or filter** on reopen reads whole columns to recompute the permutation / survivor set — on a multi-million-row frame that's seconds of a bare `Loading…` with no explanation and no way out. This is the same shape of regression #518 fixed for histograms, gated on persisted state.

Now, on reopen with saved prefs the toolbar shows **"Applying your saved sort & filter…"** (worded for whichever applies) with a **Cancel** button, after a 200 ms debounce so fast files never flash it. The column reads are cancellable:

- **Cancel** abandons the restore, **forgets** the saved sort/filter for that panel, and shows the data in natural order.
- A **genuine** (non-abort) read failure is distinguished from a cancel: natural order + a notice naming only what failed, and the saved prefs are **kept** so the next reopen can retry.
- Rows still only ever appear in their final order — no unsorted→sorted jump.

## What's in it

**Interruptible reads (no dependency bump).** Unlike sight (which needed a `@jbearak/dta-parser` bump because its read was synchronous `fs.readSync`), raven's reader already iterates Arrow record batches via `await getBatch(i)`. A new shared `batch-iter.ts` centralizes the batch walk (extracted from `sort.ts`, now used by `filter.ts` too) with a cooperative-cancellation checkpoint: with a signal it throws `AbortError` before each batch and yields the event loop after each (so a queued Cancel is observed); with no signal it's byte-identical — no checks, no yields. `abort.ts` holds `throwIfAborted` / `yieldToEventLoop` / `isAbortError`.

**Host state machine (`panel.ts`).** New `restorePending` (host→webview) and `cancelRestore` (webview→host) messages with a monotonic `restoreId` handshake. `sendInit`/`sendReplace` are serialized; `maybeBeginRestore` posts `restorePending` before the reads when an applicable pref exists; the cancel path resets in-memory sort/filter, posts natural-order, and forgets the stores; lifecycle interruptions (webview reload, dataset `replace`) bump generation + abort so the in-flight restore bails *stale* (prefs intact) while a true Cancel forgets; interactive `setSort`/`setFilters` are no-ops while restoring.

**Webview (`App.tsx`, `grid-model.ts`, `styles.css`).** The banner + Cancel button replace the bare `Loading…` (debounced); `describeRestoreMessage` / `describeToolbarRowCount` are pure + unit-tested.

## Design

`docs/superpowers/specs/2026-06-27-issue-519-data-viewer-restore-cancel-design.md` (revised across two rounds of adversarial spec review).

## Testing

New bun suites: `data-viewer-abort`, `data-viewer-sort-filter-cancel` (signal-threading: byte-identical no-signal path, abort-before/mid read), and `data-viewer-panel-restore-cancel` (28 cases: maybeBeginRestore gating, completed-sort + cancelled-filter natural order, abort-vs-real-error, serialization, generation-bump-keeps-prefs, late clear-and-forget, cancel-during-paint and during-filterApplied windows, cancel-vs-reload/replace races, no-sticky-cancel-flag). Plus `grid-model` helper cases. The existing panel sort/filter/persistence suites stay green (refactor regression guard). Webview React-effect behavior (the banner debounce + the host-owned-filter save-back guard) is verified by typecheck + webview bundle and the vscode-test integration suite; it is out of the bun unit harness's reach.

All TS gates clean (extension, webview, and `tests/bun` tsconfigs). Pre-existing failures in `data-viewer-session-server-route` / `-warning-route` / `-bootstrap-r-integration` are environmental (need R / sockets) and present on `main` — this PR adds zero new failures.

## Review

Adversarially reviewed over many rounds (Codex + `/code-review`). Codex caught two real bugs the dimension-based review missed — a lifecycle-abort-during-paint that wrongly forgot prefs, and a webview save-back that destroyed a kept-on-error filter — both fixed. Final consecutive passes clean from both.

https://claude.ai/code/session_01JLkE1yNs1DRxZSqpo6kF5B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debounced restore banner when reopening with saved sort/filter, including **“Skip and show data now”**.
* **Bug Fixes**
  * Made saved sort/filter restore cooperatively cancelable and concurrency-safe, with robust fallback to natural order and clearer handling of genuine restore failures.
  * Improved request/restore serialization to prevent overlapping restore behavior.
* **Documentation**
  * Updated data viewer docs to explain restore progress and skip semantics.
* **Tests**
  * Added coverage for abort handling, restore/cancel behavior, UI affordances, and intent/rollback flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->