### PR TITLE
fix(cli): recognize .Rmarkdown in check/lint walk; skip alloc in is_excluded_uri

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -118,8 +118,9 @@ Indexes the workspace, then reports the full diagnostic set for the requested
 files (or every R / R Markdown / Quarto file in the workspace when no PATHS are
 given): syntax errors, semantic checks, style lints, cross-file diagnostics
 (missing source files, circular dependencies, out-of-scope usage),
-missing-package warnings, and undefined-variable diagnostics. For .Rmd / .qmd
-the R code inside chunks is analyzed; prose and non-R chunks are ignored.
+missing-package warnings, and undefined-variable diagnostics. For .Rmd /
+.Rmarkdown / .qmd the R code inside chunks is analyzed; prose and non-R chunks
+are ignored.
 Honors raven.toml / .lintr.
 
 Options:
@@ -160,9 +161,9 @@ Exit codes:
 }
 
 /// Open a report target that the workspace scan did NOT index (a path reached
-/// through a different symlink alias, OR a chunk file — `.Rmd`/`.qmd` are
-/// deliberately outside the R-only workspace scan) into `state.documents` and
-/// wire its outgoing edges into the dependency graph.
+/// through a different symlink alias, OR a chunk file — `.Rmd`/`.Rmarkdown`/
+/// `.qmd` are deliberately outside the R-only workspace scan) into
+/// `state.documents` and wire its outgoing edges into the dependency graph.
 ///
 /// `text` is the already-decoded file contents (the caller owns the
 /// `read_source` error handling). `path` is used only to classify the chunk
