### PR TITLE
Clarify semicolon lint message

### DIFF
--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -1953,6 +1953,10 @@ print.data.frame <- function(x, ...) NULL
         let diags = lint("a; b\n", &config);
         assert_eq!(diags.len(), 1, "got {:?}", diags);
         assert_eq!(diags[0].range.start.character, 1);
+        assert_eq!(
+            diags[0].message,
+            "Put each statement on its own line instead of separating them with `;`."
+        );
     }
 
     #[test]

--- a/crates/raven/src/linting/rules/semicolon.rs
+++ b/crates/raven/src/linting/rules/semicolon.rs
@@ -111,7 +111,8 @@ fn scan(
             severity: Some(severity),
             source: Some(LINT_SOURCE.to_string()),
             code: Some(NumberOrString::String(rule_ids::SEMICOLON.to_string())),
-            message: "Avoid `;`; put each statement on its own line.".to_string(),
+            message: "Put each statement on its own line instead of separating them with `;`."
+                .to_string(),
             ..Default::default()
         });
     }


### PR DESCRIPTION
## Summary

- reword the semicolon lint message to avoid adjacent semicolons
- add a regression assertion for the user-facing diagnostic text

## Testing

- `cargo fmt --all`
- `cargo test -p raven --lib linting::tests::semicolon_flags_separator`
- `git diff --check`