### PR TITLE
Fix stale Quarto preview advisory

### DIFF
--- a/docs/quarto.md
+++ b/docs/quarto.md
@@ -302,9 +302,11 @@ path on your local machine is not visible to the remote extension host.
 ### The preview panel is blank
 
 Raven cannot reliably inspect a cross-origin frame to tell whether it rendered
-correctly. Eight seconds after installing the frame, the panel shows the
-advisory **If the preview looks blank, try Open in Browser.** This banner does
-not prove that loading failed; it is an honest fallback for an opaque iframe.
+correctly. If the injected theme bridge has not confirmed a responsive HTML
+page after eight seconds, the panel shows the advisory **If the preview looks
+blank, try Open in Browser.** This banner does not prove that loading failed;
+it is an honest fallback for an opaque iframe. A later response from the page
+dismisses the advisory automatically.
 
 Use **Open in Browser** to open the validated loopback URL through VS Code. For
 Remote SSH, Quarto and the readiness probe run remotely, while VS Code maps the

--- a/editors/vscode/src/quarto/quarto-preview-html.ts
+++ b/editors/vscode/src/quarto/quarto-preview-html.ts
@@ -7,6 +7,8 @@
  * frame one exact, origin-pinned ready-handshake shape and returns for every
  * other frame message. A disjoint branch accepts host delivery only from the
  * empty/webview-host origin and mirrors the host protocol's exact-key guards.
+ * Because iframe `load` is not proof of success, only that ready handshake
+ * cancels or dismisses the conservative blank-preview advisory.
  * Serving CSP is derived from the same mapped URL installed in the frame;
  * non-serving states have neither a `frame-src` directive nor an iframe.
  *
@@ -304,7 +306,18 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
                 } catch (_) { /* host falls back to the first candidate */ }
             }
 
+            function clearBlankAdvisory() {
+                if (blankTimer !== null) window.clearTimeout(blankTimer);
+                blankTimer = null;
+                banner.textContent = '';
+                banner.hidden = true;
+            }
+
             function markBridgeAvailable() {
+                // Unlike iframe load, this origin-pinned handshake proves that
+                // the framed HTML is alive. It is therefore safe to cancel or
+                // dismiss the otherwise deliberately conservative advisory.
+                clearBlankAdvisory();
                 if (bridgeTimer !== null) window.clearTimeout(bridgeTimer);
                 bridgeTimer = null;
                 if (bridgeAvailable !== true) {

--- a/tests/bun/quarto-preview-html.test.ts
+++ b/tests/bun/quarto-preview-html.test.ts
@@ -136,11 +136,14 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(html).toContain('themeEnabled = currentTheme.enabled');
     });
 
-    test('persists only sourceFsPath and installs the honest timeout banner', () => {
+    test('persists only sourceFsPath and installs a recoverable timeout banner', () => {
         const html = buildQuartoPreviewShellHtml(args({ kind: 'serving', externalUrl: 'http://localhost:9/' }));
         expect(html).toContain('vscode.setState({ sourceFsPath: initial.sourceFsPath })');
         expect(html).toContain('If the preview looks blank, try Open in Browser.');
         expect(html).toContain("vscode.postMessage({ type: 'load-timeout' })");
+        expect(html).toContain('clearBlankAdvisory();');
+        expect(html).toContain("banner.textContent = ''");
+        expect(html).toContain('banner.hidden = true');
         expect(html).toContain('}, 8000)');
     });
 
@@ -153,7 +156,7 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(html).toContain('armBridgeTimeout();');
         expect(html).toContain('postBridgePing();');
         expect(html).toContain("type: 'raven-quarto-theme-ping'");
-        expect(html).not.toContain('window.clearTimeout(blankTimer)');
+        expect(html).toContain('window.clearTimeout(blankTimer)');
         expect(html).toContain("vscode.postMessage({ type: 'theme-bridge-status', available: false })");
         expect(html).toContain("VS Code theme can't apply to this page");
         expect(html).not.toContain('themeButton.disabled = bridgeAvailable === false');
@@ -315,6 +318,16 @@ describe('buildQuartoPreviewShellHtml', () => {
             const themeButton = window.document.getElementById(
                 'raven-quarto-theme',
             ) as HTMLButtonElement;
+            const banner = window.document.getElementById('raven-quarto-load-banner')!;
+
+            // The advisory may win a slow-load race, but a later trusted
+            // bridge handshake must dismiss it and keep it dismissed.
+            const blank = timers.find((timer) => timer.delay === 8000);
+            expect(blank).toBeDefined();
+            blank!.callback();
+            blank!.active = false;
+            expect(banner.hidden).toBe(false);
+            expect(banner.textContent).toContain('try Open in Browser');
 
             frame.dispatchEvent(new window.Event('load'));
             expect(frameMessages.at(-1)).toEqual({ type: 'raven-quarto-theme-ping' });
@@ -323,6 +336,8 @@ describe('buildQuartoPreviewShellHtml', () => {
                 source: frame.contentWindow,
                 data: { type: 'raven-quarto-theme-ready' },
             }));
+            expect(banner.hidden).toBe(true);
+            expect(banner.textContent).toBe('');
 
             // A subsequent CSP-blocked/non-HTML navigation never answers its
             // load-triggered ping, but the global preference remains editable.
@@ -366,12 +381,7 @@ describe('buildQuartoPreviewShellHtml', () => {
                 (message as { type?: unknown }).type === 'raven-quarto-theme-ping'
             )).toHaveLength(3);
 
-            const blank = timers.find((timer) => timer.delay === 8000);
-            expect(blank).toBeDefined();
-            blank!.callback();
-            const banner = window.document.getElementById('raven-quarto-load-banner')!;
-            expect(banner.hidden).toBe(false);
-            expect(banner.textContent).toContain('try Open in Browser');
+            expect(banner.hidden).toBe(true);
         } finally {
             dom.window.close();
         }


### PR DESCRIPTION
## Summary

- cancel the blank-preview advisory timer when the framed Quarto page completes its trusted theme-bridge handshake
- dismiss an advisory that appeared before a slow page became responsive
- add regression coverage for the timeout/handshake race and document the recoverable behavior

## Root cause

The eight-second advisory timer was intentionally never cancelled because an iframe `load` event does not prove that a cross-origin page rendered successfully. However, the origin-pinned theme-bridge handshake does prove that the framed HTML is alive. The shell did not use that stronger signal, so the advisory eventually appeared on healthy previews and had no path to disappear.

## Impact

Healthy Quarto previews no longer acquire a permanent “If the preview looks blank” banner. If the advisory wins a slow-load race, it disappears as soon as the trusted page handshake arrives.

## Validation

- `bun test tests/bun/quarto-*.test.ts` — 198 passed
- `npm run typecheck` — passed
- `git diff --check` — passed
