### PR TITLE
Fix data-viewer transform races

### DIFF
--- a/editors/vscode/src/data-viewer/abort.ts
+++ b/editors/vscode/src/data-viewer/abort.ts
@@ -1,9 +1,10 @@
 /**
- * Cooperative-cancellation helpers for the saved-sort/filter restore on
- * open (#519). The restore reads whole columns to compute a permutation
- * / survivor set; threading an {@link AbortSignal} through those reads,
- * and yielding the event loop between Arrow record batches, lets a
- * webview Cancel actually interrupt the wait.
+ * Cooperative-cancellation helpers for data-viewer full-column scans.
+ * Saved sort/filter restore and interactive sort/filter changes read
+ * whole columns to compute a permutation / survivor set; threading an
+ * {@link AbortSignal} through those reads, and yielding the event loop
+ * between Arrow record batches, lets a webview Cancel or superseding
+ * user action interrupt the wait.
  *
  * These are host-side only (the column reads run on the extension host,
  * not in the webview). The no-signal path of every consumer stays
@@ -20,16 +21,16 @@
  */
 export function throwIfAborted(signal?: AbortSignal): void {
     if (signal?.aborted) {
-        throw new DOMException('The restore was aborted', 'AbortError');
+        throw new DOMException('The data-viewer operation was aborted', 'AbortError');
     }
 }
 
 /**
- * Release the event loop so a queued webview→host message (the Cancel)
- * is delivered before the next batch is read. `setImmediate` schedules a
- * check-phase callback that runs after the poll phase where incoming IPC
- * is handled, so the abort is observed on the next {@link throwIfAborted}.
- * Only inserted on the restore (signal-bearing) path.
+ * Release the event loop so a queued webview→host message (Cancel or a
+ * superseding sort/filter) is delivered before the next batch is read.
+ * `setImmediate` schedules a check-phase callback that runs after the poll
+ * phase where incoming IPC is handled, so the abort is observed on the
+ * next {@link throwIfAborted}. Only inserted on signal-bearing paths.
  */
 export function yieldToEventLoop(): Promise<void> {
     return new Promise<void>(resolve => {

--- a/editors/vscode/src/data-viewer/batch-iter.ts
+++ b/editors/vscode/src/data-viewer/batch-iter.ts
@@ -1,16 +1,15 @@
 /**
- * Shared record-batch iteration for the sort and filter engines.
+ * Shared record-batch iteration for full-column data-viewer scans.
  *
- * Both engines read whole columns by walking the reader's record
- * batches. Centralizing the walk here gives one place for the
- * cooperative-cancellation checkpoint (#519): when a `signal` is passed
- * (the saved-sort/filter restore on open), the iteration throws an
- * `AbortError` before each batch if aborted and yields the event loop
- * after each batch so a queued webview Cancel is delivered before the
- * next read. With no `signal` (interactive setSort/setFilters, which read
- * whole columns but are not cancellable) it is byte-identical to a plain
- * batch loop — no checks, no yields. The virtualized viewport `getRows`
- * path does not walk batches through here at all.
+ * Sort, filter, and histogram code read whole columns by walking the
+ * reader's record batches. Centralizing the walk here gives one place for the
+ * cooperative-cancellation checkpoint (#519): when a `signal` is passed,
+ * the iteration throws an `AbortError` before each batch if aborted and
+ * yields the event loop after each batch so a queued webview Cancel or
+ * superseding sort/filter is delivered before the next read. With no
+ * `signal` it is byte-identical to a plain batch loop — no checks, no
+ * yields. The virtualized viewport `getRows` path does not walk batches
+ * through here at all.
  */
 import type { ArrowSliceReader } from './arrow-reader';
 import { throwIfAborted, yieldToEventLoop } from './abort';

--- a/editors/vscode/src/data-viewer/filter.ts
+++ b/editors/vscode/src/data-viewer/filter.ts
@@ -61,6 +61,7 @@ export async function computeFilteredIndices(
         await applyEntry(reader, e, ctx, mask, signal);
         if (allZero(mask)) break;
     }
+    throwIfAborted(signal);
     return compact(mask);
 }
 
@@ -82,6 +83,7 @@ async function applyEntry(
     const include = p.kind === 'isEmpty' ? true : entry.includeMissing;
     const missing = await missingMaskFor(reader, entry.columnIndex, schema, signal);
 
+    throwIfAborted(signal);
     for (let i = 0; i < mask.length; i++) {
         if (mask[i] === 0) continue;
         if (missing[i]) {
@@ -90,6 +92,7 @@ async function applyEntry(
         }
         mask[i] = accept(i) ? 1 : 0;
     }
+    throwIfAborted(signal);
 }
 
 /** Returns a fn `(rowIndex) => boolean` whose domain is **non-missing**

--- a/editors/vscode/src/data-viewer/histograms.ts
+++ b/editors/vscode/src/data-viewer/histograms.ts
@@ -25,6 +25,8 @@
 
 import type { ArrowSliceReader } from './arrow-reader';
 import type { HistogramBin } from './messages';
+import { iterateBatches } from './batch-iter';
+import { throwIfAborted } from './abort';
 
 const BIN_COUNT = 50;
 
@@ -40,12 +42,13 @@ export function isNumericArrowType(arrowType: string): boolean {
 
 export async function computeNumericHistograms(
     reader: ArrowSliceReader,
+    opts?: { signal?: AbortSignal },
 ): Promise<Record<number, HistogramBin[]>> {
     const out: Record<number, HistogramBin[]> = {};
     const schema = reader.schema.columns;
     for (let ci = 0; ci < schema.length; ci++) {
         if (!isNumericArrowType(schema[ci].arrowType)) continue;
-        out[ci] = await computeHistogramForColumn(reader, ci);
+        out[ci] = await computeHistogramForColumn(reader, ci, opts);
     }
     return out;
 }
@@ -59,16 +62,15 @@ export async function computeNumericHistograms(
 export async function computeHistogramForColumn(
     reader: ArrowSliceReader,
     columnIndex: number,
+    opts?: { signal?: AbortSignal },
 ): Promise<HistogramBin[]> {
+    const signal = opts?.signal;
     let min = Number.POSITIVE_INFINITY;
     let max = Number.NEGATIVE_INFINITY;
     let count = 0;
-    const numBatches = reader.batchStarts.length - 1;
 
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const length = reader.batchStarts[bi + 1] - reader.batchStarts[bi];
         for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -80,6 +82,7 @@ export async function computeHistogramForColumn(
         }
     }
 
+    throwIfAborted(signal);
     if (count === 0) return [];
     if (min === max) {
         return [{ lo: min, hi: max, count }];
@@ -92,10 +95,8 @@ export async function computeHistogramForColumn(
     }
     bins[BIN_COUNT - 1].hi = max;
 
-    for (let bi = 0; bi < numBatches; bi++) {
-        const batch = await (reader as any).getBatch(bi);
+    for await (const { batch, length } of iterateBatches(reader, signal)) {
         const child = batch.getChildAt(columnIndex);
-        const length = reader.batchStarts[bi + 1] - reader.batchStarts[bi];
         for (let r = 0; r < length; r++) {
             const v = child.get(r);
             if (v === null || v === undefined) continue;
@@ -107,5 +108,6 @@ export async function computeHistogramForColumn(
             bins[idx].count++;
         }
     }
+    throwIfAborted(signal);
     return bins;
 }

--- a/editors/vscode/src/data-viewer/messages.ts
+++ b/editors/vscode/src/data-viewer/messages.ts
@@ -2,9 +2,10 @@
  * Protocol types for the data-viewer postMessage channel.
  *
  * Every message after the initial `webviewReady` handshake carries the
- * panel's monotonic `panelGeneration`. Receivers drop messages tagged with
- * an older generation than the receiver's current one — this is how stale
- * `getRows` / `copy` / `labels` responses are filtered out after a `replace`.
+ * panel's monotonic `panelGeneration`. The host bumps it on webview reload
+ * and dataset replacement; receivers drop messages from older generations
+ * so stale `getRows` / `copy` / `labels` / transform responses cannot leak
+ * across those lifecycle boundaries.
  */
 
 import type { Cell } from './wire-format';
@@ -204,12 +205,20 @@ export type ExtensionToWebview =
         requestId: number;
         sort: SortState;
         fromPersistence: boolean;
+        /** True when this is an authoritative rollback after a failed
+         *  interactive setSort request. The webview should update display
+         *  state but must not persist the rolled-back state as a new user
+         *  preference. */
+        rollback?: boolean;
+        /** Optional failure text carried by a rollback response. */
+        error?: string;
     }
     | {
         /** Lifecycle ping driving the toolbar "Sorting…" progress pill.
          *  `state: 'pending'` shows it; `'idle'` clears it. */
         type: 'sortStatus';
         panelGeneration: number;
+        requestId: number;
         state: 'pending' | 'idle';
     }
     | {
@@ -223,20 +232,28 @@ export type ExtensionToWebview =
         filter: FilterState;
         nrowFiltered: number;
         fromPersistence: boolean;
+        /** True when this is an authoritative rollback after a failed
+         *  interactive setFilters request. The webview should clear pending
+         *  intent but must not persist the rolled-back state as a new user
+         *  preference. */
+        rollback?: boolean;
+        /** Optional failure text carried by a rollback response. */
+        error?: string;
     }
     | {
         type: 'filterStatus';
         panelGeneration: number;
+        requestId: number;
         state: 'pending' | 'idle';
     }
     | {
         /** Sent before the host reads columns to reapply a saved
          *  sort/filter on open (#519), so the webview can explain the wait
          *  (instead of a bare "Loading…") and offer a skip action.
-         *  `restoreId` is a monotonic id (NOT `panelGeneration`, which the
-         *  host bumps only on dataset replace) identifying this restore so
-         *  a `cancelRestore` can be matched to it. `sort` / `filter` say
-         *  which preferences are being applied (for the wording). */
+         *  `restoreId` is a monotonic id identifying this restore so a
+         *  `cancelRestore` can be matched to it independently of lifecycle
+         *  generation bumps. `sort` / `filter` say which preferences are
+         *  being applied (for the wording). */
         type: 'restorePending';
         panelGeneration: number;
         restoreId: number;
@@ -374,6 +391,10 @@ export type WebviewToExtension =
         type: 'setSort';
         panelGeneration: number;
         requestId: number;
+        /** Request id of the sort state the webview has actually accepted
+         *  and wants restored if this request fails. Older direct callers may
+         *  omit it; the host then falls back to its current state. */
+        rollbackBaseRequestId?: number;
         keys: SortKey[];
         labelsOn: boolean;
         formatOn: boolean;
@@ -396,6 +417,10 @@ export type WebviewToExtension =
         type: 'setFilters';
         panelGeneration: number;
         requestId: number;
+        /** Request id of the filter state the webview has actually accepted
+         *  and wants restored if this request fails. Older direct callers may
+         *  omit it; the host then falls back to its current state. */
+        rollbackBaseRequestId?: number;
         entries: FilterEntry[];
         labelsOn: boolean;
     }

--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -1,11 +1,11 @@
 /**
  * DataViewerPanel — owns one webview tab keyed by panel name.
  *
- * Generations: every replace() increments `generation`. The handle()
- * method captures the current generation before any await, and drops
- * the reply if a replace landed in the meantime. The webview also tags
- * its requests with the generation it last received and silently
- * ignores responses tagged with an older one.
+ * Generations: every dataset replace and webviewReady lifecycle increments
+ * `generation`. The handle() method captures the current generation before
+ * any await, and drops the reply if a replace or reload landed in the
+ * meantime. The webview also tags its requests with the generation it last
+ * received and silently ignores responses tagged with an older one.
  */
 
 import * as vscode from 'vscode';
@@ -17,6 +17,7 @@ import {
     EMPTY_FILTER,
     EMPTY_SORT,
     ExtensionToWebview,
+    FilterEntry,
     FilterState,
     HistogramBin,
     Layout,
@@ -38,6 +39,46 @@ import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 let dataViewerTraceOutput: vscode.OutputChannel | undefined;
 
+type SortSnapshot = {
+    sort: SortState;
+    permutation?: Uint32Array;
+};
+
+type FilterSnapshot = {
+    filter: FilterState;
+    filteredIndices?: Uint32Array;
+};
+
+function cloneSortState(sort: SortState): SortState {
+    if (sort.keys.length === 0) return EMPTY_SORT;
+    return {
+        keys: sort.keys.map(k => ({ ...k })),
+        labelsOnWhenSorted: sort.labelsOnWhenSorted,
+    };
+}
+
+function cloneFilterEntry(entry: FilterEntry): FilterEntry {
+    const predicate = entry.predicate.kind === 'setIn' || entry.predicate.kind === 'setNotIn'
+        ? { ...entry.predicate, values: [...entry.predicate.values] }
+        : { ...entry.predicate };
+    return {
+        ...entry,
+        predicate: predicate as FilterEntry['predicate'],
+    };
+}
+
+function cloneFilterState(filter: FilterState): FilterState {
+    if (filter.entries.length === 0) return EMPTY_FILTER;
+    return {
+        entries: filter.entries.map(cloneFilterEntry),
+        labelsOnWhenFiltered: filter.labelsOnWhenFiltered,
+    };
+}
+
+function cloneIndices(indices: Uint32Array | undefined): Uint32Array | undefined {
+    return indices === undefined ? undefined : new Uint32Array(indices);
+}
+
 export class DataViewerPanel {
     readonly panelName: string;
     private readonly webviewPanel: vscode.WebviewPanel;
@@ -57,10 +98,14 @@ export class DataViewerPanel {
     /** Permutation backing the current sort. `undefined` ↔ identity
      *  ordering. Plumbed into every reader.getRows call below. */
     private permutation: Uint32Array | undefined;
-    /** Monotonic counter — every setSort that produces a new permutation
-     *  bumps it. Late-landing `sortApplied` responses tagged with an
-     *  older value are dropped. */
+    /** Monotonic request token — bumped for every setSort and lifecycle
+     *  abort so stale async sort work can be detected and dropped. */
     private sortGeneration = 0;
+    /** Generation-local rollback snapshots keyed by request id. The webview
+     *  tells us which accepted id to roll back to on a later failure; keeping
+     *  this host-side preserves the already-built permutation. Key 0 is the
+     *  current init/replace baseline. */
+    private sortSnapshots = new Map<number, SortSnapshot>([[0, { sort: EMPTY_SORT }]]);
     /** Current filter state. Mirrors what the webview shows in the chip
      *  strip. Updated by `setFilters` and by init/replace's restore path. */
     private filter: FilterState = EMPTY_FILTER;
@@ -70,6 +115,11 @@ export class DataViewerPanel {
     /** Monotonic counter — bumped on every setFilters call so stale
      *  async results can be detected and dropped. */
     private filterGeneration = 0;
+    /** Generation-local rollback snapshots keyed by request id. The webview
+     *  tells us which accepted id to roll back to on a later failure; keeping
+     *  this host-side preserves the already-built filtered index. Key 0 is
+     *  the current init/replace baseline. */
+    private filterSnapshots = new Map<number, FilterSnapshot>([[0, { filter: EMPTY_FILTER }]]);
     /** Per-column numeric histogram cache, keyed by column index, for the
      *  current reader. Populated lazily by the `getHistogram` handler (a
      *  histogram costs two full column scans, so we never recompute one).
@@ -97,9 +147,9 @@ export class DataViewerPanel {
      *  setSort/setFilters no-op so a generation bump can't strand it. */
     private restoring = false;
     /** Monotonic id of the active restore (-1 ⇔ none). The
-     *  restorePending/cancelRestore handshake key. NOT `generation` —
-     *  webviewReady reloads do not bump generation, so reusing it would
-     *  alias restores across a reload. */
+     *  restorePending/cancelRestore handshake key. Kept distinct from
+     *  `generation`, which invalidates stale webview messages across reloads
+     *  and dataset replacement rather than identifying a specific restore. */
     private restoreId = -1;
     /** Source of {@link restoreId}; bumped per restore begun. */
     private restoreSeq = 0;
@@ -116,6 +166,21 @@ export class DataViewerPanel {
      *  reload mid-restore must not start a concurrent send that overwrites
      *  {@link restoreAbort}). */
     private sendChain: Promise<void> = Promise.resolve();
+    /** FIFO queue for full-column scans (saved restore, sort/filter, and
+     *  histogram). The Arrow IPC reader must not service two batch streams
+     *  concurrently; preserving request order is preferable to letting a
+     *  later transform observe a partially-aborted earlier one. Interactive
+     *  sort/filter still post their pending status before entering the queue. */
+    private transformChain: Promise<void> = Promise.resolve();
+    /** Abort controller for the active or queued interactive sort. A newer
+     *  sort supersedes it; filters do not, because sort+filter compose. */
+    private sortAbort: AbortController | null = null;
+    /** Abort controller for the active or queued interactive filter. A newer
+     *  filter supersedes it; sorts do not, because sort+filter compose. */
+    private filterAbort: AbortController | null = null;
+    /** Abort controllers for active or queued histogram scans. Histograms are
+     *  on-demand full-column scans and are stale after reload/replace/close. */
+    private histogramAborts = new Set<AbortController>();
 
     private constructor(
         panelName: string,
@@ -210,6 +275,7 @@ export class DataViewerPanel {
         this.lastFocusCell = undefined;
         // Old permutation cannot be reused — sendReplace below will
         // attempt to restore a saved sort against the new reader.
+        this.abortInteractiveTransforms();
         this.sort = EMPTY_SORT;
         this.permutation = undefined;
         this.sortGeneration += 1;
@@ -218,6 +284,7 @@ export class DataViewerPanel {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
         this.filterGeneration += 1;
+        this.resetRollbackSnapshots();
         // Histograms are reader-scoped; the new reader is a different dataset.
         this.histogramCache.clear();
         const prevReader = this.reader;
@@ -249,6 +316,93 @@ export class DataViewerPanel {
         };
     }
 
+    private currentSortSnapshot(): SortSnapshot {
+        return {
+            sort: cloneSortState(this.sort),
+            permutation: cloneIndices(this.permutation),
+        };
+    }
+
+    private applySortSnapshot(snapshot: SortSnapshot): void {
+        this.sort = cloneSortState(snapshot.sort);
+        this.permutation = cloneIndices(snapshot.permutation);
+    }
+
+    private rollbackSortSnapshot(baseRequestId: number | undefined): SortSnapshot {
+        if (baseRequestId !== undefined) {
+            const snapshot = this.sortSnapshots.get(baseRequestId);
+            if (snapshot) {
+                return {
+                    sort: cloneSortState(snapshot.sort),
+                    permutation: cloneIndices(snapshot.permutation),
+                };
+            }
+        }
+        return this.currentSortSnapshot();
+    }
+
+    private recordSortSnapshot(
+        requestId: number,
+        snapshot: SortSnapshot = this.currentSortSnapshot(),
+        keepBaseRequestId?: number,
+    ): void {
+        this.sortSnapshots.set(requestId, {
+            sort: cloneSortState(snapshot.sort),
+            permutation: cloneIndices(snapshot.permutation),
+        });
+        for (const key of this.sortSnapshots.keys()) {
+            if (key !== 0 && key !== requestId && key !== keepBaseRequestId) {
+                this.sortSnapshots.delete(key);
+            }
+        }
+    }
+
+    private currentFilterSnapshot(): FilterSnapshot {
+        return {
+            filter: cloneFilterState(this.filter),
+            filteredIndices: cloneIndices(this.filteredIndices),
+        };
+    }
+
+    private applyFilterSnapshot(snapshot: FilterSnapshot): void {
+        this.filter = cloneFilterState(snapshot.filter);
+        this.filteredIndices = cloneIndices(snapshot.filteredIndices);
+    }
+
+    private rollbackFilterSnapshot(baseRequestId: number | undefined): FilterSnapshot {
+        if (baseRequestId !== undefined) {
+            const snapshot = this.filterSnapshots.get(baseRequestId);
+            if (snapshot) {
+                return {
+                    filter: cloneFilterState(snapshot.filter),
+                    filteredIndices: cloneIndices(snapshot.filteredIndices),
+                };
+            }
+        }
+        return this.currentFilterSnapshot();
+    }
+
+    private recordFilterSnapshot(
+        requestId: number,
+        snapshot: FilterSnapshot = this.currentFilterSnapshot(),
+        keepBaseRequestId?: number,
+    ): void {
+        this.filterSnapshots.set(requestId, {
+            filter: cloneFilterState(snapshot.filter),
+            filteredIndices: cloneIndices(snapshot.filteredIndices),
+        });
+        for (const key of this.filterSnapshots.keys()) {
+            if (key !== 0 && key !== requestId && key !== keepBaseRequestId) {
+                this.filterSnapshots.delete(key);
+            }
+        }
+    }
+
+    private resetRollbackSnapshots(): void {
+        this.sortSnapshots = new Map([[0, this.currentSortSnapshot()]]);
+        this.filterSnapshots = new Map([[0, this.currentFilterSnapshot()]]);
+    }
+
     // sendInit / sendReplace are serialized through `sendChain` so two
     // restores never overlap. The chain wraps only these public entry
     // points; internal delegation (an uninitialized replace) calls the
@@ -256,6 +410,12 @@ export class DataViewerPanel {
     private enqueue<T>(fn: () => Promise<T>): Promise<T> {
         const next = this.sendChain.catch(() => {}).then(fn);
         this.sendChain = next.then(() => {}, () => {});
+        return next;
+    }
+
+    private enqueueTransform<T>(fn: () => Promise<T>): Promise<T> {
+        const next = this.transformChain.catch(() => {}).then(fn);
+        this.transformChain = next.then(() => {}, () => {});
         return next;
     }
 
@@ -388,6 +548,7 @@ export class DataViewerPanel {
                         nrowFiltered: this.filteredIndices.length,
                         fromPersistence: true,
                     } satisfies ExtensionToWebview);
+                    this.recordFilterSnapshot(-1, undefined, 0);
                     // The filterApplied post is the second (and last)
                     // post-decision await window. A cancel/lifecycle abort can
                     // land during it: a lifecycle abort bumped generation →
@@ -455,6 +616,8 @@ export class DataViewerPanel {
             loadedToolbar: activeToolbar,
         });
         await this.webviewPanel.webview.postMessage(msg);
+        this.recordSortSnapshot(0);
+        this.recordFilterSnapshot(0);
     }
 
     // -------------------------------------------------------
@@ -529,6 +692,7 @@ export class DataViewerPanel {
         this.filter = EMPTY_FILTER;
         this.filteredIndices = undefined;
         this.filterGeneration += 1;
+        this.resetRollbackSnapshots();
     }
 
     /** Consume the restore handshake because the user superseded the
@@ -549,6 +713,21 @@ export class DataViewerPanel {
         this.restoring = false;
         this.restoreId = -1;
         this.restoreCancelRequested = false;
+    }
+
+    /** Abort active or queued interactive transforms when the webview
+     *  reloads/replaces/closes. The next init/replace is authoritative for
+     *  display state; stale interactive acks from the old webview must not
+     *  race into the new one. */
+    private abortInteractiveTransforms(): void {
+        this.sortAbort?.abort();
+        this.sortAbort = null;
+        this.sortGeneration += 1;
+        this.filterAbort?.abort();
+        this.filterAbort = null;
+        this.filterGeneration += 1;
+        for (const abort of this.histogramAborts) abort.abort();
+        this.histogramAborts.clear();
     }
 
     /** Schema hash of the live reader — used by the late clear-and-forget
@@ -654,11 +833,19 @@ export class DataViewerPanel {
             if (k.columnIndex < 0 || k.columnIndex > maxColIndex) return false;
         }
         try {
-            const perm = await computePermutation(reader, saved.keys, {
-                labelsOn: toolbar.labelsOn,
-                formatOn: toolbar.formatOn,
-                digits: toolbar.digits,
-            }, { signal });
+            const perm = await this.enqueueTransform(async () => {
+                if (generation !== this.generation
+                    || reader !== this.reader
+                    || signal?.aborted) {
+                    return undefined;
+                }
+                return computePermutation(reader, saved.keys, {
+                    labelsOn: toolbar.labelsOn,
+                    formatOn: toolbar.formatOn,
+                    digits: toolbar.digits,
+                }, { signal });
+            });
+            if (!perm) return false;
             if (generation !== this.generation || reader !== this.reader) return false;
             this.sort = {
                 keys: saved.keys,
@@ -701,14 +888,26 @@ export class DataViewerPanel {
             if (e.columnIndex < 0 || e.columnIndex > maxColIndex) return false;
         }
         try {
-            const indices = await computeFilteredIndices(reader, saved, {
-                labelsOn: toolbar.labelsOn,
-                formatOn: toolbar.formatOn,
-                digits: toolbar.digits,
-            }, { signal });
+            const result = await this.enqueueTransform(async (): Promise<
+                | { stale: true }
+                | { stale: false; indices: Uint32Array | undefined }
+            > => {
+                if (generation !== this.generation
+                    || reader !== this.reader
+                    || signal?.aborted) {
+                    return { stale: true };
+                }
+                const indices = await computeFilteredIndices(reader, saved, {
+                    labelsOn: toolbar.labelsOn,
+                    formatOn: toolbar.formatOn,
+                    digits: toolbar.digits,
+                }, { signal });
+                return { stale: false, indices };
+            });
+            if (result.stale) return false;
             if (generation !== this.generation || reader !== this.reader) return false;
             this.filter = { entries: saved.entries, labelsOnWhenFiltered: toolbar.labelsOn };
-            this.filteredIndices = indices;
+            this.filteredIndices = result.indices;
             this.filterGeneration += 1;
             return false;
         } catch (err) {
@@ -762,6 +961,7 @@ export class DataViewerPanel {
 
     private async handleInner(m: WebviewToExtension): Promise<void> {
         if (m.type === 'webviewReady') {
+            this.generation += 1;
             this.trace('webview-ready', { generation: this.generation });
             this.webviewReady = true;
             // A webview reload mid-restore is a lifecycle interruption, not
@@ -777,13 +977,13 @@ export class DataViewerPanel {
                 // reload (no pending cancel) keeps the prefs.
                 const cancelled = this.restoreCancelRequested;
                 const hash = this.currentSchemaHash();
-                this.generation += 1;
                 this.abortAndClearRestore();
                 // Swallow a store-write failure so it cannot skip the sendInit
                 // below and strand the reloaded webview on a permanent
                 // Loading… (worst case the cancelled pref survives the reload).
                 if (cancelled) await this.forgetPersistedPrefs(hash).catch(() => undefined);
             }
+            this.abortInteractiveTransforms();
             await this.sendInit();
             return;
         }
@@ -965,32 +1165,65 @@ export class DataViewerPanel {
                     // brush stays blank forever with no retry (unlike getRows,
                     // a missing histogram reply is unrecoverable). All degrade
                     // to "no brush". The whole-grid getRows path would also be
-                    // failing if a batch genuinely can't decode, and a decode
+                    // failing if a batch genuinely can't decode. A decode
                     // failure on a fixed Arrow file is deterministic, so the
-                    // empty result is cached below rather than re-scanning on
-                    // every popover reopen.
+                    // empty result from a failed scannable column is cached
+                    // below rather than re-scanning on every popover reopen.
                     const cols = reader.schema.columns;
                     const scannable = Number.isInteger(ci) && ci >= 0 && ci < cols.length
                         && isNumericArrowType(cols[ci].arrowType);
                     if (!scannable) {
                         bins = [];
                     } else {
-                        try {
-                            bins = await computeHistogramForColumn(reader, ci);
-                        } catch {
-                            bins = [];
-                        }
+                        const abort = new AbortController();
+                        this.histogramAborts.add(abort);
+                        bins = await this.enqueueTransform(async () => {
+                            if (this.disposed
+                                || gen !== this.generation
+                                || reader !== this.reader
+                                || abort.signal.aborted) {
+                                this.histogramAborts.delete(abort);
+                                return undefined;
+                            }
+                            const cached = this.histogramCache.get(ci);
+                            if (cached) {
+                                this.histogramAborts.delete(abort);
+                                return cached;
+                            }
+                            let computed: HistogramBin[];
+                            try {
+                                computed = await computeHistogramForColumn(reader, ci, {
+                                    signal: abort.signal,
+                                });
+                            } catch (err) {
+                                if (abort.signal.aborted || isAbortError(err)) {
+                                    this.histogramAborts.delete(abort);
+                                    return undefined;
+                                }
+                                computed = [];
+                            }
+                            // After the await: drop if the panel was disposed
+                            // or the dataset was swapped (mirrors getRows) —
+                            // no reply is owed, the new generation's webview
+                            // already cleared its in-flight marker.
+                            if (this.disposed
+                                || gen !== this.generation
+                                || reader !== this.reader
+                                || abort.signal.aborted) {
+                                this.histogramAborts.delete(abort);
+                                return undefined;
+                            }
+                            const existing = this.histogramCache.get(ci);
+                            if (existing) {
+                                this.histogramAborts.delete(abort);
+                                return existing;
+                            }
+                            this.histogramCache.set(ci, computed);
+                            this.histogramAborts.delete(abort);
+                            return computed;
+                        });
+                        if (bins === undefined) return;
                     }
-                    // After the await: drop if the panel was disposed or the
-                    // dataset was swapped (mirrors the getRows handler) — no
-                    // reply is owed, the new generation's webview already
-                    // cleared its in-flight marker. A concurrent request for
-                    // the same column may have cached a result meanwhile;
-                    // first writer wins so a late error-[] never clobbers it.
-                    if (this.disposed || gen !== this.generation || reader !== this.reader) return;
-                    const existing = this.histogramCache.get(ci);
-                    if (existing) bins = existing;
-                    else this.histogramCache.set(ci, bins);
                 }
                 const reply: ExtensionToWebview = {
                     type: 'histogram',
@@ -1031,14 +1264,20 @@ export class DataViewerPanel {
         // not reach the clear-and-forget branch and wipe this.
         this.consumeRestoreHandshake();
 
-        // Clear the current permutation and let the webview render a
-        // "Sorting…" indicator while we work. For empty `keys`, this is
-        // also the final state (no apply pass needed).
+        // Let the webview render a "Sorting..." indicator while non-empty
+        // sorts compute. The old authoritative permutation stays in place as
+        // the rollback baseline until the new result is ready to publish.
+        // For empty `keys`, clearing is immediate and final.
         this.sortGeneration += 1;
         const mySortGen = this.sortGeneration;
+        this.sortAbort?.abort();
+        const abort = new AbortController();
+        this.sortAbort = abort;
         if (m.keys.length === 0) {
             this.sort = EMPTY_SORT;
             this.permutation = undefined;
+            this.recordSortSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+            if (this.sortAbort === abort) this.sortAbort = null;
             const ack: ExtensionToWebview = {
                 type: 'sortApplied',
                 panelGeneration: gen,
@@ -1046,16 +1285,34 @@ export class DataViewerPanel {
                 sort: EMPTY_SORT,
                 fromPersistence: false,
             };
-            await this.webviewPanel.webview.postMessage(ack);
+            void this.webviewPanel.webview.postMessage(ack).then(undefined, () => undefined);
             return;
         }
 
         const pending: ExtensionToWebview = {
             type: 'sortStatus',
             panelGeneration: gen,
+            requestId: m.requestId,
             state: 'pending',
         };
         await this.webviewPanel.webview.postMessage(pending);
+
+        await this.enqueueTransform(() => this.runSetSort(m, gen, mySortGen, abort));
+    }
+
+    private async runSetSort(
+        m: Extract<WebviewToExtension, { type: 'setSort' }>,
+        gen: number,
+        mySortGen: number,
+        abort: AbortController,
+    ): Promise<void> {
+        if (gen !== this.generation
+            || mySortGen !== this.sortGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
 
         let perm: Uint32Array;
         try {
@@ -1063,7 +1320,7 @@ export class DataViewerPanel {
                 labelsOn: m.labelsOn,
                 formatOn: m.formatOn,
                 digits: m.digits,
-            });
+            }, { signal: abort.signal });
         } catch (err) {
             // Drop the failure entirely if a newer setSort or a panel
             // replace landed while computePermutation was in flight —
@@ -1072,27 +1329,63 @@ export class DataViewerPanel {
             // an error that's no longer relevant.
             if (gen !== this.generation
                 || mySortGen !== this.sortGeneration
-                || this.disposed) {
+                || this.disposed
+                || isAbortError(err)) {
+                if (this.sortAbort === abort) this.sortAbort = null;
                 return;
             }
             const idle: ExtensionToWebview = {
                 type: 'sortStatus',
                 panelGeneration: gen,
+                requestId: m.requestId,
                 state: 'idle',
             };
             await this.webviewPanel.webview.postMessage(idle);
-            const errMsg: ExtensionToWebview = {
-                type: 'error',
+            if (gen !== this.generation
+                || mySortGen !== this.sortGeneration
+                || this.disposed
+                || abort.signal.aborted) {
+                if (this.sortAbort === abort) this.sortAbort = null;
+                return;
+            }
+            const rollbackSnapshot = this.rollbackSortSnapshot(m.rollbackBaseRequestId);
+            this.applySortSnapshot(rollbackSnapshot);
+            this.recordSortSnapshot(m.requestId, rollbackSnapshot, m.rollbackBaseRequestId);
+            const rollback: ExtensionToWebview = {
+                type: 'sortApplied',
                 panelGeneration: gen,
-                message: err instanceof Error ? err.message : String(err),
+                requestId: m.requestId,
+                sort: cloneSortState(this.sort),
+                fromPersistence: false,
+                rollback: true,
+                error: err instanceof Error ? err.message : String(err),
             };
-            await this.webviewPanel.webview.postMessage(errMsg);
+            void this.webviewPanel.webview.postMessage(rollback).then(undefined, () => undefined);
+            if (this.sortAbort === abort) this.sortAbort = null;
             return;
         }
 
         // If another setSort raced in front, or the panel was replaced,
         // discard our result without publishing.
-        if (gen !== this.generation || mySortGen !== this.sortGeneration) return;
+        if (gen !== this.generation || mySortGen !== this.sortGeneration) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
+
+        const idle: ExtensionToWebview = {
+            type: 'sortStatus',
+            panelGeneration: gen,
+            requestId: m.requestId,
+            state: 'idle',
+        };
+        await this.webviewPanel.webview.postMessage(idle);
+        if (gen !== this.generation
+            || mySortGen !== this.sortGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.sortAbort === abort) this.sortAbort = null;
+            return;
+        }
 
         const next: SortState = {
             keys: m.keys,
@@ -1100,13 +1393,7 @@ export class DataViewerPanel {
         };
         this.sort = next;
         this.permutation = perm;
-
-        const idle: ExtensionToWebview = {
-            type: 'sortStatus',
-            panelGeneration: gen,
-            state: 'idle',
-        };
-        await this.webviewPanel.webview.postMessage(idle);
+        this.recordSortSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
         const ack: ExtensionToWebview = {
             type: 'sortApplied',
             panelGeneration: gen,
@@ -1114,7 +1401,8 @@ export class DataViewerPanel {
             sort: next,
             fromPersistence: false,
         };
-        await this.webviewPanel.webview.postMessage(ack);
+        void this.webviewPanel.webview.postMessage(ack).then(undefined, () => undefined);
+        if (this.sortAbort === abort) this.sortAbort = null;
     }
 
     private async handleSetFilters(
@@ -1128,21 +1416,45 @@ export class DataViewerPanel {
 
         this.filterGeneration += 1;
         const myFilterGen = this.filterGeneration;
+        this.filterAbort?.abort();
+        const abort = new AbortController();
+        this.filterAbort = abort;
         const next: FilterState = { entries: m.entries, labelsOnWhenFiltered: m.labelsOn };
 
         if (m.entries.length === 0 || m.entries.every(e => !e.enabled)) {
             this.filter = next;
             this.filteredIndices = undefined;
-            await this.webviewPanel.webview.postMessage({
+            this.recordFilterSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+            if (this.filterAbort === abort) this.filterAbort = null;
+            void this.webviewPanel.webview.postMessage({
                 type: 'filterApplied', panelGeneration: gen, requestId: m.requestId,
                 filter: next, nrowFiltered: this.reader.nrow, fromPersistence: false,
-            } satisfies ExtensionToWebview);
+            } satisfies ExtensionToWebview).then(undefined, () => undefined);
             return;
         }
 
         await this.webviewPanel.webview.postMessage({
-            type: 'filterStatus', panelGeneration: gen, state: 'pending',
+            type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'pending',
         } satisfies ExtensionToWebview);
+
+        await this.enqueueTransform(() =>
+            this.runSetFilters(m, gen, myFilterGen, abort, next));
+    }
+
+    private async runSetFilters(
+        m: Extract<WebviewToExtension, { type: 'setFilters' }>,
+        gen: number,
+        myFilterGen: number,
+        abort: AbortController,
+        next: FilterState,
+    ): Promise<void> {
+        if (gen !== this.generation
+            || myFilterGen !== this.filterGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
 
         let indices: Uint32Array | undefined;
         try {
@@ -1150,29 +1462,65 @@ export class DataViewerPanel {
                 labelsOn: m.labelsOn,
                 formatOn: true,
                 digits: this.settings.defaultDigits,
-            });
+            }, { signal: abort.signal });
         } catch (err) {
-            if (gen !== this.generation || myFilterGen !== this.filterGeneration || this.disposed) return;
+            if (gen !== this.generation
+                || myFilterGen !== this.filterGeneration
+                || this.disposed
+                || isAbortError(err)) {
+                if (this.filterAbort === abort) this.filterAbort = null;
+                return;
+            }
             await this.webviewPanel.webview.postMessage({
-                type: 'filterStatus', panelGeneration: gen, state: 'idle',
+                type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'idle',
             } satisfies ExtensionToWebview);
-            await this.webviewPanel.webview.postMessage({
-                type: 'error', panelGeneration: gen,
-                message: err instanceof Error ? err.message : String(err),
-            } satisfies ExtensionToWebview);
+            if (gen !== this.generation
+                || myFilterGen !== this.filterGeneration
+                || this.disposed
+                || abort.signal.aborted) {
+                if (this.filterAbort === abort) this.filterAbort = null;
+                return;
+            }
+            const rollbackSnapshot = this.rollbackFilterSnapshot(m.rollbackBaseRequestId);
+            this.applyFilterSnapshot(rollbackSnapshot);
+            this.recordFilterSnapshot(m.requestId, rollbackSnapshot, m.rollbackBaseRequestId);
+            void this.webviewPanel.webview.postMessage({
+                type: 'filterApplied',
+                panelGeneration: gen,
+                requestId: m.requestId,
+                filter: cloneFilterState(this.filter),
+                nrowFiltered: this.filteredIndices?.length ?? this.reader.nrow,
+                fromPersistence: false,
+                rollback: true,
+                error: err instanceof Error ? err.message : String(err),
+            } satisfies ExtensionToWebview).then(undefined, () => undefined);
+            if (this.filterAbort === abort) this.filterAbort = null;
             return;
         }
 
-        if (gen !== this.generation || myFilterGen !== this.filterGeneration) return;
+        if (gen !== this.generation || myFilterGen !== this.filterGeneration) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
+        await this.webviewPanel.webview.postMessage({
+            type: 'filterStatus', panelGeneration: gen, requestId: m.requestId, state: 'idle',
+        } satisfies ExtensionToWebview);
+        if (gen !== this.generation
+            || myFilterGen !== this.filterGeneration
+            || this.disposed
+            || abort.signal.aborted) {
+            if (this.filterAbort === abort) this.filterAbort = null;
+            return;
+        }
+
         this.filter = next;
         this.filteredIndices = indices;
-        await this.webviewPanel.webview.postMessage({
-            type: 'filterStatus', panelGeneration: gen, state: 'idle',
-        } satisfies ExtensionToWebview);
-        await this.webviewPanel.webview.postMessage({
+        this.recordFilterSnapshot(m.requestId, undefined, m.rollbackBaseRequestId);
+        void this.webviewPanel.webview.postMessage({
             type: 'filterApplied', panelGeneration: gen, requestId: m.requestId,
             filter: next, nrowFiltered: indices?.length ?? this.reader.nrow, fromPersistence: false,
-        } satisfies ExtensionToWebview);
+        } satisfies ExtensionToWebview).then(undefined, () => undefined);
+        if (this.filterAbort === abort) this.filterAbort = null;
     }
 
     private async handleCopy(
@@ -1305,6 +1653,8 @@ export class DataViewerPanel {
     private async dispose(): Promise<void> {
         if (this.disposed) return;
         this.disposed = true;
+        this.abortInteractiveTransforms();
+        this.abortAndClearRestore();
         this.trace('dispose', {});
         await this.reader.close().catch(() => undefined);
         try { await fs.unlink(this.filePath); } catch { /* ignore */ }

--- a/editors/vscode/src/data-viewer/sort.ts
+++ b/editors/vscode/src/data-viewer/sort.ts
@@ -94,8 +94,10 @@ export async function computePermutation(
     // Materialize the permutation as a plain number[] for sort(), then
     // copy back. Uint32Array.sort exists but lacks the stability guarantee
     // and the comparator signature isn't well-typed.
+    throwIfAborted(signal);
     const idx: number[] = Array.from(perm);
     idx.sort((a, b) => compareRows(a, b, cols, directions));
+    throwIfAborted(signal);
     for (let i = 0; i < nrow; i++) perm[i] = idx[i];
     return perm;
 }

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -67,6 +67,17 @@ import { FilterStrip } from './filter-strip';
 import { FilterPopover } from './filter-popover';
 import { colKind } from './filter-column-kind';
 import { useToolbarWrap } from './use-toolbar-wrap';
+import {
+    filterEntriesForNextRequest,
+    nextSortKeysForColumn,
+    sortKeysForNextRequest,
+    createIntentRequestState,
+    requestFilterIntent,
+    requestSortIntent,
+    shouldAcceptAppliedResponse,
+    shouldAcceptInteractiveResponse,
+    shouldAcceptSortResponse,
+} from './transform-intent';
 
 type VscodeApi = {
     postMessage(msg: WebviewToExtension): void;
@@ -318,10 +329,20 @@ export function App({
     const inflightRef = useRef(new Map<number, string>());
     const pendingKeysRef = useRef(new Set<string>());
     const nextRequestIdRef = useRef(0);
+    const intentRequestStateRef = useRef(createIntentRequestState());
+    const panelGenerationRef = useRef(restored?.panelGeneration ?? 0);
     /** Column indices whose histogram has been requested from the host but
      *  not yet received, so the lazy-fetch effect fires at most one
      *  getHistogram per column. Cleared on replace (new dataset). */
-    const histogramRequestedRef = useRef(new Set<number>());
+    const histogramRequestedRef = useRef(new Map<number, number>());
+    const bootstrappingRef = useRef(true);
+    const latestSortRequestIdRef = useRef<number | null>(null);
+    const latestSortIntentRef = useRef<SortState | null>(null);
+    const acceptedSortRequestIdRef = useRef(0);
+    const latestFilterRequestIdRef = useRef<number | null>(null);
+    const latestFilterIntentRef = useRef<FilterState | null>(null);
+    const acceptedFilterRequestIdRef = useRef(0);
+    const restoreInteractionBlockRef = useRef<{ sort: boolean; filter: boolean } | null>(null);
     const viewportGenerationRef = useRef(0);
     const toolbarBootstrappedRef = useRef(false);
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
@@ -354,6 +375,7 @@ export function App({
     const [sort, setSort] = useState<SortState>(restored?.sort ?? EMPTY_SORT);
     const [sortPending, setSortPending] = useState(false);
     const [filter, setFilter] = useState<FilterState>(restored?.filter ?? EMPTY_FILTER);
+    const [pendingFilterIntent, setPendingFilterIntent] = useState<FilterState | null>(null);
     const [filterPending, setFilterPending] = useState(false);
     const [nrowFiltered, setNrowFiltered] = useState<number | undefined>(restored?.nrowFiltered);
     const [histograms, setHistograms] = useState<Record<number, HistogramBin[]>>(restored?.histograms ?? {});
@@ -390,6 +412,12 @@ export function App({
         topPx?: number;
     } | null>(null);
 
+    const nextRequestId = useCallback(() => {
+        const requestId = ++nextRequestIdRef.current;
+        intentRequestStateRef.current.nextRequestId = requestId;
+        return requestId;
+    }, []);
+
     const visibleCols = useMemo(
         () => visibleColumnIndices(columns, layout.hiddenColumns),
         [columns, layout.hiddenColumns],
@@ -415,6 +443,7 @@ export function App({
      *  All grid-coordinate math must use this count so row indices never
      *  exceed the permutation length; display/identity contexts still use nrow. */
     const effectiveNrow = nrowFiltered ?? nrow;
+    const displayedFilter = pendingFilterIntent ?? filter;
     // On open, explain the background wait while saved sort/filter
     // preferences are reapplied (#519). The grid already shows natural-order
     // data, so the toolbar keeps its row-count while the banner offers a
@@ -442,7 +471,7 @@ export function App({
         },
         // sortPending/filterPending are deps because the progress pills they
         // drive widen the chip group, which can change whether it must wrap.
-        [sort.keys, filter.entries, rowCountText, layout.hiddenColumns.length, sortPending, filterPending, labelsHaveEffect, formatHasEffect],
+        [sort.keys, displayedFilter.entries, rowCountText, layout.hiddenColumns.length, sortPending, filterPending, labelsHaveEffect, formatHasEffect],
     );
     /** Transient progress pills for the toolbar chip group. The data viewer
      *  has no bottom status bar: the sort/filter chip strips carry the full
@@ -498,11 +527,16 @@ export function App({
         return { row: Math.min(effectiveNrow - 1, visibleRange.start), col: visibleCols[0] };
     }, [effectiveNrow, gridSelection, visibleCols, visibleRange.start]);
 
-    const postLifecycle = useCallback((event: string, range: VisibleRange = visibleRange, selection = gridSelection) => {
+    const postLifecycle = useCallback((
+        event: string,
+        range: VisibleRange = visibleRange,
+        selection = gridSelection,
+        generation = panelGeneration,
+    ) => {
         vscode.postMessage({
             type: 'lifecycle',
             event,
-            panelGeneration,
+            panelGeneration: generation,
             nrow,
             columns: columns.length,
             visibleRows: Math.max(0, range.end - range.start),
@@ -541,6 +575,7 @@ export function App({
     }, []);
 
     const requestRows = useCallback((range: VisibleRange) => {
+        if (bootstrappingRef.current) return;
         if (range.end <= range.start || visibleCols.length === 0) return;
         if (rowCacheRef.current.hasRange(range.start, range.end)) return;
         const columnsKey = visibleCols.join(',');
@@ -548,7 +583,7 @@ export function App({
         if (pendingKeysRef.current.has(key)) return;
 
         viewportGenerationRef.current += 1;
-        const requestId = ++nextRequestIdRef.current;
+        const requestId = nextRequestId();
         pendingKeysRef.current.add(key);
         inflightRef.current.set(requestId, key);
         vscode.postMessage({
@@ -560,7 +595,7 @@ export function App({
             end: range.end,
             columns: visibleCols,
         });
-    }, [panelGeneration, visibleCols, vscode]);
+    }, [nextRequestId, panelGeneration, visibleCols, vscode]);
 
     const scheduleMissingRowRequest = useCallback((row: number) => {
         if (effectiveNrow <= 0 || visibleCols.length === 0) return;
@@ -589,9 +624,9 @@ export function App({
     }, []);
 
     const applyInitOrReplace = useCallback((m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>) => {
-        const sameDataset = m.panelGeneration === panelGeneration
-            && m.nrow === nrow
+        const sameDataset = m.nrow === nrow
             && sameColumns(m.columns, columns);
+        panelGenerationRef.current = m.panelGeneration;
         setPanelGeneration(m.panelGeneration);
         setNrow(m.nrow);
         setColumns(m.columns);
@@ -600,6 +635,15 @@ export function App({
         setSchemaHash(m.schemaHash);
         if (m.type === 'init') setSettings(m.settings);
         setToolbar(m.toolbar);
+        latestSortRequestIdRef.current = null;
+        latestSortIntentRef.current = null;
+        acceptedSortRequestIdRef.current = 0;
+        latestFilterRequestIdRef.current = null;
+        latestFilterIntentRef.current = null;
+        acceptedFilterRequestIdRef.current = 0;
+        intentRequestStateRef.current.latestSortIntent = null;
+        intentRequestStateRef.current.latestFilterIntent = null;
+        setPendingFilterIntent(null);
         setSort(m.sort);
         setSortPending(false);
         setFilter(m.filter);
@@ -618,19 +662,24 @@ export function App({
             histogramRequestedRef.current.clear();
         }
         setFilterPending(false);
-        if (m.filter.entries.length === 0) setNrowFiltered(undefined);
+        setNrowFiltered(undefined);
         setLoading(false);
         toolbarBootstrappedRef.current = true;
         clearRows();
         setResolvedLabels({});
         setGridSelection(createEmptySelection());
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
-        postLifecycle(m.type, sameDataset ? visibleRange : { start: 0, end: 0 }, createEmptySelection());
+        postLifecycle(
+            m.type,
+            sameDataset ? visibleRange : { start: 0, end: 0 },
+            createEmptySelection(),
+            m.panelGeneration,
+        );
         window.setTimeout(() => gridRef.current?.scrollTo(0, 0, 'both'), 0);
     }, [clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
 
     const applyRows = useCallback((m: Extract<ExtensionToWebview, { type: 'rows' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         const key = inflightRef.current.get(m.requestId);
         if (!key) {
             return;
@@ -652,10 +701,10 @@ export function App({
             gridRef.current?.updateCells(damageList);
         }
         postLifecycle('rows');
-    }, [panelGeneration, postLifecycle, visibleCols.length]);
+    }, [postLifecycle, visibleCols.length]);
 
     const applyLabels = useCallback((m: Extract<ExtensionToWebview, { type: 'labels' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         setResolvedLabels(previous => ({
             ...previous,
             [m.columnIndex]: {
@@ -672,16 +721,25 @@ export function App({
         if (damageList.length > 0) {
             gridRef.current?.updateCells(damageList);
         }
-    }, [panelGeneration, visibleCols, visibleRange.end, visibleRange.start]);
+    }, [visibleCols, visibleRange.end, visibleRange.start]);
 
     const applyHistogram = useCallback((m: Extract<ExtensionToWebview, { type: 'histogram' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (histogramRequestedRef.current.get(m.columnIndex) !== m.requestId) return;
         histogramRequestedRef.current.delete(m.columnIndex);
         setHistograms(prev => ({ ...prev, [m.columnIndex]: m.bins }));
-    }, [panelGeneration]);
+    }, []);
 
     const applySortApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'sortApplied' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptSortResponse(
+            latestSortRequestIdRef.current,
+            m.requestId,
+            m.fromPersistence,
+        )) return;
+        latestSortRequestIdRef.current = null;
+        latestSortIntentRef.current = null;
+        acceptedSortRequestIdRef.current = m.requestId;
         setSort(m.sort);
         setSortPending(false);
         // Permutation just changed — every cached row window is now in
@@ -701,9 +759,14 @@ export function App({
                 OVERSCAN_ROWS,
             ));
         }
+        if (m.error) {
+            setCopyStatus('error');
+            setCopyStatusMsg(m.error);
+        }
         // Persist the latest sort. Cleared (empty keys) saves are also
-        // valid — the host treats an empty SortState as a clear.
-        if (schemaHash) {
+        // valid — the host treats an empty SortState as a clear. Rollbacks
+        // are failure recovery, not a new user preference.
+        if (schemaHash && !m.rollback) {
             vscode.postMessage({
                 type: 'saveSort',
                 panelGeneration: m.panelGeneration,
@@ -714,7 +777,6 @@ export function App({
     }, [
         clearRows,
         effectiveNrow,
-        panelGeneration,
         requestRows,
         schemaHash,
         visibleCols.length,
@@ -723,18 +785,50 @@ export function App({
     ]);
 
     const applySortStatus = useCallback((m: Extract<ExtensionToWebview, { type: 'sortStatus' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptSortResponse(latestSortRequestIdRef.current, m.requestId, false)) return;
         setSortPending(m.state === 'pending');
-    }, [panelGeneration]);
+    }, []);
 
     const applyFilterApplied = useCallback((m: Extract<ExtensionToWebview, { type: 'filterApplied' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptAppliedResponse(
+            latestFilterRequestIdRef.current,
+            m.requestId,
+            m.fromPersistence,
+        )) {
+            if (m.fromPersistence) restoreInteractionBlockRef.current = null;
+            return;
+        }
+        latestFilterRequestIdRef.current = null;
+        latestFilterIntentRef.current = null;
+        acceptedFilterRequestIdRef.current = m.requestId;
+        setPendingFilterIntent(null);
+        if (m.error) {
+            setCopyStatus('error');
+            setCopyStatusMsg(m.error);
+        }
         setFilter(m.filter);
-        // A restore echo (fromPersistence) is host-owned state already in the
-        // store — suppress its redundant save-back. A user-initiated
-        // filterApplied (fromPersistence false) must still persist, so leave
-        // the ref alone in that case.
-        if (m.fromPersistence) lastHostFilterRef.current = m.filter;
+        // Host-owned state and rollback recovery are not new user
+        // preferences. Successful user filter applies are persisted
+        // immediately (like sort applies), then marked as handled so the
+        // debounced saveFilter effect does not duplicate the write. Persisting
+        // on acknowledgement avoids losing an accepted filter if a later
+        // pending filter cancels the debounce and then rolls back.
+        if (m.fromPersistence) {
+            lastHostFilterRef.current = m.filter;
+            restoreInteractionBlockRef.current = null;
+        } else if (m.rollback) {
+            lastHostFilterRef.current = m.filter;
+        } else if (schemaHash) {
+            vscode.postMessage({
+                type: 'saveFilter',
+                panelGeneration: m.panelGeneration,
+                schemaHash,
+                filter: m.filter,
+            });
+            lastHostFilterRef.current = m.filter;
+        }
         const activeNrowFiltered = m.filter.entries.some(e => e.enabled) ? m.nrowFiltered : undefined;
         setNrowFiltered(activeNrowFiltered);
         setFilterPending(false);
@@ -754,30 +848,47 @@ export function App({
     }, [
         clearRows,
         nrow,
-        panelGeneration,
         requestRows,
+        schemaHash,
         visibleCols.length,
         visibleRange,
+        vscode,
     ]);
 
     const applyFilterStatus = useCallback((m: Extract<ExtensionToWebview, { type: 'filterStatus' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
+        if (!shouldAcceptInteractiveResponse(latestFilterRequestIdRef.current, m.requestId)) return;
         setFilterPending(m.state === 'pending');
-    }, [panelGeneration]);
+    }, []);
 
     /** Send a setFilters request. Empty `entries` clears the filter. The host
      *  replies with `filterApplied` which drives state updates. */
     const applyFilters = useCallback((entries: FilterEntry[]) => {
-        setFilterPending(entries.some(e => e.enabled));
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current || restoreInteractionBlockRef.current !== null) return;
+        const request = requestFilterIntent(
+            intentRequestStateRef.current,
+            entries,
+            toolbar.labelsOn,
+        );
+        nextRequestIdRef.current = intentRequestStateRef.current.nextRequestId;
+        const next = request.filter;
+        latestFilterIntentRef.current = next;
+        setPendingFilterIntent(next);
+        setFilterPending(next.entries.some(e => e.enabled));
+        latestFilterRequestIdRef.current = request.requestId;
         vscode.postMessage({
             type: 'setFilters',
             panelGeneration,
-            requestId,
-            entries,
-            labelsOn: toolbar.labelsOn,
+            requestId: request.requestId,
+            rollbackBaseRequestId: acceptedFilterRequestIdRef.current,
+            entries: request.entries,
+            labelsOn: next.labelsOnWhenFiltered,
         });
     }, [panelGeneration, toolbar.labelsOn, vscode]);
+
+    const filterEntriesForRequest = useCallback(() => {
+        return filterEntriesForNextRequest(filter.entries, latestFilterIntentRef.current);
+    }, [filter.entries]);
 
     const onEditFilter = useCallback((entry: FilterEntry) => {
         setFilterEditor({ entry });
@@ -786,47 +897,63 @@ export function App({
     /** Open the filter popover for a column, pre-seeded with its active filter
      *  (one-filter-per-column invariant) so editing reflects the live settings.
      *  When the column is unfiltered, `existing` is undefined and the popover
-     *  opens blank — the "add new" path. Keyed on `filter.entries` so callers
-     *  inside effects (e.g. the keyboard handler) never read a stale snapshot. */
+     *  opens blank — the "add new" path. Reads through
+     *  `filterEntriesForRequest` so rapid edits compose from the latest pending
+     *  request rather than the last host acknowledgement. */
     const openFilterEditor = useCallback(
         (columnIndex: number, leftPx: number, topPx: number) => {
-            const existing = filter.entries.find(e => e.columnIndex === columnIndex);
+            const existing = filterEntriesForRequest().find(e => e.columnIndex === columnIndex);
             setFilterEditor({ entry: existing, columnIndex, leftPx, topPx });
         },
-        [filter.entries],
+        [filterEntriesForRequest],
     );
 
     const onToggleFilterEnabled = useCallback((id: string) => {
-        applyFilters(filter.entries.map(e => e.id === id ? { ...e, enabled: !e.enabled } : e));
-    }, [applyFilters, filter.entries]);
+        applyFilters(filterEntriesForRequest().map(e => e.id === id ? { ...e, enabled: !e.enabled } : e));
+    }, [applyFilters, filterEntriesForRequest]);
 
     const onRemoveFilter = useCallback((id: string) => {
-        applyFilters(filter.entries.filter(e => e.id !== id));
-    }, [applyFilters, filter.entries]);
+        applyFilters(filterEntriesForRequest().filter(e => e.id !== id));
+    }, [applyFilters, filterEntriesForRequest]);
 
     const onClearAllFilters = useCallback(() => {
         applyFilters([]);
     }, [applyFilters]);
 
     const clearFilterOnColumn = useCallback((columnIndex: number) => {
-        applyFilters(filter.entries.filter(e => e.columnIndex !== columnIndex));
-    }, [filter, applyFilters]);
+        applyFilters(filterEntriesForRequest().filter(e => e.columnIndex !== columnIndex));
+    }, [filterEntriesForRequest, applyFilters]);
 
     /** Send a setSort request. Empty `keys` clears the sort. The host
      *  replies with `sortApplied` which drives state updates. */
     const applySort = useCallback((keys: SortKey[]) => {
-        setSortPending(true);
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current || restoreInteractionBlockRef.current !== null) return;
+        const request = requestSortIntent(
+            intentRequestStateRef.current,
+            keys,
+            toolbar.labelsOn,
+        );
+        nextRequestIdRef.current = intentRequestStateRef.current.nextRequestId;
+        const next = request.sort;
+        latestSortIntentRef.current = next;
+        setSort(next);
+        setSortPending(keys.length > 0);
+        latestSortRequestIdRef.current = request.requestId;
         vscode.postMessage({
             type: 'setSort',
             panelGeneration,
-            requestId,
-            keys,
+            requestId: request.requestId,
+            rollbackBaseRequestId: acceptedSortRequestIdRef.current,
+            keys: request.keys,
             labelsOn: toolbar.labelsOn,
             formatOn: toolbar.formatOn,
             digits: toolbar.digits,
         });
     }, [panelGeneration, toolbar, vscode]);
+
+    const sortKeysForRequest = useCallback(() => {
+        return sortKeysForNextRequest(sort.keys, latestSortIntentRef.current);
+    }, [sort.keys]);
 
     /** Pick a direction for `sourceIndex`. When `append` is true, merge
      *  into the existing sort (flipping the column's direction in place
@@ -837,50 +964,32 @@ export function App({
         direction: 'asc' | 'desc',
         append: boolean,
     ) => {
-        const existing = sort.keys.findIndex(k => k.columnIndex === sourceIndex);
-        let next: SortKey[];
-        if (!append) {
-            // Plain pick: this column becomes the sort. If user picks the
-            // same column/direction that's already active, no-op.
-            if (existing >= 0
-                && sort.keys.length === 1
-                && sort.keys[0].direction === direction) {
-                return;
-            }
-            next = [{ columnIndex: sourceIndex, direction }];
-        } else if (existing >= 0) {
-            // Shift+pick on an existing key: flip direction in place,
-            // priority preserved.
-            if (sort.keys[existing].direction === direction) return;
-            next = sort.keys.map((k, i) =>
-                i === existing ? { ...k, direction } : k);
-        } else {
-            // Shift+pick on a new column: append at the end.
-            next = [...sort.keys, { columnIndex: sourceIndex, direction }];
-        }
+        const next = nextSortKeysForColumn(sortKeysForRequest(), sourceIndex, direction, append);
+        if (!next) return;
         applySort(next);
-    }, [applySort, sort.keys]);
+    }, [applySort, sortKeysForRequest]);
 
     const clearSortOnColumn = useCallback((sourceIndex: number) => {
-        const next = sort.keys.filter(k => k.columnIndex !== sourceIndex);
-        if (next.length === sort.keys.length) return;
+        const current = sortKeysForRequest();
+        const next = current.filter(k => k.columnIndex !== sourceIndex);
+        if (next.length === current.length) return;
         applySort(next);
-    }, [applySort, sort.keys]);
+    }, [applySort, sortKeysForRequest]);
 
     const clearAllSorts = useCallback(() => {
-        if (sort.keys.length === 0) return;
+        if (sortKeysForRequest().length === 0) return;
         applySort([]);
-    }, [applySort, sort.keys.length]);
+    }, [applySort, sortKeysForRequest]);
 
     const applyCopyDone = useCallback((m: Extract<ExtensionToWebview, { type: 'copyDone' }>) => {
-        if (m.panelGeneration !== panelGeneration) return;
+        if (m.panelGeneration !== panelGenerationRef.current) return;
         setCopyStatus(m.ok ? 'copied' : 'error');
         setCopyStatusMsg(m.ok ? 'Copied' : (m.error ?? 'Copy failed'));
         window.setTimeout(() => {
             setCopyStatus('');
             setCopyStatusMsg('');
         }, 2500);
-    }, [panelGeneration]);
+    }, []);
 
     const estimatedViewportRowCount = useCallback((): number => {
         const current = visibleRange.end - visibleRange.start;
@@ -1006,6 +1115,7 @@ export function App({
     ]);
 
     useEffect(() => {
+        bootstrappingRef.current = true;
         vscode.postMessage({ type: 'webviewReady' });
     }, [vscode]);
 
@@ -1028,7 +1138,12 @@ export function App({
         const onMessage = (event: MessageEvent<ExtensionToWebview>) => {
             const m = event.data;
             if (!m || typeof m !== 'object') return;
-            if ('panelGeneration' in m && m.panelGeneration < panelGeneration) return;
+            const currentGeneration = panelGenerationRef.current;
+            if ('panelGeneration' in m && m.panelGeneration < currentGeneration) return;
+            if ('panelGeneration' in m && bootstrappingRef.current) {
+                if (m.type !== 'init' && m.type !== 'replace' && m.type !== 'restorePending') return;
+                if (m.panelGeneration <= currentGeneration) return;
+            }
             switch (m.type) {
                 case 'restorePending': {
                     // Defer showing the banner until the debounce elapses; a
@@ -1040,6 +1155,7 @@ export function App({
                         clearTimeout(restoreTimerRef.current);
                     }
                     const info = { restoreId: m.restoreId, sort: m.sort, filter: m.filter };
+                    restoreInteractionBlockRef.current = { sort: m.sort, filter: m.filter };
                     // If a banner is already visible (a prior restore whose
                     // debounce elapsed), swap its wording at once rather than
                     // showing stale text until the timer fires.
@@ -1052,6 +1168,7 @@ export function App({
                 }
                 case 'init':
                 case 'replace':
+                    bootstrappingRef.current = false;
                     // Both the normal and cancelled/late-cancel restore paths
                     // end by posting init/replace, so clear the banner here.
                     if (restoreTimerRef.current !== null) {
@@ -1060,6 +1177,10 @@ export function App({
                     }
                     setRestorePending(null);
                     setRestoreCancelling(false);
+                    if (!(restoreInteractionBlockRef.current?.filter
+                        && m.filter.entries.some(e => e.enabled))) {
+                        restoreInteractionBlockRef.current = null;
+                    }
                     restoreIdRef.current = null;
                     applyInitOrReplace(m);
                     return;
@@ -1159,15 +1280,16 @@ export function App({
         if (kind !== 'numeric' && kind !== 'labelledNumeric') return;
         if (histograms[ci] !== undefined) return;          // already cached
         if (histogramRequestedRef.current.has(ci)) return;  // request in flight
-        histogramRequestedRef.current.add(ci);
-        const requestId = ++nextRequestIdRef.current;
+        if (bootstrappingRef.current) return;
+        const requestId = nextRequestId();
+        histogramRequestedRef.current.set(ci, requestId);
         vscode.postMessage({
             type: 'getHistogram',
             panelGeneration,
             requestId,
             columnIndex: ci,
         });
-    }, [filterEditor, columns, histograms, panelGeneration, vscode]);
+    }, [filterEditor, columns, histograms, nextRequestId, panelGeneration, vscode]);
 
     useEffect(() => {
         // Guard on the same bootstrap flag as saveToolbar: until the first
@@ -1175,6 +1297,7 @@ export function App({
         // and saving it would clobber a host-persisted filter before the
         // restore round-trip completes.
         if (!toolbarBootstrappedRef.current || !schemaHash) return;
+        if (pendingFilterIntent !== null || latestFilterRequestIdRef.current !== null) return;
         // Don't echo a host-owned filter back to the store. On a genuine
         // restore-filter read failure the host keeps the saved filter but
         // sends EMPTY for display; echoing that would destroy the pref the
@@ -1190,7 +1313,7 @@ export function App({
             });
         }, 300);
         return () => window.clearTimeout(id);
-    }, [filter, panelGeneration, schemaHash, vscode]);
+    }, [filter, panelGeneration, pendingFilterIntent, schemaHash, vscode]);
 
     /** Labels-toggle invalidates sort keys derived from displayed text.
      *  When the active sort touches a factor or value-labelled column
@@ -1218,16 +1341,16 @@ export function App({
      *  filter.labelsOnWhenFiltered = toolbar.labelsOn, making the guard true
      *  on the next render and preventing an infinite re-fire loop. */
     useEffect(() => {
-        if (filter.entries.length === 0) return;
-        if (filter.labelsOnWhenFiltered === toolbar.labelsOn) return;
-        const touchesLabelled = filter.entries.some(e => {
+        if (displayedFilter.entries.length === 0) return;
+        if (displayedFilter.labelsOnWhenFiltered === toolbar.labelsOn) return;
+        const touchesLabelled = displayedFilter.entries.some(e => {
             const col = columns[e.columnIndex];
             if (!col) return false;
             return e.predicate.kind === 'setIn' || e.predicate.kind === 'setNotIn';
         });
         if (!touchesLabelled) return;
-        applyFilters(filter.entries);
-    }, [applyFilters, columns, filter, toolbar.labelsOn]);
+        applyFilters(filterEntriesForRequest());
+    }, [applyFilters, columns, displayedFilter, filterEntriesForRequest, toolbar.labelsOn]);
 
     useEffect(() => {
         if (!toolbar.labelsOn) return;
@@ -1246,7 +1369,7 @@ export function App({
         }
         for (const [colIndexRaw, indices] of Object.entries(wantByColumn)) {
             if (indices.size === 0) continue;
-            const requestId = ++nextRequestIdRef.current;
+            const requestId = nextRequestId();
             vscode.postMessage({
                 type: 'getLabels',
                 panelGeneration,
@@ -1296,7 +1419,7 @@ export function App({
         }
 
         if (rowEnd <= rowStart || colIndices.length === 0) return;
-        const requestId = ++nextRequestIdRef.current;
+        const requestId = nextRequestId();
         setCopyStatus('copying');
         setCopyStatusMsg('Copying...');
         vscode.postMessage({
@@ -1309,7 +1432,7 @@ export function App({
             digits: toolbar.digits,
             includeHeader,
         });
-    }, [effectiveNrow, gridSelection, panelGeneration, toolbar, visibleCols, vscode]);
+    }, [effectiveNrow, gridSelection, nextRequestId, panelGeneration, toolbar, visibleCols, vscode]);
 
     useEffect(() => {
         const onCopy = (event: ClipboardEvent) => {
@@ -1535,7 +1658,7 @@ export function App({
                         onClearAll={clearAllSorts}
                     />
                     <FilterStrip
-                        filter={filter}
+                        filter={displayedFilter}
                         columns={columns}
                         onEdit={onEditFilter}
                         onToggleEnabled={onToggleFilterEnabled}
@@ -1818,10 +1941,10 @@ export function App({
                             : undefined}
                         filter={contextMenu.kind === 'column' && contextMenu.columnIndex !== undefined
                             ? {
-                                hasFilter: filter.entries.some(
+                                hasFilter: displayedFilter.entries.some(
                                     e => e.columnIndex === contextMenu.columnIndex,
                                 ),
-                                anyFiltered: filter.entries.length > 0,
+                                anyFiltered: displayedFilter.entries.length > 0,
                                 onAddFilter: () => {
                                     openFilterEditor(
                                         contextMenu.columnIndex!,
@@ -1831,7 +1954,7 @@ export function App({
                                     setContextMenu(null);
                                 },
                                 onClearColumn: () => {
-                                    applyFilters(filter.entries.filter(
+                                    applyFilters(filterEntriesForRequest().filter(
                                         e => e.columnIndex !== contextMenu.columnIndex,
                                     ));
                                     setContextMenu(null);
@@ -1868,13 +1991,13 @@ export function App({
                                 const next = (() => {
                                     if (filterEditor.entry) {
                                         // Editing existing: replace by id, also enforce one-per-column.
-                                        const withoutSameCol = filter.entries.filter(
+                                        const withoutSameCol = filterEntriesForRequest().filter(
                                             e => e.id !== entry.id && e.columnIndex !== entry.columnIndex,
                                         );
                                         return [...withoutSameCol, entry];
                                     }
                                     // New: replace any existing entry for this column.
-                                    const withoutCol = filter.entries.filter(
+                                    const withoutCol = filterEntriesForRequest().filter(
                                         e => e.columnIndex !== entry.columnIndex,
                                     );
                                     return [...withoutCol, entry];

--- a/editors/vscode/src/data-viewer/webview/transform-intent.ts
+++ b/editors/vscode/src/data-viewer/webview/transform-intent.ts
@@ -1,0 +1,144 @@
+import {
+    EMPTY_FILTER,
+    EMPTY_SORT,
+    type FilterEntry,
+    type FilterState,
+    type SortKey,
+    type SortState,
+} from '../messages';
+
+function cloneFilterEntry(entry: FilterEntry): FilterEntry {
+    const predicate = entry.predicate.kind === 'setIn' || entry.predicate.kind === 'setNotIn'
+        ? { ...entry.predicate, values: [...entry.predicate.values] }
+        : { ...entry.predicate };
+    return {
+        ...entry,
+        predicate: predicate as FilterEntry['predicate'],
+    };
+}
+
+export function sortStateForRequestedKeys(
+    keys: readonly SortKey[],
+    labelsOn: boolean,
+): SortState {
+    if (keys.length === 0) return EMPTY_SORT;
+    return {
+        keys: keys.map(k => ({ ...k })),
+        labelsOnWhenSorted: labelsOn,
+    };
+}
+
+export function nextSortKeysForColumn(
+    currentKeys: readonly SortKey[],
+    sourceIndex: number,
+    direction: 'asc' | 'desc',
+    append: boolean,
+): SortKey[] | undefined {
+    const existing = currentKeys.findIndex(k => k.columnIndex === sourceIndex);
+    if (!append) {
+        if (existing >= 0
+            && currentKeys.length === 1
+            && currentKeys[0].direction === direction) {
+            return undefined;
+        }
+        return [{ columnIndex: sourceIndex, direction }];
+    }
+    if (existing >= 0) {
+        if (currentKeys[existing].direction === direction) return undefined;
+        return currentKeys.map((k, i) =>
+            i === existing ? { ...k, direction } : { ...k });
+    }
+    return [...currentKeys.map(k => ({ ...k })), { columnIndex: sourceIndex, direction }];
+}
+
+export function sortKeysForNextRequest(
+    currentKeys: readonly SortKey[],
+    latestRequestedSort: SortState | null,
+): SortKey[] {
+    return (latestRequestedSort?.keys ?? currentKeys).map(k => ({ ...k }));
+}
+
+export function filterStateForRequestedEntries(
+    entries: readonly FilterEntry[],
+    labelsOn: boolean,
+): FilterState {
+    if (entries.length === 0) return EMPTY_FILTER;
+    return {
+        entries: entries.map(cloneFilterEntry),
+        labelsOnWhenFiltered: labelsOn,
+    };
+}
+
+export function filterEntriesForNextRequest(
+    currentEntries: readonly FilterEntry[],
+    latestRequestedFilter: FilterState | null,
+): FilterEntry[] {
+    return (latestRequestedFilter?.entries ?? currentEntries).map(cloneFilterEntry);
+}
+
+export function shouldAcceptAppliedResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+    fromPersistence: boolean,
+): boolean {
+    return fromPersistence
+        ? latestRequestId === null
+        : shouldAcceptInteractiveResponse(latestRequestId, responseRequestId);
+}
+
+export function shouldAcceptSortResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+    fromPersistence: boolean,
+): boolean {
+    return shouldAcceptAppliedResponse(latestRequestId, responseRequestId, fromPersistence);
+}
+
+export function shouldAcceptInteractiveResponse(
+    latestRequestId: number | null,
+    responseRequestId: number,
+): boolean {
+    return latestRequestId !== null && responseRequestId === latestRequestId;
+}
+
+export type IntentRequestState = {
+    nextRequestId: number;
+    latestSortIntent: SortState | null;
+    latestFilterIntent: FilterState | null;
+};
+
+export function createIntentRequestState(): IntentRequestState {
+    return {
+        nextRequestId: 0,
+        latestSortIntent: null,
+        latestFilterIntent: null,
+    };
+}
+
+export function requestSortIntent(
+    state: IntentRequestState,
+    keys: readonly SortKey[],
+    labelsOn: boolean,
+): { requestId: number; keys: SortKey[]; sort: SortState } {
+    const sort = sortStateForRequestedKeys(keys, labelsOn);
+    state.latestSortIntent = sort;
+    return {
+        requestId: ++state.nextRequestId,
+        keys: sort.keys.map(k => ({ ...k })),
+        sort,
+    };
+}
+
+export function requestFilterIntent(
+    state: IntentRequestState,
+    entries: readonly FilterEntry[],
+    labelsOn: boolean,
+): { requestId: number; entries: FilterEntry[]; filter: FilterState } {
+    const filter = filterStateForRequestedEntries(entries, labelsOn);
+    state.latestFilterIntent = filter;
+    return {
+        requestId: ++state.nextRequestId,
+        entries: filter.entries.map(cloneFilterEntry),
+        filter,
+    };
+}

--- a/tests/bun/data-viewer-panel-filter.test.ts
+++ b/tests/bun/data-viewer-panel-filter.test.ts
@@ -328,6 +328,178 @@ describe('DataViewerPanel: filter round-trips', () => {
         expect(getBatchCalls).toBe(0);
     });
 
+    test('getHistogram and setSort do not read batches concurrently', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 50,
+            columnIndex: 0,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 51,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const hist = fakeWebview.posted.find(
+            m => m.type === 'histogram' && m.requestId === 50,
+        ) as any;
+        expect(hist).toBeDefined();
+        const sortAck = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 51,
+        ) as any;
+        expect(sortAck).toBeDefined();
+        expect(sortAck.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+    });
+
+    test('webview reload aborts an active histogram without replying to the stale request', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let triggeredReload = false;
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount > 1) throw new Error('histogram read after abort');
+            if (!triggeredReload) {
+                triggeredReload = true;
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+            }
+            return origGetBatch(i);
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 52,
+            columnIndex: 0,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'histogram' && m.requestId === 52))
+            .toEqual([]);
+        expect(readCount).toBe(1);
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        expect(initMessages.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('webview reload aborts an active filter before the next batch read', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount === 1) {
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+                return await origGetBatch(i);
+            }
+            throw new Error('filter read after abort');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: init.panelGeneration,
+            requestId: 54,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'filterApplied' && m.requestId === 54))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(readCount).toBe(1);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted histogram', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let rejectRead!: (err: Error) => void;
+        const readPromise = new Promise<never>((_resolve, reject) => { rejectRead = reject; });
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                return await readPromise;
+            }
+            return await origGetBatch(i);
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'getHistogram',
+            panelGeneration: init.panelGeneration,
+            requestId: 53,
+            columnIndex: 0,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        rejectRead(new Error('decode failed after abort'));
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'histogram' && m.requestId === 53))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+    });
+
     test('setFilters round-trip: filterStatus pending → filterApplied, then getRows returns matching rows', async () => {
         const { fakeWebview } = await setupPanel();
 
@@ -433,6 +605,466 @@ describe('DataViewerPanel: filter round-trips', () => {
         ) as any;
         expect(rows).toBeDefined();
         expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('overlapping setFilter and setSort serialize and compose', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 80,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 81,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 80,
+        )).toBeDefined();
+        expect(fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 81,
+        )).toBeDefined();
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 82,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 82,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('overlapping setFilters requests do not read batches concurrently and latest wins', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 1,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 2,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const applied = fakeWebview.posted.filter(m => m.type === 'filterApplied') as any[];
+        expect(applied.map(m => m.requestId)).toEqual([2]);
+        expect(applied[0].filter.entries).toEqual([{
+            id: 'e2',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare', op: '<', value: 4 },
+            enabled: true,
+            includeMissing: false,
+        }]);
+        expect(applied[0].nrowFiltered).toBe(3);
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 3,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 3,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3]);
+    });
+
+    test('setFilters read failure rolls back pending state to the authoritative filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+        const previousEntry = {
+            id: 'e1',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare' as const, op: '>' as const, value: 2 },
+            enabled: true,
+            includeMissing: false,
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 70,
+            entries: [previousEntry],
+            labelsOn: true,
+        });
+        await flush();
+        const previousApplied = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 70,
+        ) as any;
+        expect(previousApplied.nrowFiltered).toBe(3);
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('filter decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 71,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 71,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([previousEntry]);
+        expect(rollback.nrowFiltered).toBe(3);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 72,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 72,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([3, 4, 5]);
+    });
+
+    test('failed newer filter does not roll back to an unpublished superseded filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstIdleReached!: () => void;
+        const firstIdleReachedPromise = new Promise<void>(resolve => { firstIdleReached = resolve; });
+        let releaseFirstIdle!: () => void;
+        const releaseFirstIdlePromise = new Promise<void>(resolve => { releaseFirstIdle = resolve; });
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'filterStatus' && msg.requestId === 73 && msg.state === 'idle') {
+                firstIdleReached();
+                return releaseFirstIdlePromise.then(() => true);
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 73,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstIdleReachedPromise;
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('second filter decode boom');
+        };
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 74,
+            rollbackBaseRequestId: 0,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+        releaseFirstIdle();
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 74,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([]);
+        expect(rollback.nrowFiltered).toBe(5);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 75,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 75,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('failed newer filter does not roll back to an applied ack the webview ignored', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'filterApplied' && msg.requestId === 76) {
+                return new Promise<boolean>(() => {});
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 76,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async () => {
+            throw new Error('third filter decode boom');
+        };
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 77,
+            rollbackBaseRequestId: 0,
+            entries: [{
+                id: 'e2',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '<', value: 4 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'filterApplied' && m.requestId === 77,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.filter.entries).toEqual([]);
+        expect(rollback.nrowFiltered).toBe(5);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('third filter decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 78,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 78,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted interactive filter', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let firstRead = true;
+        (reader as any).getBatch = async () => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                await releaseFirstPromise;
+            }
+            throw new Error('late filter decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setFilters',
+            panelGeneration: gen,
+            requestId: 60,
+            entries: [{
+                id: 'e1',
+                columnIndex: 0,
+                predicate: { kind: 'numCompare', op: '>', value: 2 },
+                enabled: true,
+                includeMissing: false,
+            }],
+            labelsOn: true,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'filterApplied' && m.requestId === 60))
+            .toEqual([]);
     });
 
     test('saveFilter persists and restore on panel recreate sends filterApplied(fromPersistence:true)', async () => {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -80,16 +80,20 @@ async function makePanel(opts: {
     panel.sort = EMPTY_SORT;
     panel.permutation = undefined;
     panel.sortGeneration = 0;
+    panel.sortSnapshots = new Map([[0, { sort: EMPTY_SORT }]]);
     panel.filter = EMPTY_FILTER;
     panel.filteredIndices = undefined;
     panel.filterGeneration = 0;
+    panel.filterSnapshots = new Map([[0, { filter: EMPTY_FILTER }]]);
     panel.histogramCache = new Map();
+    panel.histogramAborts = new Set();
     panel.restoreAbort = null;
     panel.restoring = false;
     panel.restoreId = -1;
     panel.restoreSeq = 0;
     panel.lastToolbar = undefined;
     panel.sendChain = Promise.resolve();
+    panel.transformChain = Promise.resolve();
     panel.settings = { persistSort: true, persistFilters: true, defaultDigits: 3 };
     panel.panelName = 'p';
 

--- a/tests/bun/data-viewer-panel-sort.test.ts
+++ b/tests/bun/data-viewer-panel-sort.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from 'node:os';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIX_SRC = (n: string) =>
     join(HERE, '..', '..', 'editors/vscode/test-fixtures/data-viewer', n);
+let warnings: string[] = [];
 
 function tempCopyOf(name: string): string {
     const dir = mkdtempSync(join(tmpdir(), 'raven-panel-sort-'));
@@ -73,6 +74,10 @@ async function loadPanel() {
         window: {
             createWebviewPanel: () => new FakeWebviewPanel(),
             createOutputChannel: () => ({ appendLine: () => {}, dispose: () => {} }),
+            showWarningMessage: (msg: string) => {
+                warnings.push(msg);
+                return Promise.resolve(undefined);
+            },
         },
         workspace: {
             getConfiguration: () => ({
@@ -121,6 +126,7 @@ afterEach(async () => {
     for (const c of list) {
         try { await c(); } catch { /* swallow — best effort */ }
     }
+    warnings = [];
     mock.restore();
 });
 
@@ -170,6 +176,21 @@ async function setupPanel(settingsOverride?: Partial<typeof TEST_SETTINGS>): Pro
 }
 
 describe('DataViewerPanel: setSort → sortApplied round-trip', () => {
+    test('webview reload bumps panelGeneration so stale request ids cannot collide', async () => {
+        const { fakeWebview } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const firstInit = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        const secondInit = initMessages[initMessages.length - 1];
+
+        expect(secondInit.panelGeneration).toBeGreaterThan(firstInit.panelGeneration);
+    });
+
     test('setSort builds a permutation and broadcasts sortApplied', async () => {
         const { fakeWebview } = await setupPanel();
 
@@ -327,6 +348,452 @@ describe('DataViewerPanel: setSort → sortApplied round-trip', () => {
         const rows = fakeWebview.posted.find(m => m.type === 'rows' && m.requestId === 3) as any;
         expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
         expect(rows.originalRowIndices).toBeUndefined();
+    });
+
+    test('overlapping setSort requests do not read batches concurrently and latest wins', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 1,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 2,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        const acks = fakeWebview.posted.filter(m => m.type === 'sortApplied') as any[];
+        expect(acks.map(m => m.requestId)).toEqual([2]);
+        expect(acks[0].sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: init.panelGeneration,
+            requestId: 3,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 3,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('setSort read failure rolls back optimistic state with authoritative sortApplied', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        (reader as any).getBatch = () => { throw new Error('sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 10,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 10,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+    });
+
+    test('setSort read failure rolls back to the previous non-empty sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 11,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        const previousAck = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 11,
+        ) as any;
+        expect(previousAck.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('second sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 12,
+            keys: [{ columnIndex: 1, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 12,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+        expect(rollback.fromPersistence).toBe(false);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second sort decode boom');
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 13,
+            viewportGeneration: 1,
+            start: 0,
+            end: 3,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 13,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([5, 4, 3]);
+    });
+
+    test('failed newer sort does not roll back to an unpublished superseded sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        let firstIdleReached!: () => void;
+        const firstIdleReachedPromise = new Promise<void>(resolve => { firstIdleReached = resolve; });
+        let releaseFirstIdle!: () => void;
+        const releaseFirstIdlePromise = new Promise<void>(resolve => { releaseFirstIdle = resolve; });
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'sortStatus' && msg.requestId === 40 && msg.state === 'idle') {
+                firstIdleReached();
+                return releaseFirstIdlePromise.then(() => true);
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 40,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstIdleReachedPromise;
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('second sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 41,
+            rollbackBaseRequestId: 0,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+        releaseFirstIdle();
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 41,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('second sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 42,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 42,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('failed newer sort does not roll back to an applied ack the webview ignored', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        const gen = init.panelGeneration;
+
+        const origPostMessage = fakeWebview.postMessage.bind(fakeWebview);
+        fakeWebview.postMessage = ((msg: any) => {
+            const result = origPostMessage(msg);
+            if (msg.type === 'sortApplied' && msg.requestId === 43) {
+                return new Promise<boolean>(() => {});
+            }
+            return result;
+        }) as any;
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 43,
+            keys: [{ columnIndex: 0, direction: 'asc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = () => { throw new Error('third sort decode boom'); };
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: gen,
+            requestId: 44,
+            rollbackBaseRequestId: 0,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        const rollback = fakeWebview.posted.find(
+            m => m.type === 'sortApplied' && m.requestId === 44,
+        ) as any;
+        expect(rollback).toBeDefined();
+        expect(rollback.sort.keys).toEqual([]);
+        expect(rollback.rollback).toBe(true);
+        expect(rollback.error).toBe('third sort decode boom');
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+
+        (reader as any).getBatch = origGetBatch;
+        fakeWebview.deliverFromWebview({
+            type: 'getRows',
+            panelGeneration: gen,
+            requestId: 45,
+            viewportGeneration: 1,
+            start: 0,
+            end: 5,
+            columns: [0],
+        });
+        await flush();
+        const rows = fakeWebview.posted.find(
+            m => m.type === 'rows' && m.requestId === 45,
+        ) as any;
+        expect(rows.rows.map((r: any[]) => r[0])).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('webview reload saved-sort restore does not overlap an active interactive sort read', async () => {
+        const { fakeWebview, sortStore, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        await sortStore.save('tiny', init.schemaHash, {
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOnWhenSorted: true,
+        });
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let activeReads = 0;
+        let firstRead = true;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            if (activeReads > 0) throw new Error('concurrent batch read');
+            activeReads += 1;
+            try {
+                if (firstRead) {
+                    firstRead = false;
+                    firstEntered();
+                    await releaseFirstPromise;
+                }
+                return await origGetBatch(i);
+            } finally {
+                activeReads -= 1;
+            }
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 20,
+            keys: [{ columnIndex: 1, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(warnings).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 20))
+            .toEqual([]);
+        const initMessages = fakeWebview.posted.filter(m => m.type === 'init') as any[];
+        expect(initMessages.at(-1).sort.keys).toEqual([{ columnIndex: 0, direction: 'desc' }]);
+    });
+
+    test('webview reload suppresses a non-abort error from an aborted interactive sort', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let firstEntered!: () => void;
+        const firstEnteredPromise = new Promise<void>(resolve => { firstEntered = resolve; });
+        let releaseFirst!: () => void;
+        const releaseFirstPromise = new Promise<void>(resolve => { releaseFirst = resolve; });
+        let firstRead = true;
+        (reader as any).getBatch = async () => {
+            if (firstRead) {
+                firstRead = false;
+                firstEntered();
+                await releaseFirstPromise;
+            }
+            throw new Error('late sort decode boom');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 30,
+            keys: [{ columnIndex: 0, direction: 'desc' }],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await firstEnteredPromise;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        releaseFirst();
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 30))
+            .toEqual([]);
+    });
+
+    test('webview reload aborts an active sort before the next batch read', async () => {
+        const { fakeWebview, reader } = await setupPanel();
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await flush();
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+
+        let readCount = 0;
+        const origGetBatch = (reader as any).getBatch.bind(reader);
+        (reader as any).getBatch = async (i: number) => {
+            readCount += 1;
+            if (readCount === 1) {
+                fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+                return await origGetBatch(i);
+            }
+            throw new Error('sort read after abort');
+        };
+
+        fakeWebview.deliverFromWebview({
+            type: 'setSort',
+            panelGeneration: init.panelGeneration,
+            requestId: 31,
+            keys: [
+                { columnIndex: 0, direction: 'desc' },
+                { columnIndex: 1, direction: 'asc' },
+            ],
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+        });
+        await flush();
+
+        expect(fakeWebview.posted.filter(m => m.type === 'sortApplied' && m.requestId === 31))
+            .toEqual([]);
+        expect(fakeWebview.posted.filter(m => m.type === 'error')).toEqual([]);
+        expect(readCount).toBe(1);
     });
 
     test('persistSort=false skips sortStore writes', async () => {

--- a/tests/bun/data-viewer-transform-intent.test.ts
+++ b/tests/bun/data-viewer-transform-intent.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    createIntentRequestState,
+    filterEntriesForNextRequest,
+    filterStateForRequestedEntries,
+    sortKeysForNextRequest,
+    nextSortKeysForColumn,
+    requestFilterIntent,
+    requestSortIntent,
+    shouldAcceptAppliedResponse,
+    shouldAcceptInteractiveResponse,
+    shouldAcceptSortResponse,
+    sortStateForRequestedKeys,
+} from '../../editors/vscode/src/data-viewer/webview/transform-intent';
+import type { FilterEntry } from '../../editors/vscode/src/data-viewer/messages';
+
+describe('data viewer webview transform intent', () => {
+    test('plain sort replaces the current keys', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            1,
+            'desc',
+            false,
+        )).toEqual([{ columnIndex: 1, direction: 'desc' }]);
+    });
+
+    test('append sort adds a new column after the pending key', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            1,
+            'desc',
+            true,
+        )).toEqual([
+            { columnIndex: 0, direction: 'asc' },
+            { columnIndex: 1, direction: 'desc' },
+        ]);
+    });
+
+    test('rapid sort requests compose from the latest pending keys', () => {
+        const state = createIntentRequestState();
+        const first = requestSortIntent(
+            state,
+            [{ columnIndex: 0, direction: 'asc' }],
+            true,
+        );
+        expect(nextSortKeysForColumn(
+            sortKeysForNextRequest([], state.latestSortIntent),
+            1,
+            'desc',
+            true,
+        )).toEqual([
+            { columnIndex: 0, direction: 'asc' },
+            { columnIndex: 1, direction: 'desc' },
+        ]);
+        expect(first.requestId).toBe(1);
+    });
+
+    test('repeating the current single-column sort is a no-op', () => {
+        expect(nextSortKeysForColumn(
+            [{ columnIndex: 0, direction: 'asc' }],
+            0,
+            'asc',
+            false,
+        )).toBeUndefined();
+    });
+
+    test('requested keys become optimistic sort state immediately', () => {
+        expect(sortStateForRequestedKeys(
+            [{ columnIndex: 1, direction: 'desc' }],
+            false,
+        )).toEqual({
+            keys: [{ columnIndex: 1, direction: 'desc' }],
+            labelsOnWhenSorted: false,
+        });
+    });
+
+    test('sort host responses older than the latest optimistic request are stale', () => {
+        expect(shouldAcceptSortResponse(8, 7, false)).toBe(false);
+        expect(shouldAcceptSortResponse(8, 8, false)).toBe(true);
+        expect(shouldAcceptSortResponse(8, 9, false)).toBe(false);
+        expect(shouldAcceptSortResponse(null, 7, false)).toBe(false);
+        expect(shouldAcceptSortResponse(null, -1, true)).toBe(true);
+        expect(shouldAcceptSortResponse(8, -1, true)).toBe(false);
+    });
+
+    test('interactive status responses require the latest request id exactly', () => {
+        expect(shouldAcceptInteractiveResponse(8, 7)).toBe(false);
+        expect(shouldAcceptInteractiveResponse(8, 8)).toBe(true);
+        expect(shouldAcceptInteractiveResponse(8, 9)).toBe(false);
+        expect(shouldAcceptInteractiveResponse(null, 8)).toBe(false);
+    });
+
+    test('applied responses from persistence are stale while an interactive request is pending', () => {
+        expect(shouldAcceptAppliedResponse(null, -1, true)).toBe(true);
+        expect(shouldAcceptAppliedResponse(9, -1, true)).toBe(false);
+        expect(shouldAcceptAppliedResponse(9, 9, false)).toBe(true);
+        expect(shouldAcceptAppliedResponse(9, 8, false)).toBe(false);
+    });
+
+    test('rapid filter requests compose from the latest pending entries', () => {
+        const state = createIntentRequestState();
+        const first: FilterEntry = {
+            id: 'a',
+            columnIndex: 0,
+            predicate: { kind: 'numCompare', op: '>', value: 2 },
+            enabled: true,
+            includeMissing: false,
+        };
+        const second: FilterEntry = {
+            id: 'b',
+            columnIndex: 1,
+            predicate: { kind: 'strContains', value: 'x', caseSensitive: false, negate: false },
+            enabled: true,
+            includeMissing: false,
+        };
+
+        const firstRequest = requestFilterIntent(state, [first], true);
+        const nextBase = filterEntriesForNextRequest([], state.latestFilterIntent);
+        const secondRequest = requestFilterIntent(state, [...nextBase, second], true);
+        const next = secondRequest.filter;
+
+        expect(firstRequest.requestId).toBe(1);
+        expect(secondRequest.requestId).toBe(2);
+        expect(next.entries.map(e => e.id)).toEqual(['a', 'b']);
+        expect(next.labelsOnWhenFiltered).toBe(true);
+    });
+
+    test('pending set-membership filter values are cloned for request composition', () => {
+        const values = [1, 2];
+        const first: FilterEntry = {
+            id: 'a',
+            columnIndex: 0,
+            predicate: { kind: 'setIn', values },
+            enabled: true,
+            includeMissing: false,
+        };
+        const pending = filterStateForRequestedEntries([first], true);
+        values.push(3);
+        const base = filterEntriesForNextRequest([], pending);
+        expect((base[0].predicate as any).values).toEqual([1, 2]);
+        (base[0].predicate as any).values.push(4);
+        expect((pending.entries[0].predicate as any).values).toEqual([1, 2]);
+    });
+});

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    pretendToBeVisual: true,
+});
+const g = globalThis as Record<string, unknown>;
+g.window = dom.window;
+g.document = dom.window.document;
+g.navigator = dom.window.navigator;
+g.HTMLElement = dom.window.HTMLElement;
+g.MutationObserver = dom.window.MutationObserver;
+g.MouseEvent = dom.window.MouseEvent;
+g.MessageEvent = dom.window.MessageEvent;
+g.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+g.IS_REACT_ACT_ENVIRONMENT = true;
+
+class ResizeObserverStub {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    observe(target: Element) {
+        this.callback([{ target, contentRect: { width: 800, height: 500 } as DOMRectReadOnly }] as ResizeObserverEntry[], this as unknown as ResizeObserver);
+    }
+    unobserve() {}
+    disconnect() {}
+}
+g.ResizeObserver = ResizeObserverStub;
+(dom.window as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub;
+
+const canvasContext = new Proxy({
+    canvas: undefined,
+    measureText: (text: string) => ({ width: String(text).length * 8 }),
+    createLinearGradient: () => ({ addColorStop: () => undefined }),
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+}, {
+    get(target, prop) {
+        if (prop in target) return target[prop as keyof typeof target];
+        return () => undefined;
+    },
+    set(target, prop, value) {
+        (target as Record<PropertyKey, unknown>)[prop] = value;
+        return true;
+    },
+});
+(dom.window.HTMLCanvasElement.prototype as unknown as {
+    getContext: () => unknown;
+}).getContext = function getContext(this: HTMLCanvasElement) {
+    canvasContext.canvas = this;
+    return canvasContext;
+};
+
+const { App } = await import('../../editors/vscode/src/data-viewer/webview/App');
+
+const column = {
+    name: 'x',
+    arrowType: 'Int32',
+    dictionaryShipped: false,
+    isInteger: true,
+};
+
+const activeFilter = {
+    entries: [{
+        id: 'e1',
+        columnIndex: 0,
+        predicate: { kind: 'numCompare' as const, op: '>' as const, value: 2 },
+        enabled: true,
+        includeMissing: false,
+    }],
+    labelsOnWhenFiltered: true,
+};
+
+const emptyFilter = {
+    entries: [],
+    labelsOnWhenFiltered: true,
+};
+
+let roots: Root[] = [];
+
+afterEach(() => {
+    for (const root of roots) {
+        act(() => root.unmount());
+    }
+    roots = [];
+    document.body.innerHTML = '';
+});
+
+function initMessage() {
+    return {
+        type: 'init' as const,
+        panelGeneration: 1,
+        nrow: 5,
+        columns: [column],
+        layout: { columnWidths: {}, hiddenColumns: [] },
+        toolbar: { labelsOn: true, formatOn: true, digits: 3 },
+        settings: { missingValueStyle: 'foreground' as const, defaultDigits: 3, persistSort: true, persistFilters: true },
+        dictionaries: {},
+        schemaHash: 'schema-1',
+        sort: { keys: [], labelsOnWhenSorted: true },
+        filter: activeFilter,
+    };
+}
+
+async function renderApp() {
+    const posted: any[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const vscode = {
+        postMessage: (msg: any) => { posted.push(msg); },
+        setState: () => undefined,
+    };
+
+    await act(async () => {
+        root.render(<App vscode={vscode} />);
+    });
+    await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', { data: initMessage() }));
+    });
+    posted.length = 0;
+    return { posted };
+}
+
+async function clickClearAllFilters() {
+    const clear = document.querySelector<HTMLButtonElement>('button[aria-label="Clear all filters"]');
+    expect(clear).not.toBeNull();
+    await act(async () => {
+        clear!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+}
+
+describe('data viewer App filter persistence', () => {
+    test('does not save a rollback filterApplied response', async () => {
+        const { posted } = await renderApp();
+
+        await clickClearAllFilters();
+        const request = posted.find(m => m.type === 'setFilters');
+        expect(request).toBeDefined();
+        posted.length = 0;
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: {
+                    type: 'filterApplied',
+                    panelGeneration: 1,
+                    requestId: request.requestId,
+                    filter: activeFilter,
+                    nrowFiltered: 3,
+                    fromPersistence: false,
+                    rollback: true,
+                    error: 'filter failed',
+                },
+            }));
+        });
+        await new Promise(resolve => setTimeout(resolve, 350));
+
+        expect(posted.filter(m => m.type === 'saveFilter')).toEqual([]);
+    });
+
+    test('saves a successful user filterApplied response immediately', async () => {
+        const { posted } = await renderApp();
+
+        await clickClearAllFilters();
+        const request = posted.find(m => m.type === 'setFilters');
+        expect(request).toBeDefined();
+        posted.length = 0;
+
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: {
+                    type: 'filterApplied',
+                    panelGeneration: 1,
+                    requestId: request.requestId,
+                    filter: emptyFilter,
+                    nrowFiltered: 5,
+                    fromPersistence: false,
+                },
+            }));
+        });
+
+        expect(posted.filter(m => m.type === 'saveFilter')).toEqual([{
+            type: 'saveFilter',
+            panelGeneration: 1,
+            schemaHash: 'schema-1',
+            filter: emptyFilter,
+        }]);
+    });
+});


### PR DESCRIPTION
## Summary
- Serialize restore, sort, filter, and histogram scans through a shared transform chain.
- Gate optimistic sort/filter responses with request ids and rollback stale or failed requests to authoritative baselines.
- Add regression coverage for overlapping transforms, reload aborts, rollback paths, histogram serialization, and webview filter persistence.

## Verification
- bun test tests/bun/data-viewer-sort-filter-cancel.test.ts tests/bun/data-viewer-panel-restore-cancel.test.ts tests/bun/data-viewer-transform-intent.test.ts tests/bun/data-viewer-webview-app.test.tsx tests/bun/data-viewer-panel-sort.test.ts tests/bun/data-viewer-panel-filter.test.ts tests/bun/data-viewer-histograms.test.ts
- cd editors/vscode && bun run typecheck
- git diff --check

## Review
- Targeted App/filter-persistence review: clean.
- Full correctness/race review: clean.
- Full tests/invariants review: no must-fix findings.