### PR TITLE
fix(diagnostics): prevent retired work from publishing after lifecycle reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Each item below either spans multiple systems or is a discipline that applies in
 - **Diagnostics publishing monotonicity**
   - Diagnostics publish monotonically by document version. Dependency-triggered revalidation may republish at the same version via the force-republish mechanism, but never older.
   - Production commit paths MUST use `CrossFileDiagnosticsGate::try_consume_publish` (atomic). The `can_publish` + `record_publish` pair is racy and is for advisory pre-flight checks and tests only — see the gate's own doc comments for the TOCTOU details.
+  - Each diagnostic-eligible URI lifecycle carries a globally unique epoch (#603): minted on `did_open`/tab re-addition, retired on `did_close`/tab removal/shutdown, validated by the atomic commit so retired work can never publish into a reused lifecycle (version + revision cannot distinguish one — `Document::revision` restarts at 0 on reopen). Lifecycle transitions go through `WorldState::begin_diagnostic_lifecycle` / `retire_diagnostic_lifecycle`; mechanics live in the gate's doc comments in `cross_file/revalidation.rs`.
 
 - **LRU caches under locks**
   - Read locks: `peek()` (no promotion). Write locks: `push()` (eviction/promotion).

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -29,7 +29,7 @@ use tower_lsp::lsp_types::*;
 use crate::content_provider::ContentProvider;
 use crate::handlers;
 use crate::indentation;
-use crate::state::{IndentationSettings, SymbolConfig, WorldState};
+use crate::state::{DiagnosticsTrigger, IndentationSettings, SymbolConfig, WorldState};
 use crate::utf16::utf16_column_to_byte_offset;
 tokio::task_local! {
     static CURRENT_LSP_REQUEST_ID: JsonRpcId;
@@ -1698,7 +1698,7 @@ fn collect_close_fanout_siblings(
     state: &WorldState,
     closing_uri: &Url,
     workspace_root: &std::path::Path,
-) -> Vec<(Url, Option<i32>, Option<u64>)> {
+) -> Vec<(Url, DiagnosticsTrigger)> {
     let mut candidates: Vec<Url> = state
         .documents
         .keys()
@@ -1715,21 +1715,20 @@ fn collect_close_fanout_siblings(
     );
     candidates
         .into_iter()
-        .filter_map(|sibling_uri| {
-            state
-                .documents
-                .get(&sibling_uri)
-                .map(|doc| (sibling_uri, doc.version, Some(doc.revision)))
+        .filter(|sibling_uri| state.documents.contains_key(sibling_uri))
+        .map(|sibling_uri| {
+            let trigger = DiagnosticsTrigger::capture(state, &sibling_uri);
+            (sibling_uri, trigger)
         })
         .collect()
 }
 
 fn add_close_fanout_uris(
     state: &WorldState,
-    fanout: &mut Vec<(Url, Option<i32>, Option<u64>)>,
+    fanout: &mut Vec<(Url, DiagnosticsTrigger)>,
     additional: impl IntoIterator<Item = Url>,
 ) {
-    let mut candidates: Vec<Url> = fanout.iter().map(|(uri, _, _)| uri.clone()).collect();
+    let mut candidates: Vec<Url> = fanout.iter().map(|(uri, _)| uri.clone()).collect();
     let mut seen: std::collections::HashSet<Url> = candidates.iter().cloned().collect();
     for uri in additional {
         if state.documents.contains_key(&uri) && seen.insert(uri.clone()) {
@@ -1743,11 +1742,10 @@ fn add_close_fanout_uris(
     );
     *fanout = candidates
         .into_iter()
-        .filter_map(|uri| {
-            state
-                .documents
-                .get(&uri)
-                .map(|doc| (uri, doc.version, Some(doc.revision)))
+        .filter(|uri| state.documents.contains_key(uri))
+        .map(|uri| {
+            let trigger = DiagnosticsTrigger::capture(state, &uri);
+            (uri, trigger)
         })
         .collect();
 }
@@ -2393,6 +2391,10 @@ mod manifest_extend_tests {
         let gate = CrossFileDiagnosticsGate::new();
         let max_revalidations = 10usize;
         let open_uris: Vec<Url> = (0..20).map(|i| test_uri(&format!("R/f{i}.R"))).collect();
+        let epochs: std::collections::HashMap<Url, _> = open_uris
+            .iter()
+            .map(|u| (u.clone(), gate.begin_epoch(u)))
+            .collect();
         for u in &open_uris {
             gate.record_publish(u, 1);
         }
@@ -2407,7 +2409,7 @@ mod manifest_extend_tests {
         gate.mark_force_republish_many(affected_for_async.iter());
         for u in &affected_for_async {
             assert!(
-                gate.try_consume_publish(u, 1),
+                gate.try_consume_publish(u, 1, epochs[u]),
                 "force-marked URI must publish at v=1"
             );
         }
@@ -4800,13 +4802,13 @@ fn merge_and_cap_reenrichment_revalidations(
 /// by the cap don't carry orphaned force counters.
 fn rebuild_work_items_after_reenrichment(
     pinned_uri: &Url,
-    prev_work_items: &[(Url, Option<i32>, Option<u64>)],
+    prev_work_items: &[(Url, DiagnosticsTrigger)],
     new_neighbors: Vec<Url>,
     state: &WorldState,
-) -> Vec<(Url, Option<i32>, Option<u64>)> {
+) -> Vec<(Url, DiagnosticsTrigger)> {
     let max_revalidations = state.cross_file_config.max_revalidations_per_trigger;
     let prev_uris: std::collections::HashSet<Url> =
-        prev_work_items.iter().map(|(u, _, _)| u.clone()).collect();
+        prev_work_items.iter().map(|(u, _)| u.clone()).collect();
     let final_uris = merge_and_cap_reenrichment_revalidations(
         pinned_uri,
         prev_uris,
@@ -4817,10 +4819,8 @@ fn rebuild_work_items_after_reenrichment(
     final_uris
         .into_iter()
         .map(|u| {
-            let doc = state.documents.get(&u);
-            let trigger_version = doc.and_then(|d| d.version);
-            let trigger_revision = doc.map(|d| d.revision);
-            (u, trigger_version, trigger_revision)
+            let trigger = DiagnosticsTrigger::capture(state, &u);
+            (u, trigger)
         })
         .collect()
 }
@@ -4872,6 +4872,27 @@ async fn check_and_warn_traversal_truncation(
     }
 }
 
+/// Test-only pause point for the diagnostics publish pipelines: parks the
+/// calling worker post-compute, pre-commit when a test armed a pause for
+/// `uri` (see `DiagnosticsPublishPause`). Sits BEFORE the publish-lock
+/// acquisition so `did_close` / tab handlers (which take that lock) can run
+/// while the worker is parked. The armed gate is looked up in its own
+/// statement so the `WorldState` read guard drops before the await.
+#[cfg(any(test, feature = "test-support"))]
+async fn pause_if_armed_for_test(state_arc: &Arc<RwLock<WorldState>>, uri: &Url) {
+    let armed = {
+        let state = state_arc.read().await;
+        state.diagnostics_test_pause.take_armed(uri)
+    };
+    if let Some(pause_gate) = armed {
+        pause_gate.pause().await;
+    }
+}
+
+/// Production builds compile the pause point to a no-op.
+#[cfg(not(any(test, feature = "test-support")))]
+async fn pause_if_armed_for_test(_state_arc: &Arc<RwLock<WorldState>>, _uri: &Url) {}
+
 /// Run debounced diagnostics for a single URI.
 ///
 /// This is the shared diagnostics pipeline used by both `did_open`/`did_change`
@@ -4882,25 +4903,27 @@ async fn run_debounced_diagnostics(
     client: Client,
     affected_uri: Url,
     debounce_ms: u64,
-    trigger_version: Option<i32>,
-    trigger_revision: Option<u64>,
+    trigger: DiagnosticsTrigger,
     traversal_truncation: Option<Arc<TraversalTruncationState>>,
 ) {
     // Schedule with cancellation token, gated on the trigger still matching
-    // the document's current (version, revision) under the same read lock.
-    // A mismatched worker is already obsolete (a newer edit's worker owns
-    // the current state) or belongs to a dead open epoch (spawned before a
-    // close+reopen reset the version, which did_close's cancel cannot reach
-    // because the worker had not scheduled yet). Letting it schedule anyway
-    // would cancel a strictly fresher pending worker and then die on the
-    // same freshness comparison after the debounce, leaving the newest
-    // version unpublished until the next trigger.
+    // the document's current (version, revision, epoch) under the same read
+    // lock. A mismatched worker is already obsolete (a newer edit's worker
+    // owns the current state) or belongs to a retired lifecycle (spawned
+    // before a close+reopen or tab removal, which did_close's cancel cannot
+    // reach because the worker had not scheduled yet — the epoch comparison
+    // is what catches it even when version and revision coincide). Letting
+    // it schedule anyway would cancel a strictly fresher pending worker and
+    // then die on the same freshness comparison after the debounce, leaving
+    // the newest version unpublished until the next trigger.
+    //
+    // An epoch-less trigger is declined outright: it can never legally
+    // publish (the final commit requires a live epoch), and an all-`None`
+    // trigger would otherwise compare equal to a still-absent document and
+    // let a retired worker participate in schedule() supersession.
     let scheduled = {
         let state = state_arc.read().await;
-        let doc = state.documents.get(&affected_uri);
-        let current_version = doc.and_then(|d| d.version);
-        let current_revision = doc.map(|d| d.revision);
-        if current_version != trigger_version || current_revision != trigger_revision {
+        if trigger.epoch.is_none() || trigger.is_stale(&state, &affected_uri) {
             None
         } else {
             Some(state.cross_file_revalidation.schedule(affected_uri.clone()))
@@ -4927,10 +4950,6 @@ async fn run_debounced_diagnostics(
     let snapshot_data = {
         let state = state_arc.read().await;
 
-        let doc = state.documents.get(&affected_uri);
-        let current_version = doc.and_then(|d| d.version);
-        let current_revision = doc.map(|d| d.revision);
-
         // Every non-cancelled exit below completes this task's own pending
         // entry (generation-aware, so a successor's entry is never touched).
         // Cancelled exits skip it: cancellation always removed or replaced
@@ -4938,9 +4957,9 @@ async fn run_debounced_diagnostics(
         // bails early would strand its entry in the pending map — e.g. a
         // closed document's worker (trigger and current both absent) whose
         // URI is never scheduled again.
-        if current_version != trigger_version || current_revision != trigger_revision {
+        if trigger.is_stale(&state, &affected_uri) {
             log::trace!(
-                "Skipping stale diagnostics for {}: revision changed",
+                "Skipping stale diagnostics for {}: trigger no longer current",
                 affected_uri
             );
             state
@@ -4960,7 +4979,7 @@ async fn run_debounced_diagnostics(
             return;
         }
 
-        if let Some(ver) = current_version
+        if let Some(ver) = trigger.version
             && !state.diagnostics_gate.can_publish(&affected_uri, ver)
         {
             log::trace!("Skipping diagnostics for {}: monotonic gate", affected_uri);
@@ -5027,6 +5046,8 @@ async fn run_debounced_diagnostics(
         return;
     }
 
+    pause_if_armed_for_test(&state_arc, &affected_uri).await;
+
     // Second freshness check + atomic gate commit before publishing.
     // try_consume_publish takes write locks on the gate's maps, evaluates the
     // same predicate as can_publish, and on success updates last_published
@@ -5071,23 +5092,14 @@ async fn run_debounced_diagnostics(
             return;
         }
 
-        let doc = state.documents.get(&affected_uri);
-        let current_version = doc.and_then(|d| d.version);
-        let current_revision = doc.map(|d| d.revision);
-
         let can_publish = if !state.diagnostics_publish_allowed(&affected_uri)
-            || current_version != trigger_version
-            || current_revision != trigger_revision
+            || trigger.is_stale(&state, &affected_uri)
         {
             false
-        } else if let Some(ver) = current_version {
-            state
-                .diagnostics_gate
-                .try_consume_publish(&affected_uri, ver)
         } else {
-            true
+            trigger.commit_publish(&state.diagnostics_gate, &affected_uri)
         };
-        (can_publish, doc.is_some())
+        (can_publish, state.documents.contains_key(&affected_uri))
     };
 
     if can_publish {
@@ -5095,7 +5107,7 @@ async fn run_debounced_diagnostics(
             "diagnostics lifecycle: publish uri={} count={} path=debounced trigger_version={:?} open={}",
             affected_uri,
             diagnostics.len(),
-            trigger_version,
+            trigger.version,
             open_at_publish
         );
         client
@@ -5120,10 +5132,12 @@ async fn run_debounced_diagnostics(
         // successor, it blocks on the publish lock until this task releases
         // it, and it only re-enters this branch if it loses the same race to
         // yet another superseding edit — so it cannot loop absent new edits.
-        // If the cancellation instead came from did_close, the close's
-        // gate.clear (serialized behind the publish lock this task holds)
-        // removes the surplus marker and the respawn bails at its
-        // eligibility checks.
+        // did_close cannot be the canceller in this window: it must acquire
+        // the publish lock this task still holds before it can cancel, so a
+        // close-sourced cancellation is only observable at the earlier
+        // re-checks. A close that queues behind this task still converges:
+        // its gate.clear removes the surplus marker and the respawn bails
+        // at its trigger/eligibility checks.
         if cancel.is_cancelled() {
             state.diagnostics_gate.mark_force_republish(&affected_uri);
             tokio::spawn(respawn_publish_after_superseded(
@@ -5702,13 +5716,11 @@ impl LanguageServer for Backend {
                             state
                                 .diagnostics_gate
                                 .mark_force_republish_many(open_keys.iter());
-                            let items: Vec<(Url, Option<i32>, Option<u64>)> = open_keys
+                            let items: Vec<(Url, DiagnosticsTrigger)> = open_keys
                                 .into_iter()
                                 .map(|uri| {
-                                    let doc = state.documents.get(&uri);
-                                    let v = doc.and_then(|d| d.version);
-                                    let r = doc.map(|d| d.revision);
-                                    (uri, v, r)
+                                    let trigger = DiagnosticsTrigger::capture(&state, &uri);
+                                    (uri, trigger)
                                 })
                                 .collect();
                             let debounce = state.cross_file_config.revalidation_debounce_ms;
@@ -5755,7 +5767,7 @@ impl LanguageServer for Backend {
                         }
 
                         // Revalidate all open documents to pick up auto-detected backward edges
-                        for (uri, trigger_version, trigger_revision) in work_items {
+                        for (uri, trigger) in work_items {
                             let state_arc = state_clone.clone();
                             let client = client_clone.clone();
                             let traversal_truncation = traversal_truncation.clone();
@@ -5764,8 +5776,7 @@ impl LanguageServer for Backend {
                                 client,
                                 uri,
                                 debounce_ms,
-                                trigger_version,
-                                trigger_revision,
+                                trigger,
                                 Some(traversal_truncation),
                             ));
                         }
@@ -6045,6 +6056,21 @@ impl LanguageServer for Backend {
 
     async fn shutdown(&self) -> Result<()> {
         log::info!("ark-lsp shutting down");
+        // Retire every diagnostic lifecycle under the publish lock so no
+        // in-flight worker can publish after this response: workers already
+        // past their final commit hold the lock (we order behind them), and
+        // everything earlier fails its epoch check once we clear. Ordering
+        // matches every other lifecycle transition: publish lock first, then
+        // the state lock.
+        let diagnostics_publish_lock = {
+            let state = self.state.read().await;
+            Arc::clone(&state.diagnostics_publish_lock)
+        };
+        let _publish_guard = diagnostics_publish_lock.lock().await;
+        {
+            let state = self.state.read().await;
+            state.retire_all_diagnostic_lifecycles();
+        }
         Ok(())
     }
 
@@ -6356,6 +6382,11 @@ impl LanguageServer for Backend {
                     Some(version),
                     Some(language_id.as_str()),
                 );
+                // Fresh diagnostic lifecycle for this open (issue #603). Once
+                // per didOpen: the re-enrichment second pass re-opens the same
+                // document without an eligibility transition and must NOT mint
+                // again.
+                state.begin_diagnostic_lifecycle(&uri);
                 state.cross_file_activity.record_recent(uri.clone());
                 for graph_root in state.authoritative_revalidation_roots_for_uri(&uri) {
                     remove_file_from_cross_file_state(&mut state, &graph_root);
@@ -6454,6 +6485,11 @@ impl LanguageServer for Backend {
                 Some(version),
                 Some(language_id.as_str()),
             );
+            // Fresh diagnostic lifecycle for this open (issue #603). Once per
+            // didOpen: the re-enrichment second pass re-opens the same
+            // document without an eligibility transition and must NOT mint
+            // again.
+            state.begin_diagnostic_lifecycle(&uri);
             // Record as recently opened for activity prioritization
             state.cross_file_activity.record_recent(uri.clone());
 
@@ -6766,10 +6802,8 @@ impl LanguageServer for Backend {
             let work_items: Vec<_> = affected
                 .into_iter()
                 .map(|affected_uri| {
-                    let doc = state.documents.get(&affected_uri);
-                    let trigger_version = doc.and_then(|d| d.version);
-                    let trigger_revision = doc.map(|d| d.revision);
-                    (affected_uri, trigger_version, trigger_revision)
+                    let trigger = DiagnosticsTrigger::capture(&state, &affected_uri);
+                    (affected_uri, trigger)
                 })
                 .collect();
 
@@ -7186,12 +7220,12 @@ impl LanguageServer for Backend {
         {
             let state = self.state.read().await;
             state.diagnostics_gate.mark_force_republish_many(
-                work_items.iter().map(|(u, _, _)| u).filter(|u| **u != uri),
+                work_items.iter().map(|(u, _)| u).filter(|u| **u != uri),
             );
         }
 
         // Schedule debounced diagnostics for all affected files via revalidation system
-        for (affected_uri, trigger_version, trigger_revision) in work_items {
+        for (affected_uri, trigger) in work_items {
             let state_arc = self.state.clone();
             let client = self.client.clone();
             let traversal_truncation = self.traversal_truncation.clone();
@@ -7201,8 +7235,7 @@ impl LanguageServer for Backend {
                 client,
                 affected_uri,
                 debounce_ms,
-                trigger_version,
-                trigger_revision,
+                trigger,
                 Some(traversal_truncation),
             ));
         }
@@ -7214,7 +7247,7 @@ impl LanguageServer for Backend {
             let traversal_truncation = self.traversal_truncation.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_millis(750)).await;
-                let (trigger_version, trigger_revision) = {
+                let trigger = {
                     let state = state_arc.read().await;
                     if !state.documents.contains_key(&stabilization_uri) {
                         return;
@@ -7222,10 +7255,7 @@ impl LanguageServer for Backend {
                     state
                         .diagnostics_gate
                         .mark_force_republish(&stabilization_uri);
-                    let doc = state.documents.get(&stabilization_uri);
-                    let ver = doc.and_then(|d| d.version);
-                    let rev = doc.map(|d| d.revision);
-                    (ver, rev)
+                    DiagnosticsTrigger::capture(&state, &stabilization_uri)
                 };
 
                 run_debounced_diagnostics(
@@ -7233,8 +7263,7 @@ impl LanguageServer for Backend {
                     client,
                     stabilization_uri,
                     0,
-                    trigger_version,
-                    trigger_revision,
+                    trigger,
                     Some(traversal_truncation),
                 )
                 .await;
@@ -7693,14 +7722,12 @@ impl LanguageServer for Backend {
                 .diagnostics_gate
                 .mark_force_republish_many(affected.iter().filter(|u| **u != uri));
 
-            // Build work items with trigger revision snapshot for freshness guard
+            // Build work items with trigger snapshot for the freshness guard
             let work_items: Vec<_> = affected
                 .into_iter()
                 .map(|affected_uri| {
-                    let doc = state.documents.get(&affected_uri);
-                    let trigger_version = doc.and_then(|d| d.version);
-                    let trigger_revision = doc.map(|d| d.revision);
-                    (affected_uri, trigger_version, trigger_revision)
+                    let trigger = DiagnosticsTrigger::capture(&state, &affected_uri);
+                    (affected_uri, trigger)
                 })
                 .collect();
 
@@ -7745,7 +7772,7 @@ impl LanguageServer for Backend {
             // leak a phantom marker (a later same-URI job cancels an earlier
             // one before it consumes its mark).
             let scheduled_uris: std::collections::HashSet<Url> =
-                work_items.iter().map(|(u, _, _)| u.clone()).collect();
+                work_items.iter().map(|(u, _)| u.clone()).collect();
             tokio::spawn(async move {
                 // Extend direct library_calls with inherited packages from
                 // parent source() chains. Snapshot under the lock, release it,
@@ -7825,7 +7852,7 @@ impl LanguageServer for Backend {
                 let warmed: std::collections::HashSet<String> = packages_vec.into_iter().collect();
 
                 // After prefetch completes, trigger diagnostic revalidation
-                let (debounce_ms, trigger_version, trigger_revision, sibling_jobs) = {
+                let (debounce_ms, trigger, sibling_jobs) = {
                     let state = state_arc.read().await;
                     if !state.documents.contains_key(&revalidation_uri) {
                         return; // Document was closed during prefetch
@@ -7833,13 +7860,11 @@ impl LanguageServer for Backend {
                     state
                         .diagnostics_gate
                         .mark_force_republish(&revalidation_uri);
-                    let doc = state.documents.get(&revalidation_uri);
-                    let ver = doc.and_then(|d| d.version);
-                    let rev = doc.map(|d| d.revision);
+                    let trigger = DiagnosticsTrigger::capture(&state, &revalidation_uri);
 
                     // Cross-document sibling republish (issue #503), excluding the
                     // edited file (revalidated below by its own version bump).
-                    let mut sibling_jobs: Vec<(Url, Option<i32>, Option<u64>)> = Vec::new();
+                    let mut sibling_jobs: Vec<(Url, DiagnosticsTrigger)> = Vec::new();
                     for sib in open_docs_referencing_packages(&state, &warmed) {
                         // Skip the edited file (revalidated by its own version
                         // bump) and any URI the synchronous path already marked +
@@ -7849,27 +7874,23 @@ impl LanguageServer for Backend {
                             continue;
                         }
                         state.diagnostics_gate.mark_force_republish(&sib);
-                        let sdoc = state.documents.get(&sib);
-                        let sver = sdoc.and_then(|d| d.version);
-                        let srev = sdoc.map(|d| d.revision);
-                        sibling_jobs.push((sib, sver, srev));
+                        let strigger = DiagnosticsTrigger::capture(&state, &sib);
+                        sibling_jobs.push((sib, strigger));
                     }
                     (
                         state.cross_file_config.revalidation_debounce_ms,
-                        ver,
-                        rev,
+                        trigger,
                         sibling_jobs,
                     )
                 };
 
-                for (sib, sver, srev) in sibling_jobs {
+                for (sib, strigger) in sibling_jobs {
                     tokio::spawn(run_debounced_diagnostics(
                         state_arc.clone(),
                         client.clone(),
                         sib,
                         debounce_ms,
-                        sver,
-                        srev,
+                        strigger,
                         Some(traversal_truncation.clone()),
                     ));
                 }
@@ -7879,8 +7900,7 @@ impl LanguageServer for Backend {
                     client,
                     revalidation_uri,
                     debounce_ms,
-                    trigger_version,
-                    trigger_revision,
+                    trigger,
                     Some(traversal_truncation),
                 )
                 .await;
@@ -7890,7 +7910,7 @@ impl LanguageServer for Backend {
         // Schedule debounced diagnostics for all affected files (Requirement 0.5)
         // The edited file uses a shorter debounce for near-instant feedback;
         // dependent files use the longer revalidation debounce.
-        for (affected_uri, trigger_version, trigger_revision) in work_items {
+        for (affected_uri, trigger) in work_items {
             let state_arc = self.state.clone();
             let client = self.client.clone();
             let traversal_truncation = self.traversal_truncation.clone();
@@ -7905,8 +7925,7 @@ impl LanguageServer for Backend {
                 client,
                 affected_uri,
                 debounce,
-                trigger_version,
-                trigger_revision,
+                trigger,
                 Some(traversal_truncation),
             ));
         }
@@ -8020,7 +8039,7 @@ impl LanguageServer for Backend {
         };
         let _diagnostics_publish_guard = diagnostics_publish_lock.lock().await;
 
-        let (sibling_fanout, debounce_ms): (Vec<(Url, Option<i32>, Option<u64>)>, u64) = {
+        let (sibling_fanout, debounce_ms): (Vec<(Url, DiagnosticsTrigger)>, u64) = {
             let mut state = self.state.write().await;
 
             // Capture the pre-close view the disk resync needs, BEFORE the
@@ -8079,11 +8098,11 @@ impl LanguageServer for Backend {
             // Close in new DocumentStore (Requirement 1.5)
             state.document_store.close(uri);
 
-            // Clear diagnostics gate state
-            state.diagnostics_gate.clear(uri);
-
-            // Cancel pending revalidation
-            state.cross_file_revalidation.cancel(uri);
+            // Retire the diagnostic lifecycle: cancel pending revalidation
+            // and clear the gate, including the lifecycle epoch (#603) so a
+            // worker this cancel cannot reach (not yet scheduled) still
+            // cannot publish into a reopen at the same version/revision.
+            state.retire_diagnostic_lifecycle(uri);
 
             // Remove from activity tracking
             state.cross_file_activity.remove(uri);
@@ -8178,7 +8197,7 @@ impl LanguageServer for Backend {
             // and any open sibling that referenced them needs its diagnostics
             // recomputed. Mirrors the watched-file fanout above (including
             // `max_revalidations_per_trigger`).
-            let mut sibling_fanout: Vec<(Url, Option<i32>, Option<u64>)> = Vec::new();
+            let mut sibling_fanout: Vec<(Url, DiagnosticsTrigger)> = Vec::new();
             let pkg_visibility_changed = state.package_state.namespace_model()
                 != old_ns_model.as_ref()
                 || state.package_state.scope_contribution() != &old_contribution;
@@ -8193,7 +8212,7 @@ impl LanguageServer for Backend {
                 // watcher-driven visibility fanout already widens this
                 // way. Re-cap the union so the extension cannot bypass
                 // `max_revalidations_per_trigger`.
-                let mut uris: Vec<Url> = sibling_fanout.iter().map(|(u, _, _)| u.clone()).collect();
+                let mut uris: Vec<Url> = sibling_fanout.iter().map(|(u, _)| u.clone()).collect();
                 let mut seen: std::collections::HashSet<Url> = uris.iter().cloned().collect();
                 seen.insert(uri.clone());
                 extend_affected_for_load_all_revalidation_from_state(
@@ -8206,9 +8225,10 @@ impl LanguageServer for Backend {
                 );
                 sibling_fanout = uris
                     .into_iter()
-                    .filter_map(|u| {
-                        let doc = state.documents.get(&u)?;
-                        Some((u, doc.version, Some(doc.revision)))
+                    .filter(|u| state.documents.contains_key(u))
+                    .map(|u| {
+                        let trigger = DiagnosticsTrigger::capture(&state, &u);
+                        (u, trigger)
                     })
                     .collect();
             }
@@ -8230,7 +8250,7 @@ impl LanguageServer for Backend {
             if !sibling_fanout.is_empty() && !close_resync {
                 state
                     .diagnostics_gate
-                    .mark_force_republish_many(sibling_fanout.iter().map(|(u, _, _)| u));
+                    .mark_force_republish_many(sibling_fanout.iter().map(|(u, _)| u));
             }
 
             // Invalidate the workspace index entry so the next scan re-reads from disk.
@@ -8284,8 +8304,7 @@ impl LanguageServer for Backend {
             // the commit — through the normal gate. A close-then-reopen race
             // is handled by the resync's commit-time veto. Never calls
             // `scan_workspace` — this re-reads exactly one file.
-            let mut sibling_uris: Vec<Url> =
-                sibling_fanout.into_iter().map(|(u, _, _)| u).collect();
+            let mut sibling_uris: Vec<Url> = sibling_fanout.into_iter().map(|(u, _)| u).collect();
             for resync_uri in close_resync_uris {
                 let package_siblings = std::mem::take(&mut sibling_uris);
                 tokio::spawn(run_close_resync(
@@ -8305,7 +8324,7 @@ impl LanguageServer for Backend {
             // write lock. The debounce window collapses bursts (e.g. "close
             // all" closing many files in quick succession) into a single
             // republish per sibling.
-            for (sibling_uri, trigger_version, trigger_revision) in sibling_fanout {
+            for (sibling_uri, trigger) in sibling_fanout {
                 let state_arc = self.state.clone();
                 let client = self.client.clone();
                 let traversal_truncation = self.traversal_truncation.clone();
@@ -8314,8 +8333,7 @@ impl LanguageServer for Backend {
                     client,
                     sibling_uri,
                     debounce_ms,
-                    trigger_version,
-                    trigger_revision,
+                    trigger,
                     Some(traversal_truncation),
                 ));
             }
@@ -10665,20 +10683,21 @@ impl Backend {
         uri: &Url,
         traversal_truncation: Option<Arc<TraversalTruncationState>>,
     ) {
-        let (debounce_ms, trigger_version, trigger_revision) = {
+        let (debounce_ms, trigger) = {
             let state = state_arc.read().await;
-            let doc = state.documents.get(uri);
-            let v = doc.and_then(|d| d.version);
-            let r = doc.map(|d| d.revision);
-            (state.cross_file_config.revalidation_debounce_ms, v, r)
+            // Deliberately a FRESH capture (never inherited from a
+            // predecessor task): a respawned consumer must validate against
+            // the URI's current lifecycle, not the one its predecessor was
+            // spawned under.
+            let trigger = DiagnosticsTrigger::capture(&state, uri);
+            (state.cross_file_config.revalidation_debounce_ms, trigger)
         };
         run_debounced_diagnostics(
             state_arc,
             client,
             uri.clone(),
             debounce_ms,
-            trigger_version,
-            trigger_revision,
+            trigger,
             traversal_truncation,
         )
         .await;
@@ -10890,11 +10909,19 @@ impl Backend {
 
             state.editor_diagnostic_uris = Some(new_uris);
             for uri in &removed {
-                // In-flight work also re-checks eligibility at commit. Clearing
-                // both states retracts Problems now and lets a later tab-open
-                // publish the same document version without a force marker.
-                state.cross_file_revalidation.cancel(uri);
-                state.diagnostics_gate.clear(uri);
+                // In-flight work also re-checks eligibility at commit.
+                // Retiring the lifecycle (cancel + gate clear, including the
+                // epoch — #603) retracts Problems now, lets a later tab-open
+                // publish the same document version without a force marker,
+                // and dooms in-flight workers this cancel cannot reach.
+                state.retire_diagnostic_lifecycle(uri);
+            }
+            for uri in &added {
+                // Fresh lifecycle for each re-added tab. Must run AFTER the
+                // `editor_diagnostic_uris` replacement above: eligibility is
+                // read from it, and minting before the replacement would be
+                // a silent no-op that fails every subsequent publish closed.
+                state.begin_diagnostic_lifecycle(uri);
             }
 
             (removed, added)
@@ -11050,7 +11077,7 @@ pub(crate) async fn publish_diagnostics_inner(
     // snapshot, capture inputs for the off-lock work. NO scope
     // resolution or other heavy work happens inside this scope.
     let (
-        version,
+        trigger,
         diagnostics_enabled,
         snapshot,
         directive_meta,
@@ -11059,7 +11086,12 @@ pub(crate) async fn publish_diagnostics_inner(
         case_mismatch_severity,
     ) = {
         let state = state_arc.read().await;
-        let version = state.documents.get(uri).and_then(|d| d.version);
+        // Full trigger capture (version + revision + epoch): the direct
+        // path has no cancellation token, so the commit-time comparison
+        // against this snapshot is its only defense against a lifecycle
+        // reuse (close+reopen) or a same-version edit racing the off-lock
+        // compute below.
+        let trigger = DiagnosticsTrigger::capture(&state, uri);
 
         if !state.diagnostics_publish_allowed(uri) {
             log::trace!(
@@ -11069,8 +11101,18 @@ pub(crate) async fn publish_diagnostics_inner(
             return;
         }
 
+        // No live lifecycle epoch: the URI is closed or was retired; the
+        // final commit would fail closed anyway, so skip the compute.
+        if trigger.epoch.is_none() {
+            log::trace!(
+                "Skipping diagnostics for {}: no live diagnostic lifecycle",
+                uri
+            );
+            return;
+        }
+
         // Check if we can publish (monotonic gate)
-        if let Some(ver) = version {
+        if let Some(ver) = trigger.version {
             if !state.diagnostics_gate.can_publish(uri, ver) {
                 log::trace!(
                     "Skipping diagnostics for {}: monotonic gate (version={})",
@@ -11123,7 +11165,7 @@ pub(crate) async fn publish_diagnostics_inner(
         let case_mismatch_severity = state.cross_file_config.case_mismatch_severity;
 
         (
-            version,
+            trigger,
             diagnostics_enabled,
             snapshot,
             directive_meta,
@@ -11170,6 +11212,8 @@ pub(crate) async fn publish_diagnostics_inner(
         Vec::new()
     };
 
+    pause_if_armed_for_test(state_arc, uri).await;
+
     // Re-check freshness after async work, atomically commit gate state, before publishing.
     // try_consume_publish replaces the racy can_publish + record_publish pair.
     let publish_lock = {
@@ -11186,25 +11230,20 @@ pub(crate) async fn publish_diagnostics_inner(
             );
             return;
         }
-        if let Some(ver) = version {
-            let current_version = state.documents.get(uri).and_then(|d| d.version);
-            if current_version != Some(ver) {
-                log::trace!(
-                    "Skipping diagnostics for {}: version changed (was {:?}, now {:?})",
-                    uri,
-                    version,
-                    current_version
-                );
-                return;
-            }
-            if !state.diagnostics_gate.try_consume_publish(uri, ver) {
-                log::trace!(
-                    "Skipping diagnostics for {}: monotonic gate after async (version={})",
-                    uri,
-                    ver
-                );
-                return;
-            }
+        if trigger.is_stale(&state, uri) {
+            log::trace!(
+                "Skipping diagnostics for {}: trigger no longer current after async",
+                uri
+            );
+            return;
+        }
+        if !trigger.commit_publish(&state.diagnostics_gate, uri) {
+            log::trace!(
+                "Skipping diagnostics for {}: gate refused after async (version={:?})",
+                uri,
+                trigger.version
+            );
+            return;
         }
         state.documents.contains_key(uri)
     };
@@ -11213,7 +11252,7 @@ pub(crate) async fn publish_diagnostics_inner(
         "diagnostics lifecycle: publish uri={} count={} path=direct version={:?} open={}",
         uri,
         diagnostics.len(),
-        version,
+        trigger.version,
         open_at_publish
     );
     client
@@ -12122,6 +12161,467 @@ mod tests {
             assert_eq!(restored.uri, visible_uri);
             assert!(!restored.diagnostics.is_empty());
         }
+
+        /// Issue #603, race 1 (close → reopen at the same version/revision),
+        /// direct path. `publish_diagnostics_inner` has no cancellation
+        /// token, so before the lifecycle epoch its commit-time checks —
+        /// version equality and the (cleared) gate — could not tell the
+        /// reopened document from the one its snapshot was built against,
+        /// and the retired worker's stale diagnostics would publish.
+        ///
+        /// The old and new lifecycles carry distinguishable content: the old
+        /// text's syntax error is on line 0, the reopened text's on line 2.
+        /// The stale worker's diagnostics (line 0) must NEVER reach the
+        /// client after the close — not even transiently before a correct
+        /// republish — and the reopened lifecycle must still be able to
+        /// publish at the same document version.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn stale_direct_worker_cannot_publish_into_reopened_lifecycle() {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("reopen-race.R");
+            let old_text = "x <- (\n"; // syntax error on line 0
+            let new_text = "\n\nx <- (\n"; // syntax error on line 2
+            std::fs::write(&path, old_text).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+
+            let (mut svc, mut socket) = LspService::new(super::super::Backend::new);
+            let initialize = Request::build("initialize")
+                .id(1)
+                .params(serde_json::to_value(InitializeParams::default()).unwrap())
+                .finish();
+            let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+            assert!(response.is_some_and(|response| response.is_ok()));
+            let backend = svc.inner();
+            {
+                let mut state = backend.state.write().await;
+                state.workspace_scan_complete = true;
+                state.cross_file_config.packages_enabled = false;
+                state.cross_file_config.on_demand_indexing_enabled = false;
+                // Park every debounced worker forever; this test drives the
+                // direct path explicitly.
+                state.cross_file_config.revalidation_debounce_ms = 60_000;
+            }
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: old_text.into(),
+                    },
+                })
+                .await;
+
+            // Direct-path worker for the OLD lifecycle, parked post-compute,
+            // pre-commit at the armed pause point.
+            let pause = backend
+                .state
+                .read()
+                .await
+                .diagnostics_test_pause
+                .arm(uri.clone());
+            let worker = {
+                let state_arc = backend.state.clone();
+                let client = backend.client.clone();
+                let task_uri = uri.clone();
+                tokio::spawn(async move {
+                    super::super::publish_diagnostics_inner(&state_arc, &client, &task_uri).await;
+                })
+            };
+            tokio::time::timeout(Duration::from_secs(5), pause.wait_arrived())
+                .await
+                .expect("direct worker must reach the pre-commit pause point");
+
+            // Close (retires the lifecycle, publishes empty) and reopen at
+            // the SAME version — a fresh Document restarts revision at 0, so
+            // only the epoch distinguishes the lifecycles.
+            backend
+                .did_close(DidCloseTextDocumentParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                })
+                .await;
+            let cleared = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("close must clear diagnostics")
+                .expect("client socket must remain open");
+            let cleared: PublishDiagnosticsParams =
+                serde_json::from_value(cleared.params().unwrap().clone()).unwrap();
+            assert_eq!(cleared.uri, uri);
+            assert!(cleared.diagnostics.is_empty());
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: new_text.into(),
+                    },
+                })
+                .await;
+
+            // Release the retired worker: its epoch is stale, so it must
+            // fall out at the commit without publishing.
+            pause.release();
+            worker.await.unwrap();
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(300), socket.next())
+                    .await
+                    .is_err(),
+                "the retired worker must not publish after close+reopen"
+            );
+
+            // The reopened lifecycle must still publish at the same version.
+            backend.publish_diagnostics(&uri).await;
+            let fresh = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("the reopened lifecycle must publish at the same version")
+                .expect("client socket must remain open");
+            let fresh: PublishDiagnosticsParams =
+                serde_json::from_value(fresh.params().unwrap().clone()).unwrap();
+            assert_eq!(fresh.uri, uri);
+            assert!(!fresh.diagnostics.is_empty());
+            assert!(
+                fresh.diagnostics.iter().all(|d| d.range.start.line >= 2),
+                "published diagnostics must come from the reopened text \
+                 (line >= 2), never the retired lifecycle's (line 0): {:?}",
+                fresh.diagnostics
+            );
+        }
+
+        /// Issue #603, race 2 (tab removal → re-addition while the document
+        /// stays LSP-open): version and revision never change, so before the
+        /// epoch a retired debounced worker that had not yet scheduled when
+        /// the removal's cancel ran would pass the schedule-time freshness
+        /// check, supersede the re-added lifecycle's pending worker, and
+        /// consume the fresh gate. The epoch comparison must decline it at
+        /// schedule time, leaving the gate untouched for the new lifecycle.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn stale_debounced_worker_declines_after_tab_readdition() {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("tab-race.R");
+            let text = "x <- (\n";
+            std::fs::write(&path, text).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+
+            let (mut svc, mut socket) = LspService::new(super::super::Backend::new);
+            let initialize = Request::build("initialize")
+                .id(1)
+                .params(
+                    serde_json::to_value(InitializeParams {
+                        initialization_options: Some(serde_json::json!({
+                            "diagnosticUris": [uri.to_string()],
+                        })),
+                        ..InitializeParams::default()
+                    })
+                    .unwrap(),
+                )
+                .finish();
+            let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+            assert!(response.is_some_and(|response| response.is_ok()));
+            let backend = svc.inner();
+            {
+                let mut state = backend.state.write().await;
+                state.workspace_scan_complete = true;
+                state.cross_file_config.packages_enabled = false;
+                state.cross_file_config.on_demand_indexing_enabled = false;
+                state.cross_file_config.revalidation_debounce_ms = 60_000;
+            }
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: text.into(),
+                    },
+                })
+                .await;
+
+            // A trigger captured in the pre-removal lifecycle, exactly what a
+            // worker spawned before the tab change would carry.
+            let stale_trigger = {
+                let state = backend.state.read().await;
+                crate::state::DiagnosticsTrigger::capture(&state, &uri)
+            };
+            assert!(stale_trigger.epoch.is_some());
+
+            // Remove the tab (retires the lifecycle; publishes empty) …
+            backend
+                .handle_active_documents_changed(super::super::ActiveDocumentsChangedParams {
+                    active_uri: None,
+                    visible_uris: Vec::new(),
+                    diagnostic_uris: Some(Vec::new()),
+                    timestamp_ms: 2,
+                })
+                .await;
+            let cleared = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("removing the tab must clear diagnostics")
+                .expect("client socket must remain open");
+            let cleared: PublishDiagnosticsParams =
+                serde_json::from_value(cleared.params().unwrap().clone()).unwrap();
+            assert!(cleared.diagnostics.is_empty());
+
+            // … and re-add it. The document version and revision are
+            // unchanged; only the fresh epoch distinguishes the lifecycles.
+            // The re-add's own bounded republish stays parked in its 60s
+            // debounce so this test controls every observable publication.
+            backend
+                .handle_active_documents_changed(super::super::ActiveDocumentsChangedParams {
+                    active_uri: Some(uri.to_string()),
+                    visible_uris: vec![uri.to_string()],
+                    diagnostic_uris: Some(vec![uri.to_string()]),
+                    timestamp_ms: 3,
+                })
+                .await;
+
+            // The retired worker resumes: it must decline at schedule time
+            // (stale epoch), publish nothing, and leave the fresh gate
+            // untouched.
+            super::super::run_debounced_diagnostics(
+                backend.state.clone(),
+                backend.client.clone(),
+                uri.clone(),
+                0,
+                stale_trigger,
+                None,
+            )
+            .await;
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(300), socket.next())
+                    .await
+                    .is_err(),
+                "the retired worker must not publish after tab re-addition"
+            );
+            assert!(
+                backend
+                    .state
+                    .read()
+                    .await
+                    .diagnostics_gate
+                    .can_publish(&uri, 1),
+                "the retired worker must not consume the re-added lifecycle's gate"
+            );
+
+            // The re-added lifecycle must still publish at the same version.
+            backend.publish_diagnostics(&uri).await;
+            let restored = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("the re-added tab must publish diagnostics")
+                .expect("client socket must remain open");
+            let restored: PublishDiagnosticsParams =
+                serde_json::from_value(restored.params().unwrap().clone()).unwrap();
+            assert_eq!(restored.uri, uri);
+            assert!(!restored.diagnostics.is_empty());
+        }
+
+        /// Companion to `stale_debounced_worker_declines_after_tab_readdition`
+        /// covering the commit side of the debounced pipeline: a worker that
+        /// already computed diagnostics and is parked in the post-compute,
+        /// pre-commit window when the tab removal + re-addition happens must
+        /// not publish afterwards, and must leave the re-added lifecycle's
+        /// gate untouched. (Cancellation catches this interleaving first;
+        /// the epoch is the backstop for workers cancellation cannot reach —
+        /// this test pins the observable outcome regardless of which check
+        /// fires.)
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn paused_debounced_worker_cannot_publish_after_tab_readdition() {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("tab-pause-race.R");
+            let text = "x <- (\n";
+            std::fs::write(&path, text).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+
+            let (mut svc, mut socket) = LspService::new(super::super::Backend::new);
+            let initialize = Request::build("initialize")
+                .id(1)
+                .params(
+                    serde_json::to_value(InitializeParams {
+                        initialization_options: Some(serde_json::json!({
+                            "diagnosticUris": [uri.to_string()],
+                        })),
+                        ..InitializeParams::default()
+                    })
+                    .unwrap(),
+                )
+                .finish();
+            let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+            assert!(response.is_some_and(|response| response.is_ok()));
+            let backend = svc.inner();
+            {
+                let mut state = backend.state.write().await;
+                state.workspace_scan_complete = true;
+                state.cross_file_config.packages_enabled = false;
+                state.cross_file_config.on_demand_indexing_enabled = false;
+                // Parks did_open's own worker and the re-add's bounded
+                // republish; the manually spawned worker below passes
+                // debounce 0 explicitly.
+                state.cross_file_config.revalidation_debounce_ms = 60_000;
+            }
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: text.into(),
+                    },
+                })
+                .await;
+
+            let trigger = {
+                let state = backend.state.read().await;
+                crate::state::DiagnosticsTrigger::capture(&state, &uri)
+            };
+            let pause = backend
+                .state
+                .read()
+                .await
+                .diagnostics_test_pause
+                .arm(uri.clone());
+            let worker = tokio::spawn(super::super::run_debounced_diagnostics(
+                backend.state.clone(),
+                backend.client.clone(),
+                uri.clone(),
+                0,
+                trigger,
+                None,
+            ));
+            tokio::time::timeout(Duration::from_secs(5), pause.wait_arrived())
+                .await
+                .expect("debounced worker must reach the pre-commit pause point");
+
+            // Remove and re-add the tab while the worker is parked. Version
+            // and revision never change; the epoch is the only distinction.
+            backend
+                .handle_active_documents_changed(super::super::ActiveDocumentsChangedParams {
+                    active_uri: None,
+                    visible_uris: Vec::new(),
+                    diagnostic_uris: Some(Vec::new()),
+                    timestamp_ms: 2,
+                })
+                .await;
+            let cleared = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("removing the tab must clear diagnostics")
+                .expect("client socket must remain open");
+            let cleared: PublishDiagnosticsParams =
+                serde_json::from_value(cleared.params().unwrap().clone()).unwrap();
+            assert!(cleared.diagnostics.is_empty());
+            backend
+                .handle_active_documents_changed(super::super::ActiveDocumentsChangedParams {
+                    active_uri: Some(uri.to_string()),
+                    visible_uris: vec![uri.to_string()],
+                    diagnostic_uris: Some(vec![uri.to_string()]),
+                    timestamp_ms: 3,
+                })
+                .await;
+
+            pause.release();
+            worker.await.unwrap();
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(300), socket.next())
+                    .await
+                    .is_err(),
+                "the parked worker must not publish after tab re-addition"
+            );
+            assert!(
+                backend
+                    .state
+                    .read()
+                    .await
+                    .diagnostics_gate
+                    .can_publish(&uri, 1),
+                "the parked worker must not consume the re-added lifecycle's gate"
+            );
+
+            backend.publish_diagnostics(&uri).await;
+            let restored = tokio::time::timeout(Duration::from_secs(5), socket.next())
+                .await
+                .expect("the re-added tab must publish diagnostics")
+                .expect("client socket must remain open");
+            let restored: PublishDiagnosticsParams =
+                serde_json::from_value(restored.params().unwrap().clone()).unwrap();
+            assert_eq!(restored.uri, uri);
+            assert!(!restored.diagnostics.is_empty());
+        }
+
+        /// Server shutdown retires every diagnostic lifecycle: an in-flight
+        /// worker (here the direct path, which has no cancellation token)
+        /// that computed diagnostics before the shutdown request must not
+        /// publish after the shutdown response.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn in_flight_worker_cannot_publish_after_shutdown() {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("shutdown-race.R");
+            let text = "x <- (\n";
+            std::fs::write(&path, text).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+
+            let (mut svc, mut socket) = LspService::new(super::super::Backend::new);
+            let initialize = Request::build("initialize")
+                .id(1)
+                .params(serde_json::to_value(InitializeParams::default()).unwrap())
+                .finish();
+            let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+            assert!(response.is_some_and(|response| response.is_ok()));
+            let backend = svc.inner();
+            {
+                let mut state = backend.state.write().await;
+                state.workspace_scan_complete = true;
+                state.cross_file_config.packages_enabled = false;
+                state.cross_file_config.on_demand_indexing_enabled = false;
+                state.cross_file_config.revalidation_debounce_ms = 60_000;
+            }
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: text.into(),
+                    },
+                })
+                .await;
+
+            let pause = backend
+                .state
+                .read()
+                .await
+                .diagnostics_test_pause
+                .arm(uri.clone());
+            let worker = {
+                let state_arc = backend.state.clone();
+                let client = backend.client.clone();
+                let task_uri = uri.clone();
+                tokio::spawn(async move {
+                    super::super::publish_diagnostics_inner(&state_arc, &client, &task_uri).await;
+                })
+            };
+            tokio::time::timeout(Duration::from_secs(5), pause.wait_arrived())
+                .await
+                .expect("direct worker must reach the pre-commit pause point");
+
+            backend.shutdown().await.unwrap();
+
+            pause.release();
+            worker.await.unwrap();
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(300), socket.next())
+                    .await
+                    .is_err(),
+                "no diagnostic may publish after the shutdown response"
+            );
+        }
     }
 
     mod document_indent_units {
@@ -12705,11 +13205,11 @@ mod tests {
                 "should fan out to the two non-closing siblings"
             );
             assert!(
-                fanout.iter().all(|(u, _, _)| u != &closing),
+                fanout.iter().all(|(u, _)| u != &closing),
                 "fanout must not include the closing URI"
             );
-            assert!(fanout.iter().any(|(u, _, _)| u == &r_uri("b.R")));
-            assert!(fanout.iter().any(|(u, _, _)| u == &r_uri("c.R")));
+            assert!(fanout.iter().any(|(u, _)| u == &r_uri("b.R")));
+            assert!(fanout.iter().any(|(u, _)| u == &r_uri("c.R")));
         }
 
         #[test]
@@ -12730,9 +13230,7 @@ mod tests {
             let fanout = collect_close_fanout_siblings(&state, &closing, &pkg_root());
 
             assert!(
-                fanout
-                    .iter()
-                    .all(|(u, _, _)| u != &scratch && u != &outside),
+                fanout.iter().all(|(u, _)| u != &scratch && u != &outside),
                 "files outside R/ and tests/testthat/ must not appear in fanout"
             );
         }
@@ -12752,7 +13250,7 @@ mod tests {
             let fanout = collect_close_fanout_siblings(&state, &closing, &pkg_root());
 
             assert!(
-                fanout.iter().any(|(u, _, _)| u == &test_uri),
+                fanout.iter().any(|(u, _)| u == &test_uri),
                 "tests/testthat/ siblings should refresh on R/ close"
             );
         }
@@ -12787,13 +13285,13 @@ mod tests {
             let closing = r_uri("a.R");
             let fanout = collect_close_fanout_siblings(&state, &closing, &pkg_root());
 
-            let (got_uri, got_version, got_revision) = fanout
+            let (got_uri, got_trigger) = fanout
                 .into_iter()
-                .find(|(u, _, _)| u == &b)
+                .find(|(u, _)| u == &b)
                 .expect("b.R in fanout");
             assert_eq!(got_uri, b);
-            assert_eq!(got_version, Some(7));
-            assert_eq!(got_revision, Some(42));
+            assert_eq!(got_trigger.version, Some(7));
+            assert_eq!(got_trigger.revision, Some(42));
         }
 
         #[test]

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -11898,6 +11898,32 @@ mod tests {
         };
         use tower_lsp::{LanguageServer, LspService};
 
+        /// Poll until a pending revalidation entry exists for `uri` — i.e.
+        /// the document's own spawned debounced worker has `schedule()`d and
+        /// parked in its debounce. Tests that spawn a competing worker for
+        /// the same URI must wait for this first: a spawn racing the first
+        /// worker's schedule() can be cancelled by it instead of
+        /// deterministically superseding it.
+        async fn wait_until_pending(backend: &super::super::Backend, uri: &Url) {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            loop {
+                if backend
+                    .state
+                    .read()
+                    .await
+                    .cross_file_revalidation
+                    .has_pending_for_test(uri)
+                {
+                    return;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "the document's own worker must schedule before the test proceeds"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+
         /// Push diagnostics are server-owned. Closing Raven's last live buffer
         /// for a URI must therefore replace its nonempty Problems entries with
         /// an empty publication; removing the URI from `WorldState::documents`
@@ -12499,6 +12525,15 @@ mod tests {
                 })
                 .await;
 
+            // did_open spawned this document's own debounced worker; wait
+            // until it has schedule()d (it then parks in its 60s debounce)
+            // so the manual zero-debounce worker below deterministically
+            // supersedes it. Spawning first would race the did_open
+            // worker's late schedule(), which — same lifecycle, trigger not
+            // stale — would cancel the manual worker before it reaches the
+            // pause point.
+            wait_until_pending(backend, &uri).await;
+
             let trigger = {
                 let state = backend.state.read().await;
                 crate::state::DiagnosticsTrigger::capture(&state, &uri)
@@ -12623,6 +12658,15 @@ mod tests {
                     },
                 })
                 .await;
+
+            // did_open spawned this document's own debounced worker; wait
+            // until it has schedule()d (it then parks in its 60s debounce)
+            // so the manual zero-debounce worker below deterministically
+            // supersedes it. Spawning first would race the did_open
+            // worker's late schedule(), which — same lifecycle, trigger not
+            // stale — would cancel the manual worker before it reaches the
+            // pause point.
+            wait_until_pending(backend, &uri).await;
 
             let trigger = {
                 let state = backend.state.read().await;

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -12421,14 +12421,16 @@ mod tests {
         }
 
         /// Companion to `stale_debounced_worker_declines_after_tab_readdition`
-        /// covering the commit side of the debounced pipeline: a worker that
-        /// already computed diagnostics and is parked in the post-compute,
-        /// pre-commit window when the tab removal + re-addition happens must
-        /// not publish afterwards, and must leave the re-added lifecycle's
-        /// gate untouched. (Cancellation catches this interleaving first;
-        /// the epoch is the backstop for workers cancellation cannot reach —
-        /// this test pins the observable outcome regardless of which check
-        /// fires.)
+        /// covering the parked-worker interleaving of the debounced pipeline:
+        /// a worker that already computed diagnostics and is parked in the
+        /// post-compute, pre-commit window when the tab removal + re-addition
+        /// happens must not publish afterwards, and must leave the re-added
+        /// lifecycle's gate untouched. On this interleaving the retirement's
+        /// cancellation reaches the worker's token first and the epoch is
+        /// defense-in-depth — this test pins the observable outcome
+        /// regardless of which check fires; see
+        /// `debounced_commit_declines_stale_epoch_without_cancellation` for
+        /// the commit-side epoch check exercised in isolation.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn paused_debounced_worker_cannot_publish_after_tab_readdition() {
             let tmp = TempDir::new().unwrap();
@@ -12551,6 +12553,101 @@ mod tests {
                 serde_json::from_value(restored.params().unwrap().clone()).unwrap();
             assert_eq!(restored.uri, uri);
             assert!(!restored.diagnostics.is_empty());
+        }
+
+        /// The debounced pipeline's commit-side epoch check, exercised in
+        /// isolation. Every real retirement also cancels the worker's token,
+        /// so the epoch is unreachable on that path while cancellation works
+        /// — this test models the failure mode the epoch exists for (a
+        /// lifecycle transition whose cancel cannot reach the worker) by
+        /// retiring and re-minting the gate's epoch directly, without
+        /// touching the cancellation token. The parked worker must then be
+        /// stopped by the epoch comparison alone: no publish, and the fresh
+        /// lifecycle's gate left unconsumed.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn debounced_commit_declines_stale_epoch_without_cancellation() {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("epoch-only-race.R");
+            let text = "x <- (\n";
+            std::fs::write(&path, text).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+
+            let (mut svc, mut socket) = LspService::new(super::super::Backend::new);
+            let initialize = Request::build("initialize")
+                .id(1)
+                .params(serde_json::to_value(InitializeParams::default()).unwrap())
+                .finish();
+            let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+            assert!(response.is_some_and(|response| response.is_ok()));
+            let backend = svc.inner();
+            {
+                let mut state = backend.state.write().await;
+                state.workspace_scan_complete = true;
+                state.cross_file_config.packages_enabled = false;
+                state.cross_file_config.on_demand_indexing_enabled = false;
+                state.cross_file_config.revalidation_debounce_ms = 60_000;
+            }
+
+            backend
+                .did_open(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri: uri.clone(),
+                        language_id: "r".into(),
+                        version: 1,
+                        text: text.into(),
+                    },
+                })
+                .await;
+
+            let trigger = {
+                let state = backend.state.read().await;
+                crate::state::DiagnosticsTrigger::capture(&state, &uri)
+            };
+            let pause = backend
+                .state
+                .read()
+                .await
+                .diagnostics_test_pause
+                .arm(uri.clone());
+            let worker = tokio::spawn(super::super::run_debounced_diagnostics(
+                backend.state.clone(),
+                backend.client.clone(),
+                uri.clone(),
+                0,
+                trigger,
+                None,
+            ));
+            tokio::time::timeout(Duration::from_secs(5), pause.wait_arrived())
+                .await
+                .expect("debounced worker must reach the pre-commit pause point");
+
+            // Retire and re-mint the epoch WITHOUT cancelling: the worker's
+            // token stays live, so only the commit-side epoch comparison can
+            // stop it.
+            {
+                let state = backend.state.write().await;
+                state.diagnostics_gate.clear(&uri);
+                state.diagnostics_gate.begin_epoch(&uri);
+            }
+
+            pause.release();
+            worker.await.unwrap();
+
+            assert!(
+                tokio::time::timeout(Duration::from_millis(300), socket.next())
+                    .await
+                    .is_err(),
+                "a live-token worker with a stale epoch must not publish"
+            );
+            assert!(
+                backend
+                    .state
+                    .read()
+                    .await
+                    .diagnostics_gate
+                    .can_publish(&uri, 1),
+                "the stale-epoch worker must not consume the fresh lifecycle's gate"
+            );
         }
 
         /// Server shutdown retires every diagnostic lifecycle: an in-flight

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -12368,8 +12368,24 @@ mod tests {
 
             // … and re-add it. The document version and revision are
             // unchanged; only the fresh epoch distinguishes the lifecycles.
-            // The re-add's own bounded republish stays parked in its 60s
-            // debounce so this test controls every observable publication.
+            // With the pause armed BEFORE the re-add and the debounce
+            // flipped to 0, the re-add's OWN bounded worker (the production
+            // path, spawned by the handler) runs to the pause point and
+            // parks there: scheduled (pending in the revalidation map, token
+            // live), diagnostics computed, commit not yet run. This is the
+            // worker a stale schedule() would cancel.
+            backend
+                .state
+                .write()
+                .await
+                .cross_file_config
+                .revalidation_debounce_ms = 0;
+            let pause = backend
+                .state
+                .read()
+                .await
+                .diagnostics_test_pause
+                .arm(uri.clone());
             backend
                 .handle_active_documents_changed(super::super::ActiveDocumentsChangedParams {
                     active_uri: Some(uri.to_string()),
@@ -12378,10 +12394,20 @@ mod tests {
                     timestamp_ms: 3,
                 })
                 .await;
+            tokio::time::timeout(Duration::from_secs(5), pause.wait_arrived())
+                .await
+                .expect("the re-add's own worker must reach the pre-commit pause point");
+            {
+                let state = backend.state.read().await;
+                let fresh_trigger = crate::state::DiagnosticsTrigger::capture(&state, &uri);
+                assert_ne!(fresh_trigger.epoch, stale_trigger.epoch);
+            }
 
             // The retired worker resumes: it must decline at schedule time
-            // (stale epoch), publish nothing, and leave the fresh gate
-            // untouched.
+            // (stale epoch), publish nothing — and, critically, NOT
+            // schedule(), which would cancel the parked fresh worker. The
+            // parked worker's own publish below is the detector: it survives
+            // only if the stale worker never superseded it.
             super::super::run_debounced_diagnostics(
                 backend.state.clone(),
                 backend.client.clone(),
@@ -12398,21 +12424,17 @@ mod tests {
                     .is_err(),
                 "the retired worker must not publish after tab re-addition"
             );
-            assert!(
-                backend
-                    .state
-                    .read()
-                    .await
-                    .diagnostics_gate
-                    .can_publish(&uri, 1),
-                "the retired worker must not consume the re-added lifecycle's gate"
-            );
 
-            // The re-added lifecycle must still publish at the same version.
-            backend.publish_diagnostics(&uri).await;
+            // The re-added lifecycle's own worker — not a manual republish —
+            // must still deliver diagnostics at the same version.
+            pause.release();
             let restored = tokio::time::timeout(Duration::from_secs(5), socket.next())
                 .await
-                .expect("the re-added tab must publish diagnostics")
+                .expect(
+                    "the re-added tab's own worker must publish: a stale worker \
+                     superseding (cancelling) it would leave the tab without \
+                     diagnostics until an unrelated trigger",
+                )
                 .expect("client socket must remain open");
             let restored: PublishDiagnosticsParams =
                 serde_json::from_value(restored.params().unwrap().clone()).unwrap();
@@ -12555,15 +12577,18 @@ mod tests {
             assert!(!restored.diagnostics.is_empty());
         }
 
-        /// The debounced pipeline's commit-side epoch check, exercised in
-        /// isolation. Every real retirement also cancels the worker's token,
-        /// so the epoch is unreachable on that path while cancellation works
-        /// — this test models the failure mode the epoch exists for (a
-        /// lifecycle transition whose cancel cannot reach the worker) by
-        /// retiring and re-minting the gate's epoch directly, without
-        /// touching the cancellation token. The parked worker must then be
-        /// stopped by the epoch comparison alone: no publish, and the fresh
-        /// lifecycle's gate left unconsumed.
+        /// The debounced pipeline stopped by the epoch dimension alone.
+        /// Every real retirement also cancels the worker's token, so this
+        /// test models the failure mode the epoch exists for (a lifecycle
+        /// transition whose cancel cannot reach the worker) by retiring and
+        /// re-minting the gate's epoch directly, without touching the
+        /// cancellation token: version, revision, and eligibility all still
+        /// match, so only the trigger's epoch comparison (`is_stale` at the
+        /// final commit) can stop the parked worker. The gate-INTERNAL epoch
+        /// guard inside `try_consume_publish` is structurally unreachable
+        /// with a stale epoch from this path — `is_stale` includes the epoch
+        /// and always runs first — and is pinned separately by the gate unit
+        /// tests (`test_try_consume_publish_rejects_stale_epoch_*`).
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn debounced_commit_declines_stale_epoch_without_cancellation() {
             let tmp = TempDir::new().unwrap();

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -98,6 +98,23 @@ impl CrossFileRevalidationState {
 /// more" is enough.
 const MAX_FORCE_REPUBLISH: u32 = 64;
 
+/// Globally unique identifier for one diagnostic-eligible lifecycle of a URI
+/// (issue #603): from the moment the URI becomes eligible to own push
+/// diagnostics (a fresh `didOpen`, or a tab re-addition via
+/// `raven/activeDocumentsChanged` while the document stays LSP-open) until it
+/// stops being eligible (`didClose`, tab removal, or server shutdown).
+///
+/// Wrapping the bare `u64` prevents an epoch from being compared against a
+/// version or revision at a call site. Neither of those fields can identify a
+/// lifecycle: the client may reopen at the same version, and
+/// `Document::revision` restarts at 0 on every open. Epochs are minted from a
+/// single process-wide counter that is never reset, so a captured epoch can
+/// never coincidentally match a later lifecycle of the same URI. (`u64`
+/// exhaustion is unreachable in practice; the counter wraps rather than
+/// panics, matching the `next_generation` idiom above.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DiagnosticsEpoch(u64);
+
 /// Diagnostics publish gating to enforce monotonic publishing
 ///
 /// `force_republish` is a counter, not a set: each `mark_force_republish` adds
@@ -107,17 +124,70 @@ const MAX_FORCE_REPUBLISH: u32 = 64;
 /// multiple concurrent forced-republish requests, leaving later publishes
 /// blocked at the same version. Each marker reliably gets one matching publish
 /// through the gate.
+///
+/// `current_epoch` tracks each URI's live diagnostic lifecycle (issue #603).
+/// An entry exists iff the URI is currently diagnostic-eligible;
+/// [`Self::begin_epoch`] installs a fresh one and [`Self::clear`] retires it.
+/// [`Self::try_consume_publish`] refuses to commit a captured epoch that is no
+/// longer current, so work retired by a close or tab removal cannot publish
+/// after the URI's lifecycle is reused — even when version and revision
+/// coincide with the retired lifecycle's.
+///
+/// Lock discipline: every method that touches more than one map acquires the
+/// guards in the fixed order `current_epoch` → `last_published_version` →
+/// `force_republish` and holds all of them until its mutations are complete
+/// (nested lifetimes, not just acquisition order). Dropping the
+/// `current_epoch` guard before the version/force commit would let a
+/// concurrent retire + re-begin interleave between the epoch check and the
+/// commit, reintroducing the stale-publish race the epoch exists to close.
 #[derive(Debug, Default)]
 pub struct CrossFileDiagnosticsGate {
     /// Last published document version per URI
     last_published_version: RwLock<HashMap<Url, i32>>,
     /// Outstanding forced-republish markers per URI (dependency-triggered, version unchanged)
     force_republish: RwLock<HashMap<Url, u32>>,
+    /// Each URI's current diagnostic lifecycle epoch. Present iff the URI is
+    /// currently diagnostic-eligible and has not been retired via `clear`.
+    current_epoch: RwLock<HashMap<Url, DiagnosticsEpoch>>,
+    /// Process-wide monotonic source for `begin_epoch`. Never reset, so
+    /// retired epochs are never reused.
+    next_epoch: AtomicU64,
 }
 
 impl CrossFileDiagnosticsGate {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Begin a fresh diagnostic lifecycle for `uri`: mint a new epoch and
+    /// reset ALL gate state for the URI in one critical section.
+    ///
+    /// Called via `WorldState::begin_diagnostic_lifecycle` on every "URI
+    /// becomes diagnostic-eligible" transition (`did_open`, and
+    /// `raven/activeDocumentsChanged`'s `added` set). Clearing
+    /// `last_published_version` and `force_republish` here — rather than
+    /// relying on every caller pairing this with a prior [`Self::clear`] —
+    /// guarantees a new lifecycle can neither inherit a stale same-version
+    /// high-water mark (which would gate out its first publish) nor surplus
+    /// force markers accumulated while the URI had no live epoch (which
+    /// would authorize an unrelated same-version publish later).
+    pub fn begin_epoch(&self, uri: &Url) -> DiagnosticsEpoch {
+        let epoch = DiagnosticsEpoch(self.next_epoch.fetch_add(1, Ordering::Relaxed));
+        let mut current = self.current_epoch.write().unwrap();
+        let mut last_published = self.last_published_version.write().unwrap();
+        let mut force = self.force_republish.write().unwrap();
+        last_published.remove(uri);
+        force.remove(uri);
+        current.insert(uri.clone(), epoch);
+        epoch
+    }
+
+    /// The URI's live diagnostic lifecycle epoch, or `None` if the URI is
+    /// not currently diagnostic-eligible (never began, or retired by
+    /// [`Self::clear`]). Captured alongside version/revision when diagnostic
+    /// work starts and validated by [`Self::try_consume_publish`] at commit.
+    pub fn current_epoch(&self, uri: &Url) -> Option<DiagnosticsEpoch> {
+        self.current_epoch.read().unwrap().get(uri).copied()
     }
 
     /// Check if diagnostics can be published for this version.
@@ -180,13 +250,26 @@ impl CrossFileDiagnosticsGate {
     /// two concurrent same-version publishes each observe
     /// `force_active = true` and both proceed off a single marker.
     ///
-    /// Predicate matches `can_publish`:
+    /// `epoch` is the lifecycle epoch the caller captured when its
+    /// diagnostic work started. The commit fails closed — no version update,
+    /// no marker consumed — unless it still equals the URI's current epoch,
+    /// so work retired by a close/tab-removal can neither publish after the
+    /// lifecycle is reused nor steal the new lifecycle's force marker. The
+    /// `current_epoch` guard is held across the entire commit (see the
+    /// struct-level lock-discipline note).
+    ///
+    /// Predicate otherwise matches `can_publish`:
     ///   - if `version < last_published`: false (never publish older)
     ///   - if force counter > 0: `version >= last_published` (same OK)
     ///   - else: `version > last_published` (strictly newer)
-    pub fn try_consume_publish(&self, uri: &Url, version: i32) -> bool {
+    pub fn try_consume_publish(&self, uri: &Url, version: i32, epoch: DiagnosticsEpoch) -> bool {
+        let current = self.current_epoch.read().unwrap();
         let mut last_published = self.last_published_version.write().unwrap();
         let mut force = self.force_republish.write().unwrap();
+
+        if current.get(uri) != Some(&epoch) {
+            return false;
+        }
 
         let allowed = match last_published.get(uri) {
             Some(&last) => {
@@ -261,12 +344,30 @@ impl CrossFileDiagnosticsGate {
         force.remove(uri);
     }
 
-    /// Clear all state for a URI (e.g., when document is closed)
+    /// Clear all state for a URI, retiring its lifecycle epoch. Called (via
+    /// `WorldState::retire_diagnostic_lifecycle`) when the document closes or
+    /// its tab is removed from the editor diagnostic set. After this, no
+    /// worker holding the retired epoch can commit through
+    /// [`Self::try_consume_publish`].
     pub fn clear(&self, uri: &Url) {
+        let mut current = self.current_epoch.write().unwrap();
         let mut last_published = self.last_published_version.write().unwrap();
         let mut force = self.force_republish.write().unwrap();
+        current.remove(uri);
         last_published.remove(uri);
         force.remove(uri);
+    }
+
+    /// Clear all state for every URI, retiring every lifecycle epoch. Called
+    /// on server shutdown so no in-flight diagnostic work can publish after
+    /// the shutdown response.
+    pub fn clear_all(&self) {
+        let mut current = self.current_epoch.write().unwrap();
+        let mut last_published = self.last_published_version.write().unwrap();
+        let mut force = self.force_republish.write().unwrap();
+        current.clear();
+        last_published.clear();
+        force.clear();
     }
 
     /// Test-only accessor for the outstanding force-republish counter for
@@ -280,6 +381,76 @@ impl CrossFileDiagnosticsGate {
     pub fn force_republish_count_for_test(&self, uri: &Url) -> u32 {
         let force = self.force_republish.read().unwrap();
         force.get(uri).copied().unwrap_or(0)
+    }
+}
+
+/// Test-only pause points for the diagnostics publish pipelines (issue
+/// #603): lets a test park a worker in the post-compute, pre-commit window
+/// so it can race a lifecycle transition (close+reopen, tab removal +
+/// re-addition, shutdown) against the pending commit deterministically.
+///
+/// Lives as a field on `WorldState` — not a global static — so an armed
+/// pause's lifetime is tied to the backend under test and cannot leak into
+/// unrelated tests sharing the process.
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Debug, Default)]
+pub struct DiagnosticsPublishPause {
+    gates: RwLock<HashMap<Url, std::sync::Arc<PauseGate>>>,
+}
+
+/// One armed pause point. `arrived`/`release` are `Notify`s, so the
+/// signal is retained even if the notifier runs before the awaiter.
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Debug, Default)]
+pub struct PauseGate {
+    arrived: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl DiagnosticsPublishPause {
+    /// Arm a one-shot pause for `uri`. The returned handle lets the test
+    /// wait for a worker to arrive at the pause point and later release it.
+    pub fn arm(&self, uri: Url) -> PauseHandle {
+        let gate = std::sync::Arc::new(PauseGate::default());
+        self.gates.write().unwrap().insert(uri, gate.clone());
+        PauseHandle { gate }
+    }
+
+    /// Worker-side lookup, consuming the armed entry (one-shot so a respawn
+    /// for the same URI does not park again with nobody left to release
+    /// it). Returns an owned handle: callers MUST drop any outer lock guard
+    /// before awaiting [`PauseGate::pause`] on it.
+    pub fn take_armed(&self, uri: &Url) -> Option<std::sync::Arc<PauseGate>> {
+        self.gates.write().unwrap().remove(uri)
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl PauseGate {
+    /// Worker side: signal arrival, then park until the test releases.
+    pub async fn pause(&self) {
+        self.arrived.notify_one();
+        self.release.notified().await;
+    }
+}
+
+/// Test-side handle to an armed [`DiagnosticsPublishPause`] entry.
+#[cfg(any(test, feature = "test-support"))]
+pub struct PauseHandle {
+    gate: std::sync::Arc<PauseGate>,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl PauseHandle {
+    /// Wait until a worker has arrived at the pause point.
+    pub async fn wait_arrived(&self) {
+        self.gate.arrived.notified().await;
+    }
+
+    /// Release the parked worker.
+    pub fn release(&self) {
+        self.gate.release.notify_one();
     }
 }
 
@@ -817,6 +988,7 @@ mod tests {
         let gate = Arc::new(CrossFileDiagnosticsGate::new());
         let uri = test_uri("test.R");
 
+        let epoch = gate.begin_epoch(&uri);
         gate.record_publish(&uri, 1);
         gate.mark_force_republish(&uri);
 
@@ -832,7 +1004,7 @@ mod tests {
             let successes = successes.clone();
             handles.push(thread::spawn(move || {
                 barrier.wait();
-                if gate.try_consume_publish(&uri, 1) {
+                if gate.try_consume_publish(&uri, 1, epoch) {
                     successes.fetch_add(1, Ordering::Relaxed);
                 }
             }));
@@ -867,6 +1039,7 @@ mod tests {
         let gate = Arc::new(CrossFileDiagnosticsGate::new());
         let uri = test_uri("test.R");
 
+        let epoch = gate.begin_epoch(&uri);
         gate.record_publish(&uri, 1);
 
         const N_THREADS: usize = 32;
@@ -882,7 +1055,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 gate.mark_force_republish(&uri);
                 barrier.wait();
-                if gate.try_consume_publish(&uri, 1) {
+                if gate.try_consume_publish(&uri, 1, epoch) {
                     successes.fetch_add(1, Ordering::Relaxed);
                 }
             }));
@@ -909,6 +1082,218 @@ mod tests {
 
         // After clear, any version should be allowed
         assert!(gate.can_publish(&uri, 1));
+    }
+
+    // Lifecycle-epoch tests (issue #603)
+
+    #[test]
+    fn test_begin_epoch_mints_unique_epochs() {
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+
+        let e1 = gate.begin_epoch(&uri1);
+        let e2 = gate.begin_epoch(&uri2);
+        let e3 = gate.begin_epoch(&uri1); // same URI, new lifecycle
+
+        assert_ne!(e1, e2);
+        assert_ne!(e1, e3);
+        assert_ne!(e2, e3);
+        assert_eq!(gate.current_epoch(&uri1), Some(e3));
+        assert_eq!(gate.current_epoch(&uri2), Some(e2));
+    }
+
+    #[test]
+    fn test_current_epoch_absent_before_begin_and_after_clear() {
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri = test_uri("test.R");
+
+        assert_eq!(gate.current_epoch(&uri), None);
+        let e = gate.begin_epoch(&uri);
+        assert_eq!(gate.current_epoch(&uri), Some(e));
+        gate.clear(&uri);
+        assert_eq!(gate.current_epoch(&uri), None);
+    }
+
+    #[test]
+    fn test_try_consume_publish_rejects_stale_epoch_and_preserves_marker() {
+        // The core #603 regression: a retired lifecycle's epoch must be
+        // refused at commit even when the force marker + same-version
+        // predicate would otherwise allow the publish — and the refusal must
+        // NOT consume the marker meant for the live lifecycle.
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri = test_uri("test.R");
+
+        let old = gate.begin_epoch(&uri);
+        assert!(gate.try_consume_publish(&uri, 1, old));
+
+        let new = gate.begin_epoch(&uri); // reopen: retires `old`
+        assert!(gate.try_consume_publish(&uri, 1, new));
+        gate.mark_force_republish(&uri);
+
+        assert!(
+            !gate.try_consume_publish(&uri, 1, old),
+            "stale epoch must be refused despite an active force marker"
+        );
+        assert_eq!(
+            gate.force_republish_count_for_test(&uri),
+            1,
+            "a refused stale-epoch commit must not consume the marker"
+        );
+        assert!(
+            gate.try_consume_publish(&uri, 1, new),
+            "the live lifecycle must still get the marker's publish"
+        );
+    }
+
+    #[test]
+    fn test_try_consume_publish_rejects_retired_epoch() {
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri = test_uri("test.R");
+
+        let e = gate.begin_epoch(&uri);
+        gate.clear(&uri); // didClose / tab removal
+        assert!(
+            !gate.try_consume_publish(&uri, 1, e),
+            "no live epoch: commit must fail closed"
+        );
+        assert!(
+            gate.can_publish(&uri, 1),
+            "the refused commit must not have recorded a version"
+        );
+    }
+
+    #[test]
+    fn test_begin_epoch_resets_version_state() {
+        // A duplicate lifecycle start (no intervening clear) must not
+        // inherit the previous lifecycle's same-version high-water mark,
+        // which would gate out the new lifecycle's first publish.
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri = test_uri("test.R");
+
+        let e1 = gate.begin_epoch(&uri);
+        assert!(gate.try_consume_publish(&uri, 1, e1));
+
+        let e2 = gate.begin_epoch(&uri);
+        assert!(
+            gate.try_consume_publish(&uri, 1, e2),
+            "fresh lifecycle must publish at the same version without a force marker"
+        );
+    }
+
+    #[test]
+    fn test_begin_epoch_drops_orphaned_force_markers() {
+        // Markers accumulated while the URI had no live epoch (e.g. a hidden
+        // tab-ineligible document swept up in bulk mark_force_republish_many
+        // calls whose workers bail at the eligibility check) must not
+        // survive into the new lifecycle, where a surplus marker would
+        // authorize an unrelated same-version publish.
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri = test_uri("test.R");
+
+        gate.mark_force_republish(&uri);
+        gate.mark_force_republish(&uri);
+
+        let e = gate.begin_epoch(&uri);
+        assert_eq!(
+            gate.force_republish_count_for_test(&uri),
+            0,
+            "begin_epoch must start with clean force state"
+        );
+        assert!(gate.try_consume_publish(&uri, 1, e));
+        assert!(
+            !gate.try_consume_publish(&uri, 1, e),
+            "no marker may leak into the new lifecycle"
+        );
+    }
+
+    #[test]
+    fn test_clear_all_retires_every_epoch() {
+        let gate = CrossFileDiagnosticsGate::new();
+        let uri1 = test_uri("a.R");
+        let uri2 = test_uri("b.R");
+
+        let e1 = gate.begin_epoch(&uri1);
+        let e2 = gate.begin_epoch(&uri2);
+        gate.clear_all();
+
+        assert_eq!(gate.current_epoch(&uri1), None);
+        assert_eq!(gate.current_epoch(&uri2), None);
+        assert!(!gate.try_consume_publish(&uri1, 1, e1));
+        assert!(!gate.try_consume_publish(&uri2, 1, e2));
+    }
+
+    #[test]
+    fn test_gate_clear_races_try_consume_publish_without_wedging() {
+        // The gate is presented as the lifecycle authority, so its internal
+        // lock discipline must hold even when clear()/begin_epoch() run
+        // concurrently with try_consume_publish() (nothing at the gate level
+        // enforces the outer WorldState lock choreography). Assert two
+        // things under real contention: no deadlock, and a commit only ever
+        // succeeds for an epoch that was current at commit time.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let gate = Arc::new(CrossFileDiagnosticsGate::new());
+        let uri = test_uri("test.R");
+        let initial = gate.begin_epoch(&uri);
+
+        const N_CONSUMERS: usize = 16;
+        const N_CYCLES: usize = 200;
+        let barrier = Arc::new(Barrier::new(N_CONSUMERS + 1));
+        // Set to true only AFTER the retiring clear() has fully completed:
+        // a consumer that observes `true` before calling try_consume_publish
+        // has a happens-before edge past the retirement, so any success it
+        // then gets with `initial` is a definite stale commit (the initial
+        // epoch is never re-minted). Attempts that race the clear itself are
+        // not judged — this avoids false positives while still catching
+        // deadlocks and guard-lifetime bugs under real contention.
+        let retired = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stale_commits = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+
+        for _ in 0..N_CONSUMERS {
+            let gate = gate.clone();
+            let uri = uri.clone();
+            let barrier = barrier.clone();
+            let retired = retired.clone();
+            let stale_commits = stale_commits.clone();
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                for v in 0..N_CYCLES as i32 {
+                    let was_retired = retired.load(Ordering::SeqCst);
+                    if gate.try_consume_publish(&uri, v, initial) && was_retired {
+                        stale_commits.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+
+        let lifecycle_gate = gate.clone();
+        let lifecycle_uri = uri.clone();
+        let lifecycle_barrier = barrier.clone();
+        let lifecycle_retired = retired.clone();
+        handles.push(thread::spawn(move || {
+            lifecycle_barrier.wait();
+            lifecycle_gate.clear(&lifecycle_uri);
+            lifecycle_retired.store(true, Ordering::SeqCst);
+            // Keep churning lifecycles to contend with the consumers.
+            for _ in 0..N_CYCLES {
+                lifecycle_gate.begin_epoch(&lifecycle_uri);
+                lifecycle_gate.clear(&lifecycle_uri);
+            }
+        }));
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            stale_commits.load(Ordering::Relaxed),
+            0,
+            "no retired-epoch commit may succeed after retirement completed"
+        );
     }
 
     #[test]

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -70,6 +70,16 @@ impl CrossFileRevalidationState {
         }
     }
 
+    /// Test-only: whether a pending revalidation entry currently exists for
+    /// `uri`. Race tests use this to wait until a spawned worker has
+    /// `schedule()`d (and parked in its debounce) before superseding it —
+    /// spawning a competing worker earlier would race the first worker's
+    /// own `schedule()`, which cancels whichever token is pending.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn has_pending_for_test(&self, uri: &Url) -> bool {
+        self.pending.read().unwrap().contains_key(uri)
+    }
+
     /// Cancel pending revalidation for a URI
     pub fn cancel(&self, uri: &Url) {
         let mut pending = self.pending.write().unwrap();

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -1226,12 +1226,24 @@ mod tests {
     #[test]
     fn test_gate_clear_races_try_consume_publish_without_wedging() {
         // The gate is presented as the lifecycle authority, so its internal
-        // lock discipline must hold even when clear()/begin_epoch() run
-        // concurrently with try_consume_publish() (nothing at the gate level
-        // enforces the outer WorldState lock choreography). Assert two
-        // things under real contention: no deadlock, and a commit only ever
-        // succeeds for an epoch that was current at commit time.
-        use std::sync::atomic::{AtomicUsize, Ordering};
+        // lock discipline must hold even when clear() runs concurrently with
+        // try_consume_publish() (nothing at the gate level enforces the
+        // outer WorldState lock choreography). Assert two things under real
+        // contention: no deadlock, and the nested-guard-lifetime invariant —
+        // try_consume_publish must hold the `current_epoch` guard across the
+        // entire version/force commit.
+        //
+        // Detector: the lifecycle thread retires the epoch with a single
+        // clear() and never re-mints it. clear() takes all three write
+        // guards, so in a correct implementation every commit either fully
+        // precedes it (its `last_published_version` entry is then removed by
+        // the clear) or fully follows it (the epoch check fails; no entry is
+        // written). Only an implementation that releases the epoch guard
+        // between the check and the commit can interleave with the clear and
+        // write an entry AFTER the clear removed everything — so any
+        // surviving entry after all threads join proves the guard-lifetime
+        // bug. `can_publish(uri, i32::MIN)` is true iff no entry survived
+        // (consumers only commit versions >= 0).
         use std::sync::{Arc, Barrier};
         use std::thread;
 
@@ -1242,30 +1254,16 @@ mod tests {
         const N_CONSUMERS: usize = 16;
         const N_CYCLES: usize = 200;
         let barrier = Arc::new(Barrier::new(N_CONSUMERS + 1));
-        // Set to true only AFTER the retiring clear() has fully completed:
-        // a consumer that observes `true` before calling try_consume_publish
-        // has a happens-before edge past the retirement, so any success it
-        // then gets with `initial` is a definite stale commit (the initial
-        // epoch is never re-minted). Attempts that race the clear itself are
-        // not judged — this avoids false positives while still catching
-        // deadlocks and guard-lifetime bugs under real contention.
-        let retired = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let stale_commits = Arc::new(AtomicUsize::new(0));
         let mut handles = Vec::new();
 
         for _ in 0..N_CONSUMERS {
             let gate = gate.clone();
             let uri = uri.clone();
             let barrier = barrier.clone();
-            let retired = retired.clone();
-            let stale_commits = stale_commits.clone();
             handles.push(thread::spawn(move || {
                 barrier.wait();
                 for v in 0..N_CYCLES as i32 {
-                    let was_retired = retired.load(Ordering::SeqCst);
-                    if gate.try_consume_publish(&uri, v, initial) && was_retired {
-                        stale_commits.fetch_add(1, Ordering::Relaxed);
-                    }
+                    gate.try_consume_publish(&uri, v, initial);
                 }
             }));
         }
@@ -1273,27 +1271,22 @@ mod tests {
         let lifecycle_gate = gate.clone();
         let lifecycle_uri = uri.clone();
         let lifecycle_barrier = barrier.clone();
-        let lifecycle_retired = retired.clone();
         handles.push(thread::spawn(move || {
             lifecycle_barrier.wait();
             lifecycle_gate.clear(&lifecycle_uri);
-            lifecycle_retired.store(true, Ordering::SeqCst);
-            // Keep churning lifecycles to contend with the consumers.
-            for _ in 0..N_CYCLES {
-                lifecycle_gate.begin_epoch(&lifecycle_uri);
-                lifecycle_gate.clear(&lifecycle_uri);
-            }
         }));
 
         for h in handles {
             h.join().unwrap();
         }
 
-        assert_eq!(
-            stale_commits.load(Ordering::Relaxed),
-            0,
-            "no retired-epoch commit may succeed after retirement completed"
+        assert!(
+            gate.can_publish(&uri, i32::MIN),
+            "a last_published_version entry survived the retiring clear: a \
+             commit interleaved between the epoch check and the version/force \
+             write, so the current_epoch guard was not held across the commit"
         );
+        assert_eq!(gate.current_epoch(&uri), None);
     }
 
     #[test]

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -1244,6 +1244,16 @@ mod tests {
         // surviving entry after all threads join proves the guard-lifetime
         // bug. `can_publish(uri, i32::MIN)` is true iff no entry survived
         // (consumers only commit versions >= 0).
+        //
+        // This is a STRESS test: the postcondition is sound (a failure is
+        // always a real bug; no false positives), but detection is
+        // opportunistic — nothing can force clear() into a hypothetical
+        // broken implementation's dropped-guard window from outside the
+        // gate's public API. The deterministic epoch-guard coverage lives in
+        // test_try_consume_publish_rejects_stale_epoch_and_preserves_marker
+        // and test_try_consume_publish_rejects_retired_epoch, which pin the
+        // check-under-guard behavior directly. What this test guarantees on
+        // every run is the no-deadlock property under real contention.
         use std::sync::{Arc, Barrier};
         use std::thread;
 

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -135,7 +135,7 @@ use tree_sitter::Tree;
 
 use crate::chunks::{ChunkKind, classify_chunk_document, classify_chunk_document_for};
 use crate::content_provider::DefaultContentProvider;
-use crate::cross_file::revalidation::CrossFileDiagnosticsGate;
+use crate::cross_file::revalidation::{CrossFileDiagnosticsGate, DiagnosticsEpoch};
 use crate::cross_file::{
     CrossFileActivityState, CrossFileConfig, CrossFileFileCache, CrossFileRevalidationState,
     CrossFileWorkspaceIndex, DependencyGraph, MetadataCache,
@@ -659,6 +659,10 @@ pub struct WorldState {
     /// the client send. Without it, a computation could pass its final tab
     /// check, lose a race to an empty clear, and then republish stale Problems.
     pub diagnostics_publish_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Test-only pause points for the diagnostics publish pipelines; see
+    /// `DiagnosticsPublishPause`. Compiled out of production builds.
+    #[cfg(any(test, feature = "test-support"))]
+    pub diagnostics_test_pause: crate::cross_file::revalidation::DiagnosticsPublishPause,
 
     // Cross-file state
     pub cross_file_config: CrossFileConfig,
@@ -782,6 +786,74 @@ pub struct WorldState {
     /// Inputs to the package-mode `derive` function. Updated by event handlers
     /// before calling `apply_package_event`. See package_state::PackageInputs.
     pub package_inputs: crate::package_state::PackageInputs,
+}
+
+/// A snapshot of the lifecycle state a diagnostics run was triggered
+/// against: the URI's `(version, revision, epoch)` captured under a
+/// `WorldState` lock when the work was spawned, carried through the
+/// debounce → compute → publish pipeline, and re-compared at every
+/// freshness checkpoint via [`Self::is_stale`].
+///
+/// Bundling the three fields keeps every checkpoint epoch-aware by
+/// construction. The loose `(version, revision)` pair this replaces cannot
+/// identify a lifecycle (issue #603): a client may reopen at the same
+/// version, and `Document::revision` restarts at 0 on every open, so a
+/// worker retired by a close or tab removal could pass both comparisons
+/// against the URI's next lifecycle. The epoch is globally unique per
+/// lifecycle and never reused.
+///
+/// `version`/`revision` are `None` when the document is not open;
+/// `epoch` is `None` when the URI is not diagnostic-eligible (never began,
+/// or retired). Workers must decline to schedule when `epoch` is `None` —
+/// an all-`None` trigger compares equal to a still-absent document, but
+/// such a worker can never legally publish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DiagnosticsTrigger {
+    pub(crate) version: Option<i32>,
+    pub(crate) revision: Option<u64>,
+    pub(crate) epoch: Option<DiagnosticsEpoch>,
+}
+
+impl DiagnosticsTrigger {
+    /// Capture `uri`'s current trigger snapshot. The caller must hold a
+    /// `WorldState` lock for the duration so the three reads are coherent.
+    pub(crate) fn capture(state: &WorldState, uri: &Url) -> Self {
+        let doc = state.documents.get(uri);
+        Self {
+            version: doc.and_then(|d| d.version),
+            revision: doc.map(|d| d.revision),
+            epoch: state.diagnostics_gate.current_epoch(uri),
+        }
+    }
+
+    /// Whether the URI's current state no longer matches this trigger: the
+    /// worker is obsolete (a newer edit's worker owns the current state) or
+    /// belongs to a retired lifecycle, and must not schedule, compute, or
+    /// publish past this point.
+    pub(crate) fn is_stale(&self, state: &WorldState, uri: &Url) -> bool {
+        *self != Self::capture(state, uri)
+    }
+
+    /// Atomically commit a publish for this trigger through `gate`,
+    /// returning whether the caller may proceed to send. Encapsulates the
+    /// commit contract shared by the debounced and direct pipelines so the
+    /// two cannot drift:
+    /// - no live epoch (`epoch: None`): never publish — a retired lifecycle
+    ///   fails closed even though callers' earlier checks make this
+    ///   unreachable in practice;
+    /// - versioned: the gate's monotonic + force-marker predicate decides,
+    ///   validating the epoch under the gate's own locks;
+    /// - versionless (`version: None` with a live epoch): publish — there is
+    ///   no version to gate monotonically, so the live-epoch requirement
+    ///   (the caller's `is_stale` re-check under the publish lock) is the
+    ///   gate.
+    pub(crate) fn commit_publish(&self, gate: &CrossFileDiagnosticsGate, uri: &Url) -> bool {
+        match (self.version, self.epoch) {
+            (_, None) => false,
+            (Some(ver), Some(epoch)) => gate.try_consume_publish(uri, ver, epoch),
+            (None, Some(_)) => true,
+        }
+    }
 }
 
 impl WorldState {
@@ -1048,6 +1120,9 @@ impl WorldState {
             cross_file_file_cache: CrossFileFileCache::new(),
             diagnostics_gate: CrossFileDiagnosticsGate::new(),
             diagnostics_publish_lock: Arc::new(tokio::sync::Mutex::new(())),
+            #[cfg(any(test, feature = "test-support"))]
+            diagnostics_test_pause:
+                crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
 
             // Cross-file state
             cross_file_config: config,
@@ -1102,6 +1177,40 @@ impl WorldState {
         self.editor_diagnostic_uris
             .as_ref()
             .is_none_or(|uris| uris.contains(uri))
+    }
+
+    /// Begin a fresh diagnostics lifecycle for `uri` if it is currently
+    /// eligible to own push diagnostics ([`Self::diagnostics_publish_allowed`]);
+    /// returns `None` without minting an epoch otherwise.
+    ///
+    /// Call on every "URI becomes diagnostic-eligible" transition: `did_open`
+    /// (both the project-excluded and normal branches) and a tab re-addition
+    /// via `raven/activeDocumentsChanged` — for the latter, only AFTER
+    /// `editor_diagnostic_uris` has been replaced, since eligibility is read
+    /// from it (calling before the replacement silently mints nothing and
+    /// the re-added tab's publishes all fail closed).
+    pub(crate) fn begin_diagnostic_lifecycle(&self, uri: &Url) -> Option<DiagnosticsEpoch> {
+        self.diagnostics_publish_allowed(uri)
+            .then(|| self.diagnostics_gate.begin_epoch(uri))
+    }
+
+    /// Retire `uri`'s diagnostics lifecycle: cancel pending debounced work
+    /// and clear all gate state including the lifecycle epoch. Call on every
+    /// "URI stops being diagnostic-eligible" transition: `did_close` and tab
+    /// removal. In-flight workers holding the retired epoch fail their next
+    /// [`DiagnosticsTrigger::is_stale`] check or the atomic gate commit, so
+    /// they cannot publish into the URI's next lifecycle.
+    pub(crate) fn retire_diagnostic_lifecycle(&self, uri: &Url) {
+        self.cross_file_revalidation.cancel(uri);
+        self.diagnostics_gate.clear(uri);
+    }
+
+    /// Retire every diagnostics lifecycle and cancel all pending debounced
+    /// work. Called on server shutdown so no in-flight diagnostic work can
+    /// publish after the shutdown response.
+    pub(crate) fn retire_all_diagnostic_lifecycles(&self) {
+        self.cross_file_revalidation.cancel_all();
+        self.diagnostics_gate.clear_all();
     }
 
     fn open_alias_candidates_for_uri(&self, uri: &Url) -> Vec<Url> {

--- a/docs/development.md
+++ b/docs/development.md
@@ -273,8 +273,32 @@ Cross-file revalidation is debounced and cancelable.
 A diagnostics gate enforces monotonic publishing:
 - never publish diagnostics for an older document version
 - allow “force republish” at the same version for dependency-triggered revalidation
+- never let retired work publish into a reused URI lifecycle
+
+The third rule is the per-URI **lifecycle epoch** (#603). Version and revision
+cannot identify a lifecycle — a client may reopen at the same version, and
+`Document::revision` restarts at 0 on every open, so a worker retired by a
+close, tab removal, or shutdown could otherwise pass every freshness check
+against the URI's next lifecycle. The gate mints a globally unique epoch when
+a URI becomes diagnostic-eligible (`did_open`, or a tab re-addition after the
+`editor_diagnostic_uris` replacement), retires it on `did_close`/tab
+removal/shutdown, and refuses any commit whose captured epoch is no longer
+current — without consuming a force marker. `begin_epoch` also resets the
+URI's version/force state so a fresh lifecycle can neither inherit a stale
+same-version high-water mark nor orphaned force markers. Both publish
+pipelines carry the epoch inside `DiagnosticsTrigger` (`state.rs`), captured
+when the work is spawned; the debounced path additionally declines to
+`schedule()` on a stale or missing epoch so retired workers cannot supersede
+the live lifecycle's pending worker. Lifecycle transitions go through
+`WorldState::begin_diagnostic_lifecycle` / `retire_diagnostic_lifecycle` so
+the cancel + gate-clear pairing cannot drift between call sites.
 
 See `crates/raven/src/cross_file/revalidation.rs`.
+
+For deterministic race tests, `WorldState::diagnostics_test_pause`
+(test/test-support builds only) can park a diagnostics worker in the
+post-compute, pre-commit window; see the `#603` regression tests in
+`backend.rs`'s `diagnostic_lifecycle` module.
 
 The VS Code extension sends an optional `diagnosticUris` set in both initialization options and `raven/activeDocumentsChanged`. Initialization seeds the policy before vscode-languageclient synchronizes already-open documents; the notification keeps it current. The set is the union of resource-backed tabs (the modified side for a diff tab) and visible text editors (to include peek editors). This is intentionally distinct from `workspace.textDocuments`: review/comment extensions can call `workspace.openTextDocument()` for background files, which sends LSP `didOpen` even though no editor tab exists. Raven keeps those documents synchronized for cross-file analysis but gates their own push diagnostics. An absent set preserves standard `didOpen` behavior for older and non-VS Code clients.
 


### PR DESCRIPTION
Closes #603.

## Problem

The diagnostics gate keyed freshness only by URI, document version, and the per-open revision. `clear(uri)` erased its history and a reopened `Document` restarts at `revision = 0`, so retired in-flight diagnostic work could become eligible again after a URI lifecycle was reused:

- **Close → reopen at the same version/revision**: the direct publish path (`publish_diagnostics_inner`) has no cancellation token and checked only the version, so a worker that computed diagnostics before `didClose` could publish stale Problems into the reopened document.
- **Tab removal → re-addition** (VS Code tab-scoping, document stays LSP-open): version and revision never change at all.
- **Shutdown**: a no-op handler let in-flight workers publish after the shutdown response.

## Fix

`CrossFileDiagnosticsGate` now tracks a globally unique per-URI **lifecycle epoch** (`DiagnosticsEpoch`), minted from a never-reset counter:

- `begin_epoch` (via `WorldState::begin_diagnostic_lifecycle`) runs on `didOpen` and tab re-addition (after the `editor_diagnostic_uris` replacement), and atomically resets the URI's version high-water mark and force markers so a fresh lifecycle inherits neither.
- `clear` (via `retire_diagnostic_lifecycle` / `retire_all_diagnostic_lifecycles`) retires the epoch on `didClose`, tab removal, and shutdown — the latter under `diagnostics_publish_lock` so nothing publishes after the shutdown response.
- `try_consume_publish` takes the captured epoch and fails closed — no version update, no force marker consumed — unless it still equals the URI's current epoch, holding the epoch guard across the whole commit (fixed nested lock order `current_epoch → last_published_version → force_republish`).
- Both publish pipelines carry the epoch inside `DiagnosticsTrigger { version, revision, epoch }`, captured at spawn and re-validated at every freshness checkpoint. The debounced path declines to `schedule()` on a stale or missing epoch, so a retired worker can never cancel the live lifecycle's pending worker; the direct path gains full trigger validation (previously version-only).
- Versionless publishes, which previously bypassed the gate entirely, now require a live epoch.

`diagnostics_publish_lock` and its ordering semantics are unchanged; monotonic-version and counted force-republish behavior are preserved exactly (a stale-epoch refusal does not consume a marker).

## Tests

- Gate-level: unique minting, retirement, stale-epoch rejection with marker preservation, `begin_epoch` resetting version/force state, orphaned-marker cleanup, `clear_all`, plus a clear-vs-consume concurrency stress test for the nested-guard discipline.
- End-to-end (via a cfg-gated `DiagnosticsPublishPause` hook that parks a worker post-compute/pre-commit): close→reopen at the same version (stale content asserted to never reach the client; the reopened lifecycle still publishes at the retained version), tab removal→re-addition (schedule-time decline with the re-add's own production worker as the supersession detector, plus a paused-worker variant), the commit-side epoch check in isolation (live token, retired epoch), and post-shutdown publish suppression.

## Review

Gated on two consecutive fully clean review rounds (Codex primary + Sonnet/Opus second opinions each round). Rounds 1–3 produced findings — `begin_epoch` state reset, test-detector soundness, docstring accuracy, and a schedule-supersession flake — all fixed in follow-up commits; rounds 4 and 5 were clean from both reviewers, including independent re-derivation of the safety argument, a 520/520 repeated-execution flake check, and all CI gates (fmt, clippy `--all-targets --features test-support -D warnings`, rustdoc `-D warnings` in both feature configs, full lib suite).

https://claude.ai/code/session_01TxTEozEGZ4wyZRF4wHqCNE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated diagnostics from appearing after a file is closed and reopened, removed and re-added, or during shutdown.
  * Improved diagnostics freshness checks across immediate, debounced, and cross-file updates.
  * Strengthened lifecycle handling to ensure results from previous file sessions cannot be published in a new session.

* **Documentation**
  * Added guidance explaining diagnostics lifecycle tracking and race-condition protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->