### PR TITLE
fix(quarto): harden Stop/pending-start lifecycle (post-#625 review)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -617,8 +617,13 @@ Brief orientation for modules outside the cross-file and package-library subsyst
 
 The VS Code extension's Quarto implementation lives under
 `editors/vscode/src/quarto/`. One activation-scoped lifecycle owns the
-`QuartoRuntime`, `QuartoRenderEngine`, preview panels, and shared **Raven:
-Quarto** output channel in that extension-host window. The render engine
+`QuartoCommandLifecycle`, `QuartoRuntime`, `QuartoRenderEngine`, preview panels,
+and shared **Raven: Quarto** output channel in that extension-host window. The
+`QuartoCommandLifecycle` owns each command's asynchronous continuation
+(preview, render, and stop): `run` invokes the body synchronously — so Preview
+can register its pending-start intent before yielding — then retains the
+promise through preflight, binary discovery, subprocess work, and outcome
+handling, rejecting new bodies once shutdown begins. The render engine
 registers every child synchronously when it spawns and rejects new renders as
 soon as lifecycle shutdown begins. Render stdout/stderr still stream in full,
 but only a bounded tail is retained for result parsing and failure context.
@@ -674,10 +679,12 @@ panels and clears their static registry; otherwise a disable/enable cycle would
 retain callbacks and generation counters from the disposed runtime.
 
 Extension deactivation awaits `stopAllQuartoForDeactivation()`. That one
-thenable starts preview and render shutdown before disposing panels, so panel
-callbacks cannot start a second graceful ladder. It waits for both bounded
-aggregates and disposes the shared output channel last; `context.subscriptions`
-disposal alone is not the awaited process-kill mechanism. For debugging, run
+thenable rejects new command bodies and starts preview and render shutdown
+before disposing panels, so panel callbacks cannot start a second graceful
+ladder. It waits for all three bounded aggregates — command lifecycle, preview
+runtime, and render engine — and disposes the shared output channel last;
+`context.subscriptions` disposal alone is not the awaited process-kill
+mechanism. For debugging, run
 **Raven: Show Quarto Output** and inspect the **Raven: Quarto** output channel.
 
 ### Judge-backed Tier 2 indentation (#611)

--- a/editors/vscode/src/quarto/quarto-cancelable-delay.ts
+++ b/editors/vscode/src/quarto/quarto-cancelable-delay.ts
@@ -1,0 +1,32 @@
+/**
+ * A single cancelable timer primitive shared by every bounded Quarto wait.
+ *
+ * Consumers race a promise against this timer: the preview runtime and command
+ * lifecycle bound their shutdown teardown with it, and the command layer also
+ * bounds project-context discovery (`resolveContextForSource`) so a wedged
+ * filesystem cannot hang Stop or a Preview preflight. Keeping one implementation
+ * here means a future change to cancellation semantics or timer `unref` behavior
+ * updates every consumer at once instead of leaving one path on stale mechanics.
+ */
+
+export interface QuartoCancelableDelay {
+    promise: Promise<void>;
+    cancel(): void;
+}
+
+export function cancelableDelay(ms: number): QuartoCancelableDelay {
+    let timer: NodeJS.Timeout | null = null;
+    const promise = new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+            timer = null;
+            resolve();
+        }, ms);
+    });
+    return {
+        promise,
+        cancel: () => {
+            if (timer) clearTimeout(timer);
+            timer = null;
+        },
+    };
+}

--- a/editors/vscode/src/quarto/quarto-command-lifecycle.ts
+++ b/editors/vscode/src/quarto/quarto-command-lifecycle.ts
@@ -7,14 +7,11 @@
  * new command bodies and waits for a snapshot under a cancelable global bound.
  */
 
-export interface QuartoCommandCancelableDelay {
-    promise: Promise<void>;
-    cancel(): void;
-}
+import { cancelableDelay, QuartoCancelableDelay } from './quarto-cancelable-delay';
 
 export interface QuartoCommandLifecycleOptions {
     shutdownTimeoutMs?: number;
-    delay?: (ms: number) => QuartoCommandCancelableDelay;
+    delay?: (ms: number) => QuartoCancelableDelay;
 }
 
 export class QuartoCommandLifecycle {
@@ -49,21 +46,4 @@ export class QuartoCommandLifecycle {
             .finally(() => bound.cancel());
         return this.shutdownPromise;
     }
-}
-
-function cancelableDelay(ms: number): QuartoCommandCancelableDelay {
-    let timer: NodeJS.Timeout | null = null;
-    const promise = new Promise<void>((resolve) => {
-        timer = setTimeout(() => {
-            timer = null;
-            resolve();
-        }, ms);
-    });
-    return {
-        promise,
-        cancel: () => {
-            if (timer) clearTimeout(timer);
-            timer = null;
-        },
-    };
 }

--- a/editors/vscode/src/quarto/quarto-commands.ts
+++ b/editors/vscode/src/quarto/quarto-commands.ts
@@ -32,6 +32,7 @@ import { openExportedFile, type ExportFormat } from '../knit/open-exported-file'
 import { parseRenderedOutputPath } from '../knit/output-path';
 import { canonicalOpKey } from '../knit/raven-knit-paths';
 import { extractFrontmatter, parseFrontmatter } from '../knit/yaml-frontmatter';
+import { cancelableDelay } from './quarto-cancelable-delay';
 import { QuartoNotFoundError, type QuartoResolver } from './quarto-detect';
 import { QuartoCommandLifecycle } from './quarto-command-lifecycle';
 import { isShinyServerDocument } from './quarto-frontmatter';