@@ -189,8 +190,8 @@ fn open_disk_fallback_target(
     text: &str,
 ) {
     // Pass an honest language id so the Document classifies the chunk kind
-    // correctly: "rmd" for `.Rmd`/`.qmd` (the constructor reads the URI to
-    // classify it as Rmd and masks the prose), "r" otherwise.
+    // correctly: "rmd" for `.Rmd`/`.Rmarkdown`/`.qmd` (the constructor reads
+    // the URI to classify it as Rmd and masks the prose), "r" otherwise.
     // `file_type_from_language_id("rmd")` is `None`, so the `FileType` still
     // falls back to R via the URI — only the chunk masking differs.
     let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
@@ -751,12 +752,12 @@ async fn maybe_load_sysdata_fallback(state: &mut crate::state::WorldState) {
 ///
 /// Covers the directly-attached packages (`library()` / `require()`) of each
 /// reported file. R-source targets read their already-parsed `loaded_packages`
-/// from the workspace index (free). Chunk-bearing targets (`.Rmd`/`.qmd`) are
-/// never in the R-only scan, so they're read from disk and masked here so a
-/// chunk `library()` call warms its package's exports too — without this the
-/// undefined-variable check would conservatively suppress bare calls to an
-/// installed-but-uncached package attached only inside a chunk, under-reporting
-/// relative to the editor.
+/// from the workspace index (free). Chunk-bearing targets (`.Rmd`/
+/// `.Rmarkdown`/`.qmd`) are never in the R-only scan, so they're read from disk
+/// and masked here so a chunk `library()` call warms its package's exports too
+/// — without this the undefined-variable check would conservatively suppress
+/// bare calls to an installed-but-uncached package attached only inside a chunk,
+/// under-reporting relative to the editor.
 ///
 /// In package mode, also covers NAMESPACE whole-package `import(pkg)`
 /// directives (`scope_contribution.full_imports`) and packages attached by
@@ -1316,9 +1317,9 @@ async fn collect_target_diagnostics(
 
     // Phase 3 (sequential): targets not handled in phase 1 — a bad URL, or a
     // disk-fallback target the scan didn't index (e.g. a symlink-alias path, or
-    // an `.Rmd`/`.qmd` chunk file outside the R-only scan). Rare; the existing
-    // open → compute → close path (which uses `state.documents`) is preserved
-    // verbatim, so behavior for these is unchanged.
+    // an `.Rmd`/`.Rmarkdown`/`.qmd` chunk file outside the R-only scan). Rare;
+    // the existing open → compute → close path (which uses `state.documents`)
+    // is preserved verbatim, so behavior for these is unchanged.
     for path in targets {
         let Ok(uri) = Url::from_file_path(path) else {
             eprintln!(
@@ -1369,8 +1370,8 @@ async fn collect_target_diagnostics(
 }
 
 /// Resolve which files to report diagnostics for. Empty `paths` means every R
-/// source (`.R`/`.r`) and chunk-bearing document (`.Rmd`/`.qmd`) under the
-/// workspace root. Explicit paths are taken as-is (files) or walked
+/// source (`.R`/`.r`) and chunk-bearing document (`.Rmd`/`.Rmarkdown`/`.qmd`)
+/// under the workspace root. Explicit paths are taken as-is (files) or walked
 /// (directories). The result is sorted and de-duplicated for stable output.
 /// Chunk files are collected both as explicit args and while walking a
 /// directory, so `raven check` diagnoses the R chunks inside them (issue #343).
@@ -2200,26 +2201,50 @@ mod tests {
     }
 
     #[test]
-    fn walk_includes_rmd_and_qmd() {
+    fn walk_includes_rmd_rmarkdown_and_qmd() {
         // The empty-PATHS workspace walk collects chunk-bearing documents
         // alongside R sources, including mixed-case extensions
-        // (is_chunk_file matches `.rmd`/`.qmd` case-insensitively).
+        // (is_chunk_file matches `.rmd`/`.rmarkdown`/`.qmd`
+        // case-insensitively).
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("a.R"), "x <- 1\n").unwrap();
         fs::write(tmp.path().join("report.Rmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join("notebook.Rmarkdown"), "prose\n").unwrap();
+        fs::write(tmp.path().join(".Rmarkdown"), "prose\n").unwrap();
         fs::write(tmp.path().join("paper.qmd"), "prose\n").unwrap();
         fs::write(tmp.path().join("UPPER.RMD"), "prose\n").unwrap();
+        fs::write(tmp.path().join("UPPER.RMARKDOWN"), "prose\n").unwrap();
         fs::write(tmp.path().join("UPPER.QMD"), "prose\n").unwrap();
 
         let mut operator_error = false;
         let targets = collect_report_targets(&[], tmp.path(), &mut operator_error);
-        assert_eq!(targets.len(), 5, "got {targets:?}");
+        assert_eq!(targets.len(), 8, "got {targets:?}");
         let chunk_count = targets.iter().filter(|p| is_chunk_file(p)).count();
         assert_eq!(
-            chunk_count, 4,
-            "all four chunk files collected; got {targets:?}"
+            chunk_count, 7,
+            "all seven chunk files collected; got {targets:?}"
         );
         assert!(!operator_error);
+    }
+
+    #[test]
+    fn directory_walk_rmarkdown_chunk_syntax_error_exits_failed() {
+        let tmp = TempDir::new().unwrap();
+        let rmarkdown = tmp.path().join("report.Rmarkdown");
+        fs::write(&rmarkdown, "# Title\n```{r}\nf <- function( {\n```\n").unwrap();
+
+        let mut args = base_args(tmp.path());
+        args.paths = vec![tmp.path().to_path_buf()];
+        assert_eq!(run_blocking(args.clone()), EXIT_LINT_FAILED);
+
+        let diags = collect_diagnostics_blocking(&args);
+        let canonical_rmarkdown = std::fs::canonicalize(&rmarkdown).unwrap();
+        assert!(
+            diags.iter().any(|(path, d)| path == &canonical_rmarkdown
+                && d.range.start.line == 2
+                && d.severity == Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR)),
+            "directory walk must analyze .Rmarkdown chunks at document coordinates; got {diags:?}"
+        );
     }
 
     #[test]

--- a/crates/raven/src/cli/lint.rs
+++ b/crates/raven/src/cli/lint.rs
@@ -84,7 +84,7 @@ Usage: raven lint [OPTIONS] [PATHS...]
 
 Lints each .R / .r file against the rules configured in raven.toml
 (or .lintr) and prints diagnostics. R Markdown / Quarto files
-(.Rmd / .qmd) are linted too: the R code inside chunks is checked,
+(.Rmd / .Rmarkdown / .qmd) are linted too: the R code inside chunks is checked,
 prose and non-R chunks are ignored.
 
 Options:
@@ -350,15 +350,16 @@ fn walk(
                 return;
             }
         };
-        // For chunk files (.Rmd/.qmd), this masks the document to its R chunk
-        // bodies before parsing and linting: all non-R-body lines (prose, YAML,
-        // fences, non-R chunk bodies) become empty strings while every line keeps
-        // its original index, so lint findings carry document coordinates
-        // directly. Routed through the shared `analysis_text_for_kind` chokepoint
-        // so `raven lint` derives its R-analysis view identically to the LSP and
-        // `raven check`. Classify via the canonical `classify_chunk_document`
-        // (not a local re-derivation of the `chunk` guard above) so this site
-        // can never drift from the project-wide `.Rmd`/`.qmd` classifier.
+        // For chunk files (.Rmd/.Rmarkdown/.qmd), this masks the document to
+        // its R chunk bodies before parsing and linting: all non-R-body lines
+        // (prose, YAML, fences, non-R chunk bodies) become empty strings while
+        // every line keeps its original index, so lint findings carry document
+        // coordinates directly. Routed through the shared `analysis_text_for_kind`
+        // chokepoint so `raven lint` derives its R-analysis view identically to
+        // the LSP and `raven check`. Classify via the canonical
+        // `classify_chunk_document` (not a local re-derivation of the `chunk`
+        // guard above) so this site can never drift from the project-wide
+        // `.Rmd`/`.Rmarkdown`/`.qmd` classifier.
         let chunk_kind = crate::chunks::classify_chunk_document(&path.to_string_lossy());
         let effective_text = crate::cross_file::analysis_text_for_kind(chunk_kind, &text);
         // The trailing-blank-lines rule describes the FILE's shape, but lints
@@ -1266,13 +1267,16 @@ mod tests {
         use tempfile::TempDir;
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
-        // A directory with one .Rmd, one .qmd, and one plain .R; all have a
-        // triggering pattern so all should produce findings (.qmd shares the
-        // .Rmd dispatch path via is_chunk_file — pin it end-to-end too).
+        // A directory with one .Rmd, one .Rmarkdown, one .qmd, and one plain
+        // .R; all have a triggering pattern so all should produce findings
+        // (.Rmarkdown/.qmd share the .Rmd dispatch path via is_chunk_file —
+        // pin them end-to-end too).
         let rmd = root.join("doc.Rmd");
+        let rmarkdown = root.join("notebook.Rmarkdown");
         let qmd = root.join("paper.qmd");
         let r_file = root.join("plain.R");
         fs::write(&rmd, rmd_with_chunk_finding()).unwrap();
+        fs::write(&rmarkdown, rmd_with_chunk_finding()).unwrap();
         fs::write(&qmd, rmd_with_chunk_finding()).unwrap();
         fs::write(&r_file, "x=1\n").unwrap();
 
@@ -1282,13 +1286,18 @@ mod tests {
         let (diags, operator_error) = lint_one(root, root, &settings);
 
         assert!(!operator_error, "unexpected operator error");
-        // All three files must contribute findings.
+        // All four files must contribute findings.
         let rmd_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &rmd).collect();
+        let rmarkdown_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &rmarkdown).collect();
         let qmd_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &qmd).collect();
         let r_findings: Vec<_> = diags.iter().filter(|(p, _)| p == &r_file).collect();
         assert!(
             !rmd_findings.is_empty(),
             "directory walk must include .Rmd findings; got {diags:?}"
+        );
+        assert!(
+            !rmarkdown_findings.is_empty(),
+            "directory walk must include .Rmarkdown findings; got {diags:?}"
         );
         assert!(
             !qmd_findings.is_empty(),

--- a/crates/raven/src/cli/shared.rs
+++ b/crates/raven/src/cli/shared.rs
@@ -153,15 +153,13 @@ pub fn is_r_file(p: &Path) -> bool {
     )
 }
 
-/// True for chunk-bearing document extensions (`.Rmd` / `.qmd`), matched
-/// case-insensitively so the CLI walk agrees with the canonical
+/// True for chunk-bearing document extensions (`.Rmd` / `.Rmarkdown` / `.qmd`),
+/// matched case-insensitively so the CLI walk agrees with the canonical
 /// [`crate::chunks::classify_chunk_document`] (which lowercases the whole
 /// path) — a `report.rMd` saved on a case-insensitive filesystem must be
 /// collected by the same rule that later classifies it.
 pub fn is_chunk_file(p: &Path) -> bool {
-    p.extension()
-        .and_then(|s| s.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("rmd") || ext.eq_ignore_ascii_case("qmd"))
+    crate::chunks::classify_chunk_document(&p.to_string_lossy()) == crate::chunks::ChunkKind::Rmd
 }
 
 /// Return `path` unchanged when already absolute; otherwise resolve it against
@@ -200,11 +198,11 @@ pub fn collect_r_file_paths_with_exclusions(
 }
 
 /// Recursively collect both R sources (`.R` / `.r`) and chunk-bearing documents
-/// (`.Rmd` / `.qmd`, case-insensitive) under `dir`. Same directory walk as
-/// [`collect_r_file_paths`] — symlinked directories are followed with
-/// canonical-path cycle detection and non-source directories pruned — but the
-/// predicate also matches chunk files so their R chunks are diagnosed
-/// (issue #343).
+/// (`.Rmd` / `.Rmarkdown` / `.qmd`, case-insensitive) under `dir`. Same
+/// directory walk as [`collect_r_file_paths`] — symlinked directories are
+/// followed with canonical-path cycle detection and non-source directories
+/// pruned — but the predicate also matches chunk files so their R chunks are
+/// diagnosed (issue #343).
 ///
 /// Used by `raven check`'s report walk (empty `PATHS` or an explicit
 /// directory). Results are unsorted; callers that need deterministic order
@@ -603,12 +601,22 @@ mod tests {
         assert!(is_r_file(Path::new("a.r")));
         assert!(!is_r_file(Path::new("a.Rmd")));
         assert!(is_chunk_file(Path::new("a.Rmd")));
+        assert!(is_chunk_file(Path::new("a.Rmarkdown")));
+        assert!(is_chunk_file(Path::new("a.rmarkdown")));
+        assert!(is_chunk_file(Path::new("a.RMARKDOWN")));
         assert!(is_chunk_file(Path::new("a.qmd")));
+        // Match classify_chunk_document's suffix semantics exactly: no-stem
+        // dotfile names still end with the chunk-document suffix.
+        assert!(is_chunk_file(Path::new(".Rmd")));
+        assert!(is_chunk_file(Path::new(".Rmarkdown")));
+        assert!(is_chunk_file(Path::new(".qmd")));
         // Case-insensitive, matching classify_chunk_document — including
         // capitalizations outside the common Rmd/rmd/RMD set.
         assert!(is_chunk_file(Path::new("a.rMd")));
+        assert!(is_chunk_file(Path::new("a.rMarkDown")));
         assert!(is_chunk_file(Path::new("a.QmD")));
         assert!(!is_chunk_file(Path::new("a.R")));
+        assert!(!is_chunk_file(Path::new("a.txt")));
         assert!(!is_chunk_file(Path::new("a.rmdx")));
     }
 
@@ -638,18 +646,22 @@ mod tests {
         fs::create_dir(tmp.path().join("sub")).unwrap();
         fs::write(tmp.path().join("sub/b.r"), "2\n").unwrap();
         fs::write(tmp.path().join("c.Rmd"), "prose\n").unwrap();
-        fs::write(tmp.path().join("d.qmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join("d.Rmarkdown"), "prose\n").unwrap();
+        fs::write(tmp.path().join("e.qmd"), "prose\n").unwrap();
+        fs::write(tmp.path().join(".Rmarkdown"), "prose\n").unwrap();
         // Mixed-case chunk extensions are matched (is_chunk_file is
         // case-insensitive).
-        fs::write(tmp.path().join("e.QMD"), "prose\n").unwrap();
+        fs::write(tmp.path().join("f.QMD"), "prose\n").unwrap();
+        fs::write(tmp.path().join("g.RMARKDOWN"), "prose\n").unwrap();
         fs::write(tmp.path().join("f.txt"), "not source\n").unwrap();
         fs::create_dir(tmp.path().join(".git")).unwrap();
         fs::write(tmp.path().join(".git/g.R"), "3\n").unwrap();
 
         let mut out = Vec::new();
         collect_check_target_paths(tmp.path(), &mut out);
-        // a.R + sub/b.r + c.Rmd + d.qmd + e.QMD; .txt skipped; .git pruned.
-        assert_eq!(out.len(), 5, "got {out:?}");
+        // a.R + sub/b.r + c.Rmd + d.Rmarkdown + e.qmd + .Rmarkdown + f.QMD +
+        // g.RMARKDOWN; .txt skipped; .git pruned.
+        assert_eq!(out.len(), 8, "got {out:?}");
         assert!(out.iter().all(|p| is_r_file(p) || is_chunk_file(p)));
         assert!(out.iter().any(|p| is_chunk_file(p)));
     }

--- a/crates/raven/src/config_file/exclusions.rs
+++ b/crates/raven/src/config_file/exclusions.rs
@@ -68,6 +68,9 @@ impl CompiledWorkspaceExclusions {
     }
 
     pub fn is_excluded_uri(&self, uri: &Url) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         uri.to_file_path()
             .ok()
             .is_some_and(|path| self.is_excluded_path(&path))
@@ -261,6 +264,15 @@ fn compile_prune_matchers(pattern: &str) -> Vec<GlobMatcher> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn empty_exclusions_do_not_exclude_file_uri() {
+        let cfg = CompiledWorkspaceExclusions::default();
+        let uri = Url::from_file_path(std::env::temp_dir().join("anything.R")).unwrap();
+
+        assert!(cfg.is_empty());
+        assert!(!cfg.is_excluded_uri(&uri));
+    }
 
     #[test]
     fn last_match_wins_with_negation() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,7 +192,7 @@ Set `RAVEN_DEB_VERSION` in your CI variables to one of the versions listed by `a
 
 ### Scope
 
-`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.qmd`) are all reported. When a workspace walk or a directory argument includes `.Rmd` / `.qmd` files they are analyzed the same way the editor analyzes them: every R chunk body is treated as R code at its document coordinates, while prose, YAML front matter, and non-R chunks (Python, Bash, …) are ignored. Diagnostics are reported at the coordinates of the chunk body line where they occur, so the line and column in `text` / `json` / `sarif` output map directly to the document. Cross-file resolution from chunks works: a `source()` inside a chunk creates a real dependency edge, and missing-file and cross-file scope diagnostics are reported the same as from a `.R` file.
+`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.Rmarkdown` / `.qmd`) are all reported. When a workspace walk or a directory argument includes `.Rmd` / `.Rmarkdown` / `.qmd` files they are analyzed the same way the editor analyzes them: every R chunk body is treated as R code at its document coordinates, while prose, YAML front matter, and non-R chunks (Python, Bash, …) are ignored. Diagnostics are reported at the coordinates of the chunk body line where they occur, so the line and column in `text` / `json` / `sarif` output map directly to the document. Cross-file resolution from chunks works: a `source()` inside a chunk creates a real dependency edge, and missing-file and cross-file scope diagnostics are reported the same as from a `.R` file.
 
 ## `raven lint`
 
@@ -236,7 +236,7 @@ raven lint [OPTIONS] [PATHS...]
 
 `raven lint` runs the native style linter only. Cross-file, undefined-variable, and package diagnostics need a workspace scan; use [`raven check`](#raven-check) for those.
 
-`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.qmd`) are linted. Inside `.Rmd` / `.qmd` files, lint rules apply to R chunk bodies; prose, YAML front matter, and non-R chunks are ignored. `# nolint` / `# nolint start` / `# nolint end` and `# raven: ignore` markers inside chunk bodies work as in plain R files. Other file types are ignored silently. Passing a directory walks it recursively for `.R` / `.r`, `.Rmd`, and `.qmd` files.
+`.R` / `.r` files and R Markdown / Quarto files (`.Rmd` / `.Rmarkdown` / `.qmd`) are linted. Inside `.Rmd` / `.Rmarkdown` / `.qmd` files, lint rules apply to R chunk bodies; prose, YAML front matter, and non-R chunks are ignored. `# nolint` / `# nolint start` / `# nolint end` and `# raven: ignore` markers inside chunk bodies work as in plain R files. Other file types are ignored silently. Passing a directory walks it recursively for `.R` / `.r`, `.Rmd`, `.Rmarkdown`, and `.qmd` files.
 
 ## `raven packages`
 


### PR DESCRIPTION
Fixes #576
Fixes #579

## Summary

Two independent, disjoint-file bug fixes.

### #576 (MEDIUM) — CLI silently skipped `.Rmarkdown`
`is_chunk_file` (`crates/raven/src/cli/shared.rs`) only accepted `.rmd`/`.qmd`, so `raven check`/`raven lint` skipped `.Rmarkdown` files even though the server classifier `chunks::classify_chunk_document` and the VS Code client (#570) recognize them. `is_chunk_file` now delegates directly to `classify_chunk_document`, so the CLI predicate cannot drift from the canonical classifier and inherits its suffix-based semantics (e.g. dotfiles like `.Rmarkdown` classify correctly, which a `Path::extension()` check would miss). This single predicate backs both the single-file gate and the directory walk, so all CLI paths are fixed at once. `docs/cli.md` updated to list `.Rmarkdown`.

### #579 (LOW) — `is_excluded_uri` allocated before short-circuit
`is_excluded_uri` (`crates/raven/src/config_file/exclusions.rs`) called `uri.to_file_path()` (allocating a `PathBuf`) before checking for rules. It now returns `false` early on empty exclusions, mirroring the existing `is_excluded_path` short-circuit.

## Tests added
- `is_chunk_file` unit coverage: `.Rmarkdown`/`.rmarkdown`/`.RMARKDOWN`, mixed case, dotfiles, negatives (`.txt`, `.rmdx`).
- `check.rs` workspace-walk test extended to include `.Rmarkdown` variants.
- New end-to-end directory-walk `raven check` test surfacing a diagnostic inside a `.Rmarkdown` R chunk.
- `lint.rs` directory-walk test includes a `.Rmarkdown` fixture producing findings.
- `exclusions.rs` micro-test: empty rules return `false` from `is_excluded_uri`.

## CI-gate attestation
Run in this worktree on the 1.96.0 pinned toolchain; all passed:
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items` — exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support` — exit 0
- `cargo test -p raven --features test-support` — 5748 passed / 0 failed, 53 doctests passed (run unsandboxed; the 17 `cli::packages` network tests fail only under the command sandbox with `PermissionDenied`, a known false-failure unrelated to this diff)

## Review
Implemented by Codex; adversarially reviewed by a second Codex pass (which caught and fixed a `Path::extension()` vs classifier `ends_with` divergence on no-stem dotfiles by delegating to `classify_chunk_document`); independently approved by a Sonnet review against the issues and CLAUDE.md invariants.

https://claude.ai/code/session_01VjnMh1eFxmXGR7dSc3o73M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `raven check` and `raven lint` now recognize `.Rmarkdown` files alongside `.Rmd` and `.qmd`.
  * Directory scanning now includes `.Rmarkdown` documents when collecting chunk-bearing files.

* **Bug Fixes**
  * Improved file detection for mixed-case and dotfile-style chunk document names.
  * Empty exclusion settings now correctly leave files unexcluded.

* **Documentation**
  * Updated CLI help and scope docs to reflect the expanded `.Rmarkdown` support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->