### PR TITLE
Fix late cross-file correctness findings

### DIFF
--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -1090,66 +1090,46 @@ impl DependencyGraph {
 
                 // Check for directive-vs-AST conflict
                 if directive_from_to.contains(&pair) {
-                    // Find the directive edge for this (from, to) pair
-                    let directive_edge = directive_edges
+                    let mut found_matching_directive = false;
+                    let directive_covers_ast = directive_edges
                         .iter()
-                        .find(|e| e.directive_conflict_identity() == pair);
+                        .filter(|edge| edge.directive_conflict_identity() == pair)
+                        .any(|dir_edge| {
+                            found_matching_directive = true;
+                            let directive_call_site = dir_edge.call_site_identity();
 
-                    if let Some(dir_edge) = directive_edge {
-                        // Check if directive has a known call site
-                        let directive_call_site = dir_edge.call_site_identity();
-
-                        if directive_call_site.is_known_directive_call_site() {
-                            // Directive has known call site: only override AST edge at same call site
-                            // (Requirement 4.3)
-                            if directive_call_site == edge.call_site_identity() {
-                                // Case 1: Same call site - directive wins, skip AST edge
-                                // (Requirement 4.3)
-                                continue;
+                            if directive_call_site.is_known_directive_call_site() {
+                                // A known directive covers only an AST edge at
+                                // the same call site. All matching directives
+                                // participate because one relationship can
+                                // retain multiple distinct call sites.
+                                directive_call_site == edge.call_site_identity()
                             } else {
-                                // Case 2: Different call sites - keep both edges
-                                // (Requirement 4.4)
-                                ast_edges.push(edge);
-                                continue;
+                                // A directive without an explicit call site
+                                // covers an AST edge at the same or a later
+                                // line (Requirement 4.5).
+                                let directive_line = meta
+                                    .sources
+                                    .iter()
+                                    .find(|source| {
+                                        source.is_directive
+                                            && do_resolve(&source.path) == Some(to_uri.clone())
+                                    })
+                                    .map(|source| source.line);
+                                let ast_is_earlier = match directive_line {
+                                    Some(directive_line) => source.line < directive_line,
+                                    None => false,
+                                };
+                                !ast_is_earlier
                             }
-                        } else {
-                            // Directive has no explicit call site
-                            // (Requirement 4.5)
+                        });
 
-                            // Get the directive's line (where it appears in the file)
-                            let directive_line = meta
-                                .sources
-                                .iter()
-                                .find(|s| {
-                                    s.is_directive && do_resolve(&s.path) == Some(to_uri.clone())
-                                })
-                                .map(|s| s.line);
-
-                            // Check if AST edge is at an earlier line than the directive
-                            let ast_is_earlier = match directive_line {
-                                Some(dir_line) => source.line < dir_line,
-                                None => false, // If we can't determine directive line, don't treat AST as earlier
-                            };
-
-                            if ast_is_earlier {
-                                // Case 3: Directive without line=, AST at earlier line.
-                                // Keep AST edge (earliest call site wins). The
-                                // redundant-directive diagnostic is recomputed from
-                                // the snapshot graph by
-                                // `collect_redundant_directive_diagnostics_from_snapshot`,
-                                // not stored on this result. (Requirement 4.5, 6.2)
-                                ast_edges.push(edge);
-                                continue;
-                            } else {
-                                // AST is at same or later line than directive
-                                // Directive wins (it's earlier or at same position)
-                                // Skip AST edge
-                                continue;
-                            }
-                        }
+                    if directive_covers_ast || !found_matching_directive {
+                        // The index and edge list are populated together, so
+                        // the no-match case should be impossible. Preserve the
+                        // existing fail-closed behavior if they ever drift.
+                        continue;
                     }
-                    // No matching directive edge found (shouldn't happen), skip
-                    continue;
                 }
 
                 ast_edges.push(edge);
@@ -4977,6 +4957,55 @@ z <- 3
         assert!(
             result.diagnostics.is_empty(),
             "No diagnostics for different call sites"
+        );
+    }
+
+    /// Every directive for a relationship participates in conflict detection,
+    /// not only the first directive encountered.
+    #[test]
+    fn test_directive_vs_ast_second_matching_call_site_directive_wins() {
+        use super::super::types::ForwardSource;
+
+        let (temp_dir, workspace_url) = create_temp_workspace(&["main.R", "utils.R"]);
+        let main = temp_url(&temp_dir, "main.R");
+        let mut graph = DependencyGraph::new();
+        let meta = CrossFileMetadata {
+            sources: vec![
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 5,
+                    column: 0,
+                    is_directive: true,
+                    ..Default::default()
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 10,
+                    column: 0,
+                    is_directive: true,
+                    chdir: true,
+                    ..Default::default()
+                },
+                ForwardSource {
+                    path: "utils.R".to_string(),
+                    line: 10,
+                    column: 0,
+                    is_directive: false,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        graph.update_file(&main, &meta, Some(&workspace_url), |_| None);
+
+        let deps = graph.get_dependencies(&main);
+        assert_eq!(
+            deps.iter()
+                .map(|edge| (edge.call_site_line, edge.is_directive, edge.chdir))
+                .collect::<Vec<_>>(),
+            vec![(Some(5), true, false), (Some(10), true, true)],
+            "the second directive must suppress the AST edge at its call site"
         );
     }
 

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -956,6 +956,9 @@ impl DependencyGraph {
 
         // Collect directive edges first (they are authoritative)
         let mut directive_edges: Vec<DependencyEdge> = Vec::new();
+        // Relationship-only index for directive-vs-AST conflict detection.
+        // Edge storage is deliberately call-site-aware and is deduplicated by
+        // `GraphEdgeDedupKey` after conflict resolution.
         let mut directive_from_to: HashSet<DirectiveConflictIdentity> = HashSet::new();
 
         // Process forward directive sources (`# raven: source`, `# raven: run`, `# raven: include`)
@@ -1055,10 +1058,8 @@ impl DependencyGraph {
                     non_lending: false,
                 };
                 let pair = edge.directive_conflict_identity();
-                if !directive_from_to.contains(&pair) {
-                    directive_from_to.insert(pair);
-                    directive_edges.push(edge);
-                }
+                directive_from_to.insert(pair);
+                directive_edges.push(edge);
             }
         }
 
@@ -3588,6 +3589,45 @@ mod tests {
         let dependents = graph.get_dependents(&child);
         assert_eq!(dependents.len(), 1);
         assert_eq!(dependents[0].from, parent);
+    }
+
+    #[test]
+    fn test_backward_directives_preserve_distinct_call_sites() {
+        use super::super::types::{BackwardDirective, CallSiteSpec};
+
+        let mut graph = DependencyGraph::new();
+        let parent = Url::parse("file:///project/parent.R").unwrap();
+        let child = Url::parse("file:///project/sub/child.R").unwrap();
+        let meta = CrossFileMetadata {
+            sourced_by: vec![
+                BackwardDirective {
+                    path: "../parent.R".to_string(),
+                    call_site: CallSiteSpec::Line(10),
+                    directive_line: 0,
+                },
+                BackwardDirective {
+                    path: "../parent.R".to_string(),
+                    call_site: CallSiteSpec::Line(20),
+                    directive_line: 1,
+                },
+            ],
+            ..Default::default()
+        };
+
+        graph.update_file(&child, &meta, Some(&workspace_root()), |_| None);
+
+        let deps = graph.get_dependencies(&parent);
+        assert_eq!(deps.len(), 2);
+        assert_eq!(
+            deps.iter()
+                .map(|edge| edge.call_site_line)
+                .collect::<Vec<_>>(),
+            vec![Some(10), Some(20)]
+        );
+        assert!(
+            deps.iter()
+                .all(|edge| edge.is_directive && edge.is_backward_directive)
+        );
     }
 
     #[test]

--- a/crates/raven/src/cross_file/static_path.rs
+++ b/crates/raven/src/cross_file/static_path.rs
@@ -156,13 +156,20 @@ impl<'tree, 'text> StaticBindings<'tree, 'text> {
             return None; // cycle
         }
         let mut path_literals = Vec::new();
-        let mut record_literal = |literal| {
-            path_literals.push(literal);
-            on_path_literal(literal);
-        };
         let value =
-            fold_string_expr_with_path_literals(rhs, self.content, self, &mut record_literal);
+            fold_string_expr_with_path_literals_inner(rhs, self.content, self, &mut |literal| {
+                path_literals.push(literal)
+            });
         self.visiting.borrow_mut().remove(name);
+        if value.is_some() {
+            for literal in &path_literals {
+                on_path_literal(*literal);
+            }
+        } else {
+            // Intrinsic failures remain safe to memoize, but partial literals
+            // must never be replayed as if they belonged to a successful path.
+            path_literals.clear();
+        }
         self.memo.borrow_mut().insert(
             name.to_string(),
             MemoizedFold {
@@ -399,26 +406,50 @@ pub(crate) fn fold_string_expr<'tree>(
     content: &str,
     bindings: &StaticBindings<'tree, '_>,
 ) -> Option<String> {
-    fold_string_expr_with_path_literals(node, content, bindings, &mut |_| {})
+    fold_string_expr_with_path_literals_inner(node, content, bindings, &mut |_| {})
 }
 
 /// Fold a path-valued expression and report every accepted string literal that
 /// participates in the traversal.
 ///
 /// This is the policy-bearing fold used by both static source detection and
-/// computed-path navigation. The callback runs only for plain string literals
-/// reached through the same accepted branches as [`fold_string_expr`]; option
-/// literals and strings below rejected branches are never traversed. Memoized
-/// identifier folds replay their participating literals without changing the
-/// existing value memoization or cycle guard.
+/// computed-path navigation. The callback runs only after the complete outer
+/// fold succeeds, for plain string literals reached through the same accepted
+/// branches as [`fold_string_expr`]. Option literals and strings below rejected
+/// branches are never reported. Memoized identifier folds replay their
+/// participating literals into the same transaction without changing value
+/// memoization or the cycle guard.
 pub(crate) fn fold_string_expr_with_path_literals<'tree>(
     node: Node<'tree>,
     content: &str,
     bindings: &StaticBindings<'tree, '_>,
     on_path_literal: &mut dyn FnMut(Node<'tree>),
 ) -> Option<String> {
+    let mut path_literals = Vec::new();
+    let value =
+        fold_string_expr_with_path_literals_inner(node, content, bindings, &mut |literal| {
+            path_literals.push(literal)
+        });
+    if value.is_some() {
+        for literal in path_literals {
+            on_path_literal(literal);
+        }
+    }
+    value
+}
+
+/// Recursive implementation for one outer transactional literal fold.
+///
+/// Recursive calls use this helper so a successful inner expression cannot
+/// publish literals when a later sibling makes the outer fold fail.
+fn fold_string_expr_with_path_literals_inner<'tree>(
+    node: Node<'tree>,
+    content: &str,
+    bindings: &StaticBindings<'tree, '_>,
+    on_path_literal: &mut dyn FnMut(Node<'tree>),
+) -> Option<String> {
     match node.kind() {
-        "parenthesized_expression" => fold_string_expr_with_path_literals(
+        "parenthesized_expression" => fold_string_expr_with_path_literals_inner(
             node.named_child(0)?,
             content,
             bindings,
@@ -487,7 +518,7 @@ fn fold_file_path_call<'tree>(
             }
         } else {
             let value_node = child.child_by_field_name("value")?;
-            let part = fold_string_expr_with_path_literals(
+            let part = fold_string_expr_with_path_literals_inner(
                 value_node,
                 content,
                 bindings,
@@ -532,7 +563,7 @@ fn fold_normalize_path_call<'tree>(
     {
         return None;
     }
-    fold_string_expr_with_path_literals(path, content, bindings, on_path_literal)
+    fold_string_expr_with_path_literals_inner(path, content, bindings, on_path_literal)
 }
 
 fn node_text<'a>(node: Node<'a>, content: &'a str) -> &'a str {
@@ -789,6 +820,57 @@ source(file.path(root, root, "helpers.R"))
                 "\"helpers.R\""
             ]
         );
+    }
+
+    #[test]
+    fn callback_discards_literals_when_direct_composite_fold_fails() {
+        let (folded, literals) =
+            fold_last_source_arg_with_literals(r#"source(file.path("dir", dynamic))"#);
+
+        assert_eq!(folded, None);
+        assert!(literals.is_empty());
+    }
+
+    #[test]
+    fn callback_discards_nested_success_when_outer_fold_fails() {
+        let code = r#"
+root <- file.path("scripts", "nested")
+source(file.path(root, dynamic))
+"#;
+        let (folded, literals) = fold_last_source_arg_with_literals(code);
+
+        assert_eq!(folded, None);
+        assert!(literals.is_empty());
+    }
+
+    #[test]
+    fn failed_binding_memo_does_not_replay_partial_literals() {
+        let code = r#"
+path <- file.path("dir", dynamic)
+source(path)
+source(path)
+"#;
+        let tree = parse(code);
+        let root = tree.root_node();
+        let bindings = StaticBindings::collect(root, code);
+        let source_call = root.named_child(2).unwrap();
+        let arguments = source_call.child_by_field_name("arguments").unwrap();
+        let value =
+            super::super::source_detect::source_call_file_value_node(&arguments, code, false)
+                .unwrap();
+        let mut literals = Vec::new();
+        let folded = fold_string_expr_with_path_literals(value, code, &bindings, &mut |literal| {
+            literals.push(code[literal.byte_range()].to_string())
+        });
+
+        assert_eq!(folded, None);
+        assert!(literals.is_empty());
+        let memo = bindings.memo.borrow();
+        let cached = memo
+            .get("path")
+            .expect("intrinsic failed fold should remain memoized");
+        assert_eq!(cached.value, None);
+        assert!(cached.path_literals.is_empty());
     }
 
     #[test]

--- a/crates/raven/src/file_path_intellisense.rs
+++ b/crates/raven/src/file_path_intellisense.rs
@@ -1095,9 +1095,10 @@ fn list_directory_entries_with_canonical_workspace(
             },
         };
 
-        // Determine if this is a directory
+        // Follow symlink targets for directory classification. Workspace
+        // boundary status remains the separate canonical-target decision above.
         let is_directory = match entry.file_type() {
-            Ok(ft) => ft.is_dir(),
+            Ok(ft) => ft.is_dir() || ft.is_symlink() && path.is_dir(),
             Err(_) => {
                 // If we can't determine file type, try metadata as fallback
                 path.is_dir()
@@ -10723,6 +10724,97 @@ mod file_path_definition_tests {
             !labels.contains(&"shared.R".to_string()),
             "the excluded higher-precedence symlink must shadow the lower entry"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nested_completion_external_directory_symlink_shadows_lower_entry() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = TempDir::new().unwrap();
+        let external = TempDir::new().unwrap();
+        let root = workspace.path();
+        let anchor = root.join("tests/testthat");
+        let nested = anchor.join("fixtures");
+        fs::create_dir_all(nested.join("shared")).unwrap();
+        fs::create_dir_all(external.path().join("shared-target")).unwrap();
+        symlink(external.path().join("shared-target"), anchor.join("shared")).unwrap();
+
+        let current = nested.join("test-nested.R");
+        fs::write(&current, "").unwrap();
+        let file_uri = Url::from_file_path(&current).unwrap();
+        let workspace_root = Url::from_file_path(root).unwrap();
+        let cursor = Position {
+            line: 0,
+            character: 8,
+        };
+        let context = FilePathContext::SourceCall {
+            partial_path: String::new(),
+            content_start: cursor,
+            is_sys_source: false,
+        };
+
+        let labels: Vec<_> = file_path_completions(
+            &context,
+            &file_uri,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root),
+            cursor,
+        )
+        .into_iter()
+        .map(|item| item.label)
+        .collect();
+
+        assert!(
+            !labels.contains(&"shared".to_string()),
+            "the excluded higher-precedence directory symlink must shadow the lower directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_completion_treats_internal_directory_symlink_as_folder() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = TempDir::new().unwrap();
+        let root = workspace.path();
+        let anchor = root.join("tests/testthat");
+        let target = root.join("fixtures-target");
+        fs::create_dir_all(&anchor).unwrap();
+        fs::create_dir_all(&target).unwrap();
+        symlink(&target, anchor.join("linked-fixtures")).unwrap();
+
+        let current = anchor.join("test-completion.R");
+        fs::write(&current, "").unwrap();
+        let file_uri = Url::from_file_path(&current).unwrap();
+        let workspace_root = Url::from_file_path(root).unwrap();
+        let cursor = Position {
+            line: 0,
+            character: 8,
+        };
+        let context = FilePathContext::SourceCall {
+            partial_path: String::new(),
+            content_start: cursor,
+            is_sys_source: false,
+        };
+
+        let completions = file_path_completions(
+            &context,
+            &file_uri,
+            &CrossFileMetadata::default(),
+            Some(&workspace_root),
+            cursor,
+        );
+        let linked = completions
+            .iter()
+            .find(|item| item.label == "linked-fixtures")
+            .expect("internal directory symlink should be completed");
+
+        assert_eq!(linked.kind, Some(CompletionItemKind::FOLDER));
+        let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &linked.text_edit else {
+            panic!("directory completion should carry a text edit");
+        };
+        assert_eq!(edit.new_text, "linked-fixtures/");
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6419,10 +6419,8 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
         // closures inside defaults are excluded by `containing_default_parameter`
         // and therefore follow the ordinary late-bound function path.
         let default_expression = containing_default_parameter(*usage_node).is_some();
-        let default_body_binding = default_expression
-            && containing_function_definition(*usage_node)
-                .and_then(function_body_node)
-                .is_some_and(|body| function_body_binds_name(body, text, name));
+        let default_body_binding =
+            default_expression && default_body_binding_precedes_force(*usage_node, text, name);
         let in_scope = if let Some(stream) = stream_opt.as_mut() {
             stream.advance_to(*usage_line, *usage_col);
             stream.is_visible(name)
@@ -6437,6 +6435,53 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
                 default_eof_symbols
                     .get(name.as_str())
                     .map(|symbol| &symbol.source_uri)
+            })
+            .flatten();
+        // A URI identifies the definition site inside the sourced file, but
+        // not the source() invocation that installed the surviving binding.
+        // Keep the latest call that made the name available (its pre-call
+        // scope lacks the name), including the exact position and target, then
+        // fail closed unless that target agrees with the EOF symbol. This
+        // preserves first-provider attribution for harmless repeated calls,
+        // while an intervening caller-side rm() makes the later call the new
+        // provider. The source metadata deliberately
+        // follows Raven's existing static load-time model for top-level calls;
+        // it does not add a separate conditional-control-flow approximation.
+        let default_eof_provider = default_expression
+            .then(|| {
+                let mut provider = None;
+                for (source, target) in source_calls.iter().zip(source_target_uris.iter()).rev() {
+                    if !source.inherits_symbols() {
+                        continue;
+                    }
+                    let Some(target_uri) = target.as_ref() else {
+                        continue;
+                    };
+                    if live_exports_cache
+                        .get(target_uri)
+                        .is_none_or(|exports| !exports.contains(name.as_str()))
+                    {
+                        continue;
+                    }
+
+                    match source_scope_symbols
+                        .get(&(source.line, source.column))
+                        .and_then(|symbols| symbols.get(name.as_str()))
+                    {
+                        // Re-sourcing the same provider does not establish new
+                        // availability; keep walking to the original call.
+                        Some(pre_source_uri) if pre_source_uri == target_uri => continue,
+                        // A local or different-file binding is an availability
+                        // barrier. Do not fall through to an older source whose
+                        // contribution was removed or overwritten.
+                        Some(_) => break,
+                        None => {
+                            provider = Some((target_uri, (source.line, source.column)));
+                            break;
+                        }
+                    }
+                }
+                provider.filter(|(target_uri, _)| Some(*target_uri) == default_eof_source_uri)
             })
             .flatten();
 
@@ -6503,15 +6548,14 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
                 continue;
             }
 
-            // A default is attributed only to the candidate whose target owns
-            // the rm-aware EOF binding. A pre-existing symbol at this call site
-            // still wins: this covers earlier providers and repeated calls to
-            // the same target without confusing URI equality with provenance.
+            // Defaults use the exact provider identity derived above rather
+            // than reapplying the ordinary per-candidate proxy below. URI plus
+            // call site distinguishes a provider re-established after rm()
+            // from an earlier invocation of the same target.
             if default_expression
-                && (default_eof_source_uri != Some(target_uri)
-                    || source_scope_symbols
-                        .get(&(source.line, source.column))
-                        .is_some_and(|symbols| symbols.contains_key(name.as_str())))
+                && default_eof_provider.is_none_or(|(provider_uri, provider_site)| {
+                    provider_uri != target_uri || provider_site != (source.line, source.column)
+                })
             {
                 continue;
             }
@@ -6529,7 +6573,7 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
                     .unwrap_or(true), // No symbol record yet (will be brought by source) → still attribute
                 None => true, // Source not in pre-resolve map (e.g. doesn't inherit symbols)
             };
-            if !inherited {
+            if !default_expression && !inherited {
                 continue;
             }
 
@@ -8024,9 +8068,7 @@ fn default_expression_resolves_lazily(
         return true;
     }
 
-    containing_function_definition(node)
-        .and_then(function_body_node)
-        .is_some_and(|body| function_body_binds_name(body, text, name))
+    default_body_binding_precedes_force(node, text, name)
 }
 
 /// True when a usage inside a nested closure can resolve `name` from a later
@@ -8089,32 +8131,138 @@ fn containing_function_definition(node: Node) -> Option<Node> {
     None
 }
 
-fn function_body_binds_name(node: Node, text: &str, name: &str) -> bool {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "function_definition" {
-            continue;
-        }
+/// Whether the containing function proves that `name` is bound before the
+/// default promise containing `default_usage` can be forced.
+///
+/// A direct local assignment must be the first named body statement and its
+/// RHS must be one atomic self-evaluating literal. This narrow proof excludes
+/// branch/loop-local assignments, same-statement forcing, shadowable operators,
+/// and reflective forcing such as `get("formal")` before the assignment takes
+/// effect.
+/// Counting uncertain forms conservatively can retain a diagnostic, but cannot
+/// hide one when the promise may be forced first. A sibling formal default that
+/// names the owning formal also fails closed because forcing that sibling can
+/// transitively force this promise.
+fn default_body_binding_precedes_force(default_usage: Node, text: &str, name: &str) -> bool {
+    let Some(parameter) = containing_default_parameter(default_usage) else {
+        return false;
+    };
+    let Some(formal_name) = parameter_node_name(parameter, text) else {
+        return false;
+    };
+    let Some(function) = containing_function_definition(parameter) else {
+        return false;
+    };
+    let Some(body) = function_body_node(function) else {
+        return false;
+    };
 
-        if assignment_target_node(child)
-            .is_some_and(|target| target.kind() == "identifier" && node_text(target, text) == name)
-        {
-            return true;
-        }
-
-        if child.kind() == "for_statement"
-            && child
-                .child_by_field_name("variable")
-                .is_some_and(|var| var.kind() == "identifier" && node_text(var, text) == name)
-        {
-            return true;
-        }
-
-        if function_body_binds_name(child, text, name) {
-            return true;
-        }
+    if sibling_default_references_formal(function, parameter, text, formal_name) {
+        return false;
     }
-    false
+
+    let Some(binding_effect) = direct_body_assignment_effect(body, text, name) else {
+        return false;
+    };
+    !body_has_formal_reference_before(body, text, formal_name, binding_effect)
+}
+
+/// Effect byte of a proven first-statement local assignment to `name`.
+///
+/// Superassignment, parenthesized/nested assignments, and every RHS except one
+/// atomic self-evaluating literal fail closed. In particular, R operators are
+/// callable and shadowable, so even literal-looking `1 + 2` / `-1` expressions
+/// are not proof-safe. The assignment primitives themselves are assumed to keep
+/// their language-defined binding semantics, as elsewhere in the scope model.
+fn direct_body_assignment_effect(body: Node, text: &str, name: &str) -> Option<usize> {
+    fn assignment_effect(statement: Node, text: &str, name: &str) -> Option<usize> {
+        let target = assignment_target_node(statement)?;
+        let operator = statement.child_by_field_name("operator")?;
+        if !matches!(operator.kind(), "<-" | "=" | "->")
+            || target.kind() != "identifier"
+            || node_text(target, text) != name
+        {
+            return None;
+        }
+        let value = match operator.kind() {
+            "<-" | "=" => statement.child_by_field_name("rhs")?,
+            "->" => statement.child_by_field_name("lhs")?,
+            _ => return None,
+        };
+        matches!(
+            value.kind(),
+            "float"
+                | "integer"
+                | "complex"
+                | "string"
+                | "raw_string_literal"
+                | "true"
+                | "false"
+                | "null"
+                | "na"
+                | "inf"
+                | "nan"
+        )
+        .then_some(statement.end_byte())
+    }
+
+    if body.kind() == "binary_operator" {
+        return assignment_effect(body, text, name);
+    }
+    assignment_effect(body.named_child(0)?, text, name)
+}
+
+fn body_has_formal_reference_before(
+    node: Node,
+    text: &str,
+    formal_name: &str,
+    binding_effect: usize,
+) -> bool {
+    if node.start_byte() >= binding_effect {
+        return false;
+    }
+    if node.kind() == "identifier"
+        && node_text(node, text) == formal_name
+        && !is_structural_non_reference(node)
+    {
+        return true;
+    }
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| body_has_formal_reference_before(child, text, formal_name, binding_effect))
+}
+
+/// Whether another formal's default refers to `formal_name`, which can force
+/// this promise transitively before a body reference to the owning formal.
+fn sibling_default_references_formal(
+    function: Node,
+    owning_parameter: Node,
+    text: &str,
+    formal_name: &str,
+) -> bool {
+    let Some(parameters) = function_parameters_node(function) else {
+        return false;
+    };
+    let mut cursor = parameters.walk();
+    parameters.named_children(&mut cursor).any(|parameter| {
+        if parameter.id() == owning_parameter.id() {
+            return false;
+        }
+        let Some(default) = parameter.child_by_field_name("default") else {
+            return false;
+        };
+        subtree_has_identifier(default, text, formal_name)
+    })
+}
+
+fn subtree_has_identifier(node: Node, text: &str, name: &str) -> bool {
+    if node.kind() == "identifier" && node_text(node, text) == name {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| subtree_has_identifier(child, text, name))
 }
 
 fn parameter_node_name<'a>(node: Node<'a>, text: &'a str) -> Option<&'a str> {
@@ -56855,7 +57003,7 @@ mod position_aware_tests {
         diagnostics_from_snapshot, goto_definition,
     };
     use crate::state::{Document, WorldState};
-    use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Url};
+    use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Url};
 
     fn parse_r_code(code: &str) -> tree_sitter::Tree {
         let mut parser = tree_sitter::Parser::new();
@@ -56876,6 +57024,53 @@ mod position_aware_tests {
         let document = Document::new(content, None);
         state.documents.insert(uri.clone(), document);
         uri
+    }
+
+    fn default_source_diagnostics(
+        main_code: &str,
+        source_files: &[(&str, &str)],
+    ) -> Vec<Diagnostic> {
+        let mut state = create_test_state();
+        state.cross_file_config.out_of_scope_severity = Some(DiagnosticSeverity::WARNING);
+        state.cross_file_config.undefined_variable_severity = None;
+
+        let main_uri = Url::parse("file:///workspace/main.R").unwrap();
+        let mut files = vec![(main_uri.clone(), main_code)];
+        files.extend(source_files.iter().map(|(name, code)| {
+            (
+                Url::parse(&format!("file:///workspace/{name}")).unwrap(),
+                *code,
+            )
+        }));
+        for (uri, code) in files {
+            state
+                .documents
+                .insert(uri.clone(), Document::new(code, None));
+            state.cross_file_graph.update_file(
+                &uri,
+                &crate::cross_file::extract_metadata(code),
+                None,
+                |_| None,
+            );
+        }
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_uri).expect("build diagnostics snapshot");
+        diagnostics_from_snapshot(&snapshot, &main_uri, &DiagCancelToken::never())
+            .expect("produce diagnostics")
+    }
+
+    fn used_before_source_for<'a>(
+        diagnostics: &'a [Diagnostic],
+        name: &str,
+    ) -> Vec<&'a Diagnostic> {
+        diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.message.contains("is used before it's available")
+                    && diagnostic.message.contains(&format!("'{name}'"))
+            })
+            .collect()
     }
 
     #[test]
@@ -58610,6 +58805,40 @@ f()()
         assert!(used_before[0].message.contains("line 2"));
     }
 
