### PR TITLE
feat(quarto): apply VS Code theme to live preview via loopback bridge proxy

### DIFF
--- a/docs/quarto.md
+++ b/docs/quarto.md
@@ -160,6 +160,59 @@ startup, Quarto stdout/stderr, frontmatter parse fallbacks, render output, and
 panel advisories are logged there. The command is always available from the
 Command Palette.
 
+## Apply VS Code theme
+
+The preview toolbar's **Apply VS Code theme** toggle recolors the live Quarto
+page to match the active VS Code theme and preview fonts. Switching the toggle,
+changing either font setting, or changing the active color theme updates the
+open preview without reloading the page or re-rendering the document. The
+preference is per-user, is shared by all open Quarto preview panels, and is
+persisted across VS Code sessions.
+
+The overlay works with standard Quarto HTML documents, websites, and books.
+Raven reapplies it after Quarto's live re-render and as you follow cross-page
+navigation within a website or book. Turning the toggle off removes Raven's
+overlay and restores the appearance authored by the Quarto document and its
+theme. It does not modify the source, generated output, or the page opened by
+**Open in Browser**.
+
+The color mapping is intentionally coarse. Raven maps syntax spans into ten
+broad roles such as keyword, string, comment, and function, and covers common
+Quarto, Pandoc, and Bootstrap surfaces. It aims to make the preview feel at home
+in the editor, not to reproduce VS Code's tokenization or every custom Quarto
+theme rule exactly.
+
+At a high level, Raven places a loopback proxy in front of Quarto's local
+preview server and injects a small theme bridge into eligible HTML responses.
+The preview remains a sandboxed, cross-origin iframe. Only validated,
+non-sensitive presentation data—the enabled state, colors, and sanitized font
+families—crosses the boundary. If Raven cannot start or probe the proxy, it
+falls back to the ordinary unthemed Quarto preview instead of failing the
+preview.
+
+### Fonts
+
+The two Quarto font settings accept the same comma-separated form as CSS
+`font-family`; quoted names with spaces are valid, for example
+`"JetBrains Mono", "Fira Code", monospace`.
+
+When **Apply VS Code theme** is on, Raven resolves each font slot in this order:
+
+1. `raven.quarto.fontFamily` for body/prose or
+   `raven.quarto.monospaceFontFamily` for code, when non-empty.
+2. `markdown.preview.fontFamily` for body/prose or `editor.fontFamily` for
+   code. The monospace fallback honors `[quarto]` language-scoped
+   `editor.fontFamily` overrides.
+3. A built-in sans-serif or monospace fallback if the configured values are
+   invalid.
+
+Both Raven settings are resource-scoped, so folders in a multi-root workspace
+can choose different fonts. Changes to either Raven setting or either VS Code
+fallback update an open preview live. Raven sanitizes the values before sending
+them to the bridge and appends a generic family when needed; invalid CSS-wide
+keywords, unsafe characters, unbalanced quotes, and bare parentheses fall
+through to the next value in the chain.
+
 ## Preview ownership and keying
 
 Raven keys a preview by Quarto project when it finds one, otherwise by source
@@ -197,20 +250,26 @@ For Preview, Raven starts Quarto with `--host 127.0.0.1` and accepts only an
 `http:` URL whose host is exactly `127.0.0.1`, `localhost`, or `[::1]`. URLs
 with credentials, non-loopback hosts, malformed ports, or another scheme are
 rejected. This matters because document code can write text that resembles
-Quarto's own startup messages.
+Quarto's own startup messages. Raven then starts its own loopback-only proxy,
+fixed to that validated Quarto origin; it cannot be used as an open proxy. The
+iframe frames the VS Code-mapped proxy URL, and the proxy forwards HTTP and
+live-reload WebSocket traffic to Quarto. If proxy startup fails, Raven falls
+back to framing the validated Quarto URL directly without the theme bridge.
 
 The rendered document can contain JavaScript. Raven runs it in a sandboxed,
 cross-origin iframe rather than in the Raven-controlled webview document. The
 frame permits the capabilities ordinary Quarto output needs, including
 scripts, forms, downloads, and same-origin access to its own resources, while
 denying capabilities such as top-level navigation and popups. It cannot reach
-the outer webview DOM or VS Code API.
+the outer webview DOM or VS Code API. The injected bridge does not change that
+boundary: it accepts an exact, parent-source-checked theme message from the outer
+shell and applies only validated colors and sanitized font families.
 
-VS Code maps the validated loopback URL for each new iframe installation,
+VS Code maps the validated loopback proxy URL for each new iframe installation,
 which also enables remote port forwarding where supported. Raven does not
 cache that mapping and never opens a browser on its own. **Open in Browser** is
-the explicit escape hatch when a widget, browser policy, or remote tunnel does
-not work inside the sandboxed panel.
+the explicit escape hatch to Quarto's original URL when a widget, browser
+policy, or remote tunnel does not work inside the sandboxed panel.
 
 ## Settings
 
@@ -219,6 +278,8 @@ not work inside the sandboxed panel.
 | `raven.quarto.path` | `""` | Absolute path to a Quarto CLI executable. Leave empty to search `PATH` and the standard platform locations listed above. |
 | `raven.quarto.viewerColumn` | `"beside"` | Column for newly created preview panels: `"active"` or `"beside"`. It does not move an existing panel. |
 | `raven.quarto.render.timeoutMs` | `600000` | Hard timeout in milliseconds for a one-shot Quarto render. Cancellation and timeout stop the process tree with escalating signals. |
+| `raven.quarto.fontFamily` | `""` | Body/prose font for the live-themed preview. Empty inherits `markdown.preview.fontFamily`. |
+| `raven.quarto.monospaceFontFamily` | `""` | Monospace font for code in the live-themed preview. Empty inherits `editor.fontFamily`. |
 
 See the [settings reference](settings-reference.md) for the generated schema
 summary.
@@ -268,6 +329,18 @@ from the success notification.
   invokes Quarto. Shiny requires the separate `quarto serve` lifecycle.
 - Browser preview depends on the output format. Non-browser-previewable
   formats such as DOCX and PPTX fail preview with a 404 message; use Render.
+- A page with a restrictive `script-src` or `style-src` Content Security
+  Policy that permits scripts or styles only by nonce or hash can block the
+  injected bridge. The toggle then reports **Theme bridge unavailable on this
+  page**.
+- RevealJS presentations, heavily customized SCSS, and author-provided
+  light/dark theme toggles are themed on a best-effort, coarse basis. Raven
+  does not promise exact tokenization or full custom-theme fidelity.
+- A remote tunnel mounted under a URL path prefix, rather than mapped by
+  authority and port, is a known caveat for redirects. VS Code's usual Remote
+  SSH, WSL, and Dev Container port mappings are authority-based.
+- PDF and other non-HTML previews are unaffected by **Apply VS Code theme**;
+  Raven does not inject or theme those responses.
 - Quarto processes are window-owned. Preview and in-flight one-shot render
   processes do not continue through extension deactivation or window reload,
   and Stop does not reach previews owned by another VS Code window.

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -106,6 +106,8 @@ The **`raven.toml` path** column shows where to set a key in a project's `raven.
 | `raven.pandoc.path` | `""` | string | — | [knit](knit.md) | Absolute path to a Pandoc binary; leave empty to search PATH and standard install locations (Homebrew, /usr/local/bin, RStudio's bundled pandoc, etc.). |
 | `raven.pandoc.pdfEngine` | `"xelatex"` | `"xelatex"` \| `"pdflatex"` \| `"lualatex"` \| `"tectonic"` \| `"wkhtmltopdf"` | — | [knit](knit.md) | PDF engine used by Pandoc when exporting to PDF. |
 | `raven.plot.viewerColumn` | `"beside"` | `"active"` \| `"beside"` | — | [plot-viewer](plot-viewer.md) | Initial editor column when the plot viewer first opens. |
+| `raven.quarto.fontFamily` | `""` | string | — | [quarto](quarto.md) | Body/prose font for the live-themed Quarto Preview. |
+| `raven.quarto.monospaceFontFamily` | `""` | string | — | [quarto](quarto.md) | Monospace font for code in the live-themed Quarto Preview. |
 | `raven.quarto.path` | `""` | string | — | [quarto](quarto.md) | Absolute path to a Quarto CLI binary; leave empty to search PATH and standard install locations (Homebrew, /usr/local/bin, RStudio's bundled Quarto, etc.). |
 | `raven.quarto.render.timeoutMs` | `600000` | integer (1–2147483647) | — | [quarto](quarto.md) | Hard timeout (milliseconds) for the Quarto render subprocess. |
 | `raven.quarto.viewerColumn` | `"beside"` | `"active"` \| `"beside"` | — | [quarto](quarto.md) | Editor column used for newly-created Quarto preview panels. |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1611,6 +1611,24 @@
           "maximum": 2147483647,
           "description": "Hard timeout (milliseconds) for the Quarto render subprocess. Cancellation and timeout use the SIGINT → SIGTERM → SIGKILL process-tree ladder."
         },
+        "raven.quarto.fontFamily": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "maxLength": 500,
+          "pattern": "^[^;{}<>\\\\\\n\\r\\t\\f\\v\\u0000]*$",
+          "patternErrorMessage": "Cannot contain ; { } < > \\ or whitespace control characters.",
+          "description": "Body/prose font for the live-themed Quarto Preview. Accepts the same comma-separated form as CSS `font-family` (quoted names with spaces or parens are fine — e.g. `\"Aptos (Body)\", sans-serif`). Leave empty to inherit `markdown.preview.fontFamily`. The open preview panel updates live when this setting changes. Bare parens, unbalanced quotes, and CSS-wide keywords (`inherit`, `initial`, …) are rejected at preview time and the next layer of the fallback chain is used."
+        },
+        "raven.quarto.monospaceFontFamily": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "maxLength": 500,
+          "pattern": "^[^;{}<>\\\\\\n\\r\\t\\f\\v\\u0000]*$",
+          "patternErrorMessage": "Cannot contain ; { } < > \\ or whitespace control characters.",
+          "description": "Monospace font for code in the live-themed Quarto Preview. Accepts the same comma-separated form as CSS `font-family` (quoted names with spaces or parens are fine). Leave empty to inherit `editor.fontFamily` (honors `[quarto]` language-scoped overrides). The open preview panel updates live when this setting changes. Bare parens, unbalanced quotes, and CSS-wide keywords are rejected at preview time and the next layer of the fallback chain is used."
+        },
         "raven.knit.fontFamily": {
           "type": "string",
           "default": "",

--- a/editors/vscode/scripts/build.js
+++ b/editors/vscode/scripts/build.js
@@ -107,6 +107,17 @@ function copyOnigWasm() {
     console.log(`Copied ${path.relative(root, src)} -> ${path.relative(root, dest)}`);
 }
 
+/** Copy the injected Quarto bridge into the shipped runtime-only dist tree. */
+function copyQuartoThemeBridge() {
+    const src = path.join(root, 'src', 'quarto', 'bridge');
+    const dest = path.join(dist, 'quarto-theme-bridge');
+    fs.mkdirSync(dest, { recursive: true });
+    for (const asset of ['bridge.js', 'bridge.css']) {
+        fs.copyFileSync(path.join(src, asset), path.join(dest, asset));
+    }
+    console.log('Copied src/quarto/bridge -> dist/quarto-theme-bridge');
+}
+
 (async () => {
     try {
         await Promise.all([
@@ -125,6 +136,7 @@ function copyOnigWasm() {
             ),
         ]);
         copyOnigWasm();
+        copyQuartoThemeBridge();
     } catch (err) {
         console.error(err);
         process.exit(1);

--- a/editors/vscode/src/knit/vscode-theme-palette.ts
+++ b/editors/vscode/src/knit/vscode-theme-palette.ts
@@ -70,6 +70,8 @@ export interface ThemePaletteSuccess {
     palette: GithubPalette;
     /** The matched theme id (or label fallback). */
     themeId: string;
+    /** Display label used by VS Code's per-theme customization keys. */
+    themeLabel?: string;
     /** Whether the theme is light. From the caller's ColorThemeKind. */
     isLight: boolean;
     /**
@@ -503,6 +505,7 @@ export async function resolveActiveThemePalette(
         ok: true,
         palette,
         themeId: located.id,
+        themeLabel: located.label,
         isLight: args.isLight,
         candidateFailures,
     };

--- a/editors/vscode/src/quarto/bridge/bridge.css
+++ b/editors/vscode/src/quarto/bridge/bridge.css
@@ -1,0 +1,104 @@
+/*
+ * Raven's overlay is intentionally scoped and targeted. Author-provided
+ * light/dark toggles and heavily customized SCSS remain best-effort because
+ * overriding every authored selector would destroy the document's semantics.
+ */
+html.raven-vscode-theme,
+html.raven-vscode-theme body,
+html.raven-vscode-theme #quarto-content,
+html.raven-vscode-theme #quarto-document-content {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-fg) !important;
+    font-family: var(--raven-font-text) !important;
+}
+
+html.raven-vscode-theme a,
+html.raven-vscode-theme a:visited {
+    color: var(--raven-c-function) !important;
+}
+
+html.raven-vscode-theme hr,
+html.raven-vscode-theme .border,
+html.raven-vscode-theme [class*="border-"] {
+    border-color: var(--raven-c-punctuation) !important;
+}
+
+html.raven-vscode-theme :not(pre) > code {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-c-string) !important;
+    border: 1px solid var(--raven-c-punctuation) !important;
+    font-family: var(--raven-font-mono) !important;
+}
+
+html.raven-vscode-theme pre,
+html.raven-vscode-theme div.sourceCode,
+html.raven-vscode-theme pre.sourceCode,
+html.raven-vscode-theme pre code {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-fg) !important;
+    border-color: var(--raven-c-punctuation) !important;
+    font-family: var(--raven-font-mono) !important;
+}
+
+html.raven-vscode-theme .sourceCode .kw,
+html.raven-vscode-theme .sourceCode .cf,
+html.raven-vscode-theme .sourceCode .im { color: var(--raven-c-keyword) !important; }
+html.raven-vscode-theme .sourceCode .st,
+html.raven-vscode-theme .sourceCode .ch,
+html.raven-vscode-theme .sourceCode .ss,
+html.raven-vscode-theme .sourceCode .vs { color: var(--raven-c-string) !important; }
+html.raven-vscode-theme .sourceCode .dv,
+html.raven-vscode-theme .sourceCode .bn,
+html.raven-vscode-theme .sourceCode .fl { color: var(--raven-c-number) !important; }
+html.raven-vscode-theme .sourceCode .co,
+html.raven-vscode-theme .sourceCode .cv,
+html.raven-vscode-theme .sourceCode .do,
+html.raven-vscode-theme .sourceCode .an { color: var(--raven-c-comment) !important; }
+html.raven-vscode-theme .sourceCode .fu,
+html.raven-vscode-theme .sourceCode .bu { color: var(--raven-c-function) !important; }
+html.raven-vscode-theme .sourceCode .dt { color: var(--raven-c-type) !important; }
+html.raven-vscode-theme .sourceCode .va,
+html.raven-vscode-theme .sourceCode .at { color: var(--raven-c-variable) !important; }
+html.raven-vscode-theme .sourceCode .op { color: var(--raven-c-operator) !important; }
+html.raven-vscode-theme .sourceCode .sc,
+html.raven-vscode-theme .sourceCode .pp { color: var(--raven-c-punctuation) !important; }
+html.raven-vscode-theme .sourceCode .cn,
+html.raven-vscode-theme .sourceCode .ot { color: var(--raven-c-constant) !important; }
+
+html.raven-vscode-theme .navbar,
+html.raven-vscode-theme .navbar .dropdown-menu,
+html.raven-vscode-theme #quarto-sidebar,
+html.raven-vscode-theme #TOC,
+html.raven-vscode-theme .sidebar {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-fg) !important;
+    border-color: var(--raven-c-punctuation) !important;
+}
+
+html.raven-vscode-theme .navbar a,
+html.raven-vscode-theme #quarto-sidebar a,
+html.raven-vscode-theme #TOC a,
+html.raven-vscode-theme .sidebar a {
+    color: var(--raven-fg) !important;
+}
+
+html.raven-vscode-theme .callout,
+html.raven-vscode-theme .callout-header,
+html.raven-vscode-theme .callout-body,
+html.raven-vscode-theme .card,
+html.raven-vscode-theme .card-header,
+html.raven-vscode-theme .card-body {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-fg) !important;
+    border-color: var(--raven-c-punctuation) !important;
+}
+
+html.raven-vscode-theme table,
+html.raven-vscode-theme table th,
+html.raven-vscode-theme table td,
+html.raven-vscode-theme .table,
+html.raven-vscode-theme .table > :not(caption) > * > * {
+    background-color: var(--raven-bg) !important;
+    color: var(--raven-fg) !important;
+    border-color: var(--raven-c-punctuation) !important;
+}

--- a/editors/vscode/src/quarto/bridge/bridge.js
+++ b/editors/vscode/src/quarto/bridge/bridge.js
@@ -13,18 +13,6 @@
         'punctuation',
         'constant',
     ];
