### PR TITLE
ci: scope release publishing secrets to environments

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -350,9 +350,9 @@ jobs:
   # and signatures before users can see the update.
   #
   # Setup (one-time), then this job activates itself:
-  #   gh secret   set APT_REPO_TOKEN            -R jbearak/raven   # paste token
-  #   gh secret   set APT_REPO_GPG_PRIVATE_KEY  -R jbearak/raven   # armored private key
-  #   gh secret   set APT_REPO_GPG_PASSPHRASE   -R jbearak/raven   # optional, may be empty
+  #   gh secret   set APT_REPO_TOKEN            -R jbearak/raven --env release # paste token
+  #   gh secret   set APT_REPO_GPG_PRIVATE_KEY  -R jbearak/raven --env release # armored private key
+  #   gh secret   set APT_REPO_GPG_PASSPHRASE   -R jbearak/raven --env release # optional, may be empty
   #   gh variable set ENABLE_APT_BUMP -R jbearak/raven --body true
   # APT_REPO_TOKEN: a GitHub App installation token or fine-grained PAT scoped
   # to jbearak/apt-raven with Contents:write + Pull requests:write.
@@ -360,6 +360,7 @@ jobs:
     needs: github-release
     if: vars.ENABLE_APT_BUMP == 'true' && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
     steps:
@@ -486,7 +487,7 @@ jobs:
   # bootstrap script.
   #
   # Setup (one-time), then this job activates itself:
-  #   gh secret   set HOMEBREW_TAP_TOKEN   -R jbearak/raven   # paste token
+  #   gh secret   set HOMEBREW_TAP_TOKEN   -R jbearak/raven --env release # paste token
   #   gh variable set ENABLE_HOMEBREW_BUMP -R jbearak/raven --body true
   # HOMEBREW_TAP_TOKEN: a GitHub App installation token or fine-grained PAT
   # scoped to jbearak/homebrew-raven with Contents:write + Pull requests:write.
@@ -495,6 +496,7 @@ jobs:
     needs: github-release
     if: vars.ENABLE_HOMEBREW_BUMP == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -118,6 +118,7 @@ jobs:
   github-release:
     needs: [validate, download-artifacts]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
@@ -166,6 +167,7 @@ jobs:
     needs: [validate, download-artifacts]
     if: inputs.publish_vscode
     runs-on: ubuntu-latest
+    environment: marketplace
     permissions: {}
     steps:
       - name: Download VSIX artifacts

--- a/docs/development.md
+++ b/docs/development.md
@@ -150,12 +150,12 @@ After the build succeeds, manually run `release-publish.yml` from GitHub Actions
 
 This creates a GitHub Release with all binaries and `.vsix` files. If marketplace publishing is enabled, it uploads each platform `.vsix` to both VS Code Marketplace and Open VSX.
 
-**Required secrets** (for marketplace publishing): `VSCE_PAT`, `OVSX_PAT`.
+**Required `marketplace` environment secrets** (for marketplace publishing): `VSCE_PAT`, `OVSX_PAT`.
 
 Optional post-release packaging jobs are gated by repository variables:
 
-- `ENABLE_HOMEBREW_BUMP=true` opens a PR against `jbearak/homebrew-raven`.
-- `ENABLE_APT_BUMP=true` builds Debian packages from the Linux release artifacts and opens a PR against `jbearak/apt-raven`, a GitHub Pages-backed apt repository. This requires `APT_REPO_TOKEN`, `APT_REPO_GPG_PRIVATE_KEY`, and optionally `APT_REPO_GPG_PASSPHRASE`. The apt repository stores signed `dists/stable` metadata plus `pool/main/r/raven/*.deb`; `names.db` is still not bundled and remains user-provisioned with `raven packages update`, `fetch`, or a committed `.raven/packages.json`.
+- `ENABLE_HOMEBREW_BUMP=true` opens a PR against `jbearak/homebrew-raven`. This requires `release` environment secret `HOMEBREW_TAP_TOKEN`.
+- `ENABLE_APT_BUMP=true` builds Debian packages from the Linux release artifacts and opens a PR against `jbearak/apt-raven`, a GitHub Pages-backed apt repository. This requires `release` environment secrets `APT_REPO_TOKEN` and `APT_REPO_GPG_PRIVATE_KEY`, plus optional `APT_REPO_GPG_PASSPHRASE`. The apt repository stores signed `dists/stable` metadata plus `pool/main/r/raven/*.deb`; `names.db` is still not bundled and remains user-provisioned with `raven packages update`, `fetch`, or a committed `.raven/packages.json`.
 
 ## Cross-file internals (high-level)
 

