### PR TITLE
Fix Quarto preview theme colors

### DIFF
--- a/docs/quarto.md
+++ b/docs/quarto.md
@@ -182,7 +182,9 @@ The color mapping is intentionally coarse. Raven maps syntax spans into ten
 broad roles such as keyword, string, comment, and function, and covers common
 Quarto, Pandoc, and Bootstrap surfaces. It aims to make the preview feel at home
 in the editor, not to reproduce VS Code's tokenization or every custom Quarto
-theme rule exactly.
+theme rule exactly. The document surface follows `editor.background`, while
+inline and block code use `textCodeBlock.background`, matching VS Code's own
+Markdown preview and preserving themes that give code a distinct tint.
 
 At a high level, Raven places a loopback proxy in front of Quarto's local
 preview server and injects a small theme bridge into eligible HTML responses.

--- a/editors/vscode/src/quarto/bridge/bridge.css
+++ b/editors/vscode/src/quarto/bridge/bridge.css
@@ -24,7 +24,7 @@ html.raven-vscode-theme [class*="border-"] {
 }
 
 html.raven-vscode-theme :not(pre) > code {
-    background-color: var(--raven-bg) !important;
+    background-color: var(--raven-code-bg) !important;
     color: var(--raven-c-string) !important;
     border: 1px solid var(--raven-c-punctuation) !important;
     font-family: var(--raven-font-mono) !important;
@@ -32,12 +32,42 @@ html.raven-vscode-theme :not(pre) > code {
 
 html.raven-vscode-theme pre,
 html.raven-vscode-theme div.sourceCode,
-html.raven-vscode-theme pre.sourceCode,
 html.raven-vscode-theme pre code {
-    background-color: var(--raven-bg) !important;
     color: var(--raven-fg) !important;
     border-color: var(--raven-c-punctuation) !important;
     font-family: var(--raven-font-mono) !important;
+}
+
+html.raven-vscode-theme div.sourceCode {
+    background-color: var(--raven-bg) !important;
+}
+
+/*
+ * Match VS Code's Markdown preview by painting every block-code pre surface
+ * with textCodeBlock.background, including Pandoc's unclassified <pre><code>
+ * shape. The code child stays transparent so rgba colors are applied once.
+ */
+html.raven-vscode-theme pre {
+    background-color: var(--raven-code-bg) !important;
+}
+
+html.raven-vscode-theme pre code {
+    background-color: transparent !important;
+}
+
+/* Executed cell output is console text, not an input code block. */
+html.raven-vscode-theme .cell-output pre {
+    background-color: var(--raven-bg) !important;
+}
+
+/*
+ * Quarto assigns its "Normal" syntax color directly to each Pandoc line
+ * wrapper (`code.sourceCode > span`). Recoloring the code element alone
+ * therefore cannot change bare identifiers and punctuation, which inherit
+ * from that wrapper rather than from `code`.
+ */
+html.raven-vscode-theme code.sourceCode > span {
+    color: var(--raven-fg) !important;
 }
 
 html.raven-vscode-theme .sourceCode .kw,

--- a/editors/vscode/src/quarto/bridge/bridge.js
+++ b/editors/vscode/src/quarto/bridge/bridge.js
@@ -16,6 +16,7 @@
     var payloadKeys = [
         '__ravenQuartoTheme',
         'background',
+        'codeBackground',
         'enabled',
         'fontMono',
         'fontText',
@@ -48,7 +49,8 @@
     function isThemeMessage(value) {
         if (!isRecord(value) || !hasExactKeys(value, payloadKeys)) return false;
         if (value.__ravenQuartoTheme !== true || typeof value.enabled !== 'boolean') return false;
-        if (!isColor(value.background) || !isColor(value.foreground)) return false;
+        if (!isColor(value.background) || !isColor(value.codeBackground)
+                || !isColor(value.foreground)) return false;
         if (typeof value.fontText !== 'string' || !fontPattern.test(value.fontText)) return false;
         if (typeof value.fontMono !== 'string' || !fontPattern.test(value.fontMono)) return false;
         if (!isRecord(value.roles) || !hasExactKeys(value.roles, roleSchemaKeys)) return false;
@@ -71,6 +73,7 @@
     function applyTheme(payload) {
         var root = document.documentElement;
         root.style.setProperty('--raven-bg', payload.background);
+        root.style.setProperty('--raven-code-bg', payload.codeBackground);
         root.style.setProperty('--raven-fg', payload.foreground);
         for (var index = 0; index < roleKeys.length; index += 1) {
             var role = roleKeys[index];

--- a/editors/vscode/src/quarto/quarto-messages.ts
+++ b/editors/vscode/src/quarto/quarto-messages.ts
@@ -34,6 +34,7 @@ export type QuartoThemeRole = typeof QUARTO_THEME_ROLE_KEYS[number];
 export interface QuartoThemePayload {
     enabled: boolean;
     background: string;
+    codeBackground: string;
     foreground: string;
     roles: Record<QuartoThemeRole, string>;
     fontText: string;
@@ -67,7 +68,7 @@ export type PreviewToExtensionMessage =
     | { type: 'request-restart' }
     | { type: 'load-timeout' }
     | { type: 'report-error'; message: string }
-    | { type: 'theme-context'; background: string }
+    | { type: 'theme-context'; background: string; codeBackground: string }
     | { type: 'theme-changed'; applied: boolean }
     | { type: 'theme-bridge-status'; available: boolean };
 
@@ -78,7 +79,7 @@ const PREVIEW_MESSAGE_SCHEMAS: Record<PreviewToExtensionMessage['type'], readonl
     'request-restart': ['type'],
     'load-timeout': ['type'],
     'report-error': ['message', 'type'],
-    'theme-context': ['background', 'type'],
+    'theme-context': ['background', 'codeBackground', 'type'],
     'theme-changed': ['applied', 'type'],
     'theme-bridge-status': ['available', 'type'],
 };
@@ -107,6 +108,7 @@ function hasExactKeys(value: Record<string, unknown>, expected: readonly string[
 
 export const QUARTO_THEME_PAYLOAD_KEYS = [
     'background',
+    'codeBackground',
     'enabled',
     'fontMono',
     'fontText',
@@ -141,7 +143,8 @@ const SANITIZED_FONT = new RegExp(QUARTO_SANITIZED_FONT_PATTERN_SOURCE);
 export function isQuartoThemePayload(value: unknown): value is QuartoThemePayload {
     if (!isRecord(value) || !hasExactKeys(value, QUARTO_THEME_PAYLOAD_KEYS)) return false;
     if (typeof value.enabled !== 'boolean') return false;
-    if (!isColor(value.background) || !isColor(value.foreground)) return false;
+    if (!isColor(value.background) || !isColor(value.codeBackground) ||
+        !isColor(value.foreground)) return false;
     if (typeof value.fontText !== 'string' || !SANITIZED_FONT.test(value.fontText)) return false;
     if (typeof value.fontMono !== 'string' || !SANITIZED_FONT.test(value.fontMono)) return false;
     const roles = value.roles;
@@ -156,6 +159,7 @@ export function isRavenQuartoThemeMessage(value: unknown): value is RavenQuartoT
     return isQuartoThemePayload({
         enabled: value.enabled,
         background: value.background,
+        codeBackground: value.codeBackground,
         foreground: value.foreground,
         roles: value.roles,
         fontText: value.fontText,
@@ -230,7 +234,8 @@ export function isPreviewToExtensionMessage(value: unknown): value is PreviewToE
         case 'report-error':
             return typeof value.message === 'string';
         case 'theme-context':
-            return typeof value.background === 'string';
+            return typeof value.background === 'string' &&
+                typeof value.codeBackground === 'string';
         case 'theme-changed':
             return typeof value.applied === 'boolean';
         case 'theme-bridge-status':

--- a/editors/vscode/src/quarto/quarto-preview-html.ts
+++ b/editors/vscode/src/quarto/quarto-preview-html.ts
@@ -219,7 +219,7 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
                 'type', 'variable', 'operator', 'punctuation', 'constant'
             ];
             const payloadKeys = [
-                'background', 'enabled', 'fontMono', 'fontText',
+                'background', 'codeBackground', 'enabled', 'fontMono', 'fontText',
                 'foreground', 'roles'
             ];
             const roleSchemaKeys = roleKeys.slice().sort();
@@ -237,7 +237,8 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
             function isThemePayload(value) {
                 if (!isRecord(value) || !hasExactKeys(value, payloadKeys)) return false;
                 if (typeof value.enabled !== 'boolean') return false;
-                if (!isColor(value.background) || !isColor(value.foreground)) return false;
+                if (!isColor(value.background) || !isColor(value.codeBackground)
+                        || !isColor(value.foreground)) return false;
                 if (!isSafeFont(value.fontText) || !isSafeFont(value.fontMono)) return false;
                 if (!isRecord(value.roles) || !hasExactKeys(value.roles, roleSchemaKeys)) return false;
                 for (let i = 0; i < roleKeys.length; i++) {
@@ -299,7 +300,15 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
                         || ''
                     ).trim();
                     if (background) {
-                        vscode.postMessage({ type: 'theme-context', background });
+                        const codeBackground = (
+                            rootStyle.getPropertyValue('--vscode-textCodeBlock-background')
+                            || background
+                        ).trim();
+                        vscode.postMessage({
+                            type: 'theme-context',
+                            background,
+                            codeBackground
+                        });
                     }
                 } catch (_) { /* host falls back to the first candidate */ }
             }

--- a/editors/vscode/src/quarto/quarto-preview-panel.ts
+++ b/editors/vscode/src/quarto/quarto-preview-panel.ts
@@ -344,7 +344,10 @@ export class QuartoPreviewPanel {
                 this.deps.output.appendLine(`[panel] webview error: ${message.message}`);
                 return;
             case 'theme-context':
-                this.themeController.setEditorBackground(message.background);
+                this.themeController.setThemeContext(
+                    message.background,
+                    message.codeBackground,
+                );
                 return;
             case 'theme-changed':
                 await this.themeController.setEnabled(message.applied);

--- a/editors/vscode/src/quarto/quarto-theme-controller.ts
+++ b/editors/vscode/src/quarto/quarto-theme-controller.ts
@@ -93,6 +93,7 @@ export class QuartoThemeController implements DisposableLike {
     private sourceFsPath: string;
     private enabled: boolean;
     private latestEditorBackground: string | undefined;
+    private latestCodeBackground: string | undefined;
     private pushGeneration = 0;
     private disposed = false;
     private resolveWarned = false;
@@ -151,9 +152,11 @@ export class QuartoThemeController implements DisposableLike {
             this.deps.getConfiguration<unknown>('workbench.colorCustomizations'),
             resolvedThemeId ?? candidateThemeIds[0],
         );
+        const background = colorOverrides.background ?? palette.background;
         return {
             enabled: this.enabled,
-            background: colorOverrides.background ?? palette.background,
+            background,
+            codeBackground: this.latestCodeBackground ?? background,
             foreground: colorOverrides.foreground ?? palette.foreground,
             roles: { ...palette.roles },
             fontText: fonts.text,
@@ -174,12 +177,21 @@ export class QuartoThemeController implements DisposableLike {
         }
     }
 
-    setEditorBackground(background: string): void {
+    /** Cache the live webview colors that are unavailable from VS Code's API. */
+    setThemeContext(background: string, codeBackground: string): void {
         if (this.disposed) return;
-        const normalized = normalizeEditorBackground(background);
-        if (!normalized || normalized === this.latestEditorBackground) return;
-        this.latestEditorBackground = normalized;
-        void this.push();
+        const normalizedBackground = normalizeEditorBackground(background);
+        const normalizedCodeBackground = validCssColor(codeBackground);
+        let changed = false;
+        if (normalizedBackground && normalizedBackground !== this.latestEditorBackground) {
+            this.latestEditorBackground = normalizedBackground;
+            changed = true;
+        }
+        if (normalizedCodeBackground && normalizedCodeBackground !== this.latestCodeBackground) {
+            this.latestCodeBackground = normalizedCodeBackground;
+            changed = true;
+        }
+        if (changed) void this.push();
     }
 
     /** Persist and synchronize the toggle across every open Quarto panel. */
@@ -271,6 +283,7 @@ export class QuartoThemeController implements DisposableLike {
     private handleThemeChange(): void {
         if (this.disposed) return;
         this.latestEditorBackground = undefined;
+        this.latestCodeBackground = undefined;
         try {
             void Promise.resolve(this.deps.requestThemeContext()).catch(() => undefined);
         } catch {

--- a/tests/bun/quarto-bridge-assets.test.ts
+++ b/tests/bun/quarto-bridge-assets.test.ts
@@ -82,6 +82,7 @@ describe('packaged Quarto theme bridge sources', () => {
         // Static custom properties are set by literal name.
         for (const variable of [
             '--raven-bg',
+            '--raven-code-bg',
             '--raven-fg',
             '--raven-font-text',
             '--raven-font-mono',
@@ -106,7 +107,8 @@ describe('packaged Quarto theme bridge sources', () => {
         const css = readFileSync(join(BRIDGE_DIR, 'bridge.css'), 'utf8');
         expect(css).toContain('html.raven-vscode-theme');
         for (const variable of [
-            '--raven-bg', '--raven-fg', '--raven-c-keyword', '--raven-c-string',
+            '--raven-bg', '--raven-code-bg', '--raven-fg',
+            '--raven-c-keyword', '--raven-c-string',
             '--raven-c-number', '--raven-c-comment', '--raven-c-function',
             '--raven-c-type', '--raven-c-variable', '--raven-c-operator',
             '--raven-c-punctuation', '--raven-c-constant', '--raven-font-text',
@@ -117,6 +119,26 @@ describe('packaged Quarto theme bridge sources', () => {
         for (const surface of ['.navbar', '#quarto-sidebar', '#TOC', '.callout', '.card', 'table']) {
             expect(css).toContain(surface);
         }
+    });
+
+    test('overrides Quarto normal syntax color on Pandoc line wrappers', () => {
+        const css = readFileSync(join(BRIDGE_DIR, 'bridge.css'), 'utf8');
+        expect(css).toMatch(
+            /html\.raven-vscode-theme code\.sourceCode > span\s*\{[^}]*color:\s*var\(--raven-fg\)\s*!important;/s,
+        );
+    });
+
+    test('paints code surfaces once with the VS Code code-block background', () => {
+        const css = readFileSync(join(BRIDGE_DIR, 'bridge.css'), 'utf8');
+        expect(css).toMatch(
+            /html\.raven-vscode-theme pre\s*\{[^}]*background-color:\s*var\(--raven-code-bg\)\s*!important;/s,
+        );
+        expect(css).toMatch(
+            /html\.raven-vscode-theme pre code\s*\{[^}]*background-color:\s*transparent\s*!important;/s,
+        );
+        expect(css).toMatch(
+            /html\.raven-vscode-theme \.cell-output pre\s*\{[^}]*background-color:\s*var\(--raven-bg\)\s*!important;/s,
+        );
     });
 });
 

--- a/tests/bun/quarto-messages.test.ts
+++ b/tests/bun/quarto-messages.test.ts
@@ -14,6 +14,7 @@ function themePayload(): QuartoThemePayload {
     return {
         enabled: true,
         background: '#1e1e1e',
+        codeBackground: 'rgba(10, 10, 10, 0.4)',
         foreground: 'rgb(212, 212, 212)',
         roles: {
             keyword: '#c586c0',
@@ -103,6 +104,7 @@ describe('Quarto preview message validators', () => {
         expect(isPreviewToExtensionMessage({
             type: 'theme-context',
             background: '#1e1e1e',
+            codeBackground: 'rgba(10, 10, 10, 0.4)',
         })).toBe(true);
         expect(isPreviewToExtensionMessage({ type: 'theme-changed', applied: true })).toBe(true);
         expect(isPreviewToExtensionMessage({
@@ -123,6 +125,12 @@ describe('Quarto preview message validators', () => {
         expect(isPreviewToExtensionMessage({
             type: 'theme-context',
             background: 12,
+            codeBackground: '#181818',
+        })).toBe(false);
+        expect(isPreviewToExtensionMessage({
+            type: 'theme-context',
+            background: '#1e1e1e',
+            codeBackground: 12,
         })).toBe(false);
         expect(isPreviewToExtensionMessage({
             type: 'theme-changed',
@@ -157,6 +165,10 @@ describe('Quarto theme payload validators', () => {
         expect(isQuartoThemePayload({
             ...themePayload(),
             background: 'red; background:url(evil)',
+        })).toBe(false);
+        expect(isQuartoThemePayload({
+            ...themePayload(),
+            codeBackground: 'red; background:url(evil)',
         })).toBe(false);
         expect(isQuartoThemePayload({
             ...themePayload(),

--- a/tests/bun/quarto-preview-html.test.ts
+++ b/tests/bun/quarto-preview-html.test.ts
@@ -136,6 +136,14 @@ describe('buildQuartoPreviewShellHtml', () => {
         expect(html).toContain('themeEnabled = currentTheme.enabled');
     });
 
+    test('reports the live VS Code code-block background', () => {
+        const html = buildQuartoPreviewShellHtml(
+            args({ kind: 'serving', externalUrl: 'http://127.0.0.1:4000/' }),
+        );
+        expect(html).toContain('--vscode-textCodeBlock-background');
+        expect(html).toContain('codeBackground');
+    });
+
     test('persists only sourceFsPath and installs the honest timeout banner', () => {
         const html = buildQuartoPreviewShellHtml(args({ kind: 'serving', externalUrl: 'http://localhost:9/' }));
         expect(html).toContain('vscode.setState({ sourceFsPath: initial.sourceFsPath })');
@@ -382,6 +390,7 @@ function themePayload() {
     return {
         enabled: true,
         background: '#1e1e1e',
+        codeBackground: 'rgba(10, 10, 10, 0.4)',
         foreground: '#d4d4d4',
         roles: {
             keyword: '#c586c0',

--- a/tests/bun/quarto-theme-controller.test.ts
+++ b/tests/bun/quarto-theme-controller.test.ts
@@ -111,6 +111,7 @@ describe('QuartoThemeController', () => {
             expect(h.posted).toEqual([{
                 enabled: false,
                 background: fakePalette.background,
+                codeBackground: fakePalette.background,
                 foreground: fakePalette.foreground,
                 roles: fakePalette.roles,
                 fontText: 'Inter, sans-serif',
@@ -152,6 +153,18 @@ describe('QuartoThemeController', () => {
             await h.controller.push();
             expect(h.posted.at(-1)?.background).toBe('#202020');
             expect(h.posted.at(-1)?.foreground).toBe('rgb(240, 240, 240)');
+        } finally {
+            h.controller.dispose();
+        }
+    });
+
+    test('uses the live VS Code text-code-block background', async () => {
+        const h = harness();
+        try {
+            h.controller.setThemeContext('#101010', 'rgba(255, 255, 255, 0.08)');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(h.posted.at(-1)?.codeBackground)
+                .toBe('rgba(255, 255, 255, 0.08)');
         } finally {
             h.controller.dispose();
         }


### PR DESCRIPTION
## Summary

- apply the active VS Code editor foreground to Quarto's normal code text
- propagate `textCodeBlock.background` through the validated preview bridge
- apply the code background once to inline, highlighted, fenced, and indented code while leaving executed cell output on the document background
- document the Quarto preview color mapping and add protocol, controller, shell, and bridge regression coverage

## Root cause

Quarto assigns its normal syntax color directly to Pandoc line-wrapper spans, so changing the parent code element did not update bare identifiers in themes such as Solarized Dark. The preview bridge also carried only `editor.background`; unlike Knit Preview, it had no way to receive or apply VS Code's distinct `textCodeBlock.background` value.

## Impact

Quarto Preview code now follows the active VS Code theme more closely. Base code text remains readable, and code surfaces retain the theme's intended tint, including semi-transparent backgrounds without double layering.

## Validation

- `bun run typecheck` in `editors/vscode`
- 46 focused Quarto bridge, message, controller, and preview tests
- merged `origin/main` and retained its recoverable timeout-banner coverage