-    var roleVariables = {
-        keyword: '--raven-c-keyword',
-        string: '--raven-c-string',
-        number: '--raven-c-number',
-        comment: '--raven-c-comment',
-        function: '--raven-c-function',
-        type: '--raven-c-type',
-        variable: '--raven-c-variable',
-        operator: '--raven-c-operator',
-        punctuation: '--raven-c-punctuation',
-        constant: '--raven-c-constant',
-    };
     var payloadKeys = [
         '__ravenQuartoTheme',
         'background',
@@ -86,7 +74,7 @@
         root.style.setProperty('--raven-fg', payload.foreground);
         for (var index = 0; index < roleKeys.length; index += 1) {
             var role = roleKeys[index];
-            root.style.setProperty(roleVariables[role], payload.roles[role]);
+            root.style.setProperty('--raven-c-' + role, payload.roles[role]);
         }
         root.style.setProperty('--raven-font-text', payload.fontText);
         root.style.setProperty('--raven-font-mono', payload.fontMono);

--- a/editors/vscode/src/quarto/bridge/bridge.js
+++ b/editors/vscode/src/quarto/bridge/bridge.js
@@ -1,0 +1,114 @@
+(function () {
+    'use strict';
+
+    var roleKeys = [
+        'keyword',
+        'string',
+        'number',
+        'comment',
+        'function',
+        'type',
+        'variable',
+        'operator',
+        'punctuation',
+        'constant',
+    ];
+    var roleVariables = {
+        keyword: '--raven-c-keyword',
+        string: '--raven-c-string',
+        number: '--raven-c-number',
+        comment: '--raven-c-comment',
+        function: '--raven-c-function',
+        type: '--raven-c-type',
+        variable: '--raven-c-variable',
+        operator: '--raven-c-operator',
+        punctuation: '--raven-c-punctuation',
+        constant: '--raven-c-constant',
+    };
+    var payloadKeys = [
+        '__ravenQuartoTheme',
+        'background',
+        'enabled',
+        'fontMono',
+        'fontText',
+        'foreground',
+        'roles',
+    ];
+    var roleSchemaKeys = roleKeys.slice().sort();
+    var colorPattern = /^(?:#[0-9a-f]{3,4}|#[0-9a-f]{6}(?:[0-9a-f]{2})?|rgb\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*\)|rgba\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*(?:0|1|0?\.\d+|\d{1,3}%)\s*\))$/i;
+    // Keep this character guard aligned with sanitizeFontFamily and the
+    // raven.quarto font-setting schema. Structural checks happen upstream.
+    var fontPattern = /^[^;{}<>\\\n\r\t\f\v\0]*$/;
+
+    function isRecord(value) {
+        return value !== null && typeof value === 'object' && !Array.isArray(value);
+    }
+
+    function hasExactKeys(value, expected) {
+        var actual = Object.keys(value).sort();
+        if (actual.length !== expected.length) return false;
+        for (var index = 0; index < expected.length; index += 1) {
+            if (actual[index] !== expected[index]) return false;
+        }
+        return true;
+    }
+
+    function isColor(value) {
+        return typeof value === 'string' && colorPattern.test(value);
+    }
+
+    function isThemeMessage(value) {
+        if (!isRecord(value) || !hasExactKeys(value, payloadKeys)) return false;
+        if (value.__ravenQuartoTheme !== true || typeof value.enabled !== 'boolean') return false;
+        if (!isColor(value.background) || !isColor(value.foreground)) return false;
+        if (typeof value.fontText !== 'string' || !fontPattern.test(value.fontText)) return false;
+        if (typeof value.fontMono !== 'string' || !fontPattern.test(value.fontMono)) return false;
+        if (!isRecord(value.roles) || !hasExactKeys(value.roles, roleSchemaKeys)) return false;
+        for (var index = 0; index < roleKeys.length; index += 1) {
+            if (!isColor(value.roles[roleKeys[index]])) return false;
+        }
+        return true;
+    }
+
+    function isPingMessage(value) {
+        return isRecord(value)
+            && hasExactKeys(value, ['type'])
+            && value.type === 'raven-quarto-theme-ping';
+    }
+
+    function postReady() {
+        window.parent.postMessage({ type: 'raven-quarto-theme-ready' }, '*');
+    }
+
+    function applyTheme(payload) {
+        var root = document.documentElement;
+        root.style.setProperty('--raven-bg', payload.background);
+        root.style.setProperty('--raven-fg', payload.foreground);
+        for (var index = 0; index < roleKeys.length; index += 1) {
+            var role = roleKeys[index];
+            root.style.setProperty(roleVariables[role], payload.roles[role]);
+        }
+        root.style.setProperty('--raven-font-text', payload.fontText);
+        root.style.setProperty('--raven-font-mono', payload.fontMono);
+        root.classList.toggle('raven-vscode-theme', payload.enabled);
+    }
+
+    // Install the listener before the first ready handshake: parent delivery
+    // can be synchronous with observing that handshake.
+    window.addEventListener('message', function (event) {
+        try {
+            if (event.source !== window.parent) return;
+            if (isPingMessage(event.data)) {
+                postReady();
+                return;
+            }
+            if (!isThemeMessage(event.data)) return;
+            applyTheme(event.data);
+            postReady();
+        } catch (_error) {
+            // A malformed or hostile page message must never escape the bridge.
+        }
+    });
+
+    postReady();
+}());

--- a/editors/vscode/src/quarto/index.ts
+++ b/editors/vscode/src/quarto/index.ts
@@ -15,11 +15,13 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { registerQuartoCommands } from './quarto-commands';
+import { loadQuartoPreviewBridgeAssets } from './quarto-bridge-assets';
 import type { QuartoCommandLifecycle } from './quarto-command-lifecycle';
 import { probeQuartoBinary, QuartoResolver } from './quarto-detect';
 import { QuartoPreviewProcess } from './quarto-preview-engine';
 import { QuartoPreviewPanel, type QuartoPreviewPanelDeps } from './quarto-preview-panel';
 import { QuartoRuntime } from './quarto-preview-runtime';
+import { QuartoPreviewWithProxyProcess } from './quarto-preview-with-proxy';
 import { resolveQuartoContext } from './quarto-project';
 import { isQuartoProjectMarkerFile } from './quarto-project-fs';
 import { QuartoRenderEngine } from './quarto-render-engine';
@@ -48,9 +50,14 @@ export function registerQuarto(context: vscode.ExtensionContext): void {
         probe: probeQuartoBinary,
     });
     const renderEngine = new QuartoRenderEngine();
+    const bridgeAssets = loadQuartoPreviewBridgeAssets(
+        context.extensionUri.fsPath,
+        output,
+    );
 
     let runtime!: QuartoRuntime;
     const panelDeps: QuartoPreviewPanelDeps = {
+        context,
         output,
         stopGeneration: (key, generation) => runtime.stopGeneration(key, generation),
         keyForSource: async (sourceFsPath) => (
@@ -61,12 +68,17 @@ export function registerQuarto(context: vscode.ExtensionContext): void {
         ).key,
     };
     runtime = new QuartoRuntime({
-        processFactory: (args) => new QuartoPreviewProcess({
-            quartoPath: args.quartoPath,
-            sourceFsPath: args.sourceFsPath,
-            cwd: args.cwd,
+        processFactory: (args) => new QuartoPreviewWithProxyProcess({
             output,
+            bridgeAssets,
             onUnexpectedExit: args.onUnexpectedExit,
+            createInner: (onUnexpectedExit) => new QuartoPreviewProcess({
+                quartoPath: args.quartoPath,
+                sourceFsPath: args.sourceFsPath,
+                cwd: args.cwd,
+                output,
+                onUnexpectedExit,
+            }),
         }),
         asExternalUri: async (rawUrl) => (
             await vscode.env.asExternalUri(vscode.Uri.parse(rawUrl))

--- a/editors/vscode/src/quarto/quarto-bridge-assets.ts
+++ b/editors/vscode/src/quarto/quarto-bridge-assets.ts
@@ -1,0 +1,43 @@
+/** Defensive loading for the optional packaged Quarto theme bridge. */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { QuartoPreviewBridgeAssets } from './quarto-preview-proxy';
+
+type ReadFile = (path: fs.PathOrFileDescriptor) => Buffer;
+
+/**
+ * Load both bridge files atomically, or disable theming without aborting
+ * Quarto registration when an installation omitted either dist asset.
+ */
+export function loadQuartoPreviewBridgeAssets(
+    extensionFsPath: string,
+    output: { appendLine(value: string): unknown },
+    readFile: ReadFile = fs.readFileSync,
+): QuartoPreviewBridgeAssets | undefined {
+    try {
+        const bridgeDir = path.join(
+            extensionFsPath,
+            'dist',
+            'quarto-theme-bridge',
+        );
+        return {
+            javascript: readFile(path.join(bridgeDir, 'bridge.js')),
+            css: readFile(path.join(bridgeDir, 'bridge.css')),
+        };
+    } catch (error) {
+        try {
+            output.appendLine(
+                '[quarto] Theme bridge assets unavailable; previews will be unthemed: ' +
+                errorMessage(error),
+            );
+        } catch {
+            // Registration must remain available even if output is disposing.
+        }
+        return undefined;
+    }
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/editors/vscode/src/quarto/quarto-messages.ts
+++ b/editors/vscode/src/quarto/quarto-messages.ts
@@ -16,8 +16,49 @@ export type QuartoPreviewViewState =
     | { kind: 'stopped' }
     | { kind: 'restore-placeholder' };
 
+export const QUARTO_THEME_ROLE_KEYS = [
+    'keyword',
+    'string',
+    'number',
+    'comment',
+    'function',
+    'type',
+    'variable',
+    'operator',
+    'punctuation',
+    'constant',
+] as const;
+
+export type QuartoThemeRole = typeof QUARTO_THEME_ROLE_KEYS[number];
+
+export interface QuartoThemePayload {
+    enabled: boolean;
+    background: string;
+    foreground: string;
+    roles: Record<QuartoThemeRole, string>;
+    fontText: string;
+    fontMono: string;
+}
+
+/** Theme delivery from Raven's trusted outer shell into the Quarto page. */
+export type RavenQuartoThemeMessage = QuartoThemePayload & {
+    __ravenQuartoTheme: true;
+};
+
+/** Contentless handshake from the injected Quarto bridge to its parent shell. */
+export interface RavenQuartoThemeReadyMessage {
+    type: 'raven-quarto-theme-ready';
+}
+
+/** Contentless shell-to-page availability probe, sent after every frame load. */
+export interface RavenQuartoThemePingMessage {
+    type: 'raven-quarto-theme-ping';
+}
+
 export type ExtensionToPreviewMessage =
-    | { type: 'state-update'; payload: QuartoPreviewViewState };
+    | { type: 'state-update'; payload: QuartoPreviewViewState }
+    | { type: 'theme-update'; payload: QuartoThemePayload }
+    | { type: 'theme-context-request' };
 
 export type PreviewToExtensionMessage =
     | { type: 'webview-ready' }
@@ -25,7 +66,10 @@ export type PreviewToExtensionMessage =
     | { type: 'stop-preview' }
     | { type: 'request-restart' }
     | { type: 'load-timeout' }
-    | { type: 'report-error'; message: string };
+    | { type: 'report-error'; message: string }
+    | { type: 'theme-context'; background: string }
+    | { type: 'theme-changed'; applied: boolean }
+    | { type: 'theme-bridge-status'; available: boolean };
 
 const PREVIEW_MESSAGE_SCHEMAS: Record<PreviewToExtensionMessage['type'], readonly string[]> = {
     'webview-ready': ['type'],
@@ -34,6 +78,9 @@ const PREVIEW_MESSAGE_SCHEMAS: Record<PreviewToExtensionMessage['type'], readonl
     'request-restart': ['type'],
     'load-timeout': ['type'],
     'report-error': ['message', 'type'],
+    'theme-context': ['background', 'type'],
+    'theme-changed': ['applied', 'type'],
+    'theme-bridge-status': ['available', 'type'],
 };
 
 const VIEW_STATE_SCHEMAS: Record<QuartoPreviewViewState['kind'], readonly string[]> = {
@@ -58,6 +105,86 @@ function hasExactKeys(value: Record<string, unknown>, expected: readonly string[
     return true;
 }
 
+export const QUARTO_THEME_PAYLOAD_KEYS = [
+    'background',
+    'enabled',
+    'fontMono',
+    'fontText',
+    'foreground',
+    'roles',
+] as const;
+
+const THEME_ROLE_SCHEMA_KEYS = [...QUARTO_THEME_ROLE_KEYS].sort();
+
+export const RAVEN_QUARTO_THEME_MESSAGE_KEYS = [
+    '__ravenQuartoTheme',
+    ...QUARTO_THEME_PAYLOAD_KEYS,
+] as const;
+
+/** Shared regex source used by the host validator and generated shell. */
+export const QUARTO_CSS_COLOR_PATTERN_SOURCE = String.raw`^(?:#[0-9a-f]{3,4}|#[0-9a-f]{6}(?:[0-9a-f]{2})?|rgb\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*\)|rgba\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*(?:0|1|0?\.\d+|\d{1,3}%)\s*\))$`;
+
+/**
+ * Shared character guard for values emitted by `sanitizeFontFamily`.
+ *
+ * This deliberately matches the settings schema and sanitizer's character
+ * ban instead of rejecting every C0 control character. The producer performs
+ * the stronger structural validation (quotes, comments, commas, and parens).
+ */
+export const QUARTO_SANITIZED_FONT_PATTERN_SOURCE =
+    String.raw`^[^;{}<>\\\n\r\t\f\v\0]*$`;
+
+const CSS_COLOR = new RegExp(QUARTO_CSS_COLOR_PATTERN_SOURCE, 'i');
+const SANITIZED_FONT = new RegExp(QUARTO_SANITIZED_FONT_PATTERN_SOURCE);
+
+/** Strictly validate theme data before it can enter a CSS declaration. */
+export function isQuartoThemePayload(value: unknown): value is QuartoThemePayload {
+    if (!isRecord(value) || !hasExactKeys(value, QUARTO_THEME_PAYLOAD_KEYS)) return false;
+    if (typeof value.enabled !== 'boolean') return false;
+    if (!isColor(value.background) || !isColor(value.foreground)) return false;
+    if (typeof value.fontText !== 'string' || !SANITIZED_FONT.test(value.fontText)) return false;
+    if (typeof value.fontMono !== 'string' || !SANITIZED_FONT.test(value.fontMono)) return false;
+    const roles = value.roles;
+    if (!isRecord(roles) || !hasExactKeys(roles, THEME_ROLE_SCHEMA_KEYS)) return false;
+    return QUARTO_THEME_ROLE_KEYS.every((role) => isColor(roles[role]));
+}
+
+/** Strictly validate shell-to-page bridge delivery, including its marker. */
+export function isRavenQuartoThemeMessage(value: unknown): value is RavenQuartoThemeMessage {
+    if (!isRecord(value) || !hasExactKeys(value, RAVEN_QUARTO_THEME_MESSAGE_KEYS)) return false;
+    if (value.__ravenQuartoTheme !== true) return false;
+    return isQuartoThemePayload({
+        enabled: value.enabled,
+        background: value.background,
+        foreground: value.foreground,
+        roles: value.roles,
+        fontText: value.fontText,
+        fontMono: value.fontMono,
+    });
+}
+
+/** Strictly validate the contentless page-to-shell ready handshake. */
+export function isRavenQuartoThemeReadyMessage(
+    value: unknown,
+): value is RavenQuartoThemeReadyMessage {
+    return isRecord(value) &&
+        hasExactKeys(value, ['type']) &&
+        value.type === 'raven-quarto-theme-ready';
+}
+
+/** Strictly validate the contentless shell-to-page availability probe. */
+export function isRavenQuartoThemePingMessage(
+    value: unknown,
+): value is RavenQuartoThemePingMessage {
+    return isRecord(value) &&
+        hasExactKeys(value, ['type']) &&
+        value.type === 'raven-quarto-theme-ping';
+}
+
+function isColor(value: unknown): value is string {
+    return typeof value === 'string' && CSS_COLOR.test(value);
+}
+
 function isViewState(value: unknown): value is QuartoPreviewViewState {
     if (!isRecord(value) || typeof value.kind !== 'string') return false;
     if (!Object.prototype.hasOwnProperty.call(VIEW_STATE_SCHEMAS, value.kind)) return false;
@@ -79,9 +206,18 @@ function isViewState(value: unknown): value is QuartoPreviewViewState {
 
 /** Strictly validate a host-to-preview state update. */
 export function isExtensionToPreviewMessage(value: unknown): value is ExtensionToPreviewMessage {
-    if (!isRecord(value)) return false;
-    if (!hasExactKeys(value, ['payload', 'type'])) return false;
-    return value.type === 'state-update' && isViewState(value.payload);
+    if (!isRecord(value) || typeof value.type !== 'string') return false;
+    switch (value.type) {
+        case 'state-update':
+            return hasExactKeys(value, ['payload', 'type']) && isViewState(value.payload);
+        case 'theme-update':
+            return hasExactKeys(value, ['payload', 'type']) &&
+                isQuartoThemePayload(value.payload);
+        case 'theme-context-request':
+            return hasExactKeys(value, ['type']);
+        default:
+            return false;
+    }
 }
 
 /** Strictly validate a preview-to-host action or error report. */
@@ -90,5 +226,16 @@ export function isPreviewToExtensionMessage(value: unknown): value is PreviewToE
     if (!Object.prototype.hasOwnProperty.call(PREVIEW_MESSAGE_SCHEMAS, value.type)) return false;
     const expected = PREVIEW_MESSAGE_SCHEMAS[value.type as PreviewToExtensionMessage['type']];
     if (!hasExactKeys(value, expected)) return false;
-    return value.type !== 'report-error' || typeof value.message === 'string';
+    switch (value.type) {
+        case 'report-error':
+            return typeof value.message === 'string';
+        case 'theme-context':
+            return typeof value.background === 'string';
+        case 'theme-changed':
+            return typeof value.applied === 'boolean';
+        case 'theme-bridge-status':
+            return typeof value.available === 'boolean';
+        default:
+            return true;
+    }
 }

--- a/editors/vscode/src/quarto/quarto-preview-engine.ts
+++ b/editors/vscode/src/quarto/quarto-preview-engine.ts
@@ -97,6 +97,12 @@ export interface QuartoPreviewProcessLike {
     start(): Promise<QuartoPreviewReady>;
     stop(): Promise<void>;
     shutdown(): Promise<void>;
+    /**
+     * Optionally record the browser-facing URL (`asExternalUri` mapping of the
+     * ready origin) once known, so a response-transforming proxy can extend its
+     * request allowlist to that host/origin. A no-op for plain processes.
+     */
+    setBrowserFacingOrigin?(externalUrl: string): void;
 }
 
 export class QuartoPreviewProcess implements QuartoPreviewProcessLike {

--- a/editors/vscode/src/quarto/quarto-preview-engine.ts
+++ b/editors/vscode/src/quarto/quarto-preview-engine.ts
@@ -58,7 +58,10 @@ const SIGNAL_GRACE_MS = 5_000;
 const SHUTDOWN_TERM_GRACE_MS = 2_000;
 
 export interface QuartoPreviewReady {
+    /** URL framed by the preview runtime (the proxy URL when bridged). */
     rawUrl: string;
+    /** Original Quarto URL for Open in Browser; defaults to `rawUrl`. */
+    browserUrl?: string;
     origin: string;
     statusCode: number;
 }

--- a/editors/vscode/src/quarto/quarto-preview-html.ts
+++ b/editors/vscode/src/quarto/quarto-preview-html.ts
@@ -3,12 +3,12 @@
  *
  * Workspace-controlled Quarto output runs only in a genuinely cross-origin,
  * sandboxed iframe. The outer shell never reads the framed DOM and has no
- * network permissions of its own. Its message listener rejects the embedded
- * frame as a sender, accepts only the empty/webview-host origin used by VS
- * Code delivery, and mirrors the host protocol's exact-key validation before
- * rendering state. Serving CSP is derived from the same mapped URL installed
- * in the frame; non-serving states have neither a `frame-src` directive nor
- * an iframe.
+ * network permissions of its own. Its message listener gives the embedded
+ * frame one exact, origin-pinned ready-handshake shape and returns for every
+ * other frame message. A disjoint branch accepts host delivery only from the
+ * empty/webview-host origin and mirrors the host protocol's exact-key guards.
+ * Serving CSP is derived from the same mapped URL installed in the frame;
+ * non-serving states have neither a `frame-src` directive nor an iframe.
  *
  * All dynamic state enters the script through JSON serialized with `<`
  * escaped, then reaches visible DOM through `textContent`. The serving URL
@@ -16,12 +16,17 @@
  * URL is interpolated as executable markup.
  */
 
-import type { QuartoPreviewViewState } from './quarto-messages';
+import {
+    QUARTO_CSS_COLOR_PATTERN_SOURCE,
+    QUARTO_SANITIZED_FONT_PATTERN_SOURCE,
+    type QuartoPreviewViewState,
+} from './quarto-messages';
 
 export interface QuartoPreviewShellHtmlArgs {
     nonce: string;
     sourceFsPath: string;
     state: QuartoPreviewViewState;
+    themeEnabled: boolean;
 }
 
 function escapeHtmlAttribute(value: string): string {
@@ -55,7 +60,7 @@ function servingOrigin(state: QuartoPreviewViewState): string | null {
  * from that same value in one render, preventing mapping/CSP drift.
  */
 export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): string {
-    const { nonce, sourceFsPath, state } = args;
+    const { nonce, sourceFsPath, state, themeEnabled } = args;
     const origin = servingOrigin(state);
     const isServing = state.kind === 'serving' && origin !== null;
     const csp = [
@@ -64,7 +69,14 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
         `script-src 'nonce-${nonce}'`,
         `style-src 'nonce-${nonce}'`,
     ].join('; ');
-    const seed = jsonForScript({ sourceFsPath, state });
+    const seed = jsonForScript({
+        sourceFsPath,
+        state,
+        themeEnabled,
+        frameOrigin: origin,
+    });
+    const colorPatternSource = jsonForScript(QUARTO_CSS_COLOR_PATTERN_SOURCE);
+    const fontPatternSource = jsonForScript(QUARTO_SANITIZED_FONT_PATTERN_SOURCE);
     const safeNonce = escapeHtmlAttribute(nonce);
     const frame = isServing
         ? `<iframe id="raven-quarto-frame"
@@ -109,6 +121,14 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
             cursor: pointer;
         }
         button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+        button[aria-pressed="true"] {
+            color: var(--vscode-button-foreground);
+            background: var(--vscode-button-background);
+        }
+        button[aria-pressed="true"]:hover {
+            background: var(--vscode-button-hoverBackground);
+        }
+        button:disabled { cursor: default; opacity: 0.55; }
         #raven-quarto-status { padding: 16px; white-space: pre-wrap; }
         #raven-quarto-frame { flex: 1 1 auto; width: 100%; border: 0; background: white; }
         #raven-quarto-load-banner {
@@ -125,6 +145,8 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
         <button id="raven-quarto-open" type="button">Open in Browser</button>
         <button id="raven-quarto-stop" type="button">Stop Preview</button>
         <button id="raven-quarto-restart" type="button">Restart Preview</button>
+        <button id="raven-quarto-theme" type="button"
+          aria-pressed="${themeEnabled ? 'true' : 'false'}">Apply VS Code theme</button>
     </div>
     <div id="raven-quarto-load-banner" role="status" hidden></div>
     <div id="raven-quarto-status" role="status"></div>
@@ -139,8 +161,16 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
             const openButton = document.getElementById('raven-quarto-open');
             const stopButton = document.getElementById('raven-quarto-stop');
             const restartButton = document.getElementById('raven-quarto-restart');
+            const themeButton = document.getElementById('raven-quarto-theme');
             const banner = document.getElementById('raven-quarto-load-banner');
             const frame = document.getElementById('raven-quarto-frame');
+            const frameOrigin = initial.frameOrigin;
+            let currentState = initial.state;
+            let themeEnabled = initial.themeEnabled === true;
+            let currentTheme = null;
+            let blankTimer = null;
+            let bridgeTimer = null;
+            let bridgeAvailable = null;
 
             function isRecord(value) {
                 return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -184,12 +214,126 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
                     && isViewState(value.payload);
             }
 
+            const roleKeys = [
+                'keyword', 'string', 'number', 'comment', 'function',
+                'type', 'variable', 'operator', 'punctuation', 'constant'
+            ];
+            const payloadKeys = [
+                'background', 'enabled', 'fontMono', 'fontText',
+                'foreground', 'roles'
+            ];
+            const roleSchemaKeys = roleKeys.slice().sort();
+            const colorPattern = new RegExp(${colorPatternSource}, 'i');
+            const fontPattern = new RegExp(${fontPatternSource});
+
+            function isColor(value) {
+                return typeof value === 'string' && colorPattern.test(value);
+            }
+
+            function isSafeFont(value) {
+                return typeof value === 'string' && fontPattern.test(value);
+            }
+
+            function isThemePayload(value) {
+                if (!isRecord(value) || !hasExactKeys(value, payloadKeys)) return false;
+                if (typeof value.enabled !== 'boolean') return false;
+                if (!isColor(value.background) || !isColor(value.foreground)) return false;
+                if (!isSafeFont(value.fontText) || !isSafeFont(value.fontMono)) return false;
+                if (!isRecord(value.roles) || !hasExactKeys(value.roles, roleSchemaKeys)) return false;
+                for (let i = 0; i < roleKeys.length; i++) {
+                    if (!isColor(value.roles[roleKeys[i]])) return false;
+                }
+                return true;
+            }
+
+            function isThemeUpdate(value) {
+                return isRecord(value)
+                    && hasExactKeys(value, ['payload', 'type'])
+                    && value.type === 'theme-update'
+                    && isThemePayload(value.payload);
+            }
+
+            function isThemeContextRequest(value) {
+                return isRecord(value)
+                    && hasExactKeys(value, ['type'])
+                    && value.type === 'theme-context-request';
+            }
+
+            function isThemeReady(value) {
+                return isRecord(value)
+                    && hasExactKeys(value, ['type'])
+                    && value.type === 'raven-quarto-theme-ready';
+            }
+
+            function postBridgePing() {
+                if (!frame || !frame.contentWindow || !frameOrigin) return;
+                frame.contentWindow.postMessage({
+                    type: 'raven-quarto-theme-ping'
+                }, frameOrigin);
+            }
+
+            function syncThemeButton() {
+                themeButton.setAttribute('aria-pressed', themeEnabled ? 'true' : 'false');
+                themeButton.hidden = currentState.kind !== 'serving';
+                themeButton.title = bridgeAvailable === false
+                    ? "VS Code theme can't apply to this page"
+                    : 'Apply VS Code theme';
+            }
+
+            function postThemeToFrame() {
+                if (!frame || !frame.contentWindow || !currentTheme || !frameOrigin) return;
+                frame.contentWindow.postMessage({
+                    __ravenQuartoTheme: true,
+                    ...currentTheme
+                }, frameOrigin);
+            }
+
+            function reportThemeContext() {
+                try {
+                    const rootStyle = getComputedStyle(document.documentElement);
+                    const bodyStyle = getComputedStyle(document.body);
+                    const background = (
+                        rootStyle.getPropertyValue('--vscode-editor-background')
+                        || bodyStyle.backgroundColor
+                        || rootStyle.backgroundColor
+                        || ''
+                    ).trim();
+                    if (background) {
+                        vscode.postMessage({ type: 'theme-context', background });
+                    }
+                } catch (_) { /* host falls back to the first candidate */ }
+            }
+
+            function markBridgeAvailable() {
+                if (bridgeTimer !== null) window.clearTimeout(bridgeTimer);
+                bridgeTimer = null;
+                if (bridgeAvailable !== true) {
+                    bridgeAvailable = true;
+                    vscode.postMessage({ type: 'theme-bridge-status', available: true });
+                }
+                syncThemeButton();
+            }
+
+            function armBridgeTimeout() {
+                if (bridgeTimer !== null) window.clearTimeout(bridgeTimer);
+                bridgeAvailable = null;
+                syncThemeButton();
+                bridgeTimer = window.setTimeout(function () {
+                    bridgeTimer = null;
+                    bridgeAvailable = false;
+                    syncThemeButton();
+                    vscode.postMessage({ type: 'theme-bridge-status', available: false });
+                }, 3000);
+            }
+
             function render(next) {
+                currentState = next;
                 status.textContent = '';
                 status.hidden = next.kind === 'serving';
                 openButton.hidden = next.kind !== 'serving';
                 stopButton.hidden = next.kind !== 'starting' && next.kind !== 'serving';
                 restartButton.hidden = next.kind === 'starting' || next.kind === 'serving';
+                themeButton.hidden = next.kind !== 'serving';
 
                 switch (next.kind) {
                     case 'starting':
@@ -223,21 +367,64 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
             restartButton.addEventListener('click', function () {
                 vscode.postMessage({ type: 'request-restart' });
             });
+            themeButton.addEventListener('click', function () {
+                themeEnabled = !themeEnabled;
+                syncThemeButton();
+                if (currentTheme) {
+                    currentTheme = { ...currentTheme, enabled: themeEnabled };
+                    postThemeToFrame();
+                }
+                vscode.postMessage({ type: 'theme-changed', applied: themeEnabled });
+            });
             window.addEventListener('message', function (event) {
-                if (event.origin !== '' && event.origin !== window.origin) return;
-                if (frame && event.source === frame.contentWindow) return;
                 const message = event.data;
-                if (!isStateUpdate(message)) return;
-                render(message.payload);
+                // Branch A: a framed Quarto page can only complete the exact
+                // ready handshake from its pinned serving origin. Always
+                // return so frame data can never fall through to host actions.
+                if (frame && event.source === frame.contentWindow) {
+                    if (event.origin === frameOrigin && isThemeReady(message)) {
+                        markBridgeAvailable();
+                    }
+                    return;
+                }
+
+                // Branch B: extension-host delivery. This branch is disjoint
+                // from the frame branch above; do not combine their origins.
+                if (event.origin === '' || event.origin === window.origin) {
+                    if (isStateUpdate(message)) {
+                        render(message.payload);
+                        return;
+                    }
+                    if (isThemeUpdate(message)) {
+                        currentTheme = message.payload;
+                        themeEnabled = currentTheme.enabled;
+                        syncThemeButton();
+                        postThemeToFrame();
+                        return;
+                    }
+                    if (isThemeContextRequest(message)) {
+                        reportThemeContext();
+                    }
+                    return;
+                }
+                return;
             });
 
             render(initial.state);
+            syncThemeButton();
+            reportThemeContext();
             if (frame) {
-                window.setTimeout(function () {
+                blankTimer = window.setTimeout(function () {
+                    blankTimer = null;
                     banner.textContent = 'If the preview looks blank, try Open in Browser.';
                     banner.hidden = false;
                     vscode.postMessage({ type: 'load-timeout' });
                 }, 8000);
+                frame.addEventListener('load', function () {
+                    armBridgeTimeout();
+                    postBridgePing();
+                    postThemeToFrame();
+                });
             }
             vscode.postMessage({ type: 'webview-ready' });
         }());

--- a/editors/vscode/src/quarto/quarto-preview-panel.ts
+++ b/editors/vscode/src/quarto/quarto-preview-panel.ts
@@ -412,20 +412,23 @@ export class QuartoPreviewPanel {
     }
 
     private createThemeController(): QuartoThemeController {
-        let cachedLanguageId = 'quarto';
+        // Scope the cached languageId per source file: when the panel is
+        // retargeted to a source whose document is not open, it must fall back
+        // to the default rather than inherit the previous source's language.
+        const cachedLanguageIds = new Map<string, string>();
         const sourceScope = (sourceFsPath: string): {
             uri: vscode.Uri;
             languageId: string;
         } => {
             for (const document of vscode.workspace.textDocuments) {
                 if (document.uri.fsPath === sourceFsPath) {
-                    cachedLanguageId = document.languageId;
+                    cachedLanguageIds.set(sourceFsPath, document.languageId);
                     break;
                 }
             }
             return {
                 uri: vscode.Uri.file(sourceFsPath),
-                languageId: cachedLanguageId,
+                languageId: cachedLanguageIds.get(sourceFsPath) ?? 'quarto',
             };
         };
 

--- a/editors/vscode/src/quarto/quarto-preview-panel.ts
+++ b/editors/vscode/src/quarto/quarto-preview-panel.ts
@@ -35,19 +35,31 @@
  */
 
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { canonicalOpKey } from '../knit/raven-knit-paths';
+import { resolveFontFamilies } from '../knit/render-html';
+import { getKnitGrammarRegistry } from '../knit/post-knit-renderer';
 import { applyViewerTabIcon } from '../viewer-tab-icon';
-import type { QuartoPreviewViewState } from './quarto-messages';
+import type { QuartoPreviewViewState, QuartoThemePayload } from './quarto-messages';
 import { isPreviewToExtensionMessage } from './quarto-messages';
 import { buildQuartoPreviewShellHtml } from './quarto-preview-html';
 import type { QuartoRuntimeViewUpdate } from './quarto-preview-runtime';
+import {
+    QuartoThemeController,
+    type QuartoThemeKind,
+} from './quarto-theme-controller';
 
 export interface QuartoPreviewPanelDeps {
+    context: vscode.ExtensionContext;
     output: vscode.OutputChannel;
     stopGeneration(key: string, generation: number): Promise<unknown>;
     keyForSource(sourceFsPath: string): Promise<string>;
+    postWebviewMessage?(
+        webview: vscode.Webview,
+        message: unknown,
+    ): PromiseLike<boolean> | boolean;
 }
 
 type ViewerColumnSetting = 'active' | 'beside';
@@ -58,9 +70,11 @@ export class QuartoPreviewPanel {
     private generation: number;
     private sourceFsPath: string;
     private state: QuartoPreviewViewState;
-    private rawUrl: string | undefined;
+    private browserUrl: string | undefined;
     private frameInstalled = false;
     private disposed = false;
+    private bridgeAvailable: boolean | undefined;
+    private readonly themeController: QuartoThemeController;
 
     private constructor(
         private readonly panel: vscode.WebviewPanel,
@@ -73,6 +87,7 @@ export class QuartoPreviewPanel {
         this.generation = generation;
         this.sourceFsPath = sourceFsPath;
         this.state = state;
+        this.themeController = this.createThemeController();
         this.wire();
         this.rebuildHtml();
     }
@@ -137,10 +152,10 @@ export class QuartoPreviewPanel {
             update.state,
             deps,
         );
-        instance.rawUrl = update.rawUrl;
+        instance.browserUrl = update.browserUrl ?? update.rawUrl;
         this.instances.set(update.key, instance);
-        // The constructor rendered before rawUrl assignment, but rawUrl does
-        // not enter HTML; it is retained only for Open in Browser.
+        // The constructor rendered before browserUrl assignment, but that URL
+        // does not enter HTML; it is retained only for Open in Browser.
         return instance;
     }
 
@@ -211,6 +226,11 @@ export class QuartoPreviewPanel {
         await this.handleMessage(message);
     }
 
+    /** Test-only same-kind theme-change trigger. */
+    handleActiveThemeChangeForTesting(): void {
+        this.themeController.handleActiveThemeChangeForTesting();
+    }
+
     private applyUpdate(update: QuartoRuntimeViewUpdate): boolean {
         if (update.generation < this.generation || this.disposed) return false;
         let sourceChanged = false;
@@ -218,10 +238,12 @@ export class QuartoPreviewPanel {
             this.generation = update.generation;
             sourceChanged = this.sourceFsPath !== update.sourceFsPath;
             this.sourceFsPath = update.sourceFsPath;
-            this.rawUrl = undefined;
+            if (sourceChanged) this.themeController.updateSource(update.sourceFsPath);
+            this.browserUrl = undefined;
             this.panel.title = `Quarto Preview: ${path.basename(update.sourceFsPath)}`;
         }
-        if (update.rawUrl !== undefined) this.rawUrl = update.rawUrl;
+        if (update.browserUrl !== undefined) this.browserUrl = update.browserUrl;
+        else if (update.rawUrl !== undefined) this.browserUrl = update.rawUrl;
 
         const next = update.state;
         const rebuild = sourceChanged
@@ -238,7 +260,8 @@ export class QuartoPreviewPanel {
         this.key = update.key;
         this.generation = update.generation;
         this.sourceFsPath = update.sourceFsPath;
-        this.rawUrl = update.rawUrl;
+        this.themeController.updateSource(update.sourceFsPath);
+        this.browserUrl = update.browserUrl ?? update.rawUrl;
         this.state = update.state;
         this.panel.title = `Quarto Preview: ${path.basename(update.sourceFsPath)}`;
         this.rebuildHtml();
@@ -253,11 +276,16 @@ export class QuartoPreviewPanel {
             });
         });
         this.panel.onDidChangeViewState((event) => {
-            if (event.webviewPanel.visible) this.postState();
+            if (event.webviewPanel.visible) {
+                this.postState();
+                void this.requestThemeContext();
+                void this.themeController.push();
+            }
         });
         this.panel.onDidDispose(() => {
             if (this.disposed) return;
             this.disposed = true;
+            this.themeController.dispose();
             if (QuartoPreviewPanel.instances.get(this.key) === this) {
                 QuartoPreviewPanel.instances.delete(this.key);
             }
@@ -277,15 +305,16 @@ export class QuartoPreviewPanel {
         switch (message.type) {
             case 'webview-ready':
                 this.postState();
+                void this.themeController.push();
                 return;
             case 'open-in-browser':
-                if (this.rawUrl) {
+                if (this.browserUrl) {
                     const opened = await vscode.env.openExternal(
-                        vscode.Uri.parse(this.rawUrl),
+                        vscode.Uri.parse(this.browserUrl),
                     );
                     if (!opened) {
                         this.deps.output.appendLine(
-                            `[panel] Open in Browser failed: ${this.rawUrl}`,
+                            `[panel] Open in Browser failed: ${this.browserUrl}`,
                         );
                         await vscode.window.showWarningMessage(
                             'VS Code could not open the Quarto preview in a browser. ' +
@@ -314,6 +343,21 @@ export class QuartoPreviewPanel {
             case 'report-error':
                 this.deps.output.appendLine(`[panel] webview error: ${message.message}`);
                 return;
+            case 'theme-context':
+                this.themeController.setEditorBackground(message.background);
+                return;
+            case 'theme-changed':
+                await this.themeController.setEnabled(message.applied);
+                return;
+            case 'theme-bridge-status':
+                if (this.bridgeAvailable !== message.available) {
+                    this.bridgeAvailable = message.available;
+                    this.deps.output.appendLine(
+                        `[theme] bridge ${message.available ? 'available' : 'unavailable'} ` +
+                        `for ${this.sourceFsPath}`,
+                    );
+                }
+                return;
         }
     }
 
@@ -324,18 +368,124 @@ export class QuartoPreviewPanel {
             nonce: crypto.randomBytes(16).toString('base64'),
             sourceFsPath: this.sourceFsPath,
             state: this.state,
+            themeEnabled: this.themeController.isEnabled,
         });
+        if (this.state.kind === 'serving') void this.themeController.push();
     }
 
     private postState(): void {
         if (this.disposed) return;
-        void Promise.resolve(this.panel.webview.postMessage({
+        void this.postWebviewMessage({
             type: 'state-update',
             payload: this.state,
-        })).catch(() => {
+        }).catch(() => {
             // Hidden/disposed webviews can drop or reject delivery. Host state
             // remains authoritative and will be sent again when visible/ready.
         });
+    }
+
+    private postThemeUpdate(payload: QuartoThemePayload): Promise<boolean> {
+        if (this.disposed) return Promise.resolve(false);
+        return this.postWebviewMessage({
+            type: 'theme-update',
+            payload,
+        });
+    }
+
+    private requestThemeContext(): Promise<boolean> {
+        if (this.disposed) return Promise.resolve(false);
+        return this.postWebviewMessage({
+            type: 'theme-context-request',
+        });
+    }
+
+    private postWebviewMessage(message: unknown): Promise<boolean> {
+        if (this.disposed) return Promise.resolve(false);
+        try {
+            const delivered = this.deps.postWebviewMessage
+                ? this.deps.postWebviewMessage(this.panel.webview, message)
+                : this.panel.webview.postMessage(message);
+            return Promise.resolve(delivered).catch(() => false);
+        } catch {
+            return Promise.resolve(false);
+        }
+    }
+
+    private createThemeController(): QuartoThemeController {
+        let cachedLanguageId = 'quarto';
+        const sourceScope = (sourceFsPath: string): {
+            uri: vscode.Uri;
+            languageId: string;
+        } => {
+            for (const document of vscode.workspace.textDocuments) {
+                if (document.uri.fsPath === sourceFsPath) {
+                    cachedLanguageId = document.languageId;
+                    break;
+                }
+            }
+            return {
+                uri: vscode.Uri.file(sourceFsPath),
+                languageId: cachedLanguageId,
+            };
+        };
+
+        return new QuartoThemeController({
+            context: this.deps.context,
+            output: this.deps.output,
+            sourceFsPath: this.sourceFsPath,
+            postThemeUpdate: (payload) => this.postThemeUpdate(payload),
+            requestThemeContext: () => this.requestThemeContext(),
+            activeThemeKind: () => colorThemeKind(vscode.window.activeColorTheme.kind),
+            getConfiguration: <T>(section: string, defaultValue?: T): T | undefined =>
+                vscode.workspace.getConfiguration().get<T>(section, defaultValue as T),
+            themeResolverInputs: () => {
+                const editor = vscode.workspace.getConfiguration('editor');
+                return {
+                    extensions: vscode.extensions.all.map((extension) => ({
+                        id: extension.id,
+                        extensionPath: extension.extensionPath,
+                        packageJSON: extension.packageJSON,
+                    })),
+                    tokenColorCustomizations: editor.get('tokenColorCustomizations'),
+                    semanticTokenColorCustomizations:
+                        editor.get('semanticTokenColorCustomizations'),
+                    registry: getKnitGrammarRegistry(this.deps.context),
+                    readFile: (absolutePath) => fs.promises.readFile(absolutePath, 'utf-8'),
+                    realPath: (absolutePath) => fs.promises.realpath(absolutePath),
+                };
+            },
+            resolveFonts: (sourceFsPath) => {
+                const scope = sourceScope(sourceFsPath);
+                const uri = scope.uri;
+                const quarto = vscode.workspace.getConfiguration('raven.quarto', uri);
+                const markdown = vscode.workspace.getConfiguration('markdown.preview', uri);
+                const editor = vscode.workspace.getConfiguration('editor', scope);
+                return resolveFontFamilies(
+                    quarto.get<string>('fontFamily', ''),
+                    quarto.get<string>('monospaceFontFamily', ''),
+                    markdown.get<string>('fontFamily', ''),
+                    editor.get<string>('fontFamily', ''),
+                );
+            },
+            sourceConfigurationScope: sourceScope,
+            onDidChangeActiveColorTheme: (listener) =>
+                vscode.window.onDidChangeActiveColorTheme(listener),
+            onDidChangeConfiguration: (listener) =>
+                vscode.workspace.onDidChangeConfiguration(listener),
+        });
+    }
+}
+
+function colorThemeKind(kind: vscode.ColorThemeKind): QuartoThemeKind {
+    switch (kind) {
+        case vscode.ColorThemeKind.Light:
+            return 'light';
+        case vscode.ColorThemeKind.HighContrast:
+            return 'high-contrast';
+        case vscode.ColorThemeKind.HighContrastLight:
+            return 'high-contrast-light';
+        default:
+            return 'dark';
     }
 }
 

--- a/editors/vscode/src/quarto/quarto-preview-proxy.ts
+++ b/editors/vscode/src/quarto/quarto-preview-proxy.ts
@@ -1,0 +1,874 @@
+/**
+ * Response-transforming loopback reverse proxy for Quarto live preview.
+ *
+ * The listener binds only to IPv4 loopback and every outbound request targets
+ * the one validated loopback origin supplied at construction. Absolute-form
+ * request targets and client Host headers can therefore never turn this into
+ * an open proxy. Two reserved same-origin paths serve packaged theme-bridge
+ * assets locally when those packaged assets are available. Full,
+ * identity-encoded, ASCII-compatible text/html 200 responses stream through a
+ * context-aware scanner and receive the bridge tags before their first real
+ * closing-body tag; every other body, including
+ * compressed, partial, HEAD, and binary responses, streams byte-for-byte.
+ * Entity validators are removed only when a body is changed. Hop-by-hop
+ * request and response headers are stripped and keep-alive is disabled on
+ * both legs; WebSocket Upgrade semantics remain intact.
+ *
+ * HTTP and upgraded sockets on both sides are tracked explicitly. Closing the
+ * proxy first stops acceptance and then destroys every tracked socket, so an
+ * idle HTTP connection or Quarto live-reload WebSocket cannot hold teardown
+ * open after the preview generation has been stopped.
+ */
+
+import * as http from 'http';
+import * as net from 'net';
+import { Transform, type TransformCallback } from 'stream';
+import { validatePreviewUrl } from './preview-url-parser';
+
+const BRIDGE_JS_PATH = '/_raven-theme-bridge/bridge.js';
+const BRIDGE_CSS_PATH = '/_raven-theme-bridge/bridge.css';
+// Bridge assets use root-relative external references to remain compatible with
+// CSP 'self'. An author-supplied absolute <base href> can re-root them, an
+// accepted limitation because standard Quarto/pandoc templates emit no <base>.
+const HTML_INJECTION = Buffer.from(
+    '<link rel="stylesheet" href="/_raven-theme-bridge/bridge.css">' +
+    '<script src="/_raven-theme-bridge/bridge.js"></script>',
+);
+
+export interface QuartoPreviewBridgeAssets {
+    javascript: string | Uint8Array;
+    css: string | Uint8Array;
+}
+
+export interface QuartoPreviewProxyReady {
+    origin: string;
+    url: string;
+}
+
+export interface QuartoPreviewProxyLike {
+    start(): Promise<QuartoPreviewProxyReady>;
+    close(): Promise<void>;
+}
+
+export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
+    private readonly upstream: URL;
+    private readonly upstreamRequestHostname: string;
+    private readonly server: http.Server;
+    private readonly sockets = new Set<net.Socket>();
+    private startPromise: Promise<QuartoPreviewProxyReady> | null = null;
+    private closePromise: Promise<void> | null = null;
+    private ready: QuartoPreviewProxyReady | null = null;
+    private closing = false;
+
+    private readonly bridgeJavaScript: Buffer | null;
+    private readonly bridgeCss: Buffer | null;
+
+    constructor(upstreamOrigin: string, bridgeAssets?: QuartoPreviewBridgeAssets) {
+        const validated = validatePreviewUrl(`${upstreamOrigin.replace(/\/$/, '')}/`);
+        if (!validated || validated.origin !== upstreamOrigin.replace(/\/$/, '')) {
+            throw new Error('Quarto preview proxy requires a validated loopback origin.');
+        }
+        this.upstream = new URL(validated.origin);
+        if (this.upstream.hostname === 'localhost') {
+            this.upstream.hostname = '127.0.0.1';
+        }
+        this.upstreamRequestHostname = unbracketIpv6Hostname(this.upstream.hostname);
+        this.bridgeJavaScript = bridgeAssets
+            ? Buffer.from(bridgeAssets.javascript)
+            : null;
+        this.bridgeCss = bridgeAssets ? Buffer.from(bridgeAssets.css) : null;
+
+        this.server = http.createServer(
+            (request, response) => this.forwardHttp(request, response),
+        );
+        this.server.on('connection', (socket) => this.trackSocket(socket));
+        this.server.on('upgrade', (request, socket, head) => {
+            this.forwardWebSocket(request, socket as net.Socket, head);
+        });
+        this.server.on('connect', (_request, socket) => {
+            rejectSocket(socket as net.Socket, 405, 'CONNECT is not supported');
+        });
+        this.server.on('clientError', (_error, socket) => {
+            if (!socket.destroyed) {
+                rejectSocket(socket as net.Socket, 400, 'Bad Request');
+            }
+        });
+        // Bind errors are also observed by start(); retaining a passive error
+        // listener prevents a later server-level error from becoming an
+        // uncaught EventEmitter exception after startup has settled.
+        this.server.on('error', () => undefined);
+    }
+
+    start(): Promise<QuartoPreviewProxyReady> {
+        if (this.startPromise) return this.startPromise;
+        this.startPromise = new Promise<QuartoPreviewProxyReady>((resolve, reject) => {
+            if (this.closing) {
+                reject(new Error('Quarto preview proxy was closed before it started.'));
+                return;
+            }
+
+            const onError = (error: Error): void => {
+                this.server.off('listening', onListening);
+                reject(error);
+            };
+            const onListening = (): void => {
+                this.server.off('error', onError);
+                if (this.closing) {
+                    reject(new Error('Quarto preview proxy was closed during startup.'));
+                    return;
+                }
+                const address = this.server.address();
+                if (!address || typeof address === 'string') {
+                    reject(new Error('Quarto preview proxy did not expose a TCP address.'));
+                    return;
+                }
+                const origin = `http://127.0.0.1:${address.port}`;
+                this.ready = { origin, url: `${origin}/` };
+                resolve(this.ready);
+            };
+            this.server.once('error', onError);
+            this.server.once('listening', onListening);
+            this.server.listen({ host: '127.0.0.1', port: 0 });
+        });
+        return this.startPromise;
+    }
+
+    close(): Promise<void> {
+        if (this.closePromise) return this.closePromise;
+        this.closing = true;
+        for (const socket of this.sockets) socket.destroy();
+
+        this.closePromise = new Promise<void>((resolve) => {
+            try {
+                this.server.close(() => resolve());
+            } catch {
+                resolve();
+            }
+        });
+        return this.closePromise;
+    }
+
+    private forwardHttp(
+        request: http.IncomingMessage,
+        response: http.ServerResponse,
+    ): void {
+        if (request.method?.toUpperCase() === 'CONNECT') {
+            response.writeHead(405, { Connection: 'close' });
+            response.end('CONNECT is not supported');
+            return;
+        }
+
+        let path: string;
+        try {
+            path = fixedUpstreamPath(request.url ?? '/');
+        } catch {
+            response.writeHead(400, { Connection: 'close' });
+            response.end('Bad Request');
+            return;
+        }
+
+        const reservedPath = this.bridgeJavaScript && this.bridgeCss
+            ? reservedBridgePath(path)
+            : null;
+        if (reservedPath) {
+            this.serveBridgeAsset(request, response, reservedPath);
+            return;
+        }
+
+        const headers: http.OutgoingHttpHeaders = {
+            ...filteredRequestHeaders(request.headers),
+            host: this.upstream.host,
+            connection: 'close',
+        };
+        if (request.headers.origin !== undefined) {
+            headers.origin = this.upstream.origin;
+        }
+        delete headers['accept-encoding'];
+        const upstreamRequest = http.request({
+            protocol: 'http:',
+            hostname: this.upstreamRequestHostname,
+            port: this.upstream.port,
+            method: request.method,
+            path,
+            headers,
+            agent: false,
+        });
+        upstreamRequest.on('socket', (socket) => this.trackSocket(socket));
+        upstreamRequest.on('response', (upstreamResponse) => {
+            const statusCode = upstreamResponse.statusCode ?? 502;
+            const inject = this.bridgeJavaScript !== null &&
+                this.bridgeCss !== null &&
+                shouldInject(request, upstreamResponse);
+            const responseHeaders = filteredResponseHeaders(
+                upstreamResponse.rawHeaders,
+                {
+                    inject,
+                    statusCode,
+                    upstream: this.upstream,
+                },
+            );
+            response.writeHead(
+                statusCode,
+                upstreamResponse.statusMessage,
+                responseHeaders,
+            );
+            if (!inject) {
+                upstreamResponse.on('aborted', () => response.destroy());
+                upstreamResponse.on('error', (error) => response.destroy(error));
+                upstreamResponse.pipe(response);
+                return;
+            }
+
+            const transform = new HtmlBridgeInjectionTransform(HTML_INJECTION);
+            upstreamResponse.on('aborted', () => {
+                transform.destroy();
+                response.destroy();
+            });
+            upstreamResponse.on('error', (error) => transform.destroy(error));
+            transform.on('error', (error) => response.destroy(error));
+            upstreamResponse.pipe(transform).pipe(response);
+        });
+        upstreamRequest.on('error', (error) => {
+            if (response.headersSent) {
+                response.destroy(error);
+                return;
+            }
+            response.writeHead(502, { Connection: 'close' });
+            response.end('Bad Gateway');
+        });
+        request.on('aborted', () => upstreamRequest.destroy());
+        response.on('close', () => {
+            if (!response.writableFinished) upstreamRequest.destroy();
+        });
+        request.pipe(upstreamRequest);
+    }
+
+    private serveBridgeAsset(
+        request: http.IncomingMessage,
+        response: http.ServerResponse,
+        path: typeof BRIDGE_JS_PATH | typeof BRIDGE_CSS_PATH,
+    ): void {
+        const method = request.method?.toUpperCase() ?? 'GET';
+        if (method !== 'GET' && method !== 'HEAD') {
+            response.writeHead(405, {
+                Allow: 'GET, HEAD',
+                Connection: 'close',
+                'Content-Length': '0',
+            });
+            response.end();
+            return;
+        }
+
+        const body = path === BRIDGE_JS_PATH ? this.bridgeJavaScript : this.bridgeCss;
+        if (body === null) {
+            response.writeHead(404, { Connection: 'close', 'Content-Length': '0' });
+            response.end();
+            return;
+        }
+        response.writeHead(200, {
+            'Cache-Control': 'no-store',
+            Connection: 'close',
+            'Content-Length': String(body.length),
+            'Content-Type': path === BRIDGE_JS_PATH
+                ? 'text/javascript; charset=utf-8'
+                : 'text/css; charset=utf-8',
+        });
+        response.end(method === 'HEAD' ? undefined : body);
+    }
+
+    private forwardWebSocket(
+        request: http.IncomingMessage,
+        clientSocket: net.Socket,
+        clientHead: Buffer,
+    ): void {
+        if (request.headers.upgrade?.toLowerCase() !== 'websocket') {
+            rejectSocket(clientSocket, 400, 'WebSocket upgrade required');
+            return;
+        }
+
+        let path: string;
+        try {
+            path = fixedUpstreamPath(request.url ?? '/');
+        } catch {
+            rejectSocket(clientSocket, 400, 'Bad Request');
+            return;
+        }
+        if (reservedBridgePath(path)) {
+            rejectSocket(clientSocket, 400, 'WebSocket is not supported for bridge assets');
+            return;
+        }
+
+        this.trackSocket(clientSocket);
+        const headers: http.OutgoingHttpHeaders = {
+            ...filteredRequestHeaders(request.headers),
+            host: this.upstream.host,
+            connection: 'Upgrade',
+            upgrade: 'websocket',
+        };
+        if (request.headers.origin !== undefined) {
+            headers.origin = this.upstream.origin;
+        }
+        delete headers['accept-encoding'];
+        const upstreamRequest = http.request({
+            protocol: 'http:',
+            hostname: this.upstreamRequestHostname,
+            port: this.upstream.port,
+            method: request.method,
+            path,
+            headers,
+            agent: false,
+        });
+        upstreamRequest.on('socket', (socket) => this.trackSocket(socket));
+        upstreamRequest.on('upgrade', (upstreamResponse, upstreamSocket, upstreamHead) => {
+            if (upstreamResponse.statusCode !== 101) {
+                upstreamSocket.destroy();
+                clientSocket.destroy();
+                return;
+            }
+            this.trackSocket(upstreamSocket);
+            const statusLine = `HTTP/${upstreamResponse.httpVersion} 101 ` +
+                `${upstreamResponse.statusMessage ?? 'Switching Protocols'}\r\n`;
+            clientSocket.write(
+                statusLine + rawHeadersText(upstreamResponse.rawHeaders) + '\r\n',
+            );
+            if (upstreamHead.length > 0) clientSocket.write(upstreamHead);
+            if (clientHead.length > 0) upstreamSocket.write(clientHead);
+            pipeSockets(clientSocket, upstreamSocket);
+        });
+        upstreamRequest.on('response', (upstreamResponse) => {
+            upstreamResponse.resume();
+            clientSocket.destroy();
+        });
+        upstreamRequest.on('error', () => clientSocket.destroy());
+        clientSocket.on('error', () => upstreamRequest.destroy());
+        clientSocket.on('close', () => upstreamRequest.destroy());
+        upstreamRequest.end();
+    }
+
+    private trackSocket(socket: net.Socket): void {
+        this.sockets.add(socket);
+        socket.once('close', () => this.sockets.delete(socket));
+        if (this.closing) socket.destroy();
+    }
+}
+
+function fixedUpstreamPath(rawTarget: string): string {
+    if (rawTarget === '*') return rawTarget;
+    if (/^https?:\/\//i.test(rawTarget)) {
+        const parsed = new URL(rawTarget);
+        return `${parsed.pathname}${parsed.search}`;
+    }
+    if (!rawTarget.startsWith('/')) throw new Error('Invalid HTTP request target.');
+    return rawTarget;
+}
+
+function reservedBridgePath(
+    path: string,
+): typeof BRIDGE_JS_PATH | typeof BRIDGE_CSS_PATH | null {
+    // This accepted, astronomically unlikely route collision keeps packaged
+    // assets local; authority-based forwarding does not affect path matching.
+    if (path === '*') return null;
+    const pathname = new URL(path, 'http://proxy.invalid').pathname;
+    if (pathname === BRIDGE_JS_PATH || pathname === BRIDGE_CSS_PATH) return pathname;
+    return null;
+}
+
+function unbracketIpv6Hostname(hostname: string): string {
+    return hostname.startsWith('[') && hostname.endsWith(']')
+        ? hostname.slice(1, -1)
+        : hostname;
+}
+
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+]);
+
+export function filteredRequestHeaders(
+    incoming: http.IncomingHttpHeaders,
+): http.OutgoingHttpHeaders {
+    const stripped = new Set(HOP_BY_HOP_REQUEST_HEADERS);
+    for (const token of incoming.connection?.split(',') ?? []) {
+        const normalized = token.trim().toLowerCase();
+        if (normalized !== '') stripped.add(normalized);
+    }
+
+    const headers: http.OutgoingHttpHeaders = {};
+    for (const [name, value] of Object.entries(incoming)) {
+        if (!stripped.has(name.toLowerCase())) headers[name] = value;
+    }
+    return headers;
+}
+
+function shouldInject(
+    request: http.IncomingMessage,
+    response: http.IncomingMessage,
+): boolean {
+    if (request.method?.toUpperCase() === 'HEAD') return false;
+    if (response.statusCode !== 200) return false;
+    const fetchDestination = incomingHeader(request.headers, 'sec-fetch-dest');
+    if (fetchDestination !== undefined && !DOCUMENT_FETCH_DESTINATIONS.has(
+        fetchDestination.trim().toLowerCase(),
+    )) {
+        return false;
+    }
+    const contentType = response.headers['content-type'];
+    if (contentTypeMediaType(contentType) !== 'text/html') return false;
+    if (!isInjectableHtmlCharset(contentType)) return false;
+    const encoding = response.headers['content-encoding'];
+    if (encoding === undefined) return true;
+    return typeof encoding === 'string' && encoding.trim().toLowerCase() === 'identity';
+}
+
+const DOCUMENT_FETCH_DESTINATIONS = new Set([
+    'document',
+    'iframe',
+    'frame',
+    'nested-document',
+]);
+
+function incomingHeader(
+    headers: http.IncomingHttpHeaders,
+    target: string,
+): string | undefined {
+    for (const [name, value] of Object.entries(headers)) {
+        if (name.toLowerCase() !== target) continue;
+        return typeof value === 'string' ? value : value?.join(',');
+    }
+    return undefined;
+}
+
+function isInjectableHtmlCharset(contentType: string | undefined): boolean {
+    if (contentType === undefined) return true;
+    const match = /;\s*charset\s*=\s*(?:"([^"]*)"|'([^']*)'|([^;\s]*))/i.exec(
+        contentType,
+    );
+    if (!match) return true;
+    const charset = (match[1] ?? match[2] ?? match[3]).trim().toLowerCase();
+    return charset === 'utf-8'
+        || charset === 'utf8'
+        || charset === 'us-ascii'
+        || charset === 'ascii'
+        || charset === 'iso-8859-1'
+        || charset === 'latin1'
+        || charset === 'latin-1';
+}
+
+function contentTypeMediaType(contentType: string | undefined): string | null {
+    if (contentType === undefined) return null;
+    return contentType.split(';', 1)[0].trim().toLowerCase();
+}
+
+interface ResponseHeaderOptions {
+    inject: boolean;
+    statusCode: number;
+    upstream: URL;
+}
+
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+]);
+
+const CHANGED_ENTITY_HEADERS = new Set([
+    'content-length',
+    'etag',
+    'content-md5',
+    'digest',
+]);
+
+function filteredResponseHeaders(
+    rawHeaders: readonly string[],
+    options: ResponseHeaderOptions,
+): string[] {
+    const stripped = new Set(HOP_BY_HOP_RESPONSE_HEADERS);
+    for (let index = 0; index < rawHeaders.length; index += 2) {
+        if (rawHeaders[index].toLowerCase() !== 'connection') continue;
+        for (const token of rawHeaders[index + 1].split(',')) {
+            const normalized = token.trim().toLowerCase();
+            if (normalized !== '') stripped.add(normalized);
+        }
+    }
+
+    const headers: string[] = [];
+    for (let index = 0; index < rawHeaders.length; index += 2) {
+        const name = rawHeaders[index];
+        const lowerName = name.toLowerCase();
+        if (stripped.has(lowerName)) continue;
+        if (options.inject && CHANGED_ENTITY_HEADERS.has(lowerName)) continue;
+
+        let value = rawHeaders[index + 1];
+        if (lowerName === 'location' && options.statusCode >= 300 && options.statusCode < 400) {
+            value = rewriteLocation(value, options.upstream);
+        }
+        headers.push(name, value);
+    }
+    headers.push('Connection', 'close');
+    return headers;
+}
+
+function rewriteLocation(
+    location: string,
+    upstream: URL,
+): string {
+    let parsed: URL;
+    try {
+        parsed = location.startsWith('//')
+            ? new URL(`${upstream.protocol}${location}`)
+            : new URL(location);
+    } catch {
+        return location;
+    }
+    if (parsed.port !== upstream.port || !equivalentUpstreamHost(
+        parsed.hostname,
+        upstream.hostname,
+    )) {
+        return location;
+    }
+
+    // Resolve against the iframe's currently mapped origin in the browser.
+    // This avoids exposing the extension-host loopback address through
+    // Remote SSH, WSL, and Dev Container authority forwarding. Already
+    // relative Location values never reach this branch and remain unchanged.
+    // Root-relative bridge assets share the same limitation under unusual
+    // path-prefixed remote tunnels; authority-based VS Code forwarding, used
+    // by the supported remote environments, preserves these paths.
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+function equivalentUpstreamHost(left: string, right: string): boolean {
+    const normalizedLeft = normalizeHostname(left);
+    const normalizedRight = normalizeHostname(right);
+    return normalizedLeft === normalizedRight || (
+        LOOPBACK_HOSTNAMES.has(normalizedLeft) &&
+        LOOPBACK_HOSTNAMES.has(normalizedRight)
+    );
+}
+
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1']);
+
+function normalizeHostname(hostname: string): string {
+    return unbracketIpv6Hostname(hostname).toLowerCase();
+}
+
+class HtmlBridgeInjectionTransform extends Transform {
+    private context: HtmlScannerContext = 'normal';
+    private tag: { after: HtmlScannerContext; quote: number | null } | null = null;
+    private readonly candidate: number[] = [];
+    private commentTail = 0;
+    private injected = false;
+
+    constructor(private readonly injection: Buffer) {
+        super();
+    }
+
+    override _transform(
+        chunk: Buffer | string,
+        encoding: BufferEncoding,
+        callback: TransformCallback,
+    ): void {
+        try {
+            const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+            if (this.injected) {
+                this.push(bytes);
+                callback();
+                return;
+            }
+
+            let output = Buffer.allocUnsafe(bytes.length + 16);
+            let outputLength = 0;
+            const emit = (byte: number): void => {
+                output[outputLength++] = byte;
+            };
+            const flushOutput = (): void => {
+                if (outputLength > 0) this.push(output.subarray(0, outputLength));
+                output = Buffer.allocUnsafe(bytes.length + 16);
+                outputLength = 0;
+            };
+
+            for (const byte of bytes) this.scanByte(byte, emit, flushOutput);
+            flushOutput();
+            callback();
+        } catch (error) {
+            callback(error as Error);
+        }
+    }
+
+    override _flush(callback: TransformCallback): void {
+        try {
+            if (this.candidate.length > 0) {
+                this.push(Buffer.from(this.candidate));
+                this.candidate.length = 0;
+            }
+            if (!this.injected) {
+                this.push(this.injection);
+            }
+            callback();
+        } catch (error) {
+            callback(error as Error);
+        }
+    }
+
+    private scanByte(
+        byte: number,
+        emit: (byte: number) => void,
+        flushOutput: () => void,
+    ): void {
+        if (this.injected) {
+            emit(byte);
+            return;
+        }
+        if (this.tag) {
+            emit(byte);
+            if (this.tag.quote !== null) {
+                if (byte === this.tag.quote) this.tag.quote = null;
+                return;
+            }
+            if (byte === BYTE_DOUBLE_QUOTE || byte === BYTE_SINGLE_QUOTE) {
+                this.tag.quote = byte;
+            } else if (byte === BYTE_GREATER_THAN) {
+                this.context = this.tag.after;
+                this.tag = null;
+            }
+            return;
+        }
+
+        if (this.context === 'comment') {
+            emit(byte);
+            this.commentTail = ((this.commentTail << 8) | byte) & 0xFFFFFF;
+            if (this.commentTail === COMMENT_END) {
+                this.context = 'normal';
+                this.commentTail = 0;
+            }
+            return;
+        }
+
+        if (this.candidate.length === 0) {
+            if (byte === BYTE_LESS_THAN) this.candidate.push(byte);
+            else emit(byte);
+            return;
+        }
+
+        this.candidate.push(byte);
+        if (this.context === 'normal') {
+            this.resolveNormalCandidate(emit, flushOutput);
+        } else {
+            this.resolveRawTextCandidate(emit, flushOutput);
+        }
+    }
+
+    private resolveNormalCandidate(
+        emit: (byte: number) => void,
+        flushOutput: () => void,
+    ): void {
+        if (asciiEqual(this.candidate, BODY_CLOSE)) {
+            flushOutput();
+            this.push(this.injection);
+            this.injected = true;
+            this.emitCandidate(emit);
+            return;
+        }
+        if (asciiEqual(this.candidate, COMMENT_START)) {
+            this.emitCandidate(emit);
+            this.context = 'comment';
+            this.commentTail = 0;
+            return;
+        }
+
+        const raw = rawOpenCandidate(this.candidate);
+        if (raw?.kind === 'matched') {
+            this.emitCandidate(emit);
+            if (raw.boundary === BYTE_GREATER_THAN) {
+                this.context = raw.context;
+            } else {
+                this.tag = { after: raw.context, quote: null };
+            }
+            return;
+        }
+        if (raw?.kind === 'prefix') return;
+        if (isAsciiPrefix(this.candidate, BODY_CLOSE) ||
+            isAsciiPrefix(this.candidate, COMMENT_START)) {
+            return;
+        }
+
+        if (looksLikeTagStart(this.candidate[1])) {
+            this.emitCandidate(emit);
+            this.tag = { after: 'normal', quote: null };
+            return;
+        }
+        this.emitFirstAndRescan(emit, flushOutput);
+    }
+
+    private resolveRawTextCandidate(
+        emit: (byte: number) => void,
+        flushOutput: () => void,
+    ): void {
+        const context = this.context;
+        if (context === 'normal' || context === 'comment') {
+            throw new Error('HTML scanner entered raw-text resolution outside raw text.');
+        }
+        const target = rawTextClose(context);
+        const lastByte = this.candidate[this.candidate.length - 1];
+        if (isAsciiPrefix(this.candidate, target)) return;
+        if (this.candidate.length === target.length + 1 &&
+            asciiEqual(this.candidate.slice(0, -1), target) &&
+            isTagBoundary(lastByte)) {
+            const boundary = lastByte;
+            this.emitCandidate(emit);
+            if (boundary === BYTE_GREATER_THAN) this.context = 'normal';
+            else this.tag = { after: 'normal', quote: null };
+            return;
+        }
+        this.emitFirstAndRescan(emit, flushOutput);
+    }
+
+    private emitFirstAndRescan(
+        emit: (byte: number) => void,
+        flushOutput: () => void,
+    ): void {
+        const pending = this.candidate.splice(0);
+        emit(pending[0]);
+        for (let index = 1; index < pending.length; index++) {
+            this.scanByte(pending[index], emit, flushOutput);
+        }
+    }
+
+    private emitCandidate(emit: (byte: number) => void): void {
+        for (const byte of this.candidate) emit(byte);
+        this.candidate.length = 0;
+    }
+}
+
+type HtmlScannerContext =
+    | 'normal'
+    | 'comment'
+    | 'script'
+    | 'style'
+    | 'title'
+    | 'textarea';
+type HtmlRawTextContext = Exclude<HtmlScannerContext, 'normal' | 'comment'>;
+
+const BYTE_LESS_THAN = 0x3C;
+const BYTE_GREATER_THAN = 0x3E;
+const BYTE_SINGLE_QUOTE = 0x27;
+const BYTE_DOUBLE_QUOTE = 0x22;
+const COMMENT_END = 0x2D2D3E;
+const BODY_CLOSE = asciiBytes('</body>');
+const COMMENT_START = asciiBytes('<!--');
+const SCRIPT_OPEN = asciiBytes('<script');
+const STYLE_OPEN = asciiBytes('<style');
+const TITLE_OPEN = asciiBytes('<title');
+const TEXTAREA_OPEN = asciiBytes('<textarea');
+const SCRIPT_CLOSE = asciiBytes('</script');
+const STYLE_CLOSE = asciiBytes('</style');
+const TITLE_CLOSE = asciiBytes('</title');
+const TEXTAREA_CLOSE = asciiBytes('</textarea');
+
+function rawTextClose(context: HtmlRawTextContext): readonly number[] {
+    switch (context) {
+        case 'script': return SCRIPT_CLOSE;
+        case 'style': return STYLE_CLOSE;
+        case 'title': return TITLE_CLOSE;
+        case 'textarea': return TEXTAREA_CLOSE;
+    }
+}
+
+function rawOpenCandidate(candidate: readonly number[]):
+    | { kind: 'prefix' }
+    | { kind: 'matched'; context: HtmlRawTextContext; boundary: number }
+    | null {
+    for (const [target, context] of [
+        [SCRIPT_OPEN, 'script'],
+        [STYLE_OPEN, 'style'],
+        [TITLE_OPEN, 'title'],
+        [TEXTAREA_OPEN, 'textarea'],
+    ] as const) {
+        const lastByte = candidate[candidate.length - 1];
+        if (isAsciiPrefix(candidate, target)) return { kind: 'prefix' };
+        if (candidate.length === target.length + 1 &&
+            asciiEqual(candidate.slice(0, -1), target) &&
+            isTagBoundary(lastByte)) {
+            return { kind: 'matched', context, boundary: lastByte };
+        }
+    }
+    return null;
+}
+
+function isTagBoundary(byte: number): boolean {
+    return byte === BYTE_GREATER_THAN
+        || byte === 0x2F
+        || byte === 0x09
+        || byte === 0x0A
+        || byte === 0x0C
+        || byte === 0x0D
+        || byte === 0x20;
+}
+
+function looksLikeTagStart(byte: number | undefined): boolean {
+    if (byte === undefined) return false;
+    const lower = asciiLower(byte);
+    return (lower >= 0x61 && lower <= 0x7A)
+        || byte === 0x21
+        || byte === 0x2F
+        || byte === 0x3F;
+}
+
+function isAsciiPrefix(candidate: readonly number[], target: readonly number[]): boolean {
+    if (candidate.length > target.length) return false;
+    for (let index = 0; index < candidate.length; index++) {
+        if (asciiLower(candidate[index]) !== target[index]) return false;
+    }
+    return true;
+}
+
+function asciiEqual(candidate: readonly number[], target: readonly number[]): boolean {
+    return candidate.length === target.length && isAsciiPrefix(candidate, target);
+}
+
+function asciiLower(byte: number): number {
+    return byte >= 0x41 && byte <= 0x5A ? byte + 0x20 : byte;
+}
+
+function asciiBytes(value: string): readonly number[] {
+    return [...Buffer.from(value, 'ascii')];
+}
+
+function rawHeadersText(rawHeaders: readonly string[]): string {
+    let text = '';
+    for (let index = 0; index < rawHeaders.length; index += 2) {
+        text += `${rawHeaders[index]}: ${rawHeaders[index + 1]}\r\n`;
+    }
+    return text;
+}
+
+function pipeSockets(clientSocket: net.Socket, upstreamSocket: net.Socket): void {
+    clientSocket.pipe(upstreamSocket);
+    upstreamSocket.pipe(clientSocket);
+    clientSocket.on('end', () => upstreamSocket.end());
+    upstreamSocket.on('end', () => clientSocket.end());
+    clientSocket.on('error', () => upstreamSocket.destroy());
+    upstreamSocket.on('error', () => clientSocket.destroy());
+    clientSocket.on('close', () => upstreamSocket.destroy());
+    upstreamSocket.on('close', () => clientSocket.destroy());
+}
+
+function rejectSocket(socket: net.Socket, status: number, message: string): void {
+    if (socket.destroyed) return;
+    socket.end(
+        `HTTP/1.1 ${status} ${message}\r\n` +
+        'Connection: close\r\n' +
+        'Content-Length: 0\r\n\r\n',
+    );
+}

--- a/editors/vscode/src/quarto/quarto-preview-proxy.ts
+++ b/editors/vscode/src/quarto/quarto-preview-proxy.ts
@@ -48,6 +48,12 @@ export interface QuartoPreviewProxyReady {
 export interface QuartoPreviewProxyLike {
     start(): Promise<QuartoPreviewProxyReady>;
     close(): Promise<void>;
+    /**
+     * Record the browser-facing URL that `vscode.env.asExternalUri` mapped this
+     * proxy's origin to, so its host/origin joins the request allowlist. See
+     * {@link QuartoPreviewProxy.setBrowserFacingOrigin}.
+     */
+    setBrowserFacingOrigin(externalUrl: string): void;
 }
 
 export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
@@ -62,8 +68,17 @@ export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
 
     private readonly bridgeJavaScript: Buffer | null;
     private readonly bridgeCss: Buffer | null;
+    // The host/origin that `asExternalUri` maps this proxy to in the browser,
+    // learned after start via setBrowserFacingOrigin. null until then, so the
+    // request allowlist is loopback-only during startup (only the loopback
+    // readiness probe runs before the webview — and thus this call — loads).
+    private browserFacingHostname: string | null = null;
+    private browserFacingOrigin: string | null = null;
 
-    constructor(upstreamOrigin: string, bridgeAssets?: QuartoPreviewBridgeAssets) {
+    constructor(
+        upstreamOrigin: string,
+        bridgeAssets?: QuartoPreviewBridgeAssets,
+    ) {
         const validated = validatePreviewUrl(`${upstreamOrigin.replace(/\/$/, '')}/`);
         if (!validated || validated.origin !== upstreamOrigin.replace(/\/$/, '')) {
             throw new Error('Quarto preview proxy requires a validated loopback origin.');
@@ -148,6 +163,60 @@ export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
         return this.closePromise;
     }
 
+    /**
+     * Record the browser-facing URL that `vscode.env.asExternalUri` mapped this
+     * proxy to, adding its host/origin to the request allowlist.
+     *
+     * Every request that a legitimate browser sends carries the `Host` (and,
+     * for WebSocket handshakes, the `Origin`) of the URL the iframe was loaded
+     * from — the mapped external URL, not the raw loopback origin. Allowing that
+     * host/origin alongside loopback lets the proxy always enforce the allowlist
+     * (blocking DNS-rebinding and cross-site WebSocket reads in every topology)
+     * without guessing whether it is reached over loopback or an authenticated
+     * gateway: a rebound attacker domain matches neither and is rejected.
+     * A non-URL value leaves the proxy loopback-only.
+     */
+    setBrowserFacingOrigin(externalUrl: string): void {
+        try {
+            const url = new URL(externalUrl);
+            this.browserFacingHostname = normalizeHostname(url.hostname);
+            this.browserFacingOrigin = url.origin;
+        } catch {
+            // Leave the allowlist loopback-only.
+        }
+    }
+
+    private isAllowedHost(host: string | undefined): boolean {
+        if (isLoopbackHostHeader(host)) return true;
+        if (this.browserFacingHostname === null ||
+            host === undefined || host.includes('@')) {
+            return false;
+        }
+        try {
+            return normalizeHostname(new URL(`http://${host}`).hostname) ===
+                this.browserFacingHostname;
+        } catch {
+            return false;
+        }
+    }
+
+    private isAllowedOrigin(origin: string | undefined): boolean {
+        if (isLoopbackOrigin(origin)) return true;
+        if (this.browserFacingOrigin === null ||
+            origin === undefined || origin.includes('@')) {
+            // Mirror the Host branch's `@` guard: any userinfo (`user@`, bare
+            // `@`, `:@`) is rejected, since `.origin` would discard it and let
+            // `https://x@browser-facing-host` match. A real browser Origin never
+            // carries userinfo.
+            return false;
+        }
+        try {
+            return new URL(origin).origin === this.browserFacingOrigin;
+        } catch {
+            return false;
+        }
+    }
+
     private forwardHttp(
         request: http.IncomingMessage,
         response: http.ServerResponse,
@@ -155,6 +224,12 @@ export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
         if (request.method?.toUpperCase() === 'CONNECT') {
             response.writeHead(405, { Connection: 'close' });
             response.end('CONNECT is not supported');
+            return;
+        }
+        if (!this.isAllowedHost(request.headers.host) ||
+            !this.isAllowedOrigin(request.headers.origin)) {
+            response.writeHead(403, { Connection: 'close' });
+            response.end('Forbidden');
             return;
         }
 
@@ -285,6 +360,11 @@ export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
             rejectSocket(clientSocket, 400, 'WebSocket upgrade required');
             return;
         }
+        if (!this.isAllowedHost(request.headers.host) ||
+            !this.isAllowedOrigin(request.headers.origin)) {
+            rejectSocket(clientSocket, 403, 'Forbidden');
+            return;
+        }
 
         let path: string;
         try {
@@ -368,7 +448,15 @@ function reservedBridgePath(
     // This accepted, astronomically unlikely route collision keeps packaged
     // assets local; authority-based forwarding does not affect path matching.
     if (path === '*') return null;
-    const pathname = new URL(path, 'http://proxy.invalid').pathname;
+    // A request target such as `//[` is accepted as origin-form by `fixedUpstreamPath`
+    // but is not a valid URL; treat any unparseable target as a non-reserved path
+    // (forwarded upstream) rather than letting the throw escape the request handler.
+    let pathname: string;
+    try {
+        pathname = new URL(path, 'http://proxy.invalid').pathname;
+    } catch {
+        return null;
+    }
     if (pathname === BRIDGE_JS_PATH || pathname === BRIDGE_CSS_PATH) return pathname;
     return null;
 }
@@ -379,7 +467,9 @@ function unbracketIpv6Hostname(hostname: string): string {
         : hostname;
 }
 
-const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+// RFC 7230 §6.1 hop-by-hop headers. The request and response filters differ in
+// shape (header object vs. rawHeaders array) but strip the same token set.
+const HOP_BY_HOP_HEADERS = new Set([
     'connection',
     'keep-alive',
     'proxy-authenticate',
@@ -393,7 +483,7 @@ const HOP_BY_HOP_REQUEST_HEADERS = new Set([
 export function filteredRequestHeaders(
     incoming: http.IncomingHttpHeaders,
 ): http.OutgoingHttpHeaders {
-    const stripped = new Set(HOP_BY_HOP_REQUEST_HEADERS);
+    const stripped = new Set(HOP_BY_HOP_HEADERS);
     for (const token of incoming.connection?.split(',') ?? []) {
         const normalized = token.trim().toLowerCase();
         if (normalized !== '') stripped.add(normalized);
@@ -471,17 +561,6 @@ interface ResponseHeaderOptions {
     upstream: URL;
 }
 
-const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
-    'connection',
-    'keep-alive',
-    'proxy-authenticate',
-    'proxy-authorization',
-    'te',
-    'trailer',
-    'transfer-encoding',
-    'upgrade',
-]);
-
 const CHANGED_ENTITY_HEADERS = new Set([
     'content-length',
     'etag',
@@ -493,7 +572,7 @@ function filteredResponseHeaders(
     rawHeaders: readonly string[],
     options: ResponseHeaderOptions,
 ): string[] {
-    const stripped = new Set(HOP_BY_HOP_RESPONSE_HEADERS);
+    const stripped = new Set(HOP_BY_HOP_HEADERS);
     for (let index = 0; index < rawHeaders.length; index += 2) {
         if (rawHeaders[index].toLowerCase() !== 'connection') continue;
         for (const token of rawHeaders[index + 1].split(',')) {
@@ -563,12 +642,76 @@ function normalizeHostname(hostname: string): string {
     return unbracketIpv6Hostname(hostname).toLowerCase();
 }
 
+/**
+ * Whether a parsed authority names a loopback host with no userinfo. Userinfo
+ * is rejected because a real `Host`/`Origin` never carries it, yet the WHATWG
+ * parser would read `attacker.invalid@localhost` as host `localhost` — letting
+ * a crafted authority slip a non-loopback label past the hostname check.
+ */
+function isLoopbackUrl(url: URL): boolean {
+    if (url.username !== '' || url.password !== '') return false;
+    return LOOPBACK_HOSTNAMES.has(normalizeHostname(url.hostname));
+}
+
+/**
+ * Whether a request's `Host` header is safe for a directly-reachable loopback
+ * listener. An absent `Host` is allowed: a browser same-origin fetch always
+ * sends one, so its absence means the request is not the DNS-rebinding vector
+ * this guards against. A present `Host` must name `127.0.0.1`, `localhost`, or
+ * `[::1]` (port-agnostic) with no userinfo; anything else — including a rebound
+ * attacker domain — is rejected. An unparseable value is treated as unsafe.
+ */
+function isLoopbackHostHeader(host: string | undefined): boolean {
+    if (host === undefined) return true;
+    if (host.includes('@')) return false;
+    let url: URL;
+    try {
+        url = new URL(`http://${host}`);
+    } catch {
+        return false;
+    }
+    return isLoopbackUrl(url);
+}
+
+/**
+ * Whether a WebSocket upgrade's `Origin` is safe to relay to the loopback
+ * upstream. A browser sends `Origin` on every WebSocket handshake, so a
+ * loopback-only rule blocks cross-site WebSocket hijacking of the live-reload
+ * socket by a page on another origin (whose `Origin` would otherwise be
+ * overwritten with the trusted upstream one). An absent `Origin` is a
+ * non-browser client (not the hijacking vector); `null` and any other origin
+ * are rejected.
+ */
+function isLoopbackOrigin(origin: string | undefined): boolean {
+    if (origin === undefined) return true;
+    if (origin.includes('@')) return false;
+    let url: URL;
+    try {
+        url = new URL(origin);
+    } catch {
+        return false;
+    }
+    return isLoopbackUrl(url);
+}
+
 class HtmlBridgeInjectionTransform extends Transform {
     private context: HtmlScannerContext = 'normal';
     private tag: { after: HtmlScannerContext; quote: number | null } | null = null;
     private readonly candidate: number[] = [];
     private commentTail = 0;
     private injected = false;
+    // Within a `<script>` element, `</script>` closes the element unless it sits
+    // in HTML5's script-data (double-)escaped span — the span opened by `<!--`
+    // and closed by `-->`. We model that span conservatively: while `scriptEscaped`
+    // is set, a `</script>` is treated as script data, not the element's end tag.
+    // This is correct for the realistic cases (the legacy `<!-- ... //-->` comment
+    // hack and `<!--<script>...</script>...` double-escaping) and fails safe for
+    // pathological unbalanced input — an unmatched `<!--` merely defers injection
+    // to end-of-stream (`_flush`) rather than mis-injecting inside script text.
+    private scriptEscaped = false;
+    // Rolling window of the last up-to-4 bytes emitted as script data, used to
+    // detect the `<!--` / `-->` span delimiters.
+    private scriptDataTail = 0;
 
     constructor(private readonly injection: Buffer) {
         super();
@@ -590,6 +733,7 @@ class HtmlBridgeInjectionTransform extends Transform {
             let output = Buffer.allocUnsafe(bytes.length + 16);
             let outputLength = 0;
             const emit = (byte: number): void => {
+                this.trackScriptData(byte);
                 output[outputLength++] = byte;
             };
             const flushOutput = (): void => {
@@ -639,7 +783,7 @@ class HtmlBridgeInjectionTransform extends Transform {
             if (byte === BYTE_DOUBLE_QUOTE || byte === BYTE_SINGLE_QUOTE) {
                 this.tag.quote = byte;
             } else if (byte === BYTE_GREATER_THAN) {
-                this.context = this.tag.after;
+                this.enterContext(this.tag.after);
                 this.tag = null;
             }
             return;
@@ -691,7 +835,7 @@ class HtmlBridgeInjectionTransform extends Transform {
         if (raw?.kind === 'matched') {
             this.emitCandidate(emit);
             if (raw.boundary === BYTE_GREATER_THAN) {
-                this.context = raw.context;
+                this.enterContext(raw.context);
             } else {
                 this.tag = { after: raw.context, quote: null };
             }
@@ -725,6 +869,13 @@ class HtmlBridgeInjectionTransform extends Transform {
         if (this.candidate.length === target.length + 1 &&
             asciiEqual(this.candidate.slice(0, -1), target) &&
             isTagBoundary(lastByte)) {
+            if (context === 'script' && this.scriptEscaped) {
+                // Inside the script-data escaped span (opened by `<!--`): this
+                // `</script>` is script data, not the element's end tag, so
+                // consume it and remain in script context.
+                this.emitCandidate(emit);
+                return;
+            }
             const boundary = lastByte;
             this.emitCandidate(emit);
             if (boundary === BYTE_GREATER_THAN) this.context = 'normal';
@@ -749,6 +900,27 @@ class HtmlBridgeInjectionTransform extends Transform {
         for (const byte of this.candidate) emit(byte);
         this.candidate.length = 0;
     }
+
+    private enterContext(context: HtmlScannerContext): void {
+        this.context = context;
+        if (context === 'script') {
+            this.scriptEscaped = false;
+            this.scriptDataTail = 0;
+        }
+    }
+
+    // Track the `<!--` / `-->` script-data escaped span over emitted script
+    // bytes. Called for every byte written to output while in script context,
+    // so it follows the true output order regardless of candidate rescans.
+    private trackScriptData(byte: number): void {
+        if (this.context !== 'script') return;
+        this.scriptDataTail = ((this.scriptDataTail << 8) | byte) >>> 0;
+        if (this.scriptDataTail === SCRIPT_ESCAPE_OPEN) {
+            this.scriptEscaped = true;
+        } else if ((this.scriptDataTail & 0xFFFFFF) === COMMENT_END) {
+            this.scriptEscaped = false;
+        }
+    }
 }
 
 type HtmlScannerContext =
@@ -765,6 +937,8 @@ const BYTE_GREATER_THAN = 0x3E;
 const BYTE_SINGLE_QUOTE = 0x27;
 const BYTE_DOUBLE_QUOTE = 0x22;
 const COMMENT_END = 0x2D2D3E;
+// `<!--` and `-->` as packed big-endian bytes, for the script-data escaped span.
+const SCRIPT_ESCAPE_OPEN = 0x3C212D2D;
 const BODY_CLOSE = asciiBytes('</body>');
 const COMMENT_START = asciiBytes('<!--');
 const SCRIPT_OPEN = asciiBytes('<script');
@@ -866,6 +1040,11 @@ function pipeSockets(clientSocket: net.Socket, upstreamSocket: net.Socket): void
 
 function rejectSocket(socket: net.Socket, status: number, message: string): void {
     if (socket.destroyed) return;
+    // These raw upgrade/CONNECT sockets carry no error listener (Node removes
+    // its internal one before emitting `upgrade`/`connect`), so a client RST
+    // racing this write would emit an unhandled `error` (EPIPE/ECONNRESET) and
+    // crash the extension host. Swallow it and destroy the socket instead.
+    socket.on('error', () => socket.destroy());
     socket.end(
         `HTTP/1.1 ${status} ${message}\r\n` +
         'Connection: close\r\n' +

--- a/editors/vscode/src/quarto/quarto-preview-proxy.ts
+++ b/editors/vscode/src/quarto/quarto-preview-proxy.ts
@@ -200,21 +200,28 @@ export class QuartoPreviewProxy implements QuartoPreviewProxyLike {
         }
     }
 
+    /**
+     * Whether a request's `Origin` is safe to relay to the loopback upstream.
+     * A browser sends `Origin` on every cross-origin fetch/WebSocket, so an
+     * absent `Origin` is a non-browser client, not the hijacking vector. A
+     * present `Origin` must be **exactly** this proxy's own loopback origin or
+     * the browser-facing origin it was mapped to — NOT merely some loopback
+     * host: a page served from a different `localhost`/`127.0.0.1` port is a
+     * distinct origin and must not be able to open the proxied WebSocket
+     * (whose hostile `Origin` would otherwise be rewritten to the trusted
+     * upstream). Userinfo (`@`) is rejected because `.origin` discards it.
+     */
     private isAllowedOrigin(origin: string | undefined): boolean {
-        if (isLoopbackOrigin(origin)) return true;
-        if (this.browserFacingOrigin === null ||
-            origin === undefined || origin.includes('@')) {
-            // Mirror the Host branch's `@` guard: any userinfo (`user@`, bare
-            // `@`, `:@`) is rejected, since `.origin` would discard it and let
-            // `https://x@browser-facing-host` match. A real browser Origin never
-            // carries userinfo.
-            return false;
-        }
+        if (origin === undefined) return true;
+        if (origin.includes('@')) return false;
+        let parsed: string;
         try {
-            return new URL(origin).origin === this.browserFacingOrigin;
+            parsed = new URL(origin).origin;
         } catch {
             return false;
         }
+        return parsed === this.ready?.origin ||
+            (this.browserFacingOrigin !== null && parsed === this.browserFacingOrigin);
     }
 
     private forwardHttp(
@@ -667,27 +674,6 @@ function isLoopbackHostHeader(host: string | undefined): boolean {
     let url: URL;
     try {
         url = new URL(`http://${host}`);
-    } catch {
-        return false;
-    }
-    return isLoopbackUrl(url);
-}
-
-/**
- * Whether a WebSocket upgrade's `Origin` is safe to relay to the loopback
- * upstream. A browser sends `Origin` on every WebSocket handshake, so a
- * loopback-only rule blocks cross-site WebSocket hijacking of the live-reload
- * socket by a page on another origin (whose `Origin` would otherwise be
- * overwritten with the trusted upstream one). An absent `Origin` is a
- * non-browser client (not the hijacking vector); `null` and any other origin
- * are rejected.
- */
-function isLoopbackOrigin(origin: string | undefined): boolean {
-    if (origin === undefined) return true;
-    if (origin.includes('@')) return false;
-    let url: URL;
-    try {
-        url = new URL(origin);
     } catch {
         return false;
     }

--- a/editors/vscode/src/quarto/quarto-preview-runtime.ts
+++ b/editors/vscode/src/quarto/quarto-preview-runtime.ts
@@ -68,8 +68,10 @@ export interface QuartoRuntimeViewUpdate {
     generation: number;
     sourceFsPath: string;
     state: QuartoPreviewViewState;
-    /** Raw validated loopback URL, used only for Open in Browser. */
+    /** Raw validated loopback URL framed after external-URI mapping. */
     rawUrl?: string;
+    /** Original Quarto URL for Open in Browser; defaults to `rawUrl`. */
+    browserUrl?: string;
 }
 
 export interface QuartoRuntimeDeps {
@@ -585,6 +587,7 @@ export class QuartoRuntime {
             generation: session.generation,
             sourceFsPath: session.sourceFsPath,
             rawUrl: ready.rawUrl,
+            browserUrl: ready.browserUrl ?? ready.rawUrl,
             state: { kind: 'serving', externalUrl },
         });
     }
@@ -703,4 +706,3 @@ function readStartupTail(error: Error): string {
 function errorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err);
 }
-

--- a/editors/vscode/src/quarto/quarto-preview-runtime.ts
+++ b/editors/vscode/src/quarto/quarto-preview-runtime.ts
@@ -386,6 +386,13 @@ export class QuartoRuntime {
                 return { kind: 'superseded', generation };
             }
 
+            // Tell a response-transforming proxy the browser-facing origin so
+            // its request allowlist admits that host/origin. Done before the
+            // webview loads the external URL, so the first browser request the
+            // proxy sees already matches; only the loopback readiness probe ran
+            // earlier.
+            process.setBrowserFacingOrigin?.(externalUrl);
+
             this.emitReady(session, ready, externalUrl);
             return {
                 kind: 'ready',

--- a/editors/vscode/src/quarto/quarto-preview-with-proxy.ts
+++ b/editors/vscode/src/quarto/quarto-preview-with-proxy.ts
@@ -68,6 +68,10 @@ export class QuartoPreviewWithProxyProcess implements QuartoPreviewProcessLike {
         return this.beginTeardown('shutdown');
     }
 
+    setBrowserFacingOrigin(externalUrl: string): void {
+        this.proxy?.setBrowserFacingOrigin(externalUrl);
+    }
+
     private async startInner(): Promise<QuartoPreviewReady> {
         const quartoReady = await this.inner.start();
         this.throwIfStopping();

--- a/editors/vscode/src/quarto/quarto-preview-with-proxy.ts
+++ b/editors/vscode/src/quarto/quarto-preview-with-proxy.ts
@@ -1,0 +1,223 @@
+/**
+ * Lifecycle-safe composition of Quarto preview and its loopback proxy.
+ *
+ * Quarto is started and verified first. When both packaged bridge assets are
+ * available, a response-transforming fixed-upstream proxy is bound and the
+ * final page is probed through it; otherwise readiness returns Quarto directly.
+ * Proxied readiness reports the proxy URL so the existing runtime frames and
+ * externally maps the proxy origin without changing its generation discipline. The proxy resource
+ * is installed before bind is awaited, and every stop closes its listener and
+ * sockets before entering the inner Quarto teardown ladder. Proxy bind or
+ * readiness-probe failure is non-fatal: Raven logs one concise diagnostic and
+ * frames Quarto directly.
+ */
+
+import type * as vscode from 'vscode';
+import {
+    probeQuartoPreviewUrl,
+    type QuartoPreviewProcessLike,
+    type QuartoPreviewReady,
+} from './quarto-preview-engine';
+import {
+    QuartoPreviewProxy,
+    type QuartoPreviewBridgeAssets,
+    type QuartoPreviewProxyLike,
+    type QuartoPreviewProxyReady,
+} from './quarto-preview-proxy';
+
+export interface QuartoPreviewWithProxyProcessOptions {
+    createInner(onUnexpectedExit: (code: number | null) => void): QuartoPreviewProcessLike;
+    output: Pick<vscode.OutputChannel, 'appendLine'>;
+    onUnexpectedExit(code: number | null): void;
+    bridgeAssets?: QuartoPreviewBridgeAssets;
+    proxyFactory?: (upstreamOrigin: string) => QuartoPreviewProxyLike;
+    probe?: (rawUrl: string, signal: AbortSignal) => Promise<number>;
+}
+
+type TeardownMode = 'stop' | 'shutdown';
+
+export class QuartoPreviewWithProxyProcess implements QuartoPreviewProcessLike {
+    private readonly inner: QuartoPreviewProcessLike;
+    private proxy: QuartoPreviewProxyLike | null = null;
+    private startPromise: Promise<QuartoPreviewReady> | null = null;
+    private teardownPromise: Promise<void> | null = null;
+    private teardownMode: TeardownMode | null = null;
+    private innerTeardownStarted = false;
+    private activeProbe: AbortController | null = null;
+    private stopping = false;
+    private resolveStopStarted!: () => void;
+    private readonly stopStarted = new Promise<void>((resolve) => {
+        this.resolveStopStarted = resolve;
+    });
+
+    constructor(private readonly opts: QuartoPreviewWithProxyProcessOptions) {
+        this.inner = opts.createInner((code) => this.handleUnexpectedExit(code));
+    }
+
+    start(): Promise<QuartoPreviewReady> {
+        if (this.startPromise) return this.startPromise;
+        this.startPromise = this.startInner();
+        return this.startPromise;
+    }
+
+    stop(): Promise<void> {
+        return this.beginTeardown('stop');
+    }
+
+    shutdown(): Promise<void> {
+        return this.beginTeardown('shutdown');
+    }
+
+    private async startInner(): Promise<QuartoPreviewReady> {
+        const quartoReady = await this.inner.start();
+        this.throwIfStopping();
+
+        // With no packaged assets there is no response transformation to
+        // justify an extra HTTP/WS hop; frame the already-ready Quarto origin.
+        if (!this.opts.bridgeAssets) return quartoReady;
+
+        let proxy: QuartoPreviewProxyLike;
+        try {
+            proxy = (this.opts.proxyFactory ?? ((origin) => (
+                new QuartoPreviewProxy(origin, this.opts.bridgeAssets)
+            )))(quartoReady.origin);
+        } catch (error) {
+            this.appendFallbackDiagnostic(error);
+            return quartoReady;
+        }
+
+        // Stop can now always discover and close this resource, including
+        // while its bind promise is still pending.
+        this.proxy = proxy;
+        let proxyReady: QuartoPreviewProxyReady;
+        try {
+            const outcome = await Promise.race([
+                proxy.start().then((ready) => ({ kind: 'ready' as const, ready })),
+                this.stopStarted.then(() => ({ kind: 'stopped' as const })),
+            ]);
+            if (outcome.kind === 'stopped') {
+                throw new Error('Quarto preview proxy startup was stopped.');
+            }
+            proxyReady = outcome.ready;
+        } catch (error) {
+            if (this.stopping) throw error;
+            await this.closeProxy();
+            this.appendFallbackDiagnostic(error);
+            return quartoReady;
+        }
+        return this.probeProxy(quartoReady, proxyReady, proxy);
+    }
+
+    private async probeProxy(
+        quartoReady: QuartoPreviewReady,
+        proxyReady: QuartoPreviewProxyReady,
+        proxy: QuartoPreviewProxyLike,
+    ): Promise<QuartoPreviewReady> {
+        const rawUrl = proxyPageUrl(quartoReady.rawUrl, proxyReady.origin);
+        const controller = new AbortController();
+        this.activeProbe = controller;
+        try {
+            const probe = this.opts.probe ?? ((url: string, signal: AbortSignal) => (
+                probeQuartoPreviewUrl(url, undefined, undefined, undefined, signal)
+            ));
+            const statusCode = await probe(rawUrl, controller.signal);
+            this.throwIfStopping();
+            if (statusCode >= 500 && statusCode < 600) {
+                throw new Error(`preview proxy readiness returned HTTP ${statusCode}`);
+            }
+            return {
+                rawUrl,
+                browserUrl: quartoReady.browserUrl ?? quartoReady.rawUrl,
+                origin: proxyReady.origin,
+                statusCode,
+            };
+        } catch (error) {
+            if (this.stopping) throw error;
+            if (this.proxy === proxy) await this.closeProxy();
+            this.appendFallbackDiagnostic(error);
+            return quartoReady;
+        } finally {
+            if (this.activeProbe === controller) this.activeProbe = null;
+        }
+    }
+
+    private beginTeardown(mode: TeardownMode): Promise<void> {
+        this.stopping = true;
+        this.resolveStopStarted();
+        this.activeProbe?.abort();
+        if (this.teardownPromise) {
+            if (mode === 'shutdown' && this.teardownMode === 'stop') {
+                this.teardownMode = 'shutdown';
+                if (this.innerTeardownStarted) void this.inner.shutdown();
+            }
+            return this.teardownPromise;
+        }
+        this.teardownMode = mode;
+        this.teardownPromise = this.runTeardown();
+        return this.teardownPromise;
+    }
+
+    private async runTeardown(): Promise<void> {
+        let proxyError: unknown = null;
+        try {
+            await this.closeProxy();
+        } catch (error) {
+            proxyError = error;
+        }
+
+        this.innerTeardownStarted = true;
+        try {
+            if (this.teardownMode === 'shutdown') {
+                await this.inner.shutdown();
+            } else {
+                await this.inner.stop();
+            }
+        } catch (error) {
+            if (proxyError === null) throw error;
+            throw proxyError;
+        }
+        if (proxyError !== null) throw proxyError;
+    }
+
+    private async closeProxy(): Promise<void> {
+        const proxy = this.proxy;
+        if (!proxy) return;
+        try {
+            await proxy.close();
+        } finally {
+            if (this.proxy === proxy) this.proxy = null;
+        }
+    }
+
+    private handleUnexpectedExit(code: number | null): void {
+        void this.closeProxy().finally(() => this.opts.onUnexpectedExit(code));
+    }
+
+    private throwIfStopping(): void {
+        if (this.stopping) throw new Error('Quarto preview startup was stopped.');
+    }
+
+    private appendFallbackDiagnostic(error: unknown): void {
+        try {
+            this.opts.output.appendLine(
+                `[quarto] Preview proxy unavailable; using Quarto directly: ` +
+                errorMessage(error),
+            );
+        } catch {
+            // The activation output can already be disposing during shutdown.
+        }
+    }
+}
+
+function proxyPageUrl(quartoRawUrl: string, proxyOrigin: string): string {
+    const quarto = new URL(quartoRawUrl);
+    const proxy = new URL(proxyOrigin);
+    proxy.pathname = quarto.pathname;
+    proxy.search = quarto.search;
+    proxy.hash = quarto.hash;
+    return proxy.toString();
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/editors/vscode/src/quarto/quarto-theme-controller.ts
+++ b/editors/vscode/src/quarto/quarto-theme-controller.ts
@@ -1,0 +1,369 @@
+/**
+ * Per-panel live-theme controller for Quarto preview shells.
+ *
+ * The controller owns sequencing, persisted enabled state, cross-panel
+ * broadcast, and listener lifetime. VS Code-specific reads are supplied by
+ * the panel through `QuartoThemeControllerDeps`, which keeps this module
+ * runnable in Bun while production still reuses Knit's palette/font helpers.
+ */
+
+import { githubDark, githubLight, type GithubPalette } from '../knit/github-colors';
+import { resolveFontFamilies, type ResolvedFonts } from '../knit/render-html';
+import {
+    resolveActiveThemePalette,
+    type ThemePaletteArgs,
+    type ThemePaletteOutcome,
+} from '../knit/vscode-theme-palette';
+import {
+    QUARTO_CSS_COLOR_PATTERN_SOURCE,
+    type QuartoThemePayload,
+} from './quarto-messages';
+
+export const QUARTO_THEME_PREFERENCE_KEY = 'raven.quarto.applyVSCodeTheme';
+
+interface DisposableLike {
+    dispose(): unknown;
+}
+
+interface MementoLike {
+    get<T>(key: string): T | undefined;
+    update?(key: string, value: unknown): PromiseLike<void> | void;
+}
+
+export interface QuartoThemeContextLike {
+    globalState?: MementoLike;
+}
+
+export type QuartoThemeKind =
+    | 'light'
+    | 'dark'
+    | 'high-contrast'
+    | 'high-contrast-light';
+
+export interface QuartoConfigurationChangeLike {
+    affectsConfiguration(section: string, scope?: unknown): boolean;
+}
+
+type ThemeResolverInputs = Omit<
+    ThemePaletteArgs,
+    'activeEditorBackground' | 'candidateThemeIds' | 'isLight'
+>;
+
+export interface QuartoThemeControllerDeps {
+    context: QuartoThemeContextLike;
+    output: { appendLine(value: string): unknown };
+    sourceFsPath: string;
+    postThemeUpdate(payload: QuartoThemePayload): PromiseLike<boolean> | boolean;
+    requestThemeContext(): PromiseLike<boolean> | boolean;
+    activeThemeKind(): QuartoThemeKind;
+    getConfiguration<T>(section: string, defaultValue?: T): T | undefined;
+    themeResolverInputs(): ThemeResolverInputs;
+    resolveFonts(sourceFsPath: string): ResolvedFonts;
+    sourceConfigurationScope(sourceFsPath: string): unknown;
+    onDidChangeActiveColorTheme(listener: () => void): DisposableLike;
+    onDidChangeConfiguration(
+        listener: (event: QuartoConfigurationChangeLike) => void,
+    ): DisposableLike;
+    resolvePalette?(args: ThemePaletteArgs): Promise<ThemePaletteOutcome>;
+}
+
+const controllers = new Set<QuartoThemeController>();
+let preferenceWriteTail: Promise<void> = Promise.resolve();
+let lastKnownThemeEnabled: boolean | undefined;
+const CSS_COLOR = new RegExp(QUARTO_CSS_COLOR_PATTERN_SOURCE, 'i');
+
+const THEME_CONFIGURATION_KEYS = [
+    'workbench.colorTheme',
+    'workbench.preferredLightColorTheme',
+    'workbench.preferredDarkColorTheme',
+    'window.autoDetectColorScheme',
+    'workbench.colorCustomizations',
+    'editor.tokenColorCustomizations',
+    'editor.semanticTokenColorCustomizations',
+] as const;
+
+const FONT_CONFIGURATION_KEYS = [
+    'raven.quarto.fontFamily',
+    'raven.quarto.monospaceFontFamily',
+    'markdown.preview.fontFamily',
+    'editor.fontFamily',
+] as const;
+
+export class QuartoThemeController implements DisposableLike {
+    private sourceFsPath: string;
+    private enabled: boolean;
+    private latestEditorBackground: string | undefined;
+    private pushGeneration = 0;
+    private disposed = false;
+    private resolveWarned = false;
+    private readonly disposables: DisposableLike[];
+
+    constructor(private readonly deps: QuartoThemeControllerDeps) {
+        this.sourceFsPath = deps.sourceFsPath;
+        this.enabled = lastKnownThemeEnabled ?? readThemePreference(deps.context);
+        this.disposables = [
+            deps.onDidChangeActiveColorTheme(() => this.handleThemeChange()),
+            deps.onDidChangeConfiguration((event) => this.handleConfigurationChange(event)),
+        ];
+        controllers.add(this);
+    }
+
+    get isEnabled(): boolean {
+        return this.enabled;
+    }
+
+    /** Resolve a complete, safe bridge payload for the current host state. */
+    async resolvePayload(): Promise<QuartoThemePayload> {
+        const kind = this.deps.activeThemeKind();
+        const isLight = kind === 'light' || kind === 'high-contrast-light';
+        let palette: GithubPalette;
+        let resolvedThemeId: string | undefined;
+        try {
+            const resolve = this.deps.resolvePalette ?? resolveActiveThemePalette;
+            const outcome = await resolve({
+                ...this.deps.themeResolverInputs(),
+                candidateThemeIds: this.candidateThemeIds(isLight),
+                activeEditorBackground: this.latestEditorBackground,
+                isLight,
+            });
+            if (!outcome.ok) {
+                this.warnOnce(`${outcome.reason}: ${outcome.detail}`);
+                palette = isLight ? githubLight : githubDark;
+            } else {
+                palette = outcome.palette;
+                resolvedThemeId = outcome.themeLabel ?? outcome.themeId;
+            }
+        } catch (error) {
+            this.warnOnce(errorMessage(error));
+            palette = isLight ? githubLight : githubDark;
+        }
+
+        let fonts: ResolvedFonts;
+        try {
+            fonts = this.deps.resolveFonts(this.sourceFsPath);
+        } catch (error) {
+            this.warnOnce(`font resolution failed: ${errorMessage(error)}`);
+            fonts = resolveFontFamilies('', '', '', '');
+        }
+
+        const colorOverrides = resolveWorkbenchColorOverrides(
+            this.deps.getConfiguration<unknown>('workbench.colorCustomizations'),
+            resolvedThemeId ?? this.candidateThemeIds(isLight)[0],
+        );
+        return {
+            enabled: this.enabled,
+            background: colorOverrides.background ?? palette.background,
+            foreground: colorOverrides.foreground ?? palette.foreground,
+            roles: { ...palette.roles },
+            fontText: fonts.text,
+            fontMono: fonts.mono,
+        };
+    }
+
+    /** Resolve and deliver, dropping any result superseded while awaiting IO. */
+    async push(): Promise<boolean> {
+        if (this.disposed) return false;
+        const generation = ++this.pushGeneration;
+        const payload = await this.resolvePayload();
+        if (this.disposed || generation !== this.pushGeneration) return false;
+        try {
+            return (await this.deps.postThemeUpdate(payload)) === true;
+        } catch {
+            return false;
+        }
+    }
+
+    setEditorBackground(background: string): void {
+        if (this.disposed) return;
+        const normalized = normalizeEditorBackground(background);
+        if (!normalized || normalized === this.latestEditorBackground) return;
+        this.latestEditorBackground = normalized;
+        void this.push();
+    }
+
+    /** Persist and synchronize the toggle across every open Quarto panel. */
+    async setEnabled(applied: boolean): Promise<void> {
+        if (this.disposed) return;
+        // globalState persistence can settle later; this synchronous value is
+        // authoritative for panels constructed during that window.
+        lastKnownThemeEnabled = applied;
+        const writes: PromiseLike<unknown>[] = [];
+        const update = this.deps.context.globalState?.update;
+        if (typeof update === 'function') {
+            // globalState is shared by every panel. Serialize invocation as
+            // well as settlement so an older slow write can never land after
+            // a newer toggle intent.
+            preferenceWriteTail = preferenceWriteTail.then(async () => {
+                try {
+                    await update.call(
+                        this.deps.context.globalState,
+                        QUARTO_THEME_PREFERENCE_KEY,
+                        applied,
+                    );
+                } catch {
+                    try {
+                        this.deps.output.appendLine(
+                            '[theme] Quarto VS Code theme preference failed to persist.',
+                        );
+                    } catch {
+                        // The output facade may already be disposed during shutdown.
+                    }
+                }
+            });
+            writes.push(preferenceWriteTail);
+        }
+        for (const controller of controllers) {
+            if (controller.disposed) continue;
+            controller.enabled = applied;
+            writes.push(controller.push());
+        }
+        await Promise.allSettled(writes);
+    }
+
+    updateSource(sourceFsPath: string): void {
+        if (this.disposed || sourceFsPath === this.sourceFsPath) return;
+        this.sourceFsPath = sourceFsPath;
+        void this.push();
+    }
+
+    /** Test-only entry point for the same-kind active-theme listener path. */
+    handleActiveThemeChangeForTesting(): void {
+        this.handleThemeChange();
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.pushGeneration++;
+        controllers.delete(this);
+        for (const disposable of this.disposables) {
+            try { disposable.dispose(); } catch { /* best-effort */ }
+        }
+        this.disposables.length = 0;
+    }
+
+    private candidateThemeIds(isLight: boolean): readonly string[] {
+        const autoDetect = this.deps.getConfiguration<boolean>(
+            'window.autoDetectColorScheme',
+            false,
+        ) ?? false;
+        const candidates: string[] = [];
+        if (autoDetect) {
+            const preferredLight = this.deps.getConfiguration<string>(
+                'workbench.preferredLightColorTheme',
+                '',
+            );
+            const preferredDark = this.deps.getConfiguration<string>(
+                'workbench.preferredDarkColorTheme',
+                '',
+            );
+            const first = isLight ? preferredLight : preferredDark;
+            const second = isLight ? preferredDark : preferredLight;
+            if (first) candidates.push(first);
+            if (second && !candidates.includes(second)) candidates.push(second);
+        }
+        const active = this.deps.getConfiguration<string>('workbench.colorTheme', '');
+        if (active && !candidates.includes(active)) candidates.push(active);
+        return candidates;
+    }
+
+    private handleThemeChange(): void {
+        if (this.disposed) return;
+        this.latestEditorBackground = undefined;
+        try {
+            void Promise.resolve(this.deps.requestThemeContext()).catch(() => undefined);
+        } catch {
+            // Hidden/disposed shells can drop the best-effort request.
+        }
+        void this.push();
+    }
+
+    private handleConfigurationChange(event: QuartoConfigurationChangeLike): void {
+        if (this.disposed) return;
+        if (THEME_CONFIGURATION_KEYS.some((key) => event.affectsConfiguration(key))) {
+            this.handleThemeChange();
+            return;
+        }
+        const scope = this.deps.sourceConfigurationScope(this.sourceFsPath);
+        if (FONT_CONFIGURATION_KEYS.some((key) => event.affectsConfiguration(key, scope))) {
+            void this.push();
+        }
+    }
+
+    private warnOnce(detail: string): void {
+        if (this.resolveWarned) return;
+        this.resolveWarned = true;
+        try {
+            this.deps.output.appendLine(
+                `[theme] Quarto VS Code theme resolution failed (${detail}); ` +
+                'using fallback palette.',
+            );
+        } catch {
+            // The output facade may already be disposed during shutdown.
+        }
+    }
+}
+
+export function readThemePreference(context: QuartoThemeContextLike): boolean {
+    const state = context.globalState;
+    if (!state || typeof state.get !== 'function') return false;
+    const value = state.get<unknown>(QUARTO_THEME_PREFERENCE_KEY);
+    return typeof value === 'boolean' ? value : false;
+}
+
+function normalizeEditorBackground(value: string): string | undefined {
+    const normalized = value.trim().toLowerCase();
+    return /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/.test(normalized)
+        ? normalized
+        : undefined;
+}
+
+function resolveWorkbenchColorOverrides(
+    value: unknown,
+    activeThemeId: string | undefined,
+): { background?: string; foreground?: string } {
+    if (!isRecord(value)) return {};
+    const result: { background?: string; foreground?: string } = {};
+    layerEditorColors(result, value);
+    if (!activeThemeId) return result;
+    for (const [key, themed] of Object.entries(value)) {
+        if (!/^(\[[^\]]+\])+$/.test(key) || !isRecord(themed)) continue;
+        const selectors = [...key.matchAll(/\[([^\]]+)\]/g)];
+        if (selectors.some((match) => themeSelectorMatches(match[1], activeThemeId))) {
+            layerEditorColors(result, themed);
+        }
+    }
+    return result;
+}
+
+function themeSelectorMatches(selector: string, activeThemeId: string): boolean {
+    const pattern = selector
+        .split('*')
+        .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('.*');
+    return new RegExp(`^${pattern}$`).test(activeThemeId);
+}
+
+function layerEditorColors(
+    target: { background?: string; foreground?: string },
+    value: Record<string, unknown>,
+): void {
+    const background = validCssColor(value['editor.background']);
+    const foreground = validCssColor(value['editor.foreground']);
+    if (background) target.background = background;
+    if (foreground) target.foreground = foreground;
+}
+
+function validCssColor(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined;
+    const trimmed = value.trim();
+    return CSS_COLOR.test(trimmed) ? trimmed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/editors/vscode/src/quarto/quarto-theme-controller.ts
+++ b/editors/vscode/src/quarto/quarto-theme-controller.ts
@@ -116,13 +116,14 @@ export class QuartoThemeController implements DisposableLike {
     async resolvePayload(): Promise<QuartoThemePayload> {
         const kind = this.deps.activeThemeKind();
         const isLight = kind === 'light' || kind === 'high-contrast-light';
+        const candidateThemeIds = this.candidateThemeIds(isLight);
         let palette: GithubPalette;
         let resolvedThemeId: string | undefined;
         try {
             const resolve = this.deps.resolvePalette ?? resolveActiveThemePalette;
             const outcome = await resolve({
                 ...this.deps.themeResolverInputs(),
-                candidateThemeIds: this.candidateThemeIds(isLight),
+                candidateThemeIds,
                 activeEditorBackground: this.latestEditorBackground,
                 isLight,
             });
@@ -148,7 +149,7 @@ export class QuartoThemeController implements DisposableLike {
 
         const colorOverrides = resolveWorkbenchColorOverrides(
             this.deps.getConfiguration<unknown>('workbench.colorCustomizations'),
-            resolvedThemeId ?? this.candidateThemeIds(isLight)[0],
+            resolvedThemeId ?? candidateThemeIds[0],
         );
         return {
             enabled: this.enabled,

--- a/editors/vscode/src/test/quarto-preview-panel.test.ts
+++ b/editors/vscode/src/test/quarto-preview-panel.test.ts
@@ -21,6 +21,8 @@ suite('QuartoPreviewPanel integration', () => {
     let output: vscode.OutputChannel;
     let stops: Array<{ key: string; generation: number }>;
     let deps: QuartoPreviewPanelDeps;
+    let posted: unknown[];
+    let stored: Map<string, unknown>;
 
     suiteSetup(async () => {
         await activate();
@@ -29,12 +31,27 @@ suite('QuartoPreviewPanel integration', () => {
 
     setup(() => {
         stops = [];
+        posted = [];
+        stored = new Map();
+        const globalState = {
+            get: <T>(key: string) => stored.get(key) as T | undefined,
+            update: async (key: string, value: unknown) => { stored.set(key, value); },
+            keys: () => [...stored.keys()],
+        } as unknown as vscode.Memento;
         deps = {
+            context: {
+                subscriptions: [],
+                globalState,
+            } as unknown as vscode.ExtensionContext,
             output,
             stopGeneration: async (key, generation) => {
                 stops.push({ key, generation });
             },
             keyForSource: async (sourceFsPath) => sourceFsPath,
+            postWebviewMessage: (_webview, message) => {
+                posted.push(message);
+                return true;
+            },
         };
     });
 
@@ -281,9 +298,15 @@ suite('QuartoPreviewPanel integration', () => {
     test('Open in Browser false result warns and logs the copyable URL', async () => {
         const lines: string[] = [];
         const warnings: string[] = [];
+        const openedUrls: string[] = [];
         const originalOpenExternal = vscode.env.openExternal;
         const originalShowWarning = vscode.window.showWarningMessage;
-        (vscode.env as { openExternal: unknown }).openExternal = async () => false;
+        (vscode.env as { openExternal: unknown }).openExternal = async (
+            uri: vscode.Uri,
+        ) => {
+            openedUrls.push(uri.toString());
+            return false;
+        };
         (vscode.window as { showWarningMessage: unknown }).showWarningMessage = (
             message: string,
         ): Thenable<string | undefined> => {
@@ -297,7 +320,8 @@ suite('QuartoPreviewPanel integration', () => {
                     appendLine: (line: string) => { lines.push(line); },
                 } as unknown as vscode.OutputChannel,
             };
-            const rawUrl = 'http://127.0.0.1:4555/chapter/';
+            const rawUrl = 'http://127.0.0.1:4555/proxy/chapter/';
+            const browserUrl = 'http://127.0.0.1:4444/chapter/';
             const instance = QuartoPreviewPanel.applyRuntimeUpdate({
                 key: '/project',
                 generation: 1,
@@ -310,12 +334,17 @@ suite('QuartoPreviewPanel integration', () => {
                 generation: 1,
                 sourceFsPath: '/project/a.qmd',
                 rawUrl,
+                browserUrl,
                 state: { kind: 'serving', externalUrl: rawUrl },
             }, browserDeps);
 
             await instance.handleMessageForTesting({ type: 'open-in-browser' });
 
-            assert.deepStrictEqual(lines, [`[panel] Open in Browser failed: ${rawUrl}`]);
+            assert.ok(
+                lines.includes(`[panel] Open in Browser failed: ${browserUrl}`),
+                'browser failure remains copyable alongside theme diagnostics',
+            );
+            assert.deepStrictEqual(openedUrls, [browserUrl]);
             assert.deepStrictEqual(warnings, [
                 'VS Code could not open the Quarto preview in a browser. ' +
                 'The URL was written to Raven: Quarto output.',
@@ -366,4 +395,112 @@ suite('QuartoPreviewPanel integration', () => {
         assert.strictEqual(restored, null);
         assert.strictEqual(stops.length, 0);
     });
+
+    test('serving posts a theme update and installs handshake/load handling', async () => {
+        const instance = QuartoPreviewPanel.applyRuntimeUpdate({
+            key: '/theme-project',
+            generation: 1,
+            sourceFsPath: '/theme-project/a.qmd',
+            state: { kind: 'serving', externalUrl: 'http://127.0.0.1:4555/' },
+        }, deps);
+        assert.ok(instance);
+        await waitUntil(() => posted.some(isThemeUpdate));
+        const html = instance.getPanelForTesting().webview.html;
+        assert.ok(html.includes('event.origin === frameOrigin && isThemeReady(message)'));
+        assert.ok(html.includes("frame.addEventListener('load', function ()"));
+        assert.ok(html.includes('postThemeToFrame();'));
+        const readyStart = html.indexOf(
+            'if (event.origin === frameOrigin && isThemeReady(message))',
+        );
+        const readyEnd = html.indexOf('\n                    return;', readyStart);
+        assert.ok(!html.slice(readyStart, readyEnd).includes('postThemeToFrame();'));
+    });
+
+    test('toggle persists and broadcasts authoritative theme updates to two panels', async () => {
+        const first = QuartoPreviewPanel.applyRuntimeUpdate({
+            key: '/theme-a',
+            generation: 1,
+            sourceFsPath: '/theme-a/a.qmd',
+            state: { kind: 'starting' },
+        }, deps);
+        const second = QuartoPreviewPanel.applyRuntimeUpdate({
+            key: '/theme-b',
+            generation: 1,
+            sourceFsPath: '/theme-b/b.qmd',
+            state: { kind: 'starting' },
+        }, deps);
+        assert.ok(first);
+        assert.ok(second);
+
+        await first.handleMessageForTesting({ type: 'theme-changed', applied: true });
+
+        assert.strictEqual(stored.get('raven.quarto.applyVSCodeTheme'), true);
+        const enabledUpdates = posted.filter((message): message is {
+            type: 'theme-update';
+            payload: { enabled: boolean };
+        } => isThemeUpdate(message) && message.payload.enabled === true);
+        assert.ok(enabledUpdates.length >= 2, 'both panels receive enabled=true');
+    });
+
+    test('visible resend and same-kind theme refresh re-request context and theme', async () => {
+        const instance = QuartoPreviewPanel.applyRuntimeUpdate({
+            key: '/theme-visible',
+            generation: 1,
+            sourceFsPath: '/theme-visible/a.qmd',
+            state: { kind: 'serving', externalUrl: 'http://127.0.0.1:4556/' },
+        }, deps);
+        assert.ok(instance);
+        await waitUntil(() => posted.some(isThemeUpdate));
+        const beforeTheme = posted.filter(isThemeUpdate).length;
+
+        instance.handleActiveThemeChangeForTesting();
+        await waitUntil(() => posted.some(isThemeContextRequest));
+        await waitUntil(() => posted.filter(isThemeUpdate).length > beforeTheme);
+
+        const cover = vscode.window.createWebviewPanel(
+            'raven.quartoPreview.test.cover',
+            'Cover',
+            instance.getPanelForTesting().viewColumn ?? vscode.ViewColumn.One,
+            {},
+        );
+        try {
+            const beforeVisible = posted.filter(isThemeUpdate).length;
+            const beforeVisibleContext = posted.filter(isThemeContextRequest).length;
+            instance.getPanelForTesting().reveal(
+                instance.getPanelForTesting().viewColumn ?? vscode.ViewColumn.One,
+                false,
+            );
+            await waitUntil(() => posted.filter(isThemeUpdate).length > beforeVisible);
+            await waitUntil(() =>
+                posted.filter(isThemeContextRequest).length > beforeVisibleContext
+            );
+        } finally {
+            cover.dispose();
+        }
+    });
 });
+
+function isThemeUpdate(message: unknown): message is {
+    type: 'theme-update';
+    payload: { enabled: boolean };
+} {
+    return message !== null
+        && typeof message === 'object'
+        && (message as { type?: unknown }).type === 'theme-update';
+}
+
+function isThemeContextRequest(message: unknown): boolean {
+    return message !== null
+        && typeof message === 'object'
+        && (message as { type?: unknown }).type === 'theme-context-request';
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+    const started = Date.now();
+    while (!predicate()) {
+        if (Date.now() - started > timeoutMs) {
+            throw new Error('timed out waiting for Quarto panel theme event');
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+}

--- a/tests/bun/_helpers/quarto-preview-proxy-node.cjs
+++ b/tests/bun/_helpers/quarto-preview-proxy-node.cjs
@@ -1,0 +1,197 @@
+'use strict';
+
+const assert = require('assert/strict');
+const http = require('http');
+const net = require('net');
+
+const bundlePath = process.argv[2];
+const scenario = process.argv[3];
+const { QuartoPreviewProxy } = require(bundlePath);
+const bridgeAssets = { javascript: '', css: '' };
+
+void main().then(() => {
+    process.stdout.write('ok\n');
+}, (error) => {
+    process.stderr.write(`${error?.stack ?? String(error)}\n`);
+    process.exitCode = 1;
+});
+
+async function main() {
+    if (scenario === 'happy') return happyPath();
+    if (scenario === 'broken') return brokenUpstream();
+    if (scenario === 'teardown') return teardownSockets();
+    throw new Error(`Unknown proxy test scenario: ${scenario}`);
+}
+
+async function happyPath() {
+    let seenOrigin;
+    const upstream = websocketEchoServer((request) => {
+        seenOrigin = request.headers.origin;
+    });
+    const upstreamOrigin = await listen(upstream);
+    const proxy = new QuartoPreviewProxy(upstreamOrigin, bridgeAssets);
+    let client;
+    try {
+        const ready = await proxy.start();
+        const opened = await openWebSocket(ready.origin, 'client-head');
+        client = opened.socket;
+        assert.match(opened.bytes, /101 Switching Protocols/);
+        assert.match(opened.bytes, /upstream-head/);
+        assert.match(opened.bytes, /client-head/);
+        assert.equal(seenOrigin, upstreamOrigin);
+        const echoed = waitForData(client, 'later-payload');
+        client.write('later-payload');
+        await echoed;
+    } finally {
+        client?.destroy();
+        await proxy.close();
+        await closeServer(upstream);
+    }
+}
+
+async function brokenUpstream() {
+    const upstream = http.createServer();
+    upstream.on('upgrade', (_request, socket) => {
+        socket.end(
+            'HTTP/1.1 426 Upgrade Required\r\n' +
+            'Connection: close\r\nContent-Length: 0\r\n\r\n',
+        );
+    });
+    const upstreamOrigin = await listen(upstream);
+    const proxy = new QuartoPreviewProxy(upstreamOrigin, bridgeAssets);
+    try {
+        const ready = await proxy.start();
+        const target = new URL(ready.origin);
+        const socket = await connect(target);
+        const closed = waitForClose(socket);
+        socket.write(handshake(target));
+        await within(closed, 500, 'client stayed open after refused upgrade');
+        assert.equal(socket.destroyed, true);
+    } finally {
+        await proxy.close();
+        await closeServer(upstream);
+    }
+}
+
+async function teardownSockets() {
+    const upstream = websocketEchoServer();
+    const upstreamOrigin = await listen(upstream);
+    const proxy = new QuartoPreviewProxy(upstreamOrigin, bridgeAssets);
+    const ready = await proxy.start();
+    const target = new URL(ready.origin);
+    const idleHttp = await connect(target);
+    idleHttp.write('GET / HTTP/1.1\r\nHost: preview\r\n');
+    const websocket = (await openWebSocket(ready.origin)).socket;
+    const httpClosed = waitForClose(idleHttp);
+    const websocketClosed = waitForClose(websocket);
+
+    await within(proxy.close(), 500, 'proxy close did not settle');
+    await within(Promise.all([httpClosed, websocketClosed]), 500, 'sockets stayed open');
+    await assert.rejects(connect(target));
+    await closeServer(upstream);
+}
+
+function websocketEchoServer(onUpgrade) {
+    const server = http.createServer();
+    server.on('upgrade', (request, socket, head) => {
+        onUpgrade?.(request);
+        socket.write(
+            'HTTP/1.1 101 Switching Protocols\r\n' +
+            'Upgrade: websocket\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n' +
+            'upstream-head',
+        );
+        if (head.length > 0) socket.write(head);
+        socket.on('data', (chunk) => socket.write(chunk));
+        socket.on('error', () => undefined);
+    });
+    return server;
+}
+
+async function openWebSocket(origin, clientHead = '') {
+    const target = new URL(origin);
+    const socket = await connect(target);
+    const expected = clientHead === '' ? 'upstream-head' : clientHead;
+    const received = waitForData(socket, expected);
+    socket.write(handshake(target) + clientHead);
+    return { socket, bytes: (await within(received, 500, 'upgrade did not complete')).toString() };
+}
+
+function handshake(target) {
+    return 'GET /reload HTTP/1.1\r\n' +
+        `Host: ${target.host}\r\n` +
+        `Origin: ${target.origin}\r\n` +
+        'Connection: Upgrade\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Sec-WebSocket-Version: 13\r\n' +
+        'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n';
+}
+
+function waitForData(socket, expected) {
+    return new Promise((resolve, reject) => {
+        let bytes = Buffer.alloc(0);
+        const onData = (chunk) => {
+            bytes = Buffer.concat([bytes, chunk]);
+            if (bytes.includes(Buffer.from(expected))) {
+                cleanup();
+                resolve(bytes);
+            }
+        };
+        const onError = (error) => {
+            cleanup();
+            reject(error);
+        };
+        const cleanup = () => {
+            socket.off('data', onData);
+            socket.off('error', onError);
+        };
+        socket.on('data', onData);
+        socket.on('error', onError);
+    });
+}
+
+function waitForClose(socket) {
+    if (socket.destroyed) return Promise.resolve();
+    return new Promise((resolve) => socket.once('close', resolve));
+}
+
+function connect(target) {
+    return new Promise((resolve, reject) => {
+        const socket = net.createConnection({
+            host: target.hostname,
+            port: Number(target.port),
+        });
+        socket.once('connect', () => resolve(socket));
+        socket.once('error', reject);
+    });
+}
+
+function listen(server) {
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            const address = server.address();
+            resolve(`http://127.0.0.1:${address.port}`);
+        });
+    });
+}
+
+function closeServer(server) {
+    return new Promise((resolve) => server.close(resolve));
+}
+
+async function within(promise, ms, message) {
+    let timer;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise((_resolve, reject) => {
+                timer = setTimeout(() => reject(new Error(message)), ms);
+            }),
+        ]);
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/tests/bun/quarto-bridge-assets-load.test.ts
+++ b/tests/bun/quarto-bridge-assets-load.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { loadQuartoPreviewBridgeAssets } from '../../editors/vscode/src/quarto/quarto-bridge-assets';
+
+describe('Quarto bridge asset registration loading', () => {
+    test('a missing packaged asset logs once and leaves registration unbridged', () => {
+        const lines: string[] = [];
+        const load = () => loadQuartoPreviewBridgeAssets(
+            '/missing-extension',
+            { appendLine: (line) => { lines.push(line); } },
+            () => { throw new Error('injected ENOENT'); },
+        );
+
+        let result: ReturnType<typeof load>;
+        expect(() => { result = load(); }).not.toThrow();
+        expect(result!).toBeUndefined();
+        expect(lines).toEqual([
+            '[quarto] Theme bridge assets unavailable; previews will be unthemed: ' +
+            'injected ENOENT',
+        ]);
+    });
+});

--- a/tests/bun/quarto-bridge-assets.test.ts
+++ b/tests/bun/quarto-bridge-assets.test.ts
@@ -79,24 +79,18 @@ describe('packaged Quarto theme bridge sources', () => {
 
     test('sets every bridge CSS variable', () => {
         const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        // Static custom properties are set by literal name.
         for (const variable of [
             '--raven-bg',
             '--raven-fg',
-            '--raven-c-keyword',
-            '--raven-c-string',
-            '--raven-c-number',
-            '--raven-c-comment',
-            '--raven-c-function',
-            '--raven-c-type',
-            '--raven-c-variable',
-            '--raven-c-operator',
-            '--raven-c-punctuation',
-            '--raven-c-constant',
             '--raven-font-text',
             '--raven-font-mono',
         ]) {
             expect(source).toContain(variable);
         }
+        // Per-role custom properties are derived from the role key, whose set is
+        // pinned to the shared protocol by the first test in this suite.
+        expect(source).toContain("'--raven-c-' + role");
     });
 
     test('font validator accepts sanitizer-emitted C0 characters', () => {

--- a/tests/bun/quarto-bridge-assets.test.ts
+++ b/tests/bun/quarto-bridge-assets.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    QUARTO_CSS_COLOR_PATTERN_SOURCE,
+    QUARTO_SANITIZED_FONT_PATTERN_SOURCE,
+    QUARTO_THEME_ROLE_KEYS,
+    RAVEN_QUARTO_THEME_MESSAGE_KEYS,
+} from '../../editors/vscode/src/quarto/quarto-messages';
+
+const BRIDGE_DIR = join(
+    import.meta.dir,
+    '..',
+    '..',
+    'editors',
+    'vscode',
+    'src',
+    'quarto',
+    'bridge',
+);
+
+describe('packaged Quarto theme bridge sources', () => {
+    test('keeps inline protocol constants exactly aligned with the shared protocol', () => {
+        const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        expect(readArrayLiteral(source, 'roleKeys')).toEqual([...QUARTO_THEME_ROLE_KEYS]);
+        expect(readArrayLiteral(source, 'payloadKeys')).toEqual([
+            ...RAVEN_QUARTO_THEME_MESSAGE_KEYS,
+        ]);
+        expect(readRegexLiteral(source, 'colorPattern').source)
+            .toBe(QUARTO_CSS_COLOR_PATTERN_SOURCE);
+        expect(readRegexLiteral(source, 'fontPattern').source)
+            .toBe(QUARTO_SANITIZED_FONT_PATTERN_SOURCE);
+    });
+
+    test('installs its parent listener before posting the initial ready handshake', () => {
+        const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        const listener = source.indexOf("window.addEventListener('message'");
+        const initialReady = source.lastIndexOf('postReady();');
+        expect(listener).toBeGreaterThanOrEqual(0);
+        expect(initialReady).toBeGreaterThan(listener);
+        expect(source).toContain('event.source !== window.parent');
+        expect(source).toContain("type: 'raven-quarto-theme-ready'");
+        expect(source).toContain("value.type === 'raven-quarto-theme-ping'");
+    });
+
+    test('answers an exact ping without applying a theme', () => {
+        const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        const parent = { postMessageCalls: [] as unknown[] };
+        let listener!: (event: { source: unknown; data: unknown }) => void;
+        const styleCalls: unknown[] = [];
+        const window = {
+            parent: {
+                postMessage: (message: unknown) => parent.postMessageCalls.push(message),
+            },
+            addEventListener: (_type: string, callback: typeof listener) => {
+                listener = callback;
+            },
+        };
+        const document = {
+            documentElement: {
+                style: { setProperty: (...args: unknown[]) => styleCalls.push(args) },
+                classList: { toggle: (...args: unknown[]) => styleCalls.push(args) },
+            },
+        };
+        new Function('window', 'document', source)(window, document);
+        const initialReadyCount = parent.postMessageCalls.length;
+
+        listener({
+            source: window.parent,
+            data: { type: 'raven-quarto-theme-ping' },
+        });
+
+        expect(parent.postMessageCalls).toHaveLength(initialReadyCount + 1);
+        expect(parent.postMessageCalls.at(-1)).toEqual({
+            type: 'raven-quarto-theme-ready',
+        });
+        expect(styleCalls).toEqual([]);
+    });
+
+    test('sets every bridge CSS variable', () => {
+        const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        for (const variable of [
+            '--raven-bg',
+            '--raven-fg',
+            '--raven-c-keyword',
+            '--raven-c-string',
+            '--raven-c-number',
+            '--raven-c-comment',
+            '--raven-c-function',
+            '--raven-c-type',
+            '--raven-c-variable',
+            '--raven-c-operator',
+            '--raven-c-punctuation',
+            '--raven-c-constant',
+            '--raven-font-text',
+            '--raven-font-mono',
+        ]) {
+            expect(source).toContain(variable);
+        }
+    });
+
+    test('font validator accepts sanitizer-emitted C0 characters', () => {
+        const source = readFileSync(join(BRIDGE_DIR, 'bridge.js'), 'utf8');
+        const literal = source.match(/var fontPattern = (\/.*\/);/)?.[1];
+        expect(literal).toBeDefined();
+        const pattern = new Function(`return ${literal}`)() as RegExp;
+        expect(pattern.test('Control\u0001Font, sans-serif')).toBe(true);
+        expect(pattern.test('unsafe;font')).toBe(false);
+    });
+
+    test('scopes surface overrides and consumes every theme variable', () => {
+        const css = readFileSync(join(BRIDGE_DIR, 'bridge.css'), 'utf8');
+        expect(css).toContain('html.raven-vscode-theme');
+        for (const variable of [
+            '--raven-bg', '--raven-fg', '--raven-c-keyword', '--raven-c-string',
+            '--raven-c-number', '--raven-c-comment', '--raven-c-function',
+            '--raven-c-type', '--raven-c-variable', '--raven-c-operator',
+            '--raven-c-punctuation', '--raven-c-constant', '--raven-font-text',
+            '--raven-font-mono',
+        ]) {
+            expect(css).toContain(`var(${variable})`);
+        }
+        for (const surface of ['.navbar', '#quarto-sidebar', '#TOC', '.callout', '.card', 'table']) {
+            expect(css).toContain(surface);
+        }
+    });
+});
+
+function readArrayLiteral(source: string, name: string): unknown[] {
+    const literal = source.match(new RegExp(`var ${name} = (\\[[\\s\\S]*?\\]);`))?.[1];
+    if (!literal) throw new Error(`missing ${name} array literal`);
+    return new Function(`return ${literal}`)() as unknown[];
+}
+
+function readRegexLiteral(source: string, name: string): RegExp {
+    const literal = source.match(new RegExp(`var ${name} = (/.*?/[i]*);`))?.[1];
+    if (!literal) throw new Error(`missing ${name} regex literal`);
+    return new Function(`return ${literal}`)() as RegExp;
+}

--- a/tests/bun/quarto-messages.test.ts
+++ b/tests/bun/quarto-messages.test.ts
@@ -2,7 +2,35 @@ import { describe, expect, test } from 'bun:test';
 import {
     isExtensionToPreviewMessage,
     isPreviewToExtensionMessage,
+    isQuartoThemePayload,
+    isRavenQuartoThemeMessage,
+    isRavenQuartoThemePingMessage,
+    isRavenQuartoThemeReadyMessage,
+    type QuartoThemePayload,
 } from '../../editors/vscode/src/quarto/quarto-messages';
+import { sanitizeFontFamily } from '../../editors/vscode/src/knit/render-html';
+
+function themePayload(): QuartoThemePayload {
+    return {
+        enabled: true,
+        background: '#1e1e1e',
+        foreground: 'rgb(212, 212, 212)',
+        roles: {
+            keyword: '#c586c0',
+            string: '#ce9178',
+            number: '#b5cea8',
+            comment: '#6a9955',
+            function: '#dcdcaa',
+            type: '#4ec9b0',
+            variable: '#9cdcfe',
+            operator: '#d4d4d4',
+            punctuation: '#808080',
+            constant: 'rgba(86, 156, 214, 0.9)',
+        },
+        fontText: '-apple-system, "Segoe UI", sans-serif',
+        fontMono: '"SFMono-Regular", Consolas, monospace',
+    };
+}
 
 describe('Quarto preview message validators', () => {
     test('accepts every extension-to-preview view state', () => {
@@ -43,6 +71,22 @@ describe('Quarto preview message validators', () => {
         ).toBe(false);
     });
 
+    test('accepts new extension theme messages and rejects malformed variants', () => {
+        expect(isExtensionToPreviewMessage({
+            type: 'theme-update',
+            payload: themePayload(),
+        })).toBe(true);
+        expect(isExtensionToPreviewMessage({ type: 'theme-context-request' })).toBe(true);
+        expect(isExtensionToPreviewMessage({
+            type: 'theme-context-request',
+            extra: true,
+        })).toBe(false);
+        expect(isExtensionToPreviewMessage({
+            type: 'theme-update',
+            payload: { ...themePayload(), enabled: 'yes' },
+        })).toBe(false);
+    });
+
     test('accepts every preview-to-extension action', () => {
         for (const type of [
             'webview-ready',
@@ -56,6 +100,15 @@ describe('Quarto preview message validators', () => {
         expect(
             isPreviewToExtensionMessage({ type: 'report-error', message: 'frame failed' }),
         ).toBe(true);
+        expect(isPreviewToExtensionMessage({
+            type: 'theme-context',
+            background: '#1e1e1e',
+        })).toBe(true);
+        expect(isPreviewToExtensionMessage({ type: 'theme-changed', applied: true })).toBe(true);
+        expect(isPreviewToExtensionMessage({
+            type: 'theme-bridge-status',
+            available: false,
+        })).toBe(true);
     });
 
     test('rejects missing, extra, malformed, and unknown preview messages', () => {
@@ -67,5 +120,90 @@ describe('Quarto preview message validators', () => {
         ).toBe(false);
         expect(isPreviewToExtensionMessage({ type: 'unknown' })).toBe(false);
         expect(isPreviewToExtensionMessage(null)).toBe(false);
+        expect(isPreviewToExtensionMessage({
+            type: 'theme-context',
+            background: 12,
+        })).toBe(false);
+        expect(isPreviewToExtensionMessage({
+            type: 'theme-changed',
+            applied: 'true',
+        })).toBe(false);
+    });
+});
+
+describe('Quarto theme payload validators', () => {
+    test('accepts the exact safe payload and bridge message schemas', () => {
+        const payload = themePayload();
+        expect(isQuartoThemePayload(payload)).toBe(true);
+        expect(isRavenQuartoThemeMessage({
+            __ravenQuartoTheme: true,
+            ...payload,
+        })).toBe(true);
+        expect(isRavenQuartoThemeReadyMessage({
+            type: 'raven-quarto-theme-ready',
+        })).toBe(true);
+        expect(isRavenQuartoThemePingMessage({
+            type: 'raven-quarto-theme-ping',
+        })).toBe(true);
+    });
+
+    test('rejects missing and extra payload keys', () => {
+        const { fontMono: _missing, ...missing } = themePayload();
+        expect(isQuartoThemePayload(missing)).toBe(false);
+        expect(isQuartoThemePayload({ ...themePayload(), extra: true })).toBe(false);
+    });
+
+    test('rejects unsafe colors and fonts', () => {
+        expect(isQuartoThemePayload({
+            ...themePayload(),
+            background: 'red; background:url(evil)',
+        })).toBe(false);
+        expect(isQuartoThemePayload({
+            ...themePayload(),
+            fontText: 'system-ui; color: red',
+        })).toBe(false);
+        expect(isQuartoThemePayload({
+            ...themePayload(),
+            fontMono: 'mono\\evil',
+        })).toBe(false);
+    });
+
+    test('accepts every character shape that sanitizeFontFamily can emit', () => {
+        const font = 'Control\u0001Font, sans-serif';
+        expect(sanitizeFontFamily(font)).toBe(font);
+        expect(isQuartoThemePayload({
+            ...themePayload(),
+            fontText: font,
+            fontMono: font,
+        })).toBe(true);
+    });
+
+    test('rejects wrong, missing, extra, and malformed role sets', () => {
+        const payload = themePayload();
+        const { constant: _missing, ...missingRole } = payload.roles;
+        expect(isQuartoThemePayload({ ...payload, roles: missingRole })).toBe(false);
+        expect(isQuartoThemePayload({
+            ...payload,
+            roles: { ...payload.roles, builtin: '#ffffff' },
+        })).toBe(false);
+        expect(isQuartoThemePayload({
+            ...payload,
+            roles: { ...payload.roles, keyword: 'hsl(10, 10%, 10%)' },
+        })).toBe(false);
+    });
+
+    test('rejects bridge marker and handshake schema smuggling', () => {
+        expect(isRavenQuartoThemeMessage({
+            __ravenQuartoTheme: false,
+            ...themePayload(),
+        })).toBe(false);
+        expect(isRavenQuartoThemeReadyMessage({
+            type: 'raven-quarto-theme-ready',
+            payload: {},
+        })).toBe(false);
+        expect(isRavenQuartoThemePingMessage({
+            type: 'raven-quarto-theme-ping',
+            extra: true,
+        })).toBe(false);
     });
 });

--- a/tests/bun/quarto-preview-html.test.ts
+++ b/tests/bun/quarto-preview-html.test.ts
@@ -107,10 +107,10 @@ describe('buildQuartoPreviewShellHtml', () => {
             args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
         );
         const colorLiteral = html.match(
-            /const colorPattern = new RegExp\(((?:"(?:\\.|[^"])*)")?, 'i'\)/,
+            /const colorPattern = new RegExp\(("(?:[^"\\]|\\.)*")?, 'i'\)/,
         )?.[1];
         const fontLiteral = html.match(
-            /const fontPattern = new RegExp\(((?:"(?:\\.|[^"])*)")?\)/,
+            /const fontPattern = new RegExp\(("(?:[^"\\]|\\.)*")?\)/,
         )?.[1];
         expect(colorLiteral).toBeDefined();
         expect(fontLiteral).toBeDefined();

--- a/tests/bun/quarto-preview-html.test.ts
+++ b/tests/bun/quarto-preview-html.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
 import {
     buildQuartoPreviewShellHtml,
     type QuartoPreviewShellHtmlArgs,
@@ -10,6 +11,7 @@ function args(state: QuartoPreviewViewState): QuartoPreviewShellHtmlArgs {
         nonce: 'NONCE123',
         sourceFsPath: '/work/report.qmd',
         state,
+        themeEnabled: false,
     };
 }
 
@@ -59,17 +61,79 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(html).toContain("vscode.postMessage({ type: 'request-restart' })");
     });
 
-    test('accepts only host-origin exact-shape state updates, never iframe messages', () => {
+    test('keeps frame and host delivery in disjoint security branches', () => {
         const html = buildQuartoPreviewShellHtml(
             args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
         );
-        expect(html).toContain("event.origin !== '' && event.origin !== window.origin");
-        expect(html).toContain('event.source === frame.contentWindow');
+        const frameBranch = html.indexOf('if (frame && event.source === frame.contentWindow)');
+        const frameReturn = html.indexOf('return;', frameBranch);
+        const hostBranch = html.indexOf(
+            "if (event.origin === '' || event.origin === window.origin)",
+        );
+        expect(frameBranch).toBeGreaterThan(0);
+        expect(frameReturn).toBeGreaterThan(frameBranch);
+        expect(hostBranch).toBeGreaterThan(frameReturn);
+        expect(html).toContain('event.origin === frameOrigin && isThemeReady(message)');
         expect(html).toContain("hasExactKeys(value, ['payload', 'type'])");
         expect(html).toContain("'serving': ['externalUrl', 'kind']");
         expect(html).toContain("'failed': ['detailText', 'kind']");
         expect(html).toContain("'exited-unexpectedly': ['code', 'kind']");
-        expect(html).toContain('if (!isStateUpdate(message)) return');
+        expect(html).toContain('if (isStateUpdate(message))');
+        // A forged frame-origin state update returns in Branch A; a forged
+        // non-frame theme-context message misses Branch B's host origins.
+        expect(html).toContain('value.type === \'raven-quarto-theme-ready\'');
+        expect(html).toContain("value.type === 'theme-context-request'");
+    });
+
+    test('caches host themes but a ready handshake does not resend', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        expect(html).toContain('currentTheme = message.payload');
+        expect(html).toContain('__ravenQuartoTheme: true');
+        expect(html).toContain('}, frameOrigin)');
+        const readyStart = html.indexOf(
+            'if (event.origin === frameOrigin && isThemeReady(message))',
+        );
+        const readyEnd = html.indexOf('\n                    return;', readyStart);
+        const readyBranch = html.slice(readyStart, readyEnd);
+        expect(readyBranch).toContain('markBridgeAvailable();');
+        expect(readyBranch).not.toContain('postThemeToFrame();');
+        expect(html).toContain("hasExactKeys(value, ['type'])");
+    });
+
+    test('emits shared color/font validators with live regex escapes', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        const colorLiteral = html.match(
+            /const colorPattern = new RegExp\(((?:"(?:\\.|[^"])*)")?, 'i'\)/,
+        )?.[1];
+        const fontLiteral = html.match(
+            /const fontPattern = new RegExp\(((?:"(?:\\.|[^"])*)")?\)/,
+        )?.[1];
+        expect(colorLiteral).toBeDefined();
+        expect(fontLiteral).toBeDefined();
+        const colorPattern = new RegExp(JSON.parse(colorLiteral!), 'i');
+        const fontPattern = new RegExp(JSON.parse(fontLiteral!));
+        expect(colorPattern.test('#a1b2c3')).toBe(true);
+        expect(colorPattern.test('rgb(1, 22, 255)')).toBe(true);
+        expect(colorPattern.test('rgba(1, 22, 255, 0.5)')).toBe(true);
+        expect(fontPattern.test('Control\u0001Font, sans-serif')).toBe(true);
+    });
+
+    test('contains the persisted toggle and responsive host relay', () => {
+        const html = buildQuartoPreviewShellHtml({
+            ...args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+            themeEnabled: true,
+        });
+        expect(html).toMatch(
+            /<button[^>]*id="raven-quarto-theme"[^>]*[\s\S]*?aria-pressed="true"/,
+        );
+        expect(html).toContain('themeEnabled = !themeEnabled');
+        expect(html).toContain('currentTheme = { ...currentTheme, enabled: themeEnabled }');
+        expect(html).toContain("vscode.postMessage({ type: 'theme-changed', applied: themeEnabled })");
+        expect(html).toContain('themeEnabled = currentTheme.enabled');
     });
 
     test('persists only sourceFsPath and installs the honest timeout banner', () => {
@@ -80,12 +144,30 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(html).toContain('}, 8000)');
     });
 
+    test('re-sends on load and times out an unavailable bridge', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://localhost:9/' }),
+        );
+        expect(html).toContain("frame.addEventListener('load', function ()");
+        expect(html).toContain('postThemeToFrame();');
+        expect(html).toContain('armBridgeTimeout();');
+        expect(html).toContain('postBridgePing();');
+        expect(html).toContain("type: 'raven-quarto-theme-ping'");
+        expect(html).not.toContain('window.clearTimeout(blankTimer)');
+        expect(html).toContain("vscode.postMessage({ type: 'theme-bridge-status', available: false })");
+        expect(html).toContain("VS Code theme can't apply to this page");
+        expect(html).not.toContain('themeButton.disabled = bridgeAvailable === false');
+        expect(html).not.toContain('if (themeButton.disabled) return');
+        expect(html).toContain('}, 3000)');
+    });
+
     test('never injects hostile detail text, paths, or URLs as raw markup/script', () => {
         const hostile = '</script>"<angle>&';
         const failedHtml = buildQuartoPreviewShellHtml({
             nonce: 'NONCE123',
             sourceFsPath: `/work/${hostile}.qmd`,
             state: { kind: 'failed', detailText: `failure: ${hostile}` },
+            themeEnabled: false,
         });
         expect(failedHtml).not.toContain(hostile);
         expect(failedHtml).toContain('\\u003c/script>');
@@ -98,4 +180,222 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(servingHtml).not.toContain(hostileUrl);
         expect(servingHtml).toContain('&lt;/script&gt;&quot;&lt;angle&gt;&amp;');
     });
+
+    test('emits syntactically valid shell JavaScript', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        const match = html.match(/<script nonce="NONCE123">([\s\S]*?)<\/script>/);
+        expect(match).not.toBeNull();
+        expect(() => new Function(match![1])).not.toThrow();
+    });
+
+    test('enforces frame/host branches and resends cached themes at runtime', () => {
+        const hostMessages: unknown[] = [];
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        const dom = new JSDOM(html, { url: 'https://webview.example.test/' });
+        try {
+            const { window } = dom;
+            const frame = window.document.getElementById(
+                'raven-quarto-frame',
+            ) as HTMLIFrameElement;
+            const status = window.document.getElementById('raven-quarto-status')!;
+            const frameMessages: unknown[] = [];
+            frame.contentWindow!.postMessage = (message: unknown) => {
+                frameMessages.push(message);
+            };
+            const script = html.match(/<script nonce="NONCE123">([\s\S]*?)<\/script>/)![1];
+            const run = new Function(
+                'window',
+                'document',
+                'acquireVsCodeApi',
+                'getComputedStyle',
+                script,
+            );
+            run(
+                window,
+                window.document,
+                () => ({
+                    setState: () => undefined,
+                    postMessage: (message: unknown) => { hostMessages.push(message); },
+                }),
+                window.getComputedStyle.bind(window),
+            );
+
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: 'http://127.0.0.1:4000',
+                source: frame.contentWindow,
+                data: {
+                    type: 'state-update',
+                    payload: { kind: 'stopped' },
+                },
+            }));
+            expect(status.textContent).toBe('');
+
+            const contextsBefore = hostMessages.filter((message) =>
+                (message as { type?: unknown })?.type === 'theme-context'
+            ).length;
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: 'https://evil.example.test',
+                data: { type: 'theme-context-request' },
+            }));
+            expect(hostMessages.filter((message) =>
+                (message as { type?: unknown })?.type === 'theme-context'
+            )).toHaveLength(contextsBefore);
+
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: '',
+                data: { type: 'theme-update', payload: themePayload() },
+            }));
+            expect(frameMessages).toHaveLength(1);
+            expect(frameMessages[0]).toMatchObject({
+                __ravenQuartoTheme: true,
+                enabled: true,
+            });
+
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: 'http://127.0.0.1:4000',
+                source: frame.contentWindow,
+                data: { type: 'raven-quarto-theme-ready' },
+            }));
+            expect(frameMessages.filter((message) =>
+                (message as { __ravenQuartoTheme?: unknown }).__ravenQuartoTheme === true
+            )).toHaveLength(1);
+            expect(hostMessages).toContainEqual({
+                type: 'theme-bridge-status',
+                available: true,
+            });
+        } finally {
+            dom.window.close();
+        }
+    });
+
+    test('re-arms availability on every navigation and a later ready re-enables', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        const dom = new JSDOM(html, { url: 'https://webview.example.test/' });
+        try {
+            const { window } = dom;
+            const hostMessages: unknown[] = [];
+            const frameMessages: unknown[] = [];
+            const timers: Array<{ callback: () => void; delay: number; active: boolean }> = [];
+            window.setTimeout = ((callback: () => void, delay: number) => {
+                timers.push({ callback, delay, active: true });
+                return timers.length;
+            }) as typeof window.setTimeout;
+            window.clearTimeout = ((id: number) => {
+                if (timers[id - 1]) timers[id - 1].active = false;
+            }) as typeof window.clearTimeout;
+            const script = html.match(/<script nonce="NONCE123">([\s\S]*?)<\/script>/)![1];
+            const run = new Function(
+                'window',
+                'document',
+                'acquireVsCodeApi',
+                'getComputedStyle',
+                script,
+            );
+            run(
+                window,
+                window.document,
+                () => ({
+                    setState: () => undefined,
+                    postMessage: (message: unknown) => { hostMessages.push(message); },
+                }),
+                window.getComputedStyle.bind(window),
+            );
+            const frame = window.document.getElementById(
+                'raven-quarto-frame',
+            ) as HTMLIFrameElement;
+            frame.contentWindow!.postMessage = (message: unknown) => {
+                frameMessages.push(message);
+            };
+            const themeButton = window.document.getElementById(
+                'raven-quarto-theme',
+            ) as HTMLButtonElement;
+
+            frame.dispatchEvent(new window.Event('load'));
+            expect(frameMessages.at(-1)).toEqual({ type: 'raven-quarto-theme-ping' });
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: 'http://127.0.0.1:4000',
+                source: frame.contentWindow,
+                data: { type: 'raven-quarto-theme-ready' },
+            }));
+
+            // A subsequent CSP-blocked/non-HTML navigation never answers its
+            // load-triggered ping, but the global preference remains editable.
+            frame.dispatchEvent(new window.Event('load'));
+            const blockedTimeout = [...timers].reverse().find((timer) =>
+                timer.delay === 3000 && timer.active
+            );
+            expect(blockedTimeout).toBeDefined();
+            blockedTimeout!.callback();
+            blockedTimeout!.active = false;
+            expect(themeButton.disabled).toBe(false);
+            expect(themeButton.title).toBe("VS Code theme can't apply to this page");
+            expect(hostMessages).toContainEqual({
+                type: 'theme-bridge-status',
+                available: false,
+            });
+            themeButton.click();
+            expect(themeButton.getAttribute('aria-pressed')).toBe('true');
+            expect(hostMessages).toContainEqual({
+                type: 'theme-changed',
+                applied: true,
+            });
+
+            // A normal later page responds to its own ping and re-enables.
+            frame.dispatchEvent(new window.Event('load'));
+            window.dispatchEvent(new window.MessageEvent('message', {
+                origin: 'http://127.0.0.1:4000',
+                source: frame.contentWindow,
+                data: { type: 'raven-quarto-theme-ready' },
+            }));
+            expect(themeButton.disabled).toBe(false);
+            expect(themeButton.title).toBe('Apply VS Code theme');
+            expect(hostMessages.filter((message) =>
+                (message as { type?: unknown }).type === 'theme-bridge-status'
+            )).toEqual([
+                { type: 'theme-bridge-status', available: true },
+                { type: 'theme-bridge-status', available: false },
+                { type: 'theme-bridge-status', available: true },
+            ]);
+            expect(frameMessages.filter((message) =>
+                (message as { type?: unknown }).type === 'raven-quarto-theme-ping'
+            )).toHaveLength(3);
+
+            const blank = timers.find((timer) => timer.delay === 8000);
+            expect(blank).toBeDefined();
+            blank!.callback();
+            const banner = window.document.getElementById('raven-quarto-load-banner')!;
+            expect(banner.hidden).toBe(false);
+            expect(banner.textContent).toContain('try Open in Browser');
+        } finally {
+            dom.window.close();
+        }
+    });
 });
+
+function themePayload() {
+    return {
+        enabled: true,
+        background: '#1e1e1e',
+        foreground: '#d4d4d4',
+        roles: {
+            keyword: '#c586c0',
+            string: '#ce9178',
+            number: '#b5cea8',
+            comment: '#6a9955',
+            function: '#dcdcaa',
+            type: '#4ec9b0',
+            variable: '#9cdcfe',
+            operator: '#d4d4d4',
+            punctuation: '#808080',
+            constant: '#569cd6',
+        },
+        fontText: 'Inter, sans-serif',
+        fontMono: 'Mono, monospace',
+    };
+}

--- a/tests/bun/quarto-preview-proxy.test.ts
+++ b/tests/bun/quarto-preview-proxy.test.ts
@@ -880,15 +880,18 @@ describe('QuartoPreviewProxy HTTP passthrough', () => {
     });
 
     it('forwards requests to a bracketed IPv6 loopback upstream', async () => {
+        let seenUrl = '';
         const upstream = http.createServer((request, response) => {
-            response.end(`ipv6:${request.url ?? ''}`);
+            seenUrl = request.url ?? '';
+            response.end('ipv6-ok');
         });
         const upstreamOrigin = await listen(upstream, '::1');
         const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
         try {
             const result = await rawRequest(`${(await proxy.start()).origin}/ipv6`);
             expect(result.statusCode).toBe(200);
-            expect(result.body.toString()).toBe('ipv6:/ipv6');
+            expect(seenUrl).toBe('/ipv6');
+            expect(result.body.toString()).toBe('ipv6-ok');
         } finally {
             await proxy.close();
             await closeServer(upstream);

--- a/tests/bun/quarto-preview-proxy.test.ts
+++ b/tests/bun/quarto-preview-proxy.test.ts
@@ -268,6 +268,34 @@ describe('QuartoPreviewProxy HTTP passthrough', () => {
         }
     });
 
+    it('rejects a WebSocket Origin from a different loopback port', async () => {
+        // A page served from another localhost origin must not be able to open
+        // the proxied live-reload socket, even though its Origin is loopback.
+        let upgradeReached = false;
+        const upstream = http.createServer();
+        upstream.on('upgrade', (_request, socket) => {
+            upgradeReached = true;
+            socket.destroy();
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET /live-reload HTTP/1.1\r\n' +
+                `Host: ${new URL(ready.origin).host}\r\n` +
+                'Upgrade: websocket\r\nConnection: Upgrade\r\n' +
+                'Origin: http://127.0.0.1:1\r\n\r\n',
+            );
+            expect(upgradeReached).toBe(false);
+            expect(response.toString()).not.toContain('101');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
     it('rejects a WebSocket upgrade carrying a cross-site Origin when enforcing', async () => {
         // The proxy contacts the upstream only after the Host/Origin check
         // passes, so a rejected handshake never reaches the upstream's upgrade

--- a/tests/bun/quarto-preview-proxy.test.ts
+++ b/tests/bun/quarto-preview-proxy.test.ts
@@ -1,0 +1,834 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { spawn } from 'child_process';
+import { mkdtemp, rm } from 'fs/promises';
+import * as http from 'http';
+import * as net from 'net';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { gzipSync } from 'zlib';
+import {
+    filteredRequestHeaders,
+    QuartoPreviewProxy,
+} from '../../editors/vscode/src/quarto/quarto-preview-proxy';
+
+const BRIDGE_JS = Buffer.from('window.__ravenBridgeTest = true;');
+const BRIDGE_CSS = Buffer.from('html.raven-vscode-theme { color: red; }');
+const BRIDGE_ASSETS = { javascript: BRIDGE_JS, css: BRIDGE_CSS };
+const INJECTION =
+    '<link rel="stylesheet" href="/_raven-theme-bridge/bridge.css">' +
+    '<script src="/_raven-theme-bridge/bridge.js"></script>';
+
+interface RawResponse {
+    statusCode: number;
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+}
+
+describe('QuartoPreviewProxy HTTP passthrough', () => {
+    it('forwards GET and POST method, path, headers, status, and body', async () => {
+        const upstream = http.createServer(async (request, response) => {
+            const body = await readBody(request);
+            response.writeHead(207, {
+                'Content-Type': 'application/octet-stream',
+                'X-Upstream-Method': request.method ?? '',
+                'X-Upstream-Path': request.url ?? '',
+                'X-Request-Header': request.headers['x-request-header'] ?? '',
+            });
+            response.end(body.length === 0 ? Buffer.from('get-body') : body);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const get = await rawRequest(`${ready.origin}/chapter/?x=1`);
+            expect(get.statusCode).toBe(207);
+            expect(get.headers['x-upstream-method']).toBe('GET');
+            expect(get.headers['x-upstream-path']).toBe('/chapter/?x=1');
+            expect(get.body.toString()).toBe('get-body');
+
+            const payload = Buffer.from([0, 1, 2, 3, 255]);
+            const post = await rawRequest(`${ready.origin}/submit?q=yes`, {
+                method: 'POST',
+                headers: {
+                    'Content-Length': payload.length,
+                    'X-Request-Header': 'preserved',
+                },
+                body: payload,
+            });
+            expect(post.statusCode).toBe(207);
+            expect(post.headers['content-type']).toBe('application/octet-stream');
+            expect(post.headers['x-upstream-method']).toBe('POST');
+            expect(post.headers['x-upstream-path']).toBe('/submit?q=yes');
+            expect(post.headers['x-request-header']).toBe('preserved');
+            expect(post.body).toEqual(payload);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rewrites a forwarded HTTP Origin only when the client supplied one', async () => {
+        const seenOrigins: Array<string | undefined> = [];
+        const upstream = http.createServer((request, response) => {
+            seenOrigins.push(request.headers.origin);
+            response.end('ok');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            await rawRequest(`${ready.origin}/with-origin`, {
+                headers: { Origin: ready.origin },
+            });
+            await rawRequest(`${ready.origin}/without-origin`);
+            expect(seenOrigins).toEqual([upstreamOrigin, undefined]);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('passes compressed binary response bytes and entity headers untouched', async () => {
+        const source = Buffer.from(Array.from({ length: 512 }, (_, index) => index % 251));
+        const compressed = gzipSync(source);
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, {
+                'Content-Type': 'application/octet-stream',
+                'Content-Encoding': 'gzip',
+                'Content-Length': compressed.length,
+                ETag: '"opaque-compressed-etag"',
+            });
+            response.end(compressed);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawRequest(ready.url, {
+                headers: { 'Accept-Encoding': 'br, gzip' },
+            });
+            expect(response.headers['content-encoding']).toBe('gzip');
+            expect(response.headers['content-length']).toBe(String(compressed.length));
+            expect(response.headers.etag).toBe('"opaque-compressed-etag"');
+            expect(response.body).toEqual(compressed);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('ignores absolute-form authority and foreign Host for upstream selection', async () => {
+        let seenUrl = '';
+        let seenHost = '';
+        const upstream = http.createServer((request, response) => {
+            seenUrl = request.url ?? '';
+            seenHost = request.headers.host ?? '';
+            response.end('fixed-upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET http://example.invalid/foreign/path?q=1 HTTP/1.1\r\n' +
+                'Host: attacker.invalid:9999\r\nConnection: close\r\n\r\n',
+            );
+            expect(response.toString()).toContain('fixed-upstream');
+            expect(seenUrl).toBe('/foreign/path?q=1');
+            expect(seenHost).toBe(new URL(upstreamOrigin).host);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('injects before the first normal case-insensitive body close and drops stale entity headers', async () => {
+        const upstream = http.createServer((_request, response) => {
+            const body = '<html><body>first</BoDy><body>second</body></html>';
+            response.writeHead(200, {
+                'Content-Type': 'Text/HTML; Charset=UTF-8',
+                'Content-Length': Buffer.byteLength(body),
+                ETag: '"stale"',
+                'Content-MD5': 'stale-md5',
+                Digest: 'sha-256=stale',
+            });
+            response.end(body);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const result = await rawRequest(ready.url);
+            expect(result.body.toString()).toBe(
+                `<html><body>first${INJECTION}</BoDy><body>second</body></html>`,
+            );
+            expect(result.headers['content-length']).toBeUndefined();
+            expect(result.headers.etag).toBeUndefined();
+            expect(result.headers['content-md5']).toBeUndefined();
+            expect(result.headers.digest).toBeUndefined();
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('does not inject at a closing-body string inside an earlier inline script', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><body><script>const marker = "</body>";</script>' +
+                '<main>real body</main></body></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><body><script>const marker = "</body>";</script>' +
+                `<main>real body</main>${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('does not inject at a closing-body string inside an earlier textarea', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><body><textarea name="source">literal </body> text</TEXTAREA>' +
+                '<main>real body</main></body></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><body><textarea name="source">literal </body> text</TEXTAREA>' +
+                `<main>real body</main>${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('does not inject at a closing-body string inside an earlier title', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><head><TiTlE>literal </body> text</title></head>' +
+                '<body><main>real body</main></body></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><head><TiTlE>literal </body> text</title></head>' +
+                `<body><main>real body</main>${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('chooses the real body close before a trailing script containing body text', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><body><!-- </body> --><style>.x::after{content:"</body>"}</style>' +
+                '<main>content</main></body><script>const late = "</body>";</script></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><body><!-- </body> --><style>.x::after{content:"</body>"}</style>' +
+                `<main>content</main>${INJECTION}</body>` +
+                '<script>const late = "</body>";</script></html>',
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('matches a body close split across upstream chunks', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.write('<html><body>split</bo');
+            setTimeout(() => response.end('dy></html>'), 5);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                `<html><body>split${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('appends bridge tags when HTML has no body close', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end('<main>fragment</main>');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(`<main>fragment</main>${INJECTION}`);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('injects only document fetch destinations or requests without the header', async () => {
+        const body = '<html><body>destination</body></html>';
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, {
+                'Content-Type': 'text/html',
+                'Content-Length': Buffer.byteLength(body),
+            });
+            response.end(body);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const origin = (await proxy.start()).origin;
+            const subresource = await rawRequest(`${origin}/subresource`, {
+                headers: { 'Sec-Fetch-Dest': 'empty' },
+            });
+            const document = await rawRequest(`${origin}/document`, {
+                headers: { 'Sec-Fetch-Dest': 'document' },
+            });
+            const fallback = await rawRequest(`${origin}/fallback`);
+
+            expect(subresource.body.toString()).toBe(body);
+            expect(subresource.headers['content-length']).toBe(String(Buffer.byteLength(body)));
+            expect(document.body.toString()).toBe(
+                `<html><body>destination${INJECTION}</body></html>`,
+            );
+            expect(fallback.body.toString()).toBe(
+                `<html><body>destination${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('streams a large HTML body before upstream completion without whole-body buffering', async () => {
+        let releaseUpstream!: () => void;
+        const upstreamReleased = new Promise<void>((resolve) => {
+            releaseUpstream = resolve;
+        });
+        const firstChunk = '<html><body>' + 'x'.repeat(1024 * 1024);
+        const upstream = http.createServer(async (_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            response.write(firstChunk);
+            await upstreamReleased;
+            response.end('</body></html>');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const url = (await proxy.start()).url;
+            let resolveFirst!: (chunk: Buffer) => void;
+            const first = new Promise<Buffer>((resolve) => { resolveFirst = resolve; });
+            const done = new Promise<Buffer>((resolve, reject) => {
+                const request = http.request(url, { agent: false }, (response) => {
+                    const chunks: Buffer[] = [];
+                    response.once('data', (chunk: Buffer) => resolveFirst(Buffer.from(chunk)));
+                    response.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+                    response.on('end', () => resolve(Buffer.concat(chunks)));
+                    response.on('error', reject);
+                });
+                request.on('error', reject);
+                request.end();
+            });
+
+            expect((await first).length).toBeGreaterThan(0);
+            releaseUpstream();
+            expect((await done).toString()).toBe(
+                `${firstChunk}${INJECTION}</body></html>`,
+            );
+        } finally {
+            releaseUpstream();
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('never injects non-HTML, partial, HEAD, 304, or encoded responses', async () => {
+        const binary = Buffer.from([0, 255, 60, 47, 98, 111, 100, 121, 62, 1]);
+        const encoded = gzipSync(Buffer.from('<html><body>gzip</body></html>'));
+        const upstream = http.createServer((request, response) => {
+            if (request.url === '/binary') {
+                response.writeHead(200, {
+                    'Content-Type': 'application/octet-stream',
+                    'Content-Length': binary.length,
+                    ETag: '"binary"',
+                });
+                response.end(binary);
+            } else if (request.url === '/partial') {
+                response.writeHead(206, {
+                    'Content-Type': 'text/html',
+                    'Content-Range': 'bytes 0-15/50',
+                });
+                response.end('<body>part</body>');
+            } else if (request.url === '/not-modified') {
+                response.writeHead(304, { 'Content-Type': 'text/html', ETag: '"same"' });
+                response.end();
+            } else if (request.url === '/encoded') {
+                response.writeHead(200, {
+                    'Content-Type': 'text/html',
+                    'Content-Encoding': 'gzip',
+                    'Content-Length': encoded.length,
+                });
+                response.end(encoded);
+            } else if (request.url === '/utf16') {
+                const utf16 = Buffer.from('<html><body>utf16</body></html>', 'utf16le');
+                response.writeHead(200, {
+                    'Content-Type': 'text/html; charset=utf-16',
+                    'Content-Length': utf16.length,
+                });
+                response.end(utf16);
+            } else {
+                response.writeHead(200, {
+                    'Content-Type': 'text/html',
+                    'Content-Length': '24',
+                });
+                response.end('<body>head-only</body>');
+            }
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const origin = (await proxy.start()).origin;
+            const binaryResult = await rawRequest(`${origin}/binary`);
+            expect(binaryResult.body).toEqual(binary);
+            expect(binaryResult.headers.etag).toBe('"binary"');
+            expect((await rawRequest(`${origin}/partial`)).body.toString())
+                .toBe('<body>part</body>');
+            const notModified = await rawRequest(`${origin}/not-modified`);
+            expect(notModified.statusCode).toBe(304);
+            expect(notModified.body.length).toBe(0);
+            expect(notModified.headers.etag).toBe('"same"');
+            expect((await rawRequest(`${origin}/encoded`)).body).toEqual(encoded);
+            const utf16 = await rawRequest(`${origin}/utf16`);
+            expect(utf16.body).toEqual(
+                Buffer.from('<html><body>utf16</body></html>', 'utf16le'),
+            );
+            expect(utf16.headers['content-length']).toBe(String(utf16.body.length));
+            const head = await rawRequest(`${origin}/head`, { method: 'HEAD' });
+            expect(head.body.length).toBe(0);
+            expect(head.headers['content-length']).toBe('24');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('streams non-HTML response chunks without waiting for upstream completion', async () => {
+        let releaseUpstream!: () => void;
+        const upstreamReleased = new Promise<void>((resolve) => {
+            releaseUpstream = resolve;
+        });
+        const upstream = http.createServer(async (_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+            response.write('first');
+            await upstreamReleased;
+            response.end('second');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const url = (await proxy.start()).url;
+            let resolveFirst!: (chunk: Buffer) => void;
+            const first = new Promise<Buffer>((resolve) => { resolveFirst = resolve; });
+            const done = new Promise<Buffer>((resolve, reject) => {
+                const request = http.request(url, { agent: false }, (response) => {
+                    const chunks: Buffer[] = [];
+                    response.once('data', (chunk: Buffer) => resolveFirst(Buffer.from(chunk)));
+                    response.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+                    response.on('end', () => resolve(Buffer.concat(chunks)));
+                    response.on('error', reject);
+                });
+                request.on('error', reject);
+                request.end();
+            });
+
+            expect((await first).toString()).toBe('first');
+            releaseUpstream();
+            expect((await done).toString()).toBe('firstsecond');
+        } finally {
+            releaseUpstream();
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('strips Accept-Encoding while preserving Range and If-Range', async () => {
+        let seenEncoding: string | undefined;
+        let seenRange: string | undefined;
+        let seenIfRange: string | undefined;
+        const upstream = http.createServer((request, response) => {
+            seenEncoding = request.headers['accept-encoding'];
+            seenRange = request.headers.range;
+            seenIfRange = request.headers['if-range'];
+            response.end('ok');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            await rawRequest((await proxy.start()).url, {
+                headers: {
+                    'Accept-Encoding': 'br, gzip',
+                    Range: 'bytes=10-20',
+                    'If-Range': '"entity"',
+                },
+            });
+            expect(seenEncoding).toBeUndefined();
+            expect(seenRange).toBe('bytes=10-20');
+            expect(seenIfRange).toBe('"entity"');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('serves reserved bridge assets locally with the correct media types', async () => {
+        let forwarded = 0;
+        const upstream = http.createServer((_request, response) => {
+            forwarded += 1;
+            response.end('upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const origin = (await proxy.start()).origin;
+            const javascript = await rawRequest(
+                `${origin}/_raven-theme-bridge/bridge.js?cache=1`,
+            );
+            const css = await rawRequest(`${origin}/_raven-theme-bridge/bridge.css`);
+            expect(javascript.statusCode).toBe(200);
+            expect(javascript.headers['content-type']).toStartWith('text/javascript');
+            expect(javascript.headers['cache-control']).toBe('no-store');
+            expect(javascript.body).toEqual(BRIDGE_JS);
+            expect(css.headers['content-type']).toStartWith('text/css');
+            expect(css.body).toEqual(BRIDGE_CSS);
+            expect(forwarded).toBe(0);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rewrites loopback-equivalent absolute and protocol-relative redirects', async () => {
+        let upstreamOrigin = '';
+        const upstream = http.createServer((request, response) => {
+            const upstream = new URL(upstreamOrigin);
+            response.writeHead(302, {
+                Location: request.url === '/absolute'
+                    ? `${upstreamOrigin}/chapter/?x=1#section`
+                    : request.url === '/localhost'
+                        ? `http://localhost:${upstream.port}/x?y#z`
+                    : request.url === '/protocol-relative'
+                        ? `//localhost:${upstream.port}/appendix/?y=2#part`
+                        : request.url === '/foreign'
+                            ? 'http://example.com/x'
+                            : '/chapter/?x=1',
+            });
+            response.end();
+        });
+        upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const origin = (await proxy.start()).origin;
+            expect((await rawRequest(`${origin}/absolute`)).headers.location)
+                .toBe('/chapter/?x=1#section');
+            expect((await rawRequest(`${origin}/localhost`)).headers.location)
+                .toBe('/x?y#z');
+            expect((await rawRequest(`${origin}/protocol-relative`)).headers.location)
+                .toBe('/appendix/?y=2#part');
+            expect((await rawRequest(`${origin}/foreign`)).headers.location)
+                .toBe('http://example.com/x');
+            expect((await rawRequest(`${origin}/relative`)).headers.location)
+                .toBe('/chapter/?x=1');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('strips standard and Connection-named hop-by-hop request headers', async () => {
+        let seen: http.IncomingHttpHeaders = {};
+        const upstream = http.createServer((request, response) => {
+            seen = request.headers;
+            response.end('ok');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const origin = (await proxy.start()).origin;
+            await rawRequest(`${origin}/headers`, {
+                headers: {
+                    Connection: 'X-Remove, keep-alive',
+                    'X-Remove': 'secret',
+                    'Keep-Alive': 'timeout=10',
+                    'Proxy-Authenticate': 'Basic',
+                    'Proxy-Authorization': 'Basic secret',
+                    'X-End-To-End': 'kept',
+                },
+            });
+            expect(seen.connection).toBe('close');
+            expect(seen['x-remove']).toBeUndefined();
+            expect(seen['keep-alive']).toBeUndefined();
+            expect(seen.te).toBeUndefined();
+            expect(seen.trailer).toBeUndefined();
+            expect(seen.upgrade).toBeUndefined();
+            expect(seen['proxy-authenticate']).toBeUndefined();
+            expect(seen['proxy-authorization']).toBeUndefined();
+            expect(seen['x-end-to-end']).toBe('kept');
+            expect(filteredRequestHeaders({
+                connection: 'X-Token',
+                'x-token': 'secret',
+                'keep-alive': 'timeout=10',
+                te: 'trailers',
+                trailer: 'X-Later',
+                upgrade: 'h2c',
+                'proxy-authenticate': 'Basic',
+                'proxy-authorization': 'Basic secret',
+                'x-end-to-end': 'kept',
+            })).toEqual({ 'x-end-to-end': 'kept' });
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('forwards requests to a bracketed IPv6 loopback upstream', async () => {
+        const upstream = http.createServer((request, response) => {
+            response.end(`ipv6:${request.url ?? ''}`);
+        });
+        const upstreamOrigin = await listen(upstream, '::1');
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest(`${(await proxy.start()).origin}/ipv6`);
+            expect(result.statusCode).toBe(200);
+            expect(result.body.toString()).toBe('ipv6:/ipv6');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('keeps proxy framing available when bridge assets are absent', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end('<html><body>unbridged</body></html>');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.statusCode).toBe(200);
+            expect(result.body.toString()).toBe('<html><body>unbridged</body></html>');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('strips standard and Connection-named hop-by-hop response headers', async () => {
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, {
+                Connection: 'X-Remove, keep-alive',
+                'Keep-Alive': 'timeout=10',
+                'Proxy-Authenticate': 'Basic',
+                Upgrade: 'h2c',
+                'X-Remove': 'secret',
+                'X-End-To-End': 'kept',
+            });
+            response.end('plain');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.headers.connection).toBe('close');
+            expect(result.headers['keep-alive']).toBeUndefined();
+            expect(result.headers['proxy-authenticate']).toBeUndefined();
+            expect(result.headers.upgrade).toBeUndefined();
+            expect(result.headers['x-remove']).toBeUndefined();
+            expect(result.headers['x-end-to-end']).toBe('kept');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+});
+
+describe('QuartoPreviewProxy WebSocket and teardown', () => {
+    it('forwards a WebSocket upgrade plus client and upstream head bytes', async () => {
+        expect(await runNodeWebSocketScenario('happy')).toBe('ok');
+    });
+
+    it('closes the client promptly when upstream refuses the upgrade', async () => {
+        expect(await runNodeWebSocketScenario('broken')).toBe('ok');
+    });
+
+    it('destroys open HTTP and WebSocket sockets and closes its listener promptly', async () => {
+        expect(await runNodeWebSocketScenario('teardown')).toBe('ok');
+    });
+});
+
+function connect(target: URL): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+        const socket = net.createConnection({
+            host: target.hostname,
+            port: Number(target.port),
+        });
+        socket.once('connect', () => resolve(socket));
+        socket.once('error', reject);
+    });
+}
+
+function rawSocketRequest(origin: string, request: string): Promise<Buffer> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const socket = await connect(new URL(origin));
+            const chunks: Buffer[] = [];
+            socket.on('data', (chunk) => chunks.push(chunk));
+            socket.on('end', () => resolve(Buffer.concat(chunks)));
+            socket.on('error', reject);
+            socket.write(request);
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+function rawRequest(
+    url: string,
+    options: {
+        method?: string;
+        headers?: http.OutgoingHttpHeaders;
+        body?: Buffer;
+    } = {},
+): Promise<RawResponse> {
+    return new Promise((resolve, reject) => {
+        const request = http.request(url, {
+            method: options.method ?? 'GET',
+            headers: options.headers,
+            agent: false,
+        }, (response) => {
+            const chunks: Buffer[] = [];
+            response.on('data', (chunk) => chunks.push(chunk));
+            response.on('end', () => resolve({
+                statusCode: response.statusCode ?? 0,
+                headers: response.headers,
+                body: Buffer.concat(chunks),
+            }));
+        });
+        request.on('error', reject);
+        request.end(options.body);
+    });
+}
+
+function readBody(request: http.IncomingMessage): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        request.on('data', (chunk) => chunks.push(chunk));
+        request.on('end', () => resolve(Buffer.concat(chunks)));
+        request.on('error', reject);
+    });
+}
+
+function listen(server: http.Server, host: string = '127.0.0.1'): Promise<string> {
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, host, () => {
+            server.off('error', reject);
+            const address = server.address();
+            if (!address || typeof address === 'string') {
+                reject(new Error('server did not expose a TCP address'));
+                return;
+            }
+            const authority = host.includes(':') ? `[${host}]` : host;
+            resolve(`http://${authority}:${address.port}`);
+        });
+    });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+    return new Promise((resolve) => server.close(() => resolve()));
+}
+
+let nodeBundle: Promise<string> | null = null;
+let nodeBundleDir: string | null = null;
+
+async function runNodeWebSocketScenario(
+    scenario: 'happy' | 'broken' | 'teardown',
+): Promise<string> {
+    const bundle = await (nodeBundle ??= buildNodeProxyBundle());
+    return new Promise((resolve, reject) => {
+        const helper = join(import.meta.dir, '_helpers', 'quarto-preview-proxy-node.cjs');
+        const child = spawn('node', [helper, bundle, scenario], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf8');
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.setEncoding('utf8');
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.on('error', reject);
+        child.on('close', (code) => {
+            if (code === 0) resolve(stdout.trim() || 'ok');
+            else reject(new Error(stderr.trim() || `Node helper exited with ${String(code)}`));
+        });
+    });
+}
+
+async function buildNodeProxyBundle(): Promise<string> {
+    nodeBundleDir = await mkdtemp(join(tmpdir(), 'raven-quarto-proxy-'));
+    const result = await Bun.build({
+        entrypoints: [join(
+            import.meta.dir,
+            '..',
+            '..',
+            'editors',
+            'vscode',
+            'src',
+            'quarto',
+            'quarto-preview-proxy.ts',
+        )],
+        outdir: nodeBundleDir,
+        target: 'node',
+        format: 'cjs',
+    });
+    if (!result.success || result.outputs.length !== 1) {
+        throw new Error('Could not bundle the proxy for Node WebSocket tests.');
+    }
+    return result.outputs[0].path;
+}
+
+afterAll(async () => {
+    if (nodeBundleDir) await rm(nodeBundleDir, { recursive: true, force: true });
+});

--- a/tests/bun/quarto-preview-proxy.test.ts
+++ b/tests/bun/quarto-preview-proxy.test.ts
@@ -117,7 +117,7 @@ describe('QuartoPreviewProxy HTTP passthrough', () => {
         }
     });
 
-    it('ignores absolute-form authority and foreign Host for upstream selection', async () => {
+    it('ignores absolute-form authority for upstream selection', async () => {
         let seenUrl = '';
         let seenHost = '';
         const upstream = http.createServer((request, response) => {
@@ -132,11 +132,192 @@ describe('QuartoPreviewProxy HTTP passthrough', () => {
             const response = await rawSocketRequest(
                 ready.origin,
                 'GET http://example.invalid/foreign/path?q=1 HTTP/1.1\r\n' +
-                'Host: attacker.invalid:9999\r\nConnection: close\r\n\r\n',
+                `Host: ${new URL(ready.origin).host}\r\nConnection: close\r\n\r\n`,
             );
             expect(response.toString()).toContain('fixed-upstream');
             expect(seenUrl).toBe('/foreign/path?q=1');
             expect(seenHost).toBe(new URL(upstreamOrigin).host);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rejects a non-loopback Host header when enforcing (the default)', async () => {
+        let upstreamHit = false;
+        const upstream = http.createServer((_request, response) => {
+            upstreamHit = true;
+            response.end('fixed-upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET /page/ HTTP/1.1\r\n' +
+                'Host: attacker.invalid:9999\r\nConnection: close\r\n\r\n',
+            );
+            expect(response.toString()).toContain('403 Forbidden');
+            expect(upstreamHit).toBe(false);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('admits the browser-facing host from asExternalUri but still rejects others', async () => {
+        let seenHost = '';
+        const upstream = http.createServer((request, response) => {
+            seenHost = request.headers.host ?? '';
+            response.end('fixed-upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            // Simulate a gateway mapping (e.g. Codespaces in the browser).
+            proxy.setBrowserFacingOrigin('https://preview.example.dev/page/');
+
+            const allowed = await rawSocketRequest(
+                ready.origin,
+                'GET /page/ HTTP/1.1\r\n' +
+                'Host: preview.example.dev\r\nConnection: close\r\n\r\n',
+            );
+            expect(allowed.toString()).toContain('fixed-upstream');
+            expect(seenHost).toBe(new URL(upstreamOrigin).host);
+
+            const rejected = await rawSocketRequest(
+                ready.origin,
+                'GET /page/ HTTP/1.1\r\n' +
+                'Host: attacker.invalid:9999\r\nConnection: close\r\n\r\n',
+            );
+            expect(rejected.toString()).toContain('403 Forbidden');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rejects a Host that hides a non-loopback label behind userinfo', async () => {
+        let upstreamHit = false;
+        const upstream = http.createServer((_request, response) => {
+            upstreamHit = true;
+            response.end('fixed-upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET /page/ HTTP/1.1\r\n' +
+                'Host: attacker.invalid@localhost\r\nConnection: close\r\n\r\n',
+            );
+            expect(response.toString()).toContain('403 Forbidden');
+            expect(upstreamHit).toBe(false);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rejects an HTTP request carrying a cross-site Origin even on a loopback Host', async () => {
+        let upstreamHit = false;
+        const upstream = http.createServer((_request, response) => {
+            upstreamHit = true;
+            response.end('fixed-upstream');
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'POST /submit HTTP/1.1\r\n' +
+                `Host: ${new URL(ready.origin).host}\r\n` +
+                'Origin: https://evil.example\r\n' +
+                'Content-Length: 0\r\nConnection: close\r\n\r\n',
+            );
+            expect(response.toString()).toContain('403 Forbidden');
+            expect(upstreamHit).toBe(false);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('does not crash on a request target that is accepted but is not a valid URL', async () => {
+        const upstream = http.createServer((_request, response) => response.end('ok'));
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const host = new URL(ready.origin).host;
+            const malformed = await rawSocketRequest(
+                ready.origin,
+                `GET //[ HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`,
+            );
+            expect(malformed.toString()).toContain('HTTP/1.1');
+            // The proxy is still alive and serving after the odd request.
+            const ok = await rawRequest(ready.url);
+            expect(ok.statusCode).toBe(200);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rejects a WebSocket upgrade carrying a cross-site Origin when enforcing', async () => {
+        // The proxy contacts the upstream only after the Host/Origin check
+        // passes, so a rejected handshake never reaches the upstream's upgrade
+        // handler; the client socket is closed rather than relayed.
+        let upgradeReached = false;
+        const upstream = http.createServer();
+        upstream.on('upgrade', (_request, socket) => {
+            upgradeReached = true;
+            socket.destroy();
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET /live-reload HTTP/1.1\r\n' +
+                `Host: ${new URL(ready.origin).host}\r\n` +
+                'Upgrade: websocket\r\nConnection: Upgrade\r\n' +
+                'Origin: https://evil.example\r\n\r\n',
+            );
+            expect(upgradeReached).toBe(false);
+            expect(response.toString()).not.toContain('101');
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('rejects a WebSocket Origin that hides a foreign label behind userinfo', async () => {
+        let upgradeReached = false;
+        const upstream = http.createServer();
+        upstream.on('upgrade', (_request, socket) => {
+            upgradeReached = true;
+            socket.destroy();
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const ready = await proxy.start();
+            proxy.setBrowserFacingOrigin('https://preview.example.dev/page/');
+            const response = await rawSocketRequest(
+                ready.origin,
+                'GET /live-reload HTTP/1.1\r\n' +
+                'Host: preview.example.dev\r\n' +
+                'Upgrade: websocket\r\nConnection: Upgrade\r\n' +
+                'Origin: https://attacker.invalid@preview.example.dev\r\n\r\n',
+            );
+            expect(upgradeReached).toBe(false);
+            expect(response.toString()).not.toContain('101');
         } finally {
             await proxy.close();
             await closeServer(upstream);
@@ -187,6 +368,82 @@ describe('QuartoPreviewProxy HTTP passthrough', () => {
             const result = await rawRequest((await proxy.start()).url);
             expect(result.body.toString()).toBe(
                 '<html><body><script>const marker = "</body>";</script>' +
+                `<main>real body</main>${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('keeps scanning past a </script> that is script-data double-escaped', async () => {
+        // The inner </script> sits in the script-data escaped span opened by
+        // <!-- and closed by -->, so it does not end the element; the </body>
+        // inside the string must not be treated as the document's body close.
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><body>' +
+                '<script>var t = "<!--<script></script></body>-->";</script>' +
+                '<main>real body</main></body></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><body>' +
+                '<script>var t = "<!--<script></script></body>-->";</script>' +
+                `<main>real body</main>${INJECTION}</body></html>`,
+            );
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('never mis-injects inside script data with an unmatched <!-- (defers to EOF)', async () => {
+        // Conservative fallback: an escaped span opened by <!-- with no closing
+        // --> keeps the scanner in script data to end-of-stream, so the bridge
+        // is appended (never injected inside the script string, which would
+        // corrupt the JavaScript). The whole document body is preserved intact.
+        const body =
+            '<html><body>' +
+            '<script>const marker = "<!--<script></script></body>";</script>' +
+            '<main>real body</main></body></html>';
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(body);
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(`${body}${INJECTION}`);
+        } finally {
+            await proxy.close();
+            await closeServer(upstream);
+        }
+    });
+
+    it('closes a script normally after a balanced legacy <!-- ... //--> comment', async () => {
+        // The classic comment hack: <!-- ... //--> clears the escaped span, so
+        // the following </script> closes the element and injection lands at the
+        // real body close.
+        const upstream = http.createServer((_request, response) => {
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.end(
+                '<html><body><script><!--\nvar x = 1;\n//--></script>' +
+                '<main>real body</main></body></html>',
+            );
+        });
+        const upstreamOrigin = await listen(upstream);
+        const proxy = new QuartoPreviewProxy(upstreamOrigin, BRIDGE_ASSETS);
+        try {
+            const result = await rawRequest((await proxy.start()).url);
+            expect(result.body.toString()).toBe(
+                '<html><body><script><!--\nvar x = 1;\n//--></script>' +
                 `<main>real body</main>${INJECTION}</body></html>`,
             );
         } finally {

--- a/tests/bun/quarto-preview-runtime.test.ts
+++ b/tests/bun/quarto-preview-runtime.test.ts
@@ -134,6 +134,30 @@ const startArgs = {
 };
 
 describe('QuartoRuntime generation discipline', () => {
+    it('threads a distinct browser URL and defaults it to the framed raw URL', async () => {
+        const h = harness();
+        const first = h.runtime.startOrRestart(startArgs);
+        await waitForProcessCount(h.processes, 1);
+        h.processes[0].process.ready.resolve({
+            rawUrl: 'http://127.0.0.1:4900/proxy/',
+            browserUrl: 'http://127.0.0.1:4800/quarto/',
+            origin: 'http://127.0.0.1:4900',
+            statusCode: 200,
+        });
+        await first;
+        expect(h.updates.at(-1)?.browserUrl).toBe('http://127.0.0.1:4800/quarto/');
+
+        const second = h.runtime.startOrRestart(startArgs);
+        await waitForProcessCount(h.processes, 2);
+        h.processes[1].process.ready.resolve({
+            rawUrl: 'http://127.0.0.1:4700/direct/',
+            origin: 'http://127.0.0.1:4700',
+            statusCode: 200,
+        });
+        await second;
+        expect(h.updates.at(-1)?.browserUrl).toBe('http://127.0.0.1:4700/direct/');
+    });
+
     it('uses one monotonic generation counter across distinct keys', async () => {
         const h = harness();
         const first = h.runtime.startOrRestart({

--- a/tests/bun/quarto-preview-with-proxy.test.ts
+++ b/tests/bun/quarto-preview-with-proxy.test.ts
@@ -58,6 +58,10 @@ class FakeProxy implements QuartoPreviewProxyLike {
     async close(): Promise<void> {
         this.events.push('proxy:close');
     }
+
+    setBrowserFacingOrigin(externalUrl: string): void {
+        this.events.push(`proxy:origin:${externalUrl}`);
+    }
 }
 
 describe('QuartoPreviewWithProxyProcess', () => {

--- a/tests/bun/quarto-preview-with-proxy.test.ts
+++ b/tests/bun/quarto-preview-with-proxy.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+    QuartoPreviewProcessLike,
+    QuartoPreviewReady,
+} from '../../editors/vscode/src/quarto/quarto-preview-engine';
+import type {
+    QuartoPreviewProxyLike,
+    QuartoPreviewProxyReady,
+} from '../../editors/vscode/src/quarto/quarto-preview-proxy';
+import { QuartoPreviewWithProxyProcess } from '../../editors/vscode/src/quarto/quarto-preview-with-proxy';
+
+class Deferred<T> {
+    readonly promise: Promise<T>;
+    resolve!: (value: T) => void;
+    reject!: (error: Error) => void;
+
+    constructor() {
+        this.promise = new Promise<T>((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+}
+
+class FakeInner implements QuartoPreviewProcessLike {
+    readonly ready: QuartoPreviewReady = {
+        rawUrl: 'http://127.0.0.1:4800/chapter/?preview=1',
+        origin: 'http://127.0.0.1:4800',
+        statusCode: 200,
+    };
+
+    constructor(private readonly events: string[]) {}
+
+    async start(): Promise<QuartoPreviewReady> {
+        this.events.push('inner:start');
+        return this.ready;
+    }
+
+    async stop(): Promise<void> {
+        this.events.push('inner:stop');
+    }
+
+    async shutdown(): Promise<void> {
+        this.events.push('inner:shutdown');
+    }
+}
+
+class FakeProxy implements QuartoPreviewProxyLike {
+    readonly bind = new Deferred<QuartoPreviewProxyReady>();
+
+    constructor(private readonly events: string[]) {}
+
+    start(): Promise<QuartoPreviewProxyReady> {
+        this.events.push('proxy:start');
+        return this.bind.promise;
+    }
+
+    async close(): Promise<void> {
+        this.events.push('proxy:close');
+    }
+}
+
+describe('QuartoPreviewWithProxyProcess', () => {
+    it('frames Quarto directly and never creates a proxy when assets are unavailable', async () => {
+        const events: string[] = [];
+        let proxyCreations = 0;
+        const process = new QuartoPreviewWithProxyProcess({
+            output: { appendLine() {} },
+            onUnexpectedExit: () => undefined,
+            bridgeAssets: undefined,
+            createInner: () => new FakeInner(events),
+            proxyFactory: () => {
+                proxyCreations++;
+                return new FakeProxy(events);
+            },
+            probe: async () => { throw new Error('probe must not run'); },
+        });
+
+        expect(await process.start()).toEqual(new FakeInner([]).ready);
+        expect(proxyCreations).toBe(0);
+        expect(events).toEqual(['inner:start']);
+    });
+
+    it('returns and probes the proxy origin while preserving the Quarto page path', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const probed: string[] = [];
+        const process = createProcess(events, proxy, {
+            probe: async (url) => {
+                probed.push(url);
+                return 204;
+            },
+        });
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+
+        expect(await starting).toEqual({
+            rawUrl: 'http://127.0.0.1:4900/chapter/?preview=1',
+            browserUrl: 'http://127.0.0.1:4800/chapter/?preview=1',
+            origin: 'http://127.0.0.1:4900',
+            statusCode: 204,
+        });
+        expect(probed).toEqual([
+            'http://127.0.0.1:4900/chapter/?preview=1',
+        ]);
+    });
+
+    it('shares concurrent stop/shutdown and closes proxy before tightened teardown', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const process = createProcess(events, proxy);
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+        await starting;
+
+        const first = process.stop();
+        const second = process.shutdown();
+        expect(second).toBe(first);
+        await first;
+        expect(events.slice(-2)).toEqual(['proxy:close', 'inner:shutdown']);
+    });
+
+    it('closes an installed proxy and stops Quarto when Stop lands during bind', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const process = createProcess(events, proxy);
+        const starting = process.start();
+        await Promise.resolve();
+        expect(events).toEqual(['inner:start', 'proxy:start']);
+
+        await process.stop();
+        await expect(starting).rejects.toThrow('proxy startup was stopped');
+        expect(events).toEqual([
+            'inner:start',
+            'proxy:start',
+            'proxy:close',
+            'inner:stop',
+        ]);
+    });
+
+    it('falls back to Quarto and logs when the proxy bind fails', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const diagnostics: string[] = [];
+        const process = createProcess(events, proxy, { diagnostics });
+        const starting = process.start();
+        proxy.bind.reject(new Error('listen EADDRNOTAVAIL'));
+
+        expect(await starting).toEqual(new FakeInner([]).ready);
+        expect(events).toEqual(['inner:start', 'proxy:start', 'proxy:close']);
+        expect(diagnostics).toEqual([
+            '[quarto] Preview proxy unavailable; using Quarto directly: ' +
+            'listen EADDRNOTAVAIL',
+        ]);
+    });
+
+    it('falls back to Quarto and logs when the proxy readiness probe fails', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const diagnostics: string[] = [];
+        const process = createProcess(events, proxy, {
+            diagnostics,
+            probe: async () => { throw new Error('proxy probe timed out'); },
+        });
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+
+        expect(await starting).toEqual(new FakeInner([]).ready);
+        expect(events).toEqual(['inner:start', 'proxy:start', 'proxy:close']);
+        expect(diagnostics).toEqual([
+            '[quarto] Preview proxy unavailable; using Quarto directly: ' +
+            'proxy probe timed out',
+        ]);
+    });
+
+    it('treats a proxy 502 as unavailable and falls back to the Quarto origin', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const diagnostics: string[] = [];
+        const process = createProcess(events, proxy, {
+            diagnostics,
+            probe: async () => 502,
+        });
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+
+        expect(await starting).toEqual(new FakeInner([]).ready);
+        expect(events).toEqual(['inner:start', 'proxy:start', 'proxy:close']);
+        expect(diagnostics).toEqual([
+            '[quarto] Preview proxy unavailable; using Quarto directly: ' +
+            'preview proxy readiness returned HTTP 502',
+        ]);
+    });
+
+    it('does not fall back when Stop aborts the proxy readiness probe', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        const diagnostics: string[] = [];
+        const probeStarted = new Deferred<void>();
+        const process = createProcess(events, proxy, {
+            diagnostics,
+            probe: async (_url, signal) => {
+                probeStarted.resolve();
+                return new Promise<number>((_resolve, reject) => {
+                    signal.addEventListener(
+                        'abort',
+                        () => reject(new Error('probe aborted')),
+                        { once: true },
+                    );
+                });
+            },
+        });
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+        await probeStarted.promise;
+
+        const stopping = process.stop();
+        await expect(starting).rejects.toThrow('probe aborted');
+        await stopping;
+        expect(diagnostics).toEqual([]);
+        expect(events).toEqual([
+            'inner:start',
+            'proxy:start',
+            'proxy:close',
+            'inner:stop',
+        ]);
+    });
+
+    it('closes the proxy before propagating an unexpected Quarto exit', async () => {
+        const events: string[] = [];
+        const proxy = new FakeProxy(events);
+        let unexpectedExit: ((code: number | null) => void) | null = null;
+        const process = new QuartoPreviewWithProxyProcess({
+            output: { appendLine() {} },
+            onUnexpectedExit: (code) => events.push(`outer:exit:${String(code)}`),
+            bridgeAssets: { javascript: '', css: '' },
+            createInner: (callback) => {
+                unexpectedExit = callback;
+                return new FakeInner(events);
+            },
+            proxyFactory: () => proxy,
+            probe: async () => 200,
+        });
+        const starting = process.start();
+        proxy.bind.resolve({
+            origin: 'http://127.0.0.1:4900',
+            url: 'http://127.0.0.1:4900/',
+        });
+        await starting;
+
+        (unexpectedExit as ((code: number | null) => void) | null)?.(7);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(events.slice(-2)).toEqual(['proxy:close', 'outer:exit:7']);
+    });
+});
+
+function createProcess(
+    events: string[],
+    proxy: FakeProxy,
+    options: {
+        probe?: (url: string, signal: AbortSignal) => Promise<number>;
+        diagnostics?: string[];
+    } = {},
+): QuartoPreviewWithProxyProcess {
+    return new QuartoPreviewWithProxyProcess({
+        output: {
+            appendLine: (message) => options.diagnostics?.push(message),
+        },
+        onUnexpectedExit: () => undefined,
+        bridgeAssets: { javascript: '', css: '' },
+        createInner: () => new FakeInner(events),
+        proxyFactory: () => proxy,
+        probe: options.probe ?? (async () => 200),
+    });
+}

--- a/tests/bun/quarto-theme-controller.test.ts
+++ b/tests/bun/quarto-theme-controller.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, test } from 'bun:test';
+import { githubDark } from '../../editors/vscode/src/knit/github-colors';
+import type { ThemePaletteArgs } from '../../editors/vscode/src/knit/vscode-theme-palette';
+import {
+    QUARTO_THEME_PREFERENCE_KEY,
+    QuartoThemeController,
+    type QuartoThemeControllerDeps,
+} from '../../editors/vscode/src/quarto/quarto-theme-controller';
+import type { QuartoThemePayload } from '../../editors/vscode/src/quarto/quarto-messages';
+
+const fakePalette = {
+    background: '#101010',
+    foreground: '#eeeeee',
+    roles: {
+        keyword: '#ff0001',
+        string: '#ff0002',
+        number: '#ff0003',
+        comment: '#ff0004',
+        function: '#ff0005',
+        type: '#ff0006',
+        variable: '#ff0007',
+        operator: '#ff0008',
+        punctuation: '#ff0009',
+        constant: '#ff0010',
+    },
+};
+
+function harness(overrides: Partial<QuartoThemeControllerDeps> = {}) {
+    const stored = new Map<string, unknown>();
+    const posted: QuartoThemePayload[] = [];
+    const lines: string[] = [];
+    let themeListener: (() => void) | undefined;
+    let configListener: ((event: { affectsConfiguration(key: string): boolean }) => void) | undefined;
+    const deps: QuartoThemeControllerDeps = {
+        context: {
+            globalState: {
+                get: <T>(key: string) => stored.get(key) as T | undefined,
+                update: async (key, value) => { stored.set(key, value); },
+            },
+        },
+        output: { appendLine: (line) => { lines.push(line); } },
+        sourceFsPath: '/work/report.qmd',
+        postThemeUpdate: async (payload) => {
+            posted.push(payload);
+            return true;
+        },
+        requestThemeContext: () => true,
+        activeThemeKind: () => 'dark',
+        getConfiguration: <T>(key: string, fallback?: T) =>
+            (key === 'workbench.colorTheme' ? 'Fake Theme' : fallback) as T,
+        themeResolverInputs: () => ({
+            extensions: [],
+            tokenColorCustomizations: undefined,
+            semanticTokenColorCustomizations: undefined,
+            registry: {} as ThemePaletteArgs['registry'],
+            readFile: async () => '',
+            realPath: async (value) => value,
+        }),
+        resolvePalette: async () => ({
+            ok: true,
+            palette: fakePalette,
+            themeId: 'Fake Theme',
+            isLight: false,
+            candidateFailures: [],
+        }),
+        resolveFonts: () => ({
+            text: 'Inter, sans-serif',
+            mono: 'Mono, monospace',
+        }),
+        sourceConfigurationScope: (sourceFsPath) => sourceFsPath,
+        onDidChangeActiveColorTheme: (listener) => {
+            themeListener = listener;
+            return { dispose: () => undefined };
+        },
+        onDidChangeConfiguration: (listener) => {
+            configListener = listener;
+            return { dispose: () => undefined };
+        },
+        ...overrides,
+    };
+    return {
+        controller: new QuartoThemeController(deps),
+        stored,
+        posted,
+        lines,
+        fireTheme: () => themeListener?.(),
+        fireConfig: (keys: readonly string[]) => configListener?.({
+            affectsConfiguration: (key) => keys.includes(key),
+        }),
+    };
+}
+
+describe('QuartoThemeController', () => {
+    test('builds the payload from injected palette and font resolvers', async () => {
+        let args: ThemePaletteArgs | undefined;
+        const h = harness({
+            resolvePalette: async (received) => {
+                args = received;
+                return {
+                    ok: true,
+                    palette: fakePalette,
+                    themeId: 'Fake Theme',
+                    isLight: false,
+                    candidateFailures: [],
+                };
+            },
+        });
+        try {
+            expect(await h.controller.push()).toBe(true);
+            expect(args?.candidateThemeIds).toEqual(['Fake Theme']);
+            expect(h.posted).toEqual([{
+                enabled: false,
+                background: fakePalette.background,
+                foreground: fakePalette.foreground,
+                roles: fakePalette.roles,
+                fontText: 'Inter, sans-serif',
+                fontMono: 'Mono, monospace',
+            }]);
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('layers flat and active-theme workbench color customizations', async () => {
+        const h = harness({
+            resolvePalette: async () => ({
+                ok: true,
+                palette: fakePalette,
+                themeId: 'fake-theme-id',
+                themeLabel: 'Fake Theme',
+                isLight: false,
+                candidateFailures: [],
+            }),
+            getConfiguration: <T>(key: string, fallback?: T) => {
+                if (key === 'workbench.colorTheme') return 'Fake Theme' as T;
+                if (key === 'workbench.colorCustomizations') {
+                    return {
+                        'editor.background': '#202020',
+                        'editor.foreground': 'not-a-color',
+                        '[Fake Theme]': {
+                            'editor.foreground': 'rgb(240, 240, 240)',
+                        },
+                        '[Other Theme]': {
+                            'editor.background': '#ffffff',
+                        },
+                    } as T;
+                }
+                return fallback;
+            },
+        });
+        try {
+            await h.controller.push();
+            expect(h.posted.at(-1)?.background).toBe('#202020');
+            expect(h.posted.at(-1)?.foreground).toBe('rgb(240, 240, 240)');
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('layers combined and glob theme selectors in object key order', async () => {
+        const h = harness({
+            resolvePalette: async () => ({
+                ok: true,
+                palette: fakePalette,
+                themeId: 'default-dark-plus',
+                themeLabel: 'Default Dark+',
+                isLight: false,
+                candidateFailures: [],
+            }),
+            getConfiguration: <T>(key: string, fallback?: T) => {
+                if (key === 'workbench.colorTheme') return 'Default Dark+' as T;
+                if (key === 'workbench.colorCustomizations') {
+                    return {
+                        'editor.background': '#202020',
+                        'editor.foreground': '#dddddd',
+                        '[Default Light+][Default Dark+]': {
+                            'editor.background': '#303030',
+                        },
+                        '[Unrelated Theme]': {
+                            'editor.background': '#ffffff',
+                            'editor.foreground': '#000000',
+                        },
+                        '[*Dark*]': {
+                            'editor.foreground': 'rgb(230, 230, 230)',
+                        },
+                        '[Default *]': {
+                            'editor.background': '#404040',
+                        },
+                    } as T;
+                }
+                return fallback;
+            },
+        });
+        try {
+            await h.controller.push();
+            expect(h.posted.at(-1)?.background).toBe('#404040');
+            expect(h.posted.at(-1)?.foreground).toBe('rgb(230, 230, 230)');
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('persists and broadcasts enabled state across controllers', async () => {
+        const first = harness();
+        const second = harness();
+        try {
+            await first.controller.setEnabled(true);
+            expect(first.stored.get(QUARTO_THEME_PREFERENCE_KEY)).toBe(true);
+            expect(first.controller.isEnabled).toBe(true);
+            expect(second.controller.isEnabled).toBe(true);
+            expect(first.posted.at(-1)?.enabled).toBe(true);
+            expect(second.posted.at(-1)?.enabled).toBe(true);
+        } finally {
+            first.controller.dispose();
+            second.controller.dispose();
+        }
+    });
+
+    test('logs a failed preference write without rejecting setEnabled', async () => {
+        const h = harness({
+            context: {
+                globalState: {
+                    get: () => undefined,
+                    update: async () => { throw new Error('memento unavailable'); },
+                },
+            },
+        });
+        try {
+            await expect(h.controller.setEnabled(true)).resolves.toBeUndefined();
+            expect(h.lines).toEqual([
+                '[theme] Quarto VS Code theme preference failed to persist.',
+            ]);
+            expect(h.controller.isEnabled).toBe(true);
+            await h.controller.setEnabled(false);
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('serializes rapid persistence writes so the last toggle wins', async () => {
+        const calls: boolean[] = [];
+        const releases: Array<() => void> = [];
+        let persisted: boolean | undefined;
+        const h = harness({
+            context: {
+                globalState: {
+                    get: () => undefined,
+                    update: async (_key, value) => {
+                        calls.push(value as boolean);
+                        await new Promise<void>((resolve) => { releases.push(resolve); });
+                        persisted = value as boolean;
+                    },
+                },
+            },
+        });
+        try {
+            const older = h.controller.setEnabled(true);
+            const newer = h.controller.setEnabled(false);
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(calls).toEqual([true]);
+
+            releases[0]();
+            for (let turn = 0; turn < 10 && calls.length < 2; turn++) {
+                await Promise.resolve();
+            }
+            expect(calls).toEqual([true, false]);
+            releases[1]();
+            await Promise.all([older, newer]);
+
+            expect(persisted).toBe(false);
+            expect(h.controller.isEnabled).toBe(false);
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('drops a stale generation whose resolver finishes last', async () => {
+        const releases: Array<(value: unknown) => void> = [];
+        const h = harness({
+            resolvePalette: () => new Promise((resolve) => { releases.push(resolve); }) as never,
+        });
+        try {
+            const older = h.controller.push();
+            const newer = h.controller.push();
+            releases[1]({
+                ok: true,
+                palette: fakePalette,
+                themeId: 'newer',
+                isLight: false,
+                candidateFailures: [],
+            });
+            expect(await newer).toBe(true);
+            releases[0]({
+                ok: true,
+                palette: { ...fakePalette, background: '#222222' },
+                themeId: 'older',
+                isLight: false,
+                candidateFailures: [],
+            });
+            expect(await older).toBe(false);
+            expect(h.posted).toHaveLength(1);
+            expect(h.posted[0].background).toBe('#101010');
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('falls back to GitHub palette and logs only once when resolution throws', async () => {
+        const h = harness({
+            resolvePalette: async () => { throw new Error('injected resolver failure'); },
+        });
+        try {
+            await h.controller.push();
+            await h.controller.push();
+            expect(h.posted[0].background).toBe(githubDark.background);
+            expect(h.posted[0].roles).toEqual(githubDark.roles);
+            expect(h.lines).toHaveLength(1);
+            expect(h.lines[0]).toContain('injected resolver failure');
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('same-kind theme listener re-requests shell context and re-pushes', async () => {
+        let contextRequests = 0;
+        const h = harness({
+            requestThemeContext: () => {
+                contextRequests++;
+                return true;
+            },
+        });
+        try {
+            h.fireTheme();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(contextRequests).toBe(1);
+            expect(h.posted).toHaveLength(1);
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('a controller created during a pending preference write uses last-known state', async () => {
+        let release!: () => void;
+        const persistenceGate = new Promise<void>((resolve) => { release = resolve; });
+        const first = harness({
+            context: {
+                globalState: {
+                    get: () => false,
+                    update: async () => { await persistenceGate; },
+                },
+            },
+        });
+        let second: ReturnType<typeof harness> | undefined;
+        try {
+            const enabling = first.controller.setEnabled(true);
+            second = harness({
+                context: {
+                    globalState: {
+                        get: () => false,
+                        update: async () => undefined,
+                    },
+                },
+            });
+            expect(second.controller.isEnabled).toBe(true);
+            release();
+            await enabling;
+            await first.controller.setEnabled(false);
+        } finally {
+            release();
+            first.controller.dispose();
+            second?.controller.dispose();
+        }
+    });
+});

--- a/tests/bun/settings-reference.test.ts
+++ b/tests/bun/settings-reference.test.ts
@@ -44,6 +44,17 @@ function projectScopedLintingSchemaKeys(): string[] {
     .sort();
 }
 
+function configurationProperties(): Record<string, Record<string, unknown>> {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    contributes?: {
+      configuration?: {
+        properties?: Record<string, Record<string, unknown>>;
+      };
+    };
+  };
+  return packageJson.contributes?.configuration?.properties ?? {};
+}
+
 function rustKnownLintingKeys(): string[] {
   const source = readFileSync(tomlLoaderPath, "utf8");
   const match = source.match(/const KNOWN_LINTING_KEYS:[\s\S]*?= &\[([\s\S]*?)\];/);
@@ -69,6 +80,33 @@ test("docs/settings-reference.md matches the generator output", () => {
         `  bun editors/vscode/scripts/generate-settings-reference.mjs\n\n` +
         `Generator stderr:\n${stderr}${stdout}`,
     );
+  }
+});
+
+test("Quarto font schemas mirror Knit validation constraints", () => {
+  const properties = configurationProperties();
+  const validationKeys = [
+    "type",
+    "default",
+    "scope",
+    "maxLength",
+    "pattern",
+    "patternErrorMessage",
+  ];
+
+  for (const suffix of ["fontFamily", "monospaceFontFamily"]) {
+    const quarto = properties[`raven.quarto.${suffix}`];
+    const knit = properties[`raven.knit.${suffix}`];
+    if (!quarto || !knit) {
+      throw new Error(`Missing Quarto or Knit ${suffix} schema`);
+    }
+    for (const key of validationKeys) {
+      if (quarto[key] !== knit[key]) {
+        throw new Error(
+          `raven.quarto.${suffix}.${key} must mirror raven.knit.${suffix}.${key}`,
+        );
+      }
+    }
   }
 });
 

--- a/tests/bun/vscode-package-ignore.test.ts
+++ b/tests/bun/vscode-package-ignore.test.ts
@@ -25,5 +25,13 @@ test("VSIX package keeps runtime assets and excludes development-only files", ()
   expect(ignore.has("icon.svg")).toBe(true);
   expect(ignore.has("icon.png")).toBe(false);
   expect(ignore.has("dist/knit/**")).toBe(true);
+  expect(ignore.has("dist/quarto-theme-bridge/**")).toBe(false);
   expect(ignore.has("test-fixtures/**")).toBe(true);
+
+  const buildScript = readFileSync(
+    path.join(vscodeRoot, "scripts", "build.js"),
+    "utf8",
+  );
+  expect(buildScript).toContain("copyQuartoThemeBridge()");
+  expect(buildScript).toContain("path.join(dist, 'quarto-theme-bridge')");
 });


### PR DESCRIPTION
## Summary

Applies the active VS Code theme to the Quarto live preview. A loopback
reverse proxy sits in front of the Quarto preview server and injects a small
CSS/JS "bridge" into the proxied HTML; a theme controller pushes the editor's
resolved colors and fonts into the previewed document so the preview matches
the editor in light and dark.

See `docs/quarto.md` for the user-facing behavior.

## Review hardening

This branch went through `/code-review` (subagents) and a Codex sol
adversarial review. Both are clean. The findings that were addressed:

**Security — the loopback proxy**
- The proxy now **always** enforces a request allowlist on both its HTTP and
  WebSocket paths: the `Host` (and, for WebSocket upgrades, the `Origin`) must
  be loopback **or** the browser-facing host/origin that `asExternalUri`
  mapped the proxy to (recorded via `setBrowserFacingOrigin` before the webview
  loads). This blocks DNS-rebinding reads and cross-site WebSocket hijacking of
  the live-reload socket across every topology — local, Remote SSH/WSL/Dev
  Containers (loopback TCP forward), and browser gateways
  (Codespaces/vscode.dev/tunnels) — without guessing reachability from
  `uiKind`/`remoteName`: a rebound attacker domain matches neither and is
  rejected.
- Any userinfo in a `Host`/`Origin` authority is rejected (so
  `attacker@browser-facing-host` cannot parse to a trusted host/origin).
- Exception-safety: `reservedBridgePath` no longer lets a malformed request
  target throw out of the request handler, and `rejectSocket` attaches an
  `error` listener before writing so a client RST cannot raise an unhandled
  `EPIPE` and crash the extension host.

**Correctness — HTML injection scanner**
- The bridge-injection scanner models HTML5's script-data escaped span (opened
  by `<!--`, closed by `-->`), so a `</script>` inside a double-escaped script
  is treated as data, not the element's end tag. It is conservative and
  fail-safe: unbalanced input defers injection to end-of-stream rather than
  mis-injecting inside script text.

**Cleanups**
- Derive `--raven-c-<role>` in `bridge.js` instead of a hand-maintained map.
- Compute `candidateThemeIds` once per payload in the theme controller.
- Collapse two identical hop-by-hop header sets into one.

## Testing

- `editors/vscode`: `bun run typecheck` clean; `bun run bundle` succeeds.
- Quarto bun suites: 118 passing (proxy, with-proxy, theme controller,
  bridge assets, preview HTML, messages, runtime), including new tests for the
  Host/Origin allowlist, browser-facing-origin allowance, userinfo rejection,
  WebSocket Origin rejection, malformed-target robustness, and script-data
  double-escape handling.

No Rust changes; the Rust CI gates are unaffected.

https://claude.ai/code/session_01BnK9WQLSLxBWehmmhvCTes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Apply VS Code theme” option for Quarto live previews.
  * Live previews now synchronize colors, syntax highlighting, and typography with the active VS Code theme without reloading.
  * Added settings for body and monospace preview fonts.
  * Added safeguards and fallback behavior when theme integration is unavailable.

* **Documentation**
  * Documented theme settings, security behavior, supported scenarios, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->