### PR TITLE
[codex] Fix stale data-viewer copy completion

### DIFF
--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -1151,7 +1151,10 @@ export class DataViewerPanel {
             }
             return;
         }
-        if (m.panelGeneration !== this.generation) return;
+        if (m.panelGeneration !== this.generation) {
+            if (m.type === 'copy') await this.postStaleCopyDone(m);
+            return;
+        }
         // Capture generation BEFORE any await so a replace mid-fetch causes
         // us to drop the stale response rather than post under the new
         // generation.
@@ -1591,21 +1594,36 @@ export class DataViewerPanel {
         if (this.filterAbort === abort) this.filterAbort = null;
     }
 
-    private async handleCopy(
+    private async postCopyDone(
         m: Extract<WebviewToExtension, { type: 'copy' }>,
         gen: number,
+        ok: boolean,
+        error?: string,
     ): Promise<void> {
-        const cells = (m.range.rowEnd - m.range.rowStart) * m.range.colIndices.length;
-        const replyDone = (ok: boolean, error?: string): ExtensionToWebview => ({
+        await this.webviewPanel.webview.postMessage({
             type: 'copyDone',
             panelGeneration: gen,
             requestId: m.requestId,
             ok,
             error,
-        });
+        } satisfies ExtensionToWebview);
+    }
+
+    private async postStaleCopyDone(
+        m: Extract<WebviewToExtension, { type: 'copy' }>,
+    ): Promise<void> {
+        await this.postCopyDone(
+            m, m.panelGeneration, false, 'Data changed before copy completed',
+        );
+    }
+
+    private async handleCopy(
+        m: Extract<WebviewToExtension, { type: 'copy' }>,
+        gen: number,
+    ): Promise<void> {
+        const cells = (m.range.rowEnd - m.range.rowStart) * m.range.colIndices.length;
         if (cells > COPY_CELL_LIMIT) {
-            await this.webviewPanel.webview.postMessage(
-                replyDone(false, 'Selection exceeds copy limit'));
+            await this.postCopyDone(m, gen, false, 'Selection exceeds copy limit');
             return;
         }
         const copyPerm = this.composeEffective();
@@ -1616,7 +1634,10 @@ export class DataViewerPanel {
             viewportGeneration: Number.MAX_SAFE_INTEGER,
             permutation: copyPerm,
         });
-        if (gen !== this.generation) return;
+        if (gen !== this.generation) {
+            await this.postStaleCopyDone(m);
+            return;
+        }
 
         // Resolve labels for any non-shipped dictionary columns in the
         // selection so a Labels-on copy renders the level strings the
@@ -1635,7 +1656,10 @@ export class DataViewerPanel {
                 }
                 if (indices.size === 0) continue;
                 const labels = await this.reader.getLabels(colIdx, [...indices]);
-                if (gen !== this.generation) return;
+                if (gen !== this.generation) {
+                    await this.postStaleCopyDone(m);
+                    return;
+                }
                 resolved[colIdx] = labels;
             }
         }
@@ -1646,10 +1670,11 @@ export class DataViewerPanel {
         );
         try {
             await vscode.env.clipboard.writeText(tsv);
-            await this.webviewPanel.webview.postMessage(replyDone(true));
+            await this.postCopyDone(m, gen, true);
         } catch (err) {
-            await this.webviewPanel.webview.postMessage(
-                replyDone(false, err instanceof Error ? err.message : String(err)));
+            await this.postCopyDone(
+                m, gen, false, err instanceof Error ? err.message : String(err),
+            );
         }
     }
 

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -669,6 +669,16 @@ export function App({
         clearRows();
         setResolvedLabels({});
         setGridSelection(createEmptySelection());
+        // Clear any outstanding copy status: a copy in flight belongs to the
+        // prior generation, and the host's stale `copyDone` carries that old
+        // generation, so it is dropped by the generation guard in the message
+        // handler (and by applyCopyDone) before it can clear the toast. Reset
+        // here so a replace/init that supersedes an in-progress copy doesn't
+        // leave a stuck "Copying..." toast. A fresh copy in the new generation
+        // re-sets this; the stale `copyDone` stays dropped and cannot clobber
+        // it.
+        setCopyStatus('');
+        setCopyStatusMsg('');
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
         postLifecycle(
             m.type,

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -378,6 +378,9 @@ export function App({
     const [headerTooltip, setHeaderTooltip] = useState<HeaderTooltipState | null>(null);
     const [copyStatus, setCopyStatus] = useState<'' | 'copying' | 'copied' | 'error'>('');
     const [copyStatusMsg, setCopyStatusMsg] = useState('');
+    // Mirrors copyStatus for synchronous reads inside callbacks (e.g.
+    // applyInitOrReplace) without taking copyStatus as a dependency.
+    const copyStatusRef = useRef<'' | 'copying' | 'copied' | 'error'>('');
     const [sort, setSort] = useState<SortState>(restored?.sort ?? EMPTY_SORT);
     const [sortPending, setSortPending] = useState(false);
     const [filter, setFilter] = useState<FilterState>(restored?.filter ?? EMPTY_FILTER);
@@ -639,6 +642,10 @@ export function App({
         }
     }, []);
 
+    useEffect(() => {
+        copyStatusRef.current = copyStatus;
+    }, [copyStatus]);
+
     const applyInitOrReplace = useCallback((m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>) => {
         const sameDataset = m.nrow === nrow
             && sameColumns(m.columns, columns);
@@ -685,17 +692,18 @@ export function App({
         clearRows();
         setResolvedLabels({});
         setGridSelection(createEmptySelection());
-        // Clear any outstanding copy status: a copy in flight belongs to the
-        // prior generation, and the host's stale `copyDone` carries that old
-        // generation, so it is dropped by the generation guard in the message
-        // handler (and by applyCopyDone) before it can clear the toast. Reset
-        // here so a replace/init that supersedes an in-progress copy doesn't
-        // leave a stuck "Copying..." toast. A fresh copy in the new generation
-        // re-sets this; the stale `copyDone` stays dropped and cannot clobber
-        // it.
-        cancelCopyStatusClear();
-        setCopyStatus('');
-        setCopyStatusMsg('');
+        // Clear only an orphaned in-flight copy: a "copying" toast whose
+        // copyDone will never arrive because this replace/init bumped the
+        // generation. The host does post a stale copyDone, but it carries the
+        // old generation and is dropped by the generation guard in the message
+        // handler (and by applyCopyDone), so without this the "Copying..." toast
+        // would stay stuck. Terminal "copied"/"error" toasts are left alone:
+        // they self-clear via their own timer or are stale-but-harmless, and
+        // wiping them here would swallow a just-shown sort/filter/copy result.
+        if (copyStatusRef.current === 'copying') {
+            setCopyStatus('');
+            setCopyStatusMsg('');
+        }
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
         postLifecycle(
             m.type,
@@ -704,7 +712,7 @@ export function App({
             m.panelGeneration,
         );
         window.setTimeout(() => gridRef.current?.scrollTo(0, 0, 'both'), 0);
-    }, [cancelCopyStatusClear, clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
+    }, [clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
 
     const applyRows = useCallback((m: Extract<ExtensionToWebview, { type: 'rows' }>) => {
         if (m.panelGeneration !== panelGenerationRef.current) return;
@@ -788,6 +796,9 @@ export function App({
             ));
         }
         if (m.error) {
+            // The error reuses the shared copy-toast slot; cancel any pending
+            // copy auto-clear timer so it can't blank this error mid-read.
+            cancelCopyStatusClear();
             setCopyStatus('error');
             setCopyStatusMsg(m.error);
         }
@@ -803,6 +814,7 @@ export function App({
             });
         }
     }, [
+        cancelCopyStatusClear,
         clearRows,
         effectiveNrow,
         requestRows,
@@ -833,6 +845,9 @@ export function App({
         acceptedFilterRequestIdRef.current = m.requestId;
         setPendingFilterIntent(null);
         if (m.error) {
+            // Shares the copy-toast slot; cancel any pending copy auto-clear
+            // timer so it can't blank this error mid-read.
+            cancelCopyStatusClear();
             setCopyStatus('error');
             setCopyStatusMsg(m.error);
         }
@@ -874,6 +889,7 @@ export function App({
             ));
         }
     }, [
+        cancelCopyStatusClear,
         clearRows,
         nrow,
         requestRows,
@@ -1258,6 +1274,9 @@ export function App({
                     scrollToFraction(m.fraction);
                     return;
                 case 'error':
+                    // Shares the copy-toast slot; cancel any pending copy
+                    // auto-clear timer so it can't blank this error mid-read.
+                    cancelCopyStatusClear();
                     setCopyStatus('error');
                     setCopyStatusMsg(m.message);
                     return;
@@ -1275,6 +1294,7 @@ export function App({
         applyRows,
         applySortApplied,
         applySortStatus,
+        cancelCopyStatusClear,
         handleTestKey,
         panelGeneration,
         scrollToFraction,

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -347,6 +347,12 @@ export function App({
     const toolbarBootstrappedRef = useRef(false);
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
     const missingRowRequestTimerRef = useRef<number | null>(null);
+    // Handle for the 2500ms timer that clears a finished copy's
+    // "Copied"/"Copy failed" toast. Tracked so it can be cancelled when a new
+    // copy starts, a fresh copyDone arrives, or a generation replace clears the
+    // toast — otherwise a stale timer could blank a newer copy's in-flight
+    // "Copying..." toast partway through.
+    const copyStatusClearTimerRef = useRef<number | null>(null);
     /** Toolbar wrap measurement refs: when the sort/filter chips can't fit
      *  beside the action buttons, the chip group drops to its own second row
      *  via `.toolbar.is-wrapped`. See `useToolbarWrap` for the policy. */
@@ -621,6 +627,16 @@ export function App({
         if (missingRowRequestTimerRef.current !== null) {
             window.clearTimeout(missingRowRequestTimerRef.current);
         }
+        if (copyStatusClearTimerRef.current !== null) {
+            window.clearTimeout(copyStatusClearTimerRef.current);
+        }
+    }, []);
+
+    const cancelCopyStatusClear = useCallback(() => {
+        if (copyStatusClearTimerRef.current !== null) {
+            window.clearTimeout(copyStatusClearTimerRef.current);
+            copyStatusClearTimerRef.current = null;
+        }
     }, []);
 
     const applyInitOrReplace = useCallback((m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>) => {
@@ -677,6 +693,7 @@ export function App({
         // leave a stuck "Copying..." toast. A fresh copy in the new generation
         // re-sets this; the stale `copyDone` stays dropped and cannot clobber
         // it.
+        cancelCopyStatusClear();
         setCopyStatus('');
         setCopyStatusMsg('');
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
@@ -687,7 +704,7 @@ export function App({
             m.panelGeneration,
         );
         window.setTimeout(() => gridRef.current?.scrollTo(0, 0, 'both'), 0);
-    }, [clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
+    }, [cancelCopyStatusClear, clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
 
     const applyRows = useCallback((m: Extract<ExtensionToWebview, { type: 'rows' }>) => {
         if (m.panelGeneration !== panelGenerationRef.current) return;
@@ -994,13 +1011,15 @@ export function App({
 
     const applyCopyDone = useCallback((m: Extract<ExtensionToWebview, { type: 'copyDone' }>) => {
         if (m.panelGeneration !== panelGenerationRef.current) return;
+        cancelCopyStatusClear();
         setCopyStatus(m.ok ? 'copied' : 'error');
         setCopyStatusMsg(m.ok ? 'Copied' : (m.error ?? 'Copy failed'));
-        window.setTimeout(() => {
+        copyStatusClearTimerRef.current = window.setTimeout(() => {
+            copyStatusClearTimerRef.current = null;
             setCopyStatus('');
             setCopyStatusMsg('');
         }, 2500);
-    }, []);
+    }, [cancelCopyStatusClear]);
 
     const estimatedViewportRowCount = useCallback((): number => {
         const current = visibleRange.end - visibleRange.start;
@@ -1444,6 +1463,9 @@ export function App({
 
         if (rowEnd <= rowStart || colIndices.length === 0) return;
         const requestId = nextRequestId();
+        // A finished prior copy may still have its 2500ms clear timer pending;
+        // cancel it so it can't blank this new "Copying..." toast mid-flight.
+        cancelCopyStatusClear();
         setCopyStatus('copying');
         setCopyStatusMsg('Copying...');
         vscode.postMessage({
@@ -1456,7 +1478,7 @@ export function App({
             digits: toolbar.digits,
             includeHeader,
         });
-    }, [effectiveNrow, gridSelection, nextRequestId, panelGeneration, toolbar, visibleCols, vscode]);
+    }, [cancelCopyStatusClear, effectiveNrow, gridSelection, nextRequestId, panelGeneration, toolbar, visibleCols, vscode]);
 
     useEffect(() => {
         const onCopy = (event: ClipboardEvent) => {

--- a/editors/vscode/src/data-viewer/webview/App.tsx
+++ b/editors/vscode/src/data-viewer/webview/App.tsx
@@ -348,10 +348,9 @@ export function App({
     const missingRowRequestRef = useRef<VisibleRange | null>(null);
     const missingRowRequestTimerRef = useRef<number | null>(null);
     // Handle for the 2500ms timer that clears a finished copy's
-    // "Copied"/"Copy failed" toast. Tracked so it can be cancelled when a new
-    // copy starts, a fresh copyDone arrives, or a generation replace clears the
-    // toast — otherwise a stale timer could blank a newer copy's in-flight
-    // "Copying..." toast partway through.
+    // "Copied"/"Copy failed" toast. Cancelled by showCopyToast/clearCopyToast
+    // (the only writers of the shared copy-toast slot) so a stale timer can
+    // never blank a newer toast partway through.
     const copyStatusClearTimerRef = useRef<number | null>(null);
     /** Toolbar wrap measurement refs: when the sort/filter chips can't fit
      *  beside the action buttons, the chip group drops to its own second row
@@ -379,7 +378,8 @@ export function App({
     const [copyStatus, setCopyStatus] = useState<'' | 'copying' | 'copied' | 'error'>('');
     const [copyStatusMsg, setCopyStatusMsg] = useState('');
     // Mirrors copyStatus for synchronous reads inside callbacks (e.g.
-    // applyInitOrReplace) without taking copyStatus as a dependency.
+    // applyInitOrReplace) without taking copyStatus as a dependency. Kept in
+    // sync by showCopyToast/clearCopyToast, the only writers of the slot.
     const copyStatusRef = useRef<'' | 'copying' | 'copied' | 'error'>('');
     const [sort, setSort] = useState<SortState>(restored?.sort ?? EMPTY_SORT);
     const [sortPending, setSortPending] = useState(false);
@@ -642,9 +642,29 @@ export function App({
         }
     }, []);
 
-    useEffect(() => {
-        copyStatusRef.current = copyStatus;
-    }, [copyStatus]);
+    // The copy-toast slot (copyStatus + copyStatusMsg) is shared by copy
+    // progress/result AND sort/filter/host error toasts. Route every write
+    // through these two helpers so the slot is correct by construction: each
+    // cancels the pending auto-clear timer (so a newer toast is never blanked by
+    // the prior toast's timer) and keeps copyStatusRef in sync synchronously
+    // (so callbacks that read it — e.g. applyInitOrReplace — never see a stale
+    // value). copyStatusRef mirrors copyStatus for those synchronous reads.
+    const showCopyToast = useCallback((
+        status: 'copying' | 'copied' | 'error',
+        msg: string,
+    ) => {
+        cancelCopyStatusClear();
+        copyStatusRef.current = status;
+        setCopyStatus(status);
+        setCopyStatusMsg(msg);
+    }, [cancelCopyStatusClear]);
+
+    const clearCopyToast = useCallback(() => {
+        cancelCopyStatusClear();
+        copyStatusRef.current = '';
+        setCopyStatus('');
+        setCopyStatusMsg('');
+    }, [cancelCopyStatusClear]);
 
     const applyInitOrReplace = useCallback((m: Extract<ExtensionToWebview, { type: 'init' | 'replace' }>) => {
         const sameDataset = m.nrow === nrow
@@ -701,8 +721,7 @@ export function App({
         // they self-clear via their own timer or are stale-but-harmless, and
         // wiping them here would swallow a just-shown sort/filter/copy result.
         if (copyStatusRef.current === 'copying') {
-            setCopyStatus('');
-            setCopyStatusMsg('');
+            clearCopyToast();
         }
         if (!sameDataset) setVisibleRange({ start: 0, end: 0 });
         postLifecycle(
@@ -712,7 +731,7 @@ export function App({
             m.panelGeneration,
         );
         window.setTimeout(() => gridRef.current?.scrollTo(0, 0, 'both'), 0);
-    }, [clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
+    }, [clearCopyToast, clearRows, columns, nrow, panelGeneration, postLifecycle, visibleRange]);
 
     const applyRows = useCallback((m: Extract<ExtensionToWebview, { type: 'rows' }>) => {
         if (m.panelGeneration !== panelGenerationRef.current) return;
@@ -796,11 +815,7 @@ export function App({
             ));
         }
         if (m.error) {
-            // The error reuses the shared copy-toast slot; cancel any pending
-            // copy auto-clear timer so it can't blank this error mid-read.
-            cancelCopyStatusClear();
-            setCopyStatus('error');
-            setCopyStatusMsg(m.error);
+            showCopyToast('error', m.error);
         }
         // Persist the latest sort. Cleared (empty keys) saves are also
         // valid — the host treats an empty SortState as a clear. Rollbacks
@@ -814,9 +829,9 @@ export function App({
             });
         }
     }, [
-        cancelCopyStatusClear,
         clearRows,
         effectiveNrow,
+        showCopyToast,
         requestRows,
         schemaHash,
         visibleCols.length,
@@ -845,11 +860,7 @@ export function App({
         acceptedFilterRequestIdRef.current = m.requestId;
         setPendingFilterIntent(null);
         if (m.error) {
-            // Shares the copy-toast slot; cancel any pending copy auto-clear
-            // timer so it can't blank this error mid-read.
-            cancelCopyStatusClear();
-            setCopyStatus('error');
-            setCopyStatusMsg(m.error);
+            showCopyToast('error', m.error);
         }
         setFilter(m.filter);
         // Host-owned state and rollback recovery are not new user
@@ -889,9 +900,9 @@ export function App({
             ));
         }
     }, [
-        cancelCopyStatusClear,
         clearRows,
         nrow,
+        showCopyToast,
         requestRows,
         schemaHash,
         visibleCols.length,
@@ -1027,15 +1038,14 @@ export function App({
 
     const applyCopyDone = useCallback((m: Extract<ExtensionToWebview, { type: 'copyDone' }>) => {
         if (m.panelGeneration !== panelGenerationRef.current) return;
-        cancelCopyStatusClear();
-        setCopyStatus(m.ok ? 'copied' : 'error');
-        setCopyStatusMsg(m.ok ? 'Copied' : (m.error ?? 'Copy failed'));
+        showCopyToast(m.ok ? 'copied' : 'error', m.ok ? 'Copied' : (m.error ?? 'Copy failed'));
         copyStatusClearTimerRef.current = window.setTimeout(() => {
             copyStatusClearTimerRef.current = null;
+            copyStatusRef.current = '';
             setCopyStatus('');
             setCopyStatusMsg('');
         }, 2500);
-    }, [cancelCopyStatusClear]);
+    }, [showCopyToast]);
 
     const estimatedViewportRowCount = useCallback((): number => {
         const current = visibleRange.end - visibleRange.start;
@@ -1274,11 +1284,7 @@ export function App({
                     scrollToFraction(m.fraction);
                     return;
                 case 'error':
-                    // Shares the copy-toast slot; cancel any pending copy
-                    // auto-clear timer so it can't blank this error mid-read.
-                    cancelCopyStatusClear();
-                    setCopyStatus('error');
-                    setCopyStatusMsg(m.message);
+                    showCopyToast('error', m.message);
                     return;
             }
         };
@@ -1294,10 +1300,10 @@ export function App({
         applyRows,
         applySortApplied,
         applySortStatus,
-        cancelCopyStatusClear,
         handleTestKey,
         panelGeneration,
         scrollToFraction,
+        showCopyToast,
         vscode,
     ]);
 
@@ -1483,11 +1489,7 @@ export function App({
 
         if (rowEnd <= rowStart || colIndices.length === 0) return;
         const requestId = nextRequestId();
-        // A finished prior copy may still have its 2500ms clear timer pending;
-        // cancel it so it can't blank this new "Copying..." toast mid-flight.
-        cancelCopyStatusClear();
-        setCopyStatus('copying');
-        setCopyStatusMsg('Copying...');
+        showCopyToast('copying', 'Copying...');
         vscode.postMessage({
             type: 'copy',
             panelGeneration,
@@ -1498,7 +1500,7 @@ export function App({
             digits: toolbar.digits,
             includeHeader,
         });
-    }, [cancelCopyStatusClear, effectiveNrow, gridSelection, nextRequestId, panelGeneration, toolbar, visibleCols, vscode]);
+    }, [effectiveNrow, gridSelection, nextRequestId, panelGeneration, showCopyToast, toolbar, visibleCols, vscode]);
 
     useEffect(() => {
         const onCopy = (event: ClipboardEvent) => {

--- a/tests/bun/data-viewer-panel-persistence.test.ts
+++ b/tests/bun/data-viewer-panel-persistence.test.ts
@@ -282,4 +282,132 @@ describe('DataViewerPanel persistence round-trip', () => {
         fakePanel.dispose();
         mock.restore();
     });
+
+    test('stale copy request gets copyDone so the webview clears Copying status', async () => {
+        const { panelMod, arrowMod, layoutMod, toolbarMod, sortMod, filterMod } = await loadPanel();
+        const kv = new MemKV();
+        const layoutStore = new layoutMod.LayoutStore(kv as any, 100);
+        const toolbarStore = new toolbarMod.ToolbarStateStore(kv as any, 100);
+        const sortStore = new sortMod.SortStateStore(kv as any, 100);
+        const filterStore = new filterMod.FilterStateStore(kv as any, 100);
+
+        const path1 = tempCopyOf('tiny.arrow');
+        const reader = await arrowMod.ArrowSliceReader.open(path1);
+        const panel = await panelMod.DataViewerPanel.create(
+            'tiny', reader, path1,
+            layoutStore, toolbarStore, sortStore, filterStore,
+            TEST_SETTINGS,
+            { fsPath: '/x', toString: () => '/x' } as any,
+            () => {},
+        );
+        const fakePanel = (panel as any).webviewPanel as FakeWebviewPanel;
+        const fakeWebview = fakePanel.webview;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await new Promise(r => setTimeout(r, 0));
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        expect(init).toBeDefined();
+
+        const path2 = tempCopyOf('tiny.arrow');
+        const reader2 = await arrowMod.ArrowSliceReader.open(path2);
+        await panel.replace(reader2, path2);
+        await new Promise(r => setTimeout(r, 0));
+
+        const beforeCopy = fakeWebview.posted.length;
+        fakeWebview.deliverFromWebview({
+            type: 'copy',
+            panelGeneration: init.panelGeneration,
+            requestId: 42,
+            range: { rowStart: 0, rowEnd: 1, colIndices: [0] },
+            labelsOn: true,
+            formatOn: true,
+            digits: 3,
+            includeHeader: false,
+        });
+        await new Promise(r => setTimeout(r, 0));
+
+        const copyDone = fakeWebview.posted.slice(beforeCopy)
+            .find(m => m.type === 'copyDone') as any;
+        expect(copyDone).toEqual({
+            type: 'copyDone',
+            panelGeneration: init.panelGeneration,
+            requestId: 42,
+            ok: false,
+            error: 'Data changed before copy completed',
+        });
+
+        await reader2.close().catch(() => undefined);
+        fakePanel.dispose();
+        mock.restore();
+    });
+
+    test('copy that becomes stale during row read still gets copyDone', async () => {
+        const { panelMod, arrowMod, layoutMod, toolbarMod, sortMod, filterMod } = await loadPanel();
+        const kv = new MemKV();
+        const layoutStore = new layoutMod.LayoutStore(kv as any, 100);
+        const toolbarStore = new toolbarMod.ToolbarStateStore(kv as any, 100);
+        const sortStore = new sortMod.SortStateStore(kv as any, 100);
+        const filterStore = new filterMod.FilterStateStore(kv as any, 100);
+
+        const path1 = tempCopyOf('tiny.arrow');
+        const reader = await arrowMod.ArrowSliceReader.open(path1);
+        let releaseRows!: () => void;
+        let rowsRequested = false;
+        (reader as any).getRows = async () => {
+            rowsRequested = true;
+            await new Promise<void>(resolve => { releaseRows = resolve; });
+            return { rows: [[1]], stale: false };
+        };
+
+        const panel = await panelMod.DataViewerPanel.create(
+            'tiny', reader, path1,
+            layoutStore, toolbarStore, sortStore, filterStore,
+            TEST_SETTINGS,
+            { fsPath: '/x', toString: () => '/x' } as any,
+            () => {},
+        );
+        const fakePanel = (panel as any).webviewPanel as FakeWebviewPanel;
+        const fakeWebview = fakePanel.webview;
+
+        fakeWebview.deliverFromWebview({ type: 'webviewReady' });
+        await new Promise(r => setTimeout(r, 0));
+        const init = fakeWebview.posted.find(m => m.type === 'init') as any;
+        expect(init).toBeDefined();
+
+        const beforeCopy = fakeWebview.posted.length;
+        fakeWebview.deliverFromWebview({
+            type: 'copy',
+            panelGeneration: init.panelGeneration,
+            requestId: 43,
+            range: { rowStart: 0, rowEnd: 1, colIndices: [0] },
+            labelsOn: false,
+            formatOn: true,
+            digits: 3,
+            includeHeader: false,
+        });
+        await new Promise(r => setTimeout(r, 0));
+        expect(rowsRequested).toBe(true);
+
+        const path2 = tempCopyOf('tiny.arrow');
+        const reader2 = await arrowMod.ArrowSliceReader.open(path2);
+        const replacePromise = panel.replace(reader2, path2);
+        await new Promise(r => setTimeout(r, 0));
+        releaseRows();
+        await replacePromise;
+        await new Promise(r => setTimeout(r, 0));
+
+        const copyDone = fakeWebview.posted.slice(beforeCopy)
+            .find(m => m.type === 'copyDone') as any;
+        expect(copyDone).toEqual({
+            type: 'copyDone',
+            panelGeneration: init.panelGeneration,
+            requestId: 43,
+            ok: false,
+            error: 'Data changed before copy completed',
+        });
+
+        await reader2.close().catch(() => undefined);
+        fakePanel.dispose();
+        mock.restore();
+    });
 });

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, jest, test } from 'bun:test';
 import { JSDOM } from 'jsdom';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -221,28 +221,83 @@ describe('data viewer App copy status', () => {
     test('a stale copy-complete timer does not blank a newer copy in-flight toast', async () => {
         await renderApp();
 
-        // Copy A completes in gen 1 → "Copied" toast plus a 2.5s clear timer.
+        // Fake timers from here so the 2.5s clear timer armed by copyDone can be
+        // advanced synchronously rather than slept on.
+        jest.useFakeTimers();
+        try {
+            // Copy A completes in gen 1 → "Copied" toast plus a 2.5s clear timer.
+            await act(async () => {
+                window.dispatchEvent(new MessageEvent('message', {
+                    data: { type: 'copyDone', panelGeneration: 1, requestId: 0, ok: true },
+                }));
+            });
+            expect(document.body.textContent).toContain('Copied');
+
+            // A replace bumps the generation, then a fresh copy B starts in gen 2.
+            await act(async () => {
+                window.dispatchEvent(new MessageEvent('message', {
+                    data: { ...initMessage(), type: 'replace', panelGeneration: 2 },
+                }));
+            });
+            await act(async () => { dispatchKey('a'); });
+            await act(async () => { dispatchKey('c'); });
+            expect(document.body.textContent).toContain('Copying...');
+
+            // Copy A's stale 2.5s clear timer must have been cancelled; if it
+            // fires it would blank copy B's still-in-flight "Copying..." toast.
+            await act(async () => { jest.advanceTimersByTime(2600); });
+            expect(document.body.textContent).toContain('Copying...');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('a pending copy-clear timer does not blank a later error toast', async () => {
+        await renderApp();
+
+        jest.useFakeTimers();
+        try {
+            // A successful copy arms the 2.5s clear timer.
+            await act(async () => {
+                window.dispatchEvent(new MessageEvent('message', {
+                    data: { type: 'copyDone', panelGeneration: 1, requestId: 0, ok: true },
+                }));
+            });
+            // Within that window a host error reuses the shared toast slot.
+            await act(async () => {
+                window.dispatchEvent(new MessageEvent('message', {
+                    data: { type: 'error', message: 'Boom' },
+                }));
+            });
+            expect(document.body.textContent).toContain('Boom');
+
+            // The copy's stale clear timer must not fire and blank the error.
+            await act(async () => { jest.advanceTimersByTime(2600); });
+            expect(document.body.textContent).toContain('Boom');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('a same-shape replace does not wipe a freshly-shown error toast', async () => {
+        await renderApp();
+
+        // A host error shows in the shared toast slot.
         await act(async () => {
             window.dispatchEvent(new MessageEvent('message', {
-                data: { type: 'copyDone', panelGeneration: 1, requestId: 0, ok: true },
+                data: { type: 'error', message: 'Boom' },
             }));
         });
-        expect(document.body.textContent).toContain('Copied');
+        expect(document.body.textContent).toContain('Boom');
 
-        // A replace bumps the generation, then a fresh copy B starts in gen 2.
+        // A replace that is not superseding an in-flight copy must leave the
+        // error toast in place (only an orphaned "Copying..." is cleared).
         await act(async () => {
             window.dispatchEvent(new MessageEvent('message', {
                 data: { ...initMessage(), type: 'replace', panelGeneration: 2 },
             }));
         });
-        await act(async () => { dispatchKey('a'); });
-        await act(async () => { dispatchKey('c'); });
-        expect(document.body.textContent).toContain('Copying...');
-
-        // Copy A's stale 2.5s clear timer must have been cancelled; if it fires
-        // it would blank copy B's still-in-flight "Copying..." toast.
-        await act(async () => { await new Promise(resolve => setTimeout(resolve, 2600)); });
-        expect(document.body.textContent).toContain('Copying...');
+        expect(document.body.textContent).toContain('Boom');
     });
 });
 

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -217,6 +217,33 @@ describe('data viewer App copy status', () => {
         });
         expect(document.body.textContent).not.toContain('Copying...');
     });
+
+    test('a stale copy-complete timer does not blank a newer copy in-flight toast', async () => {
+        await renderApp();
+
+        // Copy A completes in gen 1 → "Copied" toast plus a 2.5s clear timer.
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'copyDone', panelGeneration: 1, requestId: 0, ok: true },
+            }));
+        });
+        expect(document.body.textContent).toContain('Copied');
+
+        // A replace bumps the generation, then a fresh copy B starts in gen 2.
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { ...initMessage(), type: 'replace', panelGeneration: 2 },
+            }));
+        });
+        await act(async () => { dispatchKey('a'); });
+        await act(async () => { dispatchKey('c'); });
+        expect(document.body.textContent).toContain('Copying...');
+
+        // Copy A's stale 2.5s clear timer must have been cancelled; if it fires
+        // it would blank copy B's still-in-flight "Copying..." toast.
+        await act(async () => { await new Promise(resolve => setTimeout(resolve, 2600)); });
+        expect(document.body.textContent).toContain('Copying...');
+    });
 });
 
 describe('data viewer App restore banner debounce', () => {

--- a/tests/bun/data-viewer-webview-app.test.tsx
+++ b/tests/bun/data-viewer-webview-app.test.tsx
@@ -188,6 +188,37 @@ describe('data viewer App filter persistence', () => {
     });
 });
 
+describe('data viewer App copy status', () => {
+    function dispatchKey(key: string) {
+        window.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+            key,
+            ctrlKey: true,
+            bubbles: true,
+        }));
+    }
+
+    test('a replace that supersedes an in-flight copy clears the Copying toast', async () => {
+        await renderApp();
+
+        // Select all + copy → the host is sent a `copy` request and the toast
+        // shows "Copying..." while the host reads rows.
+        await act(async () => { dispatchKey('a'); });
+        await act(async () => { dispatchKey('c'); });
+        expect(document.body.textContent).toContain('Copying...');
+
+        // The host bumps the generation (e.g. View() re-run) and replaces the
+        // data before the copy finishes. The stale `copyDone` it posts carries
+        // the old generation and is dropped by the webview's generation guard,
+        // so the replace itself must clear the stuck "Copying..." toast.
+        await act(async () => {
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { ...initMessage(), type: 'replace', panelGeneration: 2 },
+            }));
+        });
+        expect(document.body.textContent).not.toContain('Copying...');
+    });
+});
+
 describe('data viewer App restore banner debounce', () => {
     function restorePendingMessage(restoreId: number) {
         return {


### PR DESCRIPTION
## Summary
- reply to stale-generation data-viewer copy requests with copyDone so the webview clears Copying status
- also clear copy requests that become stale while row or label reads are awaiting
- add panel-level regressions for both stale-copy paths

Closes #553.

## Validation
- bun test tests/bun/data-viewer-panel-persistence.test.ts
- bun run typecheck (editors/vscode)
- git diff --check
- bun test (unsandboxed; sandboxed run cannot bind localhost port 0 for server tests)