+    #[test]
+    fn test_default_repeated_source_after_rm_attributes_second_provider() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) a\nsource(\"helpers.R\")\nrm(x)\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        let used_before: Vec<_> = used_before_source_for(&diagnostics, "x")
+            .into_iter()
+            .filter(|diagnostic| diagnostic.range.start.line == 0)
+            .collect();
+        assert_eq!(
+            used_before.len(),
+            1,
+            "the post-rm invocation is the sole surviving availability provider: {diagnostics:?}"
+        );
+        assert!(used_before[0].message.contains("line 4"));
+    }
+
+    #[test]
+    fn test_default_local_rebind_is_barrier_to_removed_source_provider() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) a\nsource(\"helpers.R\")\nrm(x)\nx <- 1\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        let default_diagnostics: Vec<_> = used_before_source_for(&diagnostics, "x")
+            .into_iter()
+            .filter(|diagnostic| diagnostic.range.start.line == 0)
+            .collect();
+        assert!(
+            default_diagnostics.is_empty(),
+            "the intervening caller-local binding must block fallback to the removed first source: {diagnostics:?}"
+        );
+    }
+
     /// A same-file top-level definition remains a valid late-bound default even
     /// when an intervening source target exports the same name. The source must
     /// not be blamed when the final default binding comes from this file.
