### PR TITLE
fix(lint): ignore escaped strings in semicolon rule

### DIFF
--- a/crates/raven/src/linting/mod.rs
+++ b/crates/raven/src/linting/mod.rs
@@ -36,9 +36,9 @@
 //!   message). Named arguments, formal parameters, `$` / `@` field names,
 //!   formula terms, subscripted uses, and callees are exempt.
 //! * `semicolon` — flag `;` statement separators in source. Unlike the other
-//!   rules, this one byte-scans the raw source (skipping every leaf-token
-//!   range: strings, comments, backticked identifiers, `%…%` operators)
-//!   because tree-sitter-r does not emit `;` as a node.
+//!   rules, this one byte-scans the raw source (skipping complete strings and
+//!   every other leaf-token range: comments, backticked identifiers, `%…%`
+//!   operators) because tree-sitter-r does not emit `;` as a node.
 //! * `equals_na` — flag `x == NA`, `x != NA`, and the typed `NA_*` variants
 //!   on either side, plus `x %in% NA`.
 //! * `object_length` — flag identifier names longer than the configured
@@ -2018,6 +2018,17 @@ print.data.frame <- function(x, ...) NULL
         // `;` inside a string or comment is not a separator.
         let diags = lint("x <- \"a;b\"\ny <- 1 # ;\n", &config);
         assert!(diags.is_empty(), "got {:?}", diags);
+    }
+
+    #[test]
+    fn semicolon_ignores_escaped_newline_inside_string() {
+        let config = semicolon_only_config();
+        let diags = lint("x <- \"line one\\nsecond; part\"\n", &config);
+        assert!(diags.is_empty(), "got {:?}", diags);
+
+        let diags = lint("x <- \"line one\\nsecond; part\"; y <- 1\n", &config);
+        assert_eq!(diags.len(), 1, "got {:?}", diags);
+        assert_eq!(diags[0].range.start.character, 29);
     }
 
     // ------------------------------------------------------------------

--- a/crates/raven/src/linting/rules/semicolon.rs
+++ b/crates/raven/src/linting/rules/semicolon.rs
@@ -3,10 +3,13 @@
 //! Mirrors `lintr::semicolon_linter`. Tree-sitter-r does not emit `;` as a
 //! named or anonymous node — it's simply a separator the parser consumes
 //! between statements. To find them we scan the raw source byte-by-byte while
-//! using the tree to skip every leaf-token range: a separator `;` always lies
-//! in the gaps *between* tokens, so any `;` inside a token span (a string,
-//! comment, backtick-quoted identifier like `` `a;b` ``, or user infix
-//! operator like `%;%`) is part of that token, never a separator.
+//! using the tree to skip complete string ranges and every other leaf-token
+//! range. Strings need explicit whole-node handling because escape sequences
+//! are child nodes, leaving the surrounding string content outside the leaf
+//! ranges. A separator `;` always lies in the gaps *between* tokens, so any
+//! `;` inside an excluded span (a string, comment, backtick-quoted identifier
+//! like `` `a;b` ``, or user infix operator like `%;%`) is part of that token,
+//! never a separator.
 //!
 //! Diagnostic anchor: the column of the `;` character itself, on the line it
 //! appears on. We emit one diagnostic per `;` so a line with two semicolons
@@ -31,9 +34,9 @@ pub(crate) fn collect(
     scan(text, &exclusions, severity, suppressions, out);
 }
 
-/// Sorted, non-overlapping byte ranges of leaf tokens — places where a `;` is
-/// part of a token (string, comment, backticked identifier, `%…%` operator),
-/// not a statement separator.
+/// Sorted, non-overlapping byte ranges of complete strings and other leaf
+/// tokens — places where a `;` is part of a token (string, comment, backticked
+/// identifier, `%…%` operator), not a statement separator.
 fn collect_exclusions(root: Node<'_>) -> Vec<(usize, usize)> {
     let mut out = Vec::new();
     walk(root, &mut out);
@@ -42,6 +45,12 @@ fn collect_exclusions(root: Node<'_>) -> Vec<(usize, usize)> {
 }
 
 fn walk(node: Node<'_>, out: &mut Vec<(usize, usize)>) {
+    // Escapes make `string` a non-leaf node. Exclude the complete literal so
+    // the un-noded content around an escape cannot be mistaken for source.
+    if node.kind() == "string" {
+        out.push((node.start_byte(), node.end_byte()));
+        return;
+    }
     if node.child_count() == 0 {
         if node.end_byte() > node.start_byte() {
             out.push((node.start_byte(), node.end_byte()));


### PR DESCRIPTION
## Summary

- exclude complete tree-sitter string nodes from the semicolon rule's raw-source scan
- preserve leaf-token exclusions for comments, backticked identifiers, and user infix operators
- add a regression test for `\n` before an in-string semicolon, plus a true-positive separator immediately after the string
- document why escaped strings require whole-node exclusion

## Root cause

The semicolon rule excluded only leaf-token byte ranges. Tree-sitter represents a string containing an escape sequence as a non-leaf `string` node with escape children, so un-noded string content after the escape was scanned as source and its `;` was misclassified as a statement separator.

## Validation

- TDD red: the new issue reproduction failed at character 22 before the fix
- `cargo test -p raven semicolon_ -- --nocapture`
- `cargo test -p raven --lib` — 5,780 passed, 12 ignored
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p raven --no-deps --document-private-items --features test-support`
- two clean local, no-export code-review passes

Closes #634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semicolon detection to ignore semicolons inside complete string literals, including strings containing escaped newlines.
  * Continued excluding comments, backticked identifiers, and operator ranges from detection.
  * Ensured diagnostics point to the correct character position for actual semicolon separators.

* **Documentation**
  * Clarified the semicolon lint rule’s scanning and exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->