### PR TITLE
Clarify Quarto and R Markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Raven also provides lightweight support for **JAGS** (`.jags`, `.bugs`) and **St
 ### R session integration
 
 - **[R console](docs/r-console.md)** — Interactive R console with statement detection and a temp-file fallback for large blocks; supports R, arf, and radian
-- **[Code chunks](docs/chunks.md)** — R Markdown / Quarto chunk detection with Run Chunk / Run Above / Run All commands, CodeLens buttons, navigation, and background highlighting; full R language intelligence (diagnostics, completion, hover, navigation) inside chunk bodies; `# %%` cell support in `.R` files
-- **[Knit Preview + Export](docs/knit.md)** — `Raven: Knit Preview` renders R Markdown to an HTML preview without requiring Pandoc; companion `Export to HTML / PDF / Word` commands save the result next to the `.Rmd` / `.Rmarkdown` via Pandoc
-- **[Quarto Preview + Render](docs/quarto.md)** — CLI-backed live preview and one-shot rendering for `.qmd` files, independent of the Quarto VS Code extension
+- **Quarto & R Markdown** — A consistent, theme-aware authoring and preview workflow for `.Rmd`, `.Rmarkdown`, and `.qmd` documents:
+  - **[R code chunks](docs/chunks.md)** — R language intelligence, execution commands, CodeLens buttons, navigation, and highlighting inside chunks
+  - **[R Markdown preview + export](docs/knit.md)** — Fast HTML preview with manual refresh, plus export to HTML, PDF, and Word
+  - **[Quarto preview + render](docs/quarto.md)** — Preview and render `.qmd` documents with Quarto, including automatic refresh after saves
 - **[Plot viewer](docs/plot-viewer.md)** — Plots render in a VS Code panel via [httpgd](https://nx10.dev/httpgd/), with history navigation, save (PNG/SVG/PDF), and theme-aware background
 - **[Data viewer](docs/data-viewer.md)** — `View(df)` opens a virtualized grid backed by Apache Arrow; viewport-based rendering keeps scrolling responsive on multi-million-row frames
 - **[Help viewer](docs/help-viewer.md)** — Scope-aware R help: hovering shows the function in scope at the cursor instead of falling through to a multi-package list when scope can't be inferred

--- a/docs/knit.md
+++ b/docs/knit.md
@@ -34,9 +34,9 @@ intentionally narrow:
 - Export commands shell out to Pandoc. PDF export additionally needs a
   PDF engine — `xelatex` (a LaTeX engine) by default, or `wkhtmltopdf`
   (WebKit-based, no LaTeX required).
-- No `.qmd` rendering in the Knit Preview pipeline. Raven's separate
-  [Quarto Preview and Render](quarto.md) commands delegate `.qmd` rendering to
-  the Quarto CLI; the two pipelines are independent.
+- Knit Preview handles `.Rmd` / `.Rmarkdown` files. For `.qmd` files, the same
+  preview button and shortcut open [Quarto Preview](quarto.md), which uses
+  Quarto to preview and render the document.
 
 For HTML, Raven calls
 [`knitr::knit`](https://yihui.org/knitr/) directly — not
@@ -486,8 +486,8 @@ those checks live in the runtime sanitizer only.
 
 | Capability | Where it lives |
 |---|---|
-| Live preview of `.Rmd` / `.Rmarkdown` | `quarto.quarto`'s `Quarto: Preview`. Raven's Knit Preview remains a static viewer with a manual Knit again button. |
-| `.qmd` preview or rendering through the Knit Preview pipeline | Use Raven's separate CLI-backed [Quarto Preview and Render](quarto.md) commands, or `quarto.quarto`. Knit Preview itself never handles `.qmd`; the pipelines are independent. |
+| Automatic refresh of `.Rmd` / `.Rmarkdown` preview after saves | Not provided. Raven's Knit Preview updates when you choose **Knit again**. |
+| `.qmd` preview or rendering with the Knit Preview command | Use Raven's [Quarto Preview and Render](quarto.md) commands, or `quarto.quarto`. Raven's shared preview shortcut selects the appropriate command for the current document format. |
 | Visual Mode and Quarto-aware YAML intelligence | `quarto.quarto`. Raven supplies `.qmd` highlighting and R-chunk language features, but not these Quarto-specific editor surfaces. |
 | html_document-specific YAML options (`theme`, `code_folding`, `df_print`, …) | Out of scope. Honoring them requires becoming `rmarkdown::html_document` (Bootstrap + JS runtime). Use `rmarkdown::render(...)` in the R console for full template fidelity. |
 | `pandoc_args:` *full* passthrough | The editor menu picks export destination (always sibling of the source document) and format, so `-o`/`--output`/`-t`/`--to`/`-w`/`--write` are stripped from YAML's `pandoc_args` and logged. Everything else flows through — see the honored-options table above. |

--- a/docs/quarto.md
+++ b/docs/quarto.md
@@ -1,16 +1,40 @@
 # Quarto preview and render
 
-Raven provides a standalone, CLI-backed Quarto workflow for `.qmd` files. It
-uses the public Quarto CLI rather than the Quarto VS Code extension:
+Raven brings Quarto preview and render commands into VS Code for `.qmd` files:
 
-- **`Raven: Quarto Preview`** starts Quarto's live preview server and embeds
-  the served page in a VS Code panel.
-- **`Raven: Quarto Render`** runs a one-shot render and reports the output
-  file.
+- **`Raven: Quarto Preview`** starts Quarto's preview server and embeds the
+  served page in a VS Code panel. Quarto automatically refreshes the preview
+  after saves.
+- **`Raven: Quarto Render`** asks Quarto to render the configured output on
+  demand and reports the output file.
 - **`Raven: Stop Quarto Preview`** stops the preview associated with the
   current document.
 - **`Raven: Show Quarto Output`** opens the shared **Raven: Quarto** output
   channel.
+
+## Why Raven includes a Quarto workflow
+
+Raven supports two ways of working with R in VS Code: you can use Raven's
+language server alongside the REditorSupport extension and let that extension
+own the R session, or you can use Raven's R console and its associated session
+features. The Quarto VS Code extension's R-cell controls support the first
+arrangement only: they dispatch through REditorSupport and do not send code to
+Raven's console. Quarto preview and render still work without REditorSupport,
+but the R-cell controls do not. Raven therefore supplies its own chunk controls
+alongside Quarto Preview and Render, making a coherent R-focused `.qmd` workflow
+possible when Raven owns the R session, without requiring either REditorSupport
+or the Quarto VS Code extension. See
+[Coexistence with the Quarto extension](coexistence.md#coexistence-with-the-quarto-extension)
+for the detailed interaction between the extensions.
+
+Raven also offers an optional preview appearance that matches VS Code. Quarto's
+authored appearance remains the default; **Apply VS Code theme** is off until
+you enable it from the preview toolbar. When enabled, Raven's loopback preview
+proxy applies the editor's fonts, background, foreground, and broad syntax
+color roles to the embedded page. The overlay does not modify the source or
+rendered output, and **Open in Browser** continues to show Quarto's original
+appearance. Turn the toolbar option off at any time to return the embedded
+preview to that appearance.
 
 Quarto commands are available from the Command Palette and, for `.qmd` files,
 inside the editor-title **Send to R** ($(play)) menu. A dedicated $(preview)
@@ -21,25 +45,18 @@ Preview, providing one consistent preview action across both formats. You can
 right-click the editor toolbar and choose **Hide** if you do not want the
 button.
 
-Quarto Preview and Render follow Raven's R-console activation gate across the
-Command Palette, editor-title button, **Send to R** menu, and keyboard shortcut.
-They appear only when `raven.rConsole.activation` resolves to enabled, and their
-handlers re-check that live setting when invoked through a command link or
-custom keybinding. They do not depend on the `quarto.quarto` extension. Preview
-and Render execute the document through Quarto and therefore also require a
-trusted workspace. Stop remains palette-accessible when the R-console gate is
-closed and available in Restricted Mode so you can terminate an existing
-preview.
-
-Raven's [Knit Preview](knit.md) remains a separate pipeline for `.Rmd` and
-`.Rmarkdown` files. Knit Preview does not handle `.qmd`, and Quarto Preview does
-not use Raven's knit renderer.
+Quarto Preview and Render are available when Raven's R-session features are
+enabled through `raven.rConsole.activation`. Because Quarto may execute code
+from the document, both commands require a trusted workspace.
 
 ## Requirements and Quarto discovery
 
 Install the [Quarto CLI](https://quarto.org/docs/get-started/) on the machine
 where the VS Code extension host runs. For a local window, that is your local
-machine. Under Remote SSH, it is the remote machine.
+machine. Under Remote SSH, it is the remote machine. Raven invokes this CLI
+directly, so the Quarto VS Code extension is not required. If you use both
+extensions, see
+[Coexistence with the Quarto extension](coexistence.md#coexistence-with-the-quarto-extension).
 
 Raven resolves Quarto lazily for the active document, in this order:
 
@@ -284,7 +301,7 @@ policy, or remote tunnel does not work inside the sandboxed panel.
 |---|---:|---|
 | `raven.quarto.path` | `""` | Absolute path to a Quarto CLI executable. Leave empty to search `PATH` and the standard platform locations listed above. |
 | `raven.quarto.viewerColumn` | `"beside"` | Column for newly created preview panels: `"active"` or `"beside"`. It does not move an existing panel. |
-| `raven.quarto.render.timeoutMs` | `600000` | Hard timeout in milliseconds for a one-shot Quarto render. Cancellation and timeout stop the process tree with escalating signals. |
+| `raven.quarto.render.timeoutMs` | `600000` | Hard timeout in milliseconds for an on-demand Quarto render. Cancellation and timeout stop the process tree with escalating signals. |
 | `raven.quarto.fontFamily` | `""` | Body/prose font for the live-themed preview. Empty inherits `markdown.preview.fontFamily`. |
 | `raven.quarto.monospaceFontFamily` | `""` | Monospace font for code in the live-themed preview. Empty inherits `editor.fontFamily`. |
 
@@ -350,7 +367,7 @@ from the success notification.
   SSH, WSL, and Dev Container port mappings are authority-based.
 - PDF and other non-HTML previews are unaffected by **Apply VS Code theme**;
   Raven does not inject or theme those responses.
-- Quarto processes are window-owned. Preview and in-flight one-shot render
+- Quarto processes are window-owned. Preview and in-flight render
   processes do not continue through extension deactivation or window reload,
   and Stop does not reach previews owned by another VS Code window.
 - Remote SSH uses VS Code's URI mapping and port-forwarding support, but Raven


### PR DESCRIPTION
## Summary

- group Quarto and R Markdown as one theme-aware authoring workflow in the README
- describe the distinct R Markdown and Quarto preview behavior in user-facing terms
- explain why Raven includes Quarto support: an R-focused workflow that does not require REditorSupport, plus an optional VS Code-themed preview
- clarify that R Markdown previews update only when the user chooses **Knit again**

## Why

The documentation previously presented Knit Preview and Quarto Preview as unrelated features and emphasized implementation details such as extension independence and process lifecycle. That obscured the shared editor workflow and the reasons Raven provides its own Quarto integration.

## Impact

Documentation only. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- verified all added documentation links resolve to existing files and anchors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the relationship between Quarto and R Markdown workflows.
  * Documented document-type-aware preview behavior for `.Rmd` and `.qmd` files.
  * Added details about Quarto preview, render, stop, and output commands.
  * Clarified preview refresh behavior, theme controls, workspace requirements, activation settings, and rendering limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->