### PR TITLE
fix: attribute default-attached hover to the real owner package (#592)

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -20438,21 +20438,33 @@ pub async fn hover(state: &WorldState, uri: &Url, position: Position) -> Option<
                     package_name
                 );
                 if let Some(pkg) = package_name {
+                    // Default-attached exports are all seeded under the synthetic
+                    // `package:base` URI; recover the real owner (e.g. stats::ave)
+                    // before fetching help / building the help-panel link. Genuine
+                    // base topics (sum, ...) resolve back to "base" unchanged.
+                    // See issue #592.
+                    let owner: String = if pkg == "base" {
+                        state.package_library.resolve_default_attached_owner(name)
+                    } else {
+                        pkg.to_string()
+                    };
+                    let owner_ref = owner.as_str();
                     let help_text =
-                        get_help_cached(&state.help_cache, name, Some(pkg), r_path.clone()).await;
+                        get_help_cached(&state.help_cache, name, Some(owner_ref), r_path.clone())
+                            .await;
                     log::trace!(
                         "hover: get_help returned {:?}",
                         help_text.as_ref().map(|s| s.len())
                     );
                     if let Some(help_text) = help_text {
                         value.push_str(&format!("```\n{}\n```", help_text));
-                        value.insert_str(0, &build_help_panel_link(name, pkg));
+                        value.insert_str(0, &build_help_panel_link(name, owner_ref));
                     } else if let Some(sig) = &symbol.signature {
                         value.push_str(&format!("```r\n{}\n```\n", sig));
-                        value.push_str(&format!("\nfrom {{{}}}", pkg));
+                        value.push_str(&format!("\nfrom {{{}}}", owner_ref));
                     } else {
                         value.push_str(&format!("```r\n{}\n```\n", name));
-                        value.push_str(&format!("\nfrom {{{}}}", pkg));
+                        value.push_str(&format!("\nfrom {{{}}}", owner_ref));
                     }
                 } else if let Some(sig) = &symbol.signature {
                     value.push_str(&format!("```r\n{}\n```\n", sig));

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -424,6 +424,17 @@ pub struct PackageLibrary {
     /// share the set across snapshots without deep-cloning every published
     /// diagnostic batch.
     base_exports: Arc<HashSet<String>>,
+    /// Durable export-name → owner-package map for the default-attached base
+    /// packages (base, stats, utils, ...). Recovers the true owner of a symbol
+    /// that the cross-file scope pools under the synthetic `package:base` URI
+    /// (see `cross_file::scope::seed_base_exports`), e.g. `ave` → `stats`.
+    ///
+    /// Deliberately excluded from [`Self::clear_cache`] and rebuilt ONLY by
+    /// [`Self::initialize`] (via `recompute_default_attached_owners`), giving it
+    /// the same durability contract as `base_exports`: `raven.refreshPackages`
+    /// clears the per-package `packages` cache but must NOT drop this map, or
+    /// hover would revert to misattributing `ave` to {base}. See issue #592.
+    default_attached_owners: Arc<HashMap<String, String>>,
     /// R subprocess interface (None if R is unavailable)
     r_subprocess: Option<RSubprocess>,
     /// Ordered fallback metadata providers (Tier 2 repo DB, then Tier 3 shipped
@@ -453,6 +464,7 @@ impl PackageLibrary {
             combined_entries_write: Mutex::new(()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
+            default_attached_owners: Arc::new(HashMap::new()),
             r_subprocess: None,
             providers: Vec::new(),
             local_dev_overlay: ArcSwap::from_pointee(None),
@@ -476,6 +488,7 @@ impl PackageLibrary {
             combined_entries_write: Mutex::new(()),
             base_packages: HashSet::new(),
             base_exports: Arc::new(HashSet::new()),
+            default_attached_owners: Arc::new(HashMap::new()),
             r_subprocess,
             providers: Vec::new(),
             local_dev_overlay: ArcSwap::from_pointee(None),
@@ -1666,6 +1679,54 @@ impl PackageLibrary {
         self.find_in_per_package_cache(symbol, loaded_packages)
     }
 
+    /// Resolve the true owner package of `symbol` from the durable
+    /// default-attached owner map.
+    ///
+    /// Default-attached base packages are seeded into the cross-file scope under
+    /// the synthetic `package:base` URI by `seed_base_exports`, so symbols like
+    /// `ave` need this map to recover their real owner (`stats`) for hover help
+    /// and `from {pkg}` attribution. The map is built by
+    /// `recompute_default_attached_owners` during [`Self::initialize`] and is not
+    /// cleared by [`Self::clear_cache`], matching `base_exports` durability. This
+    /// keeps `raven.refreshPackages` from reverting symbols like `ave` to {base}
+    /// after the clearable per-package cache is wiped. See issue #592.
+    pub fn resolve_default_attached_owner(&self, symbol: &str) -> String {
+        self.default_attached_owners
+            .get(symbol)
+            .cloned()
+            .unwrap_or_else(|| "base".to_string())
+    }
+
+    /// Rebuild [`Self::default_attached_owners`] from the current per-package
+    /// `packages` cache, over the default-attached `base_packages`.
+    ///
+    /// Processes `base` first so it wins name collisions (a symbol base genuinely
+    /// exports stays attributed to base), then the other packages in byte/ASCII
+    /// `String` order (uppercase sorts before lowercase, so e.g. `grDevices`
+    /// precedes `graphics`) for deterministic — not human-alphabetical —
+    /// resolution of any cross-package collision. Called at the end of
+    /// [`Self::initialize`] once `packages` is fully populated. First-writer-wins
+    /// via `entry().or_insert`.
+    fn recompute_default_attached_owners(&mut self) {
+        let cache = self.packages.load();
+        let mut ordered: Vec<String> = self.base_packages.iter().cloned().collect();
+        ordered.sort_by(|a, b| match (a.as_str() == "base", b.as_str() == "base") {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.cmp(b),
+        });
+
+        let mut owners: HashMap<String, String> = HashMap::new();
+        for pkg in &ordered {
+            if let Some(info) = cache.get(pkg) {
+                for export in &info.exports {
+                    owners.entry(export.clone()).or_insert_with(|| pkg.clone());
+                }
+            }
+        }
+        self.default_attached_owners = Arc::new(owners);
+    }
+
     /// Set the library paths
     ///
     /// This is used during initialization to set the library paths
@@ -2064,6 +2125,7 @@ impl PackageLibrary {
         );
 
         self.base_exports = Arc::new(all_base_exports);
+        self.recompute_default_attached_owners();
         Ok(())
     }
 
@@ -4809,6 +4871,84 @@ mod tests {
         assert_eq!(
             lib.find_package_owner_for_symbol("mutate", &loaded),
             Some("dplyr".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_default_attached_owner_recovers_true_owner() {
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_base_packages(HashSet::from(["base".to_string(), "stats".to_string()]));
+        lib.set_base_exports(HashSet::from(["ave".to_string(), "sum".to_string()]));
+
+        lib.insert_package(PackageInfo::new(
+            "base".to_string(),
+            HashSet::from(["sum".to_string()]),
+        ))
+        .await;
+        lib.insert_package(PackageInfo::new(
+            "stats".to_string(),
+            HashSet::from(["ave".to_string()]),
+        ))
+        .await;
+        lib.recompute_default_attached_owners();
+
+        assert_eq!(lib.resolve_default_attached_owner("ave"), "stats");
+        assert_eq!(lib.resolve_default_attached_owner("sum"), "base");
+        assert_eq!(lib.resolve_default_attached_owner("not_exported"), "base");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_default_attached_owner_survives_clear_cache() {
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_base_packages(HashSet::from(["base".to_string(), "stats".to_string()]));
+        lib.set_base_exports(HashSet::from(["ave".to_string(), "sum".to_string()]));
+
+        lib.insert_package(PackageInfo::new(
+            "base".to_string(),
+            HashSet::from(["sum".to_string()]),
+        ))
+        .await;
+        lib.insert_package(PackageInfo::new(
+            "stats".to_string(),
+            HashSet::from(["ave".to_string()]),
+        ))
+        .await;
+        lib.recompute_default_attached_owners();
+
+        // Simulate `raven.refreshPackages`'s post-swap clear_cache: the per-package
+        // cache is wiped but the durable owner map must survive so hover still
+        // attributes `ave` to {stats}. Regression guard for issue #592.
+        lib.clear_cache().await;
+
+        assert_eq!(lib.resolve_default_attached_owner("ave"), "stats");
+        assert_eq!(lib.resolve_default_attached_owner("sum"), "base");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_default_attached_owner_uses_deterministic_overlap_winner() {
+        let mut lib = PackageLibrary::new_empty();
+        lib.set_base_packages(HashSet::from([
+            "base".to_string(),
+            "graphics".to_string(),
+            "grDevices".to_string(),
+        ]));
+        lib.set_base_exports(HashSet::from(["shared_sym".to_string()]));
+
+        lib.insert_package(PackageInfo::new(
+            "graphics".to_string(),
+            HashSet::from(["shared_sym".to_string()]),
+        ))
+        .await;
+        lib.insert_package(PackageInfo::new(
+            "grDevices".to_string(),
+            HashSet::from(["shared_sym".to_string()]),
+        ))
+        .await;
+        lib.recompute_default_attached_owners();
+
+        assert_eq!(
+            lib.resolve_default_attached_owner("shared_sym"),
+            "grDevices"
         );
     }
 


### PR DESCRIPTION
Fixes #592.

## Problem

Hovering a default-attached R function like `ave` (which really lives in `{stats}`) rendered a plain hover — `ave` / `from {base}` — with no bold clickable help heading and no inline help text.

Default-attached exports (the 7 base packages: base, stats, utils, methods, graphics, grDevices, datasets) are pooled into the cross-file scope under one synthetic `package:base` URI (`seed_base_exports`). The hover handler read the package name straight off that URI, so it asked R for `base::ave` help — a miss, since `ave`'s help topic is in `{stats}` — and fell back to the plain `from {base}` rendering. Literal `{base}` topics such as `sum` kept working only because their help really is in `{base}`.

## Fix

Recover the true owner package before calling `get_help_cached(...)` and `build_help_panel_link(...)`.

- New durable field `PackageLibrary::default_attached_owners: Arc<HashMap<String, String>>` (export name → owner), built by `recompute_default_attached_owners()` at the end of `initialize()`. `base` is processed first so a symbol base genuinely exports stays attributed to base; the other default-attached packages resolve in deterministic byte/ASCII order (first-writer-wins).
- `resolve_default_attached_owner(symbol)` is a pure lookup into that map, defaulting to `"base"`.
- The scope-resolved package-export hover branch in `handlers.rs` calls it when the source URI strips to `"base"`, then threads the recovered owner into help lookup, the help-panel link, and the `from {pkg}` fallbacks. Non-`base` package URIs (e.g. `package:dplyr`) are unchanged.

### Why a durable map (not the per-package cache)

The map has the same durability contract as `base_exports`: it is **not** cleared by `clear_cache()`. `raven.refreshPackages` rebuilds the library via `initialize()`, swaps it in, then calls `clear_cache()` — which wipes the per-package cache while `base_exports` persists. A cache-based lookup would therefore silently revert `ave` to `{base}` after a refresh; the durable map survives it.

## Result

- `ave` resolves/renders/links as `stats::ave`, with help text available from `{stats}`.
- `sum` and other literal `{base}` topics still resolve as `base::sum`.

## Tests

- `test_resolve_default_attached_owner_recovers_true_owner` — `ave`→stats, `sum`→base, unknown→base.
- `test_resolve_default_attached_owner_survives_clear_cache` — regression guard: owner map survives `clear_cache()`.
- `test_resolve_default_attached_owner_uses_deterministic_overlap_winner` — deterministic tie-break for a cross-package name collision.

## CI gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`, and the new tests all pass locally.