### PR TITLE
Run R code blocks in regular Markdown

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -1,6 +1,6 @@
 # R Code Chunks
 
-Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delimited cells in plain `.R` files. You can run a single chunk, every chunk above the cursor, or every chunk in the document; navigate forward and backward between chunks; and see a subtle background tint that makes chunks easy to scan.
+Raven recognizes R code chunks in R Markdown / Quarto documents and `# %%`-delimited cells in plain `.R` files. In regular Markdown documentation, Raven also provides a `Run Chunk` CodeLens for fenced blocks tagged `r` or `R`. You can run a single chunk, every chunk above the cursor, or every chunk in an R Markdown / Quarto / R-cell document; navigate forward and backward between chunks; and see a subtle background tint that makes chunks easy to scan.
 
 This is the daily-driver workflow for `.Rmd` / `.Rmarkdown` / `.qmd` users coming from RStudio or vscode-R.
 
@@ -12,9 +12,16 @@ This is the daily-driver workflow for `.Rmd` / `.Rmarkdown` / `.qmd` users comin
 | Form | File types | Example header |
 |------|------------|----------------|
 | Fenced block | `.Rmd`, `.Rmarkdown`, `.qmd` | ```` ```{r setup, eval=FALSE} ```` |
+| Markdown R block | `.md`, `.markdown` | ```` ```r ```` |
 | Cell marker | `.R` | `# %% Section 1` |
 
 Fenced blocks may use either backticks or tildes, and four-or-more-character fences nest naturally (so a chunk can contain a literal `` ``` ``).
+
+Regular Markdown support is intentionally limited to execution: an `r` / `R`
+fence gets a single `Run Chunk` CodeLens that sends its body to Raven's R
+console. It does not enable knitting, chunk navigation or highlighting, or R
+language-server features in `.md` files. Like every Raven execution surface,
+the lens appears only when `raven.rConsole.activation` resolves to `enabled`.
 
 Only **R** chunks are sent to the R console. Chunks tagged with other languages (`{python}`, `{bash}`, `{julia}`, …) are still recognized for navigation and outline but not for execution.
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -14,6 +14,7 @@
         "dompurify": "3.4.11",
         "js-yaml": "^4.2.0",
         "jsonc-parser": "^3.3.1",
+        "markdown-it": "^14.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vscode-languageclient": "^9.0.1",
@@ -3631,7 +3632,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5005,7 +5005,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
       "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5183,7 +5182,6 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
       "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5241,7 +5239,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -6082,7 +6079,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7451,7 +7447,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/underscore": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,6 +29,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
+    "onLanguage:markdown",
     "onTerminalProfile:raven.rTerminal",
     "onWebviewPanel:raven.knitOutput",
     "onWebviewPanel:raven.quartoPreview"
@@ -2341,6 +2342,7 @@
     "dompurify": "3.4.11",
     "js-yaml": "^4.2.0",
     "jsonc-parser": "^3.3.1",
+    "markdown-it": "^14.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vscode-languageclient": "^9.0.1",

--- a/editors/vscode/src/chunks/chunk-codelens.ts
+++ b/editors/vscode/src/chunks/chunk-codelens.ts
@@ -86,7 +86,14 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
         // Fast path: plain `.R` files without `# %%` markers (and prose-only
         // `.Rmd` documents) skip the per-line scan entirely.
         if (!has_chunk_anchor(document.getText(), kind)) return [];
-        const lens_command_ids = resolve_lens_command_ids(document);
+        const configured_lens_command_ids = resolve_lens_command_ids(document);
+        // Regular Markdown is documentation, not a chunk-authoring format.
+        // Keep its surface deliberately narrow: an explicitly tagged R block
+        // gets only "Run Chunk", while Rmd/Qmd and `.R` cells retain the full
+        // user-configurable lens row.
+        const lens_command_ids = kind === 'markdown'
+            ? configured_lens_command_ids.filter((id) => id === 'raven.runCurrentChunk')
+            : configured_lens_command_ids;
         if (lens_command_ids.length === 0) return [];
         const lines: string[] = [];
         for (let i = 0; i < document.lineCount; i++) lines.push(document.lineAt(i).text);
@@ -134,9 +141,10 @@ class ChunkCodeLensProvider implements vscode.CodeLensProvider {
 export function register_chunk_codelens(context: vscode.ExtensionContext): ChunkCodeLensProvider {
     const provider = new ChunkCodeLensProvider();
     context.subscriptions.push(
-        // Chunks live in `.R` files (via `# %%` cells) and in `.Rmd` / `.qmd`
-        // files (via fenced code blocks). After the language-ID split each
-        // file type uses its own `languageId`, so the selector lists all three.
+        // Chunks live in `.R` files (via `# %%` cells), `.Rmd` / `.qmd` files
+        // (via knitr-style fenced blocks), and regular Markdown (via bare
+        // ` ```r ` fenced blocks). Registration itself remains gated by the
+        // resolved Raven R-console activation state in `extension.ts`.
         vscode.languages.registerCodeLensProvider(
             [
                 { scheme: 'file', language: 'r' },
@@ -145,6 +153,8 @@ export function register_chunk_codelens(context: vscode.ExtensionContext): Chunk
                 { scheme: 'untitled', language: 'rmd' },
                 { scheme: 'file', language: 'quarto' },
                 { scheme: 'untitled', language: 'quarto' },
+                { scheme: 'file', language: 'markdown' },
+                { scheme: 'untitled', language: 'markdown' },
             ],
             provider,
         ),

--- a/editors/vscode/src/chunks/chunk-commands.ts
+++ b/editors/vscode/src/chunks/chunk-commands.ts
@@ -137,6 +137,12 @@ async function run_chunk_at(
     cursor_line: number,
     target: TerminalTarget = 'managed',
 ): Promise<void> {
+    const kind = classify_chunk_document_for_document(document);
+    // Regular Markdown is deliberately an execution-only, one-block surface.
+    // Commands are registered globally, so enforce the same boundary for
+    // Command Palette and keybinding invocations as the CodeLens provider.
+    if (kind === 'markdown' && mode !== 'current') return;
+
     // Active-terminal path: bail upfront if there is no terminal to send
     // into. Otherwise the `…AndMove` variants would still advance the
     // cursor after `send_to_r` short-circuited on the "no active terminal"

--- a/editors/vscode/src/chunks/chunk-detector.ts
+++ b/editors/vscode/src/chunks/chunk-detector.ts
@@ -1,5 +1,20 @@
+const MarkdownIt = require('markdown-it') as new (options?: { html?: boolean }) => {
+    parse(source: string, env: Record<string, never>): MarkdownItToken[];
+};
+
+interface MarkdownItToken {
+    type: string;
+    map: [number, number] | null;
+    info: string;
+    markup: string;
+    content: string;
+}
+
+const markdown_parser = new MarkdownIt({ html: true });
+
 /**
- * Code-chunk detection for R Markdown / Quarto fenced blocks and `.R` cell markers.
+ * Code-chunk detection for R Markdown / Quarto fenced blocks, regular Markdown
+ * fenced code blocks, and `.R` cell markers.
  *
  * Pure functions (no VS Code dependency) — unit-testable from `tests/bun/`.
  *
@@ -7,13 +22,16 @@
  *   - Rmd/Qmd fenced block: ```` ```{r ...} ```` … ```` ``` ```` (backticks or tildes,
  *     fence must start at column 0; closing fence must use the same character and be
  *     at least as long as the opener).
+ *   - Markdown fenced block: ```` ```r ```` … ```` ``` ```` (backticks or tildes,
+ *     case-insensitive language tag, with up to three leading spaces as CommonMark
+ *     permits for a top-level fence).
  *   - `.R` cell marker: a line matching `/^#+\s*%%/` starts a new cell that extends
  *     until the next marker or end-of-file.
  *
  * The `language` field is normalized to lower case. For `.R` cells it is always `'r'`.
  */
 
-export type ChunkKind = 'rmd' | 'r';
+export type ChunkKind = 'rmd' | 'markdown' | 'r';
 export type DocumentKind = ChunkKind;
 
 export interface Chunk {
@@ -21,14 +39,14 @@ export interface Chunk {
     header_line: number;
     /**
      * 0-based line index of the last content line (inclusive).
-     * For an Rmd chunk, this is one line above `closing_fence_line` when the fence
-     * is present, or the last line of the file when unclosed.
+     * For a fenced chunk, this is one line above `closing_fence_line` when the
+     * fence is present, or the last line of the file when unclosed.
      * For a `.R` cell, this is the line above the next cell marker (or EOF).
      */
     end_line: number;
     /**
-     * 0-based line index of the closing fence (Rmd only). `null` for `.R` cells and
-     * for unclosed Rmd chunks that run off the end of the file.
+     * 0-based line index of the closing fence. `null` for `.R` cells and for
+     * unclosed fenced chunks that run off the end of the file.
      */
     closing_fence_line: number | null;
     /** Language tag from the chunk header, lower-cased. `.R` cells are always `'r'`. */
@@ -41,6 +59,8 @@ export interface Chunk {
     is_eval_false: boolean;
     /** Marker for which detection path produced this chunk. */
     kind: ChunkKind;
+    /** Parser-normalized body for Markdown fences. */
+    executable_code?: string;
 }
 
 const FENCE_HEADER_RE = /^(`{3,}|~{3,})\s*\{([A-Za-z0-9_+.\-]+)([^}]*)\}\s*$/;
@@ -70,23 +90,30 @@ const SECTION_DIVIDER_RE = /^#+(?!')\s*.*[-#+=*]{4,}\s*$/;
 export function classify_chunk_document(file_name_or_uri: string): DocumentKind {
     const lower = file_name_or_uri.toLowerCase();
     if (lower.endsWith('.rmd') || lower.endsWith('.rmarkdown') || lower.endsWith('.qmd')) return 'rmd';
+    if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'markdown';
     return 'r';
 }
 
 /**
  * Classify a document by inspecting both its languageId and its URI. Used at
  * the VS Code adapter layer (commands, CodeLens, decorations) where we have
- * a full `TextDocument`. Checks languageId first so untitled buffers — which
- * have no file extension to inspect — classify correctly under our `rmd` /
- * `quarto` language IDs, then falls back to the extension-based check as a
- * safety net for environments where another extension has claimed the
- * languageId for `.Rmd` / `.Rmarkdown` / `.qmd` files.
+ * a full `TextDocument`. Language IDs classify untitled buffers, while saved
+ * Rmd/Qmd paths retain their extension-backed classification if another
+ * extension or user association reports them as generic Markdown.
  */
 export function classify_chunk_document_for_document(
     document: { languageId: string; uri: { fsPath: string; path: string } },
 ): DocumentKind {
     const lang = document.languageId.toLowerCase();
     if (lang === 'rmd' || lang === 'quarto') return 'rmd';
+    if (lang === 'markdown') {
+        // Saved Rmd/Qmd files can be claimed as generic Markdown by a user
+        // association or sibling extension. Preserve their extension-backed
+        // knitr classification; the languageId path is authoritative for
+        // untitled Markdown buffers and ordinary Markdown paths.
+        const path_kind = classify_chunk_document(document.uri.fsPath || document.uri.path);
+        return path_kind === 'rmd' ? 'rmd' : 'markdown';
+    }
     return classify_chunk_document(document.uri.fsPath || document.uri.path);
 }
 
@@ -195,7 +222,9 @@ function eval_false_from_options(options: Record<string, string>): boolean {
  * `kind` controls which form to look for (caller decides via `classify_chunk_document`).
  */
 export function detect_chunks(lines: string[], kind: DocumentKind): Chunk[] {
-    return kind === 'rmd' ? detect_rmd_chunks(lines) : detect_r_cells(lines);
+    if (kind === 'rmd') return detect_rmd_chunks(lines);
+    if (kind === 'markdown') return detect_markdown_chunks(lines);
+    return detect_r_cells(lines);
 }
 
 function detect_rmd_chunks(lines: string[]): Chunk[] {
@@ -236,6 +265,62 @@ function detect_rmd_chunks(lines: string[]): Chunk[] {
         i = closing_line !== null ? closing_line + 1 : lines.length;
     }
     return chunks;
+}
+
+/**
+ * Detect ordinary Markdown fenced code blocks from their first info-string
+ * token. Unlike knitr chunks, these use a bare language tag (` ```r ` rather
+ * than ` ```{r} `) and carry no Raven-interpreted chunk options.
+ *
+ * `markdown-it` supplies CommonMark-compatible block parsing and source maps,
+ * so fences inside containers and raw HTML follow the same core block parsing
+ * used by VS Code's Markdown rendering. The CodeLens provider later filters
+ * the returned fence tokens through `is_runnable_chunk`.
+ */
+function detect_markdown_chunks(lines: string[]): Chunk[] {
+    const chunks: Chunk[] = [];
+    const parse_lines = mask_markdown_frontmatter(lines);
+    for (const token of markdown_parser.parse(parse_lines.join('\n'), {})) {
+        if (token.type !== 'fence' || token.map === null) continue;
+        const [header_line, block_end] = token.map;
+        const raw_info = token.info.trim();
+        const language = (raw_info.split(/[ \t]/, 1)[0] ?? '').toLowerCase();
+        const executable_code = token.content.endsWith('\n')
+            ? token.content.slice(0, -1)
+            : token.content;
+        const content_line_count = executable_code.length === 0
+            ? 0
+            : executable_code.split('\n').length;
+        const closing_fence_line = block_end > header_line + content_line_count + 1
+            ? block_end - 1
+            : null;
+        chunks.push({
+            header_line,
+            end_line: content_line_count === 0 ? header_line : header_line + content_line_count,
+            closing_fence_line,
+            language,
+            label: null,
+            options: {},
+            is_eval_false: false,
+            kind: 'markdown',
+            executable_code,
+        });
+    }
+    return chunks;
+}
+
+/** Blank terminated leading YAML front matter while preserving source lines. */
+function mask_markdown_frontmatter(lines: string[]): string[] {
+    if (lines.length === 0 || !/^---[ \t]*$/.test(lines[0].replace(/^\uFEFF/, ''))) {
+        return lines;
+    }
+    for (let i = 1; i < lines.length; i++) {
+        if (!/^(?:---|\.\.\.)[ \t]*$/.test(lines[i])) continue;
+        const masked = lines.slice();
+        for (let j = 0; j <= i; j++) masked[j] = '';
+        return masked;
+    }
+    return lines;
 }
 
 function detect_r_cells(lines: string[]): Chunk[] {
@@ -286,8 +371,8 @@ function detect_r_cells(lines: string[]): Chunk[] {
 
 /**
  * Find the chunk that contains a given 0-based line index, or `null` if the line
- * is outside any chunk. The header line and (for Rmd) the closing fence line are
- * considered "inside" the chunk.
+ * is outside any chunk. The header and closing-fence lines are considered
+ * "inside" fenced chunks.
  */
 export function find_chunk_at_line(chunks: Chunk[], line: number): Chunk | null {
     for (const c of chunks) {
@@ -359,6 +444,9 @@ export function next_runnable_chunk(chunks: Chunk[], line: number): Chunk | null
  * Excludes the header/fence lines.
  */
 export function extract_chunk_code(lines: string[], chunk: Chunk): string {
+    if (chunk.kind === 'markdown' && chunk.executable_code !== undefined) {
+        return chunk.executable_code;
+    }
     const start = chunk.header_line + 1;
     const end = chunk.end_line;
     if (start > end) return '';

--- a/editors/vscode/src/chunks/chunk-navigation.ts
+++ b/editors/vscode/src/chunks/chunk-navigation.ts
@@ -1,6 +1,17 @@
 import * as vscode from 'vscode';
 import { chunks_for_document } from './chunk-commands';
-import { Chunk, find_chunk_at_line } from './chunk-detector';
+import {
+    Chunk,
+    classify_chunk_document_for_document,
+    find_chunk_at_line,
+} from './chunk-detector';
+
+function supports_chunk_navigation(document: vscode.TextDocument): boolean {
+    // Regular Markdown intentionally gets only the execution CodeLens. Keep
+    // the globally registered palette commands from turning it into another
+    // chunk-authoring surface.
+    return classify_chunk_document_for_document(document) !== 'markdown';
+}
 
 function move_to_line(editor: vscode.TextEditor, line: number): void {
     const safe = Math.max(0, Math.min(line, editor.document.lineCount - 1));
@@ -14,6 +25,7 @@ function move_to_line(editor: vscode.TextEditor, line: number): void {
 function go_to_next(): void {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
+    if (!supports_chunk_navigation(editor.document)) return;
     const chunks = chunks_for_document(editor.document);
     if (chunks.length === 0) return;
     const cursor = editor.selection.active.line;
@@ -30,6 +42,7 @@ function go_to_next(): void {
 function go_to_previous(): void {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
+    if (!supports_chunk_navigation(editor.document)) return;
     const chunks = chunks_for_document(editor.document);
     if (chunks.length === 0) return;
     const cursor = editor.selection.active.line;
@@ -52,6 +65,7 @@ function go_to_previous(): void {
 function select_current(): void {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
+    if (!supports_chunk_navigation(editor.document)) return;
     const chunks = chunks_for_document(editor.document);
     if (chunks.length === 0) return;
     const cursor = editor.selection.active.line;

--- a/editors/vscode/src/test/chunks.test.ts
+++ b/editors/vscode/src/test/chunks.test.ts
@@ -59,6 +59,19 @@ const R_CELL_FIXTURE = [
     '',
 ].join('\n');
 
+const MARKDOWN_FIXTURE = [
+    '# Technical notes',
+    '',
+    '```r',
+    'summary(cars)',
+    '```',
+    '',
+    '```python',
+    'print("not R")',
+    '```',
+    '',
+].join('\n');
+
 const TEMP_FIXTURE_FILES: string[] = [];
 
 /**
@@ -70,17 +83,19 @@ const TEMP_FIXTURE_FILES: string[] = [];
  *     `.rmd` file exercises both paths and sidesteps a Linux VS Code
  *     1.120 quirk where untitled buffers can drop a freshly-contributed
  *     languageId when the extension host hasn't loaded yet.
+ *   - `'markdown'` — regular Markdown fenced-code mode. Written to `.md`.
  *   - `'r'` — plain R / `# %%` cell-marker mode. Uses an untitled buffer
  *     because `'r'` has been a registered languageId since day one and
  *     reliably survives the round-trip.
  */
 async function open_doc(
     content: string,
-    language: 'rmd' | 'r' = 'rmd',
+    language: 'rmd' | 'markdown' | 'r' = 'rmd',
 ): Promise<vscode.TextEditor> {
     let editor: vscode.TextEditor;
-    if (language === 'rmd') {
-        const tmp = path.join(os.tmpdir(), `raven-chunks-${randomUUID()}.rmd`);
+    if (language === 'rmd' || language === 'markdown') {
+        const extension = language === 'rmd' ? 'rmd' : 'md';
+        const tmp = path.join(os.tmpdir(), `raven-chunks-${randomUUID()}.${extension}`);
         fs.writeFileSync(tmp, content);
         TEMP_FIXTURE_FILES.push(tmp);
         const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmp));
@@ -858,6 +873,84 @@ suite('chunk commands: registration and behavior', () => {
                 previous,
                 vscode.ConfigurationTarget.Global,
             );
+        }
+    });
+
+    test('regular Markdown shows only Run Chunk for R fences and executes its body', async function () {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunkAt');
+        if (r_console_disabled) return;
+        const editor = await open_doc(MARKDOWN_FIXTURE, 'markdown');
+        const config = vscode.workspace.getConfiguration();
+        const previous = config.inspect<string[]>('raven.chunks.codeLens.commands')?.globalValue;
+        try {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                ['raven.runCurrentChunk', 'raven.runAllChunks', 'raven.runBelowChunks'],
+                vscode.ConfigurationTarget.Global,
+            );
+            const lenses = await poll_for_lenses(
+                editor.document.uri,
+                (ls) => ls.length === 1,
+            );
+            assert.strictEqual(lenses.length, 1, 'Markdown should expose one lens for its R block');
+            assert.strictEqual(lenses[0].command?.title, '▷ Run Chunk');
+
+            await dispose_any_cached_r_terminal();
+            const term = stub_create_terminal();
+            try {
+                const command = lenses[0].command;
+                assert.ok(command, 'Run Chunk lens should carry a command');
+                await vscode.commands.executeCommand(command.command, ...(command.arguments ?? []));
+                assert.ok(
+                    term.sent.join('\n').includes('summary(cars)'),
+                    `expected Markdown R block body to reach terminal, got: ${term.sent.join('\n')}`,
+                );
+                assert.ok(
+                    !term.sent.join('\n').includes('print("not R")'),
+                    'non-R Markdown block must not be sent',
+                );
+            } finally {
+                term.restore();
+            }
+        } finally {
+            await config.update(
+                'raven.chunks.codeLens.commands',
+                previous,
+                vscode.ConfigurationTarget.Global,
+            );
+        }
+    });
+
+    test('regular Markdown does not participate in chunk navigation commands', async function () {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.goToNextChunk');
+        if (r_console_disabled) return;
+        const editor = await open_doc(MARKDOWN_FIXTURE, 'markdown');
+        place_cursor(editor, 0);
+        await execute_chunk_command(editor, 'raven.goToNextChunk');
+        assert.strictEqual(
+            editor.selection.active.line,
+            0,
+            'Markdown navigation command should leave the cursor unchanged',
+        );
+    });
+
+    test('regular Markdown rejects multi-chunk and cursor-moving run commands', async function () {
+        const r_console_disabled = !(await vscode.commands.getCommands(true))
+            .includes('raven.runCurrentChunkAndMove');
+        if (r_console_disabled) return;
+        const editor = await open_doc(MARKDOWN_FIXTURE, 'markdown');
+        place_cursor(editor, 3);
+        await dispose_any_cached_r_terminal();
+        const term = stub_create_terminal();
+        try {
+            await execute_chunk_command(editor, 'raven.runCurrentChunkAndMove');
+            await execute_chunk_command(editor, 'raven.runAllChunks');
+            assert.strictEqual(editor.selection.active.line, 3);
+            assert.strictEqual(term.sent.length, 0);
+        } finally {
+            term.restore();
         }
     });
 

--- a/tests/bun/chunk-detector.test.ts
+++ b/tests/bun/chunk-detector.test.ts
@@ -37,8 +37,225 @@ describe('classify_chunk_document', () => {
         expect(classify_chunk_document('/tmp/foo.r')).toBe('r');
     });
 
+    test('treats .md / .markdown as markdown', () => {
+        expect(classify_chunk_document('/tmp/notes.md')).toBe('markdown');
+        expect(classify_chunk_document('/tmp/notes.MD')).toBe('markdown');
+        expect(classify_chunk_document('/tmp/notes.markdown')).toBe('markdown');
+    });
+
     test('falls back to r for unknown extensions', () => {
         expect(classify_chunk_document('/tmp/foo.txt')).toBe('r');
+    });
+});
+
+describe('detect_chunks — regular Markdown fenced blocks', () => {
+    test('detects case-insensitive bare R fences', () => {
+        const src = lines([
+            '# Technical notes',
+            '```R',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('r');
+        expect(chunks[0].header_line).toBe(1);
+        expect(chunks[0].end_line).toBe(2);
+        expect(chunks[0].closing_fence_line).toBe(3);
+        expect(chunks[0].kind).toBe('markdown');
+    });
+
+    test('detects tilde fences and up to three leading spaces', () => {
+        const src = lines([
+            '   ~~~r',
+            '   x <- 1',
+            ' y <- 2',
+            '  ~~~',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('r');
+        expect(chunks[0].closing_fence_line).toBe(3);
+        expect(extract_chunk_code(src, chunks[0])).toBe('x <- 1\ny <- 2');
+    });
+
+    test('recognizes non-R fences but leaves them non-runnable', () => {
+        const src = lines([
+            '```python',
+            'print("not R")',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('python');
+        expect(is_runnable_chunk(chunks[0])).toBe(false);
+    });
+
+    test('does not treat knitr-style fences as regular Markdown R blocks', () => {
+        const src = lines([
+            '```{r}',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('{r}');
+        expect(is_runnable_chunk(chunks[0])).toBe(false);
+    });
+
+    test('does not discover an R fence nested inside a longer non-R fence', () => {
+        const src = lines([
+            '````text',
+            '```r',
+            'x <- 1',
+            '```',
+            '````',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('text');
+        expect(chunks[0].closing_fence_line).toBe(4);
+    });
+
+    test('does not discover an R fence nested inside an untagged outer fence', () => {
+        const src = lines([
+            '````',
+            '```r',
+            'x <- 1',
+            '```',
+            '````',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('');
+        expect(chunks[0].closing_fence_line).toBe(4);
+    });
+
+    test('permits backticks in tilde-fence info strings without exposing nested R fences', () => {
+        const src = lines([
+            '~~~text`meta`',
+            '```r',
+            'x <- 1',
+            '```',
+            '~~~',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].language).toBe('text`meta`');
+        expect(chunks[0].closing_fence_line).toBe(4);
+    });
+
+    test('rejects backticks anywhere in a backtick-fence info string', () => {
+        const src = lines([
+            '```r title=`demo`',
+            'not part of a valid fenced block',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.every((chunk) => !is_runnable_chunk(chunk))).toBe(true);
+    });
+
+    test('ignores fenced-looking text inside multiline HTML comments', () => {
+        const src = lines([
+            '<!-- disabled example',
+            '```r',
+            'stop("must not run")',
+            '```',
+            '-->',
+            '```r',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(5);
+    });
+
+    test('does not let inline comment syntax suppress a later fence', () => {
+        const src = lines([
+            'Document the literal `<!--` token here.',
+            '',
+            '```r',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(2);
+    });
+
+    test('ignores fenced-looking text inside raw HTML blocks', () => {
+        const src = lines([
+            '<pre>',
+            '```r',
+            'stop("must not run")',
+            '```',
+            '</pre>',
+            '<div>',
+            '```r',
+            'also_not_runnable()',
+            '```',
+            '',
+            '```r',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(10);
+    });
+
+    test('dedents tabs using CommonMark four-column tab stops', () => {
+        const src = lines([
+            '   ```r',
+            '\tfoo',
+            ' \tbar',
+            '   ```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(extract_chunk_code(src, chunks[0])).toBe(' foo\n bar');
+    });
+
+    test('recognizes fences nested in Markdown containers', () => {
+        const src = lines([
+            '- example',
+            '',
+            '  ```r',
+            '  x <- 1',
+            '  ```',
+            '',
+            '> ```R',
+            '> y <- 2',
+            '> ```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(2);
+        expect(chunks[0].header_line).toBe(2);
+        expect(chunks[0].closing_fence_line).toBe(4);
+        expect(extract_chunk_code(src, chunks[0])).toBe('x <- 1');
+        expect(chunks[1].header_line).toBe(6);
+        expect(chunks[1].closing_fence_line).toBe(8);
+        expect(extract_chunk_code(src, chunks[1])).toBe('y <- 2');
+    });
+
+    test('ignores fenced-looking examples inside YAML front matter', () => {
+        const src = lines([
+            '---',
+            'title: Technical notes',
+            'example: |',
+            '  ```r',
+            '  stop("metadata only")',
+            '  ```',
+            '---',
+            '',
+            '```r',
+            'x <- 1',
+            '```',
+        ].join('\n'));
+        const chunks = detect_chunks(src, 'markdown');
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].header_line).toBe(8);
+        expect(extract_chunk_code(src, chunks[0])).toBe('x <- 1');
     });
 });
 
@@ -595,6 +812,18 @@ describe('classify_chunk_document_for_document', () => {
         expect(classify_chunk_document_for_document(qdoc)).toBe('rmd');
     });
 
+    test('prefers the Markdown languageId for untitled buffers', () => {
+        const doc = { languageId: 'Markdown', uri: { fsPath: '', path: 'Untitled-1' } };
+        expect(classify_chunk_document_for_document(doc)).toBe('markdown');
+    });
+
+    test('preserves Rmd/Qmd extension classification under a Markdown languageId', () => {
+        const rmd = { languageId: 'markdown', uri: { fsPath: '/tmp/report.Rmd', path: '/tmp/report.Rmd' } };
+        expect(classify_chunk_document_for_document(rmd)).toBe('rmd');
+        const qmd = { languageId: 'markdown', uri: { fsPath: '/tmp/report.qmd', path: '/tmp/report.qmd' } };
+        expect(classify_chunk_document_for_document(qmd)).toBe('rmd');
+    });
+
     test('falls back to URI extension for `r` languageId', () => {
         const rmd = { languageId: 'r', uri: { fsPath: '/tmp/report.Rmd', path: '/tmp/report.Rmd' } };
         expect(classify_chunk_document_for_document(rmd)).toBe('rmd');
@@ -633,6 +862,10 @@ describe('has_chunk_anchor', () => {
     test('returns true when an Rmd document contains backtick or tilde fences', () => {
         expect(has_chunk_anchor('```{r}\n1\n```\n', 'rmd')).toBe(true);
         expect(has_chunk_anchor('~~~{r}\n1\n~~~\n', 'rmd')).toBe(true);
+    });
+
+    test('returns true when a Markdown document contains a fence', () => {
+        expect(has_chunk_anchor('```r\n1\n```\n', 'markdown')).toBe(true);
     });
 
     test('does not false-trigger on single backticks (inline code)', () => {

--- a/tests/bun/vscode-config.test.ts
+++ b/tests/bun/vscode-config.test.ts
@@ -161,6 +161,24 @@ test("VS Code package metadata activates on r/jags/stan via contributes.language
   expect(languageIds).toContain("stan");
 });
 
+test("VS Code package metadata explicitly activates for Markdown CodeLens", () => {
+  // Markdown is owned by VS Code, not contributed by Raven, so it does not
+  // receive Raven's implicit activation event. The explicit event is required
+  // for the programmatic CodeLens provider to register when a Markdown file is
+  // the first Raven-relevant document opened in a window.
+  const packageJsonPath = path.join(
+    import.meta.dir,
+    "..",
+    "..",
+    "editors",
+    "vscode",
+    "package.json",
+  );
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  expect(pkg.activationEvents).toContain("onLanguage:markdown");
+});
+
 test("VS Code package metadata pins R Markdown files to the rmd language via files.associations", () => {
   // The Quarto extension contributes `editorLangId == quarto` for `.rmd` (it
   // accepts both `.qmd` and `.rmd`). When only Raven and Quarto are installed,


### PR DESCRIPTION
## What

- add a `Run Chunk` CodeLens for fenced `r` / `R` blocks in regular `.md` and `.markdown` files
- keep regular Markdown execution-only: no chunk navigation, highlighting, knitting, multi-chunk commands, or LSP attachment
- gate registration on Raven's resolved R-console activation state
- parse Markdown fences with `markdown-it`, including containers, raw HTML, comments, indentation, and YAML front matter

## Why

Technical documentation often contains runnable R examples. This makes those examples easy to execute without turning ordinary Markdown into a second R Markdown authoring mode.

## Validation

- `bun test tests/bun/chunk-detector.test.ts tests/bun/vscode-config.test.ts` — 88 passed
- `bun run typecheck`
- focused VS Code extension-host chunk suite — 32 passed
- production extension bundle succeeds
- broad repository run — 1,677 passed; the workspace wrapper hit its 10-minute timeout while its VS Code child continued (no feature failure)
- xhigh code review clean twice consecutively
