### PR TITLE
docs(indentation): fix stale pipe-chain examples; scope the style setting

### DIFF
--- a/docs/indentation.md
+++ b/docs/indentation.md
@@ -39,6 +39,8 @@ When you press Enter, Tier 1 applies first (regex-based), then Tier 2 replaces t
 
 Style names follow the [ESS (Emacs Speaks Statistics)](https://ess.r-project.org/) conventions: `rstudio` matches the RStudio IDE's default alignment; `rstudio-minus` (`RStudio-` in ESS) drops same-line paren alignment.
 
+The style choice governs **paren-argument alignment only**. Operator-chain continuation alignment (see [Pipe Chains](#pipe-chains) below) is not part of the style: it applies under both `rstudio` and `rstudio-minus` whenever Tier 2 is active, and it deliberately goes beyond what the real RStudio IDE does (RStudio indents statement-level operator continuations by one level; it never aligns them under the chain start).
+
 ### Disabling Tier 2
 
 Two ways to disable AST-aware indentation:
@@ -86,12 +88,20 @@ result <- function_call(first_arg,
 
 ### Pipe Chains
 
-Continuation lines in a pipe chain align relative to the chain start:
+Continuation lines in a pipe chain align under the chain start — for a chain on the right-hand side of an assignment, that is the first operand after the assignment operator:
 
 ```r
 result <- data %>%
-  filter(x > 0) %>%
-  mutate(y = x * 2) %>%
+          filter(x > 0) %>%
+          mutate(y = x * 2) %>%
+          select(y)
+```
+
+A continuation always gets at least one indent level from the chain-start line, so a chain whose first operand sits at the line's first column indents instead of aligning:
+
+```r
+data |>
+  filter(x > 0) |>
   select(y)
 ```
 
@@ -110,10 +120,10 @@ output <- some_function(
 
 ```r
 result <- data %>%
-  mutate(new_col = complex_function(arg1,
-                                    arg2,
-                                    arg3)) %>%
-  filter(new_col > 0)
+          mutate(new_col = complex_function(arg1,
+                                            arg2,
+                                            arg3)) %>%
+          filter(new_col > 0)
 ```
 
 ### Brace Blocks


### PR DESCRIPTION
## Summary

Follow-up to #608. While verifying the linting docs, the pipe-chain examples in `docs/indentation.md` turned out to show the **original** one-level continuation indent from the first smart-indentation implementation (`7a28e748`), which `ec74506f` / `4f8126b5` replaced with chain-start alignment the same day — the examples were never updated.

- **Pipe Chains** — corrected to chain-start alignment (continuations under `data` at column 10) and split into two examples: the assignment-RHS aligned case, and the column-0 chain that keeps the one-level floor.
- **Function Calls in Pipe Chains** — same correction; the nested call's arguments still align under `arg1` at their shifted column.
- **New scoping note** under the style table: `raven.indentation.style` governs paren-argument alignment only. Operator-chain alignment applies under both `rstudio` and `rstudio-minus` whenever Tier 2 is active, and deliberately goes beyond the real RStudio IDE (which indents statement-level continuations one level).

Every documented column was verified against the real `detect_context` → `calculate_indentation` pipeline (tab size 2, rstudio style) before writing: assignment-RHS continuations → 10, column-0 chains → 2, nested args → 44.

## Review gate

Two consecutive clean codex review passes; both independently re-derived the columns from the engine.

https://claude.ai/code/session_0153TLP6mjTRpd5JJJZkovkV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified smart indentation behavior for parenthesized arguments and operator or pipe-chain continuations.
  - Updated guidance for pipe chains, including assignment contexts and minimum indentation.
  - Revised function-call examples to reflect current formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->