--- a/tests/bun/apt-packaging.test.ts
+++ b/tests/bun/apt-packaging.test.ts
@@ -55,6 +55,7 @@ describe("apt packaging release integration", () => {
     expect(aptJob).toContain("APT_REPO_GPG_PRIVATE_KEY");
     expect(aptJob).toContain("APT_REPO_GPG_PASSPHRASE");
     expect(aptJob).toContain("repository: jbearak/apt-raven");
+    expect(aptJob).toContain("environment: release");
     expect(aptJob).toContain("scripts/debian/build-deb.sh");
     expect(aptJob).toContain("scripts/debian/update-apt-repo.sh");
     expect(aptJob).toContain("VERSION: ${{ steps.version.outputs.version }}");
@@ -65,6 +66,41 @@ describe("apt packaging release integration", () => {
     expect(aptJob).not.toContain('git diff --quiet');
     expect(workflow).toContain("lsp-linux-x64");
     expect(workflow).toContain("lsp-linux-arm64");
+  });
+
+  test("release publishing secrets are scoped to their environments", () => {
+    const releaseBuild = readRepoFile(".github", "workflows", "release-build.yml");
+    const releasePublish = readRepoFile(".github", "workflows", "release-publish.yml");
+
+    const aptJob = releaseBuild.slice(
+      releaseBuild.indexOf("  bump-apt:"),
+      releaseBuild.indexOf("  # ── Homebrew tap bump"),
+    );
+    const homebrewJob = releaseBuild.slice(releaseBuild.indexOf("  bump-homebrew:"));
+    const buildMarketplaceJob = releaseBuild.slice(
+      releaseBuild.indexOf("  publish-marketplace:"),
+      releaseBuild.indexOf("  # Smoke-test"),
+    );
+    const fallbackReleaseJob = releasePublish.slice(
+      releasePublish.indexOf("  github-release:"),
+      releasePublish.indexOf("  publish-marketplace:"),
+    );
+    const fallbackMarketplaceJob = releasePublish.slice(
+      releasePublish.indexOf("  publish-marketplace:"),
+    );
+
+    expect(aptJob).toContain("APT_REPO_GPG_PRIVATE_KEY");
+    expect(aptJob).toContain("APT_REPO_TOKEN");
+    expect(aptJob).toContain("environment: release");
+    expect(homebrewJob).toContain("HOMEBREW_TAP_TOKEN");
+    expect(homebrewJob).toContain("environment: release");
+    expect(buildMarketplaceJob).toContain("VSCE_PAT");
+    expect(buildMarketplaceJob).toContain("OVSX_PAT");
+    expect(buildMarketplaceJob).toContain("environment: marketplace");
+    expect(fallbackReleaseJob).toContain("environment: release");
+    expect(fallbackMarketplaceJob).toContain("VSCE_PAT");
+    expect(fallbackMarketplaceJob).toContain("OVSX_PAT");
+    expect(fallbackMarketplaceJob).toContain("environment: marketplace");
   });
 
   test("Bitbucket Pipelines example installs Raven through the signed apt repo", () => {


### PR DESCRIPTION
## Summary
- move release publishing jobs that consume PATs/signing keys behind their GitHub environments
- wire the manual release-publish fallback to the release and marketplace environments
- document environment-secret setup and add coverage that publishing secrets are consumed only from the expected jobs/environments

## Verification
- bun test tests/bun/apt-packaging.test.ts
- git diff --check

## Secret state checked
- release environment has APT_REPO_GPG_PRIVATE_KEY, APT_REPO_TOKEN, HOMEBREW_TAP_TOKEN
- marketplace environment has VSCE_PAT, OVSX_PAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release and publishing workflows to use protected environments, adding clearer approval and secret-scope handling for release and marketplace publishing steps.
* **Documentation**
  * Clarified release setup instructions for required environment secrets and updated guidance for release-related packaging jobs.
* **Tests**
  * Expanded automated coverage to verify release and publishing jobs use the expected environments and secret access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->