### PR TITLE
fix(package_state): recognize .Rmarkdown and case-insensitive chunk extensions

### DIFF
--- a/crates/raven/src/package_state/mod.rs
+++ b/crates/raven/src/package_state/mod.rs
@@ -263,11 +263,7 @@ pub fn is_dev_context_path(path: &Path, workspace_root: &Path) -> bool {
     let Some(rel) = path.strip_prefix(workspace_root).ok() else {
         return false;
     };
-    let is_r_extension = matches!(
-        path.extension().and_then(|e| e.to_str()),
-        Some("R" | "r" | "Rmd" | "rmd" | "qmd")
-    );
-    if !is_r_extension {
+    if !is_r_or_chunk_extension(path) {
         return false;
     }
     let Some(first) = rel.components().next().and_then(|c| c.as_os_str().to_str()) else {
@@ -286,11 +282,7 @@ pub fn is_built_doc_dir_path(path: &Path, workspace_root: &Path) -> bool {
     let Ok(rel) = path.strip_prefix(workspace_root) else {
         return false;
     };
-    let is_r_extension = matches!(
-        path.extension().and_then(|e| e.to_str()),
-        Some("R" | "r" | "Rmd" | "rmd" | "qmd")
-    );
-    if !is_r_extension {
+    if !is_r_or_chunk_extension(path) {
         return false;
     }
     let Some(first) = rel.components().next().and_then(|c| c.as_os_str().to_str()) else {
@@ -317,10 +309,24 @@ pub fn is_package_workspace_r_file(path: &Path, workspace_root: &Path) -> bool {
     if path.strip_prefix(workspace_root).is_err() {
         return false;
     }
-    matches!(
-        path.extension().and_then(|e| e.to_str()),
-        Some("R" | "r" | "Rmd" | "rmd" | "qmd")
-    )
+    is_r_or_chunk_extension(path)
+}
+
+/// Shared extension test backing [`is_dev_context_path`], [`is_built_doc_dir_path`],
+/// and [`is_package_workspace_r_file`] (issue #582) so the three predicates
+/// cannot drift from each other or from the canonical chunk classifier.
+///
+/// True for a plain R source extension (`.R`/`.r`, matched case-sensitively —
+/// there is no other real-world casing of a single-letter extension) or for
+/// any chunk-bearing document extension recognized by
+/// [`crate::chunks::classify_chunk_document`] (`.Rmd`/`.Rmarkdown`/`.qmd`,
+/// matched case-insensitively since that classifier lowercases the whole
+/// path before comparing suffixes).
+fn is_r_or_chunk_extension(path: &Path) -> bool {
+    if matches!(path.extension().and_then(|e| e.to_str()), Some("R" | "r")) {
+        return true;
+    }
+    crate::chunks::classify_chunk_document(&path.to_string_lossy()) == crate::chunks::ChunkKind::Rmd
 }
 
 /// Synchronously scan `<workspace_root>/data/` for dataset names.
@@ -693,6 +699,11 @@ mod path_tests {
             root
         ));
         assert!(is_dev_context_path(
+            Path::new("/work/pkg/vignettes/intro.Rmarkdown"),
+            root
+        ));
+        assert!(is_dev_context_path(Path::new("/work/pkg/demo/x.QMD"), root));
+        assert!(is_dev_context_path(
             Path::new("/work/pkg/man/rmd/topic.Rmd"),
             root
         ));
@@ -770,6 +781,10 @@ mod path_tests {
             Path::new("/work/pkg/inst/data.csv"),
             root
         ));
+        assert!(!is_dev_context_path(
+            Path::new("/work/pkg/demo/readme.txt"),
+            root
+        ));
         // Random dir
         assert!(!is_dev_context_path(
             Path::new("/work/pkg/src/code.R"),
@@ -784,8 +799,16 @@ mod path_tests {
             Path::new("/work/pkg/vignettes/v.R"),
             root
         ));
+        assert!(is_built_doc_dir_path(
+            Path::new("/work/pkg/vignettes/intro.Rmarkdown"),
+            root
+        ));
         assert!(is_built_doc_dir_path(Path::new("/work/pkg/man/ex.R"), root));
         assert!(is_built_doc_dir_path(Path::new("/work/pkg/demo/d.R"), root));
+        assert!(is_built_doc_dir_path(
+            Path::new("/work/pkg/demo/x.QMD"),
+            root
+        ));
         // data-raw is APPLIED to (not a built doc dir) — narrower than is_dev_context_path.
         assert!(!is_built_doc_dir_path(
             Path::new("/work/pkg/data-raw/prep.R"),
@@ -793,6 +816,10 @@ mod path_tests {
         ));
         assert!(!is_built_doc_dir_path(
             Path::new("/work/pkg/scripts/a.R"),
+            root
+        ));
+        assert!(!is_built_doc_dir_path(
+            Path::new("/work/pkg/demo/readme.txt"),
             root
         ));
     }
@@ -1139,11 +1166,19 @@ mod scan_data_tests {
             root
         ));
         assert!(is_package_workspace_r_file(
+            Path::new("/work/pkg/vignettes/intro.Rmarkdown"),
+            root
+        ));
+        assert!(is_package_workspace_r_file(
             Path::new("/work/pkg/inst/script.R"),
             root
         ));
         assert!(is_package_workspace_r_file(
             Path::new("/work/pkg/demo/demo.R"),
+            root
+        ));
+        assert!(is_package_workspace_r_file(
+            Path::new("/work/pkg/demo/x.QMD"),
             root
         ));
         assert!(is_package_workspace_r_file(
@@ -1161,6 +1196,10 @@ mod scan_data_tests {
         ));
         assert!(!is_package_workspace_r_file(
             Path::new("/work/pkg/data/foo.csv"),
+            root
+        ));
+        assert!(!is_package_workspace_r_file(
+            Path::new("/work/pkg/demo/readme.txt"),
             root
         ));
     }


### PR DESCRIPTION
## Summary

- `is_dev_context_path`, `is_built_doc_dir_path`, and `is_package_workspace_r_file` in `crates/raven/src/package_state/mod.rs` used a hand-rolled, case-sensitive extension match (`Some("R" | "r" | "Rmd" | "rmd" | "qmd")`) that missed `.Rmarkdown`/`.rmarkdown` and any non-canonical casing (`RMD`, `QMD`, `Qmd`, etc).
- Extracted a shared private helper `is_r_or_chunk_extension` that keeps the `.R`/`.r` arm exact (case-sensitive, unchanged) and delegates the chunk-extension check to the canonical `crate::chunks::classify_chunk_document` (which recognizes `.rmd`/`.rmarkdown`/`.qmd` case-insensitively), mirroring the #576/#579 "single source of truth" pattern already used by `is_chunk_file` in `cli/shared.rs`.
- All three predicates now call the one helper, so they cannot drift from each other or from the canonical classifier.
- Added unit coverage for `.Rmarkdown` and mixed-case `.QMD` positive matches, plus non-chunk-extension negative matches, for all three predicates.

Fixes #582

## Review process

- Implementation delegated to Codex (codex-rescue), reviewed diff myself.
- Ran an independent adversarial Codex review pass against the diff (correctness of `classify_chunk_document`'s whole-path suffix check, the `.R`/`.r` arm preservation, consistency across all three call sites, test adequacy, unintended-widening check against all callers). Verdict: ready to ship, no blocking issues. One non-blocking note (missing doc comment on the new private helper) — addressed by adding a doc comment.
- Independently confirmed no other call sites of the three predicates exist beyond `backend.rs`, `handlers.rs`, and `cross_file/scope.rs`, and that their broadened recognition of `.Rmarkdown`/mixed-case is exactly the intended fix, not incidental widening.

## CI gate attestation (run locally, toolchain auto-pinned to 1.96.0)

- `cargo fmt --all --check` — clean, exit 0.
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` — clean, exit 0.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items` — clean, exit 0.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support` — clean, exit 0.
- `cargo test -p raven --features test-support` — sandboxed run: 5731 passed, 17 failed (all `cli::packages::tests::*`, permission-denied panics — documented sandbox network false-failures, see repo memory). Unsandboxed rerun (`cargo test -p raven --features test-support --lib`): **5748 passed, 0 failed, 12 ignored** — confirms no real regressions.

## Test plan

- [ ] CI green on this PR (fmt, clippy, rustdoc x2, test)
- [ ] Reviewer spot-checks `is_r_or_chunk_extension` against `.Rmarkdown`/`.QMD`/`.txt` fixtures

https://claude.ai/code/session_01VjnMh1eFxmXGR7dSc3o73M