### PR TITLE
Fix lint parity and add comprehensive lintr audit

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,6 +22,35 @@ SOFTWARE.
 
 ---
 
+Raven's native lint compatibility tests adapt behavioral cases from the lintr
+test suite (https://github.com/r-lib/lintr), audited at commit
+603ab79e6db25d380c5ee96f35ffd6ba16d223aa.
+
+Copyright (c) 2014-2024, James Hester
+Copyright (c) 2025 lintr authors
+
+Licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 This project includes the R and R Markdown TextMate grammars from
 vscode-R-syntax (https://github.com/REditorSupport/vscode-R-syntax),
 copied from commit d5fbd7aca79df03112d2d3ee306bd4bef8a5526c into

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [Development Notes](docs/development.md) for build/test, profiling, and inte
 
 ## Provenance
 
-Raven includes code derived from [Ark](https://github.com/posit-dev/ark) (MIT License, Posit Software, PBC) — initial LSP wiring and tree-sitter scaffolding — and from Raven's sister project [Sight](https://github.com/jbearak/sight) (also GPL-3.0) — the cross-file awareness system (directives + position-aware scope model). The bundled R and R Markdown TextMate grammars come from [vscode-R-syntax](https://github.com/REditorSupport/vscode-R-syntax) (MIT).
+Raven includes code derived from [Ark](https://github.com/posit-dev/ark) (MIT License, Posit Software, PBC) — initial LSP wiring and tree-sitter scaffolding — and from Raven's sister project [Sight](https://github.com/jbearak/sight) (also GPL-3.0) — the cross-file awareness system (directives + position-aware scope model). The bundled R and R Markdown TextMate grammars come from [vscode-R-syntax](https://github.com/REditorSupport/vscode-R-syntax) (MIT). Raven's native lint compatibility tests adapt behavioral cases from [lintr](https://github.com/r-lib/lintr)'s test suite (MIT).
 
 Raven's downloadable package-symbol database is built from CRAN/Bioconductor metadata published by [r-universe](https://r-universe.dev), maintained by [rOpenSci](https://ropensci.org/r-universe/). See [Package database](docs/package-database.md#data-source-and-acknowledgement).
 

--- a/crates/raven/src/linting/lintr_parity.rs
+++ b/crates/raven/src/linting/lintr_parity.rs
@@ -225,6 +225,18 @@ const CASES: &[Case] = &[
     case(Rule::TAndF, "bare alias", "x <- T\n", true),
     case(Rule::TAndF, "alias assignment", "T <- 1\n", true),
     case(Rule::TAndF, "formula terms", "y ~ T + F\n", false),
+    case(
+        Rule::TAndF,
+        "nested named-argument formula term",
+        "y ~ foo(arg = T + 1)\n",
+        false,
+    ),
+    case(
+        Rule::TAndF,
+        "direct named-argument formula value",
+        "y ~ foo(arg = T)\n",
+        true,
+    ),
     case(Rule::TAndF, "subset object", "T[1]\n", false),
     case(Rule::TAndF, "named argument value", "f(na.rm = T)\n", true),
     case(Rule::Semicolon, "no separator", "x <- 1\n", false),
@@ -302,6 +314,18 @@ const CASES: &[Case] = &[
         "filter vector op",
         "filter(data, x & y)\n",
         false,
+    ),
+    case(
+        Rule::VectorLogic,
+        "magrittr-piped filter predicate",
+        "data %>% filter(x && y)\n",
+        true,
+    ),
+    case(
+        Rule::VectorLogic,
+        "native-piped filter predicate",
+        "data |> filter(x && y)\n",
+        true,
     ),
     case(
         Rule::FunctionLeftParentheses,

--- a/crates/raven/src/linting/lintr_parity.rs
+++ b/crates/raven/src/linting/lintr_parity.rs
@@ -1,0 +1,488 @@
+//! Cross-rule contract matrix adapted from lintr's upstream default tests.
+//!
+//! The cases below were audited against r-lib/lintr commit
+//! `603ab79e6db25d380c5ee96f35ffd6ba16d223aa` (3.3.0.9000, 2026-07-07)
+//! and spot-checked with the 3.3.0.1 release. They intentionally exercise
+//! default behavior that Raven advertises, not lintr options Raven does not
+//! expose (for example `allow_multiple_spaces = FALSE`) or package-aware
+//! namespace analysis. Focused rule tests remain responsible for diagnostic
+//! ranges, messages, suppressions, and Raven-specific extensions. See the
+//! repository `NOTICE` for lintr's MIT attribution.
+
+use std::collections::BTreeSet;
+
+use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
+
+use super::{LintConfig, rule_ids, run_lints};
+use crate::parser_pool::with_parser;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Rule {
+    LineLength,
+    TrailingWhitespace,
+    NoTab,
+    TrailingBlankLines,
+    AssignmentOperator,
+    ObjectName,
+    InfixSpaces,
+    CommentedCode,
+    Quotes,
+    Commas,
+    TAndF,
+    Semicolon,
+    EqualsNa,
+    ObjectLength,
+    VectorLogic,
+    FunctionLeftParentheses,
+    SpacesInside,
+    Indentation,
+}
+
+const ALL_RULES: &[Rule] = &[
+    Rule::LineLength,
+    Rule::TrailingWhitespace,
+    Rule::NoTab,
+    Rule::TrailingBlankLines,
+    Rule::AssignmentOperator,
+    Rule::ObjectName,
+    Rule::InfixSpaces,
+    Rule::CommentedCode,
+    Rule::Quotes,
+    Rule::Commas,
+    Rule::TAndF,
+    Rule::Semicolon,
+    Rule::EqualsNa,
+    Rule::ObjectLength,
+    Rule::VectorLogic,
+    Rule::FunctionLeftParentheses,
+    Rule::SpacesInside,
+    Rule::Indentation,
+];
+
+#[derive(Clone, Copy)]
+struct Case {
+    rule: Rule,
+    label: &'static str,
+    source: &'static str,
+    should_lint: bool,
+}
+
+const CASES: &[Case] = &[
+    case(Rule::LineLength, "at limit", "1234567890\n", false),
+    case(Rule::LineLength, "over limit", "12345678901\n", true),
+    case(Rule::TrailingWhitespace, "ordinary", "x <- 1  \n", true),
+    case(
+        Rule::TrailingWhitespace,
+        "empty line",
+        "x <- 1\n  \ny <- 2\n",
+        true,
+    ),
+    case(
+        Rule::TrailingWhitespace,
+        "inside multiline string",
+        "x <- 'a  \n'\n",
+        false,
+    ),
+    case(Rule::NoTab, "tab indentation", "\tx <- 1\n", true),
+    case(Rule::NoTab, "space indentation", "  x <- 1\n", false),
+    case(Rule::NoTab, "tab after comment marker", "#\tnote\n", false),
+    case(Rule::NoTab, "tab in string", "x <- \"a\tb\"\n", false),
+    case(
+        Rule::TrailingBlankLines,
+        "single terminal newline",
+        "x <- 1\n",
+        false,
+    ),
+    case(
+        Rule::TrailingBlankLines,
+        "trailing blank",
+        "x <- 1\n\n",
+        true,
+    ),
+    case(
+        Rule::TrailingBlankLines,
+        "missing terminal newline",
+        "x <- 1",
+        true,
+    ),
+    case(Rule::AssignmentOperator, "left arrow", "x <- 1\n", false),
+    case(
+        Rule::AssignmentOperator,
+        "equals assignment",
+        "x = 1\n",
+        true,
+    ),
+    case(
+        Rule::AssignmentOperator,
+        "named argument",
+        "f(x = 1)\n",
+        false,
+    ),
+    case(Rule::AssignmentOperator, "right arrow", "1 -> x\n", true),
+    case(
+        Rule::AssignmentOperator,
+        "superassignment",
+        "x <<- 1\n",
+        true,
+    ),
+    case(Rule::ObjectName, "snake case", "good_name <- 1\n", false),
+    case(Rule::ObjectName, "camel case", "badName <- 1\n", true),
+    case(
+        Rule::ObjectName,
+        "backtick camel case",
+        "`badName` <- 1\n",
+        true,
+    ),
+    case(
+        Rule::ObjectName,
+        "compound good base",
+        "good_name$BAD_FIELD <- 1\n",
+        false,
+    ),
+    case(
+        Rule::ObjectName,
+        "compound bad base",
+        "badName$field <- 1\n",
+        true,
+    ),
+    case(
+        Rule::ObjectName,
+        "S3 method",
+        "print.my_class <- function(x) x\n",
+        false,
+    ),
+    case(
+        Rule::ObjectName,
+        "namespace hook",
+        ".onLoad <- function(lib, pkg) NULL\n",
+        false,
+    ),
+    case(
+        Rule::ObjectName,
+        "assign literal",
+        "assign('badName', 1)\n",
+        true,
+    ),
+    case(Rule::InfixSpaces, "spaced addition", "x <- 1 + 2\n", false),
+    case(Rule::InfixSpaces, "tight addition", "x <- 1+2\n", true),
+    case(Rule::InfixSpaces, "tight exponent", "x <- x^2\n", false),
+    case(Rule::InfixSpaces, "spaced exponent", "x <- x ^ 2\n", false),
+    case(Rule::InfixSpaces, "tight named equals", "f(x=1)\n", true),
+    case(
+        Rule::InfixSpaces,
+        "spaced named equals",
+        "f(x = 1)\n",
+        false,
+    ),
+    case(Rule::InfixSpaces, "scientific sign", "x <- 2e-4\n", false),
+    case(Rule::CommentedCode, "prose", "# explanatory prose\n", false),
+    case(Rule::CommentedCode, "roxygen", "#' f(x)\n", false),
+    case(
+        Rule::CommentedCode,
+        "standalone assignment",
+        "# x <- 1\n",
+        true,
+    ),
+    case(
+        Rule::CommentedCode,
+        "inline call",
+        "x <- 1 # other_call()\n",
+        true,
+    ),
+    case(
+        Rule::CommentedCode,
+        "inline prose",
+        "x <- 1 # for example only\n",
+        false,
+    ),
+    case(Rule::Quotes, "double quoted", "x <- \"plain\"\n", false),
+    case(Rule::Quotes, "single quoted", "x <- 'plain'\n", true),
+    case(Rule::Quotes, "avoid escaping", "x <- '\"quoted\"'\n", false),
+    case(
+        Rule::Quotes,
+        "raw double quoted",
+        "x <- R\"(plain)\"\n",
+        false,
+    ),
+    case(Rule::Quotes, "raw single quoted", "x <- R'(plain)'\n", true),
+    case(Rule::Commas, "ordinary comma", "f(1, 2)\n", false),
+    case(Rule::Commas, "tight comma", "f(1,2)\n", true),
+    case(Rule::Commas, "space before", "f(1 , 2)\n", true),
+    case(Rule::Commas, "newline after", "f(1,\n2)\n", false),
+    case(
+        Rule::Commas,
+        "comma starts continuation line",
+        "f(1\n  ,\n2)\n",
+        false,
+    ),
+    case(Rule::Commas, "trailing subset comma", "x[1,]\n", true),
+    case(
+        Rule::TAndF,
+        "reserved literals",
+        "x <- c(TRUE, FALSE)\n",
+        false,
+    ),
+    case(Rule::TAndF, "bare alias", "x <- T\n", true),
+    case(Rule::TAndF, "alias assignment", "T <- 1\n", true),
+    case(Rule::TAndF, "formula terms", "y ~ T + F\n", false),
+    case(Rule::TAndF, "subset object", "T[1]\n", false),
+    case(Rule::TAndF, "named argument value", "f(na.rm = T)\n", true),
+    case(Rule::Semicolon, "no separator", "x <- 1\n", false),
+    case(
+        Rule::Semicolon,
+        "compound separator",
+        "x <- 1; y <- 2\n",
+        true,
+    ),
+    case(Rule::Semicolon, "trailing separator", "x <- 1;\n", true),
+    case(Rule::Semicolon, "inside string", "x <- \"a;b\"\n", false),
+    case(Rule::EqualsNa, "is.na", "is.na(x)\n", false),
+    case(Rule::EqualsNa, "equals NA", "x == NA\n", true),
+    case(Rule::EqualsNa, "typed NA", "x != NA_real_\n", true),
+    case(Rule::EqualsNa, "membership RHS", "x %in% NA\n", true),
+    case(Rule::EqualsNa, "membership LHS", "NA %in% x\n", false),
+    case(Rule::ObjectLength, "at limit", "abcde <- 1\n", false),
+    case(Rule::ObjectLength, "over limit", "abcdef <- 1\n", true),
+    case(
+        Rule::ObjectLength,
+        "quoted over limit",
+        "`abcdef` <- 1\n",
+        true,
+    ),
+    case(
+        Rule::ObjectLength,
+        "compound base",
+        "abcdef$field <- 1\n",
+        true,
+    ),
+    case(
+        Rule::ObjectLength,
+        "Unicode characters",
+        "résumé <- 1\n",
+        true,
+    ),
+    case(
+        Rule::ObjectLength,
+        "assign literal",
+        "assign('abcdef', 1)\n",
+        true,
+    ),
+    case(
+        Rule::VectorLogic,
+        "scalar conditional",
+        "if (x && y) 1\n",
+        false,
+    ),
+    case(
+        Rule::VectorLogic,
+        "vector conditional",
+        "if (x & y) 1\n",
+        true,
+    ),
+    case(
+        Rule::VectorLogic,
+        "aggregator boundary",
+        "if (any(x & y)) 1\n",
+        false,
+    ),
+    case(
+        Rule::VectorLogic,
+        "testthat assertion",
+        "expect_true(x | y)\n",
+        true,
+    ),
+    case(
+        Rule::VectorLogic,
+        "filter scalar op",
+        "filter(data, x && y)\n",
+        true,
+    ),
+    case(
+        Rule::VectorLogic,
+        "filter vector op",
+        "filter(data, x & y)\n",
+        false,
+    ),
+    case(
+        Rule::FunctionLeftParentheses,
+        "tight definition",
+        "f <- function(x) x\n",
+        false,
+    ),
+    case(
+        Rule::FunctionLeftParentheses,
+        "spaced definition",
+        "f <- function (x) x\n",
+        true,
+    ),
+    case(
+        Rule::FunctionLeftParentheses,
+        "tight call",
+        "mean(x)\n",
+        false,
+    ),
+    case(
+        Rule::FunctionLeftParentheses,
+        "spaced call",
+        "mean (x)\n",
+        true,
+    ),
+    case(
+        Rule::FunctionLeftParentheses,
+        "split call",
+        "if (x > mean\n(y)) x\n",
+        true,
+    ),
+    case(Rule::SpacesInside, "tight call", "f(x)\n", false),
+    case(Rule::SpacesInside, "padded call", "f( x )\n", true),
+    case(Rule::SpacesInside, "empty padded call", "f( )\n", true),
+    case(
+        Rule::SpacesInside,
+        "multiline call",
+        "f(\n    x\n)\n",
+        false,
+    ),
+    case(Rule::SpacesInside, "padded subset", "x[ 1 ]\n", true),
+    case(
+        Rule::SpacesInside,
+        "padded formal parameters",
+        "function( x ) x\n",
+        true,
+    ),
+    case(Rule::SpacesInside, "padded condition", "if ( x ) x\n", true),
+    case(
+        Rule::Indentation,
+        "braced block",
+        "if (x) {\n    y <- 1\n}\n",
+        false,
+    ),
+    case(
+        Rule::Indentation,
+        "underindented block",
+        "if (x) {\ny <- 1\n}\n",
+        true,
+    ),
+    case(
+        Rule::Indentation,
+        "aligned parenthesized Boolean clauses",
+        "changed <- !(\n    (is.na(old) & is.na(new)) |\n    (!is.na(old) & !is.na(new))\n)\n",
+        false,
+    ),
+];
+
+const fn case(rule: Rule, label: &'static str, source: &'static str, should_lint: bool) -> Case {
+    Case {
+        rule,
+        label,
+        source,
+        should_lint,
+    }
+}
+
+#[test]
+fn lintr_default_contract_matrix_covers_every_supported_rule() {
+    let covered: BTreeSet<_> = CASES.iter().map(|case| case.rule).collect();
+    let expected: BTreeSet<_> = ALL_RULES.iter().copied().collect();
+    assert_eq!(covered, expected, "the parity matrix must cover every rule");
+
+    for case in CASES {
+        let config = config_for(case.rule);
+        let tree = with_parser(|parser| parser.parse(case.source, None)).expect("source parses");
+        let diagnostics = run_lints(case.source, tree.root_node(), &config);
+        let rule_id = rule_id(case.rule);
+        let matching: Vec<_> = diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code.as_ref() == Some(&NumberOrString::String(rule_id.to_string()))
+            })
+            .collect();
+        assert_eq!(
+            !matching.is_empty(),
+            case.should_lint,
+            "{:?} / {}: source {:?}, diagnostics {:?}",
+            case.rule,
+            case.label,
+            case.source,
+            diagnostics
+        );
+    }
+}
+
+fn config_for(rule: Rule) -> LintConfig {
+    let mut config = LintConfig {
+        enabled: true,
+        line_length_severity: None,
+        trailing_whitespace_severity: None,
+        no_tab_severity: None,
+        trailing_blank_lines_severity: None,
+        assignment_operator_severity: None,
+        object_name_severity: None,
+        infix_spaces_severity: None,
+        commented_code_severity: None,
+        quotes_severity: None,
+        commas_severity: None,
+        t_and_f_symbol_severity: None,
+        semicolon_severity: None,
+        equals_na_severity: None,
+        object_length_severity: None,
+        vector_logic_severity: None,
+        function_left_parentheses_severity: None,
+        spaces_inside_severity: None,
+        indentation_severity: None,
+        ..LintConfig::default()
+    };
+    let severity = Some(DiagnosticSeverity::HINT);
+    match rule {
+        Rule::LineLength => {
+            config.line_length = 10;
+            config.line_length_severity = severity;
+        }
+        Rule::TrailingWhitespace => config.trailing_whitespace_severity = severity,
+        Rule::NoTab => config.no_tab_severity = severity,
+        Rule::TrailingBlankLines => config.trailing_blank_lines_severity = severity,
+        Rule::AssignmentOperator => config.assignment_operator_severity = severity,
+        Rule::ObjectName => config.object_name_severity = severity,
+        Rule::InfixSpaces => config.infix_spaces_severity = severity,
+        Rule::CommentedCode => config.commented_code_severity = severity,
+        Rule::Quotes => config.quotes_severity = severity,
+        Rule::Commas => config.commas_severity = severity,
+        Rule::TAndF => config.t_and_f_symbol_severity = severity,
+        Rule::Semicolon => config.semicolon_severity = severity,
+        Rule::EqualsNa => config.equals_na_severity = severity,
+        Rule::ObjectLength => {
+            config.object_length = 5;
+            config.object_length_severity = severity;
+        }
+        Rule::VectorLogic => config.vector_logic_severity = severity,
+        Rule::FunctionLeftParentheses => config.function_left_parentheses_severity = severity,
+        Rule::SpacesInside => config.spaces_inside_severity = severity,
+        Rule::Indentation => {
+            config.indentation_unit = 4;
+            config.indentation_severity = severity;
+        }
+    }
+    config
+}
+
+const fn rule_id(rule: Rule) -> &'static str {
+    match rule {
+        Rule::LineLength => rule_ids::LINE_LENGTH,
+        Rule::TrailingWhitespace => rule_ids::TRAILING_WHITESPACE,
+        Rule::NoTab => rule_ids::NO_TAB,
+        Rule::TrailingBlankLines => rule_ids::TRAILING_BLANK_LINES,
+        Rule::AssignmentOperator => rule_ids::ASSIGNMENT_OPERATOR,
+        Rule::ObjectName => rule_ids::OBJECT_NAME,
+        Rule::InfixSpaces => rule_ids::INFIX_SPACES,
+        Rule::CommentedCode => rule_ids::COMMENTED_CODE,
+        Rule::Quotes => rule_ids::QUOTES,
+        Rule::Commas => rule_ids::COMMAS,
+        Rule::TAndF => rule_ids::T_AND_F_SYMBOL,
+        Rule::Semicolon => rule_ids::SEMICOLON,
+        Rule::EqualsNa => rule_ids::EQUALS_NA,
+        Rule::ObjectLength => rule_ids::OBJECT_LENGTH,
+        Rule::VectorLogic => rule_ids::VECTOR_LOGIC,
+        Rule::FunctionLeftParentheses => rule_ids::FUNCTION_LEFT_PARENTHESES,
+        Rule::SpacesInside => rule_ids::SPACES_INSIDE,
+        Rule::Indentation => rule_ids::INDENTATION,
+    }
+}

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -1851,9 +1851,14 @@ print.data.frame <- function(x, ...) NULL
     #[test]
     fn t_and_f_formula_terms_are_not_boolean_usages() {
         let config = t_and_f_only_config();
-        let diags = lint("y ~ T + F\ny ~ foo(T, F)\n", &config);
+        let diags = lint(
+            "y ~ T + F\ny ~ foo(T, F)\ny ~ foo(arg = T + 1)\ny ~ foo(arg = !F)\ny ~ foo(arg = c(T))\n",
+            &config,
+        );
         assert!(diags.is_empty(), "got {diags:?}");
 
+        // lintr checks a bare alias used as the *direct* named-argument value,
+        // but nested expressions remain formula terms.
         let value = lint("y ~ foo(arg = T)\n", &config);
         assert_eq!(value.len(), 1, "got {value:?}");
     }
@@ -2099,6 +2104,41 @@ print.data.frame <- function(x, ...) NULL
         }
         assert!(lint("filter(data, x & y)\n", &config).is_empty());
         assert!(lint("stats::filter(data, x && y)\n", &config).is_empty());
+    }
+
+    #[test]
+    fn vector_logic_skips_filter_and_subset_control_arguments() {
+        let config = vector_logic_only_config();
+        for source in [
+            "dplyr::filter(data, .preserve = a && b)\n",
+            "filter(data, .by = a && b)\n",
+            "subset(data, select = a && b)\n",
+            "subset(data, drop = a || b)\n",
+        ] {
+            assert!(lint(source, &config).is_empty(), "{source:?}");
+        }
+
+        let filter = lint("dplyr::filter(data, x && y, .preserve = a && b)\n", &config);
+        assert_eq!(filter.len(), 1, "got {filter:?}");
+
+        let subset = lint(
+            "subset(data, subset = x || y, select = a && b, drop = c || d)\n",
+            &config,
+        );
+        assert_eq!(subset.len(), 1, "got {subset:?}");
+    }
+
+    #[test]
+    fn vector_logic_checks_pipe_fed_predicates() {
+        let config = vector_logic_only_config();
+        for source in [
+            "data %>% filter(x && y)\n",
+            "data %<>% filter(x && y)\n",
+            "data |> filter(x || y)\n",
+            "data |> subset(x && y)\n",
+        ] {
+            assert_eq!(lint(source, &config).len(), 1, "{source:?}");
+        }
     }
 
     // ------------------------------------------------------------------

--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -6,38 +6,40 @@
 //!
 //! Scope:
 //! * `line_length` — flag lines wider than the configured maximum.
-//! * `trailing_whitespace` — trailing spaces/tabs at end of line.
-//! * `no_tab` — one diagnostic per line that contains a tab, anchored at
-//!   the first tab on that line.
+//! * `trailing_whitespace` — trailing spaces/tabs at end of line, except line
+//!   endings inside multi-line strings (matching lintr's default).
+//! * `no_tab` — one diagnostic per line that uses a tab for indentation.
 //! * `trailing_blank_lines` — blank lines at the very end of the file.
-//! * `assignment_operator` — enforce `<-` (or `=`) for top-level assignment.
+//! * `assignment_operator` — enforce `<-` (or `=`) for assignments; the
+//!   default also rejects `<<-`, `->`, `->>`, and `%<>%`.
 //! * `object_name` — enforce accepted naming styles and regex patterns on
 //!   assignment targets and function arguments.
-//! * `infix_spaces` — flag missing spaces around binary infix operators and
+//! * `infix_spaces` — flag missing spaces around low-precedence binary infix operators and
 //!   stray spaces around tight-binding operators (`::`, `$`, `:`, unary `-/+/!`).
+//!   Exponentiation is excluded, matching lintr.
 //! * `commented_code` — flag standalone comment blocks whose body parses as R
-//!   and contains a call, assignment, operator, or function definition. This
+//!   and code-shaped end-of-line comments. This
 //!   rule re-parses each candidate comment body via the thread-local parser
 //!   pool. The same parser pool is also exercised by the suppression parser
 //!   on the rare commented-code line that carries an inline `# nolint` (see
 //!   below).
-//! * `quotes` — flag string literals not using the configured delimiter (`"`
-//!   or `'`). Raw strings are exempt.
+//! * `quotes` — flag regular or raw string literals not using the configured
+//!   delimiter (`"` or `'`) when switching would not introduce escaping.
 //! * `commas` — flag whitespace before `,` and missing whitespace after `,`
 //!   (newline after is fine).
-//! * `t_and_f_symbol` — flag bare `T` / `F` identifiers used as references to
-//!   `TRUE` / `FALSE`. Assignment targets, named arguments, formal
-//!   parameters, and `$` / `@` field names are exempt.
+//! * `t_and_f_symbol` — flag bare `T` / `F` identifiers used as references or
+//!   assignment targets. Formula terms, named argument/formal names, and
+//!   extraction/subsetting object names are exempt.
 //! * `semicolon` — flag `;` statement separators in source. Unlike the other
 //!   rules, this one byte-scans the raw source (skipping ranges that the AST
 //!   marks as `string` or `comment`) because tree-sitter-r does not emit `;`
 //!   as a node.
-//! * `equals_na` — flag `x == NA`, `x != NA`, and the typed `NA_*` variants
-//!   on either side.
+//! * `equals_na` — flag `x == NA`, `x != NA`, `x %in% NA`, and the typed
+//!   `NA_*` variants.
 //! * `object_length` — flag identifier names longer than the configured
 //!   maximum length.
-//! * `vector_logic` — flag `&` / `|` in `if` / `while` conditions; call
-//!   boundaries stop the scan so `if (any(x & y))` is left alone.
+//! * `vector_logic` — flag `&` / `|` in scalar conditions/assertions and
+//!   `&&` / `||` in `filter()` / `subset()` predicates.
 //! * `mixed_logical` — flag `|` / `||` whose immediate operand is a bare
 //!   `&` / `&&` (without parentheses), e.g. `a & b | c`. `&` binds tighter
 //!   than `|` in R, making the grouping easy to mis-read; adding parentheses
@@ -46,8 +48,8 @@
 //!   inside an `if` or `while` condition. R rejects `if (x = 1)` as a
 //!   syntax error at runtime but tree-sitter-r accepts it silently; use `==`
 //!   for equality tests and `<-` for assignment.
-//! * `function_left_parentheses` — flag whitespace between `function`
-//!   (or `\`) and `(`.
+//! * `function_left_parentheses` — flag whitespace before `(` in function
+//!   definitions and calls.
 //! * `spaces_inside` — flag whitespace immediately inside `(`, `[`, `[[`
 //!   and their closers. Empty groupings and multi-line wrapping are exempt.
 //! * `indentation` — flag lines whose leading whitespace doesn't match the
@@ -90,6 +92,8 @@ mod parse_gate;
 pub(crate) use nolint::{
     Suppressions as SuppressionsForParityTest, first_hash_body_for_parity_test,
 };
+#[cfg(test)]
+mod lintr_parity;
 pub mod rule_ids;
 mod rules;
 
@@ -145,10 +149,10 @@ fn run_lints_with(
         rules::line_length::collect(text, config.line_length, sev, &suppressions, &mut out);
     }
     if let Some(sev) = config.trailing_whitespace_severity {
-        rules::trailing_whitespace::collect(text, sev, &suppressions, &mut out);
+        rules::trailing_whitespace::collect(text, tree_root, sev, &suppressions, &mut out);
     }
     if let Some(sev) = config.no_tab_severity {
-        rules::no_tab::collect(text, sev, &suppressions, &mut out);
+        rules::no_tab::collect(text, tree_root, sev, &suppressions, &mut out);
     }
     if let Some(sev) = config.trailing_blank_lines_severity {
         rules::trailing_blank_lines::collect(text, sev, &suppressions, &mut out);
@@ -476,6 +480,29 @@ mod tests {
     }
 
     #[test]
+    fn trailing_whitespace_inside_multiline_strings_is_allowed() {
+        let mut config = solo_config();
+        config.trailing_whitespace_severity = Some(DiagnosticSeverity::HINT);
+        let diags = lint("x <- 'two spaces  \n  \n'  \n", &config);
+        assert_eq!(
+            diags.len(),
+            1,
+            "only whitespace after the string should lint: {diags:?}"
+        );
+        assert_eq!(diags[0].range.start.line, 2);
+    }
+
+    #[test]
+    fn no_tab_only_checks_indentation() {
+        let mut config = solo_config();
+        config.no_tab_severity = Some(DiagnosticSeverity::HINT);
+        let text = "#\ttab in comment\nx <- \"a\tb\"\n\tbad_indent <- 1\n";
+        let diags = lint(text, &config);
+        assert_eq!(diags.len(), 1, "got {diags:?}");
+        assert_eq!(diags[0].range.start.line, 2);
+    }
+
+    #[test]
     fn no_tab_flags_first_run_per_line() {
         let config = LintConfig {
             line_length_severity: None,
@@ -617,6 +644,22 @@ mod tests {
         let diags = lint("x <- 1\n", &config);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("Use `=`"));
+    }
+
+    #[test]
+    fn assignment_operator_default_flags_other_assignment_forms() {
+        let mut config = solo_config();
+        config.assignment_operator_severity = Some(DiagnosticSeverity::HINT);
+        for (source, operator) in [
+            ("value -> name\n", "->"),
+            ("value ->> name\n", "->>"),
+            ("name <<- value\n", "<<-"),
+            ("name %<>% transform()\n", "%<>%"),
+        ] {
+            let diags = lint(source, &config);
+            assert_eq!(diags.len(), 1, "{operator}: {diags:?}");
+            assert!(diags[0].message.contains(operator), "{operator}: {diags:?}");
+        }
     }
 
     #[test]
@@ -792,14 +835,40 @@ mod tests {
     }
 
     #[test]
-    fn object_name_skips_backtick_quoted_names() {
+    fn object_name_checks_base_of_compound_lhs() {
         let config = object_name_only_config();
-        let diags = lint("`with spaces` <- 1\n", &config);
-        assert!(
-            diags.is_empty(),
-            "backtick names should be skipped: {:?}",
-            diags
-        );
+        let diags = lint("badName$externalField <- 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {diags:?}");
+        assert!(diags[0].message.contains("badName"));
+    }
+
+    #[test]
+    fn object_name_checks_backtick_quoted_names() {
+        let config = object_name_only_config();
+        let diags = lint("`badName` <- 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert!(diags[0].message.contains("Variable name `badName`"));
+    }
+
+    #[test]
+    fn object_name_regexes_receive_unquoted_backtick_name() {
+        let mut config = object_name_only_config();
+        config.object_name_style_variable.clear();
+        config.object_name_regexes_variable =
+            vec![CompiledRegex::new("^badName$").expect("valid regex")];
+        let regex_only = lint("`badName` <- 1\n", &config);
+        assert!(regex_only.is_empty(), "got {regex_only:?}");
+
+        config.object_name_style_variable = vec![ObjectNameStyle::SnakeCase];
+        let combined = lint("`badName` <- 1\n", &config);
+        assert!(combined.is_empty(), "got {combined:?}");
+    }
+
+    #[test]
+    fn object_name_exempts_backtick_operator_s3_methods() {
+        let config = object_name_only_config();
+        let diags = lint("`+.my_class` <- function(x) x\n", &config);
+        assert!(diags.is_empty(), "got {diags:?}");
     }
 
     #[test]
@@ -964,6 +1033,18 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
+    fn infix_spaces_ignores_exponentiation_spacing() {
+        let config = infix_spaces_only_config();
+        for text in ["x <- x^2\n", "x <- x ^ 2\n"] {
+            let diags = lint(text, &config);
+            assert!(
+                diags.is_empty(),
+                "exponentiation is outside lintr's infix-spacing policy: {diags:?}"
+            );
+        }
+    }
+
+    #[test]
     fn infix_spaces_does_not_flag_alignment_whitespace() {
         // Multiple spaces around an operator are allowed — alignment is a
         // common pattern and collapsing it would be more annoying than helpful.
@@ -1077,33 +1158,19 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn infix_spaces_does_not_flag_named_argument() {
+    fn infix_spaces_checks_named_argument_equals() {
         let config = infix_spaces_only_config();
-        // tree-sitter-r parses `name=value` inside a call as an `argument`
-        // node, never a `binary_operator`. The infix-spaces rule must never
-        // touch named arguments — they are an unrelated syntactic form.
         let diags = lint("f(name=value)\n", &config);
-        assert!(
-            diags.is_empty(),
-            "named arguments must not be flagged: {:?}",
-            diags
-        );
+        assert_eq!(diags.len(), 2, "got {diags:?}");
+        assert!(lint("f(name = value)\n", &config).is_empty());
     }
 
     #[test]
-    fn infix_spaces_does_not_flag_function_default_argument() {
+    fn infix_spaces_checks_function_default_argument() {
         let config = infix_spaces_only_config();
-        // tree-sitter-r parses formal-parameter defaults like `x=1` as a
-        // `parameter` node (operator `=` is a direct child), not as a
-        // `binary_operator`. The rule must therefore leave both spaced and
-        // unspaced defaults alone.
         let no_space = lint("f <- function(x=1) x\n", &config);
         let with_space = lint("f <- function(x = 1) x\n", &config);
-        assert!(
-            no_space.is_empty(),
-            "function(x=1) defaults must not be flagged: {:?}",
-            no_space
-        );
+        assert_eq!(no_space.len(), 2, "got {no_space:?}");
         assert!(
             with_space.is_empty(),
             "function(x = 1) defaults must not be flagged: {:?}",
@@ -1341,16 +1408,11 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn commented_code_skips_end_of_line_comments() {
+    fn commented_code_checks_code_shaped_end_of_line_comments() {
         let config = commented_code_only_config();
-        // The `# x <- 2` is an end-of-line annotation, not standalone dead
-        // code. Don't flag.
         let diags = lint("x <- 1 # x <- 2\n", &config);
-        assert!(
-            diags.is_empty(),
-            "end-of-line comment must not be flagged: {:?}",
-            diags
-        );
+        assert_eq!(diags.len(), 1, "got {diags:?}");
+        assert!(lint("x <- 1 # explanatory prose\n", &config).is_empty());
     }
 
     #[test]
@@ -1594,15 +1656,17 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn quotes_skips_raw_strings() {
+    fn quotes_checks_raw_string_delimiter() {
         let config = quotes_only_config();
-        // Raw strings — both quote types are common because the body picks.
         let diags = lint("x <- r'(hi)'\n", &config);
-        assert!(
-            diags.is_empty(),
-            "raw strings must not be flagged: {:?}",
-            diags
-        );
+        assert_eq!(diags.len(), 1, "got {diags:?}");
+    }
+
+    #[test]
+    fn quotes_allows_alternate_delimiter_to_avoid_escaping() {
+        let config = quotes_only_config();
+        let diags = lint("x <- '\"already quoted\"'\n", &config);
+        assert!(diags.is_empty(), "got {diags:?}");
     }
 
     #[test]
@@ -1746,11 +1810,10 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn t_and_f_skips_assignment_target() {
+    fn t_and_f_flags_assignment_target() {
         let config = t_and_f_only_config();
-        // `T <- 0` — the LHS itself is the assignment target, not a read.
         let diags = lint("T <- 0\n", &config);
-        assert!(diags.is_empty(), "got {:?}", diags);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
     }
 
     #[test]
@@ -1770,11 +1833,10 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn t_and_f_flags_extract_lhs() {
+    fn t_and_f_skips_extract_and_subset_object_names() {
         let config = t_and_f_only_config();
-        // `T$foo` — `T` on the LHS *is* a read of the boolean.
-        let diags = lint("x <- T$foo\n", &config);
-        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        let diags = lint("T$field\nT[1]\nT[[1]]\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
     }
 
     #[test]
@@ -1784,6 +1846,16 @@ print.data.frame <- function(x, ...) NULL
         let diags = lint("f <- function(T) T + 1\n", &config);
         // Only the *use* of `T` in the body is a read.
         assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn t_and_f_formula_terms_are_not_boolean_usages() {
+        let config = t_and_f_only_config();
+        let diags = lint("y ~ T + F\ny ~ foo(T, F)\n", &config);
+        assert!(diags.is_empty(), "got {diags:?}");
+
+        let value = lint("y ~ foo(arg = T)\n", &config);
+        assert_eq!(value.len(), 1, "got {value:?}");
     }
 
     // ------------------------------------------------------------------
@@ -1877,6 +1949,15 @@ print.data.frame <- function(x, ...) NULL
         assert!(diags.is_empty(), "got {:?}", diags);
     }
 
+    #[test]
+    fn equals_na_flags_membership_only_when_na_is_rhs() {
+        let config = equals_na_only_config();
+        let bad = lint("x %in% NA\n", &config);
+        assert_eq!(bad.len(), 1, "got {bad:?}");
+        let good = lint("NA %in% x\n", &config);
+        assert!(good.is_empty(), "got {good:?}");
+    }
+
     // ------------------------------------------------------------------
     // object_length
     // ------------------------------------------------------------------
@@ -1924,10 +2005,10 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn object_length_skips_backtick_names() {
+    fn object_length_checks_backtick_names_without_delimiters() {
         let config = object_length_only_config(5);
         let diags = lint("`a very long backtick name` <- 1\n", &config);
-        assert!(diags.is_empty(), "got {:?}", diags);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
     }
 
     #[test]
@@ -1936,6 +2017,13 @@ print.data.frame <- function(x, ...) NULL
         // `obj$longer_field <- 1` — assignment doesn't introduce a new symbol.
         let diags = lint("obj$longer_field <- 1\n", &config);
         assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn object_length_checks_compound_lhs_base_and_unicode() {
+        let config = object_length_only_config(5);
+        let diags = lint("résumé_name$field <- 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {diags:?}");
     }
 
     // ------------------------------------------------------------------
@@ -1992,6 +2080,25 @@ print.data.frame <- function(x, ...) NULL
         let config = vector_logic_only_config();
         let diags = lint("if (a & b || c) 1\n", &config);
         assert_eq!(diags.len(), 1, "got {:?}", diags);
+    }
+
+    #[test]
+    fn vector_logic_checks_testthat_assertions() {
+        let config = vector_logic_only_config();
+        for source in ["expect_true(x & y)\n", "testthat::expect_false(x | y)\n"] {
+            assert_eq!(lint(source, &config).len(), 1, "{source:?}");
+        }
+        assert!(lint("expect_true(any(x & y))\n", &config).is_empty());
+    }
+
+    #[test]
+    fn vector_logic_checks_filter_and_subset_predicates() {
+        let config = vector_logic_only_config();
+        for source in ["filter(data, x && y)\n", "subset(data, x || y)\n"] {
+            assert_eq!(lint(source, &config).len(), 1, "{source:?}");
+        }
+        assert!(lint("filter(data, x & y)\n", &config).is_empty());
+        assert!(lint("stats::filter(data, x && y)\n", &config).is_empty());
     }
 
     // ------------------------------------------------------------------
@@ -2264,6 +2371,23 @@ print.data.frame <- function(x, ...) NULL
         assert!(diags.is_empty(), "got {:?}", diags);
     }
 
+    #[test]
+    fn flp_checks_named_function_calls() {
+        let config = flp_only_config();
+        for source in ["mean (x)\n", "base::mean (x)\n", "object$method (x)\n"] {
+            let diags = lint(source, &config);
+            assert_eq!(diags.len(), 1, "{source:?}: {diags:?}");
+        }
+        assert!(lint("mean(x)\n", &config).is_empty());
+    }
+
+    #[test]
+    fn flp_checks_calls_split_across_lines() {
+        let config = flp_only_config();
+        let diags = lint("if (y > mean\n(x)) TRUE\n", &config);
+        assert_eq!(diags.len(), 1, "got {diags:?}");
+    }
+
     // ------------------------------------------------------------------
     // spaces_inside
     // ------------------------------------------------------------------
@@ -2290,13 +2414,12 @@ print.data.frame <- function(x, ...) NULL
     }
 
     #[test]
-    fn spaces_inside_allows_empty_call() {
+    fn spaces_inside_distinguishes_empty_from_whitespace_only_call() {
         let config = spaces_inside_only_config();
-        // `f()` and `f( )` are both fine — empty groupings are exempt.
         let diags_empty = lint("f()\n", &config);
         let diags_padded = lint("f(  )\n", &config);
         assert!(diags_empty.is_empty(), "got {:?}", diags_empty);
-        assert!(diags_padded.is_empty(), "got {:?}", diags_padded);
+        assert_eq!(diags_padded.len(), 2, "got {:?}", diags_padded);
     }
 
     #[test]

--- a/crates/raven/src/linting/rules/assignment_operator.rs
+++ b/crates/raven/src/linting/rules/assignment_operator.rs
@@ -1,7 +1,8 @@
-//! Enforce a single assignment operator at top-level.
+//! Enforce the configured assignment operator.
 //!
-//! Walks the tree-sitter AST for `binary_operator` nodes whose `operator`
-//! field is `<-` or `=`. A `=` whose `binary_operator` lives *directly* under
+//! Walks the tree-sitter AST for assignment `binary_operator` nodes. With the
+//! default `<-` policy, `=`, `<<-`, `->`, `->>`, and `%<>%` are reported,
+//! matching `lintr::assignment_linter()` defaults. A `=` whose node lives *directly* under
 //! an `argument` node is named-argument syntax (`f(name = value)`) and is
 //! never reported. Assignments inside nested expressions — function bodies,
 //! braced blocks, control flow — are reported normally even when they appear
@@ -44,10 +45,7 @@ fn visit(
         // condition_assignment handles it with a more specific message.
         let skip_for_condition = op_text == "=" && is_if_while_condition_directly(node);
         if !skip_for_condition && !is_named_argument(node, op_text) {
-            let bad = match style {
-                AssignmentOperatorStyle::LeftArrow => op_text == "=",
-                AssignmentOperatorStyle::Equals => op_text == "<-",
-            };
+            let bad = is_disallowed_assignment(op_text, style);
             if bad {
                 let line_no = op_node.start_position().row as u32;
                 if !suppressions.is_suppressed_code(line_no, rule_ids::ASSIGNMENT_OPERATOR) {
@@ -83,6 +81,17 @@ fn visit(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         visit(child, text, style, severity, suppressions, out);
+    }
+}
+
+fn is_disallowed_assignment(op_text: &str, style: AssignmentOperatorStyle) -> bool {
+    match style {
+        AssignmentOperatorStyle::LeftArrow => {
+            matches!(op_text, "=" | "<<-" | "->" | "->>" | "%<>%")
+        }
+        AssignmentOperatorStyle::Equals => {
+            matches!(op_text, "<-" | "<<-" | "->" | "->>" | "%<>%")
+        }
     }
 }
 

--- a/crates/raven/src/linting/rules/commas.rs
+++ b/crates/raven/src/linting/rules/commas.rs
@@ -52,11 +52,15 @@ fn check_comma(
     let end = node.end_byte();
 
     // Space before comma: look at the byte immediately before. Only flag a
-    // *single-line* space — a comma at column 0 (after a leading newline) is
-    // a multi-line continuation, not a style violation.
+    // *single-line* space — a comma that is the first non-whitespace token on
+    // its line is a multi-line continuation, not a style violation.
     if start > 0 {
         let prev = bytes[start - 1];
-        if prev == b' ' || prev == b'\t' {
+        let line_start = text[..start].rfind('\n').map_or(0, |offset| offset + 1);
+        let comma_is_first_token = text[line_start..start]
+            .bytes()
+            .all(|byte| byte == b' ' || byte == b'\t');
+        if (prev == b' ' || prev == b'\t') && !comma_is_first_token {
             emit(
                 node,
                 text,

--- a/crates/raven/src/linting/rules/commented_code.rs
+++ b/crates/raven/src/linting/rules/commented_code.rs
@@ -2,10 +2,7 @@
 //!
 //! Mirrors `lintr::commented_code_linter`. A comment is flagged when:
 //!
-//! 1. It is the only content on its line (end-of-line comments next to real
-//!    code are left alone — those are annotations on the statement, not dead
-//!    code).
-//! 2. After stripping the leading `#` characters and whitespace, the remaining
+//! 1. After stripping the leading `#` characters and whitespace, the remaining
 //!    text parses cleanly as R (no `ERROR` nodes) and contains at least one
 //!    "code-like" construct — a call, an assignment, a binary or unary
 //!    operator, or a function definition. Bare identifiers, literals, and
@@ -59,7 +56,37 @@ pub(crate) fn collect(
     // preceding the `#` on its line is whitespace. End-of-line comments next
     // to code (`x <- 1 # explain`) are intentionally left alone.
     let mut standalone: Vec<StandaloneComment> = Vec::new();
-    collect_standalone(root, &lines, &mut standalone);
+    let mut inline: Vec<InlineComment> = Vec::new();
+    collect_comments(root, &lines, &mut standalone, &mut inline);
+
+    // lintr also checks code-shaped end-of-line comments. Ordinary prose
+    // annotations still fail `looks_like_code` and remain silent.
+    for comment in inline {
+        let line_text = lines.get(comment.line as usize).copied().unwrap_or("");
+        let comment_text = line_text.get(comment.start_byte_on_line..).unwrap_or("");
+        if is_skip_line(comment_text, comment.line == 0)
+            || suppressions.is_suppressed_code(comment.line, rule_ids::COMMENTED_CODE)
+        {
+            continue;
+        }
+        let stripped = strip_and_join(&[comment_text]);
+        if !looks_like_code(&stripped) {
+            continue;
+        }
+        let start_col = byte_offset_to_utf16_column(line_text, comment.start_byte_on_line);
+        let end_col = byte_offset_to_utf16_column(line_text, line_text.len());
+        out.push(Diagnostic {
+            range: Range {
+                start: Position::new(comment.line, start_col),
+                end: Position::new(comment.line, end_col),
+            },
+            severity: Some(severity),
+            source: Some(LINT_SOURCE.to_string()),
+            code: Some(NumberOrString::String(rule_ids::COMMENTED_CODE.to_string())),
+            message: "Commented code should be removed.".to_string(),
+            ..Default::default()
+        });
+    }
 
     // Group consecutive standalone comments (adjacent lines, nothing else in
     // between), then *split* each group on any line that is itself a skip
@@ -144,7 +171,18 @@ struct StandaloneComment {
     start_byte_on_line: usize,
 }
 
-fn collect_standalone<'a>(node: Node<'a>, lines: &[&str], out: &mut Vec<StandaloneComment>) {
+#[derive(Debug, Clone, Copy)]
+struct InlineComment {
+    line: u32,
+    start_byte_on_line: usize,
+}
+
+fn collect_comments<'a>(
+    node: Node<'a>,
+    lines: &[&str],
+    standalone: &mut Vec<StandaloneComment>,
+    inline: &mut Vec<InlineComment>,
+) {
     if node.kind() == "comment" {
         let start = node.start_position();
         let line_idx = start.row;
@@ -162,7 +200,12 @@ fn collect_standalone<'a>(node: Node<'a>, lines: &[&str], out: &mut Vec<Standalo
                     .bytes()
                     .all(|b| b == b' ' || b == b'\t')
             {
-                out.push(StandaloneComment {
+                standalone.push(StandaloneComment {
+                    line: line_idx as u32,
+                    start_byte_on_line: col_bytes,
+                });
+            } else if col_bytes <= line.len() {
+                inline.push(InlineComment {
                     line: line_idx as u32,
                     start_byte_on_line: col_bytes,
                 });
@@ -172,7 +215,7 @@ fn collect_standalone<'a>(node: Node<'a>, lines: &[&str], out: &mut Vec<Standalo
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_standalone(child, lines, out);
+        collect_comments(child, lines, standalone, inline);
     }
 }
 

--- a/crates/raven/src/linting/rules/equals_na.rs
+++ b/crates/raven/src/linting/rules/equals_na.rs
@@ -4,7 +4,8 @@
 //! is itself `NA`, never `TRUE`/`FALSE`. The idiomatic check is `is.na(x)`.
 //! Applies to every typed `NA` token tree-sitter-r recognises (`NA`,
 //! `NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_`), both as `==`
-//! and `!=`, on either side.
+//! and `!=` on either side, plus `x %in% NA`. `NA %in% x` is not equivalent
+//! to testing whether `x` is missing and is left alone, matching lintr.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -51,12 +52,14 @@ fn check(
         return;
     };
     let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
-    if op_text != "==" && op_text != "!=" {
+    if !matches!(op_text, "==" | "!=" | "%in%") {
         return;
     }
     let lhs = node.child_by_field_name("lhs");
     let rhs = node.child_by_field_name("rhs");
-    let na_side = if lhs.is_some_and(is_na_literal) {
+    let na_side = if op_text == "%in%" {
+        rhs.filter(|node| is_na_literal(*node))
+    } else if lhs.is_some_and(is_na_literal) {
         lhs
     } else if rhs.is_some_and(is_na_literal) {
         rhs

--- a/crates/raven/src/linting/rules/function_left_parentheses.rs
+++ b/crates/raven/src/linting/rules/function_left_parentheses.rs
@@ -1,10 +1,8 @@
-//! Flag whitespace between `function` (or `\`) and its parameter `(`.
+//! Flag whitespace before a function definition's or function call's `(`.
 //!
-//! Mirrors `lintr::function_left_parentheses_linter`. `function (x) ...` and
-//! `\ (x) ...` are valid R but the tight `function(x) ...` / `\(x) ...` is
-//! the community convention. Tree-sitter-r exposes both forms as
-//! `function_definition` with a `name` field holding the `function` keyword
-//! (or `\`) and a `parameters` field holding the `(...)` block.
+//! Mirrors `lintr::function_left_parentheses_linter`. `function (x) ...`,
+//! `\ (x) ...`, and `mean (x)` are valid R, but the tight `function(x) ...`,
+//! `\(x) ...`, and `mean(x)` forms are the community convention.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -31,8 +29,10 @@ fn visit(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    if node.kind() == "function_definition" {
-        check(node, text, severity, suppressions, out);
+    match node.kind() {
+        "function_definition" => check_definition(node, text, severity, suppressions, out),
+        "call" => check_call(node, text, severity, suppressions, out),
+        _ => {}
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -40,7 +40,7 @@ fn visit(
     }
 }
 
-fn check(
+fn check_definition(
     node: Node<'_>,
     text: &str,
     severity: DiagnosticSeverity,
@@ -95,6 +95,81 @@ fn check(
             rule_ids::FUNCTION_LEFT_PARENTHESES.to_string(),
         )),
         message: format!("Remove whitespace between `{keyword}` and `(`."),
+        ..Default::default()
+    });
+}
+
+fn check_call(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+    if !matches!(
+        function.kind(),
+        "identifier" | "string" | "namespace_operator" | "extract_operator"
+    ) {
+        return;
+    }
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return;
+    };
+    emit_gap(
+        function,
+        arguments,
+        "function call",
+        text,
+        severity,
+        suppressions,
+        out,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_gap(
+    left: Node<'_>,
+    right: Node<'_>,
+    context: &str,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let gap_start = left.end_byte();
+    let gap_end = right.start_byte();
+    if gap_end <= gap_start {
+        return;
+    }
+    let Some(gap) = text.get(gap_start..gap_end) else {
+        return;
+    };
+    if gap.is_empty() || !gap.chars().all(char::is_whitespace) {
+        return;
+    }
+    let line_no = left.end_position().row as u32;
+    if suppressions.is_suppressed_code(line_no, rule_ids::FUNCTION_LEFT_PARENTHESES) {
+        return;
+    }
+    let start_line_text = text.lines().nth(line_no as usize).unwrap_or("");
+    let start_col = byte_offset_to_utf16_column(start_line_text, left.end_position().column);
+    let end_line = right.start_position().row as u32;
+    let end_line_text = text.lines().nth(end_line as usize).unwrap_or("");
+    let end_col = byte_offset_to_utf16_column(end_line_text, right.start_position().column);
+    out.push(Diagnostic {
+        range: Range {
+            start: Position::new(line_no, start_col),
+            end: Position::new(end_line, end_col),
+        },
+        severity: Some(severity),
+        source: Some(LINT_SOURCE.to_string()),
+        code: Some(NumberOrString::String(
+            rule_ids::FUNCTION_LEFT_PARENTHESES.to_string(),
+        )),
+        message: format!("Remove whitespace before `(` in this {context}."),
         ..Default::default()
     });
 }

--- a/crates/raven/src/linting/rules/indentation.rs
+++ b/crates/raven/src/linting/rules/indentation.rs
@@ -34,7 +34,10 @@
 //!   `find_chain_start_from_ast`; the linter currently approximates this
 //!   with `node.start_position().column`, which agrees in the common cases
 //!   exercised by the test suite.) Nested binary operators may push the
-//!   expectation deeper (lintr's "tidy" default).
+//!   expectation deeper (lintr's "tidy" default). One common Boolean layout
+//!   is also accepted: when both sides of a binary operator are parenthesized
+//!   clauses inside an outer parenthesized expression, the clauses may align
+//!   with each other instead of indenting the RHS by another unit.
 //!
 //! Lines skipped without checks:
 //! * Suppressed lines (`# nolint`, `# nolint start/end`, `# raven: ignore`,
@@ -588,7 +591,16 @@ fn set_binary_operator(
     // wider assignment such as `result <- foo() +` — we accept both forms
     // so the linter doesn't disagree with the formatter's output.
     let chain_start_col = node.start_position().column as u32;
-    let expected = if chain_start_col > hanging {
+    let aligned_parenthesized_clauses = node
+        .parent()
+        .is_some_and(|parent| parent.kind() == "parenthesized_expression")
+        && node
+            .child_by_field_name("lhs")
+            .is_some_and(|lhs| lhs.kind() == "parenthesized_expression")
+        && node
+            .child_by_field_name("rhs")
+            .is_some_and(|rhs| rhs.kind() == "parenthesized_expression");
+    let expected = if chain_start_col > hanging || aligned_parenthesized_clauses {
         Expected::with_alternative(hanging, chain_start_col)
     } else {
         Expected::single(hanging)
@@ -1117,12 +1129,10 @@ mod tests {
             "expected no diagnostic on closing paren line; got {:?}",
             diags
         );
-        let operand_diag = diagnostic_on_line(&diags, 2)
-            .expect("expected continuation diagnostic on second operand line");
         assert!(
-            operand_diag.message.contains("8"),
-            "expected message to mention 8 spaces; got {:?}",
-            operand_diag
+            diagnostic_on_line(&diags, 2).is_none(),
+            "aligned parenthesized clauses should be accepted; got {:?}",
+            diags
         );
     }
 
@@ -1136,12 +1146,10 @@ mod tests {
             "expected no diagnostic on closing paren line; got {:?}",
             diags
         );
-        let operand_diag = diagnostic_on_line(&diags, 4)
-            .expect("expected continuation diagnostic on second operand line");
         assert!(
-            operand_diag.message.contains("16"),
-            "expected message to mention 16 spaces; got {:?}",
-            operand_diag
+            diagnostic_on_line(&diags, 4).is_none(),
+            "aligned parenthesized clauses should be accepted; got {:?}",
+            diags
         );
     }
 

--- a/crates/raven/src/linting/rules/infix_spaces.rs
+++ b/crates/raven/src/linting/rules/infix_spaces.rs
@@ -3,9 +3,12 @@
 //! Walks the tree-sitter AST and flags whitespace that disagrees with R's
 //! community style (matching `lintr::infix_spaces_linter` semantics):
 //!
-//! * Most binary operators (`+`, `-`, `*`, `/`, `^`, comparison, logical,
+//! * Most low-precedence binary operators (`+`, `-`, `*`, `/`, comparison, logical,
 //!   assignment, pipe, formula `~`, `%any%` user-defined operators) require at
 //!   least one space on each side.
+//! * Exponentiation (`^`) is not checked. Both `x^2` and `x ^ 2` are accepted,
+//!   matching `lintr::infix_spaces_linter`, which excludes high-precedence
+//!   operators from this rule.
 //! * Tight-binding operators (`:` sequence, `::`/`:::` namespace, `$`/`@`
 //!   member access) take no spaces on either side.
 //! * Unary `-`, `+`, `!`, and unary `?` take no space between the operator and
@@ -19,8 +22,8 @@
 //!
 //! Disambiguation between unary and binary forms is handled by tree-sitter:
 //! `-x` parses as a `unary_operator`, `a - b` as a `binary_operator`. Named
-//! arguments (`f(name = value)`) are parsed as `argument` nodes, never
-//! `binary_operator`, so they're naturally exempt.
+//! arguments and formal defaults are separate `argument` / `parameter` nodes;
+//! their `=` tokens are checked explicitly, as lintr does.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -53,12 +56,67 @@ fn visit(
             check_tight_binary(node, text, severity, suppressions, out)
         }
         "unary_operator" => check_unary(node, text, severity, suppressions, out),
+        "argument" | "parameter" => check_named_equals(node, text, severity, suppressions, out),
         _ => {}
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check_named_equals(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(lhs) = node.child_by_field_name("name") else {
+        return;
+    };
+    let Some(rhs) = node
+        .child_by_field_name("value")
+        .or_else(|| node.child_by_field_name("default"))
+    else {
+        return;
+    };
+    let mut operator = None;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "=" {
+            operator = Some(child);
+            break;
+        }
+    }
+    let Some(operator) = operator else {
+        return;
+    };
+
+    if gap_text(text, lhs.end_byte(), operator.start_byte()).is_some_and(str::is_empty) {
+        report(
+            text,
+            operator,
+            "missing space before `",
+            "=",
+            "`",
+            severity,
+            suppressions,
+            out,
+        );
+    }
+    if gap_text(text, operator.end_byte(), rhs.start_byte()).is_some_and(str::is_empty) {
+        report(
+            text,
+            operator,
+            "missing space after `",
+            "=",
+            "`",
+            severity,
+            suppressions,
+            out,
+        );
     }
 }
 
@@ -81,9 +139,10 @@ fn classify_binary(op_text: &str) -> BinaryStyle {
     }
 
     match op_text {
-        "+" | "-" | "*" | "/" | "^" | "<" | ">" | "<=" | ">=" | "==" | "!=" | "&" | "|" | "&&"
-        | "||" | "<-" | "<<-" | "->" | "->>" | "=" | "|>" | "~" => BinaryStyle::RequireSpaces,
+        "+" | "-" | "*" | "/" | "<" | ">" | "<=" | ">=" | "==" | "!=" | "&" | "|" | "&&" | "||"
+        | "<-" | "<<-" | "->" | "->>" | "=" | "|>" | "~" => BinaryStyle::RequireSpaces,
         ":" => BinaryStyle::NoSpaces,
+        "^" => BinaryStyle::Skip,
         _ => BinaryStyle::Skip,
     }
 }

--- a/crates/raven/src/linting/rules/no_tab.rs
+++ b/crates/raven/src/linting/rules/no_tab.rs
@@ -1,10 +1,14 @@
-//! Flag tab characters in source.
+//! Flag tab characters used for indentation.
 //!
-//! Reports one diagnostic per line that contains a tab, anchored at the first
-//! tab on that line. The diagnostic range covers the contiguous run of tabs
-//! so that "fix" actions or selection-aware tooling can target it cleanly.
+//! Mirrors the no-tab portion of `lintr::whitespace_linter()`: tabs after the
+//! first non-whitespace character (for example in comments or string content)
+//! are not indentation and are ignored. Reports one diagnostic per affected
+//! line, covering the first contiguous run of indentation tabs.
+
+use std::collections::HashSet;
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use tree_sitter::Node;
 
 use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
@@ -13,17 +17,28 @@ use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
     text: &str,
+    root: Node<'_>,
     severity: DiagnosticSeverity,
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
+    let mut string_interior_lines = HashSet::new();
+    collect_string_interior_lines(root, &mut string_interior_lines);
+
     for (idx, line) in text.lines().enumerate() {
         let line_no = idx as u32;
         if suppressions.is_suppressed_code(line_no, rule_ids::NO_TAB) {
             continue;
         }
+        if string_interior_lines.contains(&line_no) {
+            continue;
+        }
         let bytes = line.as_bytes();
-        let Some(start) = bytes.iter().position(|&b| b == b'\t') else {
+        let leading_len = bytes
+            .iter()
+            .take_while(|&&byte| byte == b' ' || byte == b'\t')
+            .count();
+        let Some(start) = bytes[..leading_len].iter().position(|&b| b == b'\t') else {
             continue;
         };
         let mut end = start;
@@ -43,5 +58,20 @@ pub(crate) fn collect(
             message: "Tab character; use spaces.".to_string(),
             ..Default::default()
         });
+    }
+}
+
+fn collect_string_interior_lines(node: Node<'_>, out: &mut HashSet<u32>) {
+    if node.kind() == "string" {
+        let start = node.start_position().row as u32;
+        let end = node.end_position().row as u32;
+        for line in (start + 1)..=end {
+            out.insert(line);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_string_interior_lines(child, out);
     }
 }

--- a/crates/raven/src/linting/rules/object_length.rs
+++ b/crates/raven/src/linting/rules/object_length.rs
@@ -2,15 +2,14 @@
 //!
 //! Mirrors `lintr::object_length_linter`. Length is measured in characters
 //! after stripping the same decorative leading-dot that `object_name` accepts
-//! ("hidden identifier" convention). Backtick-quoted names and non-ASCII
-//! identifiers are skipped — matching `object_name`'s carve-outs.
+//! ("hidden identifier" convention). Quoted names are measured without their
+//! delimiters, and Unicode names are measured in characters.
 //!
 //! Only positions that introduce a new symbol are checked:
-//! assignment targets (`<-`, `<<-`, top-level `=`, `->`, `->>`) and formal
-//! parameters of `function_definition`. Compound assignment targets like
-//! `obj$field <- ...` are skipped (the assignment doesn't introduce a new
-//! symbol name — only the LHS field does, and `object_name` already won't
-//! flag those for the same reason).
+//! assignment targets (`<-`, `<<-`, top-level `=`, `->`, `->>`), formal
+//! parameters, and literal binding names passed to `assign()` / `setGeneric()`.
+//! Compound assignment targets like
+//! `obj$field <- ...` check only the leftmost object name (`obj`).
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -44,12 +43,51 @@ fn visit(
         "function_definition" => {
             check_parameters(node, text, max_length, severity, suppressions, out)
         }
+        "call" => check_binding_call(node, text, max_length, severity, suppressions, out),
         _ => {}
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         visit(child, text, max_length, severity, suppressions, out);
     }
+}
+
+fn check_binding_call(
+    node: Node<'_>,
+    text: &str,
+    max_length: u32,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+    let function_text = text
+        .get(function.start_byte()..function.end_byte())
+        .unwrap_or("");
+    let formal = if function_text == "assign" || function_text.ends_with("::assign") {
+        "x"
+    } else if function_text == "setGeneric" || function_text.ends_with("::setGeneric") {
+        "name"
+    } else {
+        return;
+    };
+    let Some(name_node) = binding_name_argument(node, formal, text) else {
+        return;
+    };
+    let name = text
+        .get(name_node.start_byte()..name_node.end_byte())
+        .unwrap_or("");
+    check_name(
+        name_node,
+        name,
+        max_length,
+        text,
+        severity,
+        suppressions,
+        out,
+    );
 }
 
 fn check_assignment(
@@ -75,9 +113,9 @@ fn check_assignment(
     let Some(target) = target else {
         return;
     };
-    if target.kind() != "identifier" {
+    let Some(target) = assignment_name_target(target) else {
         return;
-    }
+    };
     let name = text
         .get(target.start_byte()..target.end_byte())
         .unwrap_or("");
@@ -123,7 +161,8 @@ fn check_name(
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
-    if name.is_empty() || should_skip_name(name) {
+    let name = strip_name_delimiters(name);
+    if name.is_empty() {
         return;
     }
     // Strip the optional leading `.` (hidden identifier convention) before
@@ -157,12 +196,61 @@ fn check_name(
     });
 }
 
-fn should_skip_name(name: &str) -> bool {
-    if name.starts_with('`') {
-        return true;
+fn strip_name_delimiters(name: &str) -> &str {
+    for delimiter in ['`', '\'', '"'] {
+        if let Some(inner) = name
+            .strip_prefix(delimiter)
+            .and_then(|rest| rest.strip_suffix(delimiter))
+        {
+            return inner;
+        }
     }
-    if !name.is_ascii() {
-        return true;
+    name
+}
+
+fn assignment_name_target(mut target: Node<'_>) -> Option<Node<'_>> {
+    loop {
+        match target.kind() {
+            "identifier" | "string" => return Some(target),
+            "extract_operator" => target = target.child_by_field_name("lhs")?,
+            "subset" | "subset2" => target = target.child_by_field_name("function")?,
+            "call" => {
+                let arguments = target.child_by_field_name("arguments")?;
+                target = first_positional_argument(arguments)?;
+            }
+            _ => return None,
+        }
     }
-    false
+}
+
+fn binding_name_argument<'tree>(
+    call: Node<'tree>,
+    formal: &str,
+    text: &str,
+) -> Option<Node<'tree>> {
+    let arguments = call.child_by_field_name("arguments")?;
+    let mut first_positional = None;
+    let mut cursor = arguments.walk();
+    for argument in arguments
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "argument")
+    {
+        let name = argument.child_by_field_name("name");
+        let value = argument.child_by_field_name("value");
+        if name.and_then(|name| text.get(name.start_byte()..name.end_byte())) == Some(formal) {
+            return value.filter(|value| value.kind() == "string");
+        }
+        if name.is_none() && first_positional.is_none() {
+            first_positional = value;
+        }
+    }
+    first_positional.filter(|value| value.kind() == "string")
+}
+
+fn first_positional_argument(arguments: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = arguments.walk();
+    arguments
+        .children(&mut cursor)
+        .find(|child| child.kind() == "argument" && child.child_by_field_name("name").is_none())?
+        .child_by_field_name("value")
 }

--- a/crates/raven/src/linting/rules/object_name.rs
+++ b/crates/raven/src/linting/rules/object_name.rs
@@ -1,8 +1,8 @@
 //! Enforce a naming scheme on user-defined symbols.
 //!
-//! Walks the tree-sitter AST and flags assignment targets and function
-//! parameters whose names don't match the configured [`ObjectNameStyle`] or
-//! custom regexes. Mirrors `lintr::object_name_linter` with three per-kind
+//! Walks the tree-sitter AST and flags assignment targets, function
+//! parameters, and literal `assign()` / `setGeneric()` binding names that do
+//! not match the configured [`ObjectNameStyle`] or custom regexes. Mirrors `lintr::object_name_linter` with three per-kind
 //! settings: `function`, `variable`, and `argument`. Each kind defaults to
 //! `snake_case` and can be independently disabled by including
 //! [`ObjectNameStyle::Any`] in its style list.
@@ -13,8 +13,9 @@
 //!
 //! Carve-outs:
 //!
-//! * **Backtick-quoted names** (`` `with spaces` <- 1 ``, operator overloads
-//!   like `` `+.foo` <- function(x, y) ... ``) are skipped, matching lintr.
+//! * **Quoted names** are checked after removing one matching pair of
+//!   backticks. This matches lintr's `strip_names()` behavior: quoting changes
+//!   what R accepts syntactically, not which naming policy applies.
 //! * **S3 method dispatch**: a function definition whose name has the shape
 //!   `<generic>.<class>` is exempt when `<generic>` is a known base R S3
 //!   generic (see [`is_known_s3_generic`]). Every dot is tried as a possible
@@ -36,8 +37,9 @@
 //! * **Named-argument `=`** (`f(name = value)`) is never an assignment target,
 //!   so it isn't checked. `=` elsewhere (top level, function bodies, braced
 //!   blocks) *is* treated as assignment and the LHS is checked.
-//! * **Compound LHS** (`obj$field <- ...`, `obj[[i]] <- ...`) is skipped: the
-//!   assignment doesn't introduce a new symbol name.
+//! * **Compound LHS** (`obj$field <- ...`, `obj[[i]] <- ...`) checks only the
+//!   leftmost object (`obj`). Field names and index expressions are ignored,
+//!   matching lintr.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -99,6 +101,7 @@ fn visit(
     match node.kind() {
         "binary_operator" => check_assignment(node, text, styles, severity, suppressions, out),
         "function_definition" => check_parameters(node, text, styles, severity, suppressions, out),
+        "call" => check_binding_call(node, text, styles, severity, suppressions, out),
         _ => {}
     }
 
@@ -106,6 +109,50 @@ fn visit(
     for child in node.children(&mut cursor) {
         visit(child, text, styles, severity, suppressions, out);
     }
+}
+
+fn check_binding_call(
+    node: Node<'_>,
+    text: &str,
+    styles: &ObjectNameStyles<'_>,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+    let function_text = node_text(function, text);
+    let kind = if function_text == "assign" || function_text.ends_with("::assign") {
+        SymbolKind::Variable
+    } else if function_text == "setGeneric" || function_text.ends_with("::setGeneric") {
+        SymbolKind::Function
+    } else {
+        return;
+    };
+    let formal = if kind == SymbolKind::Variable {
+        "x"
+    } else {
+        "name"
+    };
+    let Some(name_node) = binding_name_argument(node, formal, text) else {
+        return;
+    };
+    let name = node_text(name_node, text);
+    let patterns = patterns_for(kind, styles);
+    if patterns.is_disabled() {
+        return;
+    }
+    report_if_bad(
+        name_node,
+        name,
+        kind,
+        patterns,
+        text,
+        severity,
+        suppressions,
+        out,
+    );
 }
 
 /// Check the assignment target of a `binary_operator` node.
@@ -147,9 +194,9 @@ fn check_assignment(
         return;
     }
 
-    if target.kind() != "identifier" {
+    let Some(target) = assignment_name_target(target) else {
         return;
-    }
+    };
 
     let name = node_text(target, text);
     if name.is_empty() {
@@ -261,10 +308,11 @@ fn report_if_bad(
     if patterns.is_disabled() {
         return;
     }
-    if should_skip_name(name, kind, patterns) {
+    let policy_name = strip_name_delimiters(name);
+    if should_skip_name(policy_name, kind, patterns) {
         return;
     }
-    if matches_patterns(name, patterns) {
+    if matches_patterns(policy_name, patterns) {
         return;
     }
     let line_no = name_node.start_position().row as u32;
@@ -279,7 +327,7 @@ fn report_if_bad(
         SymbolKind::Variable => "Variable",
         SymbolKind::Argument => "Argument",
     };
-    let message = object_name_message(kind_label, name, patterns);
+    let message = object_name_message(kind_label, policy_name, patterns);
     out.push(Diagnostic {
         range: Range {
             start: Position::new(line_no, start_col),
@@ -312,10 +360,6 @@ fn matches_patterns(name: &str, patterns: KindPatterns<'_>) -> bool {
 
 /// Names that should be skipped regardless of the configured scheme.
 fn should_skip_name(name: &str, kind: SymbolKind, patterns: KindPatterns<'_>) -> bool {
-    // Backtick-quoted identifiers (operator overloads, names with spaces).
-    if name.starts_with('`') {
-        return true;
-    }
     // Non-ASCII identifiers can't be classified by the named styles' simple
     // ASCII schemes, so configurations with no regexes skip them. When
     // regexes ARE configured — regex-only or combined with styles — the name
@@ -346,6 +390,12 @@ fn should_skip_name(name: &str, kind: SymbolKind, patterns: KindPatterns<'_>) ->
     // We also strip an optional leading `.` so hidden S3 methods like
     // `.print.MyClass` resolve through `print`.
     if kind == SymbolKind::Function {
+        if matches!(
+            name,
+            ".onLoad" | ".onAttach" | ".onUnload" | ".onDetach" | ".Last.lib" | ".First" | ".Last"
+        ) {
+            return true;
+        }
         let body = name.strip_prefix('.').unwrap_or(name);
         for (i, c) in body.char_indices() {
             if c == '.' && is_known_s3_generic(&body[..i]) {
@@ -354,6 +404,69 @@ fn should_skip_name(name: &str, kind: SymbolKind, patterns: KindPatterns<'_>) ->
         }
     }
     false
+}
+
+/// Remove one matching syntactic delimiter pair before applying name policy.
+/// Only complete pairs are removed; malformed parse-recovery fragments are
+/// left untouched rather than normalized into a different name.
+fn strip_name_delimiters(name: &str) -> &str {
+    for delimiter in ['`', '\'', '"'] {
+        if let Some(inner) = name
+            .strip_prefix(delimiter)
+            .and_then(|rest| rest.strip_suffix(delimiter))
+        {
+            return inner;
+        }
+    }
+    name
+}
+
+/// Find the leftmost object governed by a compound assignment target.
+fn assignment_name_target(mut target: Node<'_>) -> Option<Node<'_>> {
+    loop {
+        match target.kind() {
+            "identifier" | "string" => return Some(target),
+            "extract_operator" => target = target.child_by_field_name("lhs")?,
+            "subset" | "subset2" => target = target.child_by_field_name("function")?,
+            "call" => {
+                let arguments = target.child_by_field_name("arguments")?;
+                target = first_positional_argument(arguments)?;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn binding_name_argument<'tree>(
+    call: Node<'tree>,
+    formal: &str,
+    text: &str,
+) -> Option<Node<'tree>> {
+    let arguments = call.child_by_field_name("arguments")?;
+    let mut first_positional = None;
+    let mut cursor = arguments.walk();
+    for argument in arguments
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "argument")
+    {
+        let name = argument.child_by_field_name("name");
+        let value = argument.child_by_field_name("value");
+        if name.and_then(|name| text.get(name.start_byte()..name.end_byte())) == Some(formal) {
+            return value.filter(|value| value.kind() == "string");
+        }
+        if name.is_none() && first_positional.is_none() {
+            first_positional = value;
+        }
+    }
+    first_positional.filter(|value| value.kind() == "string")
+}
+
+fn first_positional_argument(arguments: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = arguments.walk();
+    arguments
+        .children(&mut cursor)
+        .find(|child| child.kind() == "argument" && child.child_by_field_name("name").is_none())?
+        .child_by_field_name("value")
 }
 
 /// Base R S3 generics whose `<generic>.<class>` methods are conventionally
@@ -369,6 +482,9 @@ fn should_skip_name(name: &str, kind: SymbolKind, patterns: KindPatterns<'_>) ->
 fn is_known_s3_generic(name: &str) -> bool {
     // Sorted alphabetically so `binary_search` works.
     const GENERICS: &[&str] = &[
+        "$",
+        "+",
+        "-",
         "AIC",
         "BIC",
         "Complex",
@@ -870,9 +986,11 @@ mod tests {
     }
 
     #[test]
-    fn backtick_quoted_names_are_skipped() {
-        assert!(skip_default("`with spaces`", SymbolKind::Variable));
-        assert!(skip_default("`+.foo`", SymbolKind::Function));
+    fn backtick_quoted_names_are_checked_after_stripping_quotes() {
+        assert_eq!(strip_name_delimiters("`badName`"), "badName");
+        assert_eq!(strip_name_delimiters("\"badName\""), "badName");
+        assert_eq!(strip_name_delimiters("plain_name"), "plain_name");
+        assert!(!skip_default("badName", SymbolKind::Variable));
     }
 
     #[test]

--- a/crates/raven/src/linting/rules/quotes.rs
+++ b/crates/raven/src/linting/rules/quotes.rs
@@ -1,9 +1,10 @@
 //! Enforce a single string-literal delimiter (`"` or `'`).
 //!
 //! Mirrors `lintr::quotes_linter` / `lintr::single_quotes_linter` — the
-//! configured delimiter is required for every regular string literal. Raw
-//! strings (`r"(...)"`, `R'(...)'`, `r"---(...)---"`) are skipped: their outer
-//! quote choice is constrained by the body, not by user style.
+//! configured delimiter is required for regular and raw string literals when
+//! switching delimiters would not require escaping a delimiter already in the
+//! body. This matches lintr's default: `'plain'` and `R'(plain)'` are flagged
+//! under double-quote policy, while `'"already quoted"'` is left alone.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -56,18 +57,19 @@ fn check_string(
         Some(s) => s,
         None => return,
     };
-    if is_raw_string(lit) {
+    let Some(got) = string_delimiter(lit) else {
         return;
-    }
-    let first = match lit.as_bytes().first() {
-        Some(b) => *b,
-        None => return,
     };
-    let (wanted, got) = match (delimiter, first) {
-        (StringDelimiter::Double, b'\'') => ('"', '\''),
-        (StringDelimiter::Single, b'"') => ('\'', '"'),
+    let (wanted, got) = match (delimiter, got) {
+        (StringDelimiter::Double, '\'') => ('"', '\''),
+        (StringDelimiter::Single, '"') => ('\'', '"'),
         _ => return,
     };
+    // lintr avoids a quote-style lint when changing the outer delimiter would
+    // force escaping an occurrence of the preferred delimiter in the body.
+    if lit.contains(wanted) {
+        return;
+    }
     let line_no = node.start_position().row as u32;
     if suppressions.is_suppressed_code(line_no, rule_ids::QUOTES) {
         return;
@@ -107,6 +109,18 @@ fn is_raw_string(lit: &str) -> bool {
     matches!(bytes[1], b'"' | b'\'')
 }
 
+fn string_delimiter(lit: &str) -> Option<char> {
+    let bytes = lit.as_bytes();
+    if is_raw_string(lit) {
+        return char::from_u32(*bytes.get(1)? as u32);
+    }
+    match bytes.first().copied()? {
+        b'\'' => Some('\''),
+        b'"' => Some('"'),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +135,12 @@ mod tests {
         // `r` alone (e.g. identifier) is not a raw string.
         assert!(!is_raw_string("r"));
         assert!(!is_raw_string(""));
+    }
+
+    #[test]
+    fn delimiter_is_found_for_regular_and_raw_strings() {
+        assert_eq!(string_delimiter("'hi'"), Some('\''));
+        assert_eq!(string_delimiter("r\"(hi)\""), Some('"'));
+        assert_eq!(string_delimiter("R'(hi)'"), Some('\''));
     }
 }

--- a/crates/raven/src/linting/rules/spaces_inside.rs
+++ b/crates/raven/src/linting/rules/spaces_inside.rs
@@ -2,19 +2,17 @@
 //!
 //! Mirrors `lintr::spaces_inside_linter`. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`
 //! all have stray space against the brackets. The community convention is
-//! tight: `f(x)`, `df[1]`, `mat[[i]]`. Empty groupings — `f()`, `f( )`,
-//! `mat[]`, `mat[ ]` — are left alone: there's no token next to the bracket
-//! to crowd, and forcing `f()` vs `f( )` is too pedantic for a hint.
+//! tight: `f(x)`, `df[1]`, `mat[[i]]`. Truly empty groupings (`f()`, `mat[]`)
+//! pass, while whitespace-only single-line groupings (`f( )`, `mat[ ]`) are
+//! flagged on both sides, matching lintr.
 //! For `subset` and `subset2` only, a trailing comma that marks an omitted
 //! dimension keeps its before-close space (`x[i, ]`, `x[[i, ]]`) so this rule
 //! does not conflict with `commas_linter`; `call` nodes such as `f(a, )` are
 //! intentionally not carved out, keeping the exception scoped to R subsetting.
 //!
-//! Applies to `call`, `subset`, `subset2`, and `parenthesized_expression`
-//! nodes. The `open` and `close` field positions are used to anchor the
-//! check; the interior content is the gap between `open` and the first
-//! non-whitespace child, and between the last non-whitespace child and
-//! `close`.
+//! Applies to calls, subsetting, parenthesized expressions, formal parameter
+//! lists, and control-flow conditions. The `open` and `close` field positions
+//! anchor the check.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -55,6 +53,14 @@ fn visit(
         "parenthesized_expression" => {
             check_bracketed(node, false, text, severity, suppressions, out);
         }
+        "function_definition" => {
+            if let Some(parameters) = node.child_by_field_name("parameters") {
+                check_bracketed(parameters, false, text, severity, suppressions, out);
+            }
+        }
+        "if_statement" | "while_statement" | "for_statement" => {
+            check_bracketed(node, false, text, severity, suppressions, out);
+        }
         _ => {}
     }
     let mut cursor = node.walk();
@@ -82,12 +88,38 @@ fn check_bracketed(
     if close_start <= open_end {
         return;
     }
-    // Empty grouping (only whitespace between brackets) — allowed.
+    // A truly empty grouping is allowed. A whitespace-only single-line
+    // grouping is not: lintr emits both after-open and before-close lints.
     let interior = match text.get(open_end..close_start) {
         Some(s) => s,
         None => return,
     };
+    if interior.is_empty() {
+        return;
+    }
     if interior.chars().all(|c| c.is_whitespace()) {
+        if !interior.contains('\n') {
+            let open_text = text.get(open.start_byte()..open.end_byte()).unwrap_or("");
+            emit_after_open(
+                open,
+                open_text,
+                interior.len(),
+                text,
+                severity,
+                suppressions,
+                out,
+            );
+            let close_text = text.get(close.start_byte()..close.end_byte()).unwrap_or("");
+            emit_before_close(
+                close,
+                close_text,
+                interior.len(),
+                text,
+                severity,
+                suppressions,
+                out,
+            );
+        }
         return;
     }
 

--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -15,8 +15,9 @@
 //!   (`function(T) ...`). The `T` here is a name in the local syntax, not a
 //!   reference to the boolean.
 //! * **Formula symbols** (`y ~ T + F`) are model terms, not Boolean aliases.
-//!   A `T`/`F` used as a named-argument value inside a formula call is still a
-//!   value and remains checked.
+//!   A bare `T`/`F` used as the direct value of a named argument inside a
+//!   formula call (`y ~ foo(arg = T)`) remains checked, matching lintr. Nested
+//!   expressions such as `y ~ foo(arg = T + 1)` remain formula terms.
 //!
 //! Assignment targets are deliberately reported: rebinding `T` or `F` is
 //! exactly what makes later code relying on the aliases unsafe.

--- a/crates/raven/src/linting/rules/t_and_f_symbol.rs
+++ b/crates/raven/src/linting/rules/t_and_f_symbol.rs
@@ -9,15 +9,17 @@
 //! reports them, except in positions where the identifier doesn't actually
 //! reference the value:
 //!
-//! * **Assignment targets** (`T <- 0`, `0 -> T`, top-level `T = 0`). The user
-//!   is explicitly overwriting the name — that *is* the bug, but reporting it
-//!   on the LHS would be redundant with the other reads we already flag, so
-//!   matching lintr we skip the LHS itself.
-//! * **`$` / `@` RHS** (`obj$T`, `obj@F`). These are field names, not symbol
-//!   lookups in the calling scope.
+//! * **Extraction/subsetting object names** (`T[1]`, `T[[1]]`, `T$field`,
+//!   `obj$T`). These spell objects or fields rather than the Boolean alias.
 //! * **Named arguments** (`foo(T = TRUE)`) and **formal parameters**
 //!   (`function(T) ...`). The `T` here is a name in the local syntax, not a
 //!   reference to the boolean.
+//! * **Formula symbols** (`y ~ T + F`) are model terms, not Boolean aliases.
+//!   A `T`/`F` used as a named-argument value inside a formula call is still a
+//!   value and remains checked.
+//!
+//! Assignment targets are deliberately reported: rebinding `T` or `F` is
+//! exactly what makes later code relying on the aliases unsafe.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use tree_sitter::Node;
@@ -59,18 +61,17 @@ fn visit(
 /// True if the identifier is in a non-reference position — somewhere a `T`/`F`
 /// spelling doesn't read the boolean value.
 fn is_excluded_position(ident: Node<'_>) -> bool {
+    if is_inside_formula(ident) && !is_named_argument_value(ident) {
+        return true;
+    }
     let Some(parent) = ident.parent() else {
         return false;
     };
     match parent.kind() {
-        "binary_operator" => is_assignment_target(parent, ident),
-        "extract_operator" => {
-            // `$` / `@`: skip the RHS field name; LHS is a real reference.
-            // Centralized in `crate::extract_op` so this predicate,
-            // go-to-def's qualified-member resolver, and
-            // `handlers.rs::is_structural_label` cannot drift on the AST shape.
-            crate::extract_op::extract_operator_rhs(ident).is_some()
-        }
+        "extract_operator" => true,
+        "subset" | "subset2" => parent
+            .child_by_field_name("function")
+            .is_some_and(|function| function.id() == ident.id()),
         "argument" => {
             // Named argument: `foo(T = TRUE)` — `T` here is a parameter label.
             parent
@@ -87,18 +88,28 @@ fn is_excluded_position(ident: Node<'_>) -> bool {
     }
 }
 
-/// True iff this identifier is the assignment-target side of `binop`.
-fn is_assignment_target(binop: Node<'_>, ident: Node<'_>) -> bool {
-    let Some(op) = binop.child_by_field_name("operator") else {
-        return false;
-    };
-    let op_text = op.kind();
-    let target = match op_text {
-        "<-" | "<<-" | "=" => binop.child_by_field_name("lhs"),
-        "->" | "->>" => binop.child_by_field_name("rhs"),
-        _ => return false,
-    };
-    target.is_some_and(|t| t.id() == ident.id())
+fn is_inside_formula(mut node: Node<'_>) -> bool {
+    while let Some(parent) = node.parent() {
+        if parent.kind() == "binary_operator"
+            && parent
+                .child_by_field_name("operator")
+                .is_some_and(|operator| operator.kind() == "~")
+        {
+            return true;
+        }
+        node = parent;
+    }
+    false
+}
+
+fn is_named_argument_value(ident: Node<'_>) -> bool {
+    ident.parent().is_some_and(|parent| {
+        parent.kind() == "argument"
+            && parent.child_by_field_name("name").is_some()
+            && parent
+                .child_by_field_name("value")
+                .is_some_and(|value| value.id() == ident.id())
+    })
 }
 
 fn emit(

--- a/crates/raven/src/linting/rules/trailing_whitespace.rs
+++ b/crates/raven/src/linting/rules/trailing_whitespace.rs
@@ -1,6 +1,13 @@
 //! Flag trailing spaces/tabs at end of line.
+//!
+//! Matching `lintr::trailing_whitespace_linter()` defaults, whitespace at a
+//! line ending that is inside a multi-line string is allowed. Whitespace after
+//! the string's closing delimiter is still checked normally.
+
+use std::collections::HashSet;
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+use tree_sitter::Node;
 
 use crate::linting::LINT_SOURCE;
 use crate::linting::nolint::Suppressions;
@@ -9,10 +16,14 @@ use crate::utf16::byte_offset_to_utf16_column;
 
 pub(crate) fn collect(
     text: &str,
+    root: Node<'_>,
     severity: DiagnosticSeverity,
     suppressions: &Suppressions,
     out: &mut Vec<Diagnostic>,
 ) {
+    let mut string_continuation_lines = HashSet::new();
+    collect_string_continuation_lines(root, &mut string_continuation_lines);
+
     for (idx, line) in text.lines().enumerate() {
         let line_no = idx as u32;
         if suppressions.is_suppressed_code(line_no, rule_ids::TRAILING_WHITESPACE) {
@@ -20,6 +31,9 @@ pub(crate) fn collect(
         }
         let trimmed = line.trim_end_matches([' ', '\t']);
         if trimmed.len() == line.len() {
+            continue;
+        }
+        if string_continuation_lines.contains(&line_no) {
             continue;
         }
         let start_col = byte_offset_to_utf16_column(line, trimmed.len());
@@ -37,5 +51,24 @@ pub(crate) fn collect(
             message: "Trailing whitespace.".to_string(),
             ..Default::default()
         });
+    }
+}
+
+/// Record rows whose terminating newline occurs inside a multi-line string.
+/// For a string spanning rows `start..=end`, those are `start..end`; the end
+/// row is deliberately excluded because any whitespace after the closing
+/// delimiter belongs to source, not the string.
+fn collect_string_continuation_lines(node: Node<'_>, out: &mut HashSet<u32>) {
+    if node.kind() == "string" {
+        let start = node.start_position().row as u32;
+        let end = node.end_position().row as u32;
+        for line in start..end {
+            out.insert(line);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_string_continuation_lines(child, out);
     }
 }

--- a/crates/raven/src/linting/rules/vector_logic.rs
+++ b/crates/raven/src/linting/rules/vector_logic.rs
@@ -1,12 +1,14 @@
-//! Flag `&` / `|` in `if` / `while` conditions, where `&&` / `||` is expected.
+//! Flag vector/scalar logical operators used in the opposite context.
 //!
 //! Mirrors `lintr::vector_logic_linter`. `if (x & y)` triggers a warning in
 //! R 4.3+ (`condition has length > 1`) and silently does the wrong thing on
 //! older R when either side returns a vector. Scalar short-circuit operators
 //! (`&&` / `||`) are the correct choice in scalar contexts.
 //!
-//! The scan walks the condition expression of each `if_statement` /
-//! `while_statement` and reports every `&` / `|` operator inside, recursively.
+//! The scan walks `if` / `while` conditions and `expect_true()` /
+//! `expect_false()` assertions, reporting `&` / `|` where scalar `&&` / `||`
+//! is expected. It also checks `filter()` / `subset()` predicates in the other
+//! direction, reporting `&&` / `||` where vectorized `&` / `|` is expected.
 //! Function-call boundaries stop the recursion: `if (any(x & y))` is fine
 //! because the `&` is evaluated inside `any()` on a vector, not on the
 //! condition itself. lintr applies the same carve-out.
@@ -41,9 +43,108 @@ fn visit(
     {
         scan_condition(cond, text, severity, suppressions, out);
     }
+    if node.kind() == "call" {
+        check_call_context(node, text, severity, suppressions, out);
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         visit(child, text, severity, suppressions, out);
+    }
+}
+
+fn check_call_context(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(function) = node.child_by_field_name("function") else {
+        return;
+    };
+    let function_text = text
+        .get(function.start_byte()..function.end_byte())
+        .unwrap_or("");
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return;
+    };
+
+    if matches_function(function_text, "expect_true")
+        || matches_function(function_text, "expect_false")
+    {
+        if let Some(value) = first_argument_value(arguments) {
+            scan_condition(value, text, severity, suppressions, out);
+        }
+        return;
+    }
+
+    let is_filter = matches_function(function_text, "filter") && function_text != "stats::filter";
+    let is_subset = matches_function(function_text, "subset");
+    if !is_filter && !is_subset {
+        return;
+    }
+
+    let mut skipped_data_argument = false;
+    let mut cursor = arguments.walk();
+    for argument in arguments
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "argument")
+    {
+        let name = argument
+            .child_by_field_name("name")
+            .and_then(|name| text.get(name.start_byte()..name.end_byte()));
+        if name == Some("circular") {
+            continue;
+        }
+        let is_named_data_argument =
+            (is_filter && name == Some(".data")) || (is_subset && name == Some("x"));
+        if !skipped_data_argument && (name.is_none() || is_named_data_argument) {
+            skipped_data_argument = true;
+            continue;
+        }
+        if let Some(value) = argument.child_by_field_name("value") {
+            scan_filter_predicate(value, text, severity, suppressions, out);
+        }
+    }
+}
+
+fn matches_function(actual: &str, name: &str) -> bool {
+    actual == name || actual.rsplit(':').next() == Some(name)
+}
+
+fn first_argument_value(arguments: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = arguments.walk();
+    arguments
+        .children(&mut cursor)
+        .find(|child| child.kind() == "argument")?
+        .child_by_field_name("value")
+}
+
+fn scan_filter_predicate(
+    node: Node<'_>,
+    text: &str,
+    severity: DiagnosticSeverity,
+    suppressions: &Suppressions,
+    out: &mut Vec<Diagnostic>,
+) {
+    if matches!(
+        node.kind(),
+        "call" | "subset" | "subset2" | "function_definition"
+    ) {
+        return;
+    }
+    if node.kind() == "binary_operator"
+        && let Some(op) = node.child_by_field_name("operator")
+    {
+        let op_text = text.get(op.start_byte()..op.end_byte()).unwrap_or("");
+        if op_text == "&&" || op_text == "||" {
+            let preferred = if op_text == "&&" { "&" } else { "|" };
+            emit(op, op_text, preferred, text, severity, suppressions, out);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_filter_predicate(child, text, severity, suppressions, out);
     }
 }
 
@@ -98,9 +199,7 @@ fn emit(
         severity: Some(severity),
         source: Some(LINT_SOURCE.to_string()),
         code: Some(NumberOrString::String(rule_ids::VECTOR_LOGIC.to_string())),
-        message: format!(
-            "Use `{preferred}` in `if` / `while` conditions; `{op_text}` is the vectorised form."
-        ),
+        message: format!("Use `{preferred}` for this logical context instead of `{op_text}`."),
         ..Default::default()
     });
 }

--- a/crates/raven/src/linting/rules/vector_logic.rs
+++ b/crates/raven/src/linting/rules/vector_logic.rs
@@ -9,6 +9,10 @@
 //! `expect_false()` assertions, reporting `&` / `|` where scalar `&&` / `||`
 //! is expected. It also checks `filter()` / `subset()` predicates in the other
 //! direction, reporting `&&` / `||` where vectorized `&` / `|` is expected.
+//! For `filter()`, known scalar/control arguments (`.preserve`, `.by`, and the
+//! base `circular` argument) are excluded. For `subset()`, only the `subset`
+//! predicate is scanned; `select`, `drop`, and `...` arguments are not vector
+//! predicate contexts. Pipe-fed calls treat the data argument as implicit.
 //! Function-call boundaries stop the recursion: `if (any(x & y))` is fine
 //! because the `&` is evaluated inside `any()` on a vector, not on the
 //! condition itself. lintr applies the same carve-out.
@@ -84,7 +88,8 @@ fn check_call_context(
         return;
     }
 
-    let mut skipped_data_argument = false;
+    let mut data_supplied = call_is_pipe_fed(node, text);
+    let mut subset_predicate_supplied = false;
     let mut cursor = arguments.walk();
     for argument in arguments
         .children(&mut cursor)
@@ -93,19 +98,61 @@ fn check_call_context(
         let name = argument
             .child_by_field_name("name")
             .and_then(|name| text.get(name.start_byte()..name.end_byte()));
-        if name == Some("circular") {
-            continue;
+
+        if is_filter {
+            if matches!(name, Some("circular" | ".preserve" | ".by")) {
+                continue;
+            }
+            if name == Some(".data") {
+                data_supplied = true;
+                continue;
+            }
+            if name.is_none() && !data_supplied {
+                data_supplied = true;
+                continue;
+            }
+        } else {
+            match name {
+                Some("x") => {
+                    data_supplied = true;
+                    continue;
+                }
+                Some("subset") => subset_predicate_supplied = true,
+                Some(_) => continue,
+                None if !data_supplied => {
+                    data_supplied = true;
+                    continue;
+                }
+                None if !subset_predicate_supplied => subset_predicate_supplied = true,
+                None => continue,
+            }
         }
-        let is_named_data_argument =
-            (is_filter && name == Some(".data")) || (is_subset && name == Some("x"));
-        if !skipped_data_argument && (name.is_none() || is_named_data_argument) {
-            skipped_data_argument = true;
-            continue;
-        }
-        if let Some(value) = argument.child_by_field_name("value") {
-            scan_filter_predicate(value, text, severity, suppressions, out);
+
+        if let Some(predicate) = argument.child_by_field_name("value") {
+            scan_filter_predicate(predicate, text, severity, suppressions, out);
         }
     }
+}
+
+/// True when a forward pipe supplies the call's data argument implicitly.
+fn call_is_pipe_fed(call: Node<'_>, text: &str) -> bool {
+    let Some(parent) = call.parent() else {
+        return false;
+    };
+    if parent.kind() != "binary_operator"
+        || parent.child_by_field_name("rhs").map(|rhs| rhs.id()) != Some(call.id())
+    {
+        return false;
+    }
+
+    let mut cursor = parent.walk();
+    parent.children(&mut cursor).any(|child| {
+        child.kind() == "|>"
+            || (child.kind() == "special"
+                && text
+                    .get(child.start_byte()..child.end_byte())
+                    .is_some_and(|operator| matches!(operator, "%>%" | "%<>%")))
+    })
 }
 
 fn matches_function(actual: &str, name: &str) -> bool {

--- a/docs/development.md
+++ b/docs/development.md
@@ -650,6 +650,33 @@ cargo test -p raven --test package_corpus -- --ignored --nocapture
 - Bun tests (`tests/bun/`) cover TypeScript extension logic: plot viewer, data viewer, help viewer, send-to-R, config validation.
 - VS Code extension tests (`editors/vscode/src/test/`) use `@vscode/test-cli` with Mocha.
 
+### Native lint parity audit
+
+`crates/raven/src/linting/lintr_parity.rs` is the cross-rule compatibility
+gate for every lintr equivalent Raven advertises. The matrix was derived from
+r-lib/lintr's `tests/testthat/test-*_linter.R` files at commit
+`603ab79e6db25d380c5ee96f35ffd6ba16d223aa` (3.3.0.9000, 2026-07-07) and
+spot-checked against release 3.3.0.1. Its coverage assertion fails when a rule
+is added to Raven without a matrix entry. Keep focused tests beside each rule
+for exact messages/ranges, suppression behavior, parse-recovery cases, and
+Raven-specific extensions; the matrix owns default clean-vs-violation behavior
+across the full supported set.
+
+The parity boundary is lintr's default, statically decidable behavior. It does
+not imply support for every optional linter argument or analysis that depends
+on an installed package namespace. Raven's `.lintr` loader warns and ignores
+unsupported calls, and `docs/linting.md` documents the supported mapping.
+During an audit, use a one-linter R oracle to disambiguate behavior before
+translating a fixture, for example:
+
+```r
+lintr::lint(text = "x^2", linters = lintr::infix_spaces_linter())
+```
+
+Pin the upstream commit in the matrix comment when adopting changed upstream
+behavior, and describe any intentional divergence in both the rule's module
+docs and `docs/linting.md` rather than silently changing the fixture.
+
 ### AST inspection utility
 
 For quickly validating tree-sitter node kinds, use the `inspect_ast()` helper (see `crates/raven/src/handlers.rs`). Run with `--nocapture` to print.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -113,12 +113,17 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 
 - **Raven:** `raven.linting.trailingWhitespaceSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::trailing_whitespace_linter()`.
+- Whitespace at a line ending inside a multi-line string is allowed, matching
+  lintr's default `allow_in_strings = TRUE`; whitespace after the closing
+  delimiter is still flagged.
 
 ### Tab characters
 
 - **Raven:** `raven.linting.noTabSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::whitespace_linter()` (the no-tab portion).
-- One diagnostic per line containing a tab, anchored at the first tab on that line.
+- One diagnostic per line using a tab for indentation, anchored at the first
+  indentation tab. Tabs after the first non-whitespace character (for example
+  inside a comment or string) are not indentation and are ignored.
 
 ### Trailing blank lines
 
@@ -132,33 +137,59 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 - **Raven:** `raven.linting.assignmentOperator` (default `"<-"`, alternative `"="`), `raven.linting.assignmentOperatorSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::assignment_linter()`.
 - Named-argument `=` inside function calls (`f(name = value)`) is never flagged. Assignments inside nested expressions — function bodies, braced blocks, control flow — are checked even when they appear inside an argument list.
+- With the default `"<-"` policy, `=`, `<<-`, `->`, `->>`, and the `%<>%`
+  assignment pipe are flagged. Raven's alternative `"="` policy accepts `=`
+  and flags the other assignment forms.
 
 ### Object names
 
 - **Raven:** `raven.linting.objectNameStyleFunction`, `raven.linting.objectNameStyleVariable`, `raven.linting.objectNameStyleArgument` (each defaults to `"snake_case"`), `raven.linting.objectNameRegexesFunction`, `raven.linting.objectNameRegexesVariable`, `raven.linting.objectNameRegexesArgument` (each defaults to `[]`), `raven.linting.objectNameSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::object_name_linter(styles = ..., regexes = ...)`.
 - Each style key accepts `"snake_case"`, `"camelCase"`, `"dotted.case"`, `"UPPER_CASE"`, `"lowercase"`, `"any"` (disable that kind and ignore its regexes), or an array of those styles. Multiple styles are ORed. A name also passes if it matches any regex for that kind.
-- Regexes are Rust regexes applied as partial matches against the full identifier, including any leading `.`. Use anchors such as `^...$` when you need the whole name to match. Rust's regex engine does not support PCRE lookaround such as `(?=...)`; unsupported patterns are warned about and skipped (for the settings/`raven.toml` path the warning goes to the server log; a `.lintr` file surfaces a visible warning notification). Empty regex strings are rejected because they would match every identifier. If regex-only mode supplies regexes but none are valid, Raven retains the default named style instead of silently disabling the check (in `.lintr` the invalid call still clears editor-level regexes, since it stated the project's regex policy).
+- Regexes are Rust regexes applied as partial matches against the unquoted
+  identifier (backticks or string quotes are removed), including any leading
+  `.`. Use anchors such as `^...$` when you need the whole name to match. Rust's regex engine does not support PCRE lookaround such as `(?=...)`; unsupported patterns are warned about and skipped (for the settings/`raven.toml` path the warning goes to the server log; a `.lintr` file surfaces a visible warning notification). Empty regex strings are rejected because they would match every identifier. If regex-only mode supplies regexes but none are valid, Raven retains the default named style instead of silently disabling the check (in `.lintr` the invalid call still clears editor-level regexes, since it stated the project's regex policy).
 - An explicit empty style array with regexes is regex-only mode. If both the style array and regex array are empty, that kind's object-name check is disabled. A style value with no recognized style names is warned about and treated as empty: with valid regexes configured the kind becomes regex-only, with no regex setting at all it is disabled, and if the regex setting is present but contains no valid patterns the default style is restored rather than silently disabling the check.
-- Carve-outs: named styles always allow an optional leading `.`, but the rest of the name must still match the configured style (so `.helper` is fine under `snake_case`, but `.onLoad` is not — pick `camelCase`, add a regex for that kind, or suppress it); S3-method names of the form `<known-base-generic>.<class>` (e.g. `print.MyClass`, `as.Date.character`) are exempt; backtick-quoted names are skipped. Non-ASCII identifiers are skipped when no regexes are configured for that kind; when regexes are configured (regex-only or combined with styles), non-ASCII names are checked against the regexes — the named ASCII styles never match them.
+- Quoting is not a carve-out: `` `badName` `` is checked as `badName` in
+  named-style, regex-only, and combined modes. Compound assignment targets
+  check only their leftmost object (`badName$field <- 1` checks `badName`, not
+  `field`). Named styles always allow an optional leading `.`, but the rest of
+  the name must still match the configured style. Standard namespace/startup
+  hooks (`.onLoad`, `.onAttach`, `.onUnload`, `.onDetach`, `.Last.lib`,
+  `.First`, `.Last`) and S3-method names of the form
+  `<known-base-generic>.<class>` (e.g. `print.MyClass`, `as.Date.character`,
+  `` `+.my_class` ``) are exempt. Non-ASCII identifiers are skipped when no
+  regexes are configured for that kind; when regexes are configured
+  (regex-only or combined with styles), non-ASCII names are checked against
+  the regexes — the named ASCII styles never match them.
+- Literal names passed to `assign()` / `setGeneric()` are checked as binding
+  names as well; other string arguments to those calls are not.
 
 ### Infix spaces
 
 - **Raven:** `raven.linting.infixSpacesSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::infix_spaces_linter()`.
-- Spaces required on both sides of arithmetic, comparison, logical, assignment, pipe (`|>`, `%>%`, and any `%...%` user-defined operator), and binary `~`. No spaces on either side of `:`, `::`, `:::`, `$`, `@`. No space between a unary `-`, `+`, `!`, or `?` and its operand (the gap after the operator is checked; no constraint on what precedes it). Alignment whitespace (`x   <- 1`) is allowed; operator-at-end-of-line line continuations are skipped.
+- Spaces required on both sides of low-precedence arithmetic, comparison,
+  logical, assignment, pipe (`|>`, `%>%`, and any `%...%` user-defined
+  operator), and binary `~`; named-argument and formal-default `=` are checked
+  too. Exponentiation is outside this rule, so both `x^2` and `x ^ 2` are
+  accepted. No spaces on either side of `:`, `::`, `:::`, `$`, `@`. No space between a unary `-`, `+`, `!`, or `?` and its operand (the gap after the operator is checked; no constraint on what precedes it). Alignment whitespace (`x   <- 1`) is allowed; operator-at-end-of-line line continuations are skipped.
 
 ### Commented code
 
 - **Raven:** `raven.linting.commentedCodeSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::commented_code_linter()`.
-- Flags a standalone comment block (consecutive `#` lines) whose body parses as R and contains a call, assignment, operator, or function definition. Roxygen (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, `# NOTE:`, `# XXX:`, `# HACK:`, `# BUG:`, `# WARNING:`, `# OPTIMIZE:`), Emacs mode lines, and `# nolint` / `# raven:` / `# @lsp-…` directives are skipped. End-of-line comments next to real code (`x <- 1 # explain`) are never flagged.
+- Flags a standalone comment block (consecutive `#` lines) or end-of-line
+  comment whose body parses as R and contains a call, assignment, operator, or
+  function definition. Roxygen (`#'`), shebangs, annotation comments (`# TODO:`, `# FIXME:`, `# NOTE:`, `# XXX:`, `# HACK:`, `# BUG:`, `# WARNING:`, `# OPTIMIZE:`), Emacs mode lines, and `# nolint` / `# raven:` / `# @lsp-…` directives are skipped. Ordinary end-of-line prose (`x <- 1 # explain`) remains clean; code-shaped text (`x <- 1 # other_call()`) is flagged.
 
 ### Quotes
 
 - **Raven:** `raven.linting.stringDelimiter` (default `"\""`, alternative `"'"`), `raven.linting.quotesSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::quotes_linter()` / `lintr::single_quotes_linter()` (the two map to the two settings above).
-- Raw strings (`r"(...)"`, `R'(...)'`, `r"---(...)---"`) are exempt — the outer quote is constrained by the body.
+- Regular and raw strings follow the same delimiter policy. An alternate outer
+  delimiter is allowed when switching would require escaping the preferred
+  delimiter already present in the body (for example `'"quoted"'`).
 
 ### Commas
 
@@ -170,7 +201,10 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 
 - **Raven:** `raven.linting.tAndFSymbolSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::T_and_F_symbol_linter()`.
-- Flags bare `T` / `F` identifiers used as references to `TRUE` / `FALSE`. Assignment targets (`T <- 0`), named arguments (`foo(T = TRUE)`), formal parameters (`function(T) ...`), and `$` / `@` field names (`obj$T`) are exempt — those positions don't read the boolean.
+- Flags bare `T` / `F` identifiers used as references to `TRUE` / `FALSE`, and
+  flags assignment targets (`T <- 0`) because rebinding these aliases can
+  break later code. Formula terms (`y ~ T + F`), named argument/formal names,
+  and extraction/subsetting object or field names (`T[1]`, `obj$T`) are exempt.
 
 ### Semicolon
 
@@ -182,37 +216,53 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 
 - **Raven:** `raven.linting.equalsNaSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::equals_na_linter()`.
-- Flags `x == NA`, `x != NA`, and the typed variants (`NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_`) on either side. The comparison always returns `NA`; use `is.na(x)` instead.
+- Flags `x == NA`, `x != NA`, `x %in% NA`, and the typed variants
+  (`NA_integer_`, `NA_real_`, `NA_character_`, `NA_complex_`). Equality and
+  inequality work on either side; `NA %in% x` is intentionally left alone.
 
 ### Object length
 
 - **Raven:** `raven.linting.objectLength` (default `30`), `raven.linting.objectLengthSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::object_length_linter(length = 30)`.
-- Flags assignment targets and formal parameters whose names exceed the configured length. An optional leading `.` (hidden identifier convention) is not counted. Backtick-quoted and non-ASCII names are exempt, matching `object_name`'s carve-outs.
+- Flags assignment targets and formal parameters whose names exceed the
+  configured length. An optional leading `.` (hidden identifier convention)
+  and syntactic quote delimiters are not counted. Unicode names are measured
+  in characters. Compound targets check only their leftmost object.
+- Literal names passed to `assign()` / `setGeneric()` are measured too.
 
 ### Vector logic
 
 - **Raven:** `raven.linting.vectorLogicSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::vector_logic_linter()`.
-- Flags `&` or `|` in `if` / `while` conditions (where `&&` / `||` is the scalar short-circuit form). The scan recurses through nested logical operators but stops at call boundaries — `if (any(x & y))` is left alone because the `&` is evaluated on a vector inside `any()`.
+- Flags `&` or `|` in `if` / `while` conditions and `expect_true()` /
+  `expect_false()` assertions (where `&&` / `||` is the scalar short-circuit
+  form). It also flags `&&` / `||` in `filter()` / `subset()` predicates, where
+  vectorized `&` / `|` is required. Nested call boundaries remain conservative:
+  `if (any(x & y))` is left alone.
 
 ### Function left parentheses
 
 - **Raven:** `raven.linting.functionLeftParenthesesSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::function_left_parentheses_linter()`.
-- Flags whitespace between `function` (or the `\` lambda shorthand) and the parameter `(`. The community convention is tight: `function(x)` and `\(x)`.
+- Flags whitespace before `(` in function definitions and calls. The community
+  convention is tight: `function(x)`, `\(x)`, and `mean(x)`.
 
 ### Spaces inside
 
 - **Raven:** `raven.linting.spacesInsideSeverity` (default `"information"`).
 - **`lintr` equivalent:** `lintr::spaces_inside_linter()`.
-- Flags whitespace immediately inside `(`, `[`, `[[` and their closing counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Empty groupings (`f()`, `f( )`, `mat[]`) and multi-line wrapping are exempt — only single-line interior whitespace is flagged. A trailing comma that marks an omitted subset dimension keeps its space (`x[i, ]`) and is not flagged, keeping the rule consistent with `commas`.
+- Flags whitespace immediately inside `(`, `[`, `[[` and their closing
+  counterparts (e.g. `f( x )`, `df[ 1 ]`, `mat[[ i ]]`). Truly empty
+  groupings (`f()`, `mat[]`) and multi-line wrapping are exempt;
+  whitespace-only single-line groupings (`f( )`, `mat[ ]`) are flagged. A
+  trailing comma that marks an omitted subset dimension keeps its space
+  (`x[i, ]`) and is not flagged, keeping the rule consistent with `commas`.
 
 ### Indentation
 
 - **Raven:** `raven.linting.indentationUnit` (default `"auto"`, or a fixed integer clamped to `1..=8`), `raven.linting.indentationSeverity` (default `"information"`). When set to `"auto"` (the default), each R file is linted against VS Code's `editor.tabSize` for that specific file, so files with different tab-size settings in the same workspace are each linted correctly. Set to a fixed integer (e.g. `2` or `4`) to use the same unit for all R files regardless of editor settings. Note: if a `[[linting.overrides]]` entry explicitly sets `indentationUnit` for a file, it takes precedence over the per-file `editor.tabSize`.
 - **`lintr` equivalent:** `lintr::indentation_linter()` with its tidy-default hanging style.
-- Flags lines whose leading whitespace doesn't match the indent expected by the AST scope the line sits in: braced blocks (one unit deeper than the line of `{`); multi-line argument lists (either aligned with the column after the opener — `foo(a,\n    b)` — or hanging one unit deeper than the opener's line); continuation lines under a binary operator (one unit deeper than the line where the chain starts). A closing delimiter (`)`, `]`, `]]`, `}`) that begins its own line aligns with the line of its opener; that closer alignment takes precedence even when a multi-line binary-operator scope also covers the closer's line. A standalone comment-only line aligned with the trailing-comment column of an adjacent line expecting the same indent is not flagged, matching a common intentional documentation style; directive/suppression marker comments such as `# nolint`, `# raven: ...`, and `# @lsp-...` are excluded from this exemption and are never used as anchors — a suppressed marker like `# nolint` still has its diagnostics skipped entirely by the normal suppression mechanism, while a non-suppressing marker like `# raven: ...` or `# @lsp-ignore-next` still gets the ordinary indentation check.
+- Flags lines whose leading whitespace doesn't match the indent expected by the AST scope the line sits in: braced blocks (one unit deeper than the line of `{`); multi-line argument lists (either aligned with the column after the opener — `foo(a,\n    b)` — or hanging one unit deeper than the opener's line); continuation lines under a binary operator (one unit deeper than the line where the chain starts). Parenthesized Boolean clauses may align with one another, so the common `(condition) |` / `(condition)` layout does not gain a spurious extra level. A closing delimiter (`)`, `]`, `]]`, `}`) that begins its own line aligns with the line of its opener; that closer alignment takes precedence even when a multi-line binary-operator scope also covers the closer's line. A standalone comment-only line aligned with the trailing-comment column of an adjacent line expecting the same indent is not flagged, matching a common intentional documentation style; directive/suppression marker comments such as `# nolint`, `# raven: ...`, and `# @lsp-...` are excluded from this exemption and are never used as anchors — a suppressed marker like `# nolint` still has its diagnostics skipped entirely by the normal suppression mechanism, while a non-suppressing marker like `# raven: ...` or `# @lsp-ignore-next` still gets the ordinary indentation check.
 - Skipped without checks: blank lines, lines whose leading whitespace contains any tab (left to the `no_tab` rule), and lines that start strictly inside a multi-line string. Suppression markers behave as on every other rule.
 
 ## Migrating from `.lintr`

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -205,6 +205,9 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
   flags assignment targets (`T <- 0`) because rebinding these aliases can
   break later code. Formula terms (`y ~ T + F`), named argument/formal names,
   and extraction/subsetting object or field names (`T[1]`, `obj$T`) are exempt.
+  Matching `lintr`, a bare alias used directly as a named-argument value in a
+  formula (`y ~ foo(arg = T)`) is checked, while an alias nested in a formula
+  expression (`y ~ foo(arg = T + 1)`) remains a formula term.
 
 ### Semicolon
 
@@ -237,8 +240,10 @@ Each rule lists the Raven settings that control it and the `lintr` linter it mir
 - Flags `&` or `|` in `if` / `while` conditions and `expect_true()` /
   `expect_false()` assertions (where `&&` / `||` is the scalar short-circuit
   form). It also flags `&&` / `||` in `filter()` / `subset()` predicates, where
-  vectorized `&` / `|` is required. Nested call boundaries remain conservative:
-  `if (any(x & y))` is left alone.
+  vectorized `&` / `|` is required, including when the data is supplied by
+  `%>%`, `%<>%`, or `|>`. Scalar/control arguments are excluded: `.preserve`
+  and `.by` for `filter()`, and `select`, `drop`, and `...` for `subset()`.
+  Nested call boundaries remain conservative: `if (any(x & y))` is left alone.
 
 ### Function left parentheses
 


### PR DESCRIPTION
## Summary

- check backtick-quoted object names under every configured naming policy
- accept aligned closing parentheses and clauses in parenthesized binary expressions
- stop reporting spaces around exponentiation as missing
- audit all 18 advertised lintr-equivalent rules and fix the additional parity gaps found
- add a coverage-enforced cross-rule parity matrix plus focused regressions
- update linting and maintainer documentation and attribute adapted lintr test cases

## Audit scope

The parity matrix was audited against r-lib/lintr commit `603ab79e6db25d380c5ee96f35ffd6ba16d223aa` and spot-checked with lintr 3.3.0.1. It covers every lint rule Raven currently advertises as a lintr equivalent while leaving diagnostic ranges, suppression behavior, and Raven-specific extensions to focused tests.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo test --workspace --features test-support`

Closes #589
Closes #599