### PR TITLE
fix(data-viewer): ack interactive sort/filter dropped in restore window (#550)

### DIFF
--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -146,6 +146,15 @@ export class DataViewerPanel {
      *  in-flight vs. already-completed cancel paths and makes interactive
      *  setSort/setFilters no-op so a generation bump can't strand it. */
     private restoring = false;
+    /** True once a restore in flight has posted its paint-enabling
+     *  init/replace (so the webview can unblock and fire interactive
+     *  sort/filter) but has not yet cleared {@link restoring} in
+     *  `paintWithRestore`'s `finally`. In that window `handleSetSort` /
+     *  `handleSetFilters` reconcile a dropped interactive request with a
+     *  rollback ack instead of stranding its optimistic pill, whereas a
+     *  pre-paint request is still dropped silently (the imminent paint
+     *  resets the pill). See #550. */
+    private restorePainted = false;
     /** Monotonic id of the active restore (-1 ⇔ none). The
      *  restorePending/cancelRestore handshake key. Kept distinct from
      *  `generation`, which invalidates stale webview messages across reloads
@@ -540,6 +549,13 @@ export class DataViewerPanel {
                 return false;
             }
 
+            // The paint-enabling init/replace is now posted, so the webview can
+            // unblock and fire an interactive sort/filter before this restore's
+            // `finally` clears `restoring`. From here on, handleSetSort/
+            // handleSetFilters reconcile such a request with a rollback ack
+            // rather than dropping it silently and stranding its pill (#550).
+            this.restorePainted = true;
+
             if (cancelledBeforePaint) {
                 // Persist the forget only after the paint, so a store-write
                 // failure cannot strand the webview waiting on a message it
@@ -598,6 +614,7 @@ export class DataViewerPanel {
             // only if a concurrent refresh hasn't swapped in a newer one.
             if (began && this.restoreAbort === myAbort) {
                 this.restoring = false;
+                this.restorePainted = false;
                 this.restoreAbort = null;
             }
         }
@@ -680,6 +697,7 @@ export class DataViewerPanel {
         this.restoreAbort = new AbortController();
         this.restoreId = ++this.restoreSeq;
         this.restoring = true;
+        this.restorePainted = false;
         this.restoreCancelRequested = false;
         // Fire-and-forget so the (potentially long) column reads start at
         // once; ordering before init/replace is preserved by the transport's
@@ -730,6 +748,7 @@ export class DataViewerPanel {
         this.restoreAbort?.abort();
         this.restoreAbort = null;
         this.restoring = false;
+        this.restorePainted = false;
         this.restoreId = -1;
         this.restoreCancelRequested = false;
     }
@@ -1329,7 +1348,28 @@ export class DataViewerPanel {
         // flight: a generation bump here would make the restore discard its
         // result without posting init/replace, stranding the panel. The
         // restore posts authoritative state momentarily.
-        if (this.restoring) return;
+        if (this.restoring) {
+            // Once the restore has painted (init/replace posted) but before its
+            // `finally` clears `restoring`, the webview can unblock and fire
+            // this request. Dropping it silently strands the optimistic
+            // "Sorting…" pill, so roll the webview back to the painted,
+            // authoritative sort instead (rollback ⇒ not re-persisted). A
+            // pre-paint request needs no ack — the imminent paint resets the
+            // pill. See #550.
+            if (this.restorePainted) {
+                const ack: ExtensionToWebview = {
+                    type: 'sortApplied',
+                    panelGeneration: gen,
+                    requestId: m.requestId,
+                    sort: cloneSortState(this.sort),
+                    fromPersistence: false,
+                    rollback: true,
+                };
+                void this.webviewPanel.webview.postMessage(ack)
+                    .then(undefined, () => undefined);
+            }
+            return;
+        }
         // The user is superseding the restored prefs, so the restore
         // handshake is over — a delayed cancelRestore with the old id must
         // not reach the clear-and-forget branch and wipe this.
@@ -1481,8 +1521,28 @@ export class DataViewerPanel {
         gen: number,
     ): Promise<void> {
         // Ignore interactive filter while a restore is in flight (see
-        // handleSetSort), then consume the handshake when superseding.
-        if (this.restoring) return;
+        // handleSetSort), then consume the handshake when superseding. Once the
+        // restore has painted, roll the webview back to the painted filter so a
+        // request fired in the pre-`finally` window clears its "Filtering…"
+        // pill rather than stranding it (rollback ⇒ not re-persisted; #550).
+        if (this.restoring) {
+            if (this.restorePainted) {
+                const ack: ExtensionToWebview = {
+                    type: 'filterApplied',
+                    panelGeneration: gen,
+                    requestId: m.requestId,
+                    filter: cloneFilterState(this.filter),
+                    nrowFiltered: this.filteredIndices
+                        ? this.filteredIndices.length
+                        : this.reader.nrow,
+                    fromPersistence: false,
+                    rollback: true,
+                };
+                void this.webviewPanel.webview.postMessage(ack)
+                    .then(undefined, () => undefined);
+            }
+            return;
+        }
         this.consumeRestoreHandshake();
 
         this.filterGeneration += 1;

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -89,6 +89,7 @@ async function makePanel(opts: {
     panel.histogramAborts = new Set();
     panel.restoreAbort = null;
     panel.restoring = false;
+    panel.restorePainted = false;
     panel.restoreId = -1;
     panel.restoreSeq = 0;
     panel.pendingForgetHashes = new Set();
@@ -646,6 +647,115 @@ describe('sort/filter ignored while restoring', () => {
         expect(posted).toEqual([]);
     });
 
+    it('acks a post-paint sort request as a rollback instead of stranding the pill (#550)', async () => {
+        // After paintWithRestore posts init/replace it sets restorePainted, but
+        // `restoring` stays true until its `finally`. A sort fired in that
+        // window must be reconciled (rolled back to the painted sort) so the
+        // webview's optimistic "Sorting…" pill clears, not dropped silently.
+        const { panel, posted, sortSet } = await makePanel();
+        panel.restoring = true;
+        panel.restorePainted = true;
+        panel.sort = STORED_SORT;
+        panel.permutation = new Uint32Array(5);
+        const genBefore = panel.generation;
+
+        await panel.handleSetSort(
+            { type: 'setSort', panelGeneration: 0, requestId: 7, keys: [{ columnIndex: 1, direction: 'desc' }], labelsOn: true, formatOn: true, digits: 3 },
+            panel.generation,
+        );
+
+        // The interactive request is still declined (no generation/sort change)
+        // but the webview is told to roll back to the painted, authoritative sort.
+        expect(panel.generation).toBe(genBefore);
+        expect(panel.sortGeneration).toBe(0);
+        expect(panel.sort).toEqual(STORED_SORT);
+        expect(posted.length).toBe(1);
+        expect(posted[0]).toMatchObject({
+            type: 'sortApplied', requestId: 7, rollback: true, fromPersistence: false,
+        });
+        expect(posted[0].sort).toEqual(STORED_SORT);
+        // A rollback ack must not persist as a new preference.
+        expect(sortSet).toEqual([]);
+    });
+
+    it('acks a post-paint filter request as a rollback instead of stranding the pill (#550)', async () => {
+        const { panel, posted, filterSet } = await makePanel();
+        panel.restoring = true;
+        panel.restorePainted = true;
+        panel.filter = STORED_FILTER;
+        panel.filteredIndices = new Uint32Array([0, 1, 2]);
+        const genBefore = panel.generation;
+
+        await panel.handleSetFilters(
+            { type: 'setFilters', panelGeneration: 0, requestId: 9, rollbackBaseRequestId: 0, entries: [], labelsOn: true },
+            panel.generation,
+        );
+
+        expect(panel.generation).toBe(genBefore);
+        expect(panel.filterGeneration).toBe(0);
+        expect(panel.filter).toEqual(STORED_FILTER);
+        expect(posted.length).toBe(1);
+        expect(posted[0]).toMatchObject({
+            type: 'filterApplied', requestId: 9, rollback: true, fromPersistence: false,
+        });
+        expect(posted[0].filter).toEqual(STORED_FILTER);
+        expect(posted[0].nrowFiltered).toBe(3);
+        expect(filterSet).toEqual([]);
+    });
+
+    it('still drops a pre-paint sort request silently (restore not yet painted)', async () => {
+        // Before the paint, the imminent init/replace resets the webview's
+        // optimistic pill, so the silent drop is correct (and an ack here would
+        // reference the not-yet-restored in-memory sort).
+        const { panel, posted } = await makePanel();
+        panel.restoring = true;
+        panel.restorePainted = false;
+        const genBefore = panel.generation;
+
+        await panel.handleSetSort(
+            { type: 'setSort', panelGeneration: 0, requestId: 3, keys: [{ columnIndex: 0, direction: 'asc' }], labelsOn: true, formatOn: true, digits: 3 },
+            panel.generation,
+        );
+
+        expect(panel.generation).toBe(genBefore);
+        expect(posted).toEqual([]);
+    });
+
+    it('reconciles an interactive sort fired in the post-paint window (#550)', async () => {
+        // End-to-end through paintWithRestore: the webview unblocks on the
+        // restore's filterApplied and immediately fires an interactive setSort,
+        // which reaches the host while `restoring` is still true.
+        const { panel, posted } = await makePanel({ storedFilter: STORED_FILTER });
+        panel.restoreSort = async () => false;
+        panel.restoreFilter = async () => {
+            panel.filter = STORED_FILTER;
+            panel.filteredIndices = new Uint32Array([0, 1, 2]);
+            return false;
+        };
+        const origPost = panel.webviewPanel.webview.postMessage;
+        let fired = false;
+        panel.webviewPanel.webview.postMessage = (m: any) => {
+            const r = origPost(m);
+            if (!fired && m.type === 'filterApplied') {
+                fired = true;
+                void panel.handleSetSort(
+                    { type: 'setSort', panelGeneration: 0, requestId: 42, keys: [{ columnIndex: 0, direction: 'asc' }], labelsOn: true, formatOn: true, digits: 3 },
+                    panel.generation,
+                );
+            }
+            return r;
+        };
+
+        await panel.sendInit();
+
+        // The stray sort got a rollback ack (its pill clears) rather than silence.
+        const ack = posted.find((m: any) => m.type === 'sortApplied' && m.requestId === 42);
+        expect(ack).toBeDefined();
+        expect(ack.rollback).toBe(true);
+        expect(panel.restoring).toBe(false);
+        expect(panel.restorePainted).toBe(false);
+    });
+
     it('handleSetSort consumes restoreId so a later stale cancel cannot clear it', async () => {
         const { panel, sortSet } = await makePanel();
         panel.restoring = false;
@@ -675,6 +785,21 @@ describe('helpers', () => {
         expect(panel.restoreId).toBe(-1);
         expect(sortSet).toEqual([]);
         expect(filterSet).toEqual([]);
+    });
+
+    it('abortAndClearRestore clears restorePainted alongside restoring (#550)', async () => {
+        // restorePainted is part of the restore-in-flight state; a lifecycle
+        // abort must clear it too so it cannot linger stale into a later send.
+        const { panel } = await makePanel();
+        panel.restoring = true;
+        panel.restorePainted = true;
+        panel.restoreAbort = new AbortController();
+        panel.restoreId = 3;
+        panel.abortAndClearRestore();
+        expect(panel.restoring).toBe(false);
+        expect(panel.restorePainted).toBe(false);
+        expect(panel.restoreAbort).toBeNull();
+        expect(panel.restoreId).toBe(-1);
     });
 
     it('forgetPersistedPrefs clears both stores', async () => {


### PR DESCRIPTION
Resolves #550.

## Problem

In the data-viewer saved sort/filter restore (#519), `handleSetSort` / `handleSetFilters` (`editors/vscode/src/data-viewer/panel.ts`) early-returned `if (this.restoring) return;` and posted **no** status reply. An interactive sort/filter request arriving in the narrow window *after* `init`/`replace` is posted but *before* `paintWithRestore`'s `finally` clears `restoring` was dropped silently. The webview had already set its optimistic `sortPending`/`filterPending = true`, so the dropped request left a stranded **"Sorting…" / "Filtering…"** pill.

The realizable window is the filter-restore case: the webview's interaction block is held until the restore's `filterApplied` (fromPersistence) lands, and the host is still awaiting that same post (so `restoring` is still true) when the webview unblocks and can fire an interactive request.

## Fix

Add a `restorePainted` flag tied to the restore lifecycle:
- `false` in `maybeBeginRestore`,
- `true` immediately after `postPaint`'s post-paint generation recheck succeeds (from here on, the host's in-memory `sort`/`filter` are the authoritative *painted* state),
- cleared in `paintWithRestore`'s `finally` **and** in `abortAndClearRestore` (lifecycle aborts).

When `restoring && restorePainted`, the handlers no longer drop silently — they post a **rollback ack** (`sortApplied`/`filterApplied` with `fromPersistence: false, rollback: true`) carrying the painted authoritative state. The webview already treats `rollback: true` as "update display, do **not** persist", so the optimistic pill clears and the header re-syncs without re-saving a preference. Pre-paint requests (`restorePainted === false`) still drop silently — the imminent paint resets the pill, and acking there would reference not-yet-restored state.

## Why this is safe
- `restorePainted = true` is set in the synchronous continuation right after the `postPaint` await resumes — no message handler can interleave before it, so whenever a handler observes `restorePainted`, `this.sort`/`this.filter` already hold the painted state.
- `rollback: true` suppresses `saveSort`/`saveFilter` in the webview, so no preference is clobbered; the ack's `requestId` echoes the dropped request so `shouldAcceptInteractiveResponse` accepts it.
- Cancel-during-paint / lifecycle-abort paths bump `generation` (the message reaches the host's generation gate first) and/or route through `abortAndClearRestore`, which now also clears `restorePainted`.

## Tests
Adds host-side tests in `tests/bun/data-viewer-panel-restore-cancel.test.ts`: post-paint rollback ack for sort and for filter, the pre-paint silent-drop still holding, an end-to-end reconcile of a sort fired during the `filterApplied` window, and `abortAndClearRestore` clearing `restorePainted`. Full bun suite: 1472 pass / 0 fail; extension `tsc --noEmit` clean.

## Review
Two consecutive clean passes of Codex review + `/code-review` (no actionable findings); the `abortAndClearRestore` reset was added in response to a review observation.

https://claude.ai/code/session_01CEp9hLhV1h4NUU1QUGKK6d