@@ -44,6 +45,7 @@ import { isQuartoProjectMarkerFile } from './quarto-project-fs';
 import type {
     QuartoPendingStart,
     QuartoRuntime,
+    QuartoStopResult,
 } from './quarto-preview-runtime';
 import {
     classifyQuartoRenderResult,
@@ -63,7 +65,10 @@ export interface QuartoCommandDeps {
         | 'reconcilePendingStart'
         | 'consumePendingStart'
         | 'releasePendingStart'
-    >;
+    >
+        // Optional so command-policy test fakes need not stub them; the
+        // production runtime always provides both.
+        & Partial<Pick<QuartoRuntime, 'beginStop' | 'hasPendingStarts'>>;
     output: vscode.OutputChannel;
     runRender: (opts: QuartoRenderOptions) => Promise<KnitEngineResult>;
     resolveContext?: (sourceFsPath: string) => Promise<QuartoContext>;
@@ -71,6 +76,8 @@ export interface QuartoCommandDeps {
     openTextDocument?: (uri: vscode.Uri) => Thenable<vscode.TextDocument>;
     /** Dependency-injected clock for render-output freshness tests. */
     now?: () => number;
+    /** Project-discovery timeout override; tests use a tiny bound. */
+    contextTimeoutMs?: number;
 }
 
 export interface QuartoPreflight {
@@ -105,9 +112,8 @@ export function registerQuartoCommands(
             commandLifecycle.run(() => runPreviewCommand(uri, deps))),
         vscode.commands.registerCommand('raven.quarto.render', (uri?: vscode.Uri) =>
             commandLifecycle.run(() => runGuardedRender(uri))),
-        vscode.commands.registerCommand('raven.quarto.stopPreview', async (uri?: vscode.Uri) => {
-            await runStopCommand(uri, deps);
-        }),
+        vscode.commands.registerCommand('raven.quarto.stopPreview', (uri?: vscode.Uri) =>
+            commandLifecycle.run(() => runStopCommand(uri, deps))),
         vscode.commands.registerCommand('raven.quarto.openOutputChannel', () => {
             deps.output.show(true);
         }),
@@ -317,21 +323,55 @@ async function runStopCommand(
         );
         return;
     }
-    // Preserve pending-start cancellation without waiting for remote-fs
-    // discovery. A running project preview is normally found by source alias;
-    // only a different physical alias needs the async project-key fallback.
+    // Take the fast lexical/source-alias path first and avoid remote-fs project
+    // discovery on the common case. Allocate one stop epoch synchronously,
+    // before any await, and share it across both phases: this stamps the Stop at
+    // its issue time so a Preview for a sibling file launched *after* this click
+    // is not abandoned by the (later) project-key phase's epoch record.
+    const stopEpoch = deps.runtime.beginStop?.();
     const lexicalKey = canonicalOpKey(uri);
-    let outcome = await deps.runtime.stopByLookup(lexicalKey, uri.fsPath);
-    if (outcome === 'none') {
-        const quartoContext = await resolveContextForSource(uri.fsPath, deps);
-        if (quartoContext.key !== lexicalKey) {
-            outcome = await deps.runtime.stopByLookup(
-                quartoContext.key,
-                uri.fsPath,
-            );
+    let outcome = await deps.runtime.stopByLookup(lexicalKey, uri.fsPath, stopEpoch);
+    const stoppedSession = outcome === 'stopped';
+    // Whether the fast lexical phase already found something (a stopped session,
+    // a cancelled intent, or an in-progress stop). Used to decide the outcome
+    // floor and whether a failed project-discovery phase is worth surfacing.
+    const lexicalFoundSomething = outcome !== 'none';
+    // Run the async project-key phase when either:
+    //  - no session was stopped lexically (a project preview may still run under
+    //    the discovered project key), or
+    //  - a session WAS stopped but an intent is still pending — the stopped
+    //    session's key can differ from the current project key (project markers
+    //    changed since it started), so the project key needs its stop epoch
+    //    recorded to abandon a sibling intent that predates this Stop.
+    const needProjectPhase =
+        !stoppedSession || (deps.runtime.hasPendingStarts?.() ?? false);
+    if (needProjectPhase) {
+        try {
+            const quartoContext = await resolveContextForSource(uri.fsPath, deps);
+            if (quartoContext.key !== lexicalKey) {
+                const fallback = await deps.runtime.stopByLookup(
+                    quartoContext.key,
+                    uri.fsPath,
+                    stopEpoch,
+                );
+                // Keep the strongest result of the two phases. This preserves a
+                // lexical 'stopped'/'cancelled-pending'/'already-stopping' as a
+                // floor so a weaker fallback cannot downgrade it — e.g. a second
+                // Stop during teardown ('already-stopping') must not become a
+                // misleading "no preview running" ('none') just because the
+                // project-key lookup found nothing.
+                outcome = strongerStopResult(outcome, fallback);
+            }
+        } catch (err) {
+            // Project discovery can fail or hang (a wedged remote filesystem).
+            // It must not discard work the lexical phase already did — a stopped
+            // session, a cancelled intent, or an already-stopping session are
+            // all "found something", and the project-key phase is best-effort.
+            // Only surface the error when the Stop had otherwise found nothing.
+            if (!lexicalFoundSomething) throw err;
         }
     }
-    if (outcome === 'stopped') {
+    if (outcome === 'stopped' || outcome === 'cancelled-pending') {
         await vscode.window.showInformationMessage('Quarto preview stopped.');
     } else if (outcome === 'none') {
         await vscode.window.showInformationMessage(
@@ -339,6 +379,25 @@ async function runStopCommand(
         );
     }
     // already-stopping is intentionally a silent no-op.
+}
+
+/**
+ * Merge two Stop phases' results, keeping the more meaningful one so a weaker
+ * later phase never masks work an earlier phase already reported. Ranked:
+ * stopped a session > cancelled a pending intent > a stop already in progress
+ * > nothing found.
+ */
+function strongerStopResult(
+    a: QuartoStopResult,
+    b: QuartoStopResult,
+): QuartoStopResult {
+    const rank: Record<QuartoStopResult, number> = {
+        stopped: 3,
+        'cancelled-pending': 2,
+        'already-stopping': 1,
+        none: 0,
+    };
+    return rank[a] >= rank[b] ? a : b;
 }
 
 function createQuartoRenderRunner(deps: QuartoCommandDeps): QuartoRenderRunner {
@@ -403,6 +462,26 @@ function renderGuardKey(
     return `${kind}:${context.key}`;
 }
 
+/**
+ * Hard bound on project-context discovery. `realpath` and the ancestor
+ * marker-file walk are ordinary filesystem calls that return in microseconds
+ * on a local disk, but can wedge indefinitely on an unavailable network mount.
+ * A hang here would otherwise stall Stop (holding deactivation up to its bound)
+ * and pin a Preview intent in preflight forever; the timeout turns that
+ * un-catchable hang into a rejection every caller already handles.
+ */
+export const QUARTO_CONTEXT_TIMEOUT_MS = 10_000;
+
+class QuartoContextTimeoutError extends Error {
+    constructor(sourceFsPath: string, timeoutMs: number) {
+        super(
+            `Quarto project discovery for ${sourceFsPath} timed out after ` +
+            `${timeoutMs}ms (filesystem slow or unavailable).`,
+        );
+        this.name = 'QuartoContextTimeoutError';
+    }
+}
+
 async function resolveContextForSource(
     sourceFsPath: string,
     deps: QuartoCommandDeps,
@@ -412,7 +491,20 @@ async function resolveContextForSource(
             realpath: fs.promises.realpath,
             isProjectMarkerFile: isQuartoProjectMarkerFile,
         }));
-    return await resolveContext(sourceFsPath);
+    const timeoutMs = deps.contextTimeoutMs ?? QUARTO_CONTEXT_TIMEOUT_MS;
+    const bound = cancelableDelay(timeoutMs);
+    try {
+        const result = await Promise.race([
+            resolveContext(sourceFsPath).then((ctx) => ({ ok: true as const, ctx })),
+            bound.promise.then(() => ({ ok: false as const })),
+        ]);
+        if (!result.ok) {
+            throw new QuartoContextTimeoutError(sourceFsPath, timeoutMs);
+        }
+        return result.ctx;
+    } finally {
+        bound.cancel();
+    }
 }
 
 async function runRenderProcess(

--- a/editors/vscode/src/quarto/quarto-preview-runtime.ts
+++ b/editors/vscode/src/quarto/quarto-preview-runtime.ts
@@ -47,6 +47,7 @@
  */
 
 import { canonicalOpKey } from '../knit/raven-knit-paths';
+import { cancelableDelay, QuartoCancelableDelay } from './quarto-cancelable-delay';
 import type { QuartoPreviewViewState } from './quarto-messages';
 import type {
     QuartoPreviewProcessLike,
@@ -82,10 +83,7 @@ export interface QuartoRuntimeDeps {
     shutdownDelay?: (ms: number) => QuartoCancelableDelay;
 }
 
-export interface QuartoCancelableDelay {
-    promise: Promise<void>;
-    cancel(): void;
-}
+export type { QuartoCancelableDelay };
 
 export interface QuartoStartArgs {
     key: string;
@@ -99,7 +97,11 @@ export type QuartoStartResult =
     | { kind: 'superseded'; generation: number }
     | { kind: 'failed'; generation: number; error: Error };
 
-export type QuartoStopResult = 'stopped' | 'already-stopping' | 'none';
+export type QuartoStopResult =
+    | 'stopped'
+    | 'cancelled-pending'
+    | 'already-stopping'
+    | 'none';
 
 /** Opaque command-to-runtime ownership for a Preview still in preflight. */
 export interface QuartoPendingStart {
@@ -111,6 +113,15 @@ interface PendingStartRecord {
     readonly token: QuartoPendingStart;
     readonly sourceKey: string;
     key: string | null;
+    /**
+     * Stop-sequence value observed when this intent was registered. A later
+     * Stop targeting the intent's (eventually reconciled) key records a
+     * strictly higher sequence, letting `reconcilePendingStart` detect a Stop
+     * that landed during the register→reconcile window — before the intent's
+     * project key was known and thus before `cancelPendingStarts` could match
+     * it by key.
+     */
+    readonly registeredSeq: number;
 }
 
 /** One generation-tagged process slot. */
@@ -216,6 +227,10 @@ export class QuartoRuntime {
     private readonly pendingStarts = new Map<number, PendingStartRecord>();
     private nextPendingStartId = 0;
     private nextGeneration = 0;
+    /** Monotonic clock for ordering pending-start registration against Stops. */
+    private stopSeq = 0;
+    /** Most recent `stopSeq` at which a Stop targeted each key. */
+    private readonly stoppedKeyAt = new Map<string, number>();
     private deactivating = false;
     private shutdownPromise: Promise<void> | null = null;
 
@@ -232,15 +247,30 @@ export class QuartoRuntime {
                 token,
                 sourceKey: canonicalOpKey({ fsPath: sourceFsPath }),
                 key: null,
+                registeredSeq: this.stopSeq,
             });
         }
         return token;
     }
 
-    /** Add the final project key while retaining the original source alias. */
+    /**
+     * Add the final project key while retaining the original source alias.
+     *
+     * Returns false — abandoning the intent — when a Stop targeting this key
+     * arrived during the register→reconcile window. Until now the intent's key
+     * was `null`, so `cancelPendingStarts` could not match it; the recorded
+     * stop epoch closes that gap so a Stop can never be silently outrun by a
+     * preview whose project key was still being discovered.
+     */
     reconcilePendingStart(token: QuartoPendingStart, key: string): boolean {
         const pending = this.pendingStarts.get(token.id);
         if (!pending || this.deactivating) return false;
+        const stoppedAt = this.stoppedKeyAt.get(key);
+        if (stoppedAt !== undefined && stoppedAt > pending.registeredSeq) {
+            this.pendingStarts.delete(token.id);
+            this.pruneStopEpochs();
+            return false;
+        }
         pending.key = key;
         return true;
     }
@@ -250,12 +280,13 @@ export class QuartoRuntime {
         const pending = this.pendingStarts.get(token.id);
         if (!pending || this.deactivating) return false;
         this.pendingStarts.delete(token.id);
+        this.pruneStopEpochs();
         return true;
     }
 
     /** Release intent after any preflight/resolve early return. */
     releasePendingStart(token: QuartoPendingStart): void {
-        this.pendingStarts.delete(token.id);
+        if (this.pendingStarts.delete(token.id)) this.pruneStopEpochs();
     }
 
     /**
@@ -383,27 +414,73 @@ export class QuartoRuntime {
         }
     }
 
-    /** Stop only when the panel's generation still owns the key. */
+    /**
+     * Stop only when the panel's generation still owns the key.
+     *
+     * Panel disposal must not touch pending starts. Any intent still pending
+     * once a session exists under this key belongs to a strictly newer start
+     * attempt (its own intent was consumed before `startOrRestart` claimed the
+     * generation), so cancelling here — especially from a stale/restored
+     * generation that no longer owns the key — would silently kill a fresh
+     * Preview. Only the explicit Stop command (`stopByLookup`) cancels intents.
+     */
     async stopGeneration(key: string, generation: number): Promise<QuartoStopResult> {
-        const cancelledPending = this.cancelPendingStarts(key);
         const session = this.current(key, generation);
-        if (!session) return cancelledPending ? 'stopped' : 'none';
+        if (!session) return 'none';
         return this.stopSession(session);
+    }
+
+    /**
+     * Allocate the stop epoch for one logical Stop, synchronously at issue
+     * time. A multi-phase Stop (lexical key, then project-key fallback across
+     * an async project-discovery gap) must pass this one value to every
+     * `stopByLookup` call so an intent registered *after* the user's Stop —
+     * but before the delayed project-key phase records its epoch — is not
+     * mistaken for one that predated the Stop and falsely abandoned.
+     */
+    beginStop(): number {
+        return ++this.stopSeq;
     }
 
     /**
      * Stop lookup has no preflight contract: callers pass a freshly-computed
      * key and source path, and this method also consults the historical alias.
+     *
+     * `stopEpoch` ties every phase of one logical Stop to a single issue-time
+     * sequence value; omit it for a standalone Stop and a fresh epoch is
+     * allocated for this call alone.
      */
-    async stopByLookup(key: string, sourceFsPath: string): Promise<QuartoStopResult> {
-        const cancelledPending = this.cancelPendingStarts(key, sourceFsPath);
+    async stopByLookup(
+        key: string,
+        sourceFsPath: string,
+        stopEpoch: number = ++this.stopSeq,
+    ): Promise<QuartoStopResult> {
+        let cancelledPending = this.cancelPendingStarts(key, sourceFsPath, stopEpoch);
         let session = this.sessions.get(key) ?? null;
         if (!session) {
             const alias = this.sourceAliases.get(canonicalOpKey({ fsPath: sourceFsPath }));
             if (alias) session = this.current(alias.key, alias.generation);
         }
-        if (!session) return cancelledPending ? 'stopped' : 'none';
-        return this.stopSession(session);
+        // A cancelled intent must stay distinct from a stopped session: the
+        // command layer runs its project-key fallback whenever no *session*
+        // was stopped, so reporting a bare intent-cancel as 'stopped' here
+        // would leave a running project preview (owned under a different key)
+        // untouched while telling the user it stopped.
+        if (!session) return cancelledPending ? 'cancelled-pending' : 'none';
+        // Stopping a live session also targets its own project key, not just
+        // the caller's lookup key: when the session was found by source alias
+        // the lookup key is the lexical source key, so a sibling pending
+        // Preview for the same project would otherwise evade the stop epoch and
+        // relaunch the preview the moment this Stop reports success.
+        if (this.cancelPendingStarts(session.key, undefined, stopEpoch)) {
+            cancelledPending = true;
+        }
+        const result = await this.stopSession(session);
+        // A cancelled intent is a user-visible success; an already-stopping
+        // session (a prior Stop still draining) must not downgrade it to a
+        // silent no-op.
+        if (result === 'already-stopping' && cancelledPending) return 'cancelled-pending';
+        return result;
     }
 
     hasSession(key: string, sourceFsPath: string): boolean {
@@ -422,6 +499,7 @@ export class QuartoRuntime {
         this.sessions.clear();
         this.sourceAliases.clear();
         this.pendingStarts.clear();
+        this.stoppedKeyAt.clear();
         const all = Promise.allSettled(snapshot.map((session) => session.shutdown()));
         const bound = (this.deps.shutdownDelay ?? cancelableDelay)(
             this.deps.shutdownGlobalTimeoutMs ?? 7_000,
@@ -538,12 +616,36 @@ export class QuartoRuntime {
         }
     }
 
-    private cancelPendingStarts(key: string, sourceFsPath?: string): boolean {
+    private cancelPendingStarts(
+        key: string,
+        sourceFsPath: string | undefined,
+        stopEpoch: number,
+    ): boolean {
         const sourceKey = sourceFsPath === undefined
             ? null
             : canonicalOpKey({ fsPath: sourceFsPath });
+        // Record this Stop against every key it targets, even when no live
+        // intent matches yet: an intent registered before this Stop but not
+        // yet reconciled to `key` will consult this epoch when its project key
+        // finally resolves (see `reconcilePendingStart`). The epoch is the
+        // Stop's issue-time sequence — shared across a multi-phase Stop — so a
+        // later phase cannot record a fresher epoch than the Stop truly had.
+        //
+        // The write is monotonic (max), never a plain overwrite: two Stops for
+        // the same key can complete out of issue order (an older Stop stalled
+        // in its async project-key phase resuming after a newer Stop finished),
+        // and a stale lower epoch must never regress a newer Stop's record —
+        // that would resurrect a pending intent the newer Stop meant to abandon.
+        this.recordStopEpoch(key, stopEpoch);
+        if (sourceKey !== null) this.recordStopEpoch(sourceKey, stopEpoch);
         let cancelled = false;
         for (const [id, pending] of this.pendingStarts) {
+            // Only cancel intents that predated this Stop. An intent registered
+            // after the Stop was issued (`registeredSeq >= stopEpoch`) is a
+            // strictly newer request — a user starting a Preview after clicking
+            // Stop — and a delayed phase of the older Stop must not delete it
+            // even once it reconciles to a matching key.
+            if (pending.registeredSeq >= stopEpoch) continue;
             if (
                 pending.key === key
                 || pending.sourceKey === key
@@ -553,7 +655,43 @@ export class QuartoRuntime {
                 cancelled = true;
             }
         }
+        this.pruneStopEpochs();
         return cancelled;
+    }
+
+    /** True while any Preview intent is still in preflight. */
+    hasPendingStarts(): boolean {
+        return this.pendingStarts.size > 0;
+    }
+
+    /**
+     * Drop stop epochs that can no longer abandon any intent. An epoch at or
+     * below every live intent's `registeredSeq` predates them all, so it can
+     * never satisfy the strict `stoppedAt > registeredSeq` abandon test — for
+     * current intents or for any future one (which registers at an even higher
+     * `stopSeq`). Clearing them bounds `stoppedKeyAt` even when a Preview
+     * preflight stalls indefinitely and keeps the map non-empty.
+     */
+    private pruneStopEpochs(): void {
+        if (this.pendingStarts.size === 0) {
+            this.stoppedKeyAt.clear();
+            return;
+        }
+        let minRegisteredSeq = Infinity;
+        for (const pending of this.pendingStarts.values()) {
+            if (pending.registeredSeq < minRegisteredSeq) {
+                minRegisteredSeq = pending.registeredSeq;
+            }
+        }
+        for (const [key, epoch] of this.stoppedKeyAt) {
+            if (epoch <= minRegisteredSeq) this.stoppedKeyAt.delete(key);
+        }
+    }
+
+    /** Monotonically advance a key's stop epoch; never regress it. */
+    private recordStopEpoch(key: string, stopEpoch: number): void {
+        const previous = this.stoppedKeyAt.get(key) ?? 0;
+        if (stopEpoch > previous) this.stoppedKeyAt.set(key, stopEpoch);
     }
 }
 
@@ -566,19 +704,3 @@ function errorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err);
 }
 
-function cancelableDelay(ms: number): QuartoCancelableDelay {
-    let timer: NodeJS.Timeout | null = null;
-    const promise = new Promise<void>((resolve) => {
-        timer = setTimeout(() => {
-            timer = null;
-            resolve();
-        }, ms);
-    });
-    return {
-        promise,
-        cancel: () => {
-            if (timer) clearTimeout(timer);
-            timer = null;
-        },
-    };
-}

--- a/editors/vscode/src/test/quarto-commands.test.ts
+++ b/editors/vscode/src/test/quarto-commands.test.ts
@@ -300,9 +300,10 @@ suite('Quarto command preflight', () => {
                 return { kind: 'superseded' as const, generation: 1 };
             },
             stopByLookup: async () => {
-                const stopped = pendingActive;
+                const wasPending = pendingActive;
                 pendingActive = false;
-                return stopped ? 'stopped' as const : 'none' as const;
+                // A pending-only cancel is 'cancelled-pending', never 'stopped'.
+                return wasPending ? 'cancelled-pending' as const : 'none' as const;
             },
         };
         (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
@@ -341,6 +342,246 @@ suite('Quarto command preflight', () => {
             finishResolve.resolve('quarto');
             (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
         }
+    });
+
+    test('Stop cancels a pending intent and still stops a running project preview', async () => {
+        // Regression: cancelling a source-level pending intent used to short-
+        // circuit the project-key fallback, so Stop reported success while a
+        // preview owned under the project key kept running. Stop must consult
+        // the project key whenever no session was stopped by the lexical key.
+        const messages: string[] = [];
+        const lookups: string[] = [];
+        const original = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            message: string,
+        ): Thenable<string | undefined> => {
+            messages.push(message);
+            return Promise.resolve(undefined);
+        };
+        try {
+            const uri = vscode.Uri.file('/project/chapter.qmd');
+            const deps = fakeDeps({
+                resolveContext: async () => ({
+                    key: '/project',
+                    cwd: '/project',
+                    projectRoot: '/project',
+                }),
+                runtime: {
+                    registerPendingStart: () => { throw new Error('register must not run'); },
+                    reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+                    consumePendingStart: () => { throw new Error('consume must not run'); },
+                    releasePendingStart: () => { throw new Error('release must not run'); },
+                    startOrRestart: async () => { throw new Error('start must not run'); },
+                    stopByLookup: async (key) => {
+                        lookups.push(key);
+                        // Lexical key: only a preflight intent is cancelled.
+                        if (key === '/project/chapter.qmd') return 'cancelled-pending';
+                        // Project key: the actually-running project preview.
+                        if (key === '/project') return 'stopped';
+                        return 'none';
+                    },
+                } as QuartoCommandDeps['runtime'],
+            });
+            await runQuartoStopForTesting(uri, deps);
+
+            assert.deepStrictEqual(lookups, ['/project/chapter.qmd', '/project']);
+            assert.ok(messages.includes('Quarto preview stopped.'));
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
+        }
+    });
+
+    test('Stop that stops a session still records the project key while an intent is pending', async () => {
+        // Regression: an alias-resolved Stop that succeeds under a stale session
+        // key used to skip the project-key phase, so a sibling pending Preview
+        // for the current project (its key changed since the session started)
+        // was never abandoned and relaunched after Stop. With an intent pending,
+        // the project key must be consulted even on a 'stopped' lexical result.
+        const lookups: string[] = [];
+        const original = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            message: string,
+        ): Thenable<string | undefined> => {
+            void message;
+            return Promise.resolve(undefined);
+        };
+        try {
+            const uri = vscode.Uri.file('/project/a.qmd');
+            const deps = fakeDeps({
+                resolveContext: async () => ({
+                    key: '/project',
+                    cwd: '/project',
+                    projectRoot: '/project',
+                }),
+                runtime: {
+                    registerPendingStart: () => { throw new Error('register must not run'); },
+                    reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+                    consumePendingStart: () => { throw new Error('consume must not run'); },
+                    releasePendingStart: () => { throw new Error('release must not run'); },
+                    startOrRestart: async () => { throw new Error('start must not run'); },
+                    beginStop: () => 7,
+                    hasPendingStarts: () => true,
+                    stopByLookup: async (key) => {
+                        lookups.push(key);
+                        return key === '/project/a.qmd' ? 'stopped' : 'none';
+                    },
+                } as QuartoCommandDeps['runtime'],
+            });
+            await runQuartoStopForTesting(uri, deps);
+
+            assert.deepStrictEqual(lookups, ['/project/a.qmd', '/project']);
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
+        }
+    });
+
+    test('Stop confirms a cancelled intent even when project discovery fails', async () => {
+        // Regression: routing a pending-cancel through the project-key phase must
+        // not let a failing/hung project discovery swallow the confirmation for
+        // work already done.
+        const messages: string[] = [];
+        const original = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            message: string,
+        ): Thenable<string | undefined> => {
+            messages.push(message);
+            return Promise.resolve(undefined);
+        };
+        try {
+            const uri = vscode.Uri.file('/project/a.qmd');
+            const deps = fakeDeps({
+                resolveContext: async () => { throw new Error('remote filesystem hung'); },
+                runtime: {
+                    registerPendingStart: () => { throw new Error('register must not run'); },
+                    reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+                    consumePendingStart: () => { throw new Error('consume must not run'); },
+                    releasePendingStart: () => { throw new Error('release must not run'); },
+                    startOrRestart: async () => { throw new Error('start must not run'); },
+                    beginStop: () => 3,
+                    hasPendingStarts: () => false,
+                    stopByLookup: async () => 'cancelled-pending',
+                } as QuartoCommandDeps['runtime'],
+            });
+
+            // Must resolve (not reject) and still confirm the cancellation.
+            await runQuartoStopForTesting(uri, deps);
+            assert.ok(messages.includes('Quarto preview stopped.'));
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
+        }
+    });
+
+    test('a second Stop during teardown stays silent, not "no preview running"', async () => {
+        // Regression: a lexical 'already-stopping' (a prior Stop still draining)
+        // must not be downgraded to 'none' by a project-key fallback that finds
+        // nothing, which would show a misleading "No Quarto preview is running".
+        const messages: string[] = [];
+        const original = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            message: string,
+        ): Thenable<string | undefined> => {
+            messages.push(message);
+            return Promise.resolve(undefined);
+        };
+        try {
+            const uri = vscode.Uri.file('/project/a.qmd');
+            const deps = fakeDeps({
+                resolveContext: async () => ({
+                    key: '/project',
+                    cwd: '/project',
+                    projectRoot: '/project',
+                }),
+                runtime: {
+                    registerPendingStart: () => { throw new Error('register must not run'); },
+                    reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+                    consumePendingStart: () => { throw new Error('consume must not run'); },
+                    releasePendingStart: () => { throw new Error('release must not run'); },
+                    startOrRestart: async () => { throw new Error('start must not run'); },
+                    beginStop: () => 5,
+                    hasPendingStarts: () => false,
+                    stopByLookup: async (key) =>
+                        key === '/project/a.qmd' ? 'already-stopping' : 'none',
+                } as QuartoCommandDeps['runtime'],
+            });
+            await runQuartoStopForTesting(uri, deps);
+
+            assert.ok(
+                !messages.includes('No Quarto preview is running for this document.'),
+                'already-stopping must not surface a "no preview" message',
+            );
+            assert.ok(!messages.includes('Quarto preview stopped.'));
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
+        }
+    });
+
+    test('Stop stays bounded and confirms a cancel when project discovery hangs', async () => {
+        // Regression: a wedged remote filesystem could hang project discovery
+        // forever, leaving Stop pending and holding deactivation. Discovery is
+        // now bounded; on timeout the completed pending-cancel still confirms.
+        const messages: string[] = [];
+        const original = vscode.window.showInformationMessage;
+        (vscode.window as { showInformationMessage: unknown }).showInformationMessage = (
+            message: string,
+        ): Thenable<string | undefined> => {
+            messages.push(message);
+            return Promise.resolve(undefined);
+        };
+        try {
+            const uri = vscode.Uri.file('/project/a.qmd');
+            const deps = fakeDeps({
+                contextTimeoutMs: 20,
+                resolveContext: () => new Promise<never>(() => { /* never settles */ }),
+                runtime: {
+                    registerPendingStart: () => { throw new Error('register must not run'); },
+                    reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+                    consumePendingStart: () => { throw new Error('consume must not run'); },
+                    releasePendingStart: () => { throw new Error('release must not run'); },
+                    startOrRestart: async () => { throw new Error('start must not run'); },
+                    beginStop: () => 4,
+                    hasPendingStarts: () => false,
+                    stopByLookup: async () => 'cancelled-pending',
+                } as QuartoCommandDeps['runtime'],
+            });
+
+            // Must resolve (bounded), not hang, and still confirm the cancel.
+            await runQuartoStopForTesting(uri, deps);
+            assert.ok(messages.includes('Quarto preview stopped.'));
+        } finally {
+            (vscode.window as { showInformationMessage: unknown }).showInformationMessage = original;
+        }
+    });
+
+    test('a Preview whose project discovery hangs releases its pending intent', async () => {
+        // Regression: an indefinitely-hung Preview preflight would pin a pending
+        // intent forever, which (a) never launches and (b) keeps the runtime's
+        // stop-epoch map from ever pruning. Bounded discovery makes the hang a
+        // rejection, and the finally releases the intent.
+        let registered = 0;
+        let released = 0;
+        const runtime = {
+            registerPendingStart: (sourceFsPath: string) => {
+                registered++;
+                return { id: 1, sourceFsPath };
+            },
+            reconcilePendingStart: () => { throw new Error('reconcile must not run'); },
+            consumePendingStart: () => { throw new Error('consume must not run'); },
+            releasePendingStart: () => { released++; },
+            startOrRestart: async () => { throw new Error('start must not run'); },
+            stopByLookup: async () => 'none' as const,
+        };
+        const deps = fakeDeps({
+            contextTimeoutMs: 20,
+            resolveContext: () => new Promise<never>(() => { /* never settles */ }),
+            runtime: runtime as unknown as QuartoCommandDeps['runtime'],
+        });
+        const runPreview = createQuartoPreviewRunnerForTesting(deps);
+
+        // The hung discovery rejects via the bound; the Preview must not leak
+        // its intent.
+        await runPreview(vscode.Uri.file('/project/a.qmd')).catch(() => undefined);
+        assert.strictEqual(registered, 1);
+        assert.strictEqual(released, 1);
     });
 
     test('deactivation Preview rejection and disposed output stay silent', async () => {

--- a/tests/bun/quarto-preview-runtime.test.ts
+++ b/tests/bun/quarto-preview-runtime.test.ts
@@ -164,26 +164,173 @@ describe('QuartoRuntime generation discipline', () => {
         expect((await second).generation).toBe(2);
     });
 
-    it('Stop cancels pending Preview intent before a session exists', async () => {
+    it('Stop reports cancelled-pending (not stopped) when it only cancels an intent', async () => {
         const h = harness();
         const source = '/project/pending.qmd';
         const pending = h.runtime.registerPendingStart(source);
 
-        expect(await h.runtime.stopByLookup('/project', source)).toBe('stopped');
+        // No session exists — only a preflight intent is cancelled. That must
+        // stay distinct from 'stopped' so the command layer still runs its
+        // project-key fallback for a preview owned under a different key.
+        expect(await h.runtime.stopByLookup('/project', source)).toBe('cancelled-pending');
         expect(h.runtime.reconcilePendingStart(pending, '/project')).toBe(false);
         expect(h.runtime.consumePendingStart(pending)).toBe(false);
         expect(h.processes).toHaveLength(0);
         expect(await h.runtime.stopByLookup('/project', source)).toBe('none');
     });
 
-    it('generation Stop cancels a reconciled pending Preview intent', async () => {
+    it('panel-dispose Stop from a non-owning generation leaves a pending Preview intact', async () => {
         const h = harness();
         const pending = h.runtime.registerPendingStart('/project/pending.qmd');
         expect(h.runtime.reconcilePendingStart(pending, '/project')).toBe(true);
 
-        expect(await h.runtime.stopGeneration('/project', 99)).toBe('stopped');
+        // A stale or restored panel whose generation owns no live session must
+        // not cancel a fresh pending Preview for the same key: panel disposal
+        // is generation-scoped, and a pending intent is a strictly newer start.
+        expect(await h.runtime.stopGeneration('/project', 99)).toBe('none');
+        expect(h.runtime.consumePendingStart(pending)).toBe(true);
+        expect(h.processes).toHaveLength(0);
+    });
+
+    it('abandons a pending Preview whose key was Stopped during context discovery', async () => {
+        const h = harness();
+        // A registers a pending Preview; its project key is not yet known.
+        const pending = h.runtime.registerPendingStart('/project/a.qmd');
+
+        // A sibling Stop targets the project key while A is still in preflight
+        // discovery. cancelPendingStarts cannot match A by key (still null),
+        // so it records the stop epoch instead of cancelling A directly.
+        expect(await h.runtime.stopByLookup('/project', '/project/b.qmd')).toBe('none');
+
+        // When A finally learns its project key, reconcile detects the Stop
+        // that landed in the register→reconcile window and abandons the intent,
+        // so the preview cannot launch after the user's Stop reported nothing.
+        expect(h.runtime.reconcilePendingStart(pending, '/project')).toBe(false);
         expect(h.runtime.consumePendingStart(pending)).toBe(false);
         expect(h.processes).toHaveLength(0);
+    });
+
+    it('a shared stop epoch spares a sibling Preview registered mid-Stop', async () => {
+        const h = harness();
+        // A multi-phase Stop for doc A allocates ONE epoch up front, then runs
+        // its lexical-key phase (finds nothing).
+        const stopEpoch = h.runtime.beginStop();
+        expect(
+            await h.runtime.stopByLookup('/project/a.qmd', '/project/a.qmd', stopEpoch),
+        ).toBe('none');
+
+        // A sibling Preview for B is launched *after* the Stop was issued, in
+        // the gap before the Stop's project-key phase resolves.
+        const pendingB = h.runtime.registerPendingStart('/project/b.qmd');
+
+        // The Stop's project-key fallback records the SAME issue-time epoch, so
+        // B — registered after the Stop began — must not be mistaken for an
+        // intent that predated it. (A per-phase epoch bump would abandon B.)
+        expect(
+            await h.runtime.stopByLookup('/project', '/project/a.qmd', stopEpoch),
+        ).toBe('none');
+        expect(h.runtime.reconcilePendingStart(pendingB, '/project')).toBe(true);
+        expect(h.runtime.consumePendingStart(pendingB)).toBe(true);
+    });
+
+    it('a delayed Stop phase does not delete a sibling Preview registered after the Stop', async () => {
+        const h = harness();
+        // Stop is issued first (epoch allocated), then a sibling Preview for the
+        // same project is launched and even reconciles to the project key.
+        const stopEpoch = h.runtime.beginStop();
+        const pendingB = h.runtime.registerPendingStart('/project/b.qmd');
+        expect(h.runtime.reconcilePendingStart(pendingB, '/project')).toBe(true);
+
+        // The Stop's delayed project-key phase directly matches key '/project',
+        // but B registered *after* the Stop was issued, so the epoch-gated
+        // direct cancel must skip it — a newer request, not one the Stop meant
+        // to abandon.
+        expect(
+            await h.runtime.stopByLookup('/project', '/project/a.qmd', stopEpoch),
+        ).toBe('none');
+        expect(h.runtime.consumePendingStart(pendingB)).toBe(true);
+    });
+
+    it('Stop via source alias abandons a sibling pending Preview for the same project', async () => {
+        const h = harness();
+        // A project preview runs from doc.qmd: session keyed by project root
+        // '/project', reachable through the doc.qmd source alias.
+        const started = h.runtime.startOrRestart(startArgs);
+        await waitForProcessCount(h.processes, 1);
+        h.processes[0].process.ready.resolve({
+            rawUrl: 'http://127.0.0.1:1/',
+            origin: 'http://127.0.0.1:1',
+            statusCode: 200,
+        });
+        await started;
+
+        // A sibling Preview for another file in the same project is mid-
+        // discovery — pending, project key not yet known.
+        const pendingB = h.runtime.registerPendingStart('/project/chapter.qmd');
+
+        // Stop from doc.qmd resolves the session by its source alias, so the
+        // lookup key ('/project/doc.qmd') differs from the session key
+        // ('/project'). The stop epoch must still be recorded for '/project'.
+        const stopEpoch = h.runtime.beginStop();
+        expect(
+            await h.runtime.stopByLookup('/project/doc.qmd', '/project/doc.qmd', stopEpoch),
+        ).toBe('stopped');
+
+        // The sibling must not relaunch the preview the instant Stop succeeds.
+        expect(h.runtime.reconcilePendingStart(pendingB, '/project')).toBe(false);
+        expect(h.runtime.consumePendingStart(pendingB)).toBe(false);
+    });
+
+    it('a cancelled intent outranks an already-stopping session in the stop result', async () => {
+        const h = harness();
+        const started = h.runtime.startOrRestart(startArgs);
+        await waitForProcessCount(h.processes, 1);
+        const proc = h.processes[0].process;
+        proc.ready.resolve({
+            rawUrl: 'http://127.0.0.1:1/',
+            origin: 'http://127.0.0.1:1',
+            statusCode: 200,
+        });
+        await started;
+
+        // Begin stopping the session, holding its teardown so it stays
+        // 'stopping', then register and cancel a fresh pending for the same
+        // key with a second Stop while the first is still draining.
+        proc.stopDeferred = new Deferred<void>();
+        const firstStop = h.runtime.stopByLookup('/project', '/project/doc.qmd');
+        const pending = h.runtime.registerPendingStart('/project/doc.qmd');
+        expect(h.runtime.reconcilePendingStart(pending, '/project')).toBe(true);
+
+        // The second Stop cancelled a real intent; that success must not be
+        // downgraded to a silent 'already-stopping' no-op.
+        expect(await h.runtime.stopByLookup('/project', '/project/doc.qmd')).toBe('cancelled-pending');
+
+        proc.stopDeferred.resolve();
+        expect(await firstStop).toBe('stopped');
+    });
+
+    it('an older Stop resolving late does not un-abandon what a newer Stop caught', async () => {
+        const h = harness();
+        // Stop A is issued first (epoch 1) but stalls before its project-key
+        // phase runs.
+        const epochA = h.runtime.beginStop();
+
+        // A sibling Preview registers while Stop A is stalled.
+        const pending = h.runtime.registerPendingStart('/project/chapter.qmd');
+
+        // Stop B is issued later (epoch 2) and completes its project-key phase
+        // first, arming the epoch that should abandon the sibling intent.
+        const epochB = h.runtime.beginStop();
+        expect(epochB).toBeGreaterThan(epochA);
+        expect(await h.runtime.stopByLookup('/project', '/project/b.qmd', epochB)).toBe('none');
+
+        // Stop A's delayed project-key phase now resolves with its older epoch.
+        // A plain overwrite would regress the key's epoch below B's and let the
+        // sibling survive; the monotonic record must keep B's higher epoch.
+        expect(await h.runtime.stopByLookup('/project', '/project/a.qmd', epochA)).toBe('none');
+
+        expect(h.runtime.reconcilePendingStart(pending, '/project')).toBe(false);
+        expect(h.runtime.consumePendingStart(pending)).toBe(false);
     });
 
     it('simultaneous Start/Start claims generation 2 before generation 1 can finish', async () => {


### PR DESCRIPTION
Follow-up hardening for the Quarto CLI preview/render feature merged in #625, from a post-merge review pass (Codex sol-review + an independent Sonnet second opinion). #625 is already on `main`; this PR fixes correctness/robustness bugs found afterward in the preview **Stop / pending-start lifecycle**.

## Fixes (each with a regression test)

**Stop vs. running preview / pending intents**
- Stop no longer masks a running project preview when it only cancels a preflight intent. `stopByLookup` returns a distinct `cancelled-pending`, and `runStopCommand` runs the project-key phase whenever no *session* was stopped — so Stop from a sibling document still tears down the project server.
- An alias-resolved Stop records the epoch for the live session's own project key; and when an intent is pending, Stop consults the current project key even after a successful lexical stop (covers a project whose key changed since the session started).
- The two Stop phases are merged by strength (`stopped > cancelled-pending > already-stopping > none`), so a weak fallback can't downgrade a real result — e.g. a second Stop during teardown no longer shows a misleading "no preview running".

**Pending-start epoch discipline**
- A per-key stop epoch, allocated once per logical Stop (`beginStop`) synchronously at issue time and shared across both lookup phases, recorded monotonically (max). Both the direct pending-cancel and the reconcile-abandon are gated on issue order (`registeredSeq < stopEpoch`), so a Preview launched *after* a Stop is never abandoned by that Stop's delayed phase, and a Stop that lands in the register→reconcile window still abandons the intent.
- `stopGeneration` (panel disposal) no longer cancels pending starts — it is generation-scoped, and a pending intent is a strictly newer request.

**Robustness against a wedged filesystem**
- Project-context discovery is bounded by a hard timeout, converting an un-catchable hang into a rejection every caller handles (Stop still confirms completed work; a hung Preview releases its intent).

**Cleanups**
- Route `raven.quarto.stopPreview` through `QuartoCommandLifecycle.run`; extract the duplicated cancelable-delay primitive into `quarto-cancelable-delay.ts`; update `docs/development.md` for the third lifecycle owner.

## Verification
`cargo fmt`/tsc clean; **Bun 121/121 quarto** (full suite green); **Electron Quarto Mocha 38/38**. Gate 2 (independent Sonnet review) reached two consecutive clean passes on the pre-final commit and a clean final pass on the shipped commit.

## Known non-blocking notes (documented, not fixed here)
The review also surfaced a few items judged non-blocking — all either require a **wedged/disconnected network filesystem** or a **sub-millisecond timing coincidence layered with a mid-session project-config change**, none reachable in normal use:
- A delayed Stop could stop a sibling session that fully started within the Stop's discovery window (the sibling's preflight is strictly longer than that window).
- On a *disconnected* mount, `realpath`/`stat` are uncancellable, so a bounded-then-abandoned discovery leaves the underlying fs call running (pre-existing; not worsened here).
- Bounding covers project discovery but not `openTextDocument`/`save`, so a hang in those could still pin a pending intent; and the stop-epoch map is only fully pruned once no intent is pending.

These are good candidates for a future pass that bounds the *entire* preflight (and moves the discovery bound into the shared resolver).

https://claude.ai/code/session_01HUmnDfDrbztmpkfYrdsH8i