### PR TITLE
feat(cross-file): treat tar_option_set(packages=) as package attachment

### DIFF
--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -19295,6 +19295,93 @@ x <- 1"#;
     }
 
     #[test]
+    fn test_package_propagation_tar_option_set_parent_packages_in_child() {
+        // Issue #637: a `_targets.R`-style parent that attaches packages via
+        // `tar_option_set(packages = ...)` propagates them to sourced children,
+        // exactly like `library()` — mirrors
+        // `test_package_propagation_child_packages_in_parent` wiring.
+        use crate::cross_file::dependency::DependencyGraph;
+        use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+
+        // Parent (_targets.R shape): library(targets), tar_option_set, then
+        // source("child.R") at line 2.
+        let parent_code =
+            "library(targets)\ntar_option_set(packages = c(\"dplyr\"))\nsource(\"child.R\")";
+        let parent_tree = parse_r(parent_code);
+        let parent_uri = Url::parse("file:///project/parent.R").unwrap();
+        let parent_artifacts = compute_artifacts(&parent_uri, &parent_tree, parent_code);
+
+        // Child file: uses a dplyr verb.
+        let child_code = "mutate(df, y = 1)";
+        let child_tree = parse_r(child_code);
+        let child_uri = Url::parse("file:///project/child.R").unwrap();
+        let child_artifacts = compute_artifacts(&child_uri, &child_tree, child_code);
+
+        let workspace_root = Url::parse("file:///project").unwrap();
+
+        let mut graph = DependencyGraph::new();
+        let parent_meta = CrossFileMetadata {
+            sources: vec![ForwardSource {
+                path: "child.R".to_string(),
+                line: 2,
+                column: 0,
+                is_directive: false,
+                local: false,
+                chdir: false,
+                is_sys_source: false,
+                sys_source_global_env: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        graph.update_file(&parent_uri, &parent_meta, Some(&workspace_root), |_| None);
+
+        let get_artifacts = |uri: &Url| -> Option<Arc<ScopeArtifacts>> {
+            if uri == &parent_uri {
+                Some(Arc::new(parent_artifacts.clone()))
+            } else if uri == &child_uri {
+                Some(Arc::new(child_artifacts.clone()))
+            } else {
+                None
+            }
+        };
+
+        let get_metadata = |uri: &Url| -> Option<std::sync::Arc<CrossFileMetadata>> {
+            if uri == &parent_uri {
+                Some(std::sync::Arc::new(parent_meta.clone()))
+            } else {
+                None
+            }
+        };
+
+        // Query the child's scope: dplyr comes from the parent's
+        // tar_option_set(), which precedes the source() call.
+        let child_scope = scope_at_position_with_graph(
+            &child_uri,
+            0,
+            0,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&workspace_root),
+            10,
+            &HashSet::new(),
+            false,
+            crate::cross_file::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+
+        assert!(
+            child_scope.inherited_packages.contains("dplyr"),
+            "child sourced by a _targets.R-style parent should inherit dplyr from \
+             tar_option_set(packages = ...); inherited: {:?}",
+            child_scope.inherited_packages,
+        );
+    }
+
+    #[test]
     fn test_package_propagation_child_symbols_and_packages_in_parent() {
         // Symbols from child files are merged into parent scope, and packages
         // loaded in child files should be available after source().

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -68,7 +68,9 @@ pub struct LibraryCall {
     /// Whether the call *attaches* the package to the search path so its exports
     /// become available as bare names: `true` for `library()` / `require()`,
     /// `false` for `loadNamespace()` (which loads the namespace for qualified
-    /// `pkg::fn` access only).
+    /// `pkg::fn` access only). Packages recognized from a {targets}
+    /// `tar_option_set(packages = ...)` call are also `true` — targets attaches
+    /// them before running each target, so downstream scripts use bare names.
     ///
     /// Consumers must require `attaches` only when they gate on a *bare function*
     /// being resolvable — e.g. Shiny deferred-helper recognition
@@ -840,8 +842,9 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 // ============================================================================
 
 /// Detects package loads in the file: direct `library()`/`require()`/`loadNamespace()`
-/// calls, plus apply-family calls whose FUN argument is a bare reference to
-/// `library` or `require`.
+/// calls, apply-family calls whose FUN argument is a bare reference to
+/// `library` or `require`, and {targets} `tar_option_set(packages = ...)`
+/// calls (see `try_parse_tar_option_set_call`).
 ///
 /// For direct calls, the package must be a bare identifier (`library(dplyr)`)
 /// or a string literal (`library("dplyr")`); direct calls with
@@ -855,6 +858,12 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 /// Each apply emits one `LibraryCall` per package, all sharing the apply
 /// call's end position.
 ///
+/// For `tar_option_set(packages = ...)` calls, the bare spelling is honored
+/// only when the same file also attaches targets (`library(targets)` /
+/// `require(targets)` anywhere in the file); `targets::` / `targets:::`
+/// qualified spellings are honored unconditionally. See
+/// `append_gated_tar_option_set_calls` for the gate.
+///
 /// # Examples
 ///
 /// ```
@@ -862,18 +871,28 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 ///
 /// let mut parser = tree_sitter::Parser::new();
 /// parser.set_language(&tree_sitter_r::LANGUAGE.into()).unwrap();
-/// let source = r#"library(dplyr)"#;
+/// let source = "library(targets)\ntar_option_set(packages = c(\"dplyr\"))";
 /// let tree = parser.parse(source, None).unwrap();
 /// let calls = detect_library_calls(&tree, source);
-/// assert_eq!(calls.len(), 1);
-/// assert_eq!(calls[0].package, "dplyr");
+/// assert_eq!(calls.len(), 2);
+/// assert_eq!(calls[0].package, "targets");
+/// assert_eq!(calls[1].package, "dplyr");
+/// assert!(calls[1].attaches);
 /// ```
 pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
     log::trace!("Starting tree-sitter parsing for library() call detection");
     let mut library_calls = Vec::new();
+    let mut tar_candidates = Vec::new();
     let root = tree.root_node();
     let var_lookup = collect_var_bindings(root, content);
-    visit_node_for_library(root, content, &var_lookup, &mut library_calls);
+    visit_node_for_library(
+        root,
+        content,
+        &var_lookup,
+        &mut library_calls,
+        &mut tar_candidates,
+    );
+    append_gated_tar_option_set_calls(&mut library_calls, tar_candidates);
     log::trace!(
         "Completed library() call detection, found {} calls",
         library_calls.len()
@@ -912,6 +931,12 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
 /// `requireNamespace()` is NOT a match (it isn't a `library`/`require`/
 /// `loadNamespace` call), so it never attaches here.
 ///
+/// Top-level {targets} `tar_option_set(packages = ...)` calls also attach
+/// (targets attaches the listed packages before running each target); the bare
+/// spelling requires a top-level `library(targets)`/`require(targets)` in the
+/// same text, while `targets::`/`targets:::` qualified spellings do not — see
+/// `append_gated_tar_option_set_calls`.
+///
 /// Returns an empty set when the text cannot be parsed.
 ///
 /// # Examples
@@ -942,7 +967,17 @@ pub fn extract_attached_packages(text: &str) -> std::collections::BTreeSet<Strin
     let root = tree.root_node();
     let var_lookup = collect_var_bindings(root, text);
     let mut calls = Vec::new();
-    visit_node_for_top_level_library(root, text, &var_lookup, false, false, &mut calls);
+    let mut tar_candidates = Vec::new();
+    visit_node_for_top_level_library(
+        root,
+        text,
+        &var_lookup,
+        false,
+        false,
+        &mut calls,
+        &mut tar_candidates,
+    );
+    append_gated_tar_option_set_calls(&mut calls, tar_candidates);
     calls
         .into_iter()
         .filter(|call| call.attaches && !call.package.is_empty())
@@ -959,6 +994,11 @@ pub fn extract_attached_packages(text: &str) -> std::collections::BTreeSet<Strin
 /// code (`local({ ... })` blocks DO attach — they evaluate immediately).
 /// `inside_fn` latches once an ancestor `function_definition` is entered;
 /// `inside_quote` latches once an ancestor quoting call is entered.
+///
+/// `tar_option_set(packages = ...)` candidates found at the top level are
+/// pushed into `tar_candidates` rather than `library_calls`; the caller
+/// applies the targets-in-play gate afterwards via
+/// [`append_gated_tar_option_set_calls`].
 fn visit_node_for_top_level_library(
     node: Node,
     content: &str,
@@ -966,6 +1006,7 @@ fn visit_node_for_top_level_library(
     inside_fn: bool,
     inside_quote: bool,
     library_calls: &mut Vec<LibraryCall>,
+    tar_candidates: &mut Vec<TarOptionSetCandidate>,
 ) {
     // Identifier nodes have no children and cannot be calls.
     if node.kind() == "identifier" {
@@ -982,7 +1023,10 @@ fn visit_node_for_top_level_library(
         if let Some(lib_call) = try_parse_library_call(node, content) {
             library_calls.push(lib_call);
         } else {
+            // The apply-family and tar_option_set callee name-sets are
+            // disjoint, so at most one of these can match.
             library_calls.extend(try_parse_apply_library_call(node, content, var_lookup));
+            collect_tar_option_set_candidates(node, content, var_lookup, tar_candidates);
         }
     }
     for child in node.children(&mut node.walk()) {
@@ -993,6 +1037,7 @@ fn visit_node_for_top_level_library(
             inside_fn,
             inside_quote,
             library_calls,
+            tar_candidates,
         );
     }
 }
@@ -1037,20 +1082,25 @@ pub(crate) fn is_nonevaluating_quote_call(node: Node, content: &str) -> bool {
 }
 
 /// Recursively traverses an AST subtree and collects statically determinable
-/// package loads — both direct `library`/`require`/`loadNamespace` calls and
+/// package loads — direct `library`/`require`/`loadNamespace` calls and
 /// apply-family calls whose FUN is `library`/`require`. Direct calls push at
 /// most one `LibraryCall`; apply calls may push one entry per package, all
-/// sharing the apply call's end position.
+/// sharing the apply call's end position. {targets}
+/// `tar_option_set(packages = ...)` calls are collected separately into
+/// `tar_candidates` so the caller can apply the targets-in-play gate after
+/// the walk via [`append_gated_tar_option_set_calls`].
 ///
 /// # Parameters
 ///
 /// - `node`: the current AST node to visit (will recurse into its children).
 /// - `content`: source text for extracting node-local values when parsing calls.
 /// - `var_lookup`: name→binding map (built once via [`collect_var_bindings`])
-///   used by apply detection to resolve same-file variable references like
-///   `libs <- c(...); sapply(libs, library, character.only = TRUE)`.
+///   used by apply and tar_option_set detection to resolve same-file variable
+///   references like `libs <- c(...); sapply(libs, library, character.only = TRUE)`.
 /// - `library_calls`: mutable collector that receives discovered `LibraryCall`
 ///   entries in document order.
+/// - `tar_candidates`: mutable collector for gate-pending
+///   `tar_option_set(packages = ...)` package attachments.
 ///
 /// # Examples
 ///
@@ -1058,9 +1108,10 @@ pub(crate) fn is_nonevaluating_quote_call(node: Node, content: &str) -> bool {
 ///
 /// ```text
 /// let mut library_calls = Vec::new();
+/// let mut tar_candidates = Vec::new();
 /// let root = tree.root_node();
 /// let var_lookup = collect_var_bindings(root, source_text);
-/// visit_node_for_library(root, source_text, &var_lookup, &mut library_calls);
+/// visit_node_for_library(root, source_text, &var_lookup, &mut library_calls, &mut tar_candidates);
 /// assert!(library_calls.iter().all(|c| !c.package.is_empty()));
 /// ```
 fn visit_node_for_library(
@@ -1068,6 +1119,7 @@ fn visit_node_for_library(
     content: &str,
     var_lookup: &HashMap<String, VarBinding>,
     library_calls: &mut Vec<LibraryCall>,
+    tar_candidates: &mut Vec<TarOptionSetCandidate>,
 ) {
     // Skip identifier nodes - they have no children
     if node.kind() == "identifier" {
@@ -1078,13 +1130,16 @@ fn visit_node_for_library(
             library_calls.push(lib_call);
         } else {
             // Not a direct library/require/loadNamespace call; try the
-            // apply-family form (sapply/map/etc. of bare library/require).
+            // apply-family form (sapply/map/etc. of bare library/require) and
+            // the tar_option_set form. The two callee name-sets are disjoint,
+            // so at most one of these can match.
             library_calls.extend(try_parse_apply_library_call(node, content, var_lookup));
+            collect_tar_option_set_candidates(node, content, var_lookup, tar_candidates);
         }
     }
 
     for child in node.children(&mut node.walk()) {
-        visit_node_for_library(child, content, var_lookup, library_calls);
+        visit_node_for_library(child, content, var_lookup, library_calls, tar_candidates);
     }
 }
 
@@ -1638,6 +1693,18 @@ fn apply_arg_positions(func_node: Node, content: &str) -> Option<(usize, usize)>
 /// non-string element, named argument, or empty `c()` — anything but a fully
 /// static character vector is treated as dynamic.
 fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
+    extract_c_string_nodes_strict(node, content)
+        .map(|pairs| pairs.into_iter().map(|(s, _)| s).collect())
+}
+
+/// Like [`extract_c_strings_strict`], but pairs each extracted string with its
+/// own string-literal `Node` so callers can anchor per-package positions (see
+/// `try_parse_tar_option_set_call`). This is the single implementation; the
+/// string-only variant delegates here.
+fn extract_c_string_nodes_strict<'tree>(
+    node: Node<'tree>,
+    content: &str,
+) -> Option<Vec<(String, Node<'tree>)>> {
     if !is_c_call(node, content) {
         return None;
     }
@@ -1659,7 +1726,7 @@ fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
             return None;
         }
         let s = extract_string_literal(value_node, content)?;
-        strings.push(s);
+        strings.push((s, value_node));
     }
     if strings.is_empty() {
         None
@@ -1773,6 +1840,224 @@ fn try_parse_apply_library_call(
             attaches: true,
         })
         .collect()
+}
+
+// ============================================================================
+// targets::tar_option_set Package Detection (issue #637)
+// ============================================================================
+
+/// A package attachment extracted from a {targets}
+/// `tar_option_set(packages = ...)` call during a library-detection walk,
+/// tagged with whether the callee was the bare spelling (`tar_option_set`)
+/// rather than the qualified `targets::tar_option_set` /
+/// `targets:::tar_option_set`.
+///
+/// Bare candidates are subject to the targets-in-play gate applied after the
+/// walk — see [`append_gated_tar_option_set_calls`].
+struct TarOptionSetCandidate {
+    call: LibraryCall,
+    bare: bool,
+}
+
+/// Whether `func_node` (a call's `function` child) names {targets}'
+/// `tar_option_set`: the bare identifier `tar_option_set`, or the qualified
+/// `targets::tar_option_set` / `targets:::tar_option_set`.
+fn is_tar_option_set_callee(func_node: Node, content: &str) -> bool {
+    match func_node.kind() {
+        "identifier" => node_text(func_node, content) == "tar_option_set",
+        "namespace_operator" => {
+            let Some(lhs) = func_node.child_by_field_name("lhs") else {
+                return false;
+            };
+            let Some(rhs) = func_node.child_by_field_name("rhs") else {
+                return false;
+            };
+            lhs.kind() == "identifier"
+                && rhs.kind() == "identifier"
+                && node_text(lhs, content) == "targets"
+                && node_text(rhs, content) == "tar_option_set"
+        }
+        _ => false,
+    }
+}
+
+/// If `node` is a `tar_option_set(...)` call whose callee matches
+/// [`is_tar_option_set_callee`], parse it via
+/// [`try_parse_tar_option_set_call`] and push one gate-pending candidate per
+/// package, tagged with whether the callee was the bare spelling.
+fn collect_tar_option_set_candidates(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+    tar_candidates: &mut Vec<TarOptionSetCandidate>,
+) {
+    let Some(func_node) = node.child_by_field_name("function") else {
+        return;
+    };
+    if !is_tar_option_set_callee(func_node, content) {
+        return;
+    }
+    let bare = func_node.kind() == "identifier";
+    tar_candidates.extend(
+        try_parse_tar_option_set_call(node, content, var_lookup)
+            .into_iter()
+            .map(|call| TarOptionSetCandidate { call, bare }),
+    );
+}
+
+/// Append gate-filtered `tar_option_set(packages = ...)` attachments to
+/// `library_calls`.
+///
+/// The targets-in-play gate: a QUALIFIED callee (`targets::tar_option_set` /
+/// `targets:::tar_option_set`) is accepted unconditionally — the author has
+/// unambiguously named the {targets} package. A BARE `tar_option_set` callee
+/// is accepted only when the same walk already found an attaching load of
+/// targets (`library(targets)` / `require(targets)`), so that an unrelated
+/// user function that happens to be called `tar_option_set` doesn't silently
+/// attach packages. This mirrors the `shiny_in_play` gate precedent in
+/// `scope.rs`'s `push_shiny_deferred_scopes`. The gate is position-independent
+/// within the file: a `library(targets)` anywhere the walk visited counts,
+/// regardless of whether it appears before or after the `tar_option_set` call.
+///
+/// Must be called after the walk completes (the gate inspects the walk's
+/// collected `library_calls`), and must stay the single shared post-filter for
+/// both `detect_library_calls` and `extract_attached_packages` so the two
+/// walkers cannot drift.
+fn append_gated_tar_option_set_calls(
+    library_calls: &mut Vec<LibraryCall>,
+    tar_candidates: Vec<TarOptionSetCandidate>,
+) {
+    let targets_attached = library_calls
+        .iter()
+        .any(|call| call.attaches && call.package == "targets");
+    library_calls.extend(
+        tar_candidates
+            .into_iter()
+            .filter(|candidate| !candidate.bare || targets_attached)
+            .map(|candidate| candidate.call),
+    );
+}
+
+/// Try to interpret `node` as a {targets} `tar_option_set(packages = ...)`
+/// call and return one `LibraryCall` per statically determinable package,
+/// each with `attaches: true` — targets attaches these packages before
+/// running each target, so scripts sourced by `_targets.R` use their exports
+/// as bare names.
+///
+/// Only the NAMED `packages =` argument is honored. This is an intentional
+/// limitation: `tar_option_set`'s first formal is `tidy_eval`, not `packages`,
+/// so positional matching (`tar_option_set(TRUE, c("dplyr"))`) would require
+/// modeling the full formals list and is deliberately not attempted. Accepted
+/// value shapes:
+///
+/// - a single string literal: `packages = "dplyr"`
+/// - a strict `c()` of positional string literals:
+///   `packages = c("dplyr", "tidyr")`
+/// - an identifier resolving to a same-file, assigned-exactly-once static
+///   `c()` of string literals bound before this call (the same
+///   `VarBinding::resolved_before` machinery apply-family detection uses)
+///
+/// Anything else (dynamic calls, `character(0)`, empty `c()`) yields nothing.
+///
+/// Position anchoring: `tar_option_set()` calls routinely span 10–30 lines,
+/// and the missing-package diagnostic builds its range from a `LibraryCall`'s
+/// line/column while `# nolint` suppression is line-keyed — so for the
+/// string-literal and `c()`-of-literals shapes, each package's `LibraryCall`
+/// carries the end position of ITS OWN string-literal node (not the call's
+/// closing paren). The variable-resolved shape has no literal at the call
+/// site, so it falls back to the call's end position, mirroring the
+/// apply-family pattern.
+///
+/// Union leniency: multiple `tar_option_set` calls in one file union their
+/// packages. targets' real runtime semantics are last-call-wins for
+/// `packages =`, but raven deliberately favors false negatives (a package
+/// wrongly considered available) over false positives (flagging a defined
+/// verb as undefined) — do not "fix" this to last-call-wins.
+///
+/// The caller is responsible for the bare-vs-qualified targets-in-play gate
+/// (see [`append_gated_tar_option_set_calls`]); this function parses any
+/// callee matching [`is_tar_option_set_callee`].
+fn try_parse_tar_option_set_call(
+    node: Node,
+    content: &str,
+    var_lookup: &HashMap<String, VarBinding>,
+) -> Vec<LibraryCall> {
+    let Some(func_node) = node.child_by_field_name("function") else {
+        return Vec::new();
+    };
+    if !is_tar_option_set_callee(func_node, content) {
+        return Vec::new();
+    }
+    let Some(args_node) = node.child_by_field_name("arguments") else {
+        return Vec::new();
+    };
+    if args_node.has_error() {
+        return Vec::new();
+    }
+
+    // Find the named `packages =` argument (exact name only). A duplicate
+    // named `packages` argument would make the call itself error in R, so
+    // treat that as no match.
+    let mut packages_values: Vec<Node> = Vec::new();
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() == "argument"
+            && let Some(name_node) = child.child_by_field_name("name")
+            && node_text(name_node, content) == "packages"
+            && let Some(value_node) = child.child_by_field_name("value")
+        {
+            packages_values.push(value_node);
+        }
+    }
+    let [value_node] = packages_values.as_slice() else {
+        return Vec::new();
+    };
+
+    // Build a LibraryCall anchored at `anchor`'s end position (line + UTF-16
+    // column), matching how the other detectors in this file anchor.
+    let call_at = |package: String, anchor: Node| -> LibraryCall {
+        let end = anchor.end_position();
+        let line_text = content.lines().nth(end.row).unwrap_or("");
+        LibraryCall {
+            package,
+            line: end.row as u32,
+            column: byte_offset_to_utf16_column(line_text, end.column),
+            function_scope: None,
+            attaches: true,
+        }
+    };
+
+    match value_node.kind() {
+        // `packages = "dplyr"` — anchored at the literal itself.
+        "string" => match extract_string_literal(*value_node, content) {
+            Some(package) => vec![call_at(package, *value_node)],
+            None => Vec::new(),
+        },
+        // `pkgs <- c("a", "b"); tar_option_set(packages = pkgs)` — no literal
+        // at the call site, so anchor at the call's end position.
+        "identifier" => {
+            let text = node_text(*value_node, content);
+            match var_lookup
+                .get(text)
+                .and_then(|b| b.resolved_before(node.start_byte()))
+            {
+                Some(pkgs) => pkgs
+                    .iter()
+                    .map(|package| call_at(package.clone(), node))
+                    .collect(),
+                None => Vec::new(),
+            }
+        }
+        // `packages = c("dplyr", "tidyr")` — one call per package, each
+        // anchored at its own string-literal node.
+        _ => match extract_c_string_nodes_strict(*value_node, content) {
+            Some(pairs) => pairs
+                .into_iter()
+                .map(|(package, literal)| call_at(package, literal))
+                .collect(),
+            None => Vec::new(),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -3456,6 +3741,200 @@ library(ggplot2)"#;
         let tree = parse_r(code);
         let lib_calls = detect_library_calls(&tree, code);
         assert_eq!(lib_calls.len(), 0);
+    }
+
+    // ==================== tar_option_set package detection (#637) ====================
+
+    /// Convenience: the detected calls minus the `targets` load itself.
+    fn tar_calls(code: &str) -> Vec<LibraryCall> {
+        let tree = parse_r(code);
+        detect_library_calls(&tree, code)
+            .into_iter()
+            .filter(|c| c.package != "targets")
+            .collect()
+    }
+
+    #[test]
+    fn test_tar_option_set_inline_c_with_library_targets() {
+        let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\", \"tidyr\"))";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 2, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+        assert_eq!(calls[1].package, "tidyr");
+        assert!(calls[0].attaches);
+        assert!(calls[1].attaches);
+        // Each package is anchored at its OWN string literal, not the call end.
+        assert_eq!(calls[0].line, 1);
+        assert_eq!(calls[1].line, 1);
+        assert_ne!(
+            calls[0].column, calls[1].column,
+            "per-literal anchoring: distinct literals have distinct columns"
+        );
+        assert!(calls[0].column < calls[1].column);
+        assert!(calls[0].function_scope.is_none());
+    }
+
+    #[test]
+    fn test_tar_option_set_single_string_literal() {
+        let code = "library(targets)\ntar_option_set(packages = \"dplyr\")";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+        assert!(calls[0].attaches);
+        assert_eq!(calls[0].line, 1);
+    }
+
+    #[test]
+    fn test_tar_option_set_qualified_without_library_targets() {
+        // Qualified spellings are accepted unconditionally — no library(targets)
+        // needed.
+        let code = "targets::tar_option_set(packages = c(\"dplyr\"))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+
+        let code = "targets:::tar_option_set(packages = c(\"dplyr\"))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_tar_option_set_bare_without_library_targets_skipped() {
+        // The bare spelling requires targets to be attached somewhere in the
+        // file (targets-in-play gate).
+        let code = "tar_option_set(packages = c(\"dplyr\"))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_bare_gate_is_position_independent() {
+        // library(targets) AFTER the call still satisfies the gate.
+        let code = "tar_option_set(packages = \"dplyr\")\nlibrary(targets)";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_tar_option_set_bare_loadnamespace_targets_does_not_satisfy_gate() {
+        // loadNamespace("targets") does not attach, so it does not enable the
+        // bare spelling.
+        let code = "loadNamespace(\"targets\")\ntar_option_set(packages = c(\"dplyr\"))";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_var_resolved_anchored_at_call_end() {
+        let code =
+            "library(targets)\npkgs <- c(\"dplyr\", \"tidyr\")\ntar_option_set(packages = pkgs)";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 2, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+        assert_eq!(calls[1].package, "tidyr");
+        // No literal at the call site — both share the call's end position.
+        assert_eq!(calls[0].line, 2);
+        assert_eq!(calls[1].line, 2);
+        assert_eq!(calls[0].column, calls[1].column);
+        let call_len = "tar_option_set(packages = pkgs)".len() as u32;
+        assert_eq!(calls[0].column, call_len);
+    }
+
+    #[test]
+    fn test_tar_option_set_positional_packages_skipped() {
+        // tar_option_set's first formal is tidy_eval, so positional matching
+        // is not attempted (documented limitation).
+        let code = "library(targets)\ntar_option_set(TRUE, c(\"dplyr\"))";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_dynamic_value_skipped() {
+        let code = "library(targets)\ntar_option_set(packages = getOption(\"my.pkgs\"))";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_no_packages_arg_skipped() {
+        let code = "library(targets)\ntar_option_set(format = \"qs\")";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_character0_and_empty_c_skipped() {
+        let code = "library(targets)\ntar_option_set(packages = character(0))";
+        assert_eq!(tar_calls(code).len(), 0);
+        let code = "library(targets)\ntar_option_set(packages = c())";
+        assert_eq!(tar_calls(code).len(), 0);
+    }
+
+    #[test]
+    fn test_tar_option_set_unrelated_named_args_still_detected() {
+        let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\"), format = \"qs\", memory = \"transient\")";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_tar_option_set_multiple_calls_union() {
+        // targets' runtime is last-call-wins, but raven deliberately unions
+        // (favoring false negatives) — see try_parse_tar_option_set_call.
+        let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\"))\ntar_option_set(packages = c(\"tidyr\"))";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 2, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+        assert_eq!(calls[1].package, "tidyr");
+    }
+
+    #[test]
+    fn test_tar_option_set_multiline_anchors_at_literal_line() {
+        // The diagnostic range is built from LibraryCall.line, and `# nolint`
+        // suppression is line-keyed, so each package must anchor at its own
+        // literal's line — not the closing paren's.
+        let code = "library(targets)\ntar_option_set(\n  packages = c(\n    \"dplyr\",\n    \"tidyr\"\n  ),\n  format = \"qs\"\n)";
+        let calls = tar_calls(code);
+        assert_eq!(calls.len(), 2, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+        assert_eq!(calls[0].line, 3, "anchored at its own literal's line");
+        assert_eq!(calls[1].package, "tidyr");
+        assert_eq!(calls[1].line, 4, "anchored at its own literal's line");
+    }
+
+    #[test]
+    fn extract_attached_packages_includes_top_level_tar_option_set() {
+        let pkgs =
+            extract_attached_packages("library(targets)\ntar_option_set(packages = c(\"dplyr\"))");
+        assert!(pkgs.contains("targets"));
+        assert!(pkgs.contains("dplyr"));
+
+        // Qualified spelling needs no library(targets).
+        let pkgs = extract_attached_packages("targets::tar_option_set(packages = \"dplyr\")");
+        assert!(pkgs.contains("dplyr"));
+    }
+
+    #[test]
+    fn extract_attached_packages_excludes_function_body_tar_option_set() {
+        let pkgs = extract_attached_packages(
+            "library(targets)\nf <- function() tar_option_set(packages = c(\"dplyr\"))",
+        );
+        assert!(!pkgs.contains("dplyr"), "got: {pkgs:?}");
+    }
+
+    #[test]
+    fn extract_attached_packages_excludes_quote_wrapped_tar_option_set() {
+        let pkgs = extract_attached_packages(
+            "library(targets)\nq <- quote(tar_option_set(packages = c(\"dplyr\")))",
+        );
+        assert!(!pkgs.contains("dplyr"), "got: {pkgs:?}");
     }
 
     // ==================== system.file() detection in source() ====================

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -862,7 +862,13 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 /// only when the same file also attaches targets (`library(targets)` /
 /// `require(targets)` anywhere in the file); `targets::` / `targets:::`
 /// qualified spellings are honored unconditionally. See
-/// `append_gated_tar_option_set_calls` for the gate.
+/// `append_gated_tar_option_set_calls` for the gate. A `tar_option_set()`
+/// nested inside a non-evaluating quoting wrapper (`quote(...)`, rlang's
+/// `expr(...)`, …) is NOT detected — it never evaluates — while a quoted
+/// `library()`/`require()` still is (pre-existing leniency; see the gate
+/// note in `visit_node_for_library`).
+///
+/// The returned Vec is sorted in document order by `(line, column)`.
 ///
 /// # Examples
 ///
@@ -889,10 +895,16 @@ pub fn detect_library_calls(tree: &Tree, content: &str) -> Vec<LibraryCall> {
         root,
         content,
         &var_lookup,
+        false,
         &mut library_calls,
         &mut tar_candidates,
     );
     append_gated_tar_option_set_calls(&mut library_calls, tar_candidates);
+    // Restore document order: gated tar_option_set entries are appended after
+    // the walk, so sort by position. The sort is stable, keeping same-position
+    // entries (an apply-family call's per-package fan-out all shares the apply
+    // call's end position) in emission order.
+    library_calls.sort_by_key(|call| (call.line, call.column));
     log::trace!(
         "Completed library() call detection, found {} calls",
         library_calls.len()
@@ -1097,6 +1109,9 @@ pub(crate) fn is_nonevaluating_quote_call(node: Node, content: &str) -> bool {
 /// - `var_lookup`: name→binding map (built once via [`collect_var_bindings`])
 ///   used by apply and tar_option_set detection to resolve same-file variable
 ///   references like `libs <- c(...); sapply(libs, library, character.only = TRUE)`.
+/// - `inside_quote`: latched to `true` once an ancestor non-evaluating quoting
+///   call (see [`is_nonevaluating_quote_call`]) is entered; gates ONLY the
+///   tar_option_set candidate collection below.
 /// - `library_calls`: mutable collector that receives discovered `LibraryCall`
 ///   entries in document order.
 /// - `tar_candidates`: mutable collector for gate-pending
@@ -1111,13 +1126,14 @@ pub(crate) fn is_nonevaluating_quote_call(node: Node, content: &str) -> bool {
 /// let mut tar_candidates = Vec::new();
 /// let root = tree.root_node();
 /// let var_lookup = collect_var_bindings(root, source_text);
-/// visit_node_for_library(root, source_text, &var_lookup, &mut library_calls, &mut tar_candidates);
+/// visit_node_for_library(root, source_text, &var_lookup, false, &mut library_calls, &mut tar_candidates);
 /// assert!(library_calls.iter().all(|c| !c.package.is_empty()));
 /// ```
 fn visit_node_for_library(
     node: Node,
     content: &str,
     var_lookup: &HashMap<String, VarBinding>,
+    inside_quote: bool,
     library_calls: &mut Vec<LibraryCall>,
     tar_candidates: &mut Vec<TarOptionSetCandidate>,
 ) {
@@ -1125,6 +1141,9 @@ fn visit_node_for_library(
     if node.kind() == "identifier" {
         return;
     }
+    // A call nested inside a quoting wrapper (e.g. `quote(...)`) is captured
+    // as unevaluated code; latch so all descendants see `inside_quote`.
+    let inside_quote = inside_quote || is_nonevaluating_quote_call(node, content);
     if node.kind() == "call" {
         if let Some(lib_call) = try_parse_library_call(node, content) {
             library_calls.push(lib_call);
@@ -1134,12 +1153,27 @@ fn visit_node_for_library(
             // the tar_option_set form. The two callee name-sets are disjoint,
             // so at most one of these can match.
             library_calls.extend(try_parse_apply_library_call(node, content, var_lookup));
-            collect_tar_option_set_candidates(node, content, var_lookup, tar_candidates);
+            // Deliberate asymmetry: only tar_option_set is quote-gated on
+            // this position-aware path. `library()`/`require()` and
+            // apply-family calls inside `quote()` are still recorded here —
+            // that leniency predates tar_option_set detection and changing
+            // it is out of scope. A quoted `tar_option_set()` never
+            // evaluates, so it must not record attachments.
+            if !inside_quote {
+                collect_tar_option_set_candidates(node, content, var_lookup, tar_candidates);
+            }
         }
     }
 
     for child in node.children(&mut node.walk()) {
-        visit_node_for_library(child, content, var_lookup, library_calls, tar_candidates);
+        visit_node_for_library(
+            child,
+            content,
+            var_lookup,
+            inside_quote,
+            library_calls,
+            tar_candidates,
+        );
     }
 }
 
@@ -1918,6 +1952,11 @@ fn collect_tar_option_set_candidates(
 /// `scope.rs`'s `push_shiny_deferred_scopes`. The gate is position-independent
 /// within the file: a `library(targets)` anywhere the walk visited counts,
 /// regardless of whether it appears before or after the `tar_option_set` call.
+/// On the position-aware path (`detect_library_calls`) the gate is also
+/// file-wide and scope-blind by design — an attaching `library(targets)`
+/// inside a function body satisfies it (the top-level walker naturally
+/// excludes those); it limits name-collision false attaches and is not a
+/// correctness guarantee.
 ///
 /// Must be called after the walk completes (the gate inspects the walk's
 /// collected `library_calls`), and must stay the single shared post-filter for
@@ -1957,11 +1996,16 @@ fn append_gated_tar_option_set_calls(
 ///   `c()` of string literals bound before this call (the same
 ///   `VarBinding::resolved_before` machinery apply-family detection uses)
 ///
+/// The variable resolution is lexical-scope-blind — inherited from the
+/// apply-family `VarBinding` heuristic — so an assignment inside an unrelated
+/// function body can satisfy it; this is deliberate and favors false negatives
+/// in diagnostics.
+///
 /// Anything else (dynamic calls, `character(0)`, empty `c()`) yields nothing.
 ///
 /// Position anchoring: `tar_option_set()` calls routinely span 10–30 lines,
 /// and the missing-package diagnostic builds its range from a `LibraryCall`'s
-/// line/column while `# nolint` suppression is line-keyed — so for the
+/// line/column while `# raven: ignore` suppression is line-keyed — so for the
 /// string-literal and `c()`-of-literals shapes, each package's `LibraryCall`
 /// carries the end position of ITS OWN string-literal node (not the call's
 /// closing paren). The variable-resolved shape has no literal at the call
@@ -3897,9 +3941,9 @@ library(ggplot2)"#;
 
     #[test]
     fn test_tar_option_set_multiline_anchors_at_literal_line() {
-        // The diagnostic range is built from LibraryCall.line, and `# nolint`
-        // suppression is line-keyed, so each package must anchor at its own
-        // literal's line — not the closing paren's.
+        // The diagnostic range is built from LibraryCall.line, and
+        // `# raven: ignore` suppression is line-keyed, so each package must
+        // anchor at its own literal's line — not the closing paren's.
         let code = "library(targets)\ntar_option_set(\n  packages = c(\n    \"dplyr\",\n    \"tidyr\"\n  ),\n  format = \"qs\"\n)";
         let calls = tar_calls(code);
         assert_eq!(calls.len(), 2, "got: {calls:?}");
@@ -3935,6 +3979,51 @@ library(ggplot2)"#;
             "library(targets)\nq <- quote(tar_option_set(packages = c(\"dplyr\")))",
         );
         assert!(!pkgs.contains("dplyr"), "got: {pkgs:?}");
+    }
+
+    #[test]
+    fn test_tar_option_set_quote_wrapped_skipped_on_position_aware_path() {
+        // A quoted tar_option_set() captures code without evaluating it, so
+        // detect_library_calls must not record attachments — even for the
+        // unconditionally-honored qualified spelling.
+        let code = "q <- quote(targets::tar_option_set(packages = \"dplyr\"))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 0, "got: {calls:?}");
+
+        // Bare spelling under quote() with targets attached: only the
+        // library(targets) itself is recorded.
+        let code = "library(targets)\nq <- quote(tar_option_set(packages = \"dplyr\"))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "targets");
+
+        // Deliberate asymmetry (locked here): a plain library() inside
+        // quote() IS still recorded on this position-aware path — that
+        // leniency predates tar_option_set detection and is out of scope.
+        // (The top-level walker behind extract_attached_packages excludes
+        // it; see extract_attached_packages_excludes_quote_wrapper.)
+        let code = "q <- quote(library(dplyr))";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(calls.len(), 1, "got: {calls:?}");
+        assert_eq!(calls[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_detect_library_calls_sorted_after_tar_append() {
+        // tar_option_set entries are appended after the walk; the final Vec
+        // must still come back in document order by (line, column).
+        let code = "tar_option_set(packages = c(\"aaa\", \"bbb\"))\nlibrary(targets)\nlibrary(zzz)";
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        let positions: Vec<(u32, u32)> = calls.iter().map(|c| (c.line, c.column)).collect();
+        let mut sorted = positions.clone();
+        sorted.sort();
+        assert_eq!(positions, sorted, "got: {calls:?}");
+        let packages: Vec<&str> = calls.iter().map(|c| c.package.as_str()).collect();
+        assert_eq!(packages, vec!["aaa", "bbb", "targets", "zzz"]);
     }
 
     // ==================== system.file() detection in source() ====================

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -54068,6 +54068,139 @@ result <- helper_with_spaces(42)"#;
         assert!(diagnostics[1].message.contains("__missing_pkg2__"));
     }
 
+    /// Issue #637: a package listed in `tar_option_set(packages = ...)` gets
+    /// the same missing-package diagnostic as a `library()` call. Mirrors
+    /// `test_missing_package_diagnostic_emitted`. Assertions filter to the
+    /// probe package so the test doesn't depend on whether {targets} itself is
+    /// installed on the machine.
+    #[test]
+    fn test_missing_package_diagnostic_emitted_for_tar_option_set() {
+        let code = "library(targets)\ntar_option_set(packages = \"__nonexistent_package_xyz__\")";
+        let main_url = Url::parse("file:///workspace/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state.package_library_ready = true;
+        let Some(r_subprocess) = crate::r_subprocess::RSubprocess::new(None) else {
+            return;
+        };
+        state.package_library = std::sync::Arc::new(
+            crate::package_library::PackageLibrary::with_subprocess(Some(r_subprocess)),
+        );
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+
+        let probe: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("__nonexistent_package_xyz__"))
+            .collect();
+        assert_eq!(
+            probe.len(),
+            1,
+            "should emit one diagnostic for the tar_option_set package; got {diagnostics:?}"
+        );
+        assert!(probe[0].message.contains("No installed package"));
+        assert_eq!(probe[0].severity, Some(DiagnosticSeverity::WARNING));
+    }
+
+    /// Issue #637: every package in a `tar_option_set(packages = c(...))`
+    /// vector is checked. Mirrors
+    /// `test_missing_package_diagnostic_multiple_packages`.
+    #[test]
+    fn test_missing_package_diagnostic_multiple_packages_tar_option_set() {
+        let code = "library(targets)\ntar_option_set(packages = c(\"__missing_pkg1__\", \"__missing_pkg2__\"))";
+        let main_url = Url::parse("file:///workspace/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state.package_library_ready = true;
+        let Some(r_subprocess) = crate::r_subprocess::RSubprocess::new(None) else {
+            return;
+        };
+        state.package_library = std::sync::Arc::new(
+            crate::package_library::PackageLibrary::with_subprocess(Some(r_subprocess)),
+        );
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|d| d.message.contains("__missing_pkg1__"))
+                .count(),
+            1,
+            "should emit a diagnostic for the first tar_option_set package; got {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|d| d.message.contains("__missing_pkg2__"))
+                .count(),
+            1,
+            "should emit a diagnostic for the second tar_option_set package; got {diagnostics:?}"
+        );
+    }
+
+    /// Issue #637 per-literal anchoring: in a multi-line `tar_option_set()`
+    /// call, the missing-package diagnostic lands on the packages-literal's
+    /// line (so `# nolint` on that line suppresses it), not the closing
+    /// paren's line.
+    #[test]
+    fn test_missing_package_diagnostic_tar_option_set_multiline_anchors_literal_line() {
+        let code = "library(targets)\n\
+                    tar_option_set(\n\
+                    \x20 packages = c(\n\
+                    \x20   \"__missing_pkg1__\"\n\
+                    \x20 ),\n\
+                    \x20 format = \"qs\"\n\
+                    )";
+        let main_url = Url::parse("file:///workspace/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state.package_library_ready = true;
+        let Some(r_subprocess) = crate::r_subprocess::RSubprocess::new(None) else {
+            return;
+        };
+        state.package_library = std::sync::Arc::new(
+            crate::package_library::PackageLibrary::with_subprocess(Some(r_subprocess)),
+        );
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+
+        let probe: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("__missing_pkg1__"))
+            .collect();
+        assert_eq!(
+            probe.len(),
+            1,
+            "should emit one diagnostic for the tar_option_set package; got {diagnostics:?}"
+        );
+        assert_eq!(
+            probe[0].range.start.line, 3,
+            "diagnostic must anchor at the package literal's line (3), not the \
+             closing paren's line (6); got {:?}",
+            probe[0].range
+        );
+        assert_eq!(probe[0].range.end.line, 3);
+    }
+
     #[test]
     fn test_missing_package_diagnostic_suppressed_while_package_library_not_ready() {
         let code = "library(__nonexistent_package_xyz__)";
@@ -63352,6 +63485,34 @@ my_func <- function(a = default_value) {
             !messages.iter().any(|m| m.contains("inner")),
             "loadNamespace(shiny) must not enable Shiny deferred-scope isolation; \
              got {messages:?}"
+        );
+    }
+
+    /// Issue #637: `tar_option_set(packages = c("shiny"))` attaches shiny
+    /// (targets attaches the listed packages before running each target), so
+    /// it flips `shiny_in_play` and deferred scopes isolate exactly as with
+    /// `library(shiny)`.
+    #[test]
+    fn nse_shiny_tar_option_set_enables_deferred_scope_end_to_end() {
+        let messages = collect_undefined_messages(
+            "library(targets)\n\
+             tar_option_set(packages = c(\"shiny\"))\n\
+             server <- function(input, output, session) {\n\
+               output$plot <- renderPlot({\n\
+                 inner <- 1\n\
+                 inner\n\
+               })\n\
+               print(inner)\n\
+             }\n",
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|m| m.as_str() == "inner is not defined")
+                .count(),
+            1,
+            "shiny attached via tar_option_set must enable deferred-scope \
+             isolation like library(shiny); got {messages:?}"
         );
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -54153,8 +54153,10 @@ result <- helper_with_spaces(42)"#;
 
     /// Issue #637 per-literal anchoring: in a multi-line `tar_option_set()`
     /// call, the missing-package diagnostic lands on the packages-literal's
-    /// line (so `# nolint` on that line suppresses it), not the closing
-    /// paren's line.
+    /// line, not the closing paren's line — so a line-keyed `# raven: ignore`
+    /// trailing the literal suppresses it (asserted below; `# nolint` belongs
+    /// to the opt-in lint pipeline and does NOT suppress diagnostics — see
+    /// `nolint_does_not_suppress_diagnostic`).
     #[test]
     fn test_missing_package_diagnostic_tar_option_set_multiline_anchors_literal_line() {
         let code = "library(targets)\n\
@@ -54199,6 +54201,31 @@ result <- helper_with_spaces(42)"#;
             probe[0].range
         );
         assert_eq!(probe[0].range.end.line, 3);
+
+        // Because the diagnostic anchors at the literal's line, a line-keyed
+        // `# raven: ignore` trailing that literal suppresses it.
+        let suppressed_code = "library(targets)\n\
+                               tar_option_set(\n\
+                               \x20 packages = c(\n\
+                               \x20   \"__missing_pkg1__\" # raven: ignore\n\
+                               \x20 ),\n\
+                               \x20 format = \"qs\"\n\
+                               )";
+        let suppressed_url = Url::parse("file:///workspace/main2.R").unwrap();
+        state
+            .documents
+            .insert(suppressed_url.clone(), Document::new(suppressed_code, None));
+        let snapshot = DiagnosticsSnapshot::build(&state, &suppressed_url)
+            .expect("snapshot built for main2.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message.contains("__missing_pkg1__")),
+            "`# raven: ignore` on the literal's line must suppress the \
+             missing-package diagnostic; got {diagnostics:?}"
+        );
     }
 
     #[test]

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -183,6 +183,9 @@ Packages loaded in child files do NOT propagate back to parents (forward-only).
 | `sapply(libs, library, character.only = TRUE)` where `libs <- c("a","b")` | Yes (same-file variable) |
 | `purrr::map(c("a","b"), library, character.only = TRUE)` | Yes (purrr family) |
 | `sapply(paste0(...), library, character.only = TRUE)` | No (dynamic vector) |
+| `tar_option_set(packages = c("a","b"))` | Yes, when the file also attaches targets (see below) |
+| `targets::tar_option_set(packages = "a")` | Yes (qualified — no `library(targets)` needed) |
+| `tar_option_set(TRUE, c("a"))` | No (positional `packages` is not matched) |
 
 ### Apply-Family Loads
 
@@ -202,6 +205,50 @@ a literal vector. `character.only = TRUE` must be present (without it, R
 itself would not load the strings as packages). Dynamic constructions such as
 `paste0(...)`, `tolower(x)`, `c(libs1, libs2)`, function-parameter origins,
 or values defined in another file are silently ignored.
+
+### targets::tar_option_set() Loads
+
+Raven treats a [{targets}](https://docs.ropensci.org/targets/)
+`tar_option_set(packages = ...)` call as a package attachment — targets
+attaches the listed packages before running each target, so scripts sourced by
+`_targets.R` use their exports as bare names:
+
+```r
+# _targets.R
+library(targets)
+tar_option_set(packages = c("dplyr", "tidyr"))
+source("R/functions.R")  # dplyr and tidyr verbs resolve in functions.R
+```
+
+Details:
+
+- **Bare vs. qualified callee.** The qualified spellings
+  `targets::tar_option_set(...)` / `targets:::tar_option_set(...)` are
+  recognized unconditionally. The bare spelling `tar_option_set(...)` is
+  recognized only when the same file also attaches targets via
+  `library(targets)` / `require(targets)` — anywhere in the file, before or
+  after the call — so an unrelated user function named `tar_option_set`
+  doesn't silently attach packages.
+- **Named `packages =` only.** `tar_option_set`'s first formal is
+  `tidy_eval`, not `packages`, so positional forms like
+  `tar_option_set(TRUE, c("dplyr"))` are deliberately not matched.
+- **Accepted value shapes.** A single string literal
+  (`packages = "dplyr"`), an inline `c("a", "b", ...)` of string literals, or
+  a same-file variable assigned exactly once to such a literal vector (the
+  same rule as apply-family loads). Dynamic values, `character(0)`, and empty
+  `c()` are ignored.
+- **Per-literal anchoring.** `tar_option_set()` calls routinely span many
+  lines, so each package's missing-package diagnostic is anchored at that
+  package's own string literal — a `# nolint` on the literal's line suppresses
+  it. The variable-resolved shape anchors at the call's end instead.
+- **Union across calls.** Multiple `tar_option_set()` calls in one file union
+  their `packages =` vectors. targets' real runtime semantics are
+  last-call-wins, but raven deliberately favors false negatives here.
+- **Limitation: no `tar_source()`.** Raven only follows `source()` calls and
+  forward directives, so projects that load their function scripts via
+  `tar_source()` don't inherit the `tar_option_set` packages in those scripts
+  yet. A `# raven: source R/functions.R` directive (or a plain `source()`
+  call) in `_targets.R` restores the link.
 
 ### Keeping Packages in Sync
 


### PR DESCRIPTION
Closes #637.

Recognizes top-level `tar_option_set(packages = ...)` calls from the {targets} package as package attachment, so scripts sourced by `_targets.R` no longer flag tidyverse verbs (and other declared-package exports) as undefined variables.

## Design

All detection lives in `crates/raven/src/cross_file/source_detect.rs`; one `LibraryCall { attaches: true }` is emitted per declared package, so every downstream consumer (`ScopeEvent::PackageLoad` emission, forward propagation over `source()` edges, interface hashing/revalidation, missing-package diagnostics, meta-package expansion, completion/hover package warming) works unchanged.

- **Callee**: bare `tar_option_set`, or `targets::tar_option_set` / `targets:::tar_option_set`. The bare spelling is gated on the file also attaching targets via `library(targets)`/`require(targets)` (mirrors the `shiny_in_play` precedent, preventing a user-defined function of the same name from silently suppressing diagnostics); the qualified spelling is unconditional. `loadNamespace(targets)` does not satisfy the gate.
- **Argument**: the named `packages =` argument only (`tidy_eval` is the first positional formal, so positional matching would be wrong — documented limitation). Accepted shapes: a single string literal, a strict `c()` of string literals, or a same-file single-assignment variable (existing `VarBinding` resolution). Dynamic values, `character(0)`, and empty `c()` emit nothing.
- **Anchoring**: each package's `LibraryCall` is anchored at its own string literal (real `tar_option_set()` calls are routinely 10–30 lines, so missing-package diagnostics and line-keyed `# raven: ignore` suppression land on the right line); the variable-resolved shape falls back to the call's end position.
- **Quoting**: tar candidates inside non-evaluating quote wrappers (`quote()`, rlang `expr()`, …) are excluded on both walk paths.
- **Leniencies (deliberate, documented)**: multiple `tar_option_set` calls union their packages (targets' runtime semantics are last-wins; raven favors false negatives), and the bare-spelling gate / variable resolution are file-wide rather than lexically scoped.
- **Known limitation**: `tar_source()`-based projects don't inherit the packages (raven only follows `source()` calls and forward directives). The order-independent, file-level attachment variant is tracked as #639.

## Testing

- 19 new unit tests in `source_detect.rs` (shapes, gate, quote exclusion, per-literal anchoring, union, document-order sort, `extract_attached_packages` variants).
- Cross-file propagation test in `cross_file/scope.rs` (parent `_targets.R` → sourced child resolves `dplyr`).
- End-to-end tests in `handlers.rs`: missing-package diagnostics (single, multiple, multi-line anchoring + real `# raven: ignore` suppression assertion) and the Shiny deferred-scope gate flipping via `tar_option_set(packages = c("shiny"))`.
- Full suite: 5,804 lib tests + integration suites + 53 doctests, 0 failures. `cargo fmt --check`, clippy `-D warnings`, and rustdoc `-D warnings` (both feature configs) all clean.

## Docs

`docs/cross-file.md`: new rows in Supported Call Patterns and a "targets::tar_option_set() Loads" subsection covering the gate, accepted shapes, anchoring, union leniency, and the `tar_source()` limitation.

Reviewed pre-PR by three independent reviewer passes plus an adversarial second-opinion review; all findings were fixed in the follow-up commit or explicitly documented as deliberate leniencies (final verdict: clean to ship).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting packages declared with `targets::tar_option_set(packages = ...)`.
  * Propagated declared packages to sourced child files for improved cross-file analysis.
  * Added package diagnostics for missing packages, including multiline declarations and per-package highlighting.
  * Added support for qualified and bare `tar_option_set` calls with appropriate attachment rules.

* **Documentation**
  * Documented `tar_option_set(packages = ...)` support, accepted patterns, diagnostics, and propagation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->