### PR TITLE
docs: scope CI examples to PRs and pushes to main

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -38,10 +38,14 @@ Use [`jbearak/setup-raven`](https://github.com/jbearak/setup-raven) to install t
 ```yaml
 name: Raven
 
+# Runs on pull requests and on pushes to the default branch (main).
+# Scoping push to main avoids a duplicate run when you push to a branch
+# that already has an open pull request (pull_request already covers that).
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
 
 jobs:
   raven:
@@ -62,6 +66,9 @@ Pin `version` to a release tag when you want a fully reproducible CLI version.
 Bitbucket Pipelines runs the commands in `bitbucket-pipelines.yml`. Raven publishes a signed apt repository, so a normal Ubuntu build image can install the CLI directly. You can copy [`docs/examples/ci/bitbucket-pipelines.yml`](examples/ci/bitbucket-pipelines.yml) to `bitbucket-pipelines.yml`:
 
 ```yaml
+# Runs on pull requests and on pushes to the default branch (main).
+# repository-push is scoped to main so pushing to a branch with an open
+# pull request runs only once (via pullrequest-push), not twice.
 image: ubuntu:24.04
 
 pipelines:
@@ -83,6 +90,10 @@ pipelines:
             - raven check
 
 triggers:
+  repository-push:
+    - condition: BITBUCKET_BRANCH == "main"
+      pipelines:
+        - Raven
   pullrequest-push:
     - condition: glob(BITBUCKET_BRANCH, "**")
       pipelines:
@@ -100,6 +111,8 @@ Set `RAVEN_DEB_VERSION` in your pipeline variables to one of the versions listed
 
 If VS Code's YAML extension reports an unresolved Bitbucket schema reference such as `pipelines_configuration`, the pipeline file can still be valid. That is an editor schema issue, not a Raven or Bitbucket runtime error.
 
+Raven emits standard SARIF 2.1.0 with `raven check --format sarif` if you want to feed findings into GitHub code scanning or Bitbucket Code Insights, but for most projects the exit-code gate below is all CI needs.
+
 ## What fails the build
 
 By default, `raven check` exits with code `1` when it finds a `warning` or `error` diagnostic, and `0` otherwise. Change that threshold with `--max-severity`:
@@ -109,5 +122,7 @@ raven check --max-severity warning
 ```
 
 That command allows warnings and fails only on errors. See [Exit codes](cli.md#exit-codes) and [Diagnostics](diagnostics.md) for the full diagnostic set.
+
+A failing `raven check` fails the pipeline, but a red build does not block a merge on its own. To prevent merging when the check fails, mark it as a required status check (GitHub branch protection) or a merge check (Bitbucket).
 
 Use a committed [`raven.toml`](configuration.md) to keep local editor diagnostics and CI behavior aligned. Common CI-specific configuration includes `[workspace].exclude` for generated outputs and `diagnostics.reportUnusedSuppressions = true` when you want Raven to flag stale `# raven: ignore` comments.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -65,28 +65,35 @@ Bitbucket Pipelines runs the commands in `bitbucket-pipelines.yml`. Raven publis
 image: ubuntu:24.04
 
 pipelines:
-  default:
-    - step:
-        name: Raven
-        script:
-          - apt-get update
-          - apt-get install -y ca-certificates curl
-          - install -d -m 0755 /etc/apt/keyrings
-          - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
-          - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
-          - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
-          - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
-          - apt-get update
-          - apt-get install -y raven
-          - raven packages update
-          - raven check
+  custom:
+    Raven:
+      - step:
+          name: Raven
+          script:
+            - apt-get update
+            - apt-get install -y ca-certificates curl
+            - install -d -m 0755 /etc/apt/keyrings
+            - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
+            - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
+            - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
+            - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
+            - apt-get update
+            - apt-get install -y raven
+            - raven packages update
+            - raven check
+
+triggers:
+  pullrequest-push:
+    - condition: glob(BITBUCKET_BRANCH, "**")
+      pipelines:
+        - Raven
 ```
 
 Pin a specific Raven package version for reproducible Bitbucket runs:
 
 ```yaml
-          - apt-cache madison raven
-          - apt-get install -y "raven=${RAVEN_DEB_VERSION}"
+            - apt-cache madison raven
+            - apt-get install -y "raven=${RAVEN_DEB_VERSION}"
 ```
 
 Set `RAVEN_DEB_VERSION` in your pipeline variables to one of the versions listed by `apt-cache madison raven`, or omit the version pin to track the latest package in the apt repository.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -110,7 +110,7 @@ Set `RAVEN_DEB_VERSION` in your pipeline variables to one of the versions listed
 
 If VS Code's YAML extension reports an unresolved Bitbucket schema reference such as `pipelines_configuration`, the pipeline file can still be valid. That is an editor schema issue, not a Raven or Bitbucket runtime error.
 
-Raven emits standard SARIF 2.1.0 with `raven check --format sarif` if you want to feed findings into GitHub code scanning or Bitbucket Code Insights, but for most projects the exit-code gate below is all CI needs.
+Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub code scanning ingests directly; Bitbucket Code Insights has no native SARIF support and needs a conversion step. For most projects, though, the exit-code gate below is all CI needs.
 
 ## What fails the build
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -122,7 +122,7 @@ Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub
 
 `--max-severity LEVEL` sets the highest severity still allowed to pass; anything more severe fails the build. From most to least severe the scale is `error`, `warning`, `info`, `hint`. The default is `info`, so `warning` and `error` findings fail while `info` and `hint` pass.
 
-Raven's style and idiomatic lints — line length, naming, infix spacing, and similar — are `information`-level, so they never fail CI by default. To gate on them, enable linting (a committed `raven.toml` with `enabled = true` under `[linting]`, or a `.lintr`) and lower the threshold to `hint`, so info-level findings fail:
+Raven's style and idiomatic lints — line length, naming, infix spacing, and similar — are `information`-level, so they never fail CI by default. To gate on them, first enable linting (via `raven.toml` or a `.lintr` — see [Linting](linting.md)), then lower the threshold to `hint` so info-level findings fail:
 
 ```bash
 raven check --max-severity hint

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,13 +114,21 @@ Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub
 
 ## What fails the build
 
-By default, `raven check` exits with code `1` when it finds a `warning` or `error` diagnostic, and `0` otherwise. Change that threshold with `--max-severity`:
+"Fails the build" does not mean Raven itself failed. It means `raven check` ran successfully and found at least one diagnostic at or above your severity threshold, and it reports that through its exit code — the standard way a checker signals GitHub Actions or Bitbucket Pipelines that there is something to look at. The three exit codes are distinct:
+
+- **`0`** — nothing exceeded the threshold; the step passes.
+- **`1`** — a diagnostic exceeded the threshold; the step fails. This is the signal you want — Raven found an issue in your code, not that Raven broke.
+- **`2`** — Raven itself could not run (an unreadable path, a malformed `raven.toml`). This is a genuine operator error, separate from finding issues in your code.
+
+`--max-severity LEVEL` sets the highest severity still allowed to pass; anything more severe fails the build. From most to least severe the scale is `error`, `warning`, `info`, `hint`. The default is `info`, so `warning` and `error` findings fail while `info` and `hint` pass.
+
+Raven's style and idiomatic lints — line length, naming, infix spacing, and similar — are `information`-level, so they never fail CI by default. To gate on them, enable linting (a committed `raven.toml` with `enabled = true` under `[linting]`, or a `.lintr`) and lower the threshold to `hint`, so info-level findings fail:
 
 ```bash
-raven check --max-severity warning
+raven check --max-severity hint
 ```
 
-That command allows warnings and fails only on errors. See [Exit codes](cli.md#exit-codes) and [Diagnostics](diagnostics.md) for the full diagnostic set.
+That fails the build on style findings as well as warnings and errors; `--max-severity off` is stricter still and fails on every diagnostic. See [Linting](linting.md), [Exit codes](cli.md#exit-codes), and [Diagnostics](diagnostics.md) for the full rule and diagnostic set.
 
 A failing `raven check` fails the pipeline, but a red build does not block a merge on its own. To prevent merging when the check fails, mark it as a required status check (GitHub branch protection) or a merge check (Bitbucket).
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -110,8 +110,6 @@ Set `RAVEN_DEB_VERSION` in your pipeline variables to one of the versions listed
 
 If VS Code's YAML extension reports an unresolved Bitbucket schema reference such as `pipelines_configuration`, the pipeline file can still be valid. That is an editor schema issue, not a Raven or Bitbucket runtime error.
 
-Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub code scanning ingests directly; Bitbucket Code Insights has no native SARIF support and needs a conversion step. For most projects, though, the exit-code gate below is all CI needs.
-
 ## What fails the build
 
 "Fails the build" does not mean Raven itself failed. It means `raven check` ran successfully and found at least one diagnostic at or above your severity threshold, and it reports that through its exit code — the standard way a checker signals GitHub Actions or Bitbucket Pipelines that there is something to look at. The three exit codes are distinct:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -122,8 +122,6 @@ Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub
 
 `--max-severity LEVEL` sets the highest severity still allowed to pass; anything more severe fails the build. From most to least severe the scale is `error`, `warning`, `info`, `hint`. The default is `info`, so `warning` and `error` findings fail while `info` and `hint` pass.
 
-Despite the name, a `warning` is not a mere FYI. Raven reserves `error` for syntax/parse errors and reports genuine problems like undefined variables at `warning` — both are things you want CI to catch, which is why the default threshold fails on them. `info` and `hint` are where the more subjective, stylistic findings live by default.
-
 Raven's style and idiomatic lints — line length, naming, infix spacing, and similar — are `information`-level, so they never fail CI by default. To gate on them, first enable linting (via `raven.toml` or a `.lintr` — see [Linting](linting.md)), then lower the threshold to `hint` so info-level findings fail:
 
 ```bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,11 +41,10 @@ name: Raven
 # Runs on pull requests and on pushes to the default branch (main).
 # Scoping push to main avoids a duplicate run when you push to a branch
 # that already has an open pull request (pull_request already covers that).
-on:
+"on":
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   raven:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -122,6 +122,8 @@ Raven emits standard SARIF 2.1.0 with `raven check --format sarif`, which GitHub
 
 `--max-severity LEVEL` sets the highest severity still allowed to pass; anything more severe fails the build. From most to least severe the scale is `error`, `warning`, `info`, `hint`. The default is `info`, so `warning` and `error` findings fail while `info` and `hint` pass.
 
+Despite the name, a `warning` is not a mere FYI. Raven reserves `error` for syntax/parse errors and reports genuine problems like undefined variables at `warning` — both are things you want CI to catch, which is why the default threshold fails on them. `info` and `hint` are where the more subjective, stylistic findings live by default.
+
 Raven's style and idiomatic lints — line length, naming, infix spacing, and similar — are `information`-level, so they never fail CI by default. To gate on them, first enable linting (via `raven.toml` or a `.lintr` — see [Linting](linting.md)), then lower the threshold to `hint` so info-level findings fail:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,11 +134,10 @@ name: Raven
 # Runs on pull requests and on pushes to the default branch (main).
 # Scoping push to main avoids a duplicate run when you push to a branch
 # that already has an open pull request (pull_request already covers that).
-on:
+"on":
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   raven:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,10 +131,14 @@ You can copy [`docs/examples/ci/github-actions-raven.yml`](examples/ci/github-ac
 ```yaml
 name: Raven
 
+# Runs on pull requests and on pushes to the default branch (main).
+# Scoping push to main avoids a duplicate run when you push to a branch
+# that already has an open pull request (pull_request already covers that).
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
 
 jobs:
   raven:
@@ -161,6 +165,9 @@ To get installed/local package awareness and exact local package metadata in CI,
 Use Raven's signed apt repository from a normal Ubuntu build image. You can copy [`docs/examples/ci/bitbucket-pipelines.yml`](examples/ci/bitbucket-pipelines.yml) to `bitbucket-pipelines.yml`:
 
 ```yaml
+# Runs on pull requests and on pushes to the default branch (main).
+# repository-push is scoped to main so pushing to a branch with an open
+# pull request runs only once (via pullrequest-push), not twice.
 image: ubuntu:24.04
 
 pipelines:
@@ -182,6 +189,10 @@ pipelines:
             - raven check
 
 triggers:
+  repository-push:
+    - condition: BITBUCKET_BRANCH == "main"
+      pipelines:
+        - Raven
   pullrequest-push:
     - condition: glob(BITBUCKET_BRANCH, "**")
       pipelines:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,28 +164,35 @@ Use Raven's signed apt repository from a normal Ubuntu build image. You can copy
 image: ubuntu:24.04
 
 pipelines:
-  default:
-    - step:
-        name: Raven
-        script:
-          - apt-get update
-          - apt-get install -y ca-certificates curl
-          - install -d -m 0755 /etc/apt/keyrings
-          - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
-          - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
-          - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
-          - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
-          - apt-get update
-          - apt-get install -y raven
-          - raven packages update
-          - raven check
+  custom:
+    Raven:
+      - step:
+          name: Raven
+          script:
+            - apt-get update
+            - apt-get install -y ca-certificates curl
+            - install -d -m 0755 /etc/apt/keyrings
+            - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
+            - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
+            - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
+            - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
+            - apt-get update
+            - apt-get install -y raven
+            - raven packages update
+            - raven check
+
+triggers:
+  pullrequest-push:
+    - condition: glob(BITBUCKET_BRANCH, "**")
+      pipelines:
+        - Raven
 ```
 
 The apt repository is static HTTPS hosting for Debian repository metadata and `.deb` files; it is not a Docker image and does not run a remote installer script. The SHA-256 check pins the bootstrap keyring before apt trusts it, and the `signed-by=` keyring then makes apt verify Raven's repository metadata before it installs the package. Pin a specific Raven package version for reproducible CI:
 
 ```yaml
-          - apt-cache madison raven
-          - apt-get install -y "raven=${RAVEN_DEB_VERSION}"
+            - apt-cache madison raven
+            - apt-get install -y "raven=${RAVEN_DEB_VERSION}"
 ```
 
 Set `RAVEN_DEB_VERSION` in your CI variables to one of the versions listed by `apt-cache madison raven`, or use `latest`-style behavior by omitting the version pin. As with GitHub Actions, `raven packages update` restores broad CRAN/Bioconductor coverage but follows Raven's moving `names-db` Release; commit `.raven/packages.json` from `raven packages freeze` when package metadata should be project-pinned.

--- a/docs/examples/ci/bitbucket-pipelines.yml
+++ b/docs/examples/ci/bitbucket-pipelines.yml
@@ -1,3 +1,6 @@
+# Runs on pull requests and on pushes to the default branch (main).
+# repository-push is scoped to main so pushing to a branch with an open
+# pull request runs only once (via pullrequest-push), not twice.
 image: ubuntu:24.04
 
 pipelines:
@@ -19,6 +22,10 @@ pipelines:
             - raven check
 
 triggers:
+  repository-push:
+    - condition: BITBUCKET_BRANCH == "main"
+      pipelines:
+        - Raven
   pullrequest-push:
     - condition: glob(BITBUCKET_BRANCH, "**")
       pipelines:

--- a/docs/examples/ci/bitbucket-pipelines.yml
+++ b/docs/examples/ci/bitbucket-pipelines.yml
@@ -1,18 +1,25 @@
 image: ubuntu:24.04
 
 pipelines:
-  default:
-    - step:
-        name: Raven
-        script:
-          - apt-get update
-          - apt-get install -y ca-certificates curl
-          - install -d -m 0755 /etc/apt/keyrings
-          - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
-          - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
-          - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
-          - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
-          - apt-get update
-          - apt-get install -y raven
-          - raven packages update
-          - raven check
+  custom:
+    Raven:
+      - step:
+          name: Raven
+          script:
+            - apt-get update
+            - apt-get install -y ca-certificates curl
+            - install -d -m 0755 /etc/apt/keyrings
+            - curl -fsSL https://jbearak.github.io/apt-raven/raven-archive-keyring.gpg -o /tmp/raven-archive-keyring.gpg
+            - echo "aaaee9d0c6d944091d1a78d8aeb4f93f59dc713ee1f218052add12b0d7c743cd  /tmp/raven-archive-keyring.gpg" | sha256sum -c -
+            - install -m 0644 /tmp/raven-archive-keyring.gpg /etc/apt/keyrings/raven-archive-keyring.gpg
+            - echo "deb [signed-by=/etc/apt/keyrings/raven-archive-keyring.gpg] https://jbearak.github.io/apt-raven stable main" > /etc/apt/sources.list.d/raven.list
+            - apt-get update
+            - apt-get install -y raven
+            - raven packages update
+            - raven check
+
+triggers:
+  pullrequest-push:
+    - condition: glob(BITBUCKET_BRANCH, "**")
+      pipelines:
+        - Raven

--- a/docs/examples/ci/github-actions-raven.yml
+++ b/docs/examples/ci/github-actions-raven.yml
@@ -3,11 +3,10 @@ name: Raven
 # Runs on pull requests and on pushes to the default branch (main).
 # Scoping push to main avoids a duplicate run when you push to a branch
 # that already has an open pull request (pull_request already covers that).
-on:
+"on":
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   raven:

--- a/docs/examples/ci/github-actions-raven.yml
+++ b/docs/examples/ci/github-actions-raven.yml
@@ -1,9 +1,13 @@
 name: Raven
 
+# Runs on pull requests and on pushes to the default branch (main).
+# Scoping push to main avoids a duplicate run when you push to a branch
+# that already has an open pull request (pull_request already covers that).
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
 
 jobs:
   raven:


### PR DESCRIPTION
## Summary

Fixes two defects in the documented CI examples (GitHub Actions + Bitbucket Pipelines), surfaced while reconciling with the sibling **Sight** repo's CI trigger work. The two repos now share a byte-identical trigger design.

- **GitHub Actions double-run:** unfiltered `push:` alongside `pull_request` (`synchronize`) fired **two** runs when pushing to a branch with an open PR. Scoped `push` to `main` so PR branches are covered solely by `pull_request`.
- **Bitbucket main-coverage gap:** the example only had `pullrequest-push`, so a direct push/merge to the default branch ran nothing. Added a `repository-push` trigger scoped to `main`. The two triggers are disjoint → no double-run.
- **GitHub trigger alignment:** dropped the explicit `pull_request` activity types (`ready_for_review` only re-ran an already-checked commit, since drafts already run on the default `opened`/`synchronize` types) and quoted `"on":`, matching Sight exactly.
- Added a note that a failing check does not block a merge unless made a required status check (GitHub) / merge check (Bitbucket), plus a one-line pointer that `raven check --format sarif` feeds code-scanning / Code Insights for teams who want it.

## Resulting behavior (both platforms)

| Event | Runs? |
|---|---|
| Push to `main` | once |
| Push to a PR branch | once (PR trigger only) |
| Open a PR | once |
| Push to a branch with no PR | no run |

## Notes

- Doc snippets in `docs/ci.md` and `docs/cli.md` are kept byte-for-byte in sync with the example files under `docs/examples/ci/` (verified).
- `tests/bun/apt-packaging.test.ts` passes (7/7).
- Bitbucket `triggers:`/`repository-push`/`pullrequest-push`/`glob()` schema verified against current Atlassian docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI setup examples for GitHub Actions and Bitbucket Pipelines.
  * Examples now show clearer trigger rules for pull requests and main-branch pushes to help avoid duplicate runs.
  * Expanded guidance on when CI should pass or fail, including clearer status-check and severity-threshold behavior.
  * Added more detailed notes for Bitbucket users on pipeline structure, editor warnings, and code scanning support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->