### PR TITLE
fix(cross-file): persist chunk classification across close; classify .Rmarkdown

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -2617,7 +2617,9 @@ pub(crate) fn sysdata_r_fallback_needed(state: &WorldState) -> bool {
 
 /// Remove a file that no longer exists on disk from every cross-file
 /// structure: the dependency graph (all edges in both directions), the
-/// disk-content cache, both workspace indexes, and the metadata cache.
+/// disk-content cache, both workspace indexes, the metadata cache, and the
+/// persisted editor-derived chunk-kind override for extension-mismatched
+/// Rmd/Quarto files.
 ///
 /// Returns the affected open dependents, computed from the **pre-removal**
 /// graph via `compute_affected_dependents_after_edit` — the removal itself
@@ -2650,6 +2652,7 @@ fn remove_file_from_cross_file_state(state: &mut WorldState, uri: &Url) -> Vec<U
     state.cross_file_file_cache.invalidate(uri);
     state.cross_file_workspace_index.invalidate(uri);
     state.cross_file_meta.remove(uri);
+    state.prune_editor_chunk_kind_override(uri);
     // Prune the per-URI coalescing entry with the rest of the closed-file
     // state. A delayed retry that captured an older generation treats the
     // missing entry as a mismatch; if the URI is later recreated, its new
@@ -2960,12 +2963,12 @@ async fn resync_missing_file(
 /// (chunk bodies only, never prose); the file cache stores the RAW content —
 /// its readers mask on read. `chunk_kind` preserves the closing document's
 /// editor-language classification: a file-backed document without an
-/// `.Rmd`/`.qmd` extension opened with `languageId: rmd` was chunk-masked
-/// while open, and path-only reclassification here would parse the same disk
-/// text as plain R and mint prose `source()` edges. The close path passes
-/// the tracked `Document`'s `chunk_kind`; the watched-files path passes
-/// `None` (no editor signal exists for an external disk event) and falls
-/// back to path classification.
+/// Rmd/Quarto extension opened with `languageId: rmd` was chunk-masked while
+/// open, and path-only reclassification here would parse the same disk text as
+/// plain R and mint prose `source()` edges. The close path passes the tracked
+/// `Document`'s `chunk_kind`; the watched-files path passes `None`, which
+/// consults `WorldState`'s persisted editor-derived chunk-kind override before
+/// falling back to path classification.
 ///
 /// `undecodable_as_missing` splits `SourceReadError::InvalidEncoding`
 /// handling by caller: the close path passes `true` (the user closed a file
@@ -2997,6 +3000,7 @@ async fn resync_file_from_disk(
     // skip the disk read and parse entirely. Purely an optimization for
     // close-then-reopen and watched-event-races-open bursts — the commit-time
     // veto below remains the correctness gate.
+    let effective_chunk_kind;
     {
         let state = state_arc.read().await;
         if state.documents.contains_key(uri) {
@@ -3010,6 +3014,7 @@ async fn resync_file_from_disk(
             );
             return ResyncOutcome::Skipped;
         }
+        effective_chunk_kind = chunk_kind.unwrap_or_else(|| state.chunk_kind_for_closed_file(uri));
     }
 
     let content = match crate::state::read_source_async(&path).await {
@@ -3047,10 +3052,7 @@ async fn resync_file_from_disk(
     // Mask Rmd/Quarto prose so directives/source()/library() come from chunk
     // bodies only (#343), then parse ONCE and derive both metadata and
     // artifacts from the same tree.
-    let analysis = match chunk_kind {
-        Some(kind) => crate::cross_file::analysis_text_for_kind(kind, &content),
-        None => crate::cross_file::analysis_text_for_path(uri.path(), &content),
-    };
+    let analysis = crate::cross_file::analysis_text_for_kind(effective_chunk_kind, &content);
     let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis.as_ref(), None));
     let mut cross_file_meta =
         crate::cross_file::extract_metadata_with_tree(&analysis, tree.as_ref());
@@ -3146,11 +3148,10 @@ async fn resync_file_from_disk(
     // files and nothing repopulates it outside the scan / on-demand
     // indexing. Mirrors the on-demand insert (including its empty
     // `loaded_packages` precedent); raw contents + analysis-tree pair is the
-    // scan's own convention (masking is geometry-preserving). Known residual
-    // (issue #563): the entry does not persist `chunk_kind`, so for an
-    // extension-mismatched Rmd document (languageId-classified) tree
-    // consumers that reconstruct analysis text by path pair this masked
-    // tree with raw text.
+    // scan's own convention (masking is geometry-preserving). State-aware
+    // readers that reconstruct the analysis text from RAW contents consult
+    // `WorldState::chunk_kind_for_closed_file`, so a persisted editor-language
+    // classification keeps this tree/text pair aligned after close (#563).
     let fresh_entry = crate::workspace_index::IndexEntry {
         contents: ropey::Rope::from_str(&content),
         tree,
@@ -5263,7 +5264,7 @@ impl LanguageServer for Backend {
             // For Rmd/Quarto docs this masks the prose first so the graph,
             // DocumentStore, and on-demand indexing see only chunk-body
             // source()/library() calls and directives (#343). Classify by
-            // languageId-then-URI so untitled `.Rmd`/`.qmd` buffers (no file
+            // languageId-then-URI so untitled Rmd/Quarto buffers (no file
             // extension) are masked too — and reuse the same `chunk_kind` for
             // the DocumentStore open below so its tree/artifacts agree.
             let (chunk_kind, analysis_text) =
@@ -5296,7 +5297,7 @@ impl LanguageServer for Backend {
 
             // Update new DocumentStore with enriched metadata (Requirement 1.3).
             // `chunk_kind` was classified above by languageId-then-URI so
-            // untitled `.Rmd`/`.qmd` buffers mask their tree/artifacts (#343).
+            // untitled Rmd/Quarto buffers mask their tree/artifacts (#343).
             state
                 .document_store
                 .open_with_metadata(uri.clone(), &text, version, chunk_kind, meta.clone())
@@ -6753,7 +6754,7 @@ impl LanguageServer for Backend {
         // block below), not the URI extension: that is what fed the buffer's
         // edges into the graph in the first place, and it covers
         // extension-less R documents like `.Rprofile` as well as `.R` and
-        // `.Rmd`/`.qmd`. Non-`file:` URIs (untitled buffers) have no disk
+        // Rmd/Quarto extensions. Non-`file:` URIs (untitled buffers) have no disk
         // truth to converge to.
         let has_disk_path = uri.to_file_path().is_ok();
         let close_resync;
@@ -6793,6 +6794,9 @@ impl LanguageServer for Backend {
                 // the pre-commit graph — the buffer-derived edges stay in
                 // place until that resync's own commit replaces them.)
                 resync_chunk_kind = state.documents.get(uri).map(|doc| doc.chunk_kind);
+                if let Some(kind) = resync_chunk_kind {
+                    state.record_editor_chunk_kind_override(uri, kind);
+                }
             }
 
             // Close in new DocumentStore (Requirement 1.5)
@@ -7295,7 +7299,7 @@ impl LanguageServer for Backend {
                 }
 
                 // Rmd/Quarto files flow through like plain R since #558:
-                // `resync_file_from_disk` masks path-classified `.Rmd`/`.qmd`
+                // `resync_file_from_disk` masks path-classified Rmd/Quarto
                 // content (chunk bodies only, never prose — the pollution the
                 // old skip guarded against), and the close resync now
                 // installs graph/index state for closed Rmd documents that a
@@ -8522,8 +8526,11 @@ impl Backend {
         // `.Rmd` reached via a backward directive contributes chunk-defined
         // symbols and chunk library()/source() calls — not prose. The cached
         // content and `IndexEntry.contents` below stay RAW (see those sites).
-        let analysis_text_cow =
-            crate::cross_file::analysis_text_for_path(file_uri.path(), &content);
+        let chunk_kind = {
+            let state = self.state.read().await;
+            state.chunk_kind_for_closed_file(file_uri)
+        };
+        let analysis_text_cow = crate::cross_file::analysis_text_for_kind(chunk_kind, &content);
         let analysis_text: &str = &analysis_text_cow;
         let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis_text, None));
         let mut cross_file_meta =
@@ -8918,8 +8925,11 @@ impl Backend {
 
         // Analysis text: masked for Rmd/Quarto (chunk bodies only), raw
         // otherwise (#343). Cached content / `IndexEntry.contents` stay RAW.
-        let analysis_text_cow =
-            crate::cross_file::analysis_text_for_path(file_uri.path(), &content);
+        let chunk_kind = {
+            let state = self.state.read().await;
+            state.chunk_kind_for_closed_file(file_uri)
+        };
+        let analysis_text_cow = crate::cross_file::analysis_text_for_kind(chunk_kind, &content);
         let analysis_text: &str = &analysis_text_cow;
         let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis_text, None));
         let mut cross_file_meta =
@@ -18086,7 +18096,7 @@ mod project_config_initialize_tests {
 
     /// The close resync masks disk content with the closing document's
     /// editor-language classification, not the path: a file-backed document
-    /// WITHOUT an `.Rmd`/`.qmd` extension opened as `languageId: rmd` is
+    /// WITHOUT an Rmd/Quarto extension opened as `languageId: rmd` is
     /// chunk-masked while open, and the resync must not reclassify the same
     /// disk text as plain R (which would mint prose `source()` edges).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -18096,8 +18106,8 @@ mod project_config_initialize_tests {
         // Both decoy targets exist, so an unmasked (plain-R) parse of the
         // prose line would resolve a real edge.
         fs::write(tmp.path().join("prose_decoy.R"), "d <- 1\n").unwrap();
-        // `.Rmarkdown` is NOT matched by the path classifier (only .rmd/.qmd),
-        // so only the languageId can classify this document as R Markdown.
+        // `.md` is not matched by the path classifier, so only the languageId
+        // can classify this document as R Markdown.
         let content = concat!(
             "# Report\n",
             "\n",
@@ -18107,8 +18117,8 @@ mod project_config_initialize_tests {
             "source(\"helpers.R\")\n",
             "```\n",
         );
-        fs::write(tmp.path().join("report.Rmarkdown"), content).unwrap();
-        let (svc, report_uri) = open_in_workspace(&tmp, "report.Rmarkdown", "rmd", content).await;
+        fs::write(tmp.path().join("report.md"), content).unwrap();
+        let (svc, report_uri) = open_in_workspace(&tmp, "report.md", "rmd", content).await;
         let backend = svc.inner();
         let helpers_uri = Url::from_file_path(tmp.path().join("helpers.R")).unwrap();
         let decoy_uri = Url::from_file_path(tmp.path().join("prose_decoy.R")).unwrap();
@@ -18149,6 +18159,271 @@ mod project_config_initialize_tests {
         assert!(
             !deps.iter().any(|e| e.to == decoy_uri),
             "the resync must keep the editor-language chunk masking — prose must never become an edge"
+        );
+    }
+
+    /// Issue #563: a watched CHANGED after closing an extension-mismatched Rmd
+    /// keeps using the persisted editor-language chunk kind. Without the
+    /// override, the watched path passes `chunk_kind: None`, reclassifies this
+    /// `.md` as plain R, and prose `source()` / `# raven: source` entries become
+    /// graph edges.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn issue563_watched_change_after_closing_extension_mismatched_rmd_preserves_masking() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("helpers.R"), "helper_fn <- function() 1\n").unwrap();
+        fs::write(tmp.path().join("extra.R"), "extra_fn <- function() 2\n").unwrap();
+        fs::write(tmp.path().join("prose_call.R"), "call_decoy <- 1\n").unwrap();
+        fs::write(
+            tmp.path().join("prose_directive.R"),
+            "directive_decoy <- 1\n",
+        )
+        .unwrap();
+        let report_v1 = concat!(
+            "# Report\n",
+            "\n",
+            "# raven: source prose_directive.R\n",
+            "source(\"prose_call.R\")\n",
+            "\n",
+            "```{r}\n",
+            "source(\"helpers.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("report.md"), report_v1).unwrap();
+        let (svc, report_uri) = open_in_workspace(&tmp, "report.md", "rmd", report_v1).await;
+        let backend = svc.inner();
+        let helpers_uri = Url::from_file_path(tmp.path().join("helpers.R")).unwrap();
+        let extra_uri = Url::from_file_path(tmp.path().join("extra.R")).unwrap();
+        let prose_call_uri = Url::from_file_path(tmp.path().join("prose_call.R")).unwrap();
+        let prose_directive_uri =
+            Url::from_file_path(tmp.path().join("prose_directive.R")).unwrap();
+
+        close_doc(backend, &report_uri).await;
+        let closed_resync_installed = wait_for_state(backend, 5_000, |state| {
+            state.editor_chunk_kind_overrides.get(&report_uri).copied()
+                == Some(crate::chunks::ChunkKind::Rmd)
+                && state
+                    .cross_file_workspace_index
+                    .get_metadata(&report_uri)
+                    .is_some()
+                && state
+                    .cross_file_graph
+                    .get_dependencies(&report_uri)
+                    .iter()
+                    .any(|e| e.to == helpers_uri)
+        })
+        .await;
+        assert!(
+            closed_resync_installed,
+            "close must persist the editor chunk kind and install disk-derived state"
+        );
+
+        let report_v2 = concat!(
+            "# Report\n",
+            "\n",
+            "# raven: source prose_directive.R\n",
+            "source(\"prose_call.R\")\n",
+            "\n",
+            "```{r}\n",
+            "source(\"extra.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("report.md"), report_v2).unwrap();
+        send_watched_change(backend, &report_uri).await;
+
+        let updated = wait_for_state(backend, 5_000, |state| {
+            let deps = state.cross_file_graph.get_dependencies(&report_uri);
+            deps.iter().any(|e| e.to == extra_uri) && !deps.iter().any(|e| e.to == helpers_uri)
+        })
+        .await;
+        assert!(
+            updated,
+            "watched CHANGED must update the chunk edge for the closed mismatched Rmd"
+        );
+
+        let state = backend.state.read().await;
+        let deps = state.cross_file_graph.get_dependencies(&report_uri);
+        assert!(
+            !deps.iter().any(|e| e.to == prose_call_uri),
+            "prose source() must remain masked after watched resync"
+        );
+        assert!(
+            !deps.iter().any(|e| e.to == prose_directive_uri),
+            "prose # raven: source must remain masked after watched resync"
+        );
+    }
+
+    /// Issue #563: after the index entries for a closed extension-mismatched
+    /// Rmd are evicted, `get_enriched_metadata` falls back to the raw file
+    /// cache. That fallback must consult the persisted editor-language chunk
+    /// kind before path classification.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn issue563_get_enriched_metadata_file_cache_fallback_uses_persisted_chunk_kind() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("helpers.R"), "helper_fn <- function() 1\n").unwrap();
+        fs::write(tmp.path().join("prose_call.R"), "call_decoy <- 1\n").unwrap();
+        fs::write(
+            tmp.path().join("prose_directive.R"),
+            "directive_decoy <- 1\n",
+        )
+        .unwrap();
+        let report = concat!(
+            "# Report\n",
+            "\n",
+            "# raven: source prose_directive.R\n",
+            "source(\"prose_call.R\")\n",
+            "\n",
+            "```{r}\n",
+            "source(\"helpers.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("report.md"), report).unwrap();
+        let (svc, report_uri) = open_in_workspace(&tmp, "report.md", "rmd", report).await;
+        let backend = svc.inner();
+
+        close_doc(backend, &report_uri).await;
+        let cached = wait_for_state(backend, 5_000, |state| {
+            state.cross_file_file_cache.get(&report_uri).as_deref() == Some(report)
+                && state.editor_chunk_kind_overrides.get(&report_uri).copied()
+                    == Some(crate::chunks::ChunkKind::Rmd)
+        })
+        .await;
+        assert!(
+            cached,
+            "close resync must leave raw file-cache content and a chunk-kind override"
+        );
+
+        {
+            let state = backend.state.write().await;
+            state.workspace_index_new.invalidate(&report_uri);
+            state.cross_file_workspace_index.invalidate(&report_uri);
+        }
+
+        let state = backend.state.read().await;
+        let meta = state
+            .get_enriched_metadata(&report_uri)
+            .expect("file-cache fallback metadata must be available");
+        let source_paths: Vec<&str> = meta.sources.iter().map(|s| s.path.as_str()).collect();
+        assert_eq!(
+            source_paths,
+            vec!["helpers.R"],
+            "file-cache fallback must extract metadata from chunks only"
+        );
+    }
+
+    /// `.Rmarkdown` is a knitr-supported R Markdown extension and should be
+    /// path-classified as Rmd even with no editor language signal. A direct disk
+    /// resync is enough to prove the closed-file path masks prose before
+    /// extracting graph edges.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn issue563_rmarkdown_extension_path_classified_resync_masks_prose_without_editor_signal()
+    {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("main.R"), "x <- 1\n").unwrap();
+        fs::write(tmp.path().join("helpers.R"), "helper_fn <- function() 1\n").unwrap();
+        fs::write(tmp.path().join("prose_call.R"), "call_decoy <- 1\n").unwrap();
+        let report = concat!(
+            "# Report\n",
+            "\n",
+            "source(\"prose_call.R\")\n",
+            "\n",
+            "```{r}\n",
+            "source(\"helpers.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("report.Rmarkdown"), report).unwrap();
+        let (svc, _main_uri) = open_in_workspace(&tmp, "main.R", "r", "x <- 1\n").await;
+        let backend = svc.inner();
+        let report_uri = Url::from_file_path(tmp.path().join("report.Rmarkdown")).unwrap();
+        let helpers_uri = Url::from_file_path(tmp.path().join("helpers.R")).unwrap();
+        let prose_call_uri = Url::from_file_path(tmp.path().join("prose_call.R")).unwrap();
+
+        let outcome =
+            resync_file_from_disk(&backend.state, &report_uri, None, None, true, None).await;
+        assert!(
+            matches!(outcome, ResyncOutcome::Updated { .. }),
+            ".Rmarkdown disk resync must commit without an editor language signal"
+        );
+
+        let state = backend.state.read().await;
+        assert!(
+            !state.editor_chunk_kind_overrides.contains_key(&report_uri),
+            "path-classified .Rmarkdown files do not need an editor override"
+        );
+        let deps = state.cross_file_graph.get_dependencies(&report_uri);
+        assert!(
+            deps.iter().any(|e| e.to == helpers_uri),
+            "chunk source() must produce an edge for path-classified .Rmarkdown"
+        );
+        assert!(
+            !deps.iter().any(|e| e.to == prose_call_uri),
+            "prose source() must be masked for path-classified .Rmarkdown"
+        );
+    }
+
+    /// Issue #563: removing a file's closed cross-file state also drops the
+    /// persisted editor-language chunk-kind override. Recreating the same path
+    /// later should not inherit an old language classification until the editor
+    /// opens it again.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn issue563_deleting_extension_mismatched_rmd_prunes_persisted_chunk_kind() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("helpers.R"), "helper_fn <- function() 1\n").unwrap();
+        let report = concat!(
+            "# Report\n",
+            "\n",
+            "```{r}\n",
+            "source(\"helpers.R\")\n",
+            "```\n",
+        );
+        fs::write(tmp.path().join("report.md"), report).unwrap();
+        let (svc, report_uri) = open_in_workspace(&tmp, "report.md", "rmd", report).await;
+        let backend = svc.inner();
+
+        close_doc(backend, &report_uri).await;
+        let persisted = wait_for_state(backend, 5_000, |state| {
+            state.editor_chunk_kind_overrides.get(&report_uri).copied()
+                == Some(crate::chunks::ChunkKind::Rmd)
+                && state
+                    .cross_file_workspace_index
+                    .get_metadata(&report_uri)
+                    .is_some()
+        })
+        .await;
+        assert!(
+            persisted,
+            "close must persist the editor-derived chunk kind before deletion"
+        );
+
+        fs::remove_file(tmp.path().join("report.md")).unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: report_uri.clone(),
+                    typ: FileChangeType::DELETED,
+                }],
+            })
+            .await;
+
+        let state = backend.state.read().await;
+        assert!(
+            !state.editor_chunk_kind_overrides.contains_key(&report_uri),
+            "deletion convergence must prune the persisted chunk kind"
+        );
+        assert!(
+            state
+                .cross_file_graph
+                .get_dependencies(&report_uri)
+                .is_empty(),
+            "deletion convergence must remove graph state too"
+        );
+        assert!(
+            state
+                .cross_file_workspace_index
+                .get_metadata(&report_uri)
+                .is_none(),
+            "deletion convergence must remove workspace-index metadata"
         );
     }
 

--- a/crates/raven/src/chunks.rs
+++ b/crates/raven/src/chunks.rs
@@ -86,7 +86,7 @@ fn section_divider_re() -> &'static Regex {
 /// [`ChunkKind::R`] for unknown extensions so behavior is predictable.
 pub fn classify_chunk_document(path_or_uri: &str) -> ChunkKind {
     let lower = path_or_uri.to_ascii_lowercase();
-    if lower.ends_with(".rmd") || lower.ends_with(".qmd") {
+    if lower.ends_with(".rmd") || lower.ends_with(".rmarkdown") || lower.ends_with(".qmd") {
         ChunkKind::Rmd
     } else {
         ChunkKind::R
@@ -907,6 +907,14 @@ mod tests {
     #[test]
     fn classifies_rmd_qmd_extensions() {
         assert_eq!(classify_chunk_document("/tmp/foo.Rmd"), ChunkKind::Rmd);
+        assert_eq!(
+            classify_chunk_document("/tmp/foo.Rmarkdown"),
+            ChunkKind::Rmd
+        );
+        assert_eq!(
+            classify_chunk_document("/tmp/foo.RMARKDOWN"),
+            ChunkKind::Rmd
+        );
         assert_eq!(classify_chunk_document("/tmp/foo.qmd"), ChunkKind::Rmd);
         assert_eq!(classify_chunk_document("/tmp/foo.QMD"), ChunkKind::Rmd);
         assert_eq!(classify_chunk_document("/tmp/foo.R"), ChunkKind::R);

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -68,8 +68,8 @@ pub fn extract_metadata(content: &str) -> CrossFileMetadata {
 
 /// The R-analysis view of `content` for the file identified by `path_or_uri`:
 /// the geometry-preserving [`crate::chunks::mask_to_r`] mask for R Markdown /
-/// Quarto documents (`.Rmd` / `.qmd`), and the raw `content` borrowed
-/// unchanged for everything else.
+/// Quarto documents (`.Rmd` / `.Rmarkdown` / `.qmd`), and the raw `content`
+/// borrowed unchanged for everything else.
 ///
 /// This is the single place that pairs path-based classification with masking
 /// for closed-file / on-demand-indexing call sites that only have a path and a
@@ -144,6 +144,24 @@ pub(crate) fn classify_and_mask<'a>(
     (chunk_kind, analysis_text)
 }
 
+/// Extract cross-file metadata from `content` using an already-resolved chunk
+/// kind, masking R Markdown / Quarto prose first so directives, `source()`
+/// calls, and `library()` calls are taken from R chunk bodies only (never from
+/// prose or YAML front matter).
+///
+/// For non-Rmd files this is identical to [`extract_metadata`]. Use this at any
+/// site that extracts metadata from a file's *raw* content when the caller has
+/// a live or persisted editor-language classification. That classification must
+/// outrank path classification for extension-mismatched Rmd/Quarto files
+/// (issue #563).
+pub fn extract_metadata_for_kind(
+    chunk_kind: crate::chunks::ChunkKind,
+    content: &str,
+) -> CrossFileMetadata {
+    let analysis = analysis_text_for_kind(chunk_kind, content);
+    extract_metadata(&analysis)
+}
+
 /// Extract cross-file metadata from `content`, masking R Markdown / Quarto
 /// prose first so directives, `source()` calls, and `library()` calls are
 /// taken from R chunk bodies only (never from prose or YAML front matter).
@@ -151,11 +169,14 @@ pub(crate) fn classify_and_mask<'a>(
 /// For non-Rmd files this is identical to [`extract_metadata`]. Use this at any
 /// site that extracts metadata from a path-identified file's *raw* content
 /// (file-cache fallbacks, on-demand indexing, legacy-document arms) so that
-/// `.Rmd` / `.qmd` files contribute outgoing edges from their chunks rather
-/// than spurious prose-derived ones (issue #343).
+/// `.Rmd` / `.Rmarkdown` / `.qmd` files contribute outgoing edges from their
+/// chunks rather than spurious prose-derived ones (issue #343). State-aware
+/// closed-file callers should prefer
+/// [`WorldState::extract_metadata_for_uri`](crate::state::WorldState::extract_metadata_for_uri)
+/// so persisted editor-language chunk classification can outrank the path
+/// (issue #563).
 pub fn extract_metadata_for_path(path_or_uri: &str, content: &str) -> CrossFileMetadata {
-    let analysis = analysis_text_for_path(path_or_uri, content);
-    extract_metadata(&analysis)
+    extract_metadata_for_kind(crate::chunks::classify_chunk_document(path_or_uri), content)
 }
 
 /// Extract cross-file metadata using a pre-parsed tree when available.

--- a/crates/raven/src/document_store.rs
+++ b/crates/raven/src/document_store.rs
@@ -84,7 +84,8 @@ pub struct DocumentStoreMetrics {
 /// # Raw content vs. analysis text (Rmd/Quarto invariant)
 ///
 /// Like [`crate::state::Document`], an open `DocumentState` keeps two views of
-/// its content distinct for R Markdown / Quarto (`.Rmd` / `.qmd`) documents:
+/// its content distinct for R Markdown / Quarto (`.Rmd` / `.Rmarkdown` /
+/// `.qmd`) documents:
 ///
 /// * [`contents`](DocumentState::contents) is **always** the verbatim raw
 ///   document — `ContentProvider::get_content` returns it unchanged, so raw
@@ -108,7 +109,7 @@ pub struct DocumentStoreMetrics {
 /// Whether a document is masked is fixed by its
 /// [`chunk_kind`](DocumentState::chunk_kind), determined at open time from the
 /// editor's `languageId`-then-URI classification — **not** re-derived by path.
-/// Untitled `.Rmd`/`.qmd` buffers (`untitled:Untitled-1`, languageId
+/// Untitled Rmd/Quarto buffers (`untitled:Untitled-1`, languageId
 /// `"rmd"`/`"quarto"`) have no file extension, so re-classifying by path alone
 /// would parse them RAW and leak prose into find-references / workspace-symbol
 /// (#343). Saved `.Rmd` files classify identically either way.
@@ -337,9 +338,12 @@ impl DocumentStore {
         self.mark_update_started(&uri);
         // Parse content. `contents` keeps the RAW source; tree/metadata/
         // artifacts derive from the masked analysis text for Rmd/Quarto (#343).
-        // No `languageId` here, so classify by path — this entry point is for
-        // callers (tests, internal) that always have a real file extension;
-        // the LSP path uses `open_with_metadata` with the editor's languageId.
+        // No `languageId` or `WorldState` override map here, so classify by
+        // path — this entry point is for callers (tests, internal) that always
+        // have a real file extension; the LSP path uses `open_with_metadata`
+        // with the editor's languageId. State-aware closed-file fallbacks use
+        // `WorldState::extract_metadata_for_uri` instead, so extension-mismatch
+        // overrides do not belong in this store-local API.
         let chunk_kind = crate::chunks::classify_chunk_document(uri.path());
         let contents = Rope::from_str(content);
         let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(
@@ -416,7 +420,7 @@ impl DocumentStore {
     /// [`chunks::classify_chunk_document_for`](crate::chunks::classify_chunk_document_for)
     /// on the `did_open` `languageId`-then-URI) rather than re-classifying by
     /// path. This is the LSP open path; it is the only place that can mask
-    /// untitled `.Rmd`/`.qmd` buffers correctly (#343). Use this when metadata
+    /// untitled Rmd/Quarto buffers correctly (#343). Use this when metadata
     /// has been enriched with inherited_working_directory.
     pub async fn open_with_metadata(
         &mut self,
@@ -514,8 +518,9 @@ impl DocumentStore {
             // Rmd/Quarto (#343). The chunk kind is fixed at open and preserved
             // here — a document's language never changes mid-session — so an
             // untitled Rmd buffer keeps masking across edits. Path-based
-            // metadata extraction is acceptable for plain R; for Rmd the
-            // `update_with_metadata` variant supplies masked-derived metadata.
+            // metadata extraction is acceptable for this store-local fallback;
+            // the LSP path uses `update_with_metadata`, whose caller supplies
+            // masked-derived metadata from the live document's analysis text.
             let chunk_kind = state.chunk_kind;
             let content = state.contents.to_string();
             let metadata = Arc::new(crate::cross_file::extract_metadata_for_path(

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -21966,7 +21966,7 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
     // Pair the DocumentStore tree with its analysis text (masked for Rmd/Quarto,
     // raw otherwise) — never `get_content` (which is RAW): the tree's byte
     // offsets index into the masked text, so slicing raw content mis-slices
-    // (and can panic on a non-UTF-8 boundary) for `.Rmd`/`.qmd` files (#343).
+    // (and can panic on a non-UTF-8 boundary) for Rmd/Quarto files (#343).
     for file_uri in state.document_store.uris() {
         if &file_uri == uri {
             continue; // Already searched
@@ -21995,7 +21995,7 @@ pub fn references(state: &WorldState, uri: &Url, position: Position) -> Option<V
         }
         if let Some(tree) = &entry.tree {
             let raw = entry.contents.to_string();
-            let file_text = crate::cross_file::analysis_text_for_path(file_uri.path(), &raw);
+            let file_text = state.analysis_text_for_uri(&file_uri, &raw);
             find_references_in_tree(
                 tree.root_node(),
                 name,

--- a/crates/raven/src/parameter_resolver.rs
+++ b/crates/raven/src/parameter_resolver.rs
@@ -401,7 +401,7 @@ pub(crate) fn get_text_and_tree(
     // 1. Enriched open documents (authoritative for open files). Return the
     //    analysis text (masked for Rmd/Quarto, raw otherwise) so the caller's
     //    byte-offset slices into `tree` align — `contents` is RAW and would
-    //    mis-slice (or panic on a non-UTF-8 boundary) for `.Rmd`/`.qmd` (#343).
+    //    mis-slice (or panic on a non-UTF-8 boundary) for Rmd/Quarto docs (#343).
     if let Some(doc) = state.document_store.get_without_touch(uri) {
         if let Some(tree) = &doc.tree {
             return Some((doc.analysis_text(), tree.clone()));
@@ -428,7 +428,7 @@ pub(crate) fn get_text_and_tree(
     if let Some(entry) = state.workspace_index_new.get(uri) {
         if let Some(tree) = &entry.tree {
             let raw = entry.contents.to_string();
-            let text = crate::cross_file::analysis_text_for_path(uri.path(), &raw).into_owned();
+            let text = state.analysis_text_for_uri(uri, &raw).into_owned();
             return Some((text, tree.clone()));
         } else {
             log::debug!(
@@ -453,7 +453,7 @@ pub(crate) fn get_text_and_tree(
     //    rather than failing closed, and the (text, tree) pair stays aligned
     //    (raw == analysis for plain R, so this is behavior-neutral there) (#343).
     if let Some(content) = state.cross_file_file_cache.get(uri) {
-        let analysis = crate::cross_file::analysis_text_for_path(uri.path(), &content).into_owned();
+        let analysis = state.analysis_text_for_uri(uri, &content).into_owned();
         if let Some(tree) = crate::parser_pool::with_parser(|p| p.parse(&analysis, None)) {
             return Some((analysis, tree));
         } else {

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -187,9 +187,10 @@ pub struct Document {
     /// `loaded_packages`. Distinct field because the attachment semantics differ.
     pub data_packages: Vec<String>,
     pub file_type: FileType,
-    /// Chunk-detection kind for the outline: `Rmd` for `.Rmd`/`.qmd` documents
-    /// and for untitled buffers whose `languageId` is `rmd`/`quarto`; `R`
-    /// (i.e. `# %%` cells) otherwise. Mirrors the client-side classifier in
+    /// Chunk-detection kind for the outline: `Rmd` for `.Rmd`,
+    /// `.Rmarkdown`, and `.qmd` documents and for untitled buffers whose
+    /// `languageId` is `rmd`/`quarto`; `R` (i.e. `# %%` cells) otherwise.
+    /// Mirrors the client-side classifier in
     /// `editors/vscode/src/chunks/chunk-detector.ts`.
     pub chunk_kind: ChunkKind,
     /// Masked analysis text for Rmd/Quarto documents (`chunks::mask_to_r` of the
@@ -569,6 +570,18 @@ pub struct WorldState {
     pub cross_file_revalidation: CrossFileRevalidationState,
     pub cross_file_activity: CrossFileActivityState,
     pub cross_file_workspace_index: CrossFileWorkspaceIndex,
+    /// Last-known editor-derived chunk classification for file-backed
+    /// documents whose editor language made the file behave differently from
+    /// path classification.
+    ///
+    /// Live documents use their stored [`Document::chunk_kind`]. This tiny
+    /// closed-file override map preserves the editor `languageId: rmd/quarto`
+    /// signal after close so watched disk resyncs, on-demand indexing, and raw
+    /// file-cache metadata fallbacks keep masking extension-mismatched Rmd /
+    /// Quarto files. Entries exist only when the editor-derived kind differs
+    /// from [`classify_chunk_document`] for the URI path, and cross-file state
+    /// removal prunes them with the rest of the URI's closed-file state.
+    pub editor_chunk_kind_overrides: HashMap<Url, ChunkKind>,
     /// State-wide source for watched-file resync generations.
     ///
     /// Values are copied into `watched_file_resync_generations` per URI. Keeping
@@ -802,6 +815,7 @@ impl WorldState {
             cross_file_revalidation: CrossFileRevalidationState::new(),
             cross_file_activity: CrossFileActivityState::new(),
             cross_file_workspace_index: CrossFileWorkspaceIndex::new(),
+            editor_chunk_kind_overrides: HashMap::new(),
             watched_file_resync_generation_counter: 0,
             watched_file_resync_generations: HashMap::new(),
             libpath_watcher_handle: None,
@@ -1014,14 +1028,82 @@ impl WorldState {
         // cache invalidation) are skipped because open docs are
         // authoritative. No reader consults this cache for open documents.
         self.cross_file_file_cache.invalidate(&uri);
-        self.documents.insert(
-            uri.clone(),
-            Document::new_with_language_id(text, version, &uri, language_id),
-        );
+        let document = Document::new_with_language_id(text, version, &uri, language_id);
+        self.record_editor_chunk_kind_override(&uri, document.chunk_kind);
+        self.documents.insert(uri.clone(), document);
     }
 
     pub fn close_document(&mut self, uri: &Url) {
         self.documents.remove(uri);
+    }
+
+    /// Persist or clear the editor-derived chunk-kind override for a
+    /// file-backed document.
+    ///
+    /// Only extension mismatches are stored: when `chunk_kind` equals
+    /// [`classify_chunk_document`] for `uri.path()`, any previous override is
+    /// removed. This keeps the map small and means ordinary `.Rmd`,
+    /// `.Rmarkdown`, and `.qmd` files continue to be path-classified after
+    /// close. Untitled and other non-file URIs never have closed disk state, so
+    /// they also clear any stale entry.
+    pub fn record_editor_chunk_kind_override(&mut self, uri: &Url, chunk_kind: ChunkKind) {
+        if uri.to_file_path().is_err() || chunk_kind == classify_chunk_document(uri.path()) {
+            self.editor_chunk_kind_overrides.remove(uri);
+        } else {
+            self.editor_chunk_kind_overrides
+                .insert(uri.clone(), chunk_kind);
+        }
+    }
+
+    /// Drop the persisted editor-derived chunk-kind override for `uri`.
+    ///
+    /// Call this from every path that removes a URI's closed cross-file state
+    /// (deletion, final undecodable convergence, or workspace-index cleanup) so
+    /// a later recreated file starts from path classification until the editor
+    /// supplies a fresh language signal.
+    pub fn prune_editor_chunk_kind_override(&mut self, uri: &Url) {
+        self.editor_chunk_kind_overrides.remove(uri);
+    }
+
+    /// Return the chunk kind to use for closed-file disk content.
+    ///
+    /// The last-known editor-derived override wins over path classification.
+    /// This mirrors open-document precedence without requiring raw disk caches
+    /// or workspace-index entries to persist a full `Document`.
+    pub fn chunk_kind_for_closed_file(&self, uri: &Url) -> ChunkKind {
+        self.editor_chunk_kind_overrides
+            .get(uri)
+            .copied()
+            .unwrap_or_else(|| classify_chunk_document(uri.path()))
+    }
+
+    /// Return the R-analysis view of raw closed-file `content` for `uri`.
+    ///
+    /// This is the state-aware sibling of
+    /// [`crate::cross_file::analysis_text_for_path`]: persisted editor-derived
+    /// chunk classification wins before falling back to path classification, so
+    /// extension-mismatched Rmd/Quarto files continue to mask prose after close.
+    pub fn analysis_text_for_uri<'a>(
+        &self,
+        uri: &Url,
+        content: &'a str,
+    ) -> std::borrow::Cow<'a, str> {
+        crate::cross_file::analysis_text_for_kind(self.chunk_kind_for_closed_file(uri), content)
+    }
+
+    /// Extract metadata from raw closed-file `content` for `uri`.
+    ///
+    /// File-cache and content-provider fallbacks should use this instead of
+    /// [`crate::cross_file::extract_metadata_for_path`] whenever a
+    /// [`WorldState`] is available, because the persisted editor-derived chunk
+    /// kind must outrank path classification for extension-mismatched Rmd /
+    /// Quarto files.
+    pub fn extract_metadata_for_uri(
+        &self,
+        uri: &Url,
+        content: &str,
+    ) -> crate::cross_file::CrossFileMetadata {
+        crate::cross_file::extract_metadata_for_kind(self.chunk_kind_for_closed_file(uri), content)
     }
 
     pub fn apply_change(&mut self, uri: &Url, change: TextDocumentContentChangeEvent) {
@@ -1057,11 +1139,11 @@ impl WorldState {
         let content_provider = self.content_provider();
         if let Some(content) = content_provider.get_content(uri) {
             // Cached content is RAW; mask Rmd/Quarto before extracting so
-            // directives come from chunk bodies, not prose (#343).
-            return Some(Arc::new(crate::cross_file::extract_metadata_for_path(
-                uri.path(),
-                &content,
-            )));
+            // directives come from chunk bodies, not prose (#343). Use the
+            // persisted editor-derived chunk kind when present so an
+            // extension-mismatched Rmd/Quarto file keeps masking after close
+            // (#563).
+            return Some(Arc::new(self.extract_metadata_for_uri(uri, &content)));
         }
         None
     }
@@ -1082,7 +1164,10 @@ impl WorldState {
     /// `extract_metadata_for_path`, and `DocumentStore::compute_derived`
     /// re-derives artifacts from the masked text); the legacy-documents arm
     /// (tier 4) and the file-cache arm (tier 5) likewise mask via
-    /// `analysis_text()` / `extract_metadata_for_path`. So directives,
+    /// `analysis_text()` / `extract_metadata_for_uri`. The state-aware file
+    /// cache fallback consults persisted editor-language chunk classification
+    /// before path classification, so extension-mismatched Rmd/Quarto files do
+    /// not start treating prose as R after close (issue #563). So directives,
     /// `source()`, and `library()` always reflect chunk bodies, never prose.
     pub fn get_enriched_metadata(
         &self,
@@ -1104,13 +1189,11 @@ impl WorldState {
             .or_else(|| {
                 // Cached content is RAW; mask Rmd/Quarto before extracting so
                 // directives/source()/library() come from chunk bodies, not
-                // prose (#343).
-                self.cross_file_file_cache.get(uri).map(|content| {
-                    Arc::new(crate::cross_file::extract_metadata_for_path(
-                        uri.path(),
-                        &content,
-                    ))
-                })
+                // prose (#343), preserving any editor-language override from
+                // the closed document (#563).
+                self.cross_file_file_cache
+                    .get(uri)
+                    .map(|content| Arc::new(self.extract_metadata_for_uri(uri, &content)))
             })
     }
 
@@ -1513,6 +1596,7 @@ impl WorldState {
             }
             self.workspace_index_new.invalidate(&uri);
             self.cross_file_graph.remove_file(&uri);
+            self.prune_editor_chunk_kind_override(&uri);
         }
     }
 
@@ -1884,10 +1968,11 @@ fn process_workspace_file(path: &Path) -> Option<ProcessedFile> {
     // Pair `doc.tree` with the analysis text it was parsed from (masked for
     // Rmd/Quarto, raw otherwise) for both metadata extraction and artifact
     // computation, so byte offsets align (#343). The scan currently never sees
-    // chunk files (`is_stat_model_extension` excludes `.rmd`/`.qmd`), so this is
-    // behavior-neutral today; the pairing must stay analysis-consistent in case
-    // that ever changes — feeding raw `&text` against a masked tree would
-    // mis-slice (and panic on a non-UTF-8 boundary in multibyte prose).
+    // chunk files (`is_stat_model_extension` excludes Rmd/Quarto extensions),
+    // so this is behavior-neutral today; the pairing must stay
+    // analysis-consistent in case that ever changes — feeding raw `&text`
+    // against a masked tree would mis-slice (and panic on a non-UTF-8 boundary
+    // in multibyte prose).
     let analysis_text = doc.analysis_text();
 
     let cross_file_meta = crate::cross_file::extract_metadata(&analysis_text);

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -46,7 +46,7 @@ For dynamic or conditional paths that Raven can't detect, use [directives](direc
 
 ### R Markdown / Quarto chunks
 
-Inside `.Rmd` / `.qmd` documents, only R chunk bodies feed cross-file analysis — prose and YAML front matter are masked out before detection. A `source()` or `library()` call written in a chunk participates exactly as it would in a `.R` file; the same text in prose is ignored. Within a single document, bindings from earlier chunks are visible in later chunks (ordered-concatenation semantics) — define `x` in chunk 1 and it resolves in chunk 3. A `.R` file may also declare `# raven: sourced-by report.Rmd`, in which case Raven reads the report's chunks to supply that file's inherited scope. `.Rmd` / `.qmd` files are not added to the proactive workspace scan, so the editor sees these relationships when the Rmd is open or when a `.R` file points at it via a backward directive. See [R Code Chunks](./chunks.md#cross-file-resolution-from-chunks).
+Inside `.Rmd` / `.Rmarkdown` / `.qmd` documents, only R chunk bodies feed cross-file analysis — prose and YAML front matter are masked out before detection. A `source()` or `library()` call written in a chunk participates exactly as it would in a `.R` file; the same text in prose is ignored. Within a single document, bindings from earlier chunks are visible in later chunks (ordered-concatenation semantics) — define `x` in chunk 1 and it resolves in chunk 3. A `.R` file may also declare `# raven: sourced-by report.Rmd`, in which case Raven reads the report's chunks to supply that file's inherited scope. `.Rmd` / `.Rmarkdown` / `.qmd` files are not added to the proactive workspace scan, so the editor sees these relationships when the Rmd is open or when a `.R` file points at it via a backward directive. See [R Code Chunks](./chunks.md#cross-file-resolution-from-chunks).
 
 ## Package Awareness
 
@@ -303,6 +303,8 @@ See [Configuration](configuration.md) for the setting.
 While a file is open, its buffer is authoritative: unsaved edits that add or remove `source()` calls or directives update the dependency graph live, and disk changes to that file are ignored until it closes.
 
 When you close a file without saving, Raven re-reads just that file from disk and converges the graph back to disk truth — a `source()` edge added only in the discarded buffer disappears, and an edge the buffer had removed comes back. If the file no longer exists on disk, its graph entry is removed entirely. Open files that depend on it have their diagnostics refreshed automatically. This never triggers a workspace rescan, and reopening the file immediately always wins over the disk re-read.
+
+For file-backed R Markdown / Quarto documents whose extension does not identify them as chunk documents, Raven remembers the editor's last Rmd/Quarto language classification after close. Watched disk changes and closed-file cache fallbacks keep using chunk masking until that file's cross-file state is removed, so prose `source()` calls and directives do not start contributing graph edges just because the document is closed.
 
 ### Traversal budgets in large workspaces
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -311,12 +311,12 @@ See `index_file_on_demand` / `index_forward_chain` / `index_backward_chain` in
 
 ### Rmd/Quarto raw-content vs masked-analysis split (#343)
 
-For `.Rmd` / `.qmd` documents, everywhere we store or extract cross-file data we keep two views distinct (mirroring the `Document` type docs in `state.rs`):
+For `.Rmd` / `.Rmarkdown` / `.qmd` documents, everywhere we store or extract cross-file data we keep two views distinct (mirroring the `Document` type docs in `state.rs`):
 
 - **Raw content** — `DocumentStore::DocumentState.contents`, `IndexEntry.contents`, and the `cross_file_file_cache` entry stay verbatim. `ContentProvider::get_content` returns raw, serving snippets and non-R-language text scans.
 - **Masked analysis** — the `tree`, `metadata`, `artifacts`, and `loaded_packages` on those same entries are derived from `chunks::mask_to_r` (chunk bodies only). Byte offsets in the stored `tree` index into the masked text, exposed by `DocumentState::analysis_text()`; pairing the tree with raw content mis-slices.
 
-The single chokepoint helpers live in `cross_file/mod.rs`: `analysis_text_for_path(path, content)` (masks for Rmd, borrows raw otherwise) and `extract_metadata_for_path(path, content)`. Every metadata-extraction site that starts from a path-identified file's raw content (did_open, on-demand indexing, file-cache fallbacks in `state.rs`, the legacy-document arms in `content_provider.rs`) routes through these so `.Rmd` files contribute outgoing edges from chunks, never spurious prose-derived ones. `.Rmd`/`.qmd` are intentionally excluded from the proactive workspace scan (outgoing-only); incoming relationships come from an open Rmd or a `.R` file's `# raven: sourced-by` backward directive.
+The state-aware closed-file chokepoints live in `state.rs`: `WorldState::analysis_text_for_uri(uri, content)` and `WorldState::extract_metadata_for_uri(uri, content)`. They consult `WorldState::editor_chunk_kind_overrides` first, then fall back to path classification, so extension-mismatched Rmd/Quarto files keep masking after close. The pure path-based helpers in `cross_file/mod.rs` — `analysis_text_for_path(path, content)` and `extract_metadata_for_path(path, content)` — remain for call sites that have raw content but no `WorldState`; their classifier masks `.Rmd` / `.Rmarkdown` / `.qmd` documents and borrows raw otherwise. Raw-content fallbacks therefore still contribute outgoing edges from chunks, never spurious prose-derived ones. `.Rmd` / `.Rmarkdown` / `.qmd` are intentionally excluded from the proactive workspace scan (outgoing-only); incoming relationships come from an open Rmd/Quarto document or a `.R` file's `# raven: sourced-by` backward directive.
 
 ## Package library internals
 


### PR DESCRIPTION
## Summary

Fixes the #563 gap where a file-backed Rmd/Quarto document with a non-`.rmd`/`.qmd` extension (e.g. `report.Rmarkdown` opened as languageId `rmd`) was chunk-masked while open and at close-time resync (#558), but reverted to plain-R path classification afterward — a later watched CHANGED event or file-cache metadata fallback re-parsed the raw prose and minted spurious prose `source()`/directive edges into the cross-file graph.

Two complementary changes:

1. **Persist the editor-derived chunk kind across close.** New `WorldState::editor_chunk_kind_overrides` — a mismatch-only `URI → ChunkKind` map recorded on `didOpen`/`didClose` (entries exist only when the editor kind differs from path classification, and a reopen with a matching kind clears any stale entry). Consulted via `chunk_kind_for_closed_file` / `analysis_text_for_uri` / `extract_metadata_for_uri` in the watched disk-resync preflight (inside the existing #564 generation-coalesced primitive — no new lock acquisition, commit-time veto untouched), on-demand indexing, and the raw-content file-cache/content-provider fallbacks (`get_enriched_metadata`, `get_or_parse_metadata`, `get_text_and_tree`, `references`). Pruned with the rest of a URI's closed cross-file state (`remove_file_from_cross_file_state` on deletion / final-undecodable convergence, and workspace cleanup).
2. **Classify `.Rmarkdown` by path**, case-insensitively, in `classify_chunk_document` — it is a real knitr-supported R Markdown extension.

Precedence is unchanged in spirit: an editor-language signal (live or persisted) wins over path classification, exactly as for open documents.

## Tests

- `issue563_watched_change_after_closing_extension_mismatched_rmd_preserves_masking` — watched CHANGED after close keeps masking; no prose edges.
- `issue563_get_enriched_metadata_file_cache_fallback_uses_persisted_chunk_kind` — index-evicted file-cache fallback uses the persisted kind.
- `issue563_rmarkdown_extension_path_classified_resync_masks_prose_without_editor_signal` — `.Rmarkdown` masks with no editor signal at all.
- `issue563_deleting_extension_mismatched_rmd_prunes_persisted_chunk_kind` — deletion convergence drops the map entry.
- `chunks::tests::classifies_rmd_qmd_extensions` extended for `.Rmarkdown`/`.RMARKDOWN`.
- All #564 regression tests (generation coalescing, `watched_transient_invalid_encoding_does_not_remove_state`, etc.) pass unweakened; one #558 test mechanically retargeted from `.Rmarkdown` to `.md` since `.Rmarkdown` now path-classifies.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, rustdoc `-D warnings` in both default and `test-support` configs, and `cargo test -p raven --features test-support` (5667 passed; the 17 `cli::packages` loopback-bind failures are sandbox artifacts and pass unsandboxed) — all green.

## Review chain

codex implement → codex adversarial review (round 1: one deferred client-side finding + one docs-drift nit, fixed; round 2: clean) → Sonnet second opinion (no high-confidence findings).

**Deferred follow-up (explicit scope decision — server-side only):** the VS Code client does not yet know `.Rmarkdown` — the watcher glob in `editors/vscode/src/extension.ts`, the `package.json` language contribution, and the TS chunk-detector still list only `.rmd`/`.qmd` variants, so VS Code will not deliver watched events for `.Rmarkdown` files nor auto-assign the `rmd` language. Worth a small client-side follow-up.

**Stacked on #566** (`issue564`): this touches the same watched-resync tail; retarget to `main` when #566 merges.

https://claude.ai/code/session_01VjnMh1eFxmXGR7dSc3o73M

Fixes #563