### PR TITLE
Fix inset Quarto preview shell

### DIFF
--- a/editors/vscode/src/quarto/quarto-preview-html.ts
+++ b/editors/vscode/src/quarto/quarto-preview-html.ts
@@ -98,6 +98,7 @@ export function buildQuartoPreviewShellHtml(args: QuartoPreviewShellHtmlArgs): s
         html, body { height: 100%; }
         body {
             margin: 0;
+            padding: 0;
             display: flex;
             flex-direction: column;
             color: var(--vscode-foreground);

--- a/tests/bun/quarto-preview-html.test.ts
+++ b/tests/bun/quarto-preview-html.test.ts
@@ -16,6 +16,11 @@ function args(state: QuartoPreviewViewState): QuartoPreviewShellHtmlArgs {
 }
 
 describe('buildQuartoPreviewShellHtml', () => {
+    test('resets host body spacing so the shell fills the webview', () => {
+        const html = buildQuartoPreviewShellHtml(args({ kind: 'starting' }));
+        expect(html).toMatch(/body\s*\{[^}]*margin:\s*0;[^}]*padding:\s*0;/);
+    });
+
     test('serving state pins frame-src to the mapped origin', () => {
         const html = buildQuartoPreviewShellHtml(
             args({ kind: 'serving', externalUrl: 'https://mapped.example.test/preview/?x=1' }),


### PR DESCRIPTION
## Summary

- reset the Quarto Preview shell body padding so the toolbar and preview iframe fill the webview
- add regression coverage for the outer-shell spacing reset

## Root cause

VS Code applies default horizontal padding to webview bodies. The Quarto Preview shell reset `margin` but not `padding`, leaving the entire UI inset. Knit Preview already resets both properties.

## Impact

Quarto Preview now uses the full available panel width while preserving Quarto's own document-content layout.

## Validation

- `bun test tests/bun/quarto-preview-html.test.ts`
- `bun run typecheck` (from `editors/vscode`)
- `bun test`
- `git diff --check`
