### PR TITLE
fix(data-viewer): close residual save/clear store-layer race on restore-cancel (#552)

### DIFF
--- a/editors/vscode/src/data-viewer/panel.ts
+++ b/editors/vscode/src/data-viewer/panel.ts
@@ -176,6 +176,23 @@ export class DataViewerPanel {
      *  A `Set` (not a single hash) so overlapping forgets for two different
      *  schemas cannot clobber each other's suppression. */
     private readonly pendingForgetHashes = new Set<string>();
+    /** schemaHash → highest panel generation at which that schema's persisted
+     *  sort/filter were forgotten. A `saveSort`/`saveFilter` whose issuing
+     *  `panelGeneration` is below this epoch is a stale pre-forget write and is
+     *  dropped, so a restore-cancel cannot be resurrected by a late or racing
+     *  save (#552). Durable (never deleted) and monotonic — unlike
+     *  {@link pendingForgetHashes}, which is transient and guards the restore
+     *  *read* path during the clear window. The write-path guard moved here
+     *  because the marker could neither suppress a save landing after it was
+     *  deleted nor distinguish a stale save from a fresh post-cancel one.
+     *
+     *  Not pruned: an entry must outlive every late/debounced save for its
+     *  schema, and a save for a no-longer-current schema can still arrive after
+     *  a `replace()`, so pruning on dataset swap could reopen the resurrection
+     *  window. Growth is bounded by the number of distinct schemas the panel
+     *  ever forgets (one small number per schema) — negligible in practice —
+     *  and the whole map is reclaimed when the panel is disposed. */
+    private readonly lastForgetGen = new Map<string, number>();
     /** Active toolbar last shipped to the webview, captured so the late
      *  clear-and-forget can rebuild a `replace` without re-loading the
      *  store. */
@@ -190,6 +207,15 @@ export class DataViewerPanel {
      *  later transform observe a partially-aborted earlier one. Interactive
      *  sort/filter still post their pending status before entering the queue. */
     private transformChain: Promise<void> = Promise.resolve();
+    /** FIFO chain serializing every sort/filter persisted-pref mutation (save
+     *  AND clear). `onDidReceiveMessage` dispatches handlers without awaiting, so
+     *  a `saveSort`/`saveFilter` and a restore-cancel's forget can be in flight
+     *  at once; routing both through one chain makes the {@link lastForgetGen}
+     *  epoch check atomic with the write (no stale save lands after a clear and
+     *  resurrects a cancelled pref) and lets a forget enqueue its clear ahead of
+     *  any fresh post-paint save (#552). Distinct from {@link transformChain}
+     *  (column scans) — store writes must not wait on long column reads. */
+    private prefStoreChain: Promise<void> = Promise.resolve();
     /** Abort controller for the active or queued interactive sort. A newer
      *  sort supersedes it; filters do not, because sort+filter compose. */
     private sortAbort: AbortController | null = null;
@@ -421,20 +447,36 @@ export class DataViewerPanel {
         this.filterSnapshots = new Map([[0, this.currentFilterSnapshot()]]);
     }
 
+    /** Append `fn` to a FIFO promise chain: it runs after the prior op
+     *  regardless of that op's outcome (a rejection on the consumed side is
+     *  swallowed), and the chain tail is replaced with a rejection-isolated
+     *  follow-on so this op's failure cannot stall later callers. `read`/`write`
+     *  access the specific chain field. Shared by {@link enqueue},
+     *  {@link enqueueTransform}, and {@link enqueuePrefMutation}. */
+    private enqueueSerial<T>(
+        read: () => Promise<void>,
+        write: (tail: Promise<void>) => void,
+        fn: () => Promise<T>,
+    ): Promise<T> {
+        const next = read().catch(() => {}).then(fn);
+        write(next.then(() => {}, () => {}));
+        return next;
+    }
+
     // sendInit / sendReplace are serialized through `sendChain` so two
     // restores never overlap. The chain wraps only these public entry
     // points; internal delegation (an uninitialized replace) calls the
     // *impl* directly so it never awaits a job queued behind itself.
     private enqueue<T>(fn: () => Promise<T>): Promise<T> {
-        const next = this.sendChain.catch(() => {}).then(fn);
-        this.sendChain = next.then(() => {}, () => {});
-        return next;
+        return this.enqueueSerial(
+            () => this.sendChain, (tail) => { this.sendChain = tail; }, fn,
+        );
     }
 
     private enqueueTransform<T>(fn: () => Promise<T>): Promise<T> {
-        const next = this.transformChain.catch(() => {}).then(fn);
-        this.transformChain = next.then(() => {}, () => {});
-        return next;
+        return this.enqueueSerial(
+            () => this.transformChain, (tail) => { this.transformChain = tail; }, fn,
+        );
     }
 
     private sendInit(): Promise<boolean> {
@@ -561,6 +603,19 @@ export class DataViewerPanel {
                 // failure cannot strand the webview waiting on a message it
                 // never receives. Guarded so a concurrent reload's re-read
                 // cannot re-restore these prefs mid-clear.
+                //
+                // Unlike clearAndForgetNaturalOrder, this path forgets AFTER the
+                // paint and does NOT bump `generation`, yet it needs no
+                // enqueue-before-paint ordering: no save can race it. A
+                // saveSort/saveFilter at this paint's `generation` requires the
+                // webview to already hold that generation, which it only learns
+                // from THIS paint (it was on the prior generation before).
+                // Pre-paint saves therefore carry an older generation and are
+                // dropped by the epoch; and from this paint until the `finally`
+                // clears `restoring`, an interactive sort/filter is rolled back
+                // (handleSetSort/handleSetFilters, restoring branch), and the
+                // webview never persists a rollback ack (App.tsx). So the forget
+                // here only ever clears a store with no concurrent writer.
                 await this.forgetPersistedPrefsGuarded(layoutHash);
                 // Cancel durably honored; clear the intent so it cannot linger
                 // into a later replace()/reload (which would forget again).
@@ -786,14 +841,70 @@ export class DataViewerPanel {
      *  cannot be persisted (the UI paint is posted first, so a write
      *  failure never strands the webview). */
     private async forgetPersistedPrefs(hash: string): Promise<void> {
-        const clears: Promise<void>[] = [];
-        if (this.settings.persistSort) {
-            clears.push(this.sortStore.clear(this.panelName, hash));
-        }
-        if (this.settings.persistFilters) {
-            clears.push(this.filterStore.clear(this.panelName, hash));
-        }
-        await Promise.allSettled(clears);
+        // Record the forget epoch synchronously, BEFORE enqueuing the clear, so a
+        // racing save's in-chain check (see enqueuePrefMutation) observes it and a
+        // stale pre-forget save cannot resurrect the cancelled pref (#552). The
+        // epoch is the panel's current (post-bump, where a bump applies)
+        // generation; saves issued from the pre-forget view carry a strictly
+        // older generation and are dropped, saves issued after the webview adopts
+        // the post-forget paint carry this generation or newer and are kept.
+        // `Math.max` keeps the entry a non-decreasing high-water mark: `generation`
+        // only ever increases, so this equals `this.generation` today, but the max
+        // makes the epoch independent of call order rather than assuming it.
+        this.lastForgetGen.set(
+            hash,
+            Math.max(this.lastForgetGen.get(hash) ?? -1, this.generation),
+        );
+        await this.enqueuePrefMutation(async () => {
+            const clears: Promise<void>[] = [];
+            if (this.settings.persistSort) {
+                clears.push(this.sortStore.clear(this.panelName, hash));
+            }
+            if (this.settings.persistFilters) {
+                clears.push(this.filterStore.clear(this.panelName, hash));
+            }
+            await Promise.allSettled(clears);
+        });
+    }
+
+    /** Append a sort/filter persisted-pref mutation (save or clear) to
+     *  {@link prefStoreChain}, serializing it against every other such mutation
+     *  so the {@link lastForgetGen} epoch check is atomic with the write (#552). */
+    private enqueuePrefMutation(op: () => Promise<void>): Promise<void> {
+        return this.enqueueSerial(
+            () => this.prefStoreChain, (tail) => { this.prefStoreChain = tail; }, op,
+        );
+    }
+
+    /** Whether a `saveSort`/`saveFilter` is a stale pre-forget write for its
+     *  schema — its issuing `panelGeneration` predates the schema's recorded
+     *  forget epoch ({@link lastForgetGen}). Such a save would resurrect a
+     *  cancelled pref and is dropped; a save at or above the epoch is a fresh
+     *  post-cancel pref and is kept (#552). Single source of truth for the
+     *  comparison so the fast-path and in-chain re-checks cannot drift. */
+    private isStalePreForgetSave(panelGeneration: number, schemaHash: string): boolean {
+        return panelGeneration < (this.lastForgetGen.get(schemaHash) ?? -1);
+    }
+
+    /** Persist (or clear) a sort/filter pref through the serialized chain,
+     *  dropping a stale pre-forget save. Shared by the `saveSort`/`saveFilter`
+     *  handlers; `mutate` performs the store-specific write. The epoch is
+     *  re-checked inside the chained op so the decision is atomic with the
+     *  write — a forget recorded after the fast-path but before this op runs
+     *  still drops it (#552). */
+    private persistPrefMutation(
+        schemaHash: string,
+        panelGeneration: number,
+        enabled: boolean,
+        mutate: () => Promise<void>,
+    ): Promise<void> {
+        // Fast-path drop (the in-chain re-check below is authoritative).
+        if (this.isStalePreForgetSave(panelGeneration, schemaHash)) return Promise.resolve();
+        if (!schemaHash || !enabled) return Promise.resolve();
+        return this.enqueuePrefMutation(async () => {
+            if (this.isStalePreForgetSave(panelGeneration, schemaHash)) return;
+            await mutate();
+        });
     }
 
     /** {@link forgetPersistedPrefs} wrapped in the {@link pendingForgetHashes}
@@ -866,10 +977,27 @@ export class DataViewerPanel {
         // clears completing would otherwise re-read the still-saved prefs and
         // re-restore the cancelled sort/filter. paintWithRestore honors this.
         this.pendingForgetHashes.add(hash);
+        // Enqueue the store clear onto prefStoreChain BEFORE posting the
+        // natural-order paint: a fresh post-cancel save can only be issued once
+        // the webview adopts that paint, so it is necessarily appended to the
+        // chain AFTER this clear and FIFO preserves it (#552). forgetPersistedPrefs
+        // does its synchronous work (record epoch + enqueue) before its first
+        // await, so the clear is in the chain by the time this returns. The clear
+        // is awaited in the `finally` (not here) so the paint is still posted
+        // first — its failure can't strand the webview — while the clear is
+        // always observed and the marker is held until it completes.
+        const cleared = this.forgetPersistedPrefs(hash);
         try {
             await this.postReplaceNaturalOrder(this.generation);
-            await this.forgetPersistedPrefs(hash);
         } finally {
+            // Await the (best-effort) clear here, even if the paint rejected, for
+            // two reasons: it holds the read-path marker until the clear actually
+            // completes so a concurrent re-read can't observe the still-saved
+            // prefs mid-clear, and it observes `cleared` so a paint rejection
+            // can't leave it as an unhandled rejection. `forgetPersistedPrefs`
+            // is allSettled internally, so this never throws; swallow defensively
+            // so the paint's error (if any) still propagates.
+            await cleared.catch(() => undefined);
             // Always release the marker, even if the natural-order post rejects
             // (e.g. a disposed webview): a stuck entry would suppress every
             // future restore for this schema. Deleting only this call's own
@@ -1142,32 +1270,25 @@ export class DataViewerPanel {
                 schemaHash: m.schemaHash,
                 keys: m.sort.keys,
             });
-            // Drop a save whose schema is being durably forgotten: an
-            // interactive saveSort issued before a restore-cancel can otherwise
-            // interleave its store write after the forget's clear and resurrect
-            // the pref the user just cancelled (handle() is not serialized).
-            if (this.pendingForgetHashes.has(m.schemaHash)) return;
-            if (m.schemaHash && this.settings.persistSort) {
-                if (m.sort.keys.length === 0) {
-                    await this.sortStore.clear(this.panelName, m.schemaHash);
-                } else {
-                    await this.sortStore.save(this.panelName, m.schemaHash, m.sort);
-                }
-            }
+            // Persist through the serialized chain, dropping a stale pre-forget
+            // save so an interactive saveSort issued before a restore-cancel
+            // cannot interleave its store write after the forget's clear and
+            // resurrect the cancelled pref (handle() is not serialized — #552).
+            await this.persistPrefMutation(
+                m.schemaHash, m.panelGeneration, this.settings.persistSort,
+                () => m.sort.keys.length === 0
+                    ? this.sortStore.clear(this.panelName, m.schemaHash)
+                    : this.sortStore.save(this.panelName, m.schemaHash, m.sort),
+            );
             return;
         }
         if (m.type === 'saveFilter') {
-            // See saveSort: drop a save for a schema whose prefs are being
-            // durably forgotten so a stale interactive write cannot resurrect
-            // a cancelled filter.
-            if (this.pendingForgetHashes.has(m.schemaHash)) return;
-            if (m.schemaHash && this.settings.persistFilters) {
-                if (m.filter.entries.length === 0) {
-                    await this.filterStore.clear(this.panelName, m.schemaHash);
-                } else {
-                    await this.filterStore.save(this.panelName, m.schemaHash, m.filter);
-                }
-            }
+            await this.persistPrefMutation(
+                m.schemaHash, m.panelGeneration, this.settings.persistFilters,
+                () => m.filter.entries.length === 0
+                    ? this.filterStore.clear(this.panelName, m.schemaHash)
+                    : this.filterStore.save(this.panelName, m.schemaHash, m.filter),
+            );
             return;
         }
         if (m.panelGeneration !== this.generation) {

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -994,11 +994,15 @@ describe('helpers', () => {
         expect(filterSet).toEqual([]);
     });
 
-    it('drops a saveSort with an empty schemaHash (#552 gating)', async () => {
-        const { panel, sortSet } = await makePanel();
+    it('drops a saveSort/saveFilter with an empty schemaHash (#552 gating)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
         await panel.handleInner({
             type: 'saveSort', panelGeneration: 0, schemaHash: '', sort: STORED_SORT,
         });
+        await panel.handleInner({
+            type: 'saveFilter', panelGeneration: 0, schemaHash: '', filter: STORED_FILTER,
+        });
         expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
     });
 });

--- a/tests/bun/data-viewer-panel-restore-cancel.test.ts
+++ b/tests/bun/data-viewer-panel-restore-cancel.test.ts
@@ -93,9 +93,11 @@ async function makePanel(opts: {
     panel.restoreId = -1;
     panel.restoreSeq = 0;
     panel.pendingForgetHashes = new Set();
+    panel.lastForgetGen = new Map();
     panel.lastToolbar = undefined;
     panel.sendChain = Promise.resolve();
     panel.transformChain = Promise.resolve();
+    panel.prefStoreChain = Promise.resolve();
     panel.settings = { persistSort: true, persistFilters: true, defaultDigits: 3 };
     panel.panelName = 'p';
 
@@ -835,19 +837,123 @@ describe('helpers', () => {
         expect(filterSet).toEqual(['cleared']);
     });
 
-    it('drops a saveSort/saveFilter for a schema being forgotten (#548 codex write-race)', async () => {
+    it('forgetPersistedPrefs records the forget epoch at the current generation (#552)', async () => {
+        const { panel } = await makePanel();
+        panel.generation = 3;
+        await panel.forgetPersistedPrefs('h');
+        expect(panel.lastForgetGen.get('h')).toBe(3);
+    });
+
+    it('drops a stale-generation saveSort/saveFilter below the forget epoch (#552)', async () => {
         const { panel, sortSet, filterSet } = await makePanel();
-        // A late clear-and-forget for schema "h" is in flight.
-        panel.pendingForgetHashes.add('h');
+        // A forget for schema "h" was recorded at generation 2; saves issued from
+        // the pre-forget view (generation 1) are stale and must not resurrect it.
+        panel.lastForgetGen.set('h', 2);
         await panel.handleInner({
-            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+            type: 'saveSort', panelGeneration: 1, schemaHash: 'h', sort: STORED_SORT,
         });
         await panel.handleInner({
-            type: 'saveFilter', panelGeneration: 0, schemaHash: 'h', filter: STORED_FILTER,
+            type: 'saveFilter', panelGeneration: 1, schemaHash: 'h', filter: STORED_FILTER,
         });
-        // Stale interactive writes must not resurrect the cancelled prefs.
         expect(sortSet).toEqual([]);
         expect(filterSet).toEqual([]);
+    });
+
+    it('keeps a saveSort at or above the forget epoch (a fresh post-cancel pref, #552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        panel.lastForgetGen.set('h', 1);
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 1, schemaHash: 'h', sort: STORED_SORT,
+        });
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 2, schemaHash: 'h', sort: STORED_SORT,
+        });
+        // >= keeps the same-generation and newer saves.
+        expect(sortSet).toEqual([STORED_SORT, STORED_SORT]);
+    });
+
+    it('serializes an in-flight save ahead of a forget clear so the pref is not resurrected (#552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        // Gate the in-flight save inside the chain so the forget's clear is
+        // enqueued behind it; FIFO must run the save first, then the clear.
+        let release: () => void = () => undefined;
+        const gate = new Promise<void>((r) => { release = r; });
+        const origSave = panel.sortStore.save;
+        panel.sortStore.save = async (p: string, h: string, s: SortState) => {
+            await gate;
+            await origSave(p, h, s);
+        };
+        const savePromise = panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+        });
+        const forgetPromise = panel.forgetPersistedPrefs('h');
+        release();
+        await Promise.all([savePromise, forgetPromise]);
+        // Clear ran last → cancelled pref does not survive.
+        expect(sortSet.at(-1)).toBe('cleared');
+    });
+
+    it('in-chain epoch recheck drops a save when a forget is recorded while it waits in the chain (#552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        // Seed the chain with a gated task so the save cannot start running yet.
+        let release: () => void = () => undefined;
+        const gate = new Promise<void>((r) => { release = r; });
+        panel.prefStoreChain = panel.prefStoreChain.then(() => gate);
+        const savePromise = panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+        });
+        // The fast-path passed (epoch unset); record the forget while the save is
+        // still queued behind the gate, so only the in-chain recheck can catch it.
+        panel.lastForgetGen.set('h', 1);
+        release();
+        await savePromise;
+        expect(sortSet).toEqual([]);
+    });
+
+    it('preserves a fresh save enqueued after a forget clear (clear-before-fresh ordering, #552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        panel.generation = 1;
+        // Forget enqueues its clear first (epoch 1); the fresh save (gen 1) is
+        // enqueued after and must survive.
+        const forgetPromise = panel.forgetPersistedPrefs('h');
+        const savePromise = panel.handleInner({
+            type: 'saveSort', panelGeneration: 1, schemaHash: 'h', sort: STORED_SORT,
+        });
+        await Promise.all([forgetPromise, savePromise]);
+        expect(sortSet.at(-1)).toEqual(STORED_SORT);
+    });
+
+    it('a rejecting save op does not stall a later save (chain tail isolation, #552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        // Schema "A" rejects, "B" succeeds. Keyed by schema (not by reassignment)
+        // so the verdict does not depend on when the deferred chain op runs.
+        panel.sortStore.save = async (_p: string, h: string, s: SortState) => {
+            if (h === 'A') throw new Error('boom');
+            sortSet.push(s);
+        };
+        const p1 = panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'A', sort: STORED_SORT,
+        }).catch(() => undefined);
+        const p2 = panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'B', sort: STORED_SORT,
+        });
+        await Promise.all([p1, p2]);
+        // B's save still ran despite A's rejection (chain tail isolated).
+        expect(sortSet).toEqual([STORED_SORT]);
+    });
+
+    it('clearAndForgetNaturalOrder records the epoch, clears, and a fresh post-cancel save survives (#552)', async () => {
+        const { panel, sortSet } = await makePanel();
+        panel.generation = 0;
+        await panel.clearAndForgetNaturalOrder('h');
+        // Epoch recorded at the bumped (post-cancel) generation.
+        expect(panel.lastForgetGen.get('h')).toBe(1);
+        expect(sortSet).toContain('cleared');
+        // A fresh post-cancel save at the new generation is kept.
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 1, schemaHash: 'h', sort: STORED_SORT,
+        });
+        expect(sortSet.at(-1)).toEqual(STORED_SORT);
     });
 
     it('saves a sort/filter normally when no forget is pending for its schema (control)', async () => {
@@ -860,5 +966,39 @@ describe('helpers', () => {
         });
         expect(sortSet).toEqual([STORED_SORT]);
         expect(filterSet).toEqual([STORED_FILTER]);
+    });
+
+    it('persists an empty saveSort/saveFilter as a clear (#552 persistPrefMutation clear branch)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: EMPTY_SORT,
+        });
+        await panel.handleInner({
+            type: 'saveFilter', panelGeneration: 0, schemaHash: 'h', filter: EMPTY_FILTER,
+        });
+        // Empty keys/entries take the clear branch, not save.
+        expect(sortSet).toEqual(['cleared']);
+        expect(filterSet).toEqual(['cleared']);
+    });
+
+    it('drops a saveSort/saveFilter when its persist-* setting is disabled (#552 gating)', async () => {
+        const { panel, sortSet, filterSet } = await makePanel();
+        panel.settings = { persistSort: false, persistFilters: false, defaultDigits: 3 };
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: 'h', sort: STORED_SORT,
+        });
+        await panel.handleInner({
+            type: 'saveFilter', panelGeneration: 0, schemaHash: 'h', filter: STORED_FILTER,
+        });
+        expect(sortSet).toEqual([]);
+        expect(filterSet).toEqual([]);
+    });
+
+    it('drops a saveSort with an empty schemaHash (#552 gating)', async () => {
+        const { panel, sortSet } = await makePanel();
+        await panel.handleInner({
+            type: 'saveSort', panelGeneration: 0, schemaHash: '', sort: STORED_SORT,
+        });
+        expect(sortSet).toEqual([]);
     });
 });


### PR DESCRIPTION
Resolves #552.

## Problem
A residual sub-millisecond race remained between an in-flight interactive `saveSort`/`saveFilter` and a restore-cancel's `forgetPersistedPrefs`. `onDidReceiveMessage` dispatches handlers without awaiting, so the two store operations could be in flight concurrently. The #548 `pendingForgetHashes.has(schemaHash)` guard and the actual `store.save` were **not atomic**: a save could pass the check, begin `await store.save(...)`, and then land **after** the forget's `store.clear(...)`, resurrecting the cancelled pref on next open.

## Fix
Three cooperating pieces (issue's Option 2 + serialization):

1. **Durable per-schema generation epoch (`lastForgetGen`)** replaces the transient marker on the *write* path. A `saveSort`/`saveFilter` is dropped iff its issuing `panelGeneration` is below the schema's recorded forget epoch (kept iff `>=`). The marker was transient — it could neither suppress a save landing after it was deleted nor distinguish a stale save from a fresh post-cancel one; the durable epoch does both.
2. **FIFO chain (`prefStoreChain`) + in-chain epoch re-check.** Every sort/filter store mutation (saves **and** the forget's clears) flows through one chain (via the shared `enqueueSerial` helper now also backing `sendChain`/`transformChain`), and the epoch is re-checked inside the chained save op so the decision is atomic with the write.
3. **Clear enqueued before the natural-order paint** in `clearAndForgetNaturalOrder`: a fresh post-cancel save can only be issued once the webview adopts that paint, so it is necessarily appended after the clear and FIFO preserves it — no causality/timing assumption, no conditional-clear bookkeeping.

The restore **read** path keeps the `pendingForgetHashes` marker (a distinct concern, unchanged). No user-visible behavior change — internal concurrency hardening.

## Process
Specced and put through four rounds of adversarial review by Codex before implementing (the design converged from marker→epoch→epoch+FIFO+conditional-clear→epoch+FIFO+enqueue-before-paint as each round surfaced a flaw). Implemented test-first. Post-implementation, Codex review and `/code-review` (8→5→3 finder angles + verification) came back clean for two consecutive rounds.

## Tests
Added to `tests/bun/data-viewer-panel-restore-cancel.test.ts`: in-flight save-vs-clear ordering, in-chain epoch recheck (gated via a preceding chain task), clear-before-fresh ordering, durable stale-save drop, fresh-save kept (`>=` boundary), `clearAndForgetNaturalOrder` epoch recording, chain tail isolation, empty→clear branch, and persist-*/empty-schemaHash gating. All 496 data-viewer bun tests pass; `tsc --noEmit` clean. TypeScript-only (no Rust gates apply).

https://claude.ai/code/session_01H9yyv2uJ6dJfqSdzd4u2fF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where canceled sort/filter preferences could reappear due to racing updates.
  * Improved save and clear handling so preference changes are applied in the correct order, even during restore/cancel flows.
  * Prevented one failed queued update from blocking later preference changes.
  * Ensured empty sort/filter updates are treated as clears, and ignored when preference persistence is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->