@@ -58711,6 +58940,114 @@ source(\"helpers.R\")
                 .iter()
                 .map(|d| (d.message.clone(), d.range))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_body_binding_after_force_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  a\n  x <- 1\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        let used_before = used_before_source_for(&diagnostics, "x");
+        assert_eq!(
+            used_before.len(),
+            1,
+            "a later body assignment cannot satisfy an already-forced default: {diagnostics:?}"
+        );
+        assert!(used_before[0].message.contains("line 5"));
+    }
+
+    #[test]
+    fn test_default_parameter_nested_force_before_binding_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  g <- function() a\n  g()\n  x <- 1\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "a nested closure may force the promise before the later binding: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_assignment_rhs_force_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  x <- a\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "the assignment takes effect only after its RHS forces the promise: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_reflective_rhs_force_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  x <- get(\"a\")\n  a\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "a reflective RHS can force the promise before the assignment takes effect: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_reflective_call_before_binding_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  get(\"a\")\n  x <- 1\n  a\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "an earlier reflective call can force the promise before the binding: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_shadowable_operator_rhs_is_attributed() {
+        for code in [
+            "`+` <- function(e1, e2) get(\"a\", envir = parent.frame())\nf <- function(a = x) {\n  x <- 1 + 2\n  a\n}\nsource(\"helpers.R\")\n",
+            "`-` <- function(e1) get(\"a\", envir = parent.frame())\nf <- function(a = x) {\n  x <- -1\n  a\n}\nsource(\"helpers.R\")\n",
+        ] {
+            let diagnostics = default_source_diagnostics(code, &[("helpers.R", "x <- 42\n")]);
+            assert_eq!(
+                used_before_source_for(&diagnostics, "x").len(),
+                1,
+                "shadowable operator evaluation can force the promise before assignment: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_parameter_conditional_binding_is_not_proof() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  if (flag) x <- 1\n  a\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "a conditional binding may not execute before the promise is forced: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_sibling_default_force_is_attributed() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x, b = a) {\n  b\n  x <- 1\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert_eq!(
+            used_before_source_for(&diagnostics, "x").len(),
+            1,
+            "forcing sibling default b can transitively force a before x is bound: {diagnostics:?}"
         );
     }
 
@@ -61049,6 +61386,38 @@ other_func <- function(y = still_missing) {
              Diagnostics: {:?}",
             undefined_var_diags
         );
+    }
+
+    #[test]
+    fn test_default_parameter_reflective_rhs_does_not_suppress_undefined() {
+        let names = undefined_variable_names("f <- function(a = x) { x <- get(\"a\"); a }\n");
+        assert!(
+            names.iter().any(|name| name == "x"),
+            "reflective RHS forcing must keep the default undefined: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_reflective_prefix_does_not_suppress_undefined() {
+        let names = undefined_variable_names("f <- function(a = x) { get(\"a\"); x <- 1; a }\n");
+        assert!(
+            names.iter().any(|name| name == "x"),
+            "an earlier reflective call must keep the default undefined: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_shadowable_operator_rhs_does_not_suppress_undefined() {
+        for code in [
+            "`+` <- function(e1, e2) get(\"a\", envir = parent.frame())\nf <- function(a = x) { x <- 1 + 2; a }\n",
+            "`-` <- function(e1) get(\"a\", envir = parent.frame())\nf <- function(a = x) { x <- -1; a }\n",
+        ] {
+            let names = undefined_variable_names(code);
+            assert!(
+                names.iter().any(|name| name == "x"),
+                "shadowable operator RHS must keep the default undefined: {names:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -8195,7 +8195,6 @@ fn direct_body_assignment_effect(body: Node, text: &str, name: &str) -> Option<u
                 | "integer"
                 | "complex"
                 | "string"
-                | "raw_string_literal"
                 | "true"
                 | "false"
                 | "null"
@@ -58956,6 +58955,33 @@ source(\"helpers.R\")
             "a later body assignment cannot satisfy an already-forced default: {diagnostics:?}"
         );
         assert!(used_before[0].message.contains("line 5"));
+    }
+
+    #[test]
+    fn test_default_parameter_body_binding_before_force_suppresses_attribution() {
+        let diagnostics = default_source_diagnostics(
+            "f <- function(a = x) {\n  x <- 1\n  a\n}\nsource(\"helpers.R\")\n",
+            &[("helpers.R", "x <- 42\n")],
+        );
+        assert!(
+            used_before_source_for(&diagnostics, "x").is_empty(),
+            "a proven body binding before the force should suppress source attribution: \
+             {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_default_parameter_string_body_binding_before_force_suppresses_attribution() {
+        for rhs in [r#""ordinary""#, r#"r"(raw)""#] {
+            let code =
+                format!("f <- function(a = x) {{\n  x <- {rhs}\n  a\n}}\nsource(\"helpers.R\")\n");
+            let diagnostics = default_source_diagnostics(&code, &[("helpers.R", "x <- 42\n")]);
+            assert!(
+                used_before_source_for(&diagnostics, "x").is_empty(),
+                "ordinary and raw strings are both self-evaluating `string` nodes: \
+                 {diagnostics:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR addresses the five late correctness findings tracked in #657:

- preserve distinct call-site identity for backward directives instead of collapsing same-file relations early
- make static-path literal callbacks transactional so failed folds and failed memoized bindings cannot leak partial literals
- treat directory symlinks as folders in path completion while preserving canonical workspace-boundary checks and precedence
- attribute lazy-default diagnostics only when a direct, first-statement assignment of an atomic self-evaluating literal proves the external default cannot be forced first
- retain exact source-call provenance at EOF across repeated sources, removals, and caller-local rebinding barriers

The separate `cross_file/scope.rs` performance cleanup is intentionally excluded from this correctness-only change.

## Why

The affected paths each lost information too early or inferred ordering more broadly than R semantics justified. The changes retain call-site/provenance detail through final selection, stage speculative callback output until success, recognize valid symlinked directories, and fail closed unless promise-forcing order is proven.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo test -p raven --lib --features test-support --no-fail-fast --quiet` (6,419 passed, 12 ignored)
- `cargo test --workspace --all-targets --features test-support --no-fail-fast --quiet`
- `git diff --check`

Closes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-path completion to recognize symlinked directories and provide folder suggestions with trailing slashes.
  * Corrected path resolution so failed evaluations no longer leave behind partial or misleading path information.
  * Improved default-value diagnostics and handling across sourced files, rebinding, closures, and reflective operations.
  * Preserved distinct source locations when multiple directives reference the same dependency target.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->