### PR TITLE
fix: accept omitted-dimension subset spacing `x[i, ]` in spaces_inside (#590)

### DIFF
--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -379,7 +379,7 @@ pub fn suppressed_lint_pairs(
 mod tests {
     use super::*;
     use crate::parser_pool::with_parser;
-    use tower_lsp::lsp_types::DiagnosticSeverity;
+    use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
 
     fn enabled_config() -> LintConfig {
         LintConfig {
@@ -1669,6 +1669,30 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn commas_and_spaces_inside_accept_omitted_subset_dimension() {
+        let config = LintConfig {
+            commas_severity: Some(DiagnosticSeverity::HINT),
+            spaces_inside_severity: Some(DiagnosticSeverity::HINT),
+            ..solo_config()
+        };
+
+        let canonical = lint("x[i, ]\n", &config);
+        assert!(
+            canonical.is_empty(),
+            "`x[i, ]` must be clean with both rules enabled: {:?}",
+            canonical
+        );
+
+        let compact = lint("x[i,]\n", &config);
+        assert_eq!(compact.len(), 1, "got {:?}", compact);
+        assert_eq!(
+            compact[0].code,
+            Some(NumberOrString::String(rule_ids::COMMAS.to_string()))
+        );
+        assert_eq!(compact[0].message, "Missing space after `,`.");
+    }
+
+    #[test]
     fn commas_in_parameters_are_also_checked() {
         let config = commas_only_config();
         // Tree-sitter treats `parameter` commas the same way; the rule walks
@@ -2273,10 +2297,66 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn spaces_inside_still_flags_subset_padding() {
+        let config = spaces_inside_only_config();
+        let diags = lint("df[ 1 ]\n", &config);
+        assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
     fn spaces_inside_flags_subset2() {
         let config = spaces_inside_only_config();
         let diags = lint("a[[ 1 ]]\n", &config);
         assert_eq!(diags.len(), 2, "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_accepts_trailing_comma_subset_omission() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x[i, ]\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_accepts_trailing_comma_subset2_omission() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x[[i, ]]\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_accepts_first_dimension_omission() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x[, ]\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn spaces_inside_flags_before_close_when_subset_prev_token_is_argument() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x[i, j ]\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].message, "Remove whitespace before `]`.");
+    }
+
+    #[test]
+    fn spaces_inside_still_flags_call_trailing_comma_padding() {
+        let config = spaces_inside_only_config();
+        let diags = lint("f(a, )\n", &config);
+        assert!(
+            diags
+                .iter()
+                .any(|diag| diag.message == "Remove whitespace before `)`."),
+            "call trailing comma padding must still be flagged: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn spaces_inside_allows_comment_before_subset_close() {
+        let config = spaces_inside_only_config();
+        let diags = lint("x[i, # c\n]\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
     }
 
     #[test]

--- a/crates/raven/src/linting/rules/spaces_inside.rs
+++ b/crates/raven/src/linting/rules/spaces_inside.rs
@@ -5,6 +5,10 @@
 //! tight: `f(x)`, `df[1]`, `mat[[i]]`. Empty groupings — `f()`, `f( )`,
 //! `mat[]`, `mat[ ]` — are left alone: there's no token next to the bracket
 //! to crowd, and forcing `f()` vs `f( )` is too pedantic for a hint.
+//! For `subset` and `subset2` only, a trailing comma that marks an omitted
+//! dimension keeps its before-close space (`x[i, ]`, `x[[i, ]]`) so this rule
+//! does not conflict with `commas_linter`; `call` nodes such as `f(a, )` are
+//! intentionally not carved out, keeping the exception scoped to R subsetting.
 //!
 //! Applies to `call`, `subset`, `subset2`, and `parenthesized_expression`
 //! nodes. The `open` and `close` field positions are used to anchor the
@@ -38,12 +42,19 @@ fn visit(
     out: &mut Vec<Diagnostic>,
 ) {
     match node.kind() {
-        "call" | "subset" | "subset2" => {
+        "call" => {
             if let Some(args) = node.child_by_field_name("arguments") {
-                check_bracketed(args, text, severity, suppressions, out);
+                check_bracketed(args, false, text, severity, suppressions, out);
             }
         }
-        "parenthesized_expression" => check_bracketed(node, text, severity, suppressions, out),
+        "subset" | "subset2" => {
+            if let Some(args) = node.child_by_field_name("arguments") {
+                check_bracketed(args, true, text, severity, suppressions, out);
+            }
+        }
+        "parenthesized_expression" => {
+            check_bracketed(node, false, text, severity, suppressions, out);
+        }
         _ => {}
     }
     let mut cursor = node.walk();
@@ -54,6 +65,7 @@ fn visit(
 
 fn check_bracketed(
     node: Node<'_>,
+    is_subset: bool,
     text: &str,
     severity: DiagnosticSeverity,
     suppressions: &Suppressions,
@@ -112,6 +124,20 @@ fn check_bracketed(
     if let Some(last_rel) = last_non_ws_rel {
         let before_close = &interior[last_rel..];
         if !before_close.is_empty() && !before_close.contains('\n') {
+            if is_subset
+                && close
+                    .prev_sibling()
+                    .is_some_and(|prev| prev.kind() == "comma")
+            {
+                // Accept canonical omitted-dimension subsets like `x[i, ]` so
+                // `spaces_inside` does not conflict with `commas_linter`,
+                // which flags the alternative `x[i,]`. This applies only to
+                // subset/subset2 nodes when the last token before `]` is a
+                // comma. Comment-before-`]` cases such as `x[i, # c\n]` stay
+                // safe because the pre-existing newline guard above suppresses
+                // them, so that guard must not be removed.
+                return;
+            }
             let close_text = text.get(close.start_byte()..close.end_byte()).unwrap_or("");
             emit_before_close(
                 close,

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -203,7 +203,7 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 
 - **Raven:** `raven.linting.spacesInsideSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::spaces_inside_linter()`.
-- Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Empty groupings (`f()`, `f( )`, `mat[]`) and multi-line wrapping are exempt — only single-line interior whitespace is flagged.
+- Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Empty groupings (`f()`, `f( )`, `mat[]`) and multi-line wrapping are exempt — only single-line interior whitespace is flagged. A trailing comma that marks an omitted subset dimension keeps its space (`x[i, ]`) and is not flagged, keeping the rule consistent with `commas`.
 
 ### Indentation
 


### PR DESCRIPTION
## Summary

Fixes #590. The `spaces_inside` lint flagged the canonical R subset spelling `x[i, ]` ("Remove whitespace before `` ] ``"), while the `commas` lint flags the alternative `x[i,]` ("Missing space after `` , ``"). Together the two rules left **no lint-clean spelling** for a common omitted-dimension subset.

## Fix

In `crates/raven/src/linting/rules/spaces_inside.rs`, `check_bracketed` now takes an `is_subset` flag (true only for `subset`/`subset2`). In the before-close branch only, the "Remove whitespace before `` ] ``" diagnostic is skipped when the token immediately before the closing bracket is a `comma` (`close.prev_sibling().kind() == "comma"`).

Result — matching real lintr:
- `x[i, ]` → **fully clean** (was flagged by `spaces_inside`).
- `x[i,]` → flagged by `commas` only ("Missing space after `` , ``"), unchanged.
- `x[, ]`, `x[[i, ]]` → clean.
- `df[ 1 ]`, `x[i, j ]` → still flagged (genuine stray interior space; prev token is an `argument`, not a comma).
- `f(a, )` → still flagged. `call` nodes are intentionally **not** carved out, keeping the exception scoped to R subsetting.

The comment-before-`` ] `` case (`x[i, # c\n]`) remains safe via the pre-existing newline guard (`!before_close.contains('\n')`), not the comma check; a code comment records this coupling so the guard is not removed.

## Test plan

Added unit tests in `crates/raven/src/linting/mod.rs`:
- `spaces_inside` clean: `x[i, ]`, `x[[i, ]]`, `x[, ]`, comment-before-close.
- `spaces_inside` still flags: `df[ 1 ]` (2), `x[i, j ]` (1), `f(a, )`.
- Combined-rule regression: `x[i, ]` → zero diagnostics; `x[i,]` → exactly one `commas` diagnostic.

Verified locally on the pinned toolchain:
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` ✅ (0 warnings)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items` ✅ (default and `--features test-support`)
- `cargo test -p raven --lib` ✅ (273 linting tests; full lib suite green — the only failures are `cli::packages` HTTP-mock tests that require local socket binding, which pass unsandboxed and are unrelated to this change)

`docs/linting.md` updated to document the carve-out.

https://claude.ai/code/session_01U19cMwSwr8Tiw9ghpATyhG