### PR TITLE
Support targets::tar_source() cross-file analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Raven's sibling project [Sight](https://github.com/jbearak/sight) implements a l
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with configurable argument and chain styles
-- **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains to resolve scope across files
+- **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains and static `targets::tar_source()` batches to resolve scope across files
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **[Syntax highlighting](docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -9385,6 +9385,7 @@ fn remove_file_from_cross_file_state(state: &mut WorldState, uri: &Url) -> Vec<U
     // generation comes from the state-wide counter and cannot reuse the old
     // value.
     state.watched_file_resync_generations.remove(uri);
+    state.refresh_tar_source_watch_parents([uri.clone()]);
     neighbors
 }
 
@@ -19294,11 +19295,17 @@ impl Backend {
             }
         }
         let claim = {
-            let state = self.state.read().await;
-            match state.workspace_index.claim_enrichment(
+            let mut state = self.state.write().await;
+            let (claim, evicted) = state.workspace_index.claim_enrichment_with_eviction(
                 file_uri.clone(),
                 crate::workspace_index::ClosedProvenance::Dynamic,
-            ) {
+            );
+            if evicted.is_some() {
+                state.refresh_tar_source_watch_parents(
+                    std::iter::once(file_uri.clone()).chain(evicted),
+                );
+            }
+            match claim {
                 crate::workspace_index::ClaimEnrichment::AlreadyComplete(_) => {
                     return state.workspace_index.get_metadata(file_uri);
                 }
@@ -19788,11 +19795,17 @@ impl Backend {
             }
         }
         let (claim, refresh) = {
-            let state = self.state.read().await;
-            match state.workspace_index.claim_enrichment(
+            let mut state = self.state.write().await;
+            let (claim, evicted) = state.workspace_index.claim_enrichment_with_eviction(
                 file_uri.clone(),
                 crate::workspace_index::ClosedProvenance::Dynamic,
-            ) {
+            );
+            if evicted.is_some() {
+                state.refresh_tar_source_watch_parents(
+                    std::iter::once(file_uri.clone()).chain(evicted),
+                );
+            }
+            match claim {
                 crate::workspace_index::ClaimEnrichment::AlreadyComplete(refresh) => {
                     (None, Some(refresh))
                 }

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -1576,6 +1576,13 @@ pub struct Backend {
     request_cancellation: Arc<RequestCancellationRegistry>,
     traversal_truncation: Arc<TraversalTruncationState>,
     routing_tasks: RoutingTaskOwner,
+    /// Single-flight admission for open-parent tar refresh coordinators.
+    ///
+    /// The pending latest generation lives in `WorldState`; this synchronous
+    /// identity map exists separately so a Drop guard can release admission
+    /// on every task exit (including unwind) without awaiting a state lock.
+    open_tar_source_coordinators: Arc<std::sync::Mutex<std::collections::HashMap<Url, u64>>>,
+    open_tar_source_coordinator_generation: Arc<AtomicU64>,
     /// Coalesces concurrent same-key on-demand package initialization. A
     /// waiter rechecks readiness/current inputs after the winning transaction
     /// releases the gate, so one key never launches duplicate R/provider work.
@@ -1586,6 +1593,9 @@ pub struct Backend {
     package_library_install_keys_for_test: Arc<std::sync::Mutex<Vec<PackageInitKey>>>,
     #[cfg(test)]
     package_init_attempts_for_test: Arc<AtomicU64>,
+    #[cfg(test)]
+    open_tar_source_derivations_for_test:
+        Arc<std::sync::Mutex<std::collections::HashMap<Url, u64>>>,
 }
 
 /// Linearizes root routing-task spawn with shutdown.
@@ -1649,6 +1659,69 @@ impl RoutingTaskOwner {
 
     async fn wait(&self) {
         self.tracker.wait().await;
+    }
+}
+
+/// Panic-safe ownership of one per-parent tar refresh coordinator.
+///
+/// Release is identity-checked because an exiting coordinator can race a
+/// producer that admits its successor. A retired guard must never remove that
+/// successor's slot.
+struct OpenTarSourceCoordinatorGuard {
+    uri: Url,
+    id: u64,
+    coordinators: Arc<std::sync::Mutex<std::collections::HashMap<Url, u64>>>,
+    armed: bool,
+}
+
+impl OpenTarSourceCoordinatorGuard {
+    fn try_claim(
+        uri: Url,
+        id: u64,
+        coordinators: Arc<std::sync::Mutex<std::collections::HashMap<Url, u64>>>,
+    ) -> Option<Self> {
+        let mut running = coordinators.lock().unwrap();
+        if running.contains_key(&uri) {
+            return None;
+        }
+        running.insert(uri.clone(), id);
+        drop(running);
+        Some(Self {
+            uri,
+            id,
+            coordinators,
+            armed: true,
+        })
+    }
+
+    /// Release before re-reading desired work. That ordering closes the race
+    /// with a producer that published work but found this coordinator active.
+    fn release(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut running = self.coordinators.lock().unwrap();
+        if running.get(&self.uri).copied() == Some(self.id) {
+            running.remove(&self.uri);
+        }
+        self.armed = false;
+    }
+
+    fn try_reclaim(&mut self) -> bool {
+        debug_assert!(!self.armed);
+        let mut running = self.coordinators.lock().unwrap();
+        if running.contains_key(&self.uri) {
+            return false;
+        }
+        running.insert(self.uri.clone(), self.id);
+        self.armed = true;
+        true
+    }
+}
+
+impl Drop for OpenTarSourceCoordinatorGuard {
+    fn drop(&mut self) {
+        self.release();
     }
 }
 
@@ -2236,6 +2309,10 @@ impl Backend {
             request_cancellation,
             traversal_truncation: Arc::new(TraversalTruncationState::default()),
             routing_tasks: RoutingTaskOwner::new(),
+            open_tar_source_coordinators: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
+            open_tar_source_coordinator_generation: Arc::new(AtomicU64::new(0)),
             package_init_coordinator: Arc::new(tokio::sync::Mutex::new(())),
             #[cfg(test)]
             test_home_dir: Arc::new(std::sync::Mutex::new(None)),
@@ -2243,6 +2320,10 @@ impl Backend {
             package_library_install_keys_for_test: Arc::new(std::sync::Mutex::new(Vec::new())),
             #[cfg(test)]
             package_init_attempts_for_test: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            open_tar_source_derivations_for_test: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
         }
     }
 
@@ -9423,6 +9504,11 @@ fn extract_enriched_live_metadata_with_contexts(
     let ws_root = ws.map(|w| w.root.as_path());
     let lib_paths = state.package_library.lib_paths();
     crate::cross_file::resolve_system_file_sources(&mut meta, ws_name, ws_root, lib_paths);
+    crate::cross_file::tar_source::finalize_tar_source_requests(
+        &mut meta,
+        uri,
+        workspace_root.as_ref(),
+    );
 
     (meta, attempted.into_inner())
 }
@@ -9711,6 +9797,13 @@ fn derive_open_edit_fallback(
         captured.package_root.as_deref(),
         &captured.library_paths,
     );
+    if let Some(primary_uri) = captured.graph_roots.first() {
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut local_metadata,
+            primary_uri,
+            captured.workspace_root.as_ref(),
+        );
+    }
     let graph = captured
         .graph_roots
         .iter()
@@ -10752,18 +10845,8 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
             captured.package_workspace_root.as_deref(),
             &captured.library_paths,
         );
-        let artifacts = Arc::new(match tree.as_ref() {
-            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
-                &root.uri,
-                tree,
-                &analysis,
-                Some(&metadata),
-            ),
-            None => crate::cross_file::scope::ScopeArtifacts::default(),
-        });
         root.metadata = Some(Arc::new(metadata));
         root.content = Some(content.clone());
-        root.interface_hash = Some(artifacts.interface_hash);
         captured
             .metadata_map
             .insert(root.uri.clone(), root.metadata.as_ref().unwrap().clone());
@@ -10781,10 +10864,7 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
             snapshot: Some(snapshot.clone()),
             decoded_source: true,
         });
-        disk_material.insert(
-            root.uri.clone(),
-            (content, analysis, tree, snapshot, artifacts),
-        );
+        disk_material.insert(root.uri.clone(), (content, analysis, tree, snapshot));
     }
 
     let metadata_lookup = |uri: &Url| captured.metadata_map.get(uri).cloned();
@@ -10794,9 +10874,6 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
     let mut replacement_interface_hash = None;
     let mut resync = Vec::new();
     for root in &captured.roots {
-        if root.uri == captured.uri {
-            replacement_interface_hash = root.interface_hash;
-        }
         if let Some(metadata) = root.metadata.as_ref() {
             let mut semantic = metadata.as_ref().clone();
             if root
@@ -10813,6 +10890,28 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
                     metadata_lookup,
                     captured.max_chain_depth,
                 );
+            }
+            crate::cross_file::tar_source::finalize_tar_source_requests(
+                &mut semantic,
+                &root.uri,
+                captured.workspace_root.as_ref(),
+            );
+            let disk_artifacts = disk_material.get(&root.uri).map(|(_, analysis, tree, _)| {
+                Arc::new(match tree.as_ref() {
+                    Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                        &root.uri,
+                        tree,
+                        analysis,
+                        Some(&semantic),
+                    ),
+                    None => crate::cross_file::scope::ScopeArtifacts::default(),
+                })
+            });
+            if root.uri == captured.uri {
+                replacement_interface_hash = disk_artifacts
+                    .as_ref()
+                    .map(|artifacts| artifacts.interface_hash)
+                    .or(root.interface_hash);
             }
             let graph_metadata = WorldState::metadata_for_dependency_graph_with_exclusions(
                 &captured.exclusions,
@@ -10835,9 +10934,9 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
                 parent_content,
                 make_non_lending: root.make_non_lending,
             });
-            if let Some((content, analysis, tree, snapshot, artifacts)) =
-                disk_material.remove(&root.uri)
-            {
+            if let Some((content, analysis, tree, snapshot)) = disk_material.remove(&root.uri) {
+                let artifacts =
+                    disk_artifacts.expect("disk material always derives finalized artifacts");
                 close_disk_installs.push(PreparedOpenCloseDiskInstall {
                     uri: root.uri.clone(),
                     entry: crate::workspace_index::IndexEntry {
@@ -11300,6 +11399,11 @@ fn derive_open_install_analysis(
             &captured.library_paths,
         );
     }
+    crate::cross_file::tar_source::finalize_tar_source_requests(
+        &mut metadata,
+        &captured.uri,
+        captured.workspace_root.as_ref(),
+    );
 
     let mut prerequisites = OpenInstallPrerequisites {
         workspace_root: captured.workspace_root.clone(),
@@ -11666,8 +11770,6 @@ async fn commit_detached_open_install(
     state.try_commit_analysis(PreparedAnalysisCommit::OpenInstall(Box::new(prepared)))
 }
 
-#[cfg(test)]
-#[allow(dead_code)] // Retained to exercise detached metadata context capture in focused tests.
 struct DerivedOpenMetadataReenrichment {
     metadata: crate::cross_file::CrossFileMetadata,
     graph: Vec<PreparedOpenGraphProjection>,
@@ -11680,7 +11782,6 @@ struct DerivedOpenMetadataReenrichment {
 /// closures record absent as well as present URIs; the captured global
 /// closed-index, raw-cache, and open-context generations make those
 /// observations stale if any authority changes before commit.
-#[cfg(test)]
 fn derive_open_metadata_reenrichment(
     captured: &crate::state::CapturedOpenMetadataAnalysis,
 ) -> DerivedOpenMetadataReenrichment {
@@ -11708,6 +11809,11 @@ fn derive_open_metadata_reenrichment(
         captured.package_workspace_root.as_deref(),
         &captured.library_paths,
     );
+    crate::cross_file::tar_source::finalize_tar_source_requests(
+        &mut metadata,
+        &captured.uri,
+        captured.workspace_root.as_ref(),
+    );
 
     let input_root = captured.graph_roots.first().unwrap_or(&captured.uri);
     let mut graph = Vec::with_capacity(captured.graph_roots.len());
@@ -11725,6 +11831,11 @@ fn derive_open_metadata_reenrichment(
                         captured.max_chain_depth,
                     );
                 }
+                crate::cross_file::tar_source::finalize_tar_source_requests(
+                    &mut root_metadata,
+                    graph_uri,
+                    captured.workspace_root.as_ref(),
+                );
                 root_metadata
             };
         let old_metadata = semantic_for_root(captured.old_metadata.as_ref());
@@ -11763,8 +11874,6 @@ fn derive_open_metadata_reenrichment(
     }
 }
 
-#[cfg(test)]
-#[allow(dead_code)] // Test-only seam kept for stale metadata-CAS regression construction.
 fn commit_open_metadata_reenrichment(
     state: &mut WorldState,
     captured: crate::state::CapturedOpenMetadataAnalysis,
@@ -12537,6 +12646,11 @@ async fn resync_file_from_disk(
                 state.get_enriched_metadata(parent_uri)
             },
             state.cross_file_config.max_chain_depth,
+        );
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut cross_file_meta,
+            uri,
+            workspace_root.as_ref(),
         );
 
         let (parent_content, attempted_parents) = collect_backward_parent_content_with(
@@ -14993,6 +15107,7 @@ fn spawn_open_close_continuation(
 async fn did_close_transactional(backend: &Backend, uri: &Url) {
     let intent = {
         let mut state = backend.state.write().await;
+        state.open_tar_source_refreshes.cancel(uri);
         state.begin_open_close_intent(uri)
     };
 
@@ -16900,9 +17015,15 @@ impl LanguageServer for Backend {
             "Received watched files change: {} changes",
             params.changes.len()
         );
-        if !params.changes.is_empty() {
-            self.state.write().await.advance_workspace_scan_generation();
-        }
+        let tar_source_parents = if params.changes.is_empty() {
+            Vec::new()
+        } else {
+            let mut state = self.state.write().await;
+            state.advance_workspace_scan_generation();
+            state.record_tar_source_filesystem_events(
+                params.changes.iter().map(|change| change.uri.clone()),
+            )
+        };
 
         let (project_root, raw_client): (Option<std::path::PathBuf>, serde_json::Value) = {
             let state = self.state.read().await;
@@ -17029,12 +17150,34 @@ impl LanguageServer for Backend {
         // If every change was a config file, the source-file flow below has
         // nothing to do. Otherwise, build a filtered `params` containing
         // only the non-config events and continue.
-        let remaining_changes: Vec<FileEvent> = params
+        let mut remaining_changes: Vec<FileEvent> = params
             .changes
             .iter()
             .filter(|c| !config_file_change_uris.contains(&c.uri))
             .cloned()
             .collect();
+        let open_tar_source_parents: Vec<Url> = {
+            let state = self.state.read().await;
+            tar_source_parents
+                .iter()
+                .filter(|uri| state.is_document_open_or_alias(uri))
+                .cloned()
+                .collect()
+        };
+        for parent in tar_source_parents {
+            if open_tar_source_parents.contains(&parent)
+                || remaining_changes.iter().any(|change| change.uri == parent)
+            {
+                continue;
+            }
+            remaining_changes.push(FileEvent {
+                uri: parent,
+                typ: FileChangeType::CHANGED,
+            });
+        }
+        for parent in open_tar_source_parents {
+            self.schedule_open_tar_source_parent_refresh(parent).await;
+        }
         if remaining_changes.is_empty() {
             return;
         }
@@ -18653,6 +18796,250 @@ impl Backend {
         }
     }
 
+    /// Give one open tar parent a latest-arrival durable refresh owner.
+    ///
+    /// Scheduling publishes the newest per-URI generation before attempting
+    /// single-flight admission. If a coordinator already owns the URI, it will
+    /// observe that generation after its current uncancellable filesystem walk
+    /// finishes; no second walk is launched.
+    async fn schedule_open_tar_source_parent_refresh(&self, uri: Url) {
+        let generation = {
+            let state = self.state.read().await;
+            if state.routing_is_shutdown() || !state.documents.contains_key(&uri) {
+                return;
+            }
+            state.open_tar_source_refreshes.schedule(uri.clone()).0
+        };
+        let coordinator_id = self
+            .open_tar_source_coordinator_generation
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .expect("open tar_source coordinator generation exhausted");
+        let Some(guard) = OpenTarSourceCoordinatorGuard::try_claim(
+            uri.clone(),
+            coordinator_id,
+            self.open_tar_source_coordinators.clone(),
+        ) else {
+            return;
+        };
+        let backend = self.clone();
+        let worker_uri = uri.clone();
+        let shutdown = self.routing_tasks.shutdown_token();
+        if !self.routing_tasks.spawn_root(async move {
+            backend
+                .run_open_tar_source_parent_refresh(&worker_uri, guard, shutdown)
+                .await;
+        }) {
+            self.state
+                .read()
+                .await
+                .open_tar_source_refreshes
+                .complete(&uri, generation);
+            log::debug!("shutdown rejected open tar_source refresh for {uri}");
+        }
+    }
+
+    /// Re-expand one open parent until its exact refresh owner converges.
+    ///
+    /// Every round snapshots and derives off-lock, then validates the complete
+    /// [`AnalysisBasis`] at the normal central commit. Conflicts use bounded
+    /// exponential backoff but no retry count: correctness terminates only on
+    /// a commit, close/reopen, or shutdown. Newer events update the desired
+    /// generation and wake this same coordinator, so at most one physical
+    /// filesystem derivation runs per parent.
+    async fn run_open_tar_source_parent_refresh(
+        &self,
+        uri: &Url,
+        mut coordinator: OpenTarSourceCoordinatorGuard,
+        shutdown: CancellationToken,
+    ) {
+        let mut rejected_rounds = 0u32;
+        loop {
+            if shutdown.is_cancelled() {
+                return;
+            }
+            let Some((generation, token)) = ({
+                let state = self.state.read().await;
+                state.open_tar_source_refreshes.latest(uri)
+            }) else {
+                if !self
+                    .release_and_reclaim_open_tar_source_coordinator(
+                        uri,
+                        &mut coordinator,
+                        &shutdown,
+                    )
+                    .await
+                {
+                    return;
+                }
+                continue;
+            };
+            let captured = {
+                let state = self.state.read().await;
+                let Some(record) = state.documents.get_record(uri) else {
+                    state.open_tar_source_refreshes.complete(uri, generation);
+                    continue;
+                };
+                state.capture_open_metadata_derivation(uri, record.generation())
+            };
+            let Some(captured) = captured else {
+                log::warn!(
+                    "open tar_source refresh snapshot exceeded its context budget for {uri}"
+                );
+                self.state
+                    .read()
+                    .await
+                    .open_tar_source_refreshes
+                    .complete(uri, generation);
+                continue;
+            };
+            let derivation_input = captured.clone();
+            #[cfg(test)]
+            {
+                let mut counts = self.open_tar_source_derivations_for_test.lock().unwrap();
+                *counts.entry(uri.clone()).or_default() += 1;
+            }
+            let mut derivation = tokio::task::spawn_blocking(move || {
+                derive_open_metadata_reenrichment(&derivation_input)
+            });
+            let derived = match tokio::select! {
+                result = &mut derivation => result,
+                _ = shutdown.cancelled() => return,
+            } {
+                Ok(derived) => derived,
+                Err(error) => {
+                    log::warn!("open tar_source refresh derivation failed for {uri}: {error}");
+                    self.state
+                        .read()
+                        .await
+                        .open_tar_source_refreshes
+                        .complete(uri, generation);
+                    continue;
+                }
+            };
+            if shutdown.is_cancelled() {
+                return;
+            }
+            let latest_generation = {
+                let state = self.state.read().await;
+                state
+                    .open_tar_source_refreshes
+                    .latest(uri)
+                    .map(|(latest, _)| latest)
+            };
+            if latest_generation != Some(generation) {
+                rejected_rounds = 0;
+                continue;
+            }
+            #[cfg(test)]
+            {
+                let pause = {
+                    let state = self.state.read().await;
+                    state
+                        .open_tar_source_refresh_pre_commit_test_pause
+                        .take_armed(uri)
+                };
+                if let Some(pause) = pause {
+                    pause.pause().await;
+                }
+            }
+            let publish_lock = {
+                let state = self.state.read().await;
+                state.diagnostics_publish_lock.clone()
+            };
+            let _publish_guard = tokio::select! {
+                _ = token.cancelled() => continue,
+                _ = shutdown.cancelled() => return,
+                guard = publish_lock.lock() => guard,
+            };
+            let result = {
+                let mut state = self.state.write().await;
+                if shutdown.is_cancelled() || state.routing_is_shutdown() {
+                    return;
+                }
+                if state
+                    .open_tar_source_refreshes
+                    .latest(uri)
+                    .map(|(latest, _)| latest)
+                    != Some(generation)
+                {
+                    None
+                } else {
+                    Some(commit_open_metadata_reenrichment(
+                        &mut state,
+                        captured,
+                        derived,
+                        &[],
+                    ))
+                }
+            };
+            drop(_publish_guard);
+            let Some(result) = result else {
+                rejected_rounds = 0;
+                continue;
+            };
+            let Ok(tickets) = result else {
+                rejected_rounds = rejected_rounds.saturating_add(1);
+                let shift = rejected_rounds.saturating_sub(1).min(4);
+                let delay = std::time::Duration::from_millis((10u64 << shift).min(160));
+                tokio::select! {
+                    _ = token.cancelled() => {}
+                    _ = shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+                continue;
+            };
+            self.state
+                .read()
+                .await
+                .open_tar_source_refreshes
+                .complete(uri, generation);
+            rejected_rounds = 0;
+            Backend::publish_diagnostics_for_tickets_bounded(
+                self.state.clone(),
+                self.client.clone(),
+                tickets,
+                Some(self.traversal_truncation.clone()),
+            )
+            .await;
+            self.publish_diagnostics(uri).await;
+        }
+    }
+
+    /// Release admission before re-reading desired work, then reclaim only if
+    /// no producer admitted a successor in between. This ordering is the
+    /// no-lost-event handshake between the synchronous admission map and the
+    /// generation register in `WorldState`.
+    async fn release_and_reclaim_open_tar_source_coordinator(
+        &self,
+        uri: &Url,
+        coordinator: &mut OpenTarSourceCoordinatorGuard,
+        shutdown: &CancellationToken,
+    ) -> bool {
+        #[cfg(test)]
+        {
+            let pause = {
+                let state = self.state.read().await;
+                state
+                    .open_tar_source_refresh_pre_release_test_pause
+                    .take_armed(uri)
+            };
+            if let Some(pause) = pause {
+                pause.pause().await;
+            }
+        }
+        coordinator.release();
+        if shutdown.is_cancelled() {
+            return false;
+        }
+        let pending = {
+            let state = self.state.read().await;
+            state.open_tar_source_refreshes.latest(uri).is_some()
+        };
+        pending && coordinator.try_reclaim()
+    }
+
     /// Re-resolve aliases for one exact open client URI after a watcher event
     /// on that URI's path.
     ///
@@ -18977,15 +19364,6 @@ impl Backend {
         let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis_text, None));
         let mut cross_file_meta =
             crate::cross_file::extract_metadata_with_tree(analysis_text, tree.as_ref());
-        let artifacts = std::sync::Arc::new(match tree.as_ref() {
-            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
-                file_uri,
-                tree,
-                analysis_text,
-                Some(&cross_file_meta),
-            ),
-            None => crate::cross_file::scope::ScopeArtifacts::default(),
-        });
 
         let (
             workspace_root,
@@ -19064,6 +19442,20 @@ impl Backend {
             sys_file_ws_root.as_deref(),
             &sys_file_lib_paths,
         );
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut cross_file_meta,
+            file_uri,
+            workspace_root.as_ref(),
+        );
+        let artifacts = std::sync::Arc::new(match tree.as_ref() {
+            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                file_uri,
+                tree,
+                analysis_text,
+                Some(&cross_file_meta),
+            ),
+            None => crate::cross_file::scope::ScopeArtifacts::default(),
+        });
 
         let snapshot =
             crate::cross_file::file_cache::FileSnapshot::with_content_hash(&metadata, &content);
@@ -19283,12 +19675,17 @@ impl Backend {
             };
 
             for source in &meta.sources {
-                if let Some(resolved) =
-                    crate::cross_file::path_resolve::resolve_path_with_workspace_fallback(
-                        &source.path,
-                        &forward_ctx,
-                    )
-                {
+                let resolved = source
+                    .resolved_uri
+                    .as_ref()
+                    .and_then(|uri| uri.to_file_path().ok())
+                    .or_else(|| {
+                        crate::cross_file::path_resolve::resolve_path_with_workspace_fallback(
+                            &source.path,
+                            &forward_ctx,
+                        )
+                    });
+                if let Some(resolved) = resolved {
                     log::trace!(
                         "index_forward_chain: {} -> child {}",
                         source.path,
@@ -19469,15 +19866,6 @@ impl Backend {
             cross_file_meta.inherited_working_directory =
                 Some(inherited_wd.to_string_lossy().to_string());
         }
-        let artifacts = std::sync::Arc::new(match tree.as_ref() {
-            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
-                file_uri,
-                tree,
-                analysis_text,
-                Some(&cross_file_meta),
-            ),
-            None => crate::cross_file::scope::ScopeArtifacts::default(),
-        });
 
         let snapshot =
             crate::cross_file::file_cache::FileSnapshot::with_content_hash(&metadata, &content);
@@ -19555,6 +19943,20 @@ impl Backend {
             sys_file_ws_root.as_deref(),
             &sys_file_lib_paths,
         );
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut cross_file_meta,
+            file_uri,
+            workspace_root.as_ref(),
+        );
+        let artifacts = std::sync::Arc::new(match tree.as_ref() {
+            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                file_uri,
+                tree,
+                analysis_text,
+                Some(&cross_file_meta),
+            ),
+            None => crate::cross_file::scope::ScopeArtifacts::default(),
+        });
 
         let loaded_packages =
             extract_loaded_packages_from_library_calls(&cross_file_meta.library_calls);
@@ -30030,6 +30432,66 @@ mod refresh_packages_tests {
     mod forward_chain_inherited_wd {
         use super::make_test_backend;
         use tower_lsp::lsp_types::Url;
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn on_demand_tar_parent_builds_batch_and_indexes_members() {
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path();
+            std::fs::create_dir_all(root.join("R")).unwrap();
+            let parent_code = "targets::tar_source(\"R\")\nhelper_fn()\n";
+            std::fs::write(root.join("_targets.R"), parent_code).unwrap();
+            std::fs::write(root.join("R/helper.R"), "helper_fn <- function() 1\n").unwrap();
+
+            let root_uri = Url::from_directory_path(root).unwrap();
+            let parent_uri = Url::from_file_path(root.join("_targets.R")).unwrap();
+            let child_uri = Url::from_file_path(root.join("R/helper.R")).unwrap();
+            let backend = make_test_backend();
+            backend.state.write().await.workspace_folders = vec![root_uri.clone()];
+
+            let metadata = backend
+                .index_file_on_demand(&parent_uri)
+                .await
+                .expect("parent must index");
+            assert!(metadata.sources.iter().any(|source| {
+                source.tar_source_ordinal == Some(0)
+                    && source.resolved_uri.as_ref() == Some(&child_uri)
+            }));
+            {
+                let state = backend.state.read().await;
+                let artifacts = state
+                    .workspace_index
+                    .get_artifacts(&parent_uri)
+                    .expect("parent artifacts");
+                assert!(artifacts.timeline.iter().any(|event| matches!(
+                    event,
+                    crate::cross_file::scope::ScopeEvent::TarBatch { members, .. }
+                        if members.len() == 1
+                            && members[0].resolved_uri.as_ref() == Some(&child_uri)
+                )));
+                assert!(
+                    state
+                        .cross_file_graph
+                        .get_dependencies(&parent_uri)
+                        .iter()
+                        .any(|edge| edge.to == child_uri && edge.tar_source_ordinal == Some(0))
+                );
+            }
+
+            let traversal_backend = make_test_backend();
+            traversal_backend.state.write().await.workspace_folders = vec![root_uri.clone()];
+            traversal_backend
+                .index_forward_chain(&parent_uri, 10, Some(&root_uri))
+                .await;
+            assert!(
+                traversal_backend
+                    .state
+                    .read()
+                    .await
+                    .workspace_index
+                    .contains(&child_uri),
+                "the finalized tar member must participate in on-demand traversal"
+            );
+        }
 
         /// A 2-hop forward `source()` chain where the consumer lives in a
         /// DIFFERENT directory than the sourced files (`scripts/` → `R/`), so
@@ -47321,6 +47783,591 @@ infixContinuationStyle = "aligned"
             })),
         )
         .await
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watched_tar_member_creation_refreshes_open_parent_snapshot() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old_fn <- function() 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+        let old_uri = Url::from_file_path(tmp.path().join("R/old.R")).unwrap();
+        let new_uri = Url::from_file_path(tmp.path().join("R/new.R")).unwrap();
+
+        {
+            let state = backend.state.read().await;
+            let record = state
+                .documents
+                .get_record(&parent_uri)
+                .expect("open parent record");
+            assert!(record.metadata().sources.iter().any(|source| {
+                source.tar_source_ordinal == Some(0)
+                    && source.resolved_uri.as_ref() == Some(&old_uri)
+            }));
+            assert!(
+                !record
+                    .metadata()
+                    .sources
+                    .iter()
+                    .any(|source| { source.resolved_uri.as_ref() == Some(&new_uri) })
+            );
+        }
+
+        fs::write(tmp.path().join("R/new.R"), "new_fn <- function() 2\n").unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: new_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .documents
+                    .get_record(&parent_uri)
+                    .is_some_and(|record| {
+                        record.metadata().sources.iter().any(|source| {
+                            source.tar_source_ordinal == Some(0)
+                                && source.resolved_uri.as_ref() == Some(&new_uri)
+                        })
+                    })
+                    && state
+                        .cross_file_graph
+                        .get_dependencies(&parent_uri)
+                        .iter()
+                        .any(|edge| edge.to == new_uri && edge.tar_source_ordinal == Some(0))
+            })
+            .await,
+            "the tracked open-parent refresh must converge before assertions"
+        );
+        let state = backend.state.read().await;
+        let record = state
+            .documents
+            .get_record(&parent_uri)
+            .expect("refreshed open parent record");
+        assert!(record.metadata().sources.iter().any(|source| {
+            source.tar_source_ordinal == Some(0) && source.resolved_uri.as_ref() == Some(&new_uri)
+        }));
+        assert!(record.artifacts().timeline.iter().any(|event| matches!(
+            event,
+            crate::cross_file::scope::ScopeEvent::TarBatch { members, .. }
+                if members.len() == 2
+                    && members[0].resolved_uri.as_ref() == Some(&new_uri)
+                    && members[1].resolved_uri.as_ref() == Some(&old_uri)
+        )));
+        assert!(
+            state
+                .cross_file_graph
+                .get_dependencies(&parent_uri)
+                .iter()
+                .any(|edge| edge.to == new_uri && edge.tar_source_ordinal == Some(0))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_tar_refresh_survives_two_consecutive_basis_conflicts() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old_fn <- function() 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+        let new_uri = Url::from_file_path(tmp.path().join("R/new.R")).unwrap();
+        fs::write(tmp.path().join("R/new.R"), "new_fn <- function() 2\n").unwrap();
+
+        let first_pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_commit_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: new_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            first_pause.wait_arrived(),
+        )
+        .await
+        .expect("first refresh round must reach its commit barrier");
+
+        let second_pause = {
+            let mut state = backend.state.write().await;
+            state.advance_analysis_config_generation();
+            state
+                .open_tar_source_refresh_pre_commit_test_pause
+                .arm(parent_uri.clone())
+        };
+        first_pause.release();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            second_pause.wait_arrived(),
+        )
+        .await
+        .expect("durable owner must retry after the first rejected basis");
+
+        backend
+            .state
+            .write()
+            .await
+            .advance_analysis_config_generation();
+        second_pause.release();
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .documents
+                    .get_record(&parent_uri)
+                    .is_some_and(|record| {
+                        record
+                            .metadata()
+                            .sources
+                            .iter()
+                            .any(|source| source.resolved_uri.as_ref() == Some(&new_uri))
+                    })
+                    && !state
+                        .open_tar_source_refreshes
+                        .has_pending_for_test(&parent_uri)
+            })
+            .await,
+            "the original membership event must converge after two CAS conflicts"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn newer_open_tar_refresh_supersedes_parked_owner() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old <- 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+
+        let first_uri = Url::from_file_path(tmp.path().join("R/first.R")).unwrap();
+        fs::write(tmp.path().join("R/first.R"), "first <- 1\n").unwrap();
+        let first_pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_commit_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: first_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            first_pause.wait_arrived(),
+        )
+        .await
+        .expect("first owner must park before supersession");
+
+        let second_uri = Url::from_file_path(tmp.path().join("R/second.R")).unwrap();
+        fs::write(tmp.path().join("R/second.R"), "second <- 1\n").unwrap();
+        let second_pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_commit_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: second_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            backend
+                .open_tar_source_derivations_for_test
+                .lock()
+                .unwrap()
+                .get(&parent_uri)
+                .copied(),
+            Some(1),
+            "supersession must not start a second walk while the first is parked"
+        );
+        assert!(
+            backend
+                .open_tar_source_coordinators
+                .lock()
+                .unwrap()
+                .contains_key(&parent_uri),
+            "the same single-flight coordinator must retain admission"
+        );
+        first_pause.release();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            second_pause.wait_arrived(),
+        )
+        .await
+        .expect("the coordinator must derive the latest coalesced membership");
+        assert_eq!(
+            backend
+                .open_tar_source_derivations_for_test
+                .lock()
+                .unwrap()
+                .get(&parent_uri)
+                .copied(),
+            Some(2),
+            "the burst must coalesce to exactly one successor walk"
+        );
+        assert!(
+            backend
+                .state
+                .read()
+                .await
+                .open_tar_source_refreshes
+                .has_pending_for_test(&parent_uri),
+            "retired owner's completion must not remove its successor"
+        );
+        second_pause.release();
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .documents
+                    .get_record(&parent_uri)
+                    .is_some_and(|record| {
+                        let sources = &record.metadata().sources;
+                        sources
+                            .iter()
+                            .any(|source| source.resolved_uri.as_ref() == Some(&first_uri))
+                            && sources
+                                .iter()
+                                .any(|source| source.resolved_uri.as_ref() == Some(&second_uri))
+                    })
+                    && !state
+                        .open_tar_source_refreshes
+                        .has_pending_for_test(&parent_uri)
+            })
+            .await,
+            "the successor must commit the latest coalesced membership"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_tar_refresh_exit_recheck_cannot_strand_new_event() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old <- 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+
+        let first_uri = Url::from_file_path(tmp.path().join("R/first.R")).unwrap();
+        fs::write(tmp.path().join("R/first.R"), "first <- 1\n").unwrap();
+        let release_pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_release_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: first_uri,
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            release_pause.wait_arrived(),
+        )
+        .await
+        .expect("coordinator must pause before releasing its empty register");
+
+        let second_uri = Url::from_file_path(tmp.path().join("R/second.R")).unwrap();
+        fs::write(tmp.path().join("R/second.R"), "second <- 1\n").unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: second_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        assert_eq!(
+            backend
+                .open_tar_source_derivations_for_test
+                .lock()
+                .unwrap()
+                .get(&parent_uri)
+                .copied(),
+            Some(1),
+            "producer must publish desired work without launching a second coordinator"
+        );
+        release_pause.release();
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .documents
+                    .get_record(&parent_uri)
+                    .is_some_and(|record| {
+                        record
+                            .metadata()
+                            .sources
+                            .iter()
+                            .any(|source| source.resolved_uri.as_ref() == Some(&second_uri))
+                    })
+                    && !state
+                        .open_tar_source_refreshes
+                        .has_pending_for_test(&parent_uri)
+            })
+            .await,
+            "release-then-recheck must reclaim and service the published event"
+        );
+        assert!(
+            backend
+                .open_tar_source_derivations_for_test
+                .lock()
+                .unwrap()
+                .get(&parent_uri)
+                .copied()
+                .is_some_and(|count| count >= 2),
+            "the published exit-window event must start a successor round"
+        );
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !backend
+                .open_tar_source_coordinators
+                .lock()
+                .unwrap()
+                .contains_key(&parent_uri)
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "quiescent coordinator must release admission"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_reopen_cancels_retired_open_tar_refresh_owner() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old <- 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+
+        let new_uri = Url::from_file_path(tmp.path().join("R/new.R")).unwrap();
+        fs::write(tmp.path().join("R/new.R"), "new <- 1\n").unwrap();
+        let pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_commit_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: new_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(5), pause.wait_arrived())
+            .await
+            .expect("retired owner must be parked before close");
+
+        close_doc(backend, &parent_uri).await;
+        open_doc(backend, &parent_uri, "r", 1, parent_text).await;
+        pause.release();
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .documents
+                    .get_record(&parent_uri)
+                    .is_some_and(|record| {
+                        record
+                            .metadata()
+                            .sources
+                            .iter()
+                            .any(|source| source.resolved_uri.as_ref() == Some(&new_uri))
+                    })
+                    && !state
+                        .open_tar_source_refreshes
+                        .has_pending_for_test(&parent_uri)
+            })
+            .await,
+            "old-lifecycle work must not publish into the reopened record"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_cancels_parked_open_tar_refresh_owner() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old <- 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+
+        let new_uri = Url::from_file_path(tmp.path().join("R/new.R")).unwrap();
+        fs::write(tmp.path().join("R/new.R"), "new <- 1\n").unwrap();
+        let pause = backend
+            .state
+            .write()
+            .await
+            .open_tar_source_refresh_pre_commit_test_pause
+            .arm(parent_uri.clone());
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: new_uri,
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(5), pause.wait_arrived())
+            .await
+            .expect("refresh owner must park before shutdown");
+
+        let shutdown_backend = backend.clone();
+        let shutdown = tokio::spawn(async move {
+            tower_lsp::LanguageServer::shutdown(&shutdown_backend)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        pause.release();
+        tokio::time::timeout(std::time::Duration::from_secs(5), shutdown)
+            .await
+            .expect("shutdown must drain the cancelled tracked owner")
+            .expect("shutdown task must not panic");
+        assert!(
+            !backend
+                .state
+                .read()
+                .await
+                .open_tar_source_refreshes
+                .has_pending_for_test(&parent_uri)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watched_tar_member_creation_refreshes_closed_parent_snapshot() {
+        use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("R")).unwrap();
+        fs::write(tmp.path().join("R/old.R"), "old_fn <- function() 1\n").unwrap();
+        let parent_text = "targets::tar_source(\"R\")\n";
+        fs::write(tmp.path().join("_targets.R"), parent_text).unwrap();
+
+        let (svc, parent_uri) =
+            open_in_quiescent_workspace(&tmp, "_targets.R", "r", parent_text).await;
+        let backend = svc.inner();
+        close_doc(backend, &parent_uri).await;
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                !state.documents.contains_key(&parent_uri)
+                    && state
+                        .workspace_index
+                        .get_metadata(&parent_uri)
+                        .is_some_and(|metadata| {
+                            metadata
+                                .sources
+                                .iter()
+                                .any(|source| source.tar_source_ordinal == Some(0))
+                        })
+            })
+            .await,
+            "close resync must install the finalized closed parent"
+        );
+
+        let new_uri = Url::from_file_path(tmp.path().join("R/new.R")).unwrap();
+        fs::write(tmp.path().join("R/new.R"), "new_fn <- function() 2\n").unwrap();
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: new_uri.clone(),
+                    typ: FileChangeType::CREATED,
+                }],
+            })
+            .await;
+
+        assert!(
+            wait_for_state(backend, 5_000, |state| {
+                state
+                    .workspace_index
+                    .get_metadata(&parent_uri)
+                    .is_some_and(|metadata| {
+                        metadata
+                            .sources
+                            .iter()
+                            .any(|source| source.resolved_uri.as_ref() == Some(&new_uri))
+                    })
+                    && state
+                        .workspace_index
+                        .get_artifacts(&parent_uri)
+                        .is_some_and(|artifacts| {
+                            artifacts.timeline.iter().any(|event| {
+                                matches!(
+                                    event,
+                                    crate::cross_file::scope::ScopeEvent::TarBatch { members, .. }
+                                        if members.len() == 2
+                                )
+                            })
+                        })
+                    && state
+                        .cross_file_graph
+                        .get_dependencies(&parent_uri)
+                        .iter()
+                        .any(|edge| edge.to == new_uri)
+            })
+            .await,
+            "the watched create must resync the closed parent, artifacts, and graph"
+        );
     }
 
     async fn open_in_workspace_with_options(

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -420,7 +420,12 @@ fn materialize_cli_contextual_provider(
     state
         .cross_file_file_cache
         .insert(execution.uri.clone(), snapshot, content);
-    state.workspace_index.insert(execution.uri.clone(), entry);
+    let (_, evicted) = state.workspace_index.install_complete_with_eviction(
+        execution.uri.clone(),
+        entry,
+        crate::workspace_index::ClosedProvenance::Dynamic,
+    );
+    state.refresh_tar_source_watch_parents(std::iter::once(execution.uri.clone()).chain(evicted));
     let graph_metadata =
         state.metadata_for_dependency_graph(&execution.uri, &metadata, workspace_root);
     state.cross_file_graph.update_file(

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -176,6 +176,8 @@ Exit codes:
 /// resolve — producing false undefined-variable positives and losing
 /// missing-file context. This mirrors `backend`'s did_open: extract masked
 /// metadata for the path, enrich it with the inherited working directory,
+/// resolve `system.file()` entries, finalize static `tar_source()` requests,
+/// install one coherent open-document record (text + metadata + artifacts),
 /// pre-collect parent content for any backward directives, then update the
 /// graph. The masked extraction reads chunk-body `source()`/`library()` calls
 /// only (never prose).
@@ -195,8 +197,6 @@ fn open_disk_fallback_target(
     // `file_type_from_language_id("rmd")` is `None`, so the `FileType` still
     // falls back to R via the URI — only the chunk masking differs.
     let language_id = if is_chunk_file(path) { "rmd" } else { "r" };
-    state.open_document_with_language_id(uri.clone(), text, Some(1), Some(language_id));
-
     let workspace_root = state.workspace_folders.first().cloned();
     let max_chain_depth = state.cross_file_config.max_chain_depth;
     let mut meta = crate::cross_file::extract_metadata_for_path(uri.path(), text);
@@ -216,6 +216,19 @@ fn open_disk_fallback_target(
         let lib_paths = state.package_library.lib_paths();
         crate::cross_file::resolve_system_file_sources(&mut meta, ws_name, ws_root, lib_paths);
     }
+    crate::cross_file::tar_source::finalize_tar_source_requests(
+        &mut meta,
+        uri,
+        workspace_root.as_ref(),
+    );
+    state.open_document_with_language_id_and_metadata(
+        uri.clone(),
+        text,
+        Some(1),
+        Some(language_id),
+        std::sync::Arc::new(meta.clone()),
+        None,
+    );
 
     // Pre-collect parent content for any backward directives (`# raven: sourced-by`
     // with `match=`/inference call sites) before the mutable `update_file`
@@ -246,6 +259,177 @@ fn open_disk_fallback_target(
         workspace_root.as_ref(),
         |parent_uri| parent_content.get(parent_uri).cloned(),
     );
+}
+
+#[derive(Debug, Default)]
+struct CliContextualProviderPlan {
+    extras: std::collections::HashSet<Url>,
+    divergence: bool,
+}
+
+/// Materialize and select context-sensitive tar providers for one CLI target.
+///
+/// Workspace members reuse the consolidated index. Providers outside the scan
+/// are parsed, enriched, finalized, and installed into that same index, then
+/// the pure traversal is repeated so their own finalized forward closure can
+/// be discovered. The returned extras supplement only snapshot content
+/// collection; no occurrence node or alternate graph edge is created.
+fn prepare_cli_contextual_providers(
+    state: &mut crate::state::WorldState,
+    uri: &Url,
+) -> CliContextualProviderPlan {
+    let workspace_root = state.workspace_folders.first().cloned();
+    let max_depth = state.cross_file_config.max_forward_depth;
+    let max_visited = state.cross_file_config.max_transitive_dependents_visited;
+
+    let mut collected = crate::cross_file::tar_source::ContextualTarProviders::default();
+    for _ in 0..max_depth.max(1) {
+        let Some(root_metadata) = state.get_enriched_metadata(uri) else {
+            break;
+        };
+        collected = crate::cross_file::tar_source::collect_contextual_tar_providers(
+            uri,
+            &root_metadata,
+            workspace_root.as_ref(),
+            max_depth,
+            max_visited,
+            &|provider_uri| state.get_enriched_metadata(provider_uri),
+            &|parent_uri, source| {
+                let target = state
+                    .cross_file_graph
+                    .get_dependencies(parent_uri)
+                    .into_iter()
+                    .find(|edge| {
+                        edge.call_site_line == Some(source.line)
+                            && edge.call_site_column == Some(source.column)
+                            && edge.tar_source_ordinal == source.tar_source_ordinal
+                    })
+                    .map(|edge| edge.to.clone());
+                crate::cross_file::tar_source::GraphPrefixEdgeLookup::Known(target)
+            },
+        );
+        let mut installed_any = false;
+        let mut attempted = std::collections::HashSet::new();
+        for execution in &collected.executions {
+            if state.get_enriched_metadata(&execution.uri).is_some()
+                || !attempted.insert(execution.uri.clone())
+            {
+                continue;
+            }
+            installed_any |=
+                materialize_cli_contextual_provider(state, execution, workspace_root.as_ref());
+        }
+        if !installed_any {
+            break;
+        }
+    }
+
+    let neighborhood: std::collections::HashSet<Url> = state
+        .cross_file_graph
+        .cached_neighborhood_subgraph(
+            uri,
+            state.cross_file_config.max_chain_depth,
+            state.cross_file_config.max_transitive_dependents_visited,
+        )
+        .neighborhood
+        .iter()
+        .cloned()
+        .collect();
+    CliContextualProviderPlan {
+        extras: collected
+            .providers
+            .into_iter()
+            .filter(|provider| !neighborhood.contains(provider))
+            .collect(),
+        divergence: collected.divergence,
+    }
+}
+
+fn materialize_cli_contextual_provider(
+    state: &mut crate::state::WorldState,
+    execution: &crate::cross_file::tar_source::ContextualProviderExecution,
+    workspace_root: Option<&Url>,
+) -> bool {
+    if state.is_project_excluded_uri(&execution.uri) {
+        return false;
+    }
+    let Ok(path) = execution.uri.to_file_path() else {
+        return false;
+    };
+    let Ok(content) = crate::state::read_source(&path) else {
+        return false;
+    };
+    let Ok(fs_metadata) = std::fs::metadata(&path) else {
+        return false;
+    };
+    let analysis = crate::cross_file::analysis_text_for_path(execution.uri.path(), &content);
+    let tree = crate::parser_pool::with_parser(|parser| parser.parse(analysis.as_ref(), None));
+    let mut metadata =
+        crate::cross_file::extract_metadata_with_tree(analysis.as_ref(), tree.as_ref());
+    if metadata.working_directory.is_none()
+        && metadata.inherited_working_directory.is_none()
+        && let Some(inherited) = execution.context.inherited_working_directory.as_ref()
+    {
+        metadata.inherited_working_directory = Some(inherited.to_string_lossy().into_owned());
+    }
+    if metadata.working_directory.is_none() && metadata.inherited_working_directory.is_none() {
+        crate::cross_file::enrich_metadata_with_inherited_wd(
+            &mut metadata,
+            &execution.uri,
+            workspace_root,
+            |candidate| state.get_enriched_metadata(candidate),
+            state.cross_file_config.max_chain_depth,
+        );
+    }
+    {
+        let workspace = state.package_state.workspace();
+        crate::cross_file::resolve_system_file_sources(
+            &mut metadata,
+            workspace.map(|value| value.name.as_str()),
+            workspace.map(|value| value.root.as_path()),
+            state.package_library.lib_paths(),
+        );
+    }
+    crate::cross_file::tar_source::finalize_tar_source_requests(
+        &mut metadata,
+        &execution.uri,
+        workspace_root,
+    );
+    let artifacts = std::sync::Arc::new(match tree.as_ref() {
+        Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+            &execution.uri,
+            tree,
+            analysis.as_ref(),
+            Some(&metadata),
+        ),
+        None => crate::cross_file::scope::ScopeArtifacts::default(),
+    });
+    let snapshot =
+        crate::cross_file::file_cache::FileSnapshot::with_content_hash(&fs_metadata, &content);
+    let metadata = std::sync::Arc::new(metadata);
+    let entry = crate::workspace_index::IndexEntry {
+        contents: ropey::Rope::from_str(&content),
+        tree: tree.clone(),
+        loaded_packages: crate::state::extract_loaded_packages(&tree, analysis.as_ref()),
+        data_packages: crate::state::extract_data_packages(&tree, analysis.as_ref()),
+        snapshot: snapshot.clone(),
+        metadata: metadata.clone(),
+        artifacts,
+        indexed_at_version: state.workspace_index.version(),
+    };
+    state
+        .cross_file_file_cache
+        .insert(execution.uri.clone(), snapshot, content);
+    state.workspace_index.insert(execution.uri.clone(), entry);
+    let graph_metadata =
+        state.metadata_for_dependency_graph(&execution.uri, &metadata, workspace_root);
+    state.cross_file_graph.update_file(
+        &execution.uri,
+        graph_metadata.as_ref(),
+        workspace_root,
+        |_| None,
+    );
+    true
 }
 
 pub async fn run(args: CheckArgs) -> i32 {
@@ -1148,23 +1332,29 @@ fn format_nse_hint_footer(diags: &[(PathBuf, Diagnostic)]) -> Option<String> {
 /// inputs the async missing-file pass needs (`directive_meta`, severity). Split
 /// out so `raven check` can run this — the expensive part — across files in
 /// parallel (issue #479 WI3), then do the cheap async filesystem checks
-/// afterward. `open_documents` is the worker's one-entry overlay (see
-/// [`crate::handlers::DiagnosticsSnapshot::build_with_open_documents`]).
+/// afterward. `open_documents` is the worker's coherent one-entry store, while
+/// `contextual_providers` adds only provider content that a URI-global graph
+/// neighborhood cannot represent (see
+/// [`crate::handlers::DiagnosticsSnapshot::build_with_open_documents_and_extra_providers`]).
 fn compute_file_diagnostics_sync(
     state: &crate::state::WorldState,
     uri: &Url,
     open_documents: &impl crate::content_provider::OpenDocumentsView,
+    contextual_providers: &CliContextualProviderPlan,
 ) -> Option<(
     Vec<Diagnostic>,
     crate::cross_file::CrossFileMetadata,
     Option<DiagnosticSeverity>,
     crate::cross_file::CaseMismatchSeverity,
 )> {
-    let snapshot = crate::handlers::DiagnosticsSnapshot::build_with_open_documents(
-        state,
-        uri,
-        open_documents,
-    )?;
+    let snapshot =
+        crate::handlers::DiagnosticsSnapshot::build_with_open_documents_and_extra_providers(
+            state,
+            uri,
+            open_documents,
+            &contextual_providers.extras,
+            contextual_providers.divergence,
+        )?;
     let cancel = crate::handlers::DiagCancelToken::never();
     let sync_diags = crate::handlers::diagnostics_from_snapshot(&snapshot, uri, &cancel)?;
     let missing_file_severity = snapshot.cross_file_config.missing_file_severity;
@@ -1198,9 +1388,13 @@ async fn finalize_file_diagnostics(
     .await
 }
 
-async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -> Vec<Diagnostic> {
+async fn compute_file_diagnostics(
+    state: &mut crate::state::WorldState,
+    uri: &Url,
+) -> Vec<Diagnostic> {
+    let contextual_providers = prepare_cli_contextual_providers(state, uri);
     let Some((sync_diags, directive_meta, missing_file_severity, case_mismatch_severity)) =
-        compute_file_diagnostics_sync(state, uri, &state.documents)
+        compute_file_diagnostics_sync(state, uri, &state.documents, &contextual_providers)
     else {
         return Vec::new();
     };
@@ -1227,9 +1421,12 @@ async fn compute_file_diagnostics(state: &crate::state::WorldState, uri: &Url) -
 /// `state.documents` across workers would make each worker treat the others'
 /// targets as "open" and pull the wrong artifacts. We avoid that entirely:
 /// `state.documents` stays empty during the parallel region, and each worker
-/// passes a one-entry overlay holding only its target (see
+/// passes a coherent one-entry store holding only its target. Context-sensitive
+/// tar providers remain in the single finalized workspace index and are added
+/// to snapshot collection without changing graph edges (see
 /// `compute_file_diagnostics_sync` /
-/// `DiagnosticsSnapshot::build_with_open_documents`). This reproduces the
+/// `DiagnosticsSnapshot::build_with_open_documents_and_extra_providers`).
+/// This reproduces the
 /// sequential "exactly one open target" semantics per task, so output is
 /// byte-identical to a sequential run (asserted by
 /// `parallel_collection_matches_sequential`). The async on-disk missing-file
@@ -1269,6 +1466,16 @@ async fn collect_target_diagnostics(
     let mut all_diags: Vec<(PathBuf, Diagnostic)> = Vec::new();
     let mut reported_loaded_packages = std::collections::BTreeSet::new();
     let mut operator_error = false;
+    let mut contextual_provider_plans = std::collections::HashMap::new();
+    for path in targets {
+        let Ok(uri) = Url::from_file_path(path) else {
+            continue;
+        };
+        if state.workspace_index.contains(&uri) {
+            let plan = prepare_cli_contextual_providers(state, &uri);
+            contextual_provider_plans.insert(uri, plan);
+        }
+    }
 
     // Phase 1 (parallel, CPU-bound): indexed targets only. A target that is not
     // in the workspace index (disk-fallback) or whose path can't be a URL is
@@ -1286,10 +1493,18 @@ async fn collect_target_diagnostics(
                 crate::chunks::classify_chunk_document(uri.path()),
             );
             let loaded_packages: Vec<String> = doc.loaded_packages.to_vec();
-            let mut open_documents = std::collections::HashMap::new();
-            open_documents.insert(uri.clone(), doc);
+            let mut open_documents = crate::open_document_store::OpenDocumentStore::new();
+            open_documents.open_prepared(
+                uri.clone(),
+                doc,
+                entry.metadata.clone(),
+                entry.artifacts.clone(),
+                None,
+            );
+            let empty_plan = CliContextualProviderPlan::default();
+            let contextual_providers = contextual_provider_plans.get(&uri).unwrap_or(&empty_plan);
             let (sync_diags, directive_meta, missing_file_severity, case_mismatch_severity) =
-                compute_file_diagnostics_sync(state, &uri, &open_documents)?;
+                compute_file_diagnostics_sync(state, &uri, &open_documents, contextual_providers)?;
             Some(SyncResult {
                 path: path.clone(),
                 uri,
@@ -2820,7 +3035,13 @@ infixContinuationStyle = "indented"
                         &entry,
                         crate::chunks::classify_chunk_document(uri.path()),
                     );
-                    state.documents.insert(uri.clone(), doc);
+                    state.documents.open_prepared(
+                        uri.clone(),
+                        doc,
+                        entry.metadata.clone(),
+                        entry.artifacts.clone(),
+                        None,
+                    );
                 } else {
                     let text = crate::state::read_source(path).unwrap();
                     // Same disk-fallback path `run` uses, so production and test
@@ -2828,7 +3049,7 @@ infixContinuationStyle = "indented"
                     // parent_content map).
                     super::open_disk_fallback_target(&mut state, &uri, path, &text);
                 }
-                let diags = compute_file_diagnostics(&state, &uri).await;
+                let diags = compute_file_diagnostics(&mut state, &uri).await;
                 state.close_document(&uri);
                 for d in diags {
                     all.push((path.clone(), d));
@@ -2898,6 +3119,243 @@ infixContinuationStyle = "indented"
         assert!(
             !seq.iter().any(|(_, _, _, m)| m.contains("shared")),
             "shared() should resolve cross-file and not be flagged: {seq:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_tar_source_resolves_member_at_command_boundary() {
+        let workspace = TempDir::new().unwrap();
+        fs::create_dir_all(workspace.path().join("R")).unwrap();
+        fs::write(
+            workspace.path().join("R/functions.R"),
+            "helper_fn <- function() 1\n",
+        )
+        .unwrap();
+        let target = workspace.path().join("_targets.R");
+        fs::write(&target, "targets::tar_source(\"R\")\nhelper_fn()\n").unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![target];
+        assert_eq!(
+            run_blocking(args.clone()),
+            EXIT_OK,
+            "the real check command boundary must consume finalized tar artifacts"
+        );
+        let diagnostics = collect_diagnostics_blocking(&args);
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|(_, diagnostic)| diagnostic.message == "helper_fn is not defined"),
+            "tar member symbols must be visible to the report: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_materializes_external_tar_provider_in_consolidated_index() {
+        let workspace = TempDir::new().unwrap();
+        let external = TempDir::new().unwrap();
+        fs::create_dir_all(external.path().join("R")).unwrap();
+        fs::write(
+            external.path().join("R/functions.R"),
+            "external_helper <- function() 1\n",
+        )
+        .unwrap();
+        let target = external.path().join("_targets.R");
+        fs::write(&target, "targets::tar_source(\"R\")\nexternal_helper()\n").unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![target];
+        let diagnostics = collect_diagnostics_parallel_blocking(&args);
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|(_, diagnostic)| diagnostic.message == "external_helper is not defined"),
+            "a disk-fallback target must materialize its external provider before diagnostics: \
+             {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_repeated_tar_child_preserves_each_occurrence_path_context() {
+        let workspace = TempDir::new().unwrap();
+        fs::create_dir_all(workspace.path().join("runtime")).unwrap();
+        fs::write(workspace.path().join("child.R"), "source(\"config.R\")\n").unwrap();
+        fs::write(
+            workspace.path().join("runtime/config.R"),
+            "runtime_symbol <- function() 1\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("config.R"),
+            "root_symbol <- function() 1\n",
+        )
+        .unwrap();
+        let target = workspace.path().join("_targets.R");
+        fs::write(
+            &target,
+            "# raven: cd runtime\n\
+             targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+             targets::tar_source(\"../child.R\", change_directory = TRUE)\n\
+             runtime_symbol()\n\
+             root_symbol()\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![target];
+        let diagnostics = collect_diagnostics_parallel_blocking(&args);
+        assert!(
+            !diagnostics.iter().any(|(_, diagnostic)| matches!(
+                diagnostic.message.as_str(),
+                "runtime_symbol is not defined" | "root_symbol is not defined"
+            )),
+            "both executions of one child must resolve nested sources against their own \
+             effective PathContext: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_discovers_repeated_tar_context_below_ordinary_source() {
+        let workspace = TempDir::new().unwrap();
+        fs::create_dir_all(workspace.path().join("runtime")).unwrap();
+        fs::write(
+            workspace.path().join("main.R"),
+            "source(\"driver.R\")\nruntime_symbol()\nroot_symbol()\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("driver.R"),
+            "# raven: cd runtime\n\
+             targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+             targets::tar_source(\"../child.R\", change_directory = TRUE)\n",
+        )
+        .unwrap();
+        fs::write(workspace.path().join("child.R"), "source(\"config.R\")\n").unwrap();
+        fs::write(
+            workspace.path().join("runtime/config.R"),
+            "runtime_symbol <- function() 1\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("config.R"),
+            "root_symbol <- function() 1\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![workspace.path().join("main.R")];
+        let diagnostics = collect_diagnostics_parallel_blocking(&args);
+        assert!(
+            !diagnostics.iter().any(|(_, diagnostic)| matches!(
+                diagnostic.message.as_str(),
+                "runtime_symbol is not defined" | "root_symbol is not defined"
+            )),
+            "graph-prefix traversal must discover the downstream tar batch: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_graph_prefix_uses_uri_global_edge_before_tar_batch() {
+        let workspace = TempDir::new().unwrap();
+        fs::create_dir_all(workspace.path().join("wd1")).unwrap();
+        fs::create_dir_all(workspace.path().join("wd2")).unwrap();
+        fs::write(
+            workspace.path().join("00_other.R"),
+            "# raven: cd wd1\nsource(\"../a.R\", chdir = FALSE)\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("zz_main.R"),
+            "# raven: cd wd2\n\
+             source(\"../a.R\", chdir = FALSE)\n\
+             wd1_symbol()\n\
+             root_symbol()\n",
+        )
+        .unwrap();
+        fs::write(workspace.path().join("a.R"), "source(\"driver.R\")\n").unwrap();
+        fs::write(
+            workspace.path().join("driver.R"),
+            "# raven: cd wd1\n\
+             targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+             targets::tar_source(\"../child.R\", change_directory = TRUE)\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("wd2/driver.R"),
+            "# lexical alternate with no tar batch\n",
+        )
+        .unwrap();
+        fs::write(workspace.path().join("child.R"), "source(\"config.R\")\n").unwrap();
+        fs::write(
+            workspace.path().join("wd1/config.R"),
+            "wd1_symbol <- function() 1\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("config.R"),
+            "root_symbol <- function() 1\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![workspace.path().join("zz_main.R")];
+        let diagnostics = collect_diagnostics_parallel_blocking(&args);
+        assert!(
+            !diagnostics.iter().any(|(_, diagnostic)| matches!(
+                diagnostic.message.as_str(),
+                "wd1_symbol is not defined" | "root_symbol is not defined"
+            )),
+            "the planner must follow scope's URI-global a.R -> driver.R edge, not the queried \
+             caller's lexical wd2/driver.R alternate: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn raven_check_repeated_tar_context_survives_two_ordinary_source_hops() {
+        let workspace = TempDir::new().unwrap();
+        fs::create_dir_all(workspace.path().join("runtime")).unwrap();
+        fs::create_dir_all(workspace.path().join("shared")).unwrap();
+        fs::create_dir_all(workspace.path().join("common")).unwrap();
+        fs::write(
+            workspace.path().join("shared/child.R"),
+            "source(\"../common/helper.R\")\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("common/helper.R"),
+            "source(\"config.R\")\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("runtime/config.R"),
+            "runtime_deep <- function() 1\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.path().join("shared/config.R"),
+            "shared_deep <- function() 1\n",
+        )
+        .unwrap();
+        let target = workspace.path().join("_targets.R");
+        fs::write(
+            &target,
+            "# raven: cd runtime\n\
+             targets::tar_source(\"../shared/child.R\", change_directory = FALSE)\n\
+             targets::tar_source(\"../shared/child.R\", change_directory = TRUE)\n\
+             runtime_deep()\n\
+             shared_deep()\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(workspace.path());
+        args.paths = vec![target];
+        let diagnostics = collect_diagnostics_parallel_blocking(&args);
+        assert!(
+            !diagnostics.iter().any(|(_, diagnostic)| matches!(
+                diagnostic.message.as_str(),
+                "runtime_deep is not defined" | "shared_deep is not defined"
+            )),
+            "the occurrence PathContext must survive child -> helper -> config: {diagnostics:?}"
         );
     }
 

--- a/crates/raven/src/content_provider.rs
+++ b/crates/raven/src/content_provider.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use tower_lsp::lsp_types::Url;
 
 use crate::cross_file::file_cache::CrossFileFileCache;
-use crate::cross_file::scope::{self, ScopeArtifacts};
+use crate::cross_file::scope::ScopeArtifacts;
 use crate::cross_file::types::CrossFileMetadata;
 use crate::open_document_store::OpenDocumentStore;
 use crate::state::{Document, OpenDocumentAliases};
@@ -128,41 +128,6 @@ impl OpenDocumentsView for OpenDocumentStore {
     fn artifacts(&self, uri: &Url) -> Option<Arc<ScopeArtifacts>> {
         self.get_record(uri)
             .map(|record| record.artifacts().clone())
-    }
-
-    fn contains(&self, uri: &Url) -> bool {
-        self.contains_key(uri)
-    }
-}
-
-impl OpenDocumentsView for HashMap<Url, Document> {
-    fn document(&self, uri: &Url) -> Option<&Document> {
-        self.get(uri)
-    }
-
-    fn content(&self, uri: &Url) -> Option<String> {
-        self.get(uri).map(Document::text)
-    }
-
-    fn metadata(&self, uri: &Url) -> Option<Arc<CrossFileMetadata>> {
-        self.get(uri).map(|document| {
-            Arc::new(crate::cross_file::extract_metadata(
-                &document.analysis_text(),
-            ))
-        })
-    }
-
-    fn artifacts(&self, uri: &Url) -> Option<Arc<ScopeArtifacts>> {
-        let document = self.get(uri)?;
-        let tree = document.tree.as_ref()?;
-        let analysis_text = document.analysis_text();
-        let metadata = crate::cross_file::extract_metadata(&analysis_text);
-        Some(Arc::new(scope::compute_artifacts_with_metadata(
-            uri,
-            tree,
-            &analysis_text,
-            Some(&metadata),
-        )))
     }
 
     fn contains(&self, uri: &Url) -> bool {

--- a/crates/raven/src/cross_file/dependency.rs
+++ b/crates/raven/src/cross_file/dependency.rs
@@ -433,6 +433,12 @@ pub struct DependencyEdge {
     pub call_site_line: Option<u32>,
     /// 0-based UTF-16 column in parent where call occurs
     pub call_site_column: Option<u32>,
+    /// Ordered child index within one expanded `tar_source()` call.
+    ///
+    /// Together with the call site this disambiguates multiple executions
+    /// represented by the same R expression and makes reorder-only changes
+    /// visible to graph revision and dependent revalidation.
+    pub tar_source_ordinal: Option<u32>,
     /// Precise source destination class. Unlike the legacy metadata `local`
     /// boolean, this distinguishes a proven current frame from an unknown or
     /// external environment that must not inherit ordinary parent bindings.
@@ -496,6 +502,7 @@ struct DirectiveConflictIdentity {
 struct SourceCallSiteIdentity {
     line: Option<u32>,
     column: Option<u32>,
+    tar_source_ordinal: Option<u32>,
 }
 
 impl SourceCallSiteIdentity {
@@ -594,6 +601,7 @@ impl DependencyEdge {
         SourceCallSiteIdentity {
             line: self.call_site_line,
             column: self.call_site_column,
+            tar_source_ordinal: self.tar_source_ordinal,
         }
     }
 
@@ -976,6 +984,7 @@ impl DependencyGraph {
                             to: to_uri.clone(),
                             call_site_line: Some(source.line),
                             call_site_column: Some(source.column),
+                            tar_source_ordinal: source.tar_source_ordinal,
                             locality: source.locality,
                             chdir: source.chdir,
                             is_sys_source: source.is_sys_source,
@@ -1049,6 +1058,7 @@ impl DependencyGraph {
                     to: uri.clone(),
                     call_site_line,
                     call_site_column,
+                    tar_source_ordinal: None,
                     locality: SourceLocality::Global,
                     chdir: false,
                     is_sys_source: false,
@@ -1078,6 +1088,7 @@ impl DependencyGraph {
                     to: to_uri.clone(),
                     call_site_line: Some(source.line),
                     call_site_column: Some(source.column),
+                    tar_source_ordinal: source.tar_source_ordinal,
                     locality: source.locality,
                     chdir: source.chdir,
                     is_sys_source: source.is_sys_source,
@@ -5167,6 +5178,7 @@ z <- 3
             to: url("child.R"),
             call_site_line: Some(3),
             call_site_column: Some(7),
+            tar_source_ordinal: None,
             locality: SourceLocality::Global,
             chdir: false,
             is_sys_source: false,
@@ -5230,6 +5242,21 @@ z <- 3
             base.source_invocation_identity(),
             different_locality.source_invocation_identity(),
             "inheritance semantics must remain part of invocation identity"
+        );
+
+        let mut tar_child = base.clone();
+        tar_child.tar_source_ordinal = Some(0);
+        let mut next_tar_child = tar_child.clone();
+        next_tar_child.tar_source_ordinal = Some(1);
+        assert_ne!(
+            tar_child.source_invocation_identity(),
+            next_tar_child.source_invocation_identity(),
+            "ordered children from one tar_source call are distinct invocations"
+        );
+        assert_ne!(
+            tar_child.revision_identity(),
+            next_tar_child.revision_identity(),
+            "a tar_source membership reorder must advance graph revision"
         );
     }
 

--- a/crates/raven/src/cross_file/directive.rs
+++ b/crates/raven/src/cross_file/directive.rs
@@ -681,6 +681,7 @@ pub fn parse_directives(content: &str) -> CrossFileMetadata {
                 is_function_scoped: false,
                 system_file: None,
                 resolved_uri: None,
+                tar_source_ordinal: None,
             });
             continue;
         }

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -17,6 +17,7 @@ pub mod scope;
 pub mod source_detect;
 pub mod standalone_cache;
 pub(crate) mod static_path;
+pub mod tar_source;
 pub mod types;
 
 #[cfg(test)]
@@ -35,6 +36,7 @@ pub use path_resolve::*;
 pub use revalidation::*;
 pub use scope::*;
 pub use source_detect::*;
+pub use tar_source::*;
 pub use types::*;
 
 /// Extract cross-file metadata from R source by combining directive parsing with AST-detected `source()` and library-related calls.
@@ -194,11 +196,14 @@ pub fn extract_metadata_with_tree(
         // Sort by line number for consistent ordering
         meta.sources.sort_by_key(|s| (s.line, s.column));
 
-        // Detect library(), require(), loadNamespace() calls (Requirement 1.8)
-        let mut library_calls = source_detect::detect_library_calls(tree, content);
+        // Detect library(), require(), loadNamespace(), and static
+        // targets::tar_source() calls with one shared lazy binding table.
+        let (mut library_calls, tar_source_requests) =
+            source_detect::detect_library_and_tar_source_requests(tree, content);
         // Sort by line/column for document order (Requirement 1.8)
         library_calls.sort_by_key(|lc| (lc.line, lc.column));
         meta.library_calls = library_calls;
+        meta.tar_source_requests = tar_source_requests;
         meta.namespace_references = source_detect::detect_namespace_references(tree, content);
     } else {
         log::warn!("Failed to parse R code with tree-sitter during metadata extraction");

--- a/crates/raven/src/cross_file/path_resolve.rs
+++ b/crates/raven/src/cross_file/path_resolve.rs
@@ -34,7 +34,7 @@ use tower_lsp::lsp_types::Url;
 use super::types::CrossFileMetadata;
 
 /// Context for path resolution
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PathContext {
     /// Path of the current file
     pub file_path: PathBuf,
@@ -356,6 +356,42 @@ impl PathContext {
     }
 }
 
+/// Derive the execution context for one forward-source child.
+///
+/// A standalone child is caller-independent and re-anchors at its own
+/// metadata context. Other children inherit only the working directory that
+/// [`PathContext::forward_child_inherited_wd`] permits; an explicit child
+/// `# raven: cd` continues to win. Shared by scope resolution and the pure
+/// contextual tar-provider traversal so their path semantics cannot drift.
+pub(crate) fn forward_child_path_context<G>(
+    child_uri: &Url,
+    child_is_standalone: bool,
+    chdir: bool,
+    parent_ctx: Option<&PathContext>,
+    workspace_root: Option<&Url>,
+    get_metadata: &G,
+) -> Option<PathContext>
+where
+    G: Fn(&Url) -> Option<std::sync::Arc<super::types::CrossFileMetadata>>,
+{
+    if child_is_standalone {
+        get_metadata(child_uri)
+            .and_then(|metadata| PathContext::from_metadata(child_uri, &metadata, workspace_root))
+            .or_else(|| PathContext::forward_without_metadata(child_uri, workspace_root))
+    } else {
+        let parent_ctx = parent_ctx?;
+        let mut child_ctx = match get_metadata(child_uri) {
+            Some(metadata) => PathContext::from_metadata(child_uri, &metadata, workspace_root)?,
+            None => PathContext::forward_without_metadata(child_uri, workspace_root)?,
+        };
+        let inherited = parent_ctx.forward_child_inherited_wd(&child_ctx.file_path, chdir);
+        if child_ctx.working_directory.is_none() && inherited.is_some() {
+            child_ctx.inherited_working_directory = inherited;
+        }
+        Some(child_ctx)
+    }
+}
+
 /// Which filesystem regime produced a case-only path mismatch (issue #530).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaseMismatchRegime {
@@ -408,6 +444,49 @@ impl ResolveOutcome {
             case_mismatch: None,
         }
     }
+}
+
+/// Return every lexical path tier a forward source may select, in resolution
+/// priority order, including tiers that currently lose because another path
+/// exists first.
+///
+/// Filesystem membership watchers use this enumeration so creating a missing
+/// higher-priority target retargets an existing fallback. Workspace-root
+/// absolute paths have only the workspace tier. Relative paths use the
+/// effective working directory, the nested test compatibility directory, and
+/// finally the forward-only workspace fallback when no explicit or inherited
+/// `# raven: cd` pins resolution.
+pub(crate) fn forward_path_candidate_tiers(path: &str, context: &PathContext) -> Vec<PathBuf> {
+    if path.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+    let mut push_normalized = |candidate: PathBuf| {
+        if let Some(candidate) = normalize_path(&candidate)
+            && !candidates.contains(&candidate)
+        {
+            candidates.push(candidate);
+        }
+    };
+
+    if let Some(stripped) = path.strip_prefix('/') {
+        if let Some(root) = context.workspace_root.as_ref() {
+            push_normalized(root.join(stripped));
+        }
+        return candidates;
+    }
+
+    push_normalized(context.effective_working_directory().join(path));
+    if let Some(file_dir) = context.implicit_wd_file_dir_fallback() {
+        push_normalized(file_dir.join(path));
+    }
+    if !context.cd_in_effect()
+        && let Some(root) = context.workspace_root.as_ref()
+    {
+        push_normalized(root.join(path));
+    }
+    candidates
 }
 
 /// Resolve a path string to an absolute path, **without** the workspace-root

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -70,6 +70,16 @@ impl CrossFileRevalidationState {
         }
     }
 
+    /// Clone the latest pending owner for `uri`.
+    ///
+    /// Durable single-flight coordinators use this to consume the newest
+    /// desired generation after a predecessor's uncancellable blocking work
+    /// finishes. Callers must still use generation-checked [`Self::complete`]:
+    /// removing a later owner from an older snapshot would lose an event.
+    pub(crate) fn latest(&self, uri: &Url) -> Option<(u64, CancellationToken)> {
+        self.pending.read().unwrap().get(uri).cloned()
+    }
+
     /// Test-only: whether a pending revalidation entry currently exists for
     /// `uri`. Race tests use this to wait until a spawned worker has
     /// `schedule()`d (and parked in its debounce) before superseding it —

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -701,6 +701,17 @@ pub enum ScopeEvent {
         runtime_function_scope: RuntimeFunctionScope,
         function_scope: Option<FunctionScopeInterval>,
     },
+    /// One statically expanded `{targets}` `tar_source()` call.
+    ///
+    /// Unlike ordinary `Source` events, all members execute in one shared
+    /// environment in ordinal order. Scope resolution therefore treats the
+    /// call as one batch: member state is threaded left-to-right and later
+    /// definitions replace earlier ones.
+    TarBatch {
+        line: u32,
+        column: u32,
+        members: Vec<ForwardSource>,
+    },
     /// A function invocation frame spanning formals/defaults through the body
     FunctionScope {
         start_line: u32,
@@ -845,6 +856,12 @@ impl Default for ScopeArtifacts {
 #[derive(Debug, Clone, Default)]
 pub struct ScopeAtPosition {
     pub symbols: HashMap<Arc<str>, ScopedSymbol>,
+    /// Top-level removals still in effect at this position.
+    ///
+    /// Ordinary cross-file consumers historically needed only the surviving
+    /// symbol map. Ordered tar batches additionally need the tombstones so a
+    /// later member's `rm(x)` can remove `x` contributed by an earlier member.
+    pub(crate) removed_names: HashSet<Arc<str>>,
     pub chain: Vec<Url>,
     /// Symbols in `symbols` that came only from this scope's parent/backward
     /// prefix and have not been replaced by local definitions or forward
@@ -903,6 +920,13 @@ fn extend_visible_positions(dst: &mut HashMap<Url, (u32, u32)>, src: &HashMap<Ur
     for (uri, &(line, column)) in src {
         record_visible_position(dst, uri, line, column);
     }
+}
+
+/// Append contributor URIs in execution order, retaining only their first
+/// occurrence across both the existing chain and the appended contribution.
+fn extend_chain_first_seen(chain: &mut Vec<Url>, members: impl IntoIterator<Item = Url>) {
+    let mut seen: HashSet<Url> = chain.iter().cloned().collect();
+    chain.extend(members.into_iter().filter(|uri| seen.insert(uri.clone())));
 }
 
 /// Record that `package` was loaded by `origin_uri`. Idempotent.
@@ -1285,12 +1309,17 @@ where
 ///   collide on one key and serve the `None` (alias-free) scope to the forward
 ///   caller, dropping dataset symbols. The per-query memo never outlives the
 ///   query, so a raw address is a sound, stable identity.
+/// - `prefer_supplied_path_context`: whether ordinary relative sources in this
+///   execution prefer the recursively supplied context over URI-global graph
+///   edges. This is a two-valued resolution mode, not a tar occurrence
+///   identity; omitting it can alias graph-first and lexical-first executions.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ForwardChildKey {
     child_uri: Url,
     path_fp: u64,
     pkg_fp: u64,
     provider_fp: usize,
+    prefer_supplied_path_context: bool,
 }
 
 /// Hash a child's `PathContext` (or its absence) into a `path_fp`. Hashes the
@@ -1400,6 +1429,7 @@ fn resolve_forward_child_memoized(
     child_uri: &Url,
     path_fp: u64,
     provider_fp: usize,
+    prefer_supplied_path_context: bool,
     child_depth: usize,
     packages_for_child: &HashSet<String>,
     is_cancelled: &dyn Fn() -> bool,
@@ -1418,6 +1448,7 @@ fn resolve_forward_child_memoized(
         path_fp,
         pkg_fp: package_set_fingerprint(packages_for_child),
         provider_fp,
+        prefer_supplied_path_context,
     };
     // Reuse only a stored scope whose compute-depth is at least this reach's
     // depth (the stored scope is truncation-free, so a shallower-or-equal reach
@@ -1492,48 +1523,14 @@ fn build_forward_child_path_context<G>(
 where
     G: Fn(&Url) -> Option<std::sync::Arc<super::types::CrossFileMetadata>>,
 {
-    if child_is_standalone {
-        get_metadata(child_uri)
-            .and_then(|m| {
-                super::path_resolve::PathContext::from_metadata(child_uri, &m, workspace_root)
-            })
-            .or_else(|| {
-                super::path_resolve::PathContext::forward_without_metadata(
-                    child_uri,
-                    workspace_root,
-                )
-            })
-    } else {
-        let ctx = parent_ctx?;
-        // Start from the child's own context: its metadata when indexed, else a
-        // bare context rooted at its own directory. Both constructors parse the
-        // child URI's path (and return None if it isn't a file path), so reuse the
-        // parsed `child_ctx.file_path` below instead of parsing the URI again.
-        let mut child_ctx = match get_metadata(child_uri) {
-            Some(cm) => {
-                super::path_resolve::PathContext::from_metadata(child_uri, &cm, workspace_root)?
-            }
-            None => super::path_resolve::PathContext::forward_without_metadata(
-                child_uri,
-                workspace_root,
-            )?,
-        };
-        // Decide the inherited working directory via the shared seam that the
-        // on-demand index walk (`index_forward_chain`) also uses, so the live scope
-        // path and the dependency-graph edge cannot drift: a working directory
-        // propagates only under `chdir` or a `# raven: cd` in effect; with no cd the
-        // child resolves via its own directory + workspace-root fallback (matching
-        // `build_dependency_graph_from_workspace`). This branch is the residual seam
-        // consulted when no resolved graph edge is available. Apply the in-effect WD
-        // only when one propagates and the child declares no own `# raven: cd`;
-        // otherwise the child keeps its own context (its own cd, its own
-        // backward-directive-inherited WD, or none → own dir + fallback).
-        let inherited = ctx.forward_child_inherited_wd(&child_ctx.file_path, chdir);
-        if child_ctx.working_directory.is_none() && inherited.is_some() {
-            child_ctx.inherited_working_directory = inherited;
-        }
-        Some(child_ctx)
-    }
+    super::path_resolve::forward_child_path_context(
+        child_uri,
+        child_is_standalone,
+        chdir,
+        parent_ctx,
+        workspace_root,
+        get_metadata,
+    )
 }
 /// Finds the innermost function-scope interval that contains the given position.
 ///
@@ -1598,7 +1595,9 @@ pub(super) fn event_effect_position(event: &ScopeEvent) -> (u32, u32) {
         // effect position is one column past the call — matching the strict-<
         // check in `scope_at_position_with_graph_recursive` (line 3448).
         // `saturating_add` guards against the (theoretical) u32::MAX column.
-        ScopeEvent::Source { line, column, .. } => (*line, column.saturating_add(1)),
+        ScopeEvent::Source { line, column, .. } | ScopeEvent::TarBatch { line, column, .. } => {
+            (*line, column.saturating_add(1))
+        }
         ScopeEvent::FunctionScope {
             start_line,
             start_column,
@@ -1674,11 +1673,13 @@ fn apply_removal(
         None => {
             for sym in symbols {
                 scope.symbols.remove(sym.as_str());
+                scope.removed_names.insert(Arc::from(sym.as_str()));
             }
         }
         Some(rm_scope) if active_function_scopes.contains(&rm_scope) => {
             for sym in symbols {
                 scope.symbols.remove(sym.as_str());
+                scope.removed_names.insert(Arc::from(sym.as_str()));
             }
         }
         _ => {}
@@ -1782,7 +1783,7 @@ fn annotate_event_function_scopes(artifacts: &mut ScopeArtifacts, line_index: &L
                     None
                 };
             }
-            ScopeEvent::FunctionScope { .. } => {}
+            ScopeEvent::TarBatch { .. } | ScopeEvent::FunctionScope { .. } => {}
         }
     }
 }
@@ -2298,6 +2299,37 @@ pub fn compute_artifacts_with_metadata(
     // Add directive sources from metadata (if provided) that don't overlap with AST sources
     // This ensures `# raven: source` directives are included in scope resolution
     if let Some(meta) = metadata {
+        // Expanded `tar_source()` members share one call site but represent a
+        // single ordered evaluation environment. Keep them out of the ordinary
+        // `Source` path (whose graph lookup and streaming cache are call-site
+        // keyed) and emit one adjudicated batch event per call.
+        let mut batch_members: Vec<ForwardSource> = Vec::new();
+        let mut batch_site: Option<(u32, u32)> = None;
+        let flush_batch = |artifacts: &mut ScopeArtifacts,
+                           batch_site: &mut Option<(u32, u32)>,
+                           batch_members: &mut Vec<ForwardSource>| {
+            if let Some((line, column)) = batch_site.take() {
+                artifacts.timeline.push(ScopeEvent::TarBatch {
+                    line,
+                    column,
+                    members: std::mem::take(batch_members),
+                });
+            }
+        };
+        for source in meta
+            .sources
+            .iter()
+            .filter(|source| source.tar_source_ordinal.is_some())
+        {
+            let site = (source.line, source.column);
+            if batch_site.is_some_and(|existing| existing != site) {
+                flush_batch(&mut artifacts, &mut batch_site, &mut batch_members);
+            }
+            batch_site = Some(site);
+            batch_members.push(source.clone());
+        }
+        flush_batch(&mut artifacts, &mut batch_site, &mut batch_members);
+
         for source in &meta.sources {
             if source.is_directive {
                 // Check if there's already an AST source at the same line pointing to the same path
@@ -2505,7 +2537,7 @@ pub fn scope_at_position(
                     scope.symbols.insert(symbol.name.clone(), symbol.clone());
                 }
             }
-            ScopeEvent::Source { .. } => {
+            ScopeEvent::Source { .. } | ScopeEvent::TarBatch { .. } => {
                 // Source events are handled by the cross-file traversal in
                 // scope_at_position_with_graph
             }
@@ -2716,7 +2748,7 @@ where
                     scope.symbols.insert(symbol.name.clone(), symbol.clone());
                 }
             }
-            ScopeEvent::Source { .. } => {
+            ScopeEvent::Source { .. } | ScopeEvent::TarBatch { .. } => {
                 // Source events are handled by the cross-file traversal in
                 // scope_at_position_with_graph
             }
@@ -5615,6 +5647,7 @@ where
         package_contribution,
         package_query_uri,
         data_alias_provider,
+        false,
         &forward_child_memo,
     )
 }
@@ -5931,6 +5964,7 @@ where
         package_contribution,
         package_query_uri,
         data_alias_provider,
+        false,
         &forward_child_memo,
     )
 }
@@ -6087,6 +6121,10 @@ where
         declared_only: bool,
         package_barrier: bool,
         function_invocation: Option<(u32, u32)>,
+        /// Tar members sharing one call site are distinct executions. Keeping
+        /// the ordinal here prevents the ordinary same-parent substitution
+        /// rule from collapsing their lazy sibling cutoffs.
+        tar_source_ordinal: Option<u32>,
     }
     let mut parent_edge_indices: HashMap<ParentInvocationKey, usize> = HashMap::new();
     let mut parent_edges: Vec<&super::dependency::DependencyEdge> = Vec::new();
@@ -6106,6 +6144,7 @@ where
             declared_only: inheritance_class,
             package_barrier,
             function_invocation,
+            tar_source_ordinal: edge.tar_source_ordinal,
         };
         match parent_edge_indices.get(&key).copied() {
             Some(existing_index) => {
@@ -6198,7 +6237,9 @@ where
         // Note: We pass empty inherited_packages here because the parent will collect
         // its own inherited packages from its parents via the dependency graph
         // We pass base_exports since child files also need access to base R functions
-        let (parent_query_line, parent_query_col) = if query_inside_function {
+        let (parent_query_line, parent_query_col) = if edge.tar_source_ordinal.is_some() {
+            (call_site_line, call_site_col)
+        } else if query_inside_function {
             (u32::MAX, u32::MAX)
         } else {
             (call_site_line, call_site_col)
@@ -6209,7 +6250,8 @@ where
         }
 
         let empty_packages = HashSet::new();
-        let parent_scope = scope_at_position_with_graph_recursive(
+        let batch_visited_base = visited.clone();
+        let mut parent_scope = scope_at_position_with_graph_recursive(
             &edge.from,
             parent_query_line,
             parent_query_col,
@@ -6217,7 +6259,7 @@ where
             get_metadata,
             graph,
             workspace_root,
-            parent_ctx,
+            parent_ctx.clone(),
             max_depth,
             current_depth + 1,
             visited,
@@ -6250,8 +6292,72 @@ where
             // scope for the issue's single-file acceptance criteria; the
             // literal-stem `Def` fallback still flows through the prefix.
             None,
+            false,
             forward_child_memo,
         );
+
+        // A queried tar member sees the exact prefix of siblings executed
+        // before its own ordinal. Compute that prefix lazily only for this
+        // incoming edge, and never evaluate the member itself.
+        if let Some(ordinal) = edge.tar_source_ordinal
+            && let Some(parent_artifacts) = get_artifacts(&edge.from)
+            && let Some(ScopeEvent::TarBatch { members, .. }) =
+                parent_artifacts.timeline.iter().find(|event| {
+                    matches!(
+                        event,
+                        ScopeEvent::TarBatch { line, column, .. }
+                            if *line == call_site_line && *column == call_site_col
+                    )
+                })
+        {
+            let cutoff = usize::try_from(ordinal)
+                .unwrap_or(usize::MAX)
+                .min(members.len());
+            let contribution = resolve_tar_batch_contribution(
+                &edge.from,
+                &members[..cutoff],
+                &parent_scope,
+                get_artifacts,
+                get_metadata,
+                graph,
+                workspace_root,
+                parent_ctx.as_ref(),
+                max_depth,
+                current_depth + 1,
+                &batch_visited_base,
+                base_exports,
+                hoist_globals,
+                backward_dep_mode,
+                is_cancelled,
+                None,
+            );
+            for name in contribution.removed_names {
+                parent_scope.symbols.remove(&name);
+                parent_scope.parent_prefix_symbol_names.remove(&name);
+                parent_scope.removed_names.insert(name);
+            }
+            for (name, symbol) in contribution.symbols {
+                parent_scope.parent_prefix_symbol_names.remove(&name);
+                parent_scope.removed_names.remove(&name);
+                parent_scope.symbols.insert(name, symbol);
+            }
+            parent_scope.chain.extend(contribution.chain);
+            extend_visible_positions(
+                &mut parent_scope.visible_positions,
+                &contribution.visible_positions,
+            );
+            parent_scope
+                .depth_exceeded
+                .extend(contribution.depth_exceeded);
+            for package in contribution.packages {
+                parent_scope.loaded_packages.insert(package.clone());
+                propagate_package_origins(
+                    &contribution.package_origins,
+                    &package,
+                    &mut parent_scope.package_origins,
+                );
+            }
+        }
 
         // Merge parent symbols (they are available at the START of this file).
         // NonInheriting destinations receive declaration facts only. Global and
@@ -6399,6 +6505,195 @@ where
     prefix
 }
 
+/// Resolve one ordered `tar_source()` batch without walking a member's
+/// backward parents.
+///
+/// The supplied `initial_scope` is the environment visible immediately before
+/// the batch. Each member receives that environment plus every preceding
+/// member's effects. A member runs with an explicit pre-computed prefix, which
+/// skips STEP 1 and prevents its incoming tar edge from recursing into the
+/// parent batch. Batch members deliberately bypass both forward-child and
+/// standalone caches: sibling symbols/removals are real inputs that those
+/// URI-keyed caches do not encode. Each member gets its own fork of the same
+/// ancestor `visited` snapshot; member-local visits never suppress a later
+/// sibling.
+#[allow(clippy::too_many_arguments)]
+fn resolve_tar_batch_contribution<F, G>(
+    parent_uri: &Url,
+    members: &[ForwardSource],
+    initial_scope: &ScopeAtPosition,
+    get_artifacts: &F,
+    get_metadata: &G,
+    graph: &super::dependency::DependencyGraph,
+    workspace_root: Option<&Url>,
+    parent_path_ctx: Option<&super::path_resolve::PathContext>,
+    max_depth: usize,
+    current_depth: usize,
+    ancestor_visited: &HashMap<Url, (u32, u32)>,
+    base_exports: &HashSet<String>,
+    hoist_globals: bool,
+    backward_dep_mode: super::config::BackwardDependencyMode,
+    is_cancelled: &dyn Fn() -> bool,
+    data_alias_provider: Option<&DataAliasProvider<'_>>,
+) -> ChildSourceContribution
+where
+    F: Fn(&Url) -> Option<Arc<ScopeArtifacts>>,
+    G: Fn(&Url) -> Option<std::sync::Arc<super::types::CrossFileMetadata>>,
+{
+    let mut contribution = ChildSourceContribution::default();
+    let mut rolling_symbols = initial_scope.symbols.clone();
+    let mut rolling_packages: HashSet<String> = initial_scope
+        .inherited_packages
+        .iter()
+        .chain(initial_scope.loaded_packages.iter())
+        .cloned()
+        .collect();
+    let mut rolling_origins = initial_scope.package_origins.clone();
+
+    for source in members {
+        if is_cancelled() {
+            break;
+        }
+        let ordinal = source.tar_source_ordinal;
+        let child_uri = source.resolved_uri.clone().or_else(|| {
+            graph
+                .get_dependencies(parent_uri)
+                .iter()
+                .find(|edge| {
+                    edge.call_site_line == Some(source.line)
+                        && edge.call_site_column == Some(source.column)
+                        && edge.tar_source_ordinal == ordinal
+                })
+                .map(|edge| edge.to.clone())
+        });
+        let Some(child_uri) = child_uri else {
+            continue;
+        };
+        if current_depth + 1 >= max_depth {
+            contribution
+                .depth_exceeded
+                .push((parent_uri.clone(), source.line, source.column));
+            continue;
+        }
+
+        let child_is_standalone = get_metadata(&child_uri).is_some_and(|m| m.standalone);
+        let child_ctx = build_forward_child_path_context(
+            &child_uri,
+            child_is_standalone,
+            source.chdir,
+            parent_path_ctx,
+            workspace_root,
+            get_metadata,
+        );
+
+        let member_prefix = if child_is_standalone {
+            Arc::new(ParentPrefix::default())
+        } else {
+            Arc::new(ParentPrefix {
+                symbols: rolling_symbols.clone(),
+                inherited_packages: rolling_packages.clone(),
+                package_origins: rolling_origins.clone(),
+                ..ParentPrefix::default()
+            })
+        };
+        let child_provider = if child_is_standalone {
+            None
+        } else {
+            data_alias_provider
+        };
+        let mut member_visited = ancestor_visited.clone();
+        // A fresh memo has no standalone-cache context. Passing
+        // `isolate_forward_source_visits = false` below also keeps every
+        // ordinary descendant off ForwardChildMemo for this batch execution.
+        let member_forward_memo = std::cell::RefCell::new(ForwardChildMemo::default());
+        let empty_packages = HashSet::new();
+        let member_scope = scope_at_position_with_graph_recursive(
+            &child_uri,
+            u32::MAX,
+            u32::MAX,
+            get_artifacts,
+            get_metadata,
+            graph,
+            workspace_root,
+            child_ctx,
+            max_depth,
+            current_depth + 1,
+            &mut member_visited,
+            &empty_packages,
+            base_exports,
+            hoist_globals,
+            backward_dep_mode,
+            is_cancelled,
+            false,
+            Some(&member_prefix),
+            None,
+            None,
+            child_provider,
+            true,
+            &member_forward_memo,
+        );
+
+        extend_visible_positions(
+            &mut contribution.visible_positions,
+            &member_scope.visible_positions,
+        );
+        contribution
+            .chain
+            .extend(member_scope.chain.iter().cloned());
+        contribution
+            .depth_exceeded
+            .extend(member_scope.depth_exceeded.iter().cloned());
+
+        // Removals cross member boundaries because every script evaluates in
+        // the same targets environment.
+        for name in &member_scope.removed_names {
+            rolling_symbols.remove(name);
+            contribution.symbols.remove(name);
+            contribution.removed_names.insert(name.clone());
+        }
+
+        // Parent-prefix-only names are inherited environment, not bindings
+        // produced by executing this member.
+        for (name, symbol) in member_scope.symbols {
+            if member_scope.parent_prefix_symbol_names.contains(&name) {
+                continue;
+            }
+            rolling_symbols.insert(name.clone(), symbol.clone());
+            contribution.removed_names.remove(&name);
+            contribution.symbols.insert(name, symbol);
+        }
+
+        // Only packages attached while executing the member are new batch
+        // effects. Their origin remains the loading member (or its descendant),
+        // never the batch parent, so same-file leak filtering stays sound.
+        for package in member_scope.loaded_packages {
+            rolling_packages.insert(package.clone());
+            contribution.packages.insert(package.clone());
+            propagate_package_origins(
+                &member_scope.package_origins,
+                &package,
+                &mut rolling_origins,
+            );
+            propagate_package_origins(
+                &member_scope.package_origins,
+                &package,
+                &mut contribution.package_origins,
+            );
+        }
+    }
+
+    let member_chain = std::mem::take(&mut contribution.chain);
+    extend_chain_first_seen(&mut contribution.chain, member_chain);
+    contribution.depth_exceeded.sort_unstable_by(|left, right| {
+        left.0
+            .as_str()
+            .cmp(right.0.as_str())
+            .then_with(|| (left.1, left.2).cmp(&(right.1, right.2)))
+    });
+    contribution.depth_exceeded.dedup();
+    contribution
+}
+
 /// Compute the lexical and cross-file scope visible at a position using the dependency graph.
 ///
 /// This collects symbols visible at (line, column) in `uri` by merging parent (backward) symbols
@@ -6475,6 +6770,14 @@ fn scope_at_position_with_graph_recursive<F, G>(
     // receive it — that prefix is cached provider-independently, so it always
     // passes `None`. `None` disables expansion (literal-stem `Def` fallback).
     data_alias_provider: Option<&DataAliasProvider<'_>>,
+    // A direct tar-batch member may execute more than once with distinct
+    // inherited/chdir contexts. For that one execution, ordinary relative
+    // source paths must prefer this recursively supplied context over the
+    // URI-global graph edge. The preference and derived context propagate
+    // through non-standalone ordinary descendants without carrying any
+    // call-site/ordinal identity. `system.file` stays pre-resolved, and a
+    // standalone child severs caller context.
+    prefer_supplied_path_context: bool,
     // Per-query memo of forward-sourced child EOF scopes (issue #472). Threaded
     // through STEP 1's parent walk and STEP 2's forward children so each
     // distinct `(child, path context, package set)` is resolved once per
@@ -6822,6 +7125,7 @@ where
                     column,
                     query_inside_function,
                 ) {
+                    scope.removed_names.remove(&symbol.name);
                     scope.symbols.insert(symbol.name.clone(), symbol.clone());
                     scope.parent_prefix_symbol_names.remove(&symbol.name);
                 }
@@ -6860,32 +7164,36 @@ where
                     // (which doesn't). This ensures paths like source("subdir/file.R")
                     // that rely on workspace-root-relative resolution work correctly
                     // in scope resolution, matching the dependency graph's behavior.
-                    let child_uri = graph
-                        .get_dependencies(uri)
-                        .iter()
-                        .find(|edge| {
-                            edge.call_site_line == Some(*src_line)
-                                && edge.call_site_column == Some(*src_col)
+                    let resolve_lexically = || {
+                        path_ctx.as_ref().and_then(|ctx| {
+                            let resolved =
+                                super::path_resolve::resolve_path_with_workspace_fallback(
+                                    &source.path,
+                                    ctx,
+                                )?;
+                            super::path_resolve::path_to_uri(&resolved)
                         })
-                        .map(|edge| edge.to.clone())
-                        .or_else(|| {
-                            // Fallback: use pre-resolved URI or resolve path
-                            // directly. Forward source()/directive paths use the
-                            // workspace-root fallback variant so this last-resort
-                            // seam honors the same fallback invariant as the graph
-                            // edge it stands in for (CLAUDE.md: the fallback must
-                            // hold uniformly across scope resolution).
-                            source.resolved_uri.clone().or_else(|| {
-                                path_ctx.as_ref().and_then(|ctx| {
-                                    let resolved =
-                                        super::path_resolve::resolve_path_with_workspace_fallback(
-                                            &source.path,
-                                            ctx,
-                                        )?;
-                                    super::path_resolve::path_to_uri(&resolved)
-                                })
+                    };
+                    let graph_uri = || {
+                        graph
+                            .get_dependencies(uri)
+                            .iter()
+                            .find(|edge| {
+                                edge.call_site_line == Some(*src_line)
+                                    && edge.call_site_column == Some(*src_col)
                             })
-                        });
+                            .map(|edge| edge.to.clone())
+                    };
+                    let child_uri = if prefer_supplied_path_context && source.system_file.is_none()
+                    {
+                        resolve_lexically()
+                            .or_else(|| source.resolved_uri.clone())
+                            .or_else(graph_uri)
+                    } else {
+                        graph_uri()
+                            .or_else(|| source.resolved_uri.clone())
+                            .or_else(resolve_lexically)
+                    };
 
                     if let Some(child_uri) = child_uri {
                         // Check if we would exceed max depth
@@ -6988,6 +7296,8 @@ where
                             workspace_root,
                             get_metadata,
                         );
+                        let child_prefer_supplied_path_context =
+                            prefer_supplied_path_context && !child_is_standalone;
 
                         // Early exit on cancellation before expensive recursive traversal
                         if is_cancelled() {
@@ -7020,6 +7330,7 @@ where
                                 &child_uri,
                                 path_fp,
                                 provider_fp,
+                                child_prefer_supplied_path_context,
                                 current_depth + 1,
                                 packages_for_child,
                                 is_cancelled,
@@ -7054,6 +7365,7 @@ where
                                         None,
                                         None,
                                         child_provider,
+                                        child_prefer_supplied_path_context,
                                         forward_child_memo,
                                     )
                                 },
@@ -7081,6 +7393,7 @@ where
                                 None,
                                 None,
                                 child_provider,
+                                child_prefer_supplied_path_context,
                                 forward_child_memo,
                             )
                         };
@@ -7140,8 +7453,10 @@ where
                                     continue;
                                 }
                                 if scope.parent_prefix_symbol_names.remove(&name) {
+                                    scope.removed_names.remove(&name);
                                     scope.symbols.insert(name, symbol);
                                 } else {
+                                    scope.removed_names.remove(&name);
                                     scope.symbols.entry(name).or_insert(symbol);
                                 }
                             }
@@ -7170,6 +7485,70 @@ where
                     }
                 }
             }
+            ScopeEvent::TarBatch {
+                line: batch_line,
+                column: batch_column,
+                members,
+            } => {
+                let passes_position = (*batch_line, *batch_column) < (line, column);
+                if !(passes_position || query_inside_function) {
+                    continue;
+                }
+                if current_depth + 1 >= max_depth {
+                    scope
+                        .depth_exceeded
+                        .push((uri.clone(), *batch_line, *batch_column));
+                    continue;
+                }
+                let visited_base = forward_visited_base.as_ref().unwrap_or(visited);
+                let contribution = resolve_tar_batch_contribution(
+                    uri,
+                    members,
+                    &scope,
+                    get_artifacts,
+                    get_metadata,
+                    graph,
+                    workspace_root,
+                    path_ctx.as_ref(),
+                    max_depth,
+                    current_depth,
+                    visited_base,
+                    base_exports,
+                    hoist_globals,
+                    backward_dep_mode,
+                    is_cancelled,
+                    data_alias_provider,
+                );
+                for name in contribution.removed_names {
+                    scope.symbols.remove(&name);
+                    scope.parent_prefix_symbol_names.remove(&name);
+                    scope.removed_names.insert(name);
+                }
+                for (name, symbol) in contribution.symbols {
+                    if scope.parent_prefix_symbol_names.contains(&name) {
+                        forward_contributed.insert(name.clone());
+                    }
+                    scope.parent_prefix_symbol_names.remove(&name);
+                    scope.removed_names.remove(&name);
+                    // Ordered tar members share one environment: the batch's
+                    // later winner replaces any binding visible before it.
+                    scope.symbols.insert(name, symbol);
+                }
+                extend_chain_first_seen(&mut scope.chain, contribution.chain);
+                extend_visible_positions(
+                    &mut scope.visible_positions,
+                    &contribution.visible_positions,
+                );
+                scope.depth_exceeded.extend(contribution.depth_exceeded);
+                for package in contribution.packages {
+                    scope.loaded_packages.insert(package.clone());
+                    propagate_package_origins(
+                        &contribution.package_origins,
+                        &package,
+                        &mut scope.package_origins,
+                    );
+                }
+            }
             ScopeEvent::FunctionScope {
                 start_line,
                 start_column,
@@ -7185,6 +7564,7 @@ where
                     && (line, column) <= (*end_line, *end_column)
                 {
                     for param in parameters {
+                        scope.removed_names.remove(&param.name);
                         scope.symbols.insert(param.name.clone(), param.clone());
                         scope.parent_prefix_symbol_names.remove(&param.name);
                     }
@@ -7266,6 +7646,7 @@ where
                             }
                         })
                         .or_insert_with(|| symbol.clone());
+                    scope.removed_names.remove(&symbol.name);
                 }
             }
             ScopeEvent::DataLoad {
@@ -7309,6 +7690,7 @@ where
                         };
                         for (name, symbol) in expand_data_load(stems, package, &attached, provider)
                         {
+                            scope.removed_names.remove(&name);
                             scope.parent_prefix_symbol_names.remove(&name);
                             scope.symbols.insert(name, symbol);
                         }
@@ -7990,11 +8372,33 @@ struct ScopeFrame {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChildSourceContribution {
     pub symbols: HashMap<Arc<str>, ScopedSymbol>,
+    pub removed_names: HashSet<Arc<str>>,
     pub packages: HashSet<String>,
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
     pub chain: Vec<Url>,
     pub visible_positions: HashMap<Url, (u32, u32)>,
     pub depth_exceeded: Vec<(Url, u32, u32)>,
+}
+
+fn merge_tar_batch_into_frame(frame: &mut ScopeFrame, contribution: ChildSourceContribution) {
+    for name in contribution.removed_names {
+        frame.symbols.remove(&name);
+        frame.removed_names.insert(name);
+    }
+    for (name, symbol) in contribution.symbols {
+        frame.removed_names.remove(&name);
+        // A tar batch is one sequential environment: the last member to bind
+        // a name wins over both earlier members and the pre-batch frame.
+        frame.symbols.insert(name, symbol);
+    }
+    frame.packages.extend(contribution.packages);
+    for (package, origins) in contribution.package_origins {
+        frame
+            .package_origins
+            .entry(package)
+            .or_default()
+            .extend(origins);
+    }
 }
 
 /// Streaming scope state.
@@ -8063,6 +8467,10 @@ where
     /// position. The same call site may be applied to both the strict and
     /// late frames; computing once and reusing is the whole point.
     source_contributions: HashMap<(u32, u32), ChildSourceContribution>,
+    /// Ordered `targets::tar_source()` batch contributions. Kept separate
+    /// from ordinary source contributions because the two event kinds have
+    /// different merge semantics.
+    tar_batch_contributions: HashMap<(u32, u32, bool), ChildSourceContribution>,
 
     /// Cross-file resolution context (closures + config, mirrors
     /// `scope_at_position_with_graph_cached`'s parameters).
@@ -8407,6 +8815,7 @@ where
             timeline_cursor: 0,
             cursor: (0, 0),
             source_contributions: HashMap::new(),
+            tar_batch_contributions: HashMap::new(),
             get_artifacts,
             get_metadata,
             graph,
@@ -8606,6 +9015,22 @@ where
                     }
                 }
             }
+            ScopeEvent::TarBatch {
+                line,
+                column,
+                members,
+            } => {
+                let key = (line, column, false);
+                if !self.tar_batch_contributions.contains_key(&key) {
+                    let initial_scope =
+                        Self::tar_batch_initial_scope(&self.prefix_top, &self.global_strict_frame);
+                    let contribution =
+                        self.resolve_tar_batch(line, column, &members, &initial_scope);
+                    self.tar_batch_contributions.insert(key, contribution);
+                }
+                let contribution = self.tar_batch_contributions[&key].clone();
+                merge_tar_batch_into_frame(&mut self.global_strict_frame, contribution);
+            }
             ScopeEvent::Declaration {
                 symbol,
                 function_scope,
@@ -8683,6 +9108,76 @@ where
         }
         out.extend(self.choose_prefix().inherited_packages.iter().cloned());
         out
+    }
+
+    /// Materialize the environment visible immediately before a global tar
+    /// batch from the supplied streaming frame.
+    fn tar_batch_initial_scope(prefix: &ParentPrefix, frame: &ScopeFrame) -> ScopeAtPosition {
+        let mut symbols = prefix.symbols.clone();
+        let mut parent_prefix_symbol_names: HashSet<Arc<str>> = symbols.keys().cloned().collect();
+        for (name, symbol) in &frame.symbols {
+            parent_prefix_symbol_names.remove(name);
+            symbols.insert(name.clone(), symbol.clone());
+        }
+        for name in &frame.removed_names {
+            symbols.remove(name);
+            parent_prefix_symbol_names.remove(name);
+        }
+
+        let mut package_origins = prefix.package_origins.clone();
+        for (package, origins) in &frame.package_origins {
+            package_origins
+                .entry(package.clone())
+                .or_default()
+                .extend(origins.iter().cloned());
+        }
+
+        ScopeAtPosition {
+            symbols,
+            removed_names: frame.removed_names.clone(),
+            chain: Vec::new(),
+            parent_prefix_symbol_names,
+            visible_positions: HashMap::new(),
+            depth_exceeded: Vec::new(),
+            inherited_packages: prefix.inherited_packages.clone(),
+            loaded_packages: frame.packages.clone(),
+            package_origins,
+        }
+    }
+
+    fn resolve_tar_batch(
+        &self,
+        line: u32,
+        column: u32,
+        members: &[ForwardSource],
+        initial_scope: &ScopeAtPosition,
+    ) -> ChildSourceContribution {
+        let mut visited = HashMap::new();
+        visited.insert(self.queried_uri.clone(), (u32::MAX, u32::MAX));
+        let mut contribution = resolve_tar_batch_contribution(
+            self.queried_uri,
+            members,
+            initial_scope,
+            self.get_artifacts,
+            self.get_metadata,
+            self.graph,
+            self.workspace_root,
+            self.path_ctx.as_ref(),
+            self.max_depth,
+            0,
+            &visited,
+            self.base_exports,
+            self.hoist_globals,
+            self.backward_dep_mode,
+            self.is_cancelled,
+            self.data_alias_provider,
+        );
+        if self.max_depth <= 1 && contribution.depth_exceeded.is_empty() {
+            contribution
+                .depth_exceeded
+                .push((self.queried_uri.clone(), line, column));
+        }
+        contribution
     }
 
     /// Pick the frame to apply an event with the given `function_scope` to.
@@ -8798,6 +9293,7 @@ where
         );
         let mut scope = ScopeAtPosition {
             symbols: prefix.symbols.clone(),
+            removed_names: HashSet::new(),
             chain,
             parent_prefix_symbol_names: prefix.symbols.keys().cloned().collect(),
             visible_positions,
@@ -8878,10 +9374,12 @@ where
         // flat set is consistent with the recursive resolver's timeline order.
         for name in &global.removed_names {
             scope.symbols.remove(name);
+            scope.removed_names.insert(name.clone());
         }
         for (_iv, frame) in &self.function_stack {
             for name in &frame.removed_names {
                 scope.symbols.remove(name);
+                scope.removed_names.insert(name.clone());
             }
         }
 
@@ -8906,6 +9404,20 @@ where
             let effect_col = src_col.saturating_add(1);
             if (src_line, effect_col) <= self.cursor {
                 scope.chain.extend(contrib.chain.iter().cloned());
+                extend_visible_positions(&mut scope.visible_positions, &contrib.visible_positions);
+                scope
+                    .depth_exceeded
+                    .extend(contrib.depth_exceeded.iter().cloned());
+            }
+        }
+        let inside = self.query_inside_function();
+        for (&(batch_line, batch_col, late), contrib) in &self.tar_batch_contributions {
+            if late != inside {
+                continue;
+            }
+            let effect_col = batch_col.saturating_add(1);
+            if late || (batch_line, effect_col) <= self.cursor {
+                extend_chain_first_seen(&mut scope.chain, contrib.chain.iter().cloned());
                 extend_visible_positions(&mut scope.visible_positions, &contrib.visible_positions);
                 scope
                     .depth_exceeded
@@ -9133,6 +9645,22 @@ where
                         .extend(origins);
                 }
             }
+            ScopeEvent::TarBatch {
+                line,
+                column,
+                members,
+            } => {
+                let key = (*line, *column, true);
+                if !self.tar_batch_contributions.contains_key(&key) {
+                    let initial_scope =
+                        Self::tar_batch_initial_scope(&self.prefix_in_function, frame);
+                    let contribution =
+                        self.resolve_tar_batch(*line, *column, members, &initial_scope);
+                    self.tar_batch_contributions.insert(key, contribution);
+                }
+                let contribution = self.tar_batch_contributions[&key].clone();
+                merge_tar_batch_into_frame(frame, contribution);
+            }
             ScopeEvent::Declaration {
                 symbol,
                 function_scope,
@@ -9320,6 +9848,7 @@ where
             &child_uri,
             path_fp,
             provider_fp,
+            false,
             1,
             &empty_packages,
             self.is_cancelled,
@@ -9346,6 +9875,7 @@ where
                     None,
                     None,
                     child_provider,
+                    false,
                     &self.forward_child_memo,
                 )
             },
@@ -13210,6 +13740,7 @@ outside_var <- 2"#;
         parent_artifacts.timeline.sort_by_key(|event| match event {
             ScopeEvent::Def { line, column, .. } => (*line, *column),
             ScopeEvent::Source { line, column, .. } => (*line, *column),
+            ScopeEvent::TarBatch { line, column, .. } => (*line, *column),
             ScopeEvent::FunctionScope {
                 start_line,
                 start_column,
@@ -13640,6 +14171,7 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
         parent_artifacts.timeline.sort_by_key(|event| match event {
             ScopeEvent::Def { line, column, .. } => (*line, *column),
             ScopeEvent::Source { line, column, .. } => (*line, *column),
+            ScopeEvent::TarBatch { line, column, .. } => (*line, *column),
             ScopeEvent::FunctionScope {
                 start_line,
                 start_column,
@@ -15021,6 +15553,7 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
             .iter()
             .map(|e| match e {
                 ScopeEvent::Source { .. } => "Source",
+                ScopeEvent::TarBatch { .. } => "TarBatch",
                 ScopeEvent::Removal { .. } => "Removal",
                 _ => "Other",
             })
@@ -15103,6 +15636,7 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
             .map(|e| match e {
                 ScopeEvent::Def { .. } => "Def",
                 ScopeEvent::Source { .. } => "Source",
+                ScopeEvent::TarBatch { .. } => "TarBatch",
                 ScopeEvent::FunctionScope { .. } => "FunctionScope",
                 ScopeEvent::Removal { .. } => "Removal",
                 ScopeEvent::PackageLoad { .. } => "PackageLoad",
@@ -15122,6 +15656,7 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
             .map(|e| match e {
                 ScopeEvent::Def { line, .. } => *line,
                 ScopeEvent::Source { line, .. } => *line,
+                ScopeEvent::TarBatch { line, .. } => *line,
                 ScopeEvent::FunctionScope { start_line, .. } => *start_line,
                 ScopeEvent::Removal { line, .. } => *line,
                 ScopeEvent::PackageLoad { line, .. } => *line,
@@ -15738,6 +16273,7 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
             .map(|e| match e {
                 ScopeEvent::Def { line, .. } => ("Def", *line),
                 ScopeEvent::Source { line, .. } => ("Source", *line),
+                ScopeEvent::TarBatch { line, .. } => ("TarBatch", *line),
                 ScopeEvent::FunctionScope { start_line, .. } => ("FunctionScope", *start_line),
                 ScopeEvent::Removal { line, .. } => ("Removal", *line),
                 ScopeEvent::PackageLoad { line, .. } => ("PackageLoad", *line),
@@ -31212,6 +31748,953 @@ mod package_contribution_tests {
             !scope.symbols.contains_key("mpg"),
             "dataset 'mpg' must NOT be visible outside workspace. visible: {:?}",
             scope.symbols.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn tar_batch_is_sequential_with_later_winner_and_removal() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        std::fs::write(root.join("R/01-first.R"), "shared <- 1\nkept <- 1\n").unwrap();
+        std::fs::write(root.join("R/02-second.R"), "shared <- 2\nrm(kept)\n").unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let first_uri = Url::from_file_path(root.join("R/01-first.R")).unwrap();
+        let second_uri = Url::from_file_path(root.join("R/02-second.R")).unwrap();
+
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let first_code = "shared <- 1\nkept <- 1\n";
+        let second_code = "shared <- 2\nrm(kept)\n";
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (
+                first_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(first_code)),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(second_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                first_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &first_uri,
+                    &parse_r(first_code),
+                    first_code,
+                )),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &second_uri,
+                    &parse_r(second_code),
+                    second_code,
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let scope = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            None,
+        );
+        assert_eq!(
+            scope.symbols.get("shared").map(|symbol| &symbol.source_uri),
+            Some(&second_uri),
+            "the later tar member must replace the earlier binding"
+        );
+        assert!(
+            !scope.symbols.contains_key("kept"),
+            "a later tar member removal must cross the sibling boundary"
+        );
+
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+        let base_exports = HashSet::new();
+        let mut stream = ScopeStream::new(
+            &parent_uri,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            &prefix_cache,
+            None,
+            None,
+        )
+        .unwrap();
+        stream.advance_to(u32::MAX, u32::MAX);
+        let streamed = stream.snapshot();
+        assert_eq!(
+            streamed
+                .symbols
+                .get("shared")
+                .map(|symbol| &symbol.source_uri),
+            Some(&second_uri)
+        );
+        assert!(!streamed.symbols.contains_key("kept"));
+    }
+
+    #[test]
+    fn tar_option_packages_flow_into_tar_member_and_member_definition_flows_back() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let member_code = "build_result <- function(df) mutate(df, ready = TRUE)\n";
+        std::fs::write(root.join("R/build.R"), member_code).unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "library(targets)\n\
+                           tar_option_set(packages = c(\"dplyr\"))\n\
+                           targets::tar_source(\"R\")\n\
+                           build_result(data.frame())\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let member_uri = Url::from_file_path(root.join("R/build.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let member_metadata = crate::cross_file::extract_metadata(member_code);
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (member_uri.clone(), Arc::new(member_metadata.clone())),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                member_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &member_uri,
+                    &parse_r(member_code),
+                    member_code,
+                    Some(&member_metadata),
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+
+        let member_scope = scope_at_position_with_graph(
+            &member_uri,
+            0,
+            0,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(
+            member_scope.inherited_packages.contains("dplyr"),
+            "`tar_option_set(packages = ...)` before the batch must reach the tar member: {:?}",
+            member_scope.inherited_packages
+        );
+
+        let parent_scope = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            None,
+        );
+        assert_eq!(
+            parent_scope
+                .symbols
+                .get("build_result")
+                .map(|symbol| &symbol.source_uri),
+            Some(&member_uri),
+            "the tar member definition must flow back into `_targets.R` after the batch"
+        );
+    }
+
+    #[test]
+    fn non_inheriting_tar_driver_keeps_process_packages_but_not_member_symbols() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let main_path = root.join("main.R");
+        let main_code = "sys.source(\"driver.R\", envir = new.env())\n";
+        std::fs::write(&main_path, main_code).unwrap();
+        let driver_path = root.join("driver.R");
+        let driver_code = "targets::tar_source(\"member.R\")\n";
+        std::fs::write(&driver_path, driver_code).unwrap();
+        let member_path = root.join("member.R");
+        let member_code = "library(syntheticpkg)\nprivate_member <- 1\n";
+        std::fs::write(&member_path, member_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let main_uri = Url::from_file_path(&main_path).unwrap();
+        let driver_uri = Url::from_file_path(&driver_path).unwrap();
+        let member_uri = Url::from_file_path(&member_path).unwrap();
+        let main_metadata = crate::cross_file::extract_metadata(main_code);
+        assert_eq!(
+            main_metadata.sources[0].locality,
+            super::super::types::SourceLocality::NonInheriting
+        );
+        let mut driver_metadata = crate::cross_file::extract_metadata(driver_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut driver_metadata,
+            &driver_uri,
+            Some(&root_uri),
+        );
+        let member_metadata = crate::cross_file::extract_metadata(member_code);
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (main_uri.clone(), Arc::new(main_metadata.clone())),
+            (driver_uri.clone(), Arc::new(driver_metadata.clone())),
+            (member_uri.clone(), Arc::new(member_metadata.clone())),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                main_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &main_uri,
+                    &parse_r(main_code),
+                    main_code,
+                    Some(&main_metadata),
+                )),
+            ),
+            (
+                driver_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &driver_uri,
+                    &parse_r(driver_code),
+                    driver_code,
+                    Some(&driver_metadata),
+                )),
+            ),
+            (
+                member_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &member_uri,
+                    &parse_r(member_code),
+                    member_code,
+                    Some(&member_metadata),
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&main_uri, &main_metadata, Some(&root_uri), |_| None);
+        graph.update_file(&driver_uri, &driver_metadata, Some(&root_uri), |_| None);
+
+        let scope = scope_at_position_with_graph(
+            &main_uri,
+            u32::MAX,
+            u32::MAX,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(
+            scope.loaded_packages.contains("syntheticpkg"),
+            "NonInheriting execution must retain the member's process-wide package attachment: {:?}",
+            scope.loaded_packages
+        );
+        assert!(
+            !scope.symbols.contains_key("private_member"),
+            "NonInheriting merge must still suppress ordinary member symbols"
+        );
+    }
+
+    #[test]
+    fn tar_batch_rolls_packages_origins_and_data_aliases_across_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let first_code = "library(dplyr)\n";
+        let second_code = "data(api)\nlibrary(tidyr)\n";
+        std::fs::write(root.join("R/01-packages.R"), first_code).unwrap();
+        std::fs::write(root.join("R/02-data.R"), second_code).unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let first_uri = Url::from_file_path(root.join("R/01-packages.R")).unwrap();
+        let second_uri = Url::from_file_path(root.join("R/02-data.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (
+                first_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(first_code)),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(second_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                first_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &first_uri,
+                    &parse_r(first_code),
+                    first_code,
+                )),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &second_uri,
+                    &parse_r(second_code),
+                    second_code,
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let lookup = |package: &str, stem: &str| {
+            if package == "dplyr" && stem == "api" {
+                vec!["api_rows".to_string()]
+            } else {
+                Vec::new()
+            }
+        };
+        let base_packages = HashSet::new();
+        let provider = DataAliasProvider {
+            lookup: &lookup,
+            base_packages: &base_packages,
+        };
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let scope = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            Some(&provider),
+        );
+        for package in ["dplyr", "tidyr"] {
+            assert!(
+                scope.loaded_packages.contains(package),
+                "{package} must roll into the parent batch scope: {:?}",
+                scope.loaded_packages
+            );
+        }
+        assert_eq!(
+            scope
+                .symbols
+                .get("api_rows")
+                .map(|symbol| symbol.source_uri.as_str()),
+            Some("package:dplyr"),
+            "the second sibling's bare data() must see the first sibling's package"
+        );
+        assert!(
+            scope.package_origins["dplyr"]
+                .iter()
+                .any(|origin| origin.as_ref() == &first_uri)
+        );
+        assert!(
+            scope.package_origins["tidyr"]
+                .iter()
+                .any(|origin| origin.as_ref() == &second_uri)
+        );
+
+        let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+        let base_exports = HashSet::new();
+        let mut stream = ScopeStream::new(
+            &parent_uri,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            &prefix_cache,
+            None,
+            Some(&provider),
+        )
+        .unwrap();
+        stream.advance_to(u32::MAX, u32::MAX);
+        let streamed = stream.snapshot();
+        assert_eq!(streamed.symbols, scope.symbols);
+        assert_eq!(streamed.loaded_packages, scope.loaded_packages);
+        assert_eq!(streamed.inherited_packages, scope.inherited_packages);
+        assert_eq!(streamed.package_origins, scope.package_origins);
+    }
+
+    #[test]
+    fn standalone_tar_member_isolated_from_earlier_sibling_inputs() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let first_code = "earlier <- 1\nlibrary(dplyr)\n";
+        let second_code = "# raven: standalone\ndata(api)\nlibrary(tidyr)\n";
+        std::fs::write(root.join("R/01-first.R"), first_code).unwrap();
+        std::fs::write(root.join("R/02-standalone.R"), second_code).unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let first_uri = Url::from_file_path(root.join("R/01-first.R")).unwrap();
+        let second_uri = Url::from_file_path(root.join("R/02-standalone.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (
+                first_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(first_code)),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(second_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                first_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &first_uri,
+                    &parse_r(first_code),
+                    first_code,
+                )),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &second_uri,
+                    &parse_r(second_code),
+                    second_code,
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let lookup = |package: &str, stem: &str| {
+            if package == "dplyr" && stem == "api" {
+                vec!["api_rows".to_string()]
+            } else {
+                Vec::new()
+            }
+        };
+        let base_packages = HashSet::new();
+        let provider = DataAliasProvider {
+            lookup: &lookup,
+            base_packages: &base_packages,
+        };
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let parent_scope = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            Some(&provider),
+        );
+        assert!(parent_scope.loaded_packages.contains("dplyr"));
+        assert!(parent_scope.loaded_packages.contains("tidyr"));
+        assert!(
+            !parent_scope.symbols.contains_key("api_rows"),
+            "a standalone member must not receive the earlier sibling's package or data provider"
+        );
+
+        let member_scope = scope_at_position_with_graph(
+            &second_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            Some(&provider),
+        );
+        assert!(!member_scope.symbols.contains_key("earlier"));
+        assert!(!member_scope.inherited_packages.contains("dplyr"));
+        assert!(member_scope.loaded_packages.contains("tidyr"));
+    }
+
+    #[test]
+    fn tar_batch_stream_uses_late_prefix_and_preserves_hoisted_provenance() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let member_code = "data(api)\n";
+        std::fs::write(root.join("R/data.R"), member_code).unwrap();
+        let target_code = "targets::tar_source(\"R\")\nf <- function() {\n  api_rows\n}\n";
+        let target_path = root.join("_targets.R");
+        std::fs::write(&target_path, target_code).unwrap();
+        let driver_code = "source(\"_targets.R\")\nlibrary(dplyr)\n";
+        let driver_path = root.join("driver.R");
+        std::fs::write(&driver_path, driver_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let target_uri = Url::from_file_path(target_path).unwrap();
+        let member_uri = Url::from_file_path(root.join("R/data.R")).unwrap();
+        let driver_uri = Url::from_file_path(driver_path).unwrap();
+        let mut target_metadata = crate::cross_file::extract_metadata(target_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut target_metadata,
+            &target_uri,
+            Some(&root_uri),
+        );
+        let driver_metadata = crate::cross_file::extract_metadata(driver_code);
+        let member_metadata = crate::cross_file::extract_metadata(member_code);
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (target_uri.clone(), Arc::new(target_metadata.clone())),
+            (driver_uri.clone(), Arc::new(driver_metadata.clone())),
+            (member_uri.clone(), Arc::new(member_metadata)),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                target_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &target_uri,
+                    &parse_r(target_code),
+                    target_code,
+                    Some(&target_metadata),
+                )),
+            ),
+            (
+                driver_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &driver_uri,
+                    &parse_r(driver_code),
+                    driver_code,
+                )),
+            ),
+            (
+                member_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &member_uri,
+                    &parse_r(member_code),
+                    member_code,
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&target_uri, &target_metadata, Some(&root_uri), |_| None);
+        graph.update_file(&driver_uri, &driver_metadata, Some(&root_uri), |_| None);
+        let lookup = |package: &str, stem: &str| {
+            if package == "dplyr" && stem == "api" {
+                vec!["api_rows".to_string()]
+            } else {
+                Vec::new()
+            }
+        };
+        let base_packages = HashSet::new();
+        let provider = DataAliasProvider {
+            lookup: &lookup,
+            base_packages: &base_packages,
+        };
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let base_exports = HashSet::new();
+        let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+        let mut stream = ScopeStream::new(
+            &target_uri,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            true,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            &prefix_cache,
+            None,
+            Some(&provider),
+        )
+        .unwrap();
+
+        stream.advance_to(0, u32::MAX);
+        assert!(
+            !stream.snapshot().symbols.contains_key("api_rows"),
+            "the strict prefix at the tar call must not see the driver's later package"
+        );
+        stream.advance_to(2, 4);
+        let streamed = stream.snapshot();
+        let recursive = scope_at_position_with_graph(
+            &target_uri,
+            2,
+            4,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            true,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            Some(&provider),
+        );
+        assert!(
+            recursive.symbols.contains_key("api_rows"),
+            "the in-function late prefix must hoist the driver's later dplyr attachment"
+        );
+        assert_eq!(streamed.symbols, recursive.symbols);
+        assert_eq!(streamed.loaded_packages, recursive.loaded_packages);
+        assert_eq!(streamed.inherited_packages, recursive.inherited_packages);
+        assert_eq!(streamed.package_origins, recursive.package_origins);
+        assert_eq!(streamed.chain, recursive.chain);
+        assert_eq!(streamed.visible_positions, recursive.visible_positions);
+        assert!(
+            streamed.chain.contains(&member_uri),
+            "late-hoisted batch provenance must retain the member URI"
+        );
+    }
+
+    #[test]
+    fn tar_batch_resolves_each_member_once_at_scale() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+
+        let mut metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> =
+            HashMap::new();
+        let mut artifacts: HashMap<Url, Arc<ScopeArtifacts>> = HashMap::new();
+        let mut members = Vec::new();
+        for ordinal in 0..32 {
+            let path = root.join(format!("R/{ordinal:02}.R"));
+            let code = format!("member_{ordinal} <- {ordinal}\n");
+            std::fs::write(&path, &code).unwrap();
+            let uri = Url::from_file_path(path).unwrap();
+            metadata.insert(
+                uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(&code)),
+            );
+            artifacts.insert(
+                uri.clone(),
+                Arc::new(compute_artifacts(&uri, &parse_r(&code), &code)),
+            );
+            members.push(uri);
+        }
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        artifacts.insert(
+            parent_uri.clone(),
+            Arc::new(compute_artifacts_with_metadata(
+                &parent_uri,
+                &parse_r(parent_code),
+                parent_code,
+                Some(&parent_metadata),
+            )),
+        );
+        metadata.insert(parent_uri.clone(), Arc::new(parent_metadata.clone()));
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let reads = std::cell::RefCell::new(HashMap::<Url, usize>::new());
+        let get_artifacts = |uri: &Url| {
+            if uri != &parent_uri {
+                *reads.borrow_mut().entry(uri.clone()).or_default() += 1;
+            }
+            artifacts.get(uri).cloned()
+        };
+        let scope = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            64,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            None,
+        );
+        for (ordinal, member) in members.iter().enumerate() {
+            let name = format!("member_{ordinal}");
+            assert!(scope.symbols.contains_key(name.as_str()));
+            assert_eq!(
+                reads.borrow().get(member),
+                Some(&1),
+                "member {ordinal} must be resolved exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn tar_member_inherits_only_earlier_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let first_code = "earlier <- 1\n";
+        let second_code = "middle <- earlier\n";
+        let third_code = "later <- 3\n";
+        std::fs::write(root.join("R/01-first.R"), first_code).unwrap();
+        std::fs::write(root.join("R/02-second.R"), second_code).unwrap();
+        std::fs::write(root.join("R/03-third.R"), third_code).unwrap();
+        let parent_path = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(parent_path).unwrap();
+        let first_uri = Url::from_file_path(root.join("R/01-first.R")).unwrap();
+        let second_uri = Url::from_file_path(root.join("R/02-second.R")).unwrap();
+        let third_uri = Url::from_file_path(root.join("R/03-third.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (
+                first_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(first_code)),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(second_code)),
+            ),
+            (
+                third_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(third_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                first_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &first_uri,
+                    &parse_r(first_code),
+                    first_code,
+                )),
+            ),
+            (
+                second_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &second_uri,
+                    &parse_r(second_code),
+                    second_code,
+                )),
+            ),
+            (
+                third_uri.clone(),
+                Arc::new(compute_artifacts(
+                    &third_uri,
+                    &parse_r(third_code),
+                    third_code,
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        assert!(
+            graph
+                .get_dependents(&second_uri)
+                .iter()
+                .any(|edge| { edge.from == parent_uri && edge.tar_source_ordinal == Some(1) }),
+            "second member must retain its ordinal edge: {:?}",
+            graph.get_dependents(&second_uri)
+        );
+        assert!(
+            artifacts[&parent_uri].timeline.iter().any(|event| {
+                matches!(event, ScopeEvent::TarBatch { members, .. } if members.len() == 3)
+            }),
+            "parent artifacts must retain the ordered tar batch: {:?}",
+            artifacts[&parent_uri].timeline
+        );
+
+        let scope = scope_at_position_with_graph(
+            &second_uri,
+            u32::MAX,
+            u32::MAX,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(
+            scope.symbols.contains_key("earlier"),
+            "scope keys: {:?}; chain: {:?}",
+            scope.symbols.keys().collect::<Vec<_>>(),
+            scope.chain
+        );
+        assert!(
+            !scope.symbols.contains_key("later"),
+            "a tar member must not inherit a later sibling"
         );
     }
 }

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -11,7 +11,7 @@ use tree_sitter::{Node, Tree};
 
 use super::binding::RuntimeFunctionScope;
 use super::scope::FunctionScopeInterval;
-use super::types::{ForwardSource, SourceLocality, byte_offset_to_utf16_column};
+use super::types::{ForwardSource, SourceLocality, TarSourceRequest, byte_offset_to_utf16_column};
 
 /// Maximum depth followed by suppressive-only static source-closure scans.
 pub(crate) const STATIC_SOURCE_MAX_DEPTH: usize = 64;
@@ -624,6 +624,7 @@ fn try_parse_source_call<'tree, 'text>(
         is_function_scoped: runtime_function_scope.is_function_scoped_at(node),
         system_file,
         resolved_uri: None,
+        tar_source_ordinal: None,
     })
 }
 
@@ -2204,27 +2205,28 @@ struct TarOptionSetCandidate {
 /// Whether `func_node` (a call's `function` child) names {targets}'
 /// `tar_option_set`: the bare identifier `tar_option_set`, or the qualified
 /// `targets::tar_option_set` / `targets:::tar_option_set`.
-fn is_tar_option_set_callee(func_node: Node, content: &str) -> bool {
+fn targets_callee_kind(func_node: Node, content: &str, fn_name: &str) -> Option<bool> {
     match func_node.kind() {
-        "identifier" => node_text(func_node, content) == "tar_option_set",
-        "namespace_operator" => {
-            let Some(lhs) = func_node.child_by_field_name("lhs") else {
-                return false;
-            };
-            let Some(rhs) = func_node.child_by_field_name("rhs") else {
-                return false;
-            };
-            lhs.kind() == "identifier"
-                && rhs.kind() == "identifier"
-                && node_text(lhs, content) == "targets"
-                && node_text(rhs, content) == "tar_option_set"
+        "identifier" => {
+            (crate::namespace_completion::unquote_package(node_text(func_node, content)) == fn_name)
+                .then_some(true)
         }
-        _ => false,
+        "namespace_operator" => {
+            let lhs = func_node.child_by_field_name("lhs")?;
+            let rhs = func_node.child_by_field_name("rhs")?;
+            (lhs.kind() == "identifier"
+                && rhs.kind() == "identifier"
+                && crate::namespace_completion::unquote_package(node_text(lhs, content))
+                    == "targets"
+                && crate::namespace_completion::unquote_package(node_text(rhs, content)) == fn_name)
+                .then_some(false)
+        }
+        _ => None,
     }
 }
 
 /// If `node` is a `tar_option_set(...)` call whose callee matches
-/// [`is_tar_option_set_callee`], parse it via
+/// [`targets_callee_kind`], parse it via
 /// [`try_parse_tar_option_set_call`] and push one gate-pending candidate per
 /// package, tagged with whether the callee was the bare spelling.
 fn collect_tar_option_set_candidates(
@@ -2238,10 +2240,9 @@ fn collect_tar_option_set_candidates(
     let Some(func_node) = node.child_by_field_name("function") else {
         return;
     };
-    if !is_tar_option_set_callee(func_node, content) {
+    let Some(bare) = targets_callee_kind(func_node, content, "tar_option_set") else {
         return;
-    }
-    let bare = func_node.kind() == "identifier";
+    };
     tar_candidates.extend(
         try_parse_tar_option_set_call(node, content, bindings)
             .into_iter()
@@ -2335,7 +2336,7 @@ fn append_gated_tar_option_set_calls(output: &mut LibraryWalkOutput) {
 ///
 /// The caller is responsible for the bare-vs-qualified targets-in-play gate
 /// (see [`append_gated_tar_option_set_calls`]); this function parses any
-/// callee matching [`is_tar_option_set_callee`].
+/// callee matching [`targets_callee_kind`].
 fn try_parse_tar_option_set_call(
     node: Node,
     content: &str,
@@ -2344,7 +2345,7 @@ fn try_parse_tar_option_set_call(
     let Some(func_node) = node.child_by_field_name("function") else {
         return Vec::new();
     };
-    if !is_tar_option_set_callee(func_node, content) {
+    if targets_callee_kind(func_node, content, "tar_option_set").is_none() {
         return Vec::new();
     }
     let Some(args_node) = node.child_by_field_name("arguments") else {
@@ -2424,6 +2425,266 @@ fn try_parse_tar_option_set_call(
     }
 }
 
+// ============================================================================
+// targets::tar_source Detection (issue #648)
+// ============================================================================
+
+struct TarSourceCandidate {
+    request: TarSourceRequest,
+    bare: bool,
+}
+
+/// Detect statically resolvable, top-level `{targets}` `tar_source()` calls.
+///
+/// Qualified calls need no attachment gate. A bare call is accepted only when
+/// the same evaluated top-level code attaches `{targets}`. Proven capture
+/// wrappers are traversed only through their evaluated controls/splices, using
+/// the same capture-aware binding machinery as source and package detection.
+pub fn detect_tar_source_requests(tree: &Tree, content: &str) -> Vec<TarSourceRequest> {
+    let root = tree.root_node();
+    let mut bindings = super::static_path::LazyStaticBindings::new(root, content);
+    detect_tar_source_requests_with_bindings(root, content, &mut bindings)
+}
+
+fn detect_tar_source_requests_with_bindings(
+    root: Node,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+) -> Vec<TarSourceRequest> {
+    let mut candidates = Vec::new();
+    let mut targets_attached = false;
+    visit_node_for_tar_source(
+        root,
+        content,
+        bindings,
+        RuntimeFunctionScope::Lexical,
+        &mut targets_attached,
+        &mut candidates,
+    );
+    candidates
+        .into_iter()
+        .filter(|candidate| !candidate.bare || targets_attached)
+        .map(|candidate| candidate.request)
+        .collect()
+}
+
+/// Detect library calls and tar requests while sharing one lazy binding table.
+pub(crate) fn detect_library_and_tar_source_requests(
+    tree: &Tree,
+    content: &str,
+) -> (Vec<LibraryCall>, Vec<TarSourceRequest>) {
+    let root = tree.root_node();
+    let mut bindings = super::static_path::LazyStaticBindings::new(root, content);
+    let library_calls = detect_library_calls_with_bindings(tree, content, &mut bindings);
+    let requests = detect_tar_source_requests_with_bindings(root, content, &mut bindings);
+    (library_calls, requests)
+}
+
+fn visit_node_for_tar_source(
+    node: Node,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+    runtime_function_scope: RuntimeFunctionScope,
+    targets_attached: &mut bool,
+    candidates: &mut Vec<TarSourceCandidate>,
+) {
+    if node.kind() == "identifier" {
+        return;
+    }
+
+    if node.kind() == "call" {
+        if let Some(capture) = bindings.capturing_call_kind_at(node) {
+            let captured_runtime_scope = runtime_function_scope.for_evaluated_capture_part(node);
+            super::binding::visit_evaluated_capture_parts(
+                node,
+                content,
+                capture,
+                &mut |evaluated, _frame, _role| {
+                    visit_node_for_tar_source(
+                        evaluated,
+                        content,
+                        bindings,
+                        captured_runtime_scope,
+                        targets_attached,
+                        candidates,
+                    );
+                },
+            );
+            return;
+        }
+
+        if !runtime_function_scope.is_function_scoped_at(node) {
+            if call_attaches_targets(node, content, bindings) {
+                *targets_attached = true;
+            }
+            if let Some(func_node) = node.child_by_field_name("function")
+                && let Some(bare) = targets_callee_kind(func_node, content, "tar_source")
+                && (!bare
+                    || !bindings
+                        .get()
+                        .named_binding_may_shadow_at("tar_source", node, false))
+                && let Some(request) = try_parse_tar_source_call(node, content, bindings)
+            {
+                candidates.push(TarSourceCandidate { request, bare });
+            }
+        }
+    }
+
+    let child_runtime_scope = if node.kind() == "function_definition" {
+        runtime_function_scope.enter_function()
+    } else {
+        runtime_function_scope
+    };
+    for child in node.children(&mut node.walk()) {
+        visit_node_for_tar_source(
+            child,
+            content,
+            bindings,
+            child_runtime_scope,
+            targets_attached,
+            candidates,
+        );
+    }
+}
+
+fn call_attaches_targets(
+    node: Node,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+) -> bool {
+    if try_parse_apply_library_call(node, content, bindings)
+        .iter()
+        .any(|call| call.attaches && call.package == "targets")
+    {
+        return true;
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    let loader = match function.kind() {
+        "identifier" => crate::namespace_completion::unquote_package(node_text(function, content)),
+        "namespace_operator" => {
+            let Some(lhs) = function.child_by_field_name("lhs") else {
+                return false;
+            };
+            let Some(rhs) = function.child_by_field_name("rhs") else {
+                return false;
+            };
+            if crate::namespace_completion::unquote_package(node_text(lhs, content)) != "base" {
+                return false;
+            }
+            crate::namespace_completion::unquote_package(node_text(rhs, content))
+        }
+        _ => return false,
+    };
+    if !matches!(loader, "library" | "require") {
+        return false;
+    }
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    if arguments.has_error() || has_character_only_true(&arguments, content) {
+        return false;
+    }
+    extract_package_name(&arguments, content)
+        .is_some_and(|package| crate::namespace_completion::unquote_package(&package) == "targets")
+}
+
+/// Parse `tar_source(files, envir, change_directory)` using R argument matching.
+fn try_parse_tar_source_call(
+    node: Node,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+) -> Option<TarSourceRequest> {
+    let args = node.child_by_field_name("arguments")?;
+    if args.has_error() {
+        return None;
+    }
+    const FORMALS: [&str; 3] = ["files", "envir", "change_directory"];
+    let mut values: [Option<Node>; 3] = [None, None, None];
+    let mut bound = [false; 3];
+    let mut partial_named = Vec::new();
+    let mut positional = Vec::new();
+    let mut cursor = args.walk();
+    for argument in args.children(&mut cursor) {
+        if argument.kind() != "argument" {
+            continue;
+        }
+        let value = argument.child_by_field_name("value");
+        if let Some(name_node) = argument.child_by_field_name("name") {
+            let name = crate::namespace_completion::unquote_package(node_text(name_node, content));
+            if let Some(index) = FORMALS.iter().position(|formal| *formal == name) {
+                if bound[index] {
+                    return None;
+                }
+                bound[index] = true;
+                values[index] = value;
+            } else {
+                partial_named.push((name, value));
+            }
+        } else {
+            positional.push(value);
+        }
+    }
+    for (name, value) in partial_named {
+        let matches: Vec<_> = FORMALS
+            .iter()
+            .enumerate()
+            .filter_map(|(index, formal)| formal.starts_with(name).then_some(index))
+            .collect();
+        let [index] = matches.as_slice() else {
+            return None;
+        };
+        if bound[*index] {
+            return None;
+        }
+        bound[*index] = true;
+        values[*index] = value;
+    }
+    for value in positional {
+        let index = bound.iter().position(|is_bound| !is_bound)?;
+        bound[index] = true;
+        values[index] = value;
+    }
+
+    if values[1].is_some() {
+        return None;
+    }
+    let change_directory = match values[2] {
+        None => false,
+        Some(value) => match node_text(value, content) {
+            "TRUE" => true,
+            "FALSE" => false,
+            _ => return None,
+        },
+    };
+    let files = match values[0] {
+        None => vec!["R".to_string()],
+        Some(value) => match value.kind() {
+            "string" => vec![extract_string_literal(value, content)?],
+            "identifier" => {
+                let name = super::binding::plain_identifier_name(value, content)?;
+                bindings.resolve_package_vector(name, node)?
+            }
+            _ => {
+                let pairs = super::binding::extract_bare_c_plain_strings(value, content)?;
+                if !bindings.package_c_is_trusted_at(node) {
+                    return None;
+                }
+                pairs.into_iter().map(|(string, _)| string).collect()
+            }
+        },
+    };
+    let start = node.start_position();
+    let line_text = content.lines().nth(start.row).unwrap_or("");
+    Some(TarSourceRequest {
+        files,
+        line: start.row as u32,
+        column: byte_offset_to_utf16_column(line_text, start.column),
+        change_directory,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2435,6 +2696,103 @@ mod tests {
             .set_language(&tree_sitter_r::LANGUAGE.into())
             .unwrap();
         parser.parse(code, None).unwrap()
+    }
+
+    fn tar_requests(code: &str) -> Vec<TarSourceRequest> {
+        detect_tar_source_requests(&parse_r(code), code)
+    }
+
+    #[test]
+    fn tar_source_bare_gate_is_top_level_and_position_independent() {
+        let requests = tar_requests("tar_source()\nlibrary(targets)");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].files, ["R"]);
+
+        assert!(tar_requests("tar_source <- function(...) {}\ntar_source()").is_empty());
+        assert!(tar_requests("f <- function() library(targets)\ntar_source()").is_empty());
+        assert!(tar_requests("quote(library(targets))\ntar_source()").is_empty());
+    }
+
+    #[test]
+    fn tar_source_qualified_calls_and_capture_boundaries() {
+        let requests = tar_requests(
+            "targets::tar_source(\"one.R\")\ntargets:::tar_source(c(\"two.R\", \"dir\"))",
+        );
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].files, ["one.R"]);
+        assert_eq!(requests[1].files, ["two.R", "dir"]);
+
+        assert!(tar_requests("f <- function() targets::tar_source(\"x.R\")").is_empty());
+        assert!(tar_requests("quote(targets::tar_source(\"x.R\"))").is_empty());
+        assert!(tar_requests("rlang::expr(targets::tar_source(\"x.R\"))").is_empty());
+        assert_eq!(
+            tar_requests("rlang::expr(!!targets::tar_source(\"x.R\"))").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn tar_source_accepts_backtick_callee_and_formal_spellings() {
+        let requests =
+            tar_requests("targets::`tar_source`(`files` = \"one.R\", `change_directory` = TRUE)");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].files, ["one.R"]);
+        assert!(requests[0].change_directory);
+    }
+
+    #[test]
+    fn tar_source_static_vectors_reuse_capture_aware_bindings() {
+        let requests = tar_requests("paths <- c(\"R\", \"setup.R\")\ntargets::tar_source(paths)");
+        assert_eq!(requests[0].files, ["R", "setup.R"]);
+
+        for code in [
+            "targets::tar_source(paths)\npaths <- c(\"R\")",
+            "paths <- c(\"R\")\npaths <- c(\"more\")\ntargets::tar_source(paths)",
+            "if (ok) paths <- c(\"R\")\ntargets::tar_source(paths)",
+            "paths <- c(\"R\")\npaths[1] <- \"other\"\ntargets::tar_source(paths)",
+            "paths <- c(\"R\")\nfor (paths in \"other\") {}\ntargets::tar_source(paths)",
+            "paths <- c(\"R\")\nrm(paths)\ntargets::tar_source(paths)",
+            "paths <- c(\"R\")\nassign(\"paths\", \"other.R\")\ntargets::tar_source(paths)",
+        ] {
+            assert!(
+                tar_requests(code).is_empty(),
+                "unexpected request for: {code}"
+            );
+        }
+    }
+
+    #[test]
+    fn tar_source_matches_formals_and_static_flags() {
+        let request = tar_requests("targets::tar_source(ch = TRUE, fil = c(\"R\", \"setup.R\"))");
+        assert_eq!(request.len(), 1);
+        assert!(request[0].change_directory);
+        assert_eq!(request[0].files, ["R", "setup.R"]);
+
+        for code in [
+            "targets::tar_source(files =)",
+            "targets::tar_source(envir =)",
+            "targets::tar_source(change_directory =)",
+            "targets::tar_source(, ,)",
+        ] {
+            let requests = tar_requests(code);
+            assert_eq!(requests.len(), 1, "expected defaults for: {code}");
+            assert_eq!(requests[0].files, ["R"]);
+            assert!(!requests[0].change_directory);
+        }
+
+        for code in [
+            "targets::tar_source(\"x.R\", globalenv())",
+            "targets::tar_source(files = \"x.R\", files = \"y.R\")",
+            "targets::tar_source(files = \"x.R\", fil = \"y.R\")",
+            "targets::tar_source(\"x.R\", change_directory = flag)",
+            "targets::tar_source(\"x.R\", change_directory = T)",
+            "targets::tar_source(unknown = \"x.R\")",
+        ] {
+            assert!(
+                tar_requests(code).is_empty(),
+                "unexpected request for: {code}"
+            );
+        }
     }
 
     #[test]

--- a/crates/raven/src/cross_file/tar_source.rs
+++ b/crates/raven/src/cross_file/tar_source.rs
@@ -1,0 +1,1399 @@
+//! Filesystem-backed expansion of static `{targets}` `tar_source()` requests.
+//!
+//! Detection is filesystem-free and stores ordered [`TarSourceRequest`] values
+//! in metadata. This module classifies those requests after working-directory
+//! enrichment and recursively enumerates `.R`/`.r` scripts.
+//!
+//! Expansion has no process-global cache or lifecycle state. Callers own both
+//! the prior authoritative metadata and any event-generation fencing needed
+//! around the filesystem walk. [`expand_tar_source_requests`] returns a detached
+//! value; [`apply_tar_source_expansion`] installs it into caller-owned metadata.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+
+use super::path_resolve::{
+    PathContext, forward_child_path_context, forward_path_candidate_tiers, normalize_path_public,
+    path_to_uri, resolve_path_with_workspace_fallback,
+};
+use super::types::{CrossFileMetadata, ForwardSource, SourceLocality, TarSourceRequest};
+
+/// Detached result of expanding all requests in one metadata record.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TarSourceExpansion {
+    /// Ordered tar-derived forward sources.
+    pub sources: Vec<ForwardSource>,
+    /// Existing and potential membership roots, including symlink targets.
+    pub watch_paths: Vec<PathBuf>,
+}
+
+/// Context-sensitive provider files needed in addition to a URI-global graph
+/// neighborhood when resolving finalized tar batches.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ContextualTarProviders {
+    /// Every provider reached from a tar member execution, sorted by URI.
+    /// Callers subtract their already-collected graph neighborhood.
+    pub providers: Vec<Url>,
+    /// Distinct execution contexts in bounded traversal order. CLI callers use
+    /// the first context for a provider that is not yet materialized.
+    pub executions: Vec<ContextualProviderExecution>,
+    /// Whether one URI was reached under more than one execution context or
+    /// traversal was truncated before context equality could be proved.
+    pub divergence: bool,
+    /// Whether the shared visited/depth/per-URI-context budget stopped work.
+    pub truncated: bool,
+}
+
+/// One context-sensitive provider execution discovered by the pure traversal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextualProviderExecution {
+    pub uri: Url,
+    pub context: PathContext,
+    pub prefer_supplied_path_context: bool,
+    /// False while walking the ordinary URI-global prefix before the first
+    /// tar-derived edge. CLI materialization consumes both modes; only
+    /// contextual executions are added to snapshot provider sets.
+    pub contextual: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ContextualProviderVisit {
+    uri: Url,
+    context: PathContext,
+    mode: ContextualProviderMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ContextualProviderMode {
+    GraphPrefix,
+    Contextual { prefer_supplied_path_context: bool },
+}
+
+/// Result of looking up one ordinary source occurrence in the URI-global graph.
+///
+/// `Unknown` means the caller's graph view does not contain the parent URI,
+/// while `Known(None)` means the parent is present but that occurrence has no
+/// resolved edge. The distinction lets bounded snapshot callers fail closed on
+/// a truncated graph without inventing a lexical target that scope would skip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphPrefixEdgeLookup {
+    Unknown,
+    Known(Option<Url>),
+}
+
+/// Maximum distinct execution contexts retained for one provider URI.
+///
+/// The global visited cap remains the primary budget; this smaller local bound
+/// prevents one repeated helper from consuming all of it.
+const MAX_CONTEXTS_PER_PROVIDER_URI: usize = 16;
+
+/// Collect the bounded ordinary-prefix and context-sensitive forward closure
+/// rooted at a diagnostic target.
+///
+/// This is a pure traversal over detached metadata and a read-only graph-edge
+/// lookup. Before the first tar-derived edge, ordinary sources match their
+/// URI-global graph edge by call site and ordinal in `GraphPrefix` mode so a
+/// downstream driver can host the batch. There is deliberately no lexical
+/// fallback in that mode: scope skips metadata occurrences without a matching
+/// graph edge, and the planner must follow the same prefix. Traversal is
+/// deliberately locality-agnostic: scope executes even `NonInheriting` edges
+/// (filtering symbols but merging process-wide package attachments), so the
+/// planner follows every exact edge and leaves locality-specific merge
+/// semantics entirely to scope — pruning here would starve a downstream tar
+/// batch of its supplemental provider artifacts. A tar edge switches
+/// permanently to contextual traversal, keyed only by provider URI, derived
+/// [`PathContext`], and the two-valued lexical-first mode. Standalone children
+/// re-anchor and sever that preference. `system.file()` targets use their
+/// pre-resolved URI.
+///
+/// Prefix and contextual visits share one depth/visited/context budget. Any
+/// truncation fails closed by setting `divergence`, which disables the
+/// URI-keyed standalone cache. The collector performs no filesystem or graph
+/// mutation. Because prefix selection reads graph edges, caller-side
+/// memoization must include the graph edge revision.
+pub fn collect_contextual_tar_providers<G, E>(
+    root_uri: &Url,
+    root_metadata: &CrossFileMetadata,
+    workspace_root: Option<&Url>,
+    max_depth: usize,
+    max_visited: usize,
+    get_metadata: &G,
+    get_graph_prefix_edge: &E,
+) -> ContextualTarProviders
+where
+    G: Fn(&Url) -> Option<std::sync::Arc<CrossFileMetadata>>,
+    E: Fn(&Url, &ForwardSource) -> GraphPrefixEdgeLookup,
+{
+    let Some(root_context) = PathContext::from_metadata(root_uri, root_metadata, workspace_root)
+    else {
+        return ContextualTarProviders::default();
+    };
+    let mut queue = VecDeque::from([(
+        ContextualProviderVisit {
+            uri: root_uri.clone(),
+            context: root_context,
+            mode: ContextualProviderMode::GraphPrefix,
+        },
+        0usize,
+    )]);
+
+    let mut result = ContextualTarProviders::default();
+    let mut providers = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut contexts_by_uri: HashMap<Url, HashSet<(PathContext, ContextualProviderMode)>> =
+        HashMap::new();
+
+    while let Some((visit, depth)) = queue.pop_front() {
+        if visited.len() >= max_visited {
+            result.truncated = true;
+            result.divergence = true;
+            break;
+        }
+        let contexts = contexts_by_uri.entry(visit.uri.clone()).or_default();
+        let context_key = (visit.context.clone(), visit.mode);
+        if !contexts.contains(&context_key) {
+            if !contexts.is_empty() {
+                result.divergence = true;
+            }
+            if contexts.len() >= MAX_CONTEXTS_PER_PROVIDER_URI {
+                result.truncated = true;
+                result.divergence = true;
+                continue;
+            }
+            contexts.insert(context_key);
+        }
+        if !visited.insert(visit.clone()) {
+            continue;
+        }
+        let contextual_preference = match visit.mode {
+            ContextualProviderMode::GraphPrefix => None,
+            ContextualProviderMode::Contextual {
+                prefer_supplied_path_context,
+            } => Some(prefer_supplied_path_context),
+        };
+        if contextual_preference.is_some() {
+            providers.insert(visit.uri.clone());
+        }
+        if visit.uri != *root_uri {
+            result.executions.push(ContextualProviderExecution {
+                uri: visit.uri.clone(),
+                context: visit.context.clone(),
+                prefer_supplied_path_context: contextual_preference.unwrap_or(false),
+                contextual: contextual_preference.is_some(),
+            });
+        }
+
+        let metadata = if visit.uri == *root_uri {
+            std::sync::Arc::new(root_metadata.clone())
+        } else if let Some(metadata) = get_metadata(&visit.uri) {
+            metadata
+        } else {
+            // The provider execution exists but its forward closure is unknown.
+            // CLI callers may materialize it and repeat the traversal; LSP
+            // callers must disable the URI-keyed standalone cache meanwhile.
+            result.divergence = true;
+            continue;
+        };
+        if matches!(visit.mode, ContextualProviderMode::GraphPrefix)
+            && PathContext::from_metadata(&visit.uri, &metadata, workspace_root)
+                .is_some_and(|global| global != visit.context)
+            && metadata
+                .sources
+                .iter()
+                .any(|source| source.tar_source_ordinal.is_some())
+        {
+            result.divergence = true;
+        }
+        if depth >= max_depth {
+            if !metadata.sources.is_empty() {
+                result.truncated = true;
+                result.divergence = true;
+            }
+            continue;
+        }
+        for source in &metadata.sources {
+            let child_uri = match visit.mode {
+                ContextualProviderMode::GraphPrefix => {
+                    if source.tar_source_ordinal.is_some() {
+                        contextual_source_uri(source, &visit.context, true)
+                    } else if let Some(uri) = source.resolved_uri.clone() {
+                        Some(uri)
+                    } else {
+                        match get_graph_prefix_edge(&visit.uri, source) {
+                            GraphPrefixEdgeLookup::Unknown => {
+                                result.truncated = true;
+                                result.divergence = true;
+                                None
+                            }
+                            GraphPrefixEdgeLookup::Known(uri) => uri,
+                        }
+                    }
+                }
+                ContextualProviderMode::Contextual {
+                    prefer_supplied_path_context,
+                } => contextual_source_uri(source, &visit.context, prefer_supplied_path_context),
+            };
+            let Some(child_uri) = child_uri else {
+                continue;
+            };
+            let child_is_standalone =
+                get_metadata(&child_uri).is_some_and(|child| child.standalone);
+            let Some(child_context) = forward_child_path_context(
+                &child_uri,
+                child_is_standalone,
+                source.chdir,
+                Some(&visit.context),
+                workspace_root,
+                get_metadata,
+            ) else {
+                continue;
+            };
+            let child_mode = match visit.mode {
+                ContextualProviderMode::GraphPrefix if source.tar_source_ordinal.is_none() => {
+                    ContextualProviderMode::GraphPrefix
+                }
+                ContextualProviderMode::GraphPrefix => ContextualProviderMode::Contextual {
+                    prefer_supplied_path_context: !child_is_standalone,
+                },
+                ContextualProviderMode::Contextual {
+                    prefer_supplied_path_context,
+                } => ContextualProviderMode::Contextual {
+                    prefer_supplied_path_context: (source.tar_source_ordinal.is_some()
+                        || prefer_supplied_path_context)
+                        && !child_is_standalone,
+                },
+            };
+            queue.push_back((
+                ContextualProviderVisit {
+                    uri: child_uri,
+                    context: child_context,
+                    mode: child_mode,
+                },
+                depth + 1,
+            ));
+        }
+    }
+
+    result.providers = providers.into_iter().collect();
+    result
+        .providers
+        .sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+    result
+}
+
+fn contextual_source_uri(
+    source: &ForwardSource,
+    context: &PathContext,
+    prefer_supplied_path_context: bool,
+) -> Option<Url> {
+    if source.system_file.is_some() {
+        return source.resolved_uri.clone();
+    }
+    if source.tar_source_ordinal.is_some() {
+        return source.resolved_uri.clone().or_else(|| {
+            resolve_path_with_workspace_fallback(&source.path, context)
+                .and_then(|path| path_to_uri(&path))
+        });
+    }
+    let lexical = || {
+        resolve_path_with_workspace_fallback(&source.path, context)
+            .and_then(|path| path_to_uri(&path))
+    };
+    if prefer_supplied_path_context {
+        lexical().or_else(|| source.resolved_uri.clone())
+    } else {
+        source.resolved_uri.clone().or_else(lexical)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct RequestExpansion {
+    files: Vec<PathBuf>,
+    watch_paths: Vec<PathBuf>,
+}
+
+/// Expand every static `tar_source()` request without mutating metadata.
+///
+/// Each request has its own first-occurrence deduplication set and ordinal
+/// sequence; separate calls that reach the same URI remain distinct. The
+/// caller must invoke this after inherited-working-directory enrichment and
+/// without holding shared state locks.
+pub fn expand_tar_source_requests(
+    metadata: &CrossFileMetadata,
+    uri: &Url,
+    workspace_root: Option<&Url>,
+) -> TarSourceExpansion {
+    let Some(context) = PathContext::from_metadata(uri, metadata, workspace_root) else {
+        return TarSourceExpansion::default();
+    };
+    let mut result = TarSourceExpansion::default();
+    for request in &metadata.tar_source_requests {
+        let expansion = expand_request(request, &context);
+        result.watch_paths.extend(expansion.watch_paths);
+        for (ordinal, path) in expansion.files.into_iter().enumerate() {
+            let Some(resolved_uri) = path_to_uri(&path) else {
+                continue;
+            };
+            result.sources.push(ForwardSource {
+                path: path.to_string_lossy().into_owned(),
+                line: request.line,
+                column: request.column,
+                locality: SourceLocality::Global,
+                chdir: request.change_directory,
+                // `targets::tar_source()` evaluates scripts in its selected
+                // environment; accepted requests are restricted to the
+                // default/global destination.
+                is_sys_source: false,
+                resolved_uri: Some(resolved_uri),
+                tar_source_ordinal: Some(ordinal as u32),
+                ..Default::default()
+            });
+        }
+    }
+    result.watch_paths.sort();
+    result.watch_paths.dedup();
+    result
+        .sources
+        .sort_by_key(|source| (source.line, source.column, source.tar_source_ordinal));
+    result
+}
+
+/// Replace the derived tar portion of `metadata` with `expansion`.
+///
+/// Syntax-derived requests and ordinary/directive sources are preserved.
+pub fn apply_tar_source_expansion(metadata: &mut CrossFileMetadata, expansion: TarSourceExpansion) {
+    metadata
+        .sources
+        .retain(|source| source.tar_source_ordinal.is_none());
+    metadata.sources.extend(expansion.sources);
+    metadata.tar_source_expansion_watch_paths = expansion.watch_paths;
+    metadata
+        .sources
+        .sort_by_key(|source| (source.line, source.column, source.tar_source_ordinal));
+}
+
+/// Expand and install all static requests into caller-owned metadata.
+pub fn finalize_tar_source_requests(
+    metadata: &mut CrossFileMetadata,
+    uri: &Url,
+    workspace_root: Option<&Url>,
+) {
+    let expansion = expand_tar_source_requests(metadata, uri, workspace_root);
+    apply_tar_source_expansion(metadata, expansion);
+}
+
+/// Reuse a prior record's derived expansion when its syntax and effective path
+/// context are identical.
+///
+/// This is the only cache-like seam in the module: ownership and freshness stay
+/// with the caller's authoritative record. Returns `true` when reuse occurred.
+pub fn reuse_tar_source_expansion(
+    metadata: &mut CrossFileMetadata,
+    previous: &CrossFileMetadata,
+    uri: &Url,
+    workspace_root: Option<&Url>,
+) -> bool {
+    if metadata.tar_source_requests != previous.tar_source_requests {
+        return false;
+    }
+    let current_context = PathContext::from_metadata(uri, metadata, workspace_root);
+    let previous_context = PathContext::from_metadata(uri, previous, workspace_root);
+    if current_context != previous_context {
+        return false;
+    }
+    let expansion = TarSourceExpansion {
+        sources: previous
+            .sources
+            .iter()
+            .filter(|source| source.tar_source_ordinal.is_some())
+            .cloned()
+            .collect(),
+        watch_paths: previous.tar_source_expansion_watch_paths.clone(),
+    };
+    apply_tar_source_expansion(metadata, expansion);
+    true
+}
+
+/// Whether either path is equal to or lexically contains the other.
+///
+/// Matching is symmetric because a file event below a requested directory and
+/// a directory event above a requested file must both select the parent.
+pub fn paths_overlap(left: &Path, right: &Path) -> bool {
+    if left == right || left.starts_with(right) || right.starts_with(left) {
+        return true;
+    }
+    let left_components = left.components().count();
+    let right_components = right.components().count();
+    if left_components >= right_components {
+        path_starts_with_ascii_case(left, right)
+    } else {
+        path_starts_with_ascii_case(right, left)
+    }
+}
+
+fn path_starts_with_ascii_case(path: &Path, base: &Path) -> bool {
+    let mut path_components = path.components();
+    base.components().all(|base_component| {
+        path_components.next().is_some_and(|path_component| {
+            os_str_eq_ignore_ascii_case(path_component.as_os_str(), base_component.as_os_str())
+        })
+    })
+}
+
+#[cfg(unix)]
+fn os_str_eq_ignore_ascii_case(left: &std::ffi::OsStr, right: &std::ffi::OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    left.as_bytes().eq_ignore_ascii_case(right.as_bytes())
+}
+
+#[cfg(windows)]
+fn os_str_eq_ignore_ascii_case(left: &std::ffi::OsStr, right: &std::ffi::OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut left = left.encode_wide();
+    let mut right = right.encode_wide();
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return true,
+            (Some(a), Some(b))
+                if u8::try_from(a)
+                    .ok()
+                    .zip(u8::try_from(b).ok())
+                    .is_some_and(|(a, b)| a.eq_ignore_ascii_case(&b))
+                    || a == b => {}
+            _ => return false,
+        }
+    }
+}
+
+/// Return existing and potential paths watched by the requests.
+///
+/// This full helper may perform case-correcting filesystem resolution.
+pub fn tar_source_watch_paths(
+    metadata: &CrossFileMetadata,
+    uri: &Url,
+    workspace_root: Option<&Url>,
+) -> Vec<PathBuf> {
+    let mut paths = tar_source_lexical_watch_paths(metadata, uri, workspace_root);
+    let Some(context) = PathContext::from_metadata(uri, metadata, workspace_root) else {
+        return paths;
+    };
+    for request in &metadata.tar_source_requests {
+        for raw in &request.files {
+            if let Some(path) = resolve_path_with_workspace_fallback(raw, &context) {
+                paths.push(path);
+            }
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// Return stat-free lexical and previously published watch paths.
+pub(crate) fn tar_source_lexical_watch_paths(
+    metadata: &CrossFileMetadata,
+    uri: &Url,
+    workspace_root: Option<&Url>,
+) -> Vec<PathBuf> {
+    let Some(context) = PathContext::from_metadata(uri, metadata, workspace_root) else {
+        return Vec::new();
+    };
+    let mut paths = Vec::new();
+    for request in &metadata.tar_source_requests {
+        for raw in &request.files {
+            paths.extend(forward_path_candidate_tiers(raw, &context));
+        }
+    }
+    paths.extend(metadata.tar_source_expansion_watch_paths.iter().cloned());
+    // Preserve the previous successful spelling until an authoritative
+    // replacement commits. This catches a deletion after a case-lenient or
+    // symlinked resolution.
+    paths.extend(
+        metadata
+            .sources
+            .iter()
+            .filter(|source| source.tar_source_ordinal.is_some())
+            .filter_map(|source| source.resolved_uri.as_ref())
+            .filter_map(|uri| uri.to_file_path().ok()),
+    );
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn expand_request(request: &TarSourceRequest, context: &PathContext) -> RequestExpansion {
+    let mut expansion = RequestExpansion::default();
+    let mut seen = HashSet::new();
+    for raw in &request.files {
+        let candidates = candidate_watch_paths(raw, context);
+        expansion.watch_paths.extend(candidates.iter().cloned());
+        for candidate in &candidates {
+            if std::fs::symlink_metadata(candidate)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+            {
+                record_symlink_watch_paths(candidate, &mut expansion.watch_paths);
+            }
+        }
+        let Some(path) = resolve_path_with_workspace_fallback(raw, context) else {
+            continue;
+        };
+        if path.is_file() {
+            push_r_file(&mut expansion.files, &mut seen, path);
+        } else if path.is_dir() {
+            let entries = walkdir::WalkDir::new(&path)
+                .follow_links(true)
+                .into_iter()
+                .filter_entry(|entry| {
+                    entry.depth() == 0 || !entry.file_name().to_string_lossy().starts_with('.')
+                });
+            let mut directory_files = Vec::new();
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) => {
+                        if let Some(path) = error.path() {
+                            record_symlink_watch_paths(path, &mut expansion.watch_paths);
+                        }
+                        continue;
+                    }
+                };
+                if entry.path_is_symlink() {
+                    record_symlink_watch_paths(entry.path(), &mut expansion.watch_paths);
+                }
+                if entry.file_type().is_file() {
+                    directory_files.push(entry.into_path());
+                }
+            }
+            // Deterministic LC_COLLATE=C approximation over full relative paths.
+            directory_files.sort_by_cached_key(|file| relative_full_path_key(&path, file));
+            for file in directory_files {
+                push_r_file(&mut expansion.files, &mut seen, file);
+            }
+        }
+    }
+    expansion.watch_paths.sort();
+    expansion.watch_paths.dedup();
+    expansion
+}
+
+/// Retain both lexical and canonical target spellings of a symlink.
+fn record_symlink_watch_paths(path: &Path, watch_paths: &mut Vec<PathBuf>) {
+    if let Ok(target) = std::fs::read_link(path) {
+        let target = if target.is_absolute() {
+            target
+        } else {
+            let lexical_parent = path.parent().unwrap_or_else(|| Path::new(""));
+            let lexical_target = lexical_parent.join(&target);
+            watch_paths.push(normalize_path_public(&lexical_target).unwrap_or(lexical_target));
+            let resolved_parent = lexical_parent
+                .canonicalize()
+                .unwrap_or_else(|_| lexical_parent.to_path_buf());
+            resolved_parent.join(target)
+        };
+        watch_paths.push(normalize_path_public(&target).unwrap_or(target));
+    }
+    if let Ok(target) = std::fs::canonicalize(path) {
+        watch_paths.push(target);
+    }
+}
+
+/// Rebase expanded tar children when one document has multiple graph roots.
+pub fn remap_tar_sources_for_graph_root(
+    root_meta: &mut CrossFileMetadata,
+    input_root: &Url,
+    input_meta: &CrossFileMetadata,
+    root: &Url,
+    workspace_root: Option<&Url>,
+) {
+    let Some(input_context) = PathContext::from_metadata(input_root, input_meta, workspace_root)
+    else {
+        return;
+    };
+    let Some(root_context) = PathContext::from_metadata(root, root_meta, workspace_root) else {
+        return;
+    };
+    let input_base = input_context.effective_working_directory();
+    let root_base = root_context.effective_working_directory();
+    if input_base == root_base {
+        return;
+    }
+
+    for source in &mut root_meta.sources {
+        if source.tar_source_ordinal.is_none() {
+            continue;
+        }
+        let Some(path) = source
+            .resolved_uri
+            .as_ref()
+            .and_then(|uri| uri.to_file_path().ok())
+        else {
+            continue;
+        };
+        let relative = path
+            .strip_prefix(&input_base)
+            .map(PathBuf::from)
+            .ok()
+            .or_else(|| {
+                let request = input_meta.tar_source_requests.iter().find(|request| {
+                    request.line == source.line && request.column == source.column
+                })?;
+                request.files.iter().find_map(|raw| {
+                    let raw_path = Path::new(raw);
+                    if raw_path.is_absolute()
+                        || !raw_path
+                            .components()
+                            .any(|component| component == std::path::Component::ParentDir)
+                    {
+                        return None;
+                    }
+                    let old_target = normalize_path_public(&input_base.join(raw_path))?;
+                    if path == old_target {
+                        return Some(raw_path.to_path_buf());
+                    }
+                    Some(raw_path.join(path.strip_prefix(old_target).ok()?))
+                })
+            });
+        let Some(relative) = relative else {
+            continue;
+        };
+        let Some(rebased) = normalize_path_public(&root_base.join(relative)) else {
+            continue;
+        };
+        let Ok(uri) = Url::from_file_path(&rebased) else {
+            continue;
+        };
+        source.path = rebased.to_string_lossy().into_owned();
+        source.resolved_uri = Some(uri);
+    }
+}
+
+#[cfg(unix)]
+fn relative_full_path_key(root: &Path, file: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    file.strip_prefix(root)
+        .unwrap_or(file)
+        .as_os_str()
+        .as_bytes()
+        .to_vec()
+}
+
+#[cfg(windows)]
+fn relative_full_path_key(root: &Path, file: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    let relative = file.strip_prefix(root).unwrap_or(file);
+    let mut key = Vec::new();
+    for (index, component) in relative.components().enumerate() {
+        if index > 0 {
+            key.push(u16::from(b'/'));
+        }
+        key.extend(component.as_os_str().encode_wide());
+    }
+    key
+}
+
+fn candidate_watch_paths(raw: &str, context: &PathContext) -> Vec<PathBuf> {
+    let mut paths = forward_path_candidate_tiers(raw, context);
+    if let Some(path) = resolve_path_with_workspace_fallback(raw, context) {
+        paths.push(path);
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn push_r_file(files: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    let is_r = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "R" | "r"));
+    if is_r && seen.insert(path.clone()) {
+        files.push(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn touch(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    fn finalize(root: &Path, parent: &Path, code: &str) -> CrossFileMetadata {
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(parent).unwrap();
+        let mut metadata = crate::cross_file::extract_metadata(code);
+        finalize_tar_source_requests(&mut metadata, &parent_uri, Some(&root_uri));
+        metadata
+    }
+
+    fn relative_sources(root: &Path, metadata: &CrossFileMetadata) -> Vec<String> {
+        metadata
+            .sources
+            .iter()
+            .filter(|source| source.tar_source_ordinal.is_some())
+            .map(|source| {
+                source
+                    .resolved_uri
+                    .as_ref()
+                    .unwrap()
+                    .to_file_path()
+                    .unwrap()
+                    .strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn expands_mixed_inputs_recursively_with_per_call_dedup() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("R/b.R"), "");
+        touch(&root.join("R/nested/a.r"), "");
+        touch(&root.join("R/skip.txt"), "");
+        touch(&root.join("setup.R"), "");
+        let parent = root.join("_targets.R");
+        touch(&parent, "");
+
+        let metadata = finalize(
+            root,
+            &parent,
+            "targets::tar_source(c(\"setup.R\", \"R\", \"setup.R\"))",
+        );
+        assert_eq!(
+            relative_sources(root, &metadata),
+            ["setup.R", "R/b.R", "R/nested/a.r"]
+        );
+        assert!(
+            metadata
+                .sources
+                .iter()
+                .filter_map(|source| source.tar_source_ordinal)
+                .eq(0..3)
+        );
+    }
+
+    #[test]
+    fn excludes_hidden_entries_but_allows_explicit_hidden_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("R/a.R"), "");
+        touch(&root.join("R/.hidden.R"), "");
+        touch(&root.join("R/.hidden/z.R"), "");
+        touch(&root.join(".scripts/explicit.R"), "");
+        let parent = root.join("_targets.R");
+        touch(&parent, "");
+
+        let metadata = finalize(root, &parent, "targets::tar_source(c(\"R\", \".scripts\"))");
+        assert_eq!(
+            relative_sources(root, &metadata),
+            ["R/a.R", ".scripts/explicit.R"]
+        );
+    }
+
+    #[test]
+    fn deduplicates_per_call_but_not_across_calls() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("a.R"), "");
+        let parent = root.join("_targets.R");
+        touch(&parent, "");
+        let metadata = finalize(
+            root,
+            &parent,
+            "targets::tar_source(c(\"a.R\", \"a.R\"))\ntargets::tar_source(\"a.R\")",
+        );
+        assert_eq!(relative_sources(root, &metadata), ["a.R", "a.R"]);
+        assert_eq!(
+            metadata
+                .sources
+                .iter()
+                .filter_map(|source| source.tar_source_ordinal)
+                .collect::<Vec<_>>(),
+            [0, 0]
+        );
+    }
+
+    #[test]
+    fn missing_request_remains_watchable_then_refreshes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let parent = root.join("_targets.R");
+        touch(&parent, "");
+        let code = "targets::tar_source(\"later\")";
+        let mut metadata = finalize(root, &parent, code);
+        assert!(relative_sources(root, &metadata).is_empty());
+        assert_eq!(metadata.tar_source_requests.len(), 1);
+        assert!(
+            tar_source_watch_paths(
+                &metadata,
+                &Url::from_file_path(&parent).unwrap(),
+                Some(&Url::from_directory_path(root).unwrap())
+            )
+            .iter()
+            .any(|path| path.ends_with("later"))
+        );
+
+        touch(&root.join("later/new.R"), "");
+        finalize_tar_source_requests(
+            &mut metadata,
+            &Url::from_file_path(&parent).unwrap(),
+            Some(&Url::from_directory_path(root).unwrap()),
+        );
+        assert_eq!(relative_sources(root, &metadata), ["later/new.R"]);
+    }
+
+    #[test]
+    fn expansion_uses_workspace_explicit_inherited_and_implicit_forward_tiers() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("R/workspace.R"), "workspace <- 1\n");
+        touch(&root.join("runtime/R/runtime.R"), "runtime <- 1\n");
+        touch(
+            &root.join("tests/testthat/R/test-helper.R"),
+            "test_helper <- 1\n",
+        );
+
+        let workspace_parent = root.join("scripts/_targets.R");
+        touch(&workspace_parent, "targets::tar_source(\"R\")\n");
+        assert_eq!(
+            relative_sources(
+                root,
+                &finalize(root, &workspace_parent, "targets::tar_source(\"R\")\n")
+            ),
+            ["R/workspace.R"]
+        );
+
+        let explicit_parent = root.join("scripts/explicit.R");
+        let explicit_code = "# raven: cd ../runtime\ntargets::tar_source(\"R\")\n";
+        touch(&explicit_parent, explicit_code);
+        assert_eq!(
+            relative_sources(root, &finalize(root, &explicit_parent, explicit_code)),
+            ["runtime/R/runtime.R"]
+        );
+
+        let inherited_parent = root.join("scripts/inherited.R");
+        let inherited_code = "targets::tar_source(\"R\")\n";
+        touch(&inherited_parent, inherited_code);
+        let inherited_uri = Url::from_file_path(&inherited_parent).unwrap();
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let mut inherited = crate::cross_file::extract_metadata(inherited_code);
+        inherited.inherited_working_directory =
+            Some(root.join("runtime").to_string_lossy().into_owned());
+        finalize_tar_source_requests(&mut inherited, &inherited_uri, Some(&root_uri));
+        assert_eq!(relative_sources(root, &inherited), ["runtime/R/runtime.R"]);
+
+        let implicit_parent = root.join("tests/testthat/test-parent.R");
+        touch(&implicit_parent, inherited_code);
+        assert_eq!(
+            relative_sources(root, &finalize(root, &implicit_parent, inherited_code)),
+            ["tests/testthat/R/test-helper.R"]
+        );
+    }
+
+    #[test]
+    fn reuse_requires_identical_requests_and_path_context() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("R/a.R"), "");
+        let parent = root.join("_targets.R");
+        touch(&parent, "");
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let previous = finalize(root, &parent, "targets::tar_source(\"R\")");
+
+        let mut same = crate::cross_file::extract_metadata("targets::tar_source(\"R\")");
+        assert!(reuse_tar_source_expansion(
+            &mut same,
+            &previous,
+            &parent_uri,
+            Some(&root_uri)
+        ));
+        assert_eq!(relative_sources(root, &same), ["R/a.R"]);
+
+        let mut changed = crate::cross_file::extract_metadata(
+            "# raven: cd elsewhere\ntargets::tar_source(\"R\")",
+        );
+        assert!(!reuse_tar_source_expansion(
+            &mut changed,
+            &previous,
+            &parent_uri,
+            Some(&root_uri)
+        ));
+    }
+
+    #[test]
+    fn overlap_is_symmetric_and_ascii_case_lenient() {
+        assert!(paths_overlap(
+            Path::new("/workspace/R/child.R"),
+            Path::new("/workspace/r")
+        ));
+        assert!(paths_overlap(
+            Path::new("/workspace"),
+            Path::new("/workspace/R/child.R")
+        ));
+        assert!(!paths_overlap(
+            Path::new("/workspace/R"),
+            Path::new("/workspace/other")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_path_order_uses_raw_non_utf8_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = Path::new("/workspace");
+        let lower = root.join(OsString::from_vec(b"a\x80.R".to_vec()));
+        let higher = root.join(OsString::from_vec(b"a\xff.R".to_vec()));
+        assert!(relative_full_path_key(root, &lower) < relative_full_path_key(root, &higher));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_files_directories_and_broken_targets_remain_watchable() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("real.R"), "real <- 1\n");
+        touch(&root.join("real-dir/nested.R"), "nested <- 1\n");
+        symlink("real.R", root.join("linked.R")).unwrap();
+        symlink("real-dir", root.join("linked-dir")).unwrap();
+        symlink("missing-target.R", root.join("broken.R")).unwrap();
+        let parent = root.join("_targets.R");
+        let code = "targets::tar_source(c(\"linked.R\", \"linked-dir\", \"broken.R\"))\n";
+        touch(&parent, code);
+
+        let metadata = finalize(root, &parent, code);
+        assert_eq!(
+            metadata
+                .sources
+                .iter()
+                .filter(|source| source.tar_source_ordinal.is_some())
+                .count(),
+            2
+        );
+        assert!(
+            metadata
+                .tar_source_expansion_watch_paths
+                .contains(&root.join("missing-target.R")),
+            "broken symlink target spelling must remain watchable"
+        );
+        assert!(
+            metadata
+                .tar_source_expansion_watch_paths
+                .contains(&root.join("real-dir").canonicalize().unwrap()),
+            "directory symlink target must remain watchable"
+        );
+    }
+
+    #[test]
+    fn contextual_providers_discover_tar_batch_below_ordinary_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("main.R"), "source(\"driver.R\")\n");
+        let driver_code = "# raven: cd runtime\n\
+                           targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+                           targets::tar_source(\"../child.R\", change_directory = TRUE)\n";
+        touch(&root.join("driver.R"), driver_code);
+        touch(&root.join("child.R"), "source(\"config.R\")\n");
+        touch(&root.join("runtime/config.R"), "runtime_symbol <- 1\n");
+        touch(&root.join("config.R"), "root_symbol <- 1\n");
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let main_uri = Url::from_file_path(root.join("main.R")).unwrap();
+        let driver_uri = Url::from_file_path(root.join("driver.R")).unwrap();
+        let child_uri = Url::from_file_path(root.join("child.R")).unwrap();
+        let runtime_uri = Url::from_file_path(root.join("runtime/config.R")).unwrap();
+        let config_uri = Url::from_file_path(root.join("config.R")).unwrap();
+        let main_metadata = crate::cross_file::extract_metadata("source(\"driver.R\")\n");
+        let driver_metadata = finalize(root, &root.join("driver.R"), driver_code);
+        let metadata = HashMap::from([
+            (driver_uri.clone(), std::sync::Arc::new(driver_metadata)),
+            (
+                child_uri.clone(),
+                std::sync::Arc::new(crate::cross_file::extract_metadata(
+                    "source(\"config.R\")\n",
+                )),
+            ),
+            (
+                runtime_uri.clone(),
+                std::sync::Arc::new(crate::cross_file::extract_metadata("runtime_symbol <- 1\n")),
+            ),
+            (
+                config_uri.clone(),
+                std::sync::Arc::new(crate::cross_file::extract_metadata("root_symbol <- 1\n")),
+            ),
+        ]);
+        let mut graph = crate::cross_file::dependency::DependencyGraph::new();
+        graph.update_file(&main_uri, &main_metadata, Some(&root_uri), |_| None);
+        for uri in [&driver_uri, &child_uri, &runtime_uri, &config_uri] {
+            graph.update_file(uri, metadata[uri].as_ref(), Some(&root_uri), |_| None);
+        }
+        let edge_revision = graph.edge_revision();
+        let main_edges = graph.get_dependencies(&main_uri);
+
+        let collected = collect_contextual_tar_providers(
+            &main_uri,
+            &main_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|parent, source| {
+                let target = graph
+                    .get_dependencies(parent)
+                    .into_iter()
+                    .find(|edge| {
+                        edge.call_site_line == Some(source.line)
+                            && edge.call_site_column == Some(source.column)
+                            && edge.tar_source_ordinal == source.tar_source_ordinal
+                    })
+                    .map(|edge| edge.to.clone());
+                GraphPrefixEdgeLookup::Known(target)
+            },
+        );
+        assert!(collected.divergence);
+        assert!(collected.providers.contains(&runtime_uri));
+        assert!(collected.providers.contains(&config_uri));
+        assert!(
+            collected
+                .executions
+                .iter()
+                .any(|execution| execution.uri == driver_uri && !execution.contextual)
+        );
+        assert_eq!(graph.edge_revision(), edge_revision);
+        assert_eq!(graph.get_dependencies(&main_uri), main_edges);
+    }
+
+    #[test]
+    fn graph_prefix_unknown_edges_fail_closed_without_lexical_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("main.R"), "source(\"driver.R\")\n");
+        touch(&root.join("driver.R"), "targets::tar_source(\"child.R\")\n");
+        touch(&root.join("child.R"), "member <- 1\n");
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let main_uri = Url::from_file_path(root.join("main.R")).unwrap();
+        let main_metadata = crate::cross_file::extract_metadata("source(\"driver.R\")\n");
+
+        let unknown = collect_contextual_tar_providers(
+            &main_uri,
+            &main_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|_| None,
+            &|_, _| GraphPrefixEdgeLookup::Unknown,
+        );
+        assert!(unknown.truncated);
+        assert!(unknown.divergence);
+        assert!(
+            unknown.providers.is_empty(),
+            "an unknown graph prefix must not be replaced with the lexically existing driver"
+        );
+
+        let known_unresolved = collect_contextual_tar_providers(
+            &main_uri,
+            &main_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|_| None,
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(!known_unresolved.truncated);
+        assert!(!known_unresolved.divergence);
+        assert!(known_unresolved.providers.is_empty());
+    }
+
+    #[test]
+    fn graph_prefix_follows_non_inheriting_edges_to_tar_batch() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let main_code = "sys.source(\"driver.R\", envir = new.env())\n";
+        touch(&root.join("main.R"), main_code);
+        let driver_code = "targets::tar_source(\"child.R\")\n";
+        touch(&root.join("driver.R"), driver_code);
+        touch(&root.join("child.R"), "member <- 1\n");
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let main_uri = Url::from_file_path(root.join("main.R")).unwrap();
+        let driver_uri = Url::from_file_path(root.join("driver.R")).unwrap();
+        let child_uri = Url::from_file_path(root.join("child.R")).unwrap();
+        let main_metadata = crate::cross_file::extract_metadata(main_code);
+        assert_eq!(
+            main_metadata.sources[0].locality,
+            SourceLocality::NonInheriting,
+            "test premise: a new.env() sys.source must be NonInheriting"
+        );
+        let driver_metadata = finalize(root, &root.join("driver.R"), driver_code);
+        let metadata = HashMap::from([
+            (driver_uri.clone(), std::sync::Arc::new(driver_metadata)),
+            (
+                child_uri.clone(),
+                std::sync::Arc::new(crate::cross_file::extract_metadata("member <- 1\n")),
+            ),
+        ]);
+        let mut graph = crate::cross_file::dependency::DependencyGraph::new();
+        graph.update_file(&main_uri, &main_metadata, Some(&root_uri), |_| None);
+        for uri in [&driver_uri, &child_uri] {
+            graph.update_file(uri, metadata[uri].as_ref(), Some(&root_uri), |_| None);
+        }
+
+        let collected = collect_contextual_tar_providers(
+            &main_uri,
+            &main_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|parent, source| {
+                let target = graph
+                    .get_dependencies(parent)
+                    .into_iter()
+                    .find(|edge| {
+                        edge.call_site_line == Some(source.line)
+                            && edge.call_site_column == Some(source.column)
+                            && edge.tar_source_ordinal == source.tar_source_ordinal
+                    })
+                    .map(|edge| edge.to.clone());
+                GraphPrefixEdgeLookup::Known(target)
+            },
+        );
+        assert!(
+            collected.providers.contains(&child_uri),
+            "a NonInheriting graph-prefix edge must still host the driver's tar batch: {collected:?}"
+        );
+        assert!(
+            collected
+                .executions
+                .iter()
+                .any(|execution| execution.uri == driver_uri && !execution.contextual),
+            "{collected:?}"
+        );
+        assert!(!collected.divergence);
+        assert!(!collected.truncated);
+
+        // Locality-agnostic traversal must not weaken fail-closed behavior: an
+        // Unknown graph view still yields no providers through the same edge.
+        let unknown = collect_contextual_tar_providers(
+            &main_uri,
+            &main_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Unknown,
+        );
+        assert!(unknown.truncated);
+        assert!(unknown.divergence);
+        assert!(unknown.providers.is_empty());
+    }
+
+    #[test]
+    fn contextual_closure_follows_non_inheriting_edges_for_process_effects() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let parent = root.join("_targets.R");
+        let parent_code = "targets::tar_source(\"child.R\")\n";
+        touch(&parent, parent_code);
+        let child_code = "sys.source(\"helper.R\", envir = new.env())\n";
+        touch(&root.join("child.R"), child_code);
+        let helper_code = "library(syntheticpkg)\nprivate_helper <- 1\n";
+        touch(&root.join("helper.R"), helper_code);
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let child_uri = Url::from_file_path(root.join("child.R")).unwrap();
+        let helper_uri = Url::from_file_path(root.join("helper.R")).unwrap();
+        let parent_metadata = finalize(root, &parent, parent_code);
+        let child_metadata = crate::cross_file::extract_metadata(child_code);
+        assert_eq!(
+            child_metadata.sources[0].locality,
+            SourceLocality::NonInheriting
+        );
+        let metadata = HashMap::from([
+            (child_uri.clone(), std::sync::Arc::new(child_metadata)),
+            (
+                helper_uri.clone(),
+                std::sync::Arc::new(crate::cross_file::extract_metadata(helper_code)),
+            ),
+        ]);
+
+        let collected = collect_contextual_tar_providers(
+            &parent_uri,
+            &parent_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(collected.providers.contains(&child_uri));
+        assert!(
+            collected.providers.contains(&helper_uri),
+            "contextual traversal must retain a NonInheriting helper so scope can observe its \
+             process-wide package/data effects: {collected:?}"
+        );
+        assert!(!collected.divergence);
+        assert!(!collected.truncated);
+    }
+
+    #[test]
+    fn contextual_providers_are_sorted_and_distinguish_repeated_child_contexts() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("child.R"), "source(\"config.R\")\n");
+        touch(&root.join("runtime/config.R"), "runtime <- 1\n");
+        touch(&root.join("config.R"), "root <- 1\n");
+        let parent = root.join("_targets.R");
+        let code = "# raven: cd runtime\n\
+                    targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+                    targets::tar_source(\"../child.R\", change_directory = TRUE)\n";
+        touch(&parent, code);
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let child_uri = Url::from_file_path(root.join("child.R")).unwrap();
+        let runtime_uri = Url::from_file_path(root.join("runtime/config.R")).unwrap();
+        let config_uri = Url::from_file_path(root.join("config.R")).unwrap();
+        let parent_metadata = finalize(root, &parent, code);
+        let metadata = HashMap::from([(
+            child_uri.clone(),
+            std::sync::Arc::new(crate::cross_file::extract_metadata(
+                "source(\"config.R\")\n",
+            )),
+        )]);
+        let mut graph = crate::cross_file::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        graph.update_file(
+            &child_uri,
+            metadata[&child_uri].as_ref(),
+            Some(&root_uri),
+            |_| None,
+        );
+        let edge_revision = graph.edge_revision();
+        let child_edges = graph.get_dependencies(&child_uri);
+
+        let collected = collect_contextual_tar_providers(
+            &parent_uri,
+            &parent_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(collected.divergence);
+        assert!(!collected.truncated);
+        assert!(collected.providers.contains(&runtime_uri));
+        assert!(collected.providers.contains(&config_uri));
+        assert!(
+            collected
+                .providers
+                .windows(2)
+                .all(|pair| pair[0].as_str() <= pair[1].as_str())
+        );
+        assert_eq!(graph.edge_revision(), edge_revision);
+        assert_eq!(
+            graph.get_dependencies(&child_uri),
+            child_edges,
+            "context collection must not add alternate graph edges"
+        );
+    }
+
+    #[test]
+    fn contextual_providers_keep_coincident_contexts_non_divergent() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("child.R"), "source(\"config.R\")\n");
+        touch(&root.join("runtime/config.R"), "runtime <- 1\n");
+        let parent = root.join("_targets.R");
+        let code = "# raven: cd runtime\n\
+                    targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+                    targets::tar_source(\"../child.R\", change_directory = FALSE)\n";
+        touch(&parent, code);
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let child_uri = Url::from_file_path(root.join("child.R")).unwrap();
+        let runtime_uri = Url::from_file_path(root.join("runtime/config.R")).unwrap();
+        let parent_metadata = finalize(root, &parent, code);
+        let metadata = HashMap::from([
+            (
+                child_uri,
+                std::sync::Arc::new(crate::cross_file::extract_metadata(
+                    "source(\"config.R\")\n",
+                )),
+            ),
+            (
+                runtime_uri,
+                std::sync::Arc::new(crate::cross_file::extract_metadata("runtime <- 1\n")),
+            ),
+        ]);
+
+        let collected = collect_contextual_tar_providers(
+            &parent_uri,
+            &parent_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(!collected.divergence);
+        assert!(!collected.truncated);
+    }
+
+    #[test]
+    fn contextual_provider_budget_and_cycle_terminate_safe_direction() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        touch(&root.join("a.R"), "source(\"a.R\")\n");
+        touch(&root.join("b.R"), "b <- 1\n");
+        let parent = root.join("_targets.R");
+        let code = "targets::tar_source(c(\"a.R\", \"b.R\"))\n";
+        touch(&parent, code);
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let a_uri = Url::from_file_path(root.join("a.R")).unwrap();
+        let parent_metadata = finalize(root, &parent, code);
+        let metadata = HashMap::from([(
+            a_uri,
+            std::sync::Arc::new(crate::cross_file::extract_metadata("source(\"a.R\")\n")),
+        )]);
+
+        let bounded = collect_contextual_tar_providers(
+            &parent_uri,
+            &parent_metadata,
+            Some(&root_uri),
+            10,
+            1,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(bounded.truncated);
+        assert!(bounded.divergence);
+
+        let cyclic = collect_contextual_tar_providers(
+            &parent_uri,
+            &parent_metadata,
+            Some(&root_uri),
+            10,
+            100,
+            &|uri| metadata.get(uri).cloned(),
+            &|_, _| GraphPrefixEdgeLookup::Known(None),
+        );
+        assert!(!cyclic.truncated);
+        assert!(cyclic.providers.len() <= 2);
+    }
+}

--- a/crates/raven/src/cross_file/types.rs
+++ b/crates/raven/src/cross_file/types.rs
@@ -188,6 +188,17 @@ pub struct CrossFileMetadata {
     pub sourced_by: Vec<BackwardDirective>,
     /// Forward directives and detected source() calls
     pub sources: Vec<ForwardSource>,
+    /// Statically recognized top-level `{targets}` `tar_source()` calls.
+    ///
+    /// Requests remain durable even when none of their paths currently exist.
+    /// Filesystem expansion is a separate, workspace-aware phase performed
+    /// after working-directory enrichment.
+    #[serde(default)]
+    pub tar_source_requests: Vec<TarSourceRequest>,
+    /// Existing and potential filesystem roots retained by the last
+    /// `tar_source()` expansion, including real targets of followed symlinks.
+    #[serde(default)]
+    pub tar_source_expansion_watch_paths: Vec<std::path::PathBuf>,
     /// Working directory override (explicit `# raven: cd`)
     pub working_directory: Option<String>,
     /// Working directory inherited from parent via backward directive.
@@ -252,6 +263,27 @@ pub struct CrossFileMetadata {
     /// Detected `pkg::member` namespace references (issue #503).
     #[serde(default)]
     pub namespace_references: Vec<NamespaceReference>,
+}
+
+/// One statically recognized top-level `{targets}` `tar_source()` call.
+///
+/// `files` preserves the user's vector order. Expansion and first-occurrence
+/// deduplication are scoped to this request: separate calls that name the same
+/// script represent separate executions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+pub struct TarSourceRequest {
+    /// Statically resolved `files` argument, or `["R"]` when omitted.
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// 0-based line of the call.
+    #[serde(default)]
+    pub line: u32,
+    /// 0-based UTF-16 column of the call.
+    #[serde(default)]
+    pub column: u32,
+    /// Static `change_directory = TRUE` value.
+    #[serde(default)]
+    pub change_directory: bool,
 }
 
 impl CrossFileMetadata {
@@ -371,6 +403,11 @@ pub struct ForwardSource {
     /// calling `resolve_path` (which can't handle true absolute paths outside
     /// the workspace). Set by `resolve_system_file_sources` for branch-2 hits.
     pub resolved_uri: Option<tower_lsp::lsp_types::Url>,
+    /// Ordered child index within one expanded `tar_source()` call.
+    ///
+    /// `Some` also identifies this source as tar-derived. The call identity is
+    /// `(line, column)` and the ordinal disambiguates members sharing it.
+    pub tar_source_ordinal: Option<u32>,
 }
 
 fn default_sys_source_global_env() -> bool {
@@ -409,6 +446,8 @@ struct ForwardSourceWire {
     system_file: Option<super::source_detect::SystemFileCall>,
     #[serde(default)]
     resolved_uri: Option<tower_lsp::lsp_types::Url>,
+    #[serde(default)]
+    tar_source_ordinal: Option<u32>,
 }
 
 impl Serialize for ForwardSource {
@@ -418,7 +457,7 @@ impl Serialize for ForwardSource {
     {
         let local = !self.is_sys_source && self.locality != SourceLocality::Global;
         let sys_source_global_env = !self.is_sys_source || self.locality == SourceLocality::Global;
-        let mut state = serializer.serialize_struct("ForwardSource", 15)?;
+        let mut state = serializer.serialize_struct("ForwardSource", 16)?;
         state.serialize_field("path", &self.path)?;
         state.serialize_field("line", &self.line)?;
         state.serialize_field("column", &self.column)?;
@@ -434,6 +473,7 @@ impl Serialize for ForwardSource {
         state.serialize_field("is_function_scoped", &self.is_function_scoped)?;
         state.serialize_field("system_file", &self.system_file)?;
         state.serialize_field("resolved_uri", &self.resolved_uri)?;
+        state.serialize_field("tar_source_ordinal", &self.tar_source_ordinal)?;
         state.end()
     }
 }
@@ -467,6 +507,7 @@ impl<'de> Deserialize<'de> for ForwardSource {
             is_function_scoped: wire.is_function_scoped,
             system_file: wire.system_file,
             resolved_uri: wire.resolved_uri,
+            tar_source_ordinal: wire.tar_source_ordinal,
         })
     }
 }

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -441,10 +441,11 @@ impl DiagnosticsSnapshot {
         Self::build_with_open_documents(state, uri, &state.documents)
     }
 
-    /// Like [`Self::build`] but with an explicit open-documents map instead of
+    /// Like [`Self::build`] but with an explicit open-documents view instead of
     /// `state.documents`. `raven check`'s parallel loop (issue #479 WI3) passes a
-    /// one-entry map holding just the worker's target, so exactly one document
-    /// is "open" per task without sharing/mutating `state.documents`. The LSP
+    /// coherent one-record store holding just the worker's target, so exactly
+    /// one document is "open" per task without sharing/mutating
+    /// `state.documents`. The LSP
     /// path calls [`Self::build`], which forwards `&state.documents` and so is
     /// behavior-identical. `get_enriched_metadata` is intentionally NOT
     /// redirected: for an indexed target it resolves from the workspace index
@@ -455,6 +456,30 @@ impl DiagnosticsSnapshot {
         state: &WorldState,
         uri: &Url,
         open_documents: &impl OpenDocumentsView,
+    ) -> Option<Self> {
+        Self::build_with_open_documents_and_extra_providers(
+            state,
+            uri,
+            open_documents,
+            &HashSet::new(),
+            false,
+        )
+    }
+
+    /// Build with an additional context-sensitive provider set.
+    ///
+    /// The dependency graph remains URI-global; callers use this only to make
+    /// already-finalized artifacts available to scope resolution when a tar
+    /// execution's supplied [`crate::cross_file::path_resolve::PathContext`]
+    /// selects a different provider than the graph edge. `context_divergence`
+    /// disables the URI-keyed standalone cache even when every provider already
+    /// belongs to the graph neighborhood.
+    pub(crate) fn build_with_open_documents_and_extra_providers(
+        state: &WorldState,
+        uri: &Url,
+        open_documents: &impl OpenDocumentsView,
+        extra_provider_uris: &HashSet<Url>,
+        context_divergence: bool,
     ) -> Option<Self> {
         let build_start = std::time::Instant::now();
         let doc = open_documents.document(uri)?;
@@ -520,6 +545,39 @@ impl DiagnosticsSnapshot {
                 .cached_neighborhood_subgraph(uri, max_depth, max_visited);
         let neighborhood_elapsed = neighborhood_start.elapsed();
         let content_provider = state.content_provider_with_documents(open_documents);
+        // The dependency graph remains URI-global, but ordered tar execution
+        // may reach one provider URI under multiple PathContexts. Collect the
+        // ordinary graph-prefix-to-tar closure for every snapshot so LSP and
+        // CLI use the same contextual provider plan. This is pure in-memory
+        // collection under the state snapshot: no filesystem or graph writes.
+        let contextual_providers = crate::cross_file::tar_source::collect_contextual_tar_providers(
+            uri,
+            &directive_meta,
+            state.workspace_folders.first(),
+            state.cross_file_config.max_forward_depth,
+            max_visited,
+            &|provider_uri| content_provider.get_metadata(provider_uri),
+            &|parent_uri, source| {
+                if !payload.neighborhood.contains(parent_uri) {
+                    return crate::cross_file::tar_source::GraphPrefixEdgeLookup::Unknown;
+                }
+                let target = payload
+                    .subgraph
+                    .get_dependencies(parent_uri)
+                    .into_iter()
+                    .find(|edge| {
+                        edge.call_site_line == Some(source.line)
+                            && edge.call_site_column == Some(source.column)
+                            && edge.tar_source_ordinal == source.tar_source_ordinal
+                    })
+                    .map(|edge| edge.to.clone());
+                crate::cross_file::tar_source::GraphPrefixEdgeLookup::Known(target)
+            },
+        );
+        let mut all_extra_provider_uris = extra_provider_uris.clone();
+        all_extra_provider_uris.extend(contextual_providers.providers);
+        let context_divergence =
+            context_divergence || contextual_providers.divergence || contextual_providers.truncated;
 
         let precollect_start = std::time::Instant::now();
         let mut artifacts_map = HashMap::new();
@@ -536,7 +594,7 @@ impl DiagnosticsSnapshot {
         // Computed in this already-O(neighborhood) loop, so it adds no new
         // asymptotic cost (just a `bool` OR per entry already being inserted).
         let mut any_nse_or_func_directives = directive_meta.has_nse_or_func_directives();
-        for neighbor_uri in &payload.neighborhood {
+        for neighbor_uri in payload.neighborhood.iter().chain(&all_extra_provider_uris) {
             if let Some(artifacts) = content_provider.get_artifacts(neighbor_uri) {
                 artifacts_map.insert(neighbor_uri.clone(), artifacts);
             }
@@ -645,7 +703,9 @@ impl DiagnosticsSnapshot {
             // graph (the trimmed `cross_file_graph` above is a clone whose
             // counter resets to 0). `None` when disabled via the env toggle
             // (cache-on vs cache-off byte-identity gate).
-            standalone_ctx: if crate::cross_file::standalone_cache::standalone_cache_disabled() {
+            standalone_ctx: if context_divergence
+                || crate::cross_file::standalone_cache::standalone_cache_disabled()
+            {
                 None
             } else {
                 Some(crate::cross_file::standalone_cache::StandaloneCacheCtx {
@@ -22726,6 +22786,192 @@ fn hover_blocking(state: &WorldState, uri: &Url, position: Position) -> Option<H
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn contextual_divergence_disables_standalone_cache_even_without_extras() {
+        let uri = Url::parse("file:///workspace/report.R").unwrap();
+        let mut state = WorldState::new();
+        state.open_document(uri.clone(), "x <- 1\n", Some(1));
+        let extras = HashSet::new();
+
+        let ordinary = DiagnosticsSnapshot::build_with_open_documents_and_extra_providers(
+            &state,
+            &uri,
+            &state.documents,
+            &extras,
+            false,
+        )
+        .unwrap();
+        assert!(
+            ordinary.standalone_ctx.is_some(),
+            "coincident contexts with no extras keep the persistent cache"
+        );
+
+        let divergent = DiagnosticsSnapshot::build_with_open_documents_and_extra_providers(
+            &state,
+            &uri,
+            &state.documents,
+            &extras,
+            true,
+        )
+        .unwrap();
+        assert!(
+            divergent.standalone_ctx.is_none(),
+            "context divergence must disable the URI-keyed cache even when extras are empty"
+        );
+    }
+
+    #[test]
+    fn ordinary_snapshot_collects_alternate_tar_provider_direct_and_below_source() {
+        use std::sync::Arc;
+        use std::time::SystemTime;
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("runtime")).unwrap();
+        std::fs::write(temp.path().join("child.R"), "source(\"config.R\")\n").unwrap();
+        std::fs::write(temp.path().join("config.R"), "root_symbol <- 1\n").unwrap();
+        std::fs::write(
+            temp.path().join("runtime/config.R"),
+            "runtime_symbol <- 1\n",
+        )
+        .unwrap();
+        let parent_code = "# raven: cd runtime\n\
+                           targets::tar_source(\"../child.R\", change_directory = FALSE)\n\
+                           targets::tar_source(\"../child.R\", change_directory = TRUE)\n\
+                           runtime_symbol\nroot_symbol\n";
+        let parent_path = temp.path().join("_targets.R");
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(temp.path()).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let child_uri = Url::from_file_path(temp.path().join("child.R")).unwrap();
+        let root_config_uri = Url::from_file_path(temp.path().join("config.R")).unwrap();
+        let runtime_config_uri = Url::from_file_path(temp.path().join("runtime/config.R")).unwrap();
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![root_uri.clone()];
+
+        fn index_closed(
+            state: &mut WorldState,
+            uri: &Url,
+            code: &str,
+            workspace_root: &Url,
+        ) -> Arc<crate::cross_file::CrossFileMetadata> {
+            let doc = crate::state::Document::new_with_uri(code, None, uri);
+            let mut metadata = crate::cross_file::extract_metadata(code);
+            crate::cross_file::tar_source::finalize_tar_source_requests(
+                &mut metadata,
+                uri,
+                Some(workspace_root),
+            );
+            let metadata = Arc::new(metadata);
+            let artifacts = Arc::new(crate::cross_file::scope::compute_artifacts_with_metadata(
+                uri,
+                doc.tree.as_ref().expect("fixture parses"),
+                code,
+                Some(&metadata),
+            ));
+            let entry = crate::workspace_index::IndexEntry {
+                contents: doc.contents.clone(),
+                tree: doc.tree.clone(),
+                loaded_packages: doc.loaded_packages.clone(),
+                data_packages: vec![],
+                snapshot: crate::cross_file::file_cache::FileSnapshot {
+                    mtime: SystemTime::UNIX_EPOCH,
+                    size: code.len() as u64,
+                    content_hash: None,
+                },
+                metadata: metadata.clone(),
+                artifacts,
+                indexed_at_version: state.workspace_index.version(),
+            };
+            assert!(state.workspace_index.insert(uri.clone(), entry));
+            metadata
+        }
+
+        let child_metadata =
+            index_closed(&mut state, &child_uri, "source(\"config.R\")\n", &root_uri);
+        let root_config_metadata = index_closed(
+            &mut state,
+            &root_config_uri,
+            "root_symbol <- 1\n",
+            &root_uri,
+        );
+        let runtime_config_metadata = index_closed(
+            &mut state,
+            &runtime_config_uri,
+            "runtime_symbol <- 1\n",
+            &root_uri,
+        );
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let parent_metadata = Arc::new(parent_metadata);
+        state.open_document_with_language_id_and_metadata(
+            parent_uri.clone(),
+            parent_code,
+            Some(1),
+            Some("r"),
+            parent_metadata.clone(),
+            None,
+        );
+        for (uri, metadata) in [
+            (&parent_uri, &parent_metadata),
+            (&child_uri, &child_metadata),
+            (&root_config_uri, &root_config_metadata),
+            (&runtime_config_uri, &runtime_config_metadata),
+        ] {
+            state
+                .cross_file_graph
+                .update_file(uri, metadata, Some(&root_uri), |_| None);
+        }
+
+        assert!(
+            !state
+                .cross_file_graph
+                .cached_neighborhood_subgraph(&parent_uri, 10, 100)
+                .neighborhood
+                .contains(&runtime_config_uri),
+            "precondition: URI-global child edge selects only root/config.R"
+        );
+        let snapshot = DiagnosticsSnapshot::build(&state, &parent_uri).unwrap();
+        assert!(
+            snapshot.artifacts_map.contains_key(&runtime_config_uri),
+            "normal LSP snapshot must precollect the alternate contextual provider"
+        );
+        assert!(
+            snapshot.standalone_ctx.is_none(),
+            "multiple contexts for one child disable the URI-keyed standalone cache"
+        );
+
+        let main_uri = Url::from_file_path(temp.path().join("main.R")).unwrap();
+        let main_code = "source(\"_targets.R\")\nruntime_symbol\nroot_symbol\n";
+        std::fs::write(temp.path().join("main.R"), main_code).unwrap();
+        let main_metadata = Arc::new(crate::cross_file::extract_metadata(main_code));
+        state.open_document_with_language_id_and_metadata(
+            main_uri.clone(),
+            main_code,
+            Some(1),
+            Some("r"),
+            main_metadata.clone(),
+            None,
+        );
+        state
+            .cross_file_graph
+            .update_file(&main_uri, &main_metadata, Some(&root_uri), |_| None);
+
+        let nested = DiagnosticsSnapshot::build(&state, &main_uri).unwrap();
+        assert!(
+            nested.artifacts_map.contains_key(&runtime_config_uri),
+            "main -> driver -> repeated tar child must collect the alternate provider"
+        );
+        assert!(
+            nested.standalone_ctx.is_none(),
+            "nested contextual divergence must also disable the URI-keyed cache"
+        );
+    }
 
     #[test]
     fn read_file_content_strips_bom_on_disk_fallback() {

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -965,6 +965,16 @@ pub struct WorldState {
     #[cfg(test)]
     pub(crate) alias_reconcile_pre_commit_test_pause:
         crate::cross_file::revalidation::DiagnosticsPublishPause,
+    /// Deterministic barrier after open tar-parent derivation and before its
+    /// central CAS. One-shot arming lets tests reject consecutive rounds.
+    #[cfg(test)]
+    pub(crate) open_tar_source_refresh_pre_commit_test_pause:
+        crate::cross_file::revalidation::DiagnosticsPublishPause,
+    /// Deterministic barrier after the desired register becomes empty and
+    /// before the single-flight coordinator releases admission.
+    #[cfg(test)]
+    pub(crate) open_tar_source_refresh_pre_release_test_pause:
+        crate::cross_file::revalidation::DiagnosticsPublishPause,
     /// Deterministic barrier after an on-demand package build and before its
     /// exact input/readiness CAS.
     #[cfg(test)]
@@ -1131,6 +1141,13 @@ pub struct WorldState {
     /// the analysis missed; a missed bump cannot cause a stale-content hit.
     pub package_config_generation: u64,
     pub cross_file_revalidation: CrossFileRevalidationState,
+    /// Latest-owner lifecycle for durable open-parent `tar_source()` refresh.
+    ///
+    /// Each filesystem event supersedes the prior desired generation. One
+    /// backend-owned coordinator per URI serializes physical filesystem walks
+    /// and retries exact-basis conflicts until it commits, the open lifecycle
+    /// disappears, or backend shutdown drains it.
+    pub(crate) open_tar_source_refreshes: CrossFileRevalidationState,
     pub cross_file_activity: CrossFileActivityState,
     /// Editor resources eligible to own push diagnostics, when the client
     /// supplies an explicit UI-resource set.
@@ -1198,6 +1215,15 @@ pub struct WorldState {
     /// events or closes recreate the entry from the state-wide counter, so old
     /// generations are never reused.
     pub watched_file_resync_generations: HashMap<Url, u64>,
+    /// Monotonic fence for filesystem events that may change static
+    /// `targets::tar_source()` membership.
+    tar_source_event_generation: u64,
+    tar_source_watch_generation_counter: u64,
+    /// Monotonic identities survive registry removal as tombstones.
+    tar_source_watch_path_generations: HashMap<PathBuf, u64>,
+    /// Durable bidirectional ownership registry for finalized tar requests.
+    tar_source_watch_paths_by_parent: HashMap<Url, Vec<PathBuf>>,
+    tar_source_parents_by_watch_path: HashMap<PathBuf, HashSet<Url>>,
     /// Exact applied watcher lifecycle; handle ownership is never exposed for
     /// cloning outside the central watcher CAS paths.
     libpath_watcher: LibpathWatcherState,
@@ -1371,6 +1397,8 @@ impl DiagnosticsTrigger {
 pub(crate) struct AnalysisBasis {
     subject: AnalysisSubjectBasis,
     watched_file_generation: Option<u64>,
+    tar_source_event_generation: u64,
+    tar_source_watch_generations: Vec<(PathBuf, u64)>,
     graph_revision: u64,
     graph_authority_generation: u64,
     open_context_authority_generation: OpenContextAuthorityGeneration,
@@ -1523,6 +1551,7 @@ struct ChunkOverrideGeneration(u64);
 pub(crate) struct WorkspaceScanInputBasis {
     intent: WorkspaceScanIntentToken,
     scan_generation: u64,
+    tar_source_event_generation: u64,
     analysis_config_generation: AnalysisConfigGeneration,
     chunk_override_generation: ChunkOverrideGeneration,
     pub(crate) workspace_folders: Vec<Url>,
@@ -1882,6 +1911,7 @@ impl PreparedWatchedBatchAnalysis {
 #[derive(Clone)]
 struct SystemFileAnalysisBasis {
     routing: SystemFileRoutingStamp,
+    tar_source_event_generation: u64,
     workspace_index_version: u64,
     workspace_index_max_files: usize,
     workspace_index_max_file_size_bytes: usize,
@@ -2986,7 +3016,7 @@ pub(crate) struct PreparedOpenAliasReconcileAnalysis {
 /// Captured coherently with `basis` under one brief `WorldState` lock. Parsing,
 /// inherited-WD traversal, alias-root projection, and path filtering run only
 /// after the lock is dropped.
-#[cfg(test)]
+#[derive(Clone)]
 pub(crate) struct CapturedOpenMetadataAnalysis {
     basis: AnalysisBasis,
     pub(crate) uri: Url,
@@ -5286,6 +5316,7 @@ impl WorldState {
         Some(WorkspaceScanInputBasis {
             intent,
             scan_generation: self.workspace_scan_generation,
+            tar_source_event_generation: self.tar_source_event_generation,
             analysis_config_generation: self.analysis_config_generation,
             chunk_override_generation: self.chunk_override_generation,
             workspace_folders: self.workspace_folders.clone(),
@@ -5301,6 +5332,7 @@ impl WorldState {
     fn workspace_scan_input_basis_is_current(&self, basis: &WorkspaceScanInputBasis) -> bool {
         self.workspace_scan_intent_is_current(basis.intent)
             && self.workspace_scan_generation == basis.scan_generation
+            && self.tar_source_event_generation == basis.tar_source_event_generation
             && self.analysis_config_generation == basis.analysis_config_generation
             && self.chunk_override_generation == basis.chunk_override_generation
             && self.workspace_folders == basis.workspace_folders
@@ -5438,6 +5470,124 @@ impl WorldState {
     /// inheriting its unclaimed candidates.
     pub(crate) fn advance_workspace_scan_generation(&mut self) {
         self.workspace_scan_generation = self.workspace_scan_generation.wrapping_add(1);
+    }
+
+    /// Fence detached tar expansion before consulting the reverse registry,
+    /// then return every finalized parent whose request may overlap an event.
+    ///
+    /// The unconditional generation bump closes the race where a CREATE
+    /// arrives after a request begins walking the filesystem but before that
+    /// parent has installed its first registry entry.
+    pub(crate) fn record_tar_source_filesystem_events(
+        &mut self,
+        event_uris: impl IntoIterator<Item = Url>,
+    ) -> Vec<Url> {
+        let event_paths: Vec<PathBuf> = event_uris
+            .into_iter()
+            .filter_map(|uri| uri.to_file_path().ok())
+            .collect();
+        if event_paths.is_empty() {
+            return Vec::new();
+        }
+        self.tar_source_event_generation = self
+            .tar_source_event_generation
+            .checked_add(1)
+            .expect("tar_source filesystem-event generation exhausted");
+
+        let mut overlapping_roots: Vec<PathBuf> = self
+            .tar_source_parents_by_watch_path
+            .keys()
+            .filter(|watch_path| {
+                event_paths.iter().any(|event_path| {
+                    crate::cross_file::tar_source::paths_overlap(event_path, watch_path)
+                })
+            })
+            .cloned()
+            .collect();
+        overlapping_roots.sort();
+        overlapping_roots.dedup();
+        for root in &overlapping_roots {
+            self.bump_tar_source_watch_path_generation(root);
+        }
+
+        let mut parents = HashSet::new();
+        for event_path in &event_paths {
+            for (watch_path, owners) in &self.tar_source_parents_by_watch_path {
+                if crate::cross_file::tar_source::paths_overlap(event_path, watch_path) {
+                    parents.extend(owners.iter().cloned());
+                }
+            }
+        }
+        let mut parents: Vec<_> = parents.into_iter().collect();
+        parents.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        parents
+    }
+
+    fn bump_tar_source_watch_path_generation(&mut self, path: &Path) {
+        self.tar_source_watch_generation_counter = self
+            .tar_source_watch_generation_counter
+            .checked_add(1)
+            .expect("tar_source watch-root generation exhausted");
+        self.tar_source_watch_path_generations
+            .insert(path.to_path_buf(), self.tar_source_watch_generation_counter);
+    }
+
+    /// Rebuild the bidirectional tar watch registry from authoritative
+    /// finalized records. This is called only after a successful commit while
+    /// holding the WorldState write lock, so rejected preparations cannot
+    /// leak registry mutations.
+    fn rebuild_tar_source_watch_registry(&mut self) {
+        let previous_by_path = self.tar_source_parents_by_watch_path.clone();
+        let mut by_parent: HashMap<Url, Vec<PathBuf>> = HashMap::new();
+
+        for uri in self.workspace_index.artifact_uris() {
+            if self.is_document_open_or_alias(&uri) {
+                continue;
+            }
+            if let Some(metadata) = self.workspace_index.get_metadata(&uri) {
+                let mut paths = metadata.tar_source_expansion_watch_paths.clone();
+                paths.sort();
+                paths.dedup();
+                if !paths.is_empty() {
+                    by_parent.insert(uri, paths);
+                }
+            }
+        }
+        for uri in self.documents.keys() {
+            let Some(record) = self.documents.get_record(uri) else {
+                continue;
+            };
+            let mut paths = record.metadata().tar_source_expansion_watch_paths.clone();
+            paths.sort();
+            paths.dedup();
+            if paths.is_empty() {
+                by_parent.remove(uri);
+            } else {
+                by_parent.insert(uri.clone(), paths);
+            }
+        }
+
+        let mut by_path: HashMap<PathBuf, HashSet<Url>> = HashMap::new();
+        for (parent, paths) in &by_parent {
+            for path in paths {
+                by_path
+                    .entry(path.clone())
+                    .or_default()
+                    .insert(parent.clone());
+            }
+        }
+        let mut changed_paths: HashSet<PathBuf> = previous_by_path.keys().cloned().collect();
+        changed_paths.extend(by_path.keys().cloned());
+        let mut changed_paths: Vec<_> = changed_paths
+            .into_iter()
+            .filter(|path| previous_by_path.get(path) != by_path.get(path))
+            .collect();
+        changed_paths.sort();
+        for path in changed_paths {
+            self.bump_tar_source_watch_path_generation(&path);
+        }
+        self.tar_source_watch_paths_by_parent = by_parent;
+        self.tar_source_parents_by_watch_path = by_path;
     }
 
     /// Current operational generation of raw package inputs.
@@ -6040,6 +6190,12 @@ impl WorldState {
             alias_reconcile_pre_commit_test_pause:
                 crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
             #[cfg(test)]
+            open_tar_source_refresh_pre_commit_test_pause:
+                crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
+            #[cfg(test)]
+            open_tar_source_refresh_pre_release_test_pause:
+                crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
+            #[cfg(test)]
             package_init_pre_commit_test_pause:
                 crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
             #[cfg(test)]
@@ -6129,6 +6285,7 @@ impl WorldState {
             ),
             package_config_generation: 0,
             cross_file_revalidation: CrossFileRevalidationState::new(),
+            open_tar_source_refreshes: CrossFileRevalidationState::new(),
             cross_file_activity: CrossFileActivityState::new(),
             editor_diagnostic_uris: None,
             editor_eligibility_generation: EditorEligibilityGeneration(0),
@@ -6137,6 +6294,11 @@ impl WorldState {
             editor_chunk_kind_overrides: HashMap::new(),
             watched_file_resync_generation_counter: 0,
             watched_file_resync_generations: HashMap::new(),
+            tar_source_event_generation: 0,
+            tar_source_watch_generation_counter: 0,
+            tar_source_watch_path_generations: HashMap::new(),
+            tar_source_watch_paths_by_parent: HashMap::new(),
+            tar_source_parents_by_watch_path: HashMap::new(),
             libpath_watcher: LibpathWatcherState::Disabled,
             libpath_watcher_owner_generation: Self::mint_libpath_watcher_owner_generation(),
             package_library_ready: false,
@@ -6512,6 +6674,7 @@ impl WorldState {
     /// publish after the shutdown response.
     pub(crate) fn retire_all_diagnostic_lifecycles(&self) {
         self.cross_file_revalidation.cancel_all();
+        self.open_tar_source_refreshes.cancel_all();
         self.diagnostics_gate.clear_all();
     }
 
@@ -7004,12 +7167,13 @@ impl WorldState {
         self.advance_open_context_authority_generation();
     }
 
-    /// Open one editor-owned document with its already-enriched metadata.
+    /// Open one document authority with its already-enriched metadata.
     ///
     /// The mature [`Document`] constructor is the sole masking/parser/package
     /// derivation path; [`OpenDocumentStore`] derives metadata-dependent scope
-    /// artifacts from that exact tree and analysis text.
-    #[cfg(test)]
+    /// artifacts from that exact tree and analysis text. The CLI disk-fallback
+    /// path uses this after completing the same metadata finalization order as
+    /// workspace scanning.
     pub(crate) fn open_document_with_language_id_and_metadata(
         &mut self,
         uri: Url,
@@ -7176,9 +7340,26 @@ impl WorldState {
         subject: AnalysisSubjectBasis,
         uri: &Url,
     ) -> AnalysisBasis {
+        let tar_source_watch_generations = self
+            .tar_source_watch_paths_by_parent
+            .get(uri)
+            .into_iter()
+            .flatten()
+            .map(|path| {
+                (
+                    path.clone(),
+                    self.tar_source_watch_path_generations
+                        .get(path)
+                        .copied()
+                        .unwrap_or(0),
+                )
+            })
+            .collect();
         AnalysisBasis {
             subject,
             watched_file_generation: self.watched_file_resync_generations.get(uri).copied(),
+            tar_source_event_generation: self.tar_source_event_generation,
+            tar_source_watch_generations,
             graph_revision: self.cross_file_graph.edge_revision(),
             graph_authority_generation: self.workspace_graph_authority_generation(),
             open_context_authority_generation: self.open_context_authority_generation,
@@ -7459,7 +7640,6 @@ impl WorldState {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn capture_open_metadata_derivation(
         &self,
         uri: &Url,
@@ -7536,7 +7716,6 @@ impl WorldState {
         })
     }
 
-    #[cfg(test)]
     pub(crate) fn prepare_captured_open_metadata_analysis(
         &self,
         captured: CapturedOpenMetadataAnalysis,
@@ -7600,6 +7779,13 @@ impl WorldState {
             || (closed_subject && self.is_document_open_or_alias(uri))
             || self.watched_file_resync_generations.get(uri).copied()
                 != basis.watched_file_generation
+            || self.tar_source_event_generation != basis.tar_source_event_generation
+            || basis
+                .tar_source_watch_generations
+                .iter()
+                .any(|(path, generation)| {
+                    self.tar_source_watch_path_generations.get(path).copied() != Some(*generation)
+                })
             || self.cross_file_graph.edge_revision() != basis.graph_revision
             || self.workspace_graph_authority_generation() != basis.graph_authority_generation
             || self.open_context_authority_generation != basis.open_context_authority_generation
@@ -7796,39 +7982,42 @@ impl WorldState {
         &mut self,
         prepared: PreparedAnalysisCommit,
     ) -> Result<AnalysisCommitEffects, AnalysisCommitRejected> {
-        let mutations = match prepared {
+        let result = match prepared {
             PreparedAnalysisCommit::WorkspaceScan(prepared) => {
-                return self.try_commit_workspace_scan(*prepared);
+                self.try_commit_workspace_scan(*prepared)
             }
-            PreparedAnalysisCommit::SystemFile(prepared) => {
-                return self.try_commit_system_file(*prepared);
-            }
-            PreparedAnalysisCommit::OpenClose(prepared) => {
-                return self.try_commit_open_close(*prepared);
-            }
+            PreparedAnalysisCommit::SystemFile(prepared) => self.try_commit_system_file(*prepared),
+            PreparedAnalysisCommit::OpenClose(prepared) => self.try_commit_open_close(*prepared),
             PreparedAnalysisCommit::OpenInstall(prepared) => {
-                return self.try_commit_open_install(*prepared);
+                self.try_commit_open_install(*prepared)
             }
-            PreparedAnalysisCommit::OpenEdit(prepared) => {
-                return self.try_commit_open_edit(*prepared);
-            }
+            PreparedAnalysisCommit::OpenEdit(prepared) => self.try_commit_open_edit(*prepared),
             PreparedAnalysisCommit::OpenMetadata(prepared) => {
-                return self.try_commit_open_metadata(*prepared);
+                self.try_commit_open_metadata(*prepared)
             }
             PreparedAnalysisCommit::OpenAliasReconcile(prepared) => {
-                return self.try_commit_open_alias_reconcile(*prepared);
+                self.try_commit_open_alias_reconcile(*prepared)
             }
-            PreparedAnalysisCommit::Upsert(prepared) => {
-                vec![PreparedClosedMutation::Upsert(prepared)]
-            }
-            PreparedAnalysisCommit::Remove { basis, uri } => {
-                vec![PreparedClosedMutation::Remove { basis, uri }]
-            }
+            PreparedAnalysisCommit::Upsert(prepared) => self.try_commit_closed_batch(
+                vec![PreparedClosedMutation::Upsert(prepared)],
+                None,
+                true,
+                false,
+            ),
+            PreparedAnalysisCommit::Remove { basis, uri } => self.try_commit_closed_batch(
+                vec![PreparedClosedMutation::Remove { basis, uri }],
+                None,
+                true,
+                false,
+            ),
             PreparedAnalysisCommit::WatchedBatch(prepared) => {
-                return self.try_commit_watched_batch(*prepared);
+                self.try_commit_watched_batch(*prepared)
             }
         };
-        self.try_commit_closed_batch(mutations, None, true, false)
+        if result.is_ok() {
+            self.rebuild_tar_source_watch_registry();
+        }
+        result
     }
 
     fn try_commit_watched_batch(
@@ -8011,6 +8200,7 @@ impl WorldState {
             .map(|uri| (uri.clone(), self.documents.record_token(uri)))
             .collect();
         index.version == basis.workspace_index_version
+            && self.tar_source_event_generation == basis.tar_source_event_generation
             && self.workspace_index.config().max_files == basis.workspace_index_max_files
             && self.workspace_index.config().max_file_size_bytes
                 == basis.workspace_index_max_file_size_bytes
@@ -8396,6 +8586,7 @@ impl WorldState {
                 &self.library_routing_reconcile_wake_generation,
             );
         }
+        self.rebuild_tar_source_watch_registry();
 
         Ok((
             LibraryRoutingTransferredEffects {
@@ -9351,6 +9542,7 @@ impl WorldState {
         // Build the dependency graph from all workspace entries so that
         // forward-created backward edges are available for auto-detect mode.
         self.build_dependency_graph_from_workspace();
+        self.rebuild_tar_source_watch_registry();
         self.workspace_scan_complete = true;
         log::info!(
             "[Background] Dependency graph built from workspace entries, workspace_scan_complete = true"
@@ -9543,6 +9735,7 @@ impl WorldState {
         CapturedSystemFileAnalysis {
             basis: SystemFileAnalysisBasis {
                 routing,
+                tar_source_event_generation: self.tar_source_event_generation,
                 workspace_index_version: index.version,
                 workspace_index_max_files: self.workspace_index.config().max_files,
                 workspace_index_max_file_size_bytes: self
@@ -10737,6 +10930,35 @@ pub(crate) fn derive_workspace_dependency_graph(
         }
     }
 
+    // Tar expansion is the final metadata derivation stage: inherited WD and
+    // system.file resolution are already stable. Rebuild artifacts from the
+    // finalized metadata so the timeline and interface hash contain the
+    // ordered batch rather than the syntax-only request.
+    for (uri, entry) in entries.iter_mut() {
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            Arc::make_mut(&mut entry.metadata),
+            uri,
+            workspace_root,
+        );
+        let analysis = entry.contents.to_string();
+        entry.artifacts = Arc::new(match entry.tree.as_ref() {
+            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                uri,
+                tree,
+                &analysis,
+                Some(entry.metadata.as_ref()),
+            ),
+            None => crate::cross_file::scope::ScopeArtifacts::default(),
+        });
+    }
+    for (uri, metadata) in &mut open_metadata {
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            Arc::make_mut(metadata),
+            uri,
+            workspace_root,
+        );
+    }
+
     let mut content: HashMap<Url, String> = entries
         .iter()
         .map(|(uri, entry)| (uri.clone(), entry.contents.to_string()))
@@ -11293,6 +11515,24 @@ pub fn scan_workspace_with_exclusions(
             );
             break;
         }
+    }
+
+    for (uri, entry) in &mut entries {
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            Arc::make_mut(&mut entry.metadata),
+            uri,
+            workspace_root.as_ref(),
+        );
+        let analysis = entry.contents.to_string();
+        entry.artifacts = Arc::new(match entry.tree.as_ref() {
+            Some(tree) => crate::cross_file::scope::compute_artifacts_with_metadata(
+                uri,
+                tree,
+                &analysis,
+                Some(entry.metadata.as_ref()),
+            ),
+            None => crate::cross_file::scope::ScopeArtifacts::default(),
+        });
     }
 
     log::info!("Scanned {} workspace files", entries.len());
@@ -14690,5 +14930,236 @@ mod tests {
             crate::libpath_watcher::LibpathEvent::Rescan
         ));
         seed.ack();
+    }
+
+    #[test]
+    fn tar_watch_event_fence_distinguishes_overlap_from_root_generation() {
+        let parent = Url::parse("file:///workspace/_targets.R").unwrap();
+        let root = PathBuf::from("/workspace/R");
+        let mut state = WorldState::new();
+        state
+            .tar_source_parents_by_watch_path
+            .insert(root.clone(), HashSet::from([parent.clone()]));
+        state
+            .tar_source_watch_paths_by_parent
+            .insert(parent.clone(), vec![root.clone()]);
+        state.bump_tar_source_watch_path_generation(&root);
+        let root_generation = state.tar_source_watch_path_generations[&root];
+        let global_generation = state.tar_source_event_generation;
+
+        let unrelated = state
+            .record_tar_source_filesystem_events([
+                Url::parse("file:///workspace/other/file.R").unwrap()
+            ]);
+        assert!(unrelated.is_empty());
+        assert!(state.tar_source_event_generation > global_generation);
+        assert_eq!(
+            state.tar_source_watch_path_generations[&root], root_generation,
+            "an unrelated event advances the global pre-registry fence but not the root identity"
+        );
+
+        let overlapping = state
+            .record_tar_source_filesystem_events(
+                [Url::parse("file:///workspace/R/new.R").unwrap()],
+            );
+        assert_eq!(overlapping, [parent]);
+        assert!(state.tar_source_watch_path_generations[&root] > root_generation);
+    }
+
+    #[test]
+    fn tar_watch_root_replacement_bumps_tombstone_and_stales_basis() {
+        let parent = Url::parse("file:///workspace/_targets.R").unwrap();
+        let old_root = PathBuf::from("/workspace/R");
+        let new_root = PathBuf::from("/workspace/src");
+        let mut state = WorldState::new();
+        state.open_document(parent.clone(), "targets::tar_source(\"R\")\n", Some(1));
+        let generation = state.documents.get_record(&parent).unwrap().generation();
+        let mut metadata = crate::cross_file::CrossFileMetadata {
+            tar_source_expansion_watch_paths: vec![old_root.clone()],
+            ..Default::default()
+        };
+        state
+            .documents
+            .replace_metadata_if_current(&parent, generation, Arc::new(metadata.clone()))
+            .unwrap();
+        state.rebuild_tar_source_watch_registry();
+        let basis = state.capture_open_analysis_basis(&parent).unwrap();
+        let old_generation = state.tar_source_watch_path_generations[&old_root];
+
+        let generation = state.documents.get_record(&parent).unwrap().generation();
+        metadata.tar_source_expansion_watch_paths = vec![new_root.clone()];
+        state
+            .documents
+            .replace_metadata_if_current(&parent, generation, Arc::new(metadata))
+            .unwrap();
+        state.rebuild_tar_source_watch_registry();
+
+        assert!(
+            !state
+                .tar_source_parents_by_watch_path
+                .contains_key(&old_root)
+        );
+        assert_eq!(
+            state.tar_source_parents_by_watch_path[&new_root],
+            HashSet::from([parent.clone()])
+        );
+        assert!(state.tar_source_watch_path_generations[&old_root] > old_generation);
+        assert!(
+            !state.analysis_basis_is_current(&basis, &parent, &HashSet::new()),
+            "a basis captured against the retired root must not commit"
+        );
+    }
+
+    #[test]
+    fn tar_watch_event_after_walk_rejects_store_and_registry_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("R")).unwrap();
+        std::fs::write(temp.path().join("R/old.R"), "old_value <- 1\n").unwrap();
+        let parent_path = temp.path().join("_targets.R");
+        let parent_text = "targets::tar_source(\"R\")\n";
+        std::fs::write(&parent_path, parent_text).unwrap();
+        let root_uri = Url::from_directory_path(temp.path()).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let old_uri = Url::from_file_path(temp.path().join("R/old.R")).unwrap();
+        let new_uri = Url::from_file_path(temp.path().join("R/new.R")).unwrap();
+
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![root_uri.clone()];
+        state.open_document(parent_uri.clone(), parent_text, Some(1));
+        let mut initial_metadata = crate::cross_file::extract_metadata(parent_text);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut initial_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let initial_generation = state
+            .documents
+            .get_record(&parent_uri)
+            .unwrap()
+            .generation();
+        state
+            .documents
+            .replace_metadata_if_current(
+                &parent_uri,
+                initial_generation,
+                Arc::new(initial_metadata.clone()),
+            )
+            .unwrap();
+        state
+            .cross_file_graph
+            .update_file(&parent_uri, &initial_metadata, Some(&root_uri), |_| None);
+        state.rebuild_tar_source_watch_registry();
+
+        let expected_generation = state
+            .documents
+            .get_record(&parent_uri)
+            .unwrap()
+            .generation();
+        let captured = state
+            .capture_open_metadata_derivation(&parent_uri, expected_generation)
+            .unwrap();
+        let owners_before = state.tar_source_watch_paths_by_parent.clone();
+        let reverse_before = state.tar_source_parents_by_watch_path.clone();
+
+        // The detached derivation performs its filesystem walk and observes
+        // the new member before attempting to commit.
+        std::fs::write(temp.path().join("R/new.R"), "new_value <- 2\n").unwrap();
+        let mut walked_metadata = crate::cross_file::extract_metadata(parent_text);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut walked_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        assert!(
+            walked_metadata
+                .sources
+                .iter()
+                .any(|source| { source.resolved_uri.as_ref() == Some(&new_uri) })
+        );
+
+        // A watcher event lands after the walk but before the prepared
+        // metadata/store/registry transaction reaches its CAS.
+        assert_eq!(
+            state.record_tar_source_filesystem_events([new_uri.clone()]),
+            std::slice::from_ref(&parent_uri)
+        );
+        let prepared = state
+            .prepare_captured_open_metadata_analysis(
+                captured,
+                Arc::new(walked_metadata),
+                PreparedOpenCommitPlan::default(),
+                Vec::new(),
+            )
+            .unwrap();
+        assert!(matches!(
+            state.try_commit_analysis(PreparedAnalysisCommit::OpenMetadata(Box::new(prepared))),
+            Err(AnalysisCommitRejected::StaleBasis)
+        ));
+
+        let record = state.documents.get_record(&parent_uri).unwrap();
+        assert_eq!(record.generation(), expected_generation);
+        assert!(
+            record
+                .metadata()
+                .sources
+                .iter()
+                .any(|source| { source.resolved_uri.as_ref() == Some(&old_uri) })
+        );
+        assert!(
+            !record
+                .metadata()
+                .sources
+                .iter()
+                .any(|source| { source.resolved_uri.as_ref() == Some(&new_uri) })
+        );
+        assert_eq!(state.tar_source_watch_paths_by_parent, owners_before);
+        assert_eq!(state.tar_source_parents_by_watch_path, reverse_before);
+        assert!(
+            state
+                .cross_file_graph
+                .get_dependencies(&parent_uri)
+                .iter()
+                .all(|edge| edge.to != new_uri),
+            "a rejected walk must not mutate the graph"
+        );
+    }
+
+    #[test]
+    fn workspace_scan_finalizes_tar_metadata_artifacts_and_graph() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("R")).unwrap();
+        std::fs::write(
+            temp.path().join("_targets.R"),
+            "targets::tar_source(\"R\")\n",
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("R/member.R"), "member <- 1\n").unwrap();
+        let root = Url::from_directory_path(temp.path()).unwrap();
+        let parent = Url::from_file_path(temp.path().join("_targets.R")).unwrap();
+        let member = Url::from_file_path(temp.path().join("R/member.R")).unwrap();
+
+        let entries = scan_workspace(std::slice::from_ref(&root), 10);
+        let entry = entries
+            .get(&parent)
+            .expect("targets parent must be scanned");
+        assert!(entry.metadata.sources.iter().any(|source| {
+            source.tar_source_ordinal == Some(0) && source.resolved_uri.as_ref() == Some(&member)
+        }));
+        assert!(entry.artifacts.timeline.iter().any(|event| matches!(
+            event,
+            crate::cross_file::scope::ScopeEvent::TarBatch { members, .. }
+                if members.len() == 1
+        )));
+
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![root];
+        state.apply_workspace_index(entries);
+        assert!(
+            state
+                .cross_file_graph
+                .get_dependencies(&parent)
+                .iter()
+                .any(|edge| edge.to == member && edge.tar_source_ordinal == Some(0))
+        );
     }
 }

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -1286,6 +1286,12 @@ pub struct WorldState {
     pub(crate) watched_batch_test_commit_attempts: usize,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) analysis_revalidation_reservation_count: usize,
+    /// Instrumentation for keeping ordinary analysis commits off the
+    /// workspace-wide tar watch-registry sweep.
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) tar_source_watch_full_rebuild_count: usize,
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) tar_source_watch_parent_check_count: usize,
     /// Whether the background workspace scan has completed and the dependency
     /// graph has been populated from workspace entries. In `Auto` backward
     /// dependency mode, undefined variable diagnostics are deferred for files
@@ -1880,6 +1886,26 @@ pub(crate) enum PreparedAnalysisCommit {
     OpenAliasReconcile(Box<PreparedOpenAliasReconcileAnalysis>),
     OpenInstall(Box<PreparedOpenInstallAnalysis>),
     OpenClose(Box<PreparedOpenCloseAnalysis>),
+}
+
+/// Bounded post-commit check for whether authoritative tar watch topology may
+/// have changed.
+///
+/// Ordinary commits name only the parents whose open/closed authority changed.
+/// A full workspace replacement skips the gate because every parent may have
+/// changed. The existing full rebuild remains the single writer of both
+/// registry directions and the root-generation tombstones.
+enum TarSourceWatchRegistryRefresh {
+    Full,
+    Parents(Vec<Url>),
+}
+
+impl TarSourceWatchRegistryRefresh {
+    fn push_parent(&mut self, parent: Option<Url>) {
+        if let (Self::Parents(parents), Some(parent)) = (self, parent) {
+            parents.push(parent);
+        }
+    }
 }
 
 /// One all-or-none watched-file transaction spanning closed-file and package
@@ -5537,7 +5563,32 @@ impl WorldState {
     /// holding the WorldState write lock, so rejected preparations cannot
     /// leak registry mutations.
     fn rebuild_tar_source_watch_registry(&mut self) {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            self.tar_source_watch_full_rebuild_count += 1;
+        }
         let previous_by_path = self.tar_source_parents_by_watch_path.clone();
+        let (by_parent, by_path) = self.collect_authoritative_tar_source_watch_registry();
+        let mut changed_paths: HashSet<PathBuf> = previous_by_path.keys().cloned().collect();
+        changed_paths.extend(by_path.keys().cloned());
+        let mut changed_paths: Vec<_> = changed_paths
+            .into_iter()
+            .filter(|path| previous_by_path.get(path) != by_path.get(path))
+            .collect();
+        changed_paths.sort();
+        for path in changed_paths {
+            self.bump_tar_source_watch_path_generation(&path);
+        }
+        self.tar_source_watch_paths_by_parent = by_parent;
+        self.tar_source_parents_by_watch_path = by_path;
+    }
+
+    /// Compute the authoritative bidirectional registry without mutating
+    /// generations. Tests use this as an explicit full-sweep oracle for the
+    /// bounded post-commit gate.
+    fn collect_authoritative_tar_source_watch_registry(
+        &self,
+    ) -> (HashMap<Url, Vec<PathBuf>>, HashMap<PathBuf, HashSet<Url>>) {
         let mut by_parent: HashMap<Url, Vec<PathBuf>> = HashMap::new();
 
         for uri in self.workspace_index.artifact_uris() {
@@ -5576,18 +5627,68 @@ impl WorldState {
                     .insert(parent.clone());
             }
         }
-        let mut changed_paths: HashSet<PathBuf> = previous_by_path.keys().cloned().collect();
-        changed_paths.extend(by_path.keys().cloned());
-        let mut changed_paths: Vec<_> = changed_paths
-            .into_iter()
-            .filter(|path| previous_by_path.get(path) != by_path.get(path))
-            .collect();
-        changed_paths.sort();
-        for path in changed_paths {
-            self.bump_tar_source_watch_path_generation(&path);
+        (by_parent, by_path)
+    }
+
+    /// Read one parent's effective post-commit watch roots using the same
+    /// authority precedence as [`Self::rebuild_tar_source_watch_registry`].
+    fn authoritative_tar_source_watch_paths(&self, parent: &Url) -> Vec<PathBuf> {
+        let metadata = if let Some(record) = self.documents.get_record(parent) {
+            Some(Arc::clone(record.metadata()))
+        } else if self.is_document_open_or_alias(parent) {
+            None
+        } else {
+            self.workspace_index.get_metadata(parent)
+        };
+        let mut paths = metadata
+            .map(|metadata| metadata.tar_source_expansion_watch_paths.clone())
+            .unwrap_or_default();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    /// Gate the rare full rebuild behind bounded authoritative parent checks.
+    ///
+    /// The common edit path names one parent. If its normalized roots still
+    /// match the installed parent map, the check is O(1) in workspace size and
+    /// performs no per-artifact index reads. A topology change deliberately
+    /// falls back to the full rebuild so bidirectional ownership, net
+    /// owner-set generation bumps, and tombstone retention keep one writer.
+    fn refresh_tar_source_watch_registry(&mut self, refresh: TarSourceWatchRegistryRefresh) {
+        let needs_rebuild = match refresh {
+            TarSourceWatchRegistryRefresh::Full => true,
+            TarSourceWatchRegistryRefresh::Parents(mut parents) => {
+                parents.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+                parents.dedup();
+                parents.into_iter().any(|parent| {
+                    #[cfg(any(test, feature = "test-support"))]
+                    {
+                        self.tar_source_watch_parent_check_count += 1;
+                    }
+                    let authoritative = self.authoritative_tar_source_watch_paths(&parent);
+                    self.tar_source_watch_paths_by_parent
+                        .get(&parent)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default()
+                        != authoritative.as_slice()
+                })
+            }
+        };
+        if needs_rebuild {
+            self.rebuild_tar_source_watch_registry();
         }
-        self.tar_source_watch_paths_by_parent = by_parent;
-        self.tar_source_parents_by_watch_path = by_path;
+    }
+
+    /// Reconcile a bounded set of parents after an authoritative mutation that
+    /// intentionally bypasses [`Self::try_commit_analysis`].
+    pub(crate) fn refresh_tar_source_watch_parents(
+        &mut self,
+        parents: impl IntoIterator<Item = Url>,
+    ) {
+        self.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(
+            parents.into_iter().collect(),
+        ));
     }
 
     /// Current operational generation of raw package inputs.
@@ -6327,6 +6428,10 @@ impl WorldState {
             watched_batch_test_commit_attempts: 0,
             #[cfg(any(test, feature = "test-support"))]
             analysis_revalidation_reservation_count: 0,
+            #[cfg(any(test, feature = "test-support"))]
+            tar_source_watch_full_rebuild_count: 0,
+            #[cfg(any(test, feature = "test-support"))]
+            tar_source_watch_parent_check_count: 0,
             workspace_scan_complete: false,
             package_state: crate::package_state::PackageState::new(),
             package_state_record_generation: 0,
@@ -7144,20 +7249,27 @@ impl WorldState {
 
     /// Resize all LRU caches based on configuration.
     /// Called after parsing initialization options.
-    pub fn resize_caches(&self, config: &crate::cross_file::config::CrossFileConfig) {
+    pub fn resize_caches(&mut self, config: &crate::cross_file::config::CrossFileConfig) {
         self.cross_file_meta
             .resize(config.cache_metadata_max_entries);
         self.cross_file_file_cache.resize(
             config.cache_file_content_max_entries,
             config.cache_existence_max_entries,
         );
-        self.workspace_index
-            .resize_artifacts(config.cache_workspace_index_max_entries);
+        let evicted = self
+            .workspace_index
+            .resize_artifacts_with_evictions(config.cache_workspace_index_max_entries);
+        if !evicted.is_empty() {
+            self.refresh_tar_source_watch_parents(evicted);
+        }
     }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn open_document(&mut self, uri: Url, text: &str, version: Option<i32>) {
+        let mut tar_watch_parents = vec![uri.clone()];
+        tar_watch_parents.extend(self.canonical_uris_for_open_document(&uri));
         let aliases = self.register_open_document_aliases(&uri);
+        tar_watch_parents.extend(aliases.iter().cloned());
         self.cross_file_file_cache.invalidate(&uri);
         for alias in aliases {
             self.cross_file_file_cache.invalidate(&alias);
@@ -7165,6 +7277,9 @@ impl WorldState {
         self.documents
             .insert(uri.clone(), Document::new_with_uri(text, version, &uri));
         self.advance_open_context_authority_generation();
+        self.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(
+            tar_watch_parents,
+        ));
     }
 
     /// Open one document authority with its already-enriched metadata.
@@ -7194,7 +7309,10 @@ impl WorldState {
         metadata: Arc<crate::cross_file::CrossFileMetadata>,
         lifecycle_epoch: Option<DiagnosticsEpoch>,
     ) -> Arc<OpenDocumentRecord> {
+        let mut tar_watch_parents = vec![uri.clone()];
+        tar_watch_parents.extend(self.canonical_uris_for_open_document(&uri));
         let aliases = self.register_open_document_aliases(&uri);
+        tar_watch_parents.extend(aliases.iter().cloned());
         self.cross_file_file_cache.invalidate(&uri);
         self.record_editor_chunk_kind_override(&uri, document.chunk_kind);
         for alias in aliases {
@@ -7204,6 +7322,9 @@ impl WorldState {
             .documents
             .open(uri, document, metadata, lifecycle_epoch);
         self.advance_open_context_authority_generation();
+        self.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(
+            tar_watch_parents,
+        ));
         record
     }
 
@@ -7230,6 +7351,8 @@ impl WorldState {
     pub fn close_document(&mut self, uri: &Url) -> Vec<Url> {
         self.cancel_open_install_intent(uri);
         let aliases = self.open_document_aliases.close(uri);
+        let mut tar_watch_parents = vec![uri.clone()];
+        tar_watch_parents.extend(aliases.iter().cloned());
         let removed_record = self.documents.close(uri).is_some();
         if removed_record || !aliases.is_empty() {
             self.advance_open_context_authority_generation();
@@ -7237,6 +7360,9 @@ impl WorldState {
         if let Ok(mut cache) = self.effective_lint_config_cache.lock() {
             cache.remove(uri.as_str());
         }
+        self.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(
+            tar_watch_parents,
+        ));
         aliases
     }
 
@@ -7970,6 +8096,91 @@ impl WorldState {
         }
     }
 
+    fn extend_tar_watch_open_plan_parents(parents: &mut Vec<Url>, plan: &PreparedOpenCommitPlan) {
+        parents.extend(plan.reset_closed_roots.iter().cloned());
+        parents.extend(plan.retire_closed_roots.iter().cloned());
+        parents.extend(
+            plan.close_disk_installs
+                .iter()
+                .map(|install| install.uri.clone()),
+        );
+    }
+
+    fn tar_watch_refresh_for_system_file(
+        prepared: &PreparedSystemFileAnalysis,
+    ) -> TarSourceWatchRegistryRefresh {
+        let mut parents = prepared
+            .index
+            .as_ref()
+            .into_iter()
+            .flat_map(|index| index.changed_uris().iter().cloned())
+            .collect::<Vec<_>>();
+        parents.extend(
+            prepared
+                .open_metadata
+                .iter()
+                .map(|replacement| replacement.uri.clone()),
+        );
+        TarSourceWatchRegistryRefresh::Parents(parents)
+    }
+
+    /// Capture every parent whose authoritative open/closed record may change
+    /// before a prepared commit consumes or rewrites its transition inputs.
+    fn tar_watch_refresh_for_prepared(
+        &self,
+        prepared: &PreparedAnalysisCommit,
+    ) -> TarSourceWatchRegistryRefresh {
+        let mut parents = Vec::new();
+        match prepared {
+            PreparedAnalysisCommit::WorkspaceScan(_) => {
+                return TarSourceWatchRegistryRefresh::Full;
+            }
+            PreparedAnalysisCommit::SystemFile(prepared) => {
+                return Self::tar_watch_refresh_for_system_file(prepared);
+            }
+            PreparedAnalysisCommit::Upsert(prepared) => {
+                parents.push(prepared.uri.clone());
+            }
+            PreparedAnalysisCommit::Remove { uri, .. } => {
+                parents.push(uri.clone());
+            }
+            PreparedAnalysisCommit::WatchedBatch(prepared) => {
+                parents.extend(prepared.mutations.iter().map(|mutation| match mutation {
+                    PreparedClosedMutation::Upsert(prepared) => prepared.uri.clone(),
+                    PreparedClosedMutation::Remove { uri, .. } => uri.clone(),
+                }));
+            }
+            PreparedAnalysisCommit::OpenInstall(prepared) => {
+                parents.push(prepared.uri.clone());
+                parents.extend(self.canonical_uris_for_open_document(&prepared.uri));
+                parents.extend(prepared.aliases.iter().cloned());
+                Self::extend_tar_watch_open_plan_parents(&mut parents, &prepared.plan);
+            }
+            PreparedAnalysisCommit::OpenEdit(prepared) => {
+                parents.push(prepared.uri.clone());
+                Self::extend_tar_watch_open_plan_parents(&mut parents, &prepared.plan);
+            }
+            PreparedAnalysisCommit::OpenMetadata(prepared) => {
+                parents.push(prepared.uri.clone());
+                Self::extend_tar_watch_open_plan_parents(&mut parents, &prepared.plan);
+            }
+            PreparedAnalysisCommit::OpenAliasReconcile(prepared) => {
+                parents.push(prepared.uri.clone());
+                // Capture the old aliases before registration replaces them.
+                parents.extend(self.canonical_uris_for_open_document(&prepared.uri));
+                parents.extend(prepared.aliases.iter().cloned());
+                Self::extend_tar_watch_open_plan_parents(&mut parents, &prepared.plan);
+            }
+            PreparedAnalysisCommit::OpenClose(prepared) => {
+                parents.push(prepared.uri.clone());
+                parents.extend(self.canonical_uris_for_open_document(&prepared.uri));
+                parents.extend(prepared.expected_aliases.iter().cloned());
+                Self::extend_tar_watch_open_plan_parents(&mut parents, &prepared.plan);
+            }
+        }
+        TarSourceWatchRegistryRefresh::Parents(parents)
+    }
+
     /// Validate and commit one prepared analysis transaction while the caller
     /// holds the sole `WorldState` write lock.
     ///
@@ -7982,12 +8193,15 @@ impl WorldState {
         &mut self,
         prepared: PreparedAnalysisCommit,
     ) -> Result<AnalysisCommitEffects, AnalysisCommitRejected> {
+        let mut tar_watch_refresh = self.tar_watch_refresh_for_prepared(&prepared);
         let result = match prepared {
             PreparedAnalysisCommit::WorkspaceScan(prepared) => {
                 self.try_commit_workspace_scan(*prepared)
             }
             PreparedAnalysisCommit::SystemFile(prepared) => self.try_commit_system_file(*prepared),
-            PreparedAnalysisCommit::OpenClose(prepared) => self.try_commit_open_close(*prepared),
+            PreparedAnalysisCommit::OpenClose(prepared) => {
+                self.try_commit_open_close(*prepared, &mut tar_watch_refresh)
+            }
             PreparedAnalysisCommit::OpenInstall(prepared) => {
                 self.try_commit_open_install(*prepared)
             }
@@ -8003,19 +8217,21 @@ impl WorldState {
                 None,
                 true,
                 false,
+                &mut tar_watch_refresh,
             ),
             PreparedAnalysisCommit::Remove { basis, uri } => self.try_commit_closed_batch(
                 vec![PreparedClosedMutation::Remove { basis, uri }],
                 None,
                 true,
                 false,
+                &mut tar_watch_refresh,
             ),
             PreparedAnalysisCommit::WatchedBatch(prepared) => {
-                self.try_commit_watched_batch(*prepared)
+                self.try_commit_watched_batch(*prepared, &mut tar_watch_refresh)
             }
         };
         if result.is_ok() {
-            self.rebuild_tar_source_watch_registry();
+            self.refresh_tar_source_watch_registry(tar_watch_refresh);
         }
         result
     }
@@ -8023,6 +8239,7 @@ impl WorldState {
     fn try_commit_watched_batch(
         &mut self,
         prepared: PreparedWatchedBatchAnalysis,
+        tar_watch_refresh: &mut TarSourceWatchRegistryRefresh,
     ) -> Result<AnalysisCommitEffects, AnalysisCommitRejected> {
         if prepared
             .watched_generations
@@ -8048,6 +8265,7 @@ impl WorldState {
             prepared.package,
             false,
             prepared.durable_package_handoff,
+            tar_watch_refresh,
         )
     }
 
@@ -8316,6 +8534,7 @@ impl WorldState {
         ),
         AnalysisCommitRejected,
     > {
+        let tar_watch_refresh = Self::tar_watch_refresh_for_system_file(&prepared.system_file);
         let PreparedLibraryRoutingAnalysis {
             basis,
             prospective,
@@ -8586,7 +8805,7 @@ impl WorldState {
                 &self.library_routing_reconcile_wake_generation,
             );
         }
-        self.rebuild_tar_source_watch_registry();
+        self.refresh_tar_source_watch_registry(tar_watch_refresh);
 
         Ok((
             LibraryRoutingTransferredEffects {
@@ -8601,6 +8820,7 @@ impl WorldState {
     fn try_commit_open_close(
         &mut self,
         mut prepared: PreparedOpenCloseAnalysis,
+        tar_watch_refresh: &mut TarSourceWatchRegistryRefresh,
     ) -> Result<AnalysisCommitEffects, AnalysisCommitRejected> {
         let targets = HashSet::from([prepared.uri.clone()]);
         if !self.analysis_basis_is_current(&prepared.basis, &prepared.uri, &targets)
@@ -8631,8 +8851,10 @@ impl WorldState {
             .and_then(|package| self.install_prepared_package_projection(package));
 
         for install in prepared.plan.close_disk_installs.drain(..) {
-            self.workspace_index
+            let (_, evicted) = self
+                .workspace_index
                 .install_complete_preserving_provenance(install.uri.clone(), install.entry);
+            tar_watch_refresh.push_parent(evicted);
             self.cross_file_file_cache
                 .insert(install.uri, install.snapshot, install.content);
         }
@@ -9139,6 +9361,7 @@ impl WorldState {
         package: Option<(PackageProjectionBasis, PreparedPackageProjection)>,
         reserve_closed_fanout: bool,
         durable_package_handoff: bool,
+        tar_watch_refresh: &mut TarSourceWatchRegistryRefresh,
     ) -> Result<AnalysisCommitEffects, AnalysisCommitRejected> {
         let mut targets = HashSet::with_capacity(mutations.len());
         let no_duplicates = mutations.iter().all(|mutation| {
@@ -9219,21 +9442,24 @@ impl WorldState {
                         && matches!(&prepared.basis.subject, AnalysisSubjectBasis::Observed(_));
                     let report_unmarked_fanout = !reserve_closed_fanout
                         || matches!(&prepared.basis.subject, AnalysisSubjectBasis::Pending(_));
-                    let committed = match &prepared.basis.subject {
+                    let (committed, evicted) = match &prepared.basis.subject {
                         AnalysisSubjectBasis::Pending(claim) => self
                             .workspace_index
-                            .commit_enrichment(claim, prepared.entry)
-                            .is_ok(),
+                            .commit_enrichment_with_eviction(claim, prepared.entry)
+                            .map(|(_, evicted)| (true, evicted))
+                            .unwrap_or((false, None)),
                         AnalysisSubjectBasis::Complete(token) => self
                             .workspace_index
-                            .commit_complete_refresh(token, prepared.entry)
-                            .is_ok(),
+                            .commit_complete_refresh_with_eviction(token, prepared.entry)
+                            .map(|(_, evicted)| (true, evicted))
+                            .unwrap_or((false, None)),
                         AnalysisSubjectBasis::Observed(_) => {
-                            self.workspace_index.install_complete_preserving_provenance(
-                                prepared.uri.clone(),
-                                prepared.entry,
-                            );
-                            true
+                            let (_, evicted) =
+                                self.workspace_index.install_complete_preserving_provenance(
+                                    prepared.uri.clone(),
+                                    prepared.entry,
+                                );
+                            (true, evicted)
                         }
                         AnalysisSubjectBasis::Open(_)
                         | AnalysisSubjectBasis::OpenInstall(_)
@@ -9241,6 +9467,7 @@ impl WorldState {
                             unreachable!("open subjects never enter the closed commit path")
                         }
                     };
+                    tar_watch_refresh.push_parent(evicted);
                     debug_assert!(committed, "prevalidated closed CAS remains current");
 
                     let result = self.cross_file_graph.update_file(
@@ -9563,7 +9790,14 @@ impl WorldState {
             content_hash: None,
         };
         let processed = processed_workspace_document(uri.clone(), document, snapshot);
-        self.workspace_index.insert(uri, processed.entry);
+        let (_, evicted) = self.workspace_index.install_complete_with_eviction(
+            uri.clone(),
+            processed.entry,
+            crate::workspace_index::ClosedProvenance::Dynamic,
+        );
+        let mut parents = vec![uri];
+        parents.extend(evicted);
+        self.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(parents));
     }
 
     /// Build the dependency graph from all entries in the workspace index.
@@ -10144,6 +10378,7 @@ impl WorldState {
 
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&tree_sitter_r::LANGUAGE.into()).ok();
+        let mut tar_watch_parents = Vec::new();
 
         for uri in external_uris {
             if self.workspace_index.enrichment_status(&uri).is_some() {
@@ -10187,7 +10422,16 @@ impl WorldState {
                 artifacts,
                 indexed_at_version: 0,
             };
-            self.workspace_index.insert(uri, entry);
+            let (_, evicted) = self.workspace_index.install_complete_with_eviction(
+                uri.clone(),
+                entry,
+                crate::workspace_index::ClosedProvenance::Dynamic,
+            );
+            tar_watch_parents.push(uri);
+            tar_watch_parents.extend(evicted);
+        }
+        if !tar_watch_parents.is_empty() {
+            self.refresh_tar_source_watch_parents(tar_watch_parents);
         }
     }
 }
@@ -11612,6 +11856,31 @@ mod tests {
             mtime: std::time::SystemTime::UNIX_EPOCH,
             size,
             content_hash: Some(content_hash),
+        }
+    }
+
+    fn assert_tar_watch_registry_matches_full_oracle(state: &WorldState) {
+        let (by_parent, by_path) = state.collect_authoritative_tar_source_watch_registry();
+        assert_eq!(state.tar_source_watch_paths_by_parent, by_parent);
+        assert_eq!(state.tar_source_parents_by_watch_path, by_path);
+    }
+
+    fn tar_watch_test_entry(
+        metadata: crate::cross_file::CrossFileMetadata,
+    ) -> crate::workspace_index::IndexEntry {
+        crate::workspace_index::IndexEntry {
+            contents: Rope::from_str("x <- 1\n"),
+            tree: None,
+            loaded_packages: Vec::new(),
+            data_packages: Vec::new(),
+            snapshot: crate::cross_file::file_cache::FileSnapshot {
+                mtime: std::time::SystemTime::UNIX_EPOCH,
+                size: 1,
+                content_hash: None,
+            },
+            metadata: Arc::new(metadata),
+            artifacts: Arc::new(crate::cross_file::scope::ScopeArtifacts::default()),
+            indexed_at_version: 0,
         }
     }
 
@@ -14967,6 +15236,392 @@ mod tests {
     }
 
     #[test]
+    fn plain_open_edit_checks_one_parent_without_full_registry_sweep() {
+        let mut state = WorldState::new();
+        for index in 0..256 {
+            let uri = Url::parse(&format!("file:///workspace/closed-{index}.R")).unwrap();
+            state.insert_workspace_document_for_test(
+                uri.clone(),
+                Document::new_with_uri("closed <- 1\n", None, &uri),
+            );
+        }
+        let uri = Url::parse("file:///workspace/open.R").unwrap();
+        state.open_document(uri.clone(), "before <- 1\n", Some(1));
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+        let checks_before = state.tar_source_watch_parent_check_count;
+
+        commit_test_edit(
+            &mut state,
+            &uri,
+            "after <- 2\n",
+            crate::cross_file::CrossFileMetadata::default(),
+            PreparedOpenCommitPlan::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count, rebuilds_before,
+            "ordinary typing must not scan the workspace-wide tar watch registry"
+        );
+        assert_eq!(
+            state.tar_source_watch_parent_check_count,
+            checks_before + 1,
+            "the OpenEdit gate must inspect only its subject parent"
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+    }
+
+    #[test]
+    fn gated_tar_watch_refresh_matches_full_oracle_across_root_transitions() {
+        let parent = Url::parse("file:///workspace/_targets.R").unwrap();
+        let old_root = PathBuf::from("/workspace/R");
+        let new_root = PathBuf::from("/workspace/src");
+        let mut state = WorldState::new();
+        state.open_document(parent.clone(), "targets::tar_source(\"R\")\n", Some(1));
+
+        let generation = state.documents.get_record(&parent).unwrap().generation();
+        state
+            .documents
+            .replace_metadata_if_current(
+                &parent,
+                generation,
+                Arc::new(crate::cross_file::CrossFileMetadata {
+                    tar_source_expansion_watch_paths: vec![old_root.clone()],
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+        state.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(vec![
+            parent.clone(),
+        ]));
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count,
+            rebuilds_before + 1
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+        let old_generation = state.tar_source_watch_path_generations[&old_root];
+
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+        state.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(vec![
+            parent.clone(),
+        ]));
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count, rebuilds_before,
+            "an identical root set must stay on the bounded gate"
+        );
+        assert_eq!(
+            state.tar_source_watch_path_generations[&old_root], old_generation,
+            "an identical owner set must not bump its generation"
+        );
+
+        let generation = state.documents.get_record(&parent).unwrap().generation();
+        state
+            .documents
+            .replace_metadata_if_current(
+                &parent,
+                generation,
+                Arc::new(crate::cross_file::CrossFileMetadata {
+                    tar_source_expansion_watch_paths: vec![new_root.clone()],
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+        state.refresh_tar_source_watch_registry(TarSourceWatchRegistryRefresh::Parents(vec![
+            parent.clone(),
+        ]));
+        assert_tar_watch_registry_matches_full_oracle(&state);
+        assert!(
+            !state
+                .tar_source_parents_by_watch_path
+                .contains_key(&old_root)
+        );
+        assert!(state.tar_source_watch_path_generations[&old_root] > old_generation);
+        let retired_generation = state.tar_source_watch_path_generations[&old_root];
+        let new_generation = state.tar_source_watch_path_generations[&new_root];
+
+        state.close_document(&parent);
+        assert_tar_watch_registry_matches_full_oracle(&state);
+        assert!(state.tar_source_watch_paths_by_parent.is_empty());
+        assert!(state.tar_source_parents_by_watch_path.is_empty());
+        assert_eq!(
+            state.tar_source_watch_path_generations[&old_root], retired_generation,
+            "an unrelated later transition must preserve the old root tombstone"
+        );
+        assert!(state.tar_source_watch_path_generations[&new_root] > new_generation);
+    }
+
+    #[test]
+    fn targeted_eviction_retires_tar_watch_root_and_rejected_swap_is_inert() {
+        use crate::cross_file::file_cache::FileSnapshot;
+        use crate::workspace_index::{
+            ClosedProvenance, IndexEntry, WorkspaceIndexConfig, WorkspaceIndexTargetedChanges,
+        };
+
+        let victim = Url::parse("file:///workspace/_targets.R").unwrap();
+        let replacement = Url::parse("file:///workspace/replacement.R").unwrap();
+        let stale_replacement = Url::parse("file:///workspace/stale-replacement.R").unwrap();
+        let root = PathBuf::from("/workspace/R");
+        let make_entry = |metadata| IndexEntry {
+            contents: Rope::from_str("x <- 1\n"),
+            tree: None,
+            loaded_packages: Vec::new(),
+            data_packages: Vec::new(),
+            snapshot: FileSnapshot {
+                mtime: std::time::SystemTime::UNIX_EPOCH,
+                size: 1,
+                content_hash: None,
+            },
+            metadata: Arc::new(metadata),
+            artifacts: Arc::new(crate::cross_file::scope::ScopeArtifacts::default()),
+            indexed_at_version: 0,
+        };
+
+        let mut state = WorldState::new();
+        state.workspace_index = WorkspaceIndex::new(WorkspaceIndexConfig {
+            max_files: 1,
+            ..Default::default()
+        });
+        state.workspace_index.resize_artifacts(1);
+        state.workspace_index.install_complete(
+            victim.clone(),
+            make_entry(crate::cross_file::CrossFileMetadata {
+                tar_source_expansion_watch_paths: vec![root.clone()],
+                ..Default::default()
+            }),
+            ClosedProvenance::Dynamic,
+        );
+        state.rebuild_tar_source_watch_registry();
+        let root_generation = state.tar_source_watch_path_generations[&root];
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+
+        let prepared = state
+            .workspace_index
+            .prepare_targeted_batch_if_current(
+                state.workspace_index.version(),
+                WorkspaceIndexTargetedChanges {
+                    metadata: Vec::new(),
+                    installs: vec![(
+                        replacement.clone(),
+                        make_entry(crate::cross_file::CrossFileMetadata::default()),
+                        ClosedProvenance::Dynamic,
+                    )],
+                    removals: Vec::new(),
+                    pins: HashSet::new(),
+                },
+            )
+            .unwrap()
+            .unwrap();
+        assert!(
+            prepared.changed_uris().contains(&victim),
+            "the prepared swap must carry its implicit Complete eviction victim"
+        );
+        let refresh = TarSourceWatchRegistryRefresh::Parents(prepared.changed_uris().to_vec());
+        assert!(
+            state
+                .workspace_index
+                .commit_prepared_targeted_batch(prepared)
+                .unwrap()
+        );
+        state.refresh_tar_source_watch_registry(refresh);
+
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count,
+            rebuilds_before + 1,
+            "one successful ownership change needs exactly one full rebuild"
+        );
+        assert_eq!(
+            state.tar_source_watch_path_generations[&root],
+            root_generation.wrapping_add(1),
+            "retiring the last owner bumps the root tombstone exactly once"
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+
+        let prepared = state
+            .workspace_index
+            .prepare_targeted_batch_if_current(
+                state.workspace_index.version(),
+                WorkspaceIndexTargetedChanges {
+                    metadata: Vec::new(),
+                    installs: vec![(
+                        stale_replacement,
+                        make_entry(crate::cross_file::CrossFileMetadata::default()),
+                        ClosedProvenance::Dynamic,
+                    )],
+                    removals: Vec::new(),
+                    pins: HashSet::new(),
+                },
+            )
+            .unwrap()
+            .unwrap();
+        let owners_before = state.tar_source_watch_paths_by_parent.clone();
+        let reverse_before = state.tar_source_parents_by_watch_path.clone();
+        let generations_before = state.tar_source_watch_path_generations.clone();
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+        assert!(state.workspace_index.replace_complete_metadata(
+            &replacement,
+            Arc::new(crate::cross_file::CrossFileMetadata::default())
+        ));
+        assert!(
+            !state
+                .workspace_index
+                .commit_prepared_targeted_batch(prepared)
+                .unwrap()
+        );
+        assert_eq!(state.tar_source_watch_paths_by_parent, owners_before);
+        assert_eq!(state.tar_source_parents_by_watch_path, reverse_before);
+        assert_eq!(state.tar_source_watch_path_generations, generations_before);
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count, rebuilds_before,
+            "a rejected targeted CAS must not reach the registry gate"
+        );
+    }
+
+    #[test]
+    fn closed_upsert_reconciles_implicit_tar_watch_eviction() {
+        use crate::workspace_index::{ClosedProvenance, WorkspaceIndexConfig};
+
+        let victim = Url::parse("file:///workspace/_targets.R").unwrap();
+        let subject = Url::parse("file:///workspace/new.R").unwrap();
+        let root = PathBuf::from("/workspace/R");
+        let mut state = WorldState::new();
+        state.workspace_index = WorkspaceIndex::new(WorkspaceIndexConfig {
+            max_files: 1,
+            ..Default::default()
+        });
+        state.workspace_index.resize_artifacts(1);
+        state.workspace_index.install_complete(
+            victim.clone(),
+            tar_watch_test_entry(crate::cross_file::CrossFileMetadata {
+                tar_source_expansion_watch_paths: vec![root.clone()],
+                ..Default::default()
+            }),
+            ClosedProvenance::Dynamic,
+        );
+        state.rebuild_tar_source_watch_registry();
+        let root_generation = state.tar_source_watch_path_generations[&root];
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+
+        let basis = state.capture_closed_removal_analysis_basis(&subject);
+        let entry = tar_watch_test_entry(crate::cross_file::CrossFileMetadata::default());
+        let prepared = PreparedClosedAnalysis::new(
+            basis,
+            subject.clone(),
+            entry.clone(),
+            entry.snapshot.clone(),
+            entry.contents.to_string(),
+            entry.metadata.clone(),
+            None,
+            HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        state
+            .try_commit_analysis(PreparedAnalysisCommit::Upsert(Box::new(prepared)))
+            .unwrap();
+
+        assert!(!state.workspace_index.is_complete(&victim));
+        assert!(state.workspace_index.is_complete(&subject));
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count,
+            rebuilds_before + 1
+        );
+        assert_eq!(
+            state.tar_source_watch_path_generations[&root],
+            root_generation.wrapping_add(1)
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+    }
+
+    #[test]
+    fn pending_claim_reconciles_eviction_before_enrichment_finishes() {
+        use crate::workspace_index::{ClaimEnrichment, ClosedProvenance, WorkspaceIndexConfig};
+
+        let victim = Url::parse("file:///workspace/_targets.R").unwrap();
+        let pending = Url::parse("file:///workspace/pending.R").unwrap();
+        let root = PathBuf::from("/workspace/R");
+        let mut state = WorldState::new();
+        state.workspace_index = WorkspaceIndex::new(WorkspaceIndexConfig {
+            max_files: 1,
+            ..Default::default()
+        });
+        state.workspace_index.resize_artifacts(1);
+        state.workspace_index.install_complete(
+            victim.clone(),
+            tar_watch_test_entry(crate::cross_file::CrossFileMetadata {
+                tar_source_expansion_watch_paths: vec![root.clone()],
+                ..Default::default()
+            }),
+            ClosedProvenance::Dynamic,
+        );
+        state.rebuild_tar_source_watch_registry();
+        let root_generation = state.tar_source_watch_path_generations[&root];
+
+        let (claim, evicted) = state
+            .workspace_index
+            .claim_enrichment_with_eviction(pending.clone(), ClosedProvenance::Dynamic);
+        assert_eq!(evicted.as_ref(), Some(&victim));
+        state.refresh_tar_source_watch_parents(std::iter::once(pending).chain(evicted));
+
+        assert_eq!(
+            state.tar_source_watch_path_generations[&root],
+            root_generation.wrapping_add(1),
+            "claim admission retires the evicted owner before detached enrichment"
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+        let ClaimEnrichment::Claimed(claim) = claim else {
+            panic!("expected a fresh Pending claim");
+        };
+        state.workspace_index.abort_enrichment(&claim).unwrap();
+        assert_tar_watch_registry_matches_full_oracle(&state);
+    }
+
+    #[test]
+    fn live_cache_shrink_reconciles_evicted_tar_watch_owner() {
+        use crate::workspace_index::ClosedProvenance;
+
+        let victim = Url::parse("file:///workspace/_targets.R").unwrap();
+        let survivor = Url::parse("file:///workspace/survivor.R").unwrap();
+        let root = PathBuf::from("/workspace/R");
+        let mut state = WorldState::new();
+        state.workspace_index.resize_artifacts(2);
+        state.workspace_index.install_complete(
+            victim.clone(),
+            tar_watch_test_entry(crate::cross_file::CrossFileMetadata {
+                tar_source_expansion_watch_paths: vec![root.clone()],
+                ..Default::default()
+            }),
+            ClosedProvenance::Dynamic,
+        );
+        state.workspace_index.install_complete(
+            survivor.clone(),
+            tar_watch_test_entry(crate::cross_file::CrossFileMetadata::default()),
+            ClosedProvenance::Dynamic,
+        );
+        state.rebuild_tar_source_watch_registry();
+        let root_generation = state.tar_source_watch_path_generations[&root];
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
+
+        let config = crate::cross_file::config::CrossFileConfig {
+            cache_workspace_index_max_entries: 1,
+            ..Default::default()
+        };
+        state.resize_caches(&config);
+
+        assert!(!state.workspace_index.is_complete(&victim));
+        assert!(state.workspace_index.is_complete(&survivor));
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count,
+            rebuilds_before + 1
+        );
+        assert_eq!(
+            state.tar_source_watch_path_generations[&root],
+            root_generation.wrapping_add(1)
+        );
+        assert_tar_watch_registry_matches_full_oracle(&state);
+    }
+
+    #[test]
     fn tar_watch_root_replacement_bumps_tombstone_and_stales_basis() {
         let parent = Url::parse("file:///workspace/_targets.R").unwrap();
         let old_root = PathBuf::from("/workspace/R");
@@ -15060,6 +15715,7 @@ mod tests {
             .unwrap();
         let owners_before = state.tar_source_watch_paths_by_parent.clone();
         let reverse_before = state.tar_source_parents_by_watch_path.clone();
+        let rebuilds_before = state.tar_source_watch_full_rebuild_count;
 
         // The detached derivation performs its filesystem walk and observes
         // the new member before attempting to commit.
@@ -15114,6 +15770,10 @@ mod tests {
         );
         assert_eq!(state.tar_source_watch_paths_by_parent, owners_before);
         assert_eq!(state.tar_source_parents_by_watch_path, reverse_before);
+        assert_eq!(
+            state.tar_source_watch_full_rebuild_count, rebuilds_before,
+            "a rejected CAS must not reach the post-commit registry gate"
+        );
         assert!(
             state
                 .cross_file_graph

--- a/crates/raven/src/workspace_index.rs
+++ b/crates/raven/src/workspace_index.rs
@@ -282,6 +282,14 @@ pub(crate) struct WorkspaceIndexTargetedChanges {
 pub(crate) struct PreparedWorkspaceIndexTargetedBatch {
     expected_version: u64,
     state: IndexState,
+    changed_uris: Vec<Url>,
+}
+
+impl PreparedWorkspaceIndexTargetedBatch {
+    /// URIs whose authoritative Complete records differ in this prepared swap.
+    pub(crate) fn changed_uris(&self) -> &[Url] {
+        &self.changed_uris
+    }
 }
 
 fn push_with_pins<V>(
@@ -888,11 +896,23 @@ impl WorkspaceIndex {
     pub fn install_complete(
         &self,
         uri: Url,
-        mut entry: IndexEntry,
+        entry: IndexEntry,
         provenance: ClosedProvenance,
     ) -> bool {
+        self.install_complete_with_eviction(uri, entry, provenance)
+            .0
+    }
+
+    /// Internal form of [`Self::install_complete`] that reports the
+    /// artifact-tier Complete record evicted by this install, if any.
+    pub(crate) fn install_complete_with_eviction(
+        &self,
+        uri: Url,
+        mut entry: IndexEntry,
+        provenance: ClosedProvenance,
+    ) -> (bool, Option<Url>) {
         let Ok(mut state) = self.inner.write() else {
-            return false;
+            return (false, None);
         };
         let next_version = state.version.wrapping_add(1);
         entry.indexed_at_version = next_version;
@@ -900,7 +920,7 @@ impl WorkspaceIndex {
         artifact.indexed_at_version = next_version;
         artifact.provenance = provenance;
 
-        Self::install_complete_locked(
+        let evicted = Self::install_complete_locked(
             &mut state,
             uri.clone(),
             artifact,
@@ -914,7 +934,7 @@ impl WorkspaceIndex {
         if let Ok(mut metrics) = self.metrics.write() {
             metrics.insertions += 1;
         }
-        full_resident
+        (full_resident, evicted)
     }
 
     /// Refresh a finalized record without changing who owns its lifecycle.
@@ -922,9 +942,9 @@ impl WorkspaceIndex {
         &self,
         uri: Url,
         entry: IndexEntry,
-    ) -> bool {
+    ) -> (bool, Option<Url>) {
         let provenance = self.provenance(&uri).unwrap_or(ClosedProvenance::Dynamic);
-        self.install_complete(uri, entry, provenance)
+        self.install_complete_with_eviction(uri, entry, provenance)
     }
 
     /// Replace metadata for one finalized record in both residency tiers.
@@ -965,7 +985,7 @@ impl WorkspaceIndex {
         mut artifact: ArtifactEntry,
         full: Option<IndexEntry>,
         max_file_size_bytes: usize,
-    ) {
+    ) -> Option<Url> {
         artifact.record_generation = Self::mint_record_generation();
         let mut protected = state.pinned.clone();
         protected.extend(
@@ -975,13 +995,14 @@ impl WorkspaceIndex {
                 .filter(|(_, slot)| matches!(slot, ArtifactSlot::Pending { .. }))
                 .map(|(pending_uri, _)| pending_uri.clone()),
         );
-        if let Some(evicted) = push_with_pins(
+        let evicted = push_with_pins(
             &mut state.artifacts,
             &protected,
             uri.clone(),
             ArtifactSlot::Complete(artifact),
-        ) {
-            state.full.pop(&evicted);
+        );
+        if let Some(evicted) = &evicted {
+            state.full.pop(evicted);
         }
 
         if let Some(full) = full {
@@ -991,21 +1012,37 @@ impl WorkspaceIndex {
                 push_with_pins(&mut state.full, &state.pinned, uri, full);
             }
         }
+        evicted
     }
 
     /// Atomically claim enrichment for an absent URI.
     pub fn claim_enrichment(&self, uri: Url, provenance: ClosedProvenance) -> ClaimEnrichment {
+        self.claim_enrichment_with_eviction(uri, provenance).0
+    }
+
+    /// Internal form of [`Self::claim_enrichment`] that reports a Complete
+    /// artifact evicted while reserving a new Pending slot.
+    pub(crate) fn claim_enrichment_with_eviction(
+        &self,
+        uri: Url,
+        provenance: ClosedProvenance,
+    ) -> (ClaimEnrichment, Option<Url>) {
         let Ok(mut state) = self.inner.write() else {
-            return ClaimEnrichment::AlreadyPending;
+            return (ClaimEnrichment::AlreadyPending, None);
         };
         match state.artifacts.peek(&uri) {
             Some(ArtifactSlot::Complete(entry)) => {
-                return ClaimEnrichment::AlreadyComplete(CompleteRefreshToken {
-                    uri,
-                    record_generation: entry.record_generation,
-                });
+                return (
+                    ClaimEnrichment::AlreadyComplete(CompleteRefreshToken {
+                        uri,
+                        record_generation: entry.record_generation,
+                    }),
+                    None,
+                );
             }
-            Some(ArtifactSlot::Pending { .. }) => return ClaimEnrichment::AlreadyPending,
+            Some(ArtifactSlot::Pending { .. }) => {
+                return (ClaimEnrichment::AlreadyPending, None);
+            }
             None => {}
         }
 
@@ -1019,7 +1056,7 @@ impl WorkspaceIndex {
                 .filter(|(_, slot)| matches!(slot, ArtifactSlot::Pending { .. }))
                 .map(|(pending_uri, _)| pending_uri.clone()),
         );
-        if let Some(evicted) = push_with_pins(
+        let evicted = push_with_pins(
             &mut state.artifacts,
             &protected,
             uri.clone(),
@@ -1027,19 +1064,32 @@ impl WorkspaceIndex {
                 claim_generation: generation,
                 provenance,
             },
-        ) {
-            state.full.pop(&evicted);
+        );
+        if let Some(evicted) = &evicted {
+            state.full.pop(evicted);
         }
         state.version = state.version.wrapping_add(1);
-        ClaimEnrichment::Claimed(EnrichmentClaim { uri, generation })
+        (
+            ClaimEnrichment::Claimed(EnrichmentClaim { uri, generation }),
+            evicted,
+        )
     }
 
     /// Commit a claimed Pending record atomically into both projections.
     pub fn commit_enrichment(
         &self,
         claim: &EnrichmentClaim,
-        mut entry: IndexEntry,
+        entry: IndexEntry,
     ) -> Result<bool, EnrichmentCommitError> {
+        self.commit_enrichment_with_eviction(claim, entry)
+            .map(|(full_resident, _)| full_resident)
+    }
+
+    pub(crate) fn commit_enrichment_with_eviction(
+        &self,
+        claim: &EnrichmentClaim,
+        mut entry: IndexEntry,
+    ) -> Result<(bool, Option<Url>), EnrichmentCommitError> {
         let mut state = self
             .inner
             .write()
@@ -1056,7 +1106,7 @@ impl WorkspaceIndex {
         let mut artifact = ArtifactEntry::from(&entry);
         artifact.indexed_at_version = next_version;
         artifact.provenance = provenance;
-        Self::install_complete_locked(
+        let evicted = Self::install_complete_locked(
             &mut state,
             claim.uri.clone(),
             artifact,
@@ -1064,7 +1114,7 @@ impl WorkspaceIndex {
             self.config.max_file_size_bytes,
         );
         state.version = next_version;
-        Ok(state.full.contains(&claim.uri))
+        Ok((state.full.contains(&claim.uri), evicted))
     }
 
     pub(crate) fn enrichment_claim_is_current(&self, claim: &EnrichmentClaim) -> bool {
@@ -1127,8 +1177,17 @@ impl WorkspaceIndex {
     pub fn commit_complete_refresh(
         &self,
         token: &CompleteRefreshToken,
-        mut entry: IndexEntry,
+        entry: IndexEntry,
     ) -> Result<bool, EnrichmentCommitError> {
+        self.commit_complete_refresh_with_eviction(token, entry)
+            .map(|(full_resident, _)| full_resident)
+    }
+
+    pub(crate) fn commit_complete_refresh_with_eviction(
+        &self,
+        token: &CompleteRefreshToken,
+        mut entry: IndexEntry,
+    ) -> Result<(bool, Option<Url>), EnrichmentCommitError> {
         let mut state = self
             .inner
             .write()
@@ -1146,7 +1205,7 @@ impl WorkspaceIndex {
         let mut artifact = ArtifactEntry::from(&entry);
         artifact.indexed_at_version = next_version;
         artifact.provenance = provenance;
-        Self::install_complete_locked(
+        let evicted = Self::install_complete_locked(
             &mut state,
             token.uri.clone(),
             artifact,
@@ -1154,7 +1213,7 @@ impl WorkspaceIndex {
             self.config.max_file_size_bytes,
         );
         state.version = next_version;
-        Ok(state.full.contains(&token.uri))
+        Ok((state.full.contains(&token.uri), evicted))
     }
 
     /// Abort a Pending claim; stale claims cannot remove a newer generation.
@@ -1265,6 +1324,13 @@ impl WorkspaceIndex {
         {
             return Ok(None);
         }
+        let mut changed_uris: Vec<_> = changes
+            .metadata
+            .iter()
+            .map(|(uri, _)| uri.clone())
+            .chain(changes.installs.iter().map(|(uri, ..)| uri.clone()))
+            .chain(changes.removals.iter().cloned())
+            .collect();
         if changes.metadata.iter().any(|(uri, _)| {
             !matches!(
                 candidate.artifacts.peek(uri),
@@ -1302,13 +1368,15 @@ impl WorkspaceIndex {
             let mut artifact = ArtifactEntry::from(&entry);
             artifact.indexed_at_version = next_version;
             artifact.provenance = provenance;
-            Self::install_complete_locked(
+            if let Some(evicted) = Self::install_complete_locked(
                 &mut candidate,
                 uri,
                 artifact,
                 Some(entry),
                 self.config.max_file_size_bytes,
-            );
+            ) {
+                changed_uris.push(evicted);
+            }
         }
         let user_cap_nz = Self::effective_cap_for(&self.config);
         let user_cap = user_cap_nz.get();
@@ -1322,10 +1390,13 @@ impl WorkspaceIndex {
         {
             candidate.artifacts.resize(cap);
         }
+        changed_uris.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        changed_uris.dedup();
         candidate.version = next_version;
         Ok(Some(PreparedWorkspaceIndexTargetedBatch {
             expected_version,
             state: candidate,
+            changed_uris,
         }))
     }
 
@@ -1478,7 +1549,14 @@ impl WorkspaceIndex {
 
     /// Resize the artifact-only tier.
     pub fn resize_artifacts(&self, cap: usize) {
+        self.resize_artifacts_with_evictions(cap);
+    }
+
+    /// Internal form of [`Self::resize_artifacts`] that reports every
+    /// Complete record removed while enforcing the smaller artifact cap.
+    pub(crate) fn resize_artifacts_with_evictions(&self, cap: usize) -> Vec<Url> {
         let cap = crate::cross_file::cache::non_zero_or(cap, DEFAULT_ARTIFACT_CAPACITY);
+        let mut evicted = Vec::new();
         if let Ok(mut state) = self.inner.write() {
             state.artifact_user_cap = cap.get();
             while state.artifacts.len() > cap.get() {
@@ -1496,6 +1574,7 @@ impl WorkspaceIndex {
                 };
                 state.artifacts.pop(&victim);
                 state.full.pop(&victim);
+                evicted.push(victim);
             }
             let runtime_cap = cap.get().max(state.artifacts.len());
             if let Some(runtime_cap) = NonZeroUsize::new(runtime_cap)
@@ -1513,6 +1592,7 @@ impl WorkspaceIndex {
             }
             state.version = state.version.wrapping_add(1);
         }
+        evicted
     }
 
     // ========================================================================
@@ -2338,6 +2418,42 @@ mod tests {
         assert!(index.contains(&uri2));
         assert!(index.contains(&uri3));
         assert_eq!(index.len(), 3);
+    }
+
+    #[test]
+    fn targeted_batch_reports_implicit_complete_eviction_victims() {
+        let index = WorkspaceIndex::new(WorkspaceIndexConfig {
+            max_files: 1,
+            ..make_test_config()
+        });
+        index.resize_artifacts(1);
+        let victim = test_uri("victim.R");
+        let replacement = test_uri("replacement.R");
+        index.insert(victim.clone(), make_test_entry(0));
+
+        let prepared = index
+            .prepare_targeted_batch_if_current(
+                index.version(),
+                WorkspaceIndexTargetedChanges {
+                    metadata: Vec::new(),
+                    installs: vec![(
+                        replacement.clone(),
+                        make_test_entry(0),
+                        ClosedProvenance::Dynamic,
+                    )],
+                    removals: Vec::new(),
+                    pins: HashSet::new(),
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        let mut expected = vec![victim.clone(), replacement.clone()];
+        expected.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        assert_eq!(prepared.changed_uris(), expected);
+        assert!(index.commit_prepared_targeted_batch(prepared).unwrap());
+        assert!(!index.is_complete(&victim));
+        assert!(index.is_complete(&replacement));
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ If you are new to CI, start with [Automated checks in CI](ci.md). It explains wh
 
 Most language ecosystems have a CI checker that reads code without executing it — `cargo check`, `tsc`, `pyright`, `ruff`. R's tooling grew up around a different need: `R CMD check` and the CI ecosystem around it verify *packages*, which means installing every dependency and running code. There's little equivalent for *analysis repositories* — the scripts that make up most scientific and statistical work — and that gap is what these commands fill.
 
-Raven's core is static, semantic analysis with **position-aware scope**: it tracks what's defined at each point in a script — line by line, and inside each function — so it can flag an undefined variable, including one used before it's defined. Crucially for analysis repos, it follows `source()` chains, building a map of how your scripts depend on one another and resolving scope across them. No other R tool does this, and it's what makes `raven check` useful both for package development and for the analysis repositories the rest of the R tooling largely overlooks.
+Raven's core is static, semantic analysis with **position-aware scope**: it tracks what's defined at each point in a script — line by line, and inside each function — so it can flag an undefined variable, including one used before it's defined. Crucially for analysis repos, it follows `source()` chains and static `targets::tar_source()` batches, building a map of how your scripts depend on one another and resolving scope across them. No other R tool does this, and it's what makes `raven check` useful both for package development and for the analysis repositories the rest of the R tooling largely overlooks.
 
 If you aren't building a package, you usually don't want CI to *run* your scripts — and you certainly don't want to install every package they depend on just to check them. Raven finishes in about a second; compiling a dependency tree can take hours, which makes the check slow and expensive. At scale it would also push avoidable load onto CRAN mirrors and the wider ecosystem. So Raven runs **without R, and without your repo's packages installed**.
 
@@ -63,6 +63,15 @@ exclude = ["generated/**", "archive/**", "!generated/keep.R"]
 `[workspace].exclude` defaults to `[]`. Patterns are project-root-relative globs, matched against paths relative to the containing workspace root. `*` and `?` do not cross `/`; use `**` for recursive matches, such as `**/*.log` for `.log` files at any depth. They apply to the workspace index and to default `raven check` discovery. Directory globs like `generated/**` prune whole directories before the parallel parse/index phase; when any negated re-include pattern (`!pattern`) is present, Raven disables directory pruning for the list so a re-included file is never skipped early. The full ordered matcher still filters files, with the last matching pattern winning.
 
 Explicit file arguments bypass these exclusions: `raven check generated/one.R` still reports `generated/one.R` even if `generated/**` is excluded. Directory arguments are discovery walks, so exclusions apply inside them.
+
+Static `targets::tar_source()` batches retain their ordered execution context
+during CLI analysis, including when the same script is selected more than once
+with different working-directory behavior. `raven check` supplements the
+ordinary URI-based dependency neighborhood with a bounded, context-sensitive
+provider traversal; providers outside the initial workspace scan are parsed
+and finalized into the same workspace index before diagnostics run. This
+affects scope only: navigation, missing-file checks, and dependency
+revalidation continue to use one URI-global graph edge per source entry.
 
 ### Options
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -273,11 +273,63 @@ Details:
 - **Union across calls.** Multiple `tar_option_set()` calls in one file union
   their `packages =` vectors. targets' real runtime semantics are
   last-call-wins, but raven deliberately favors false negatives here.
-- **Limitation: no `tar_source()`.** Raven only follows `source()` calls and
-  forward directives, so projects that load their function scripts via
-  `tar_source()` don't inherit the `tar_option_set` packages in those scripts
-  yet. A `# raven: source R/functions.R` directive (or a plain `source()`
-  call) in `_targets.R` restores the link.
+
+### targets::tar_source() Scripts
+
+Raven expands static `targets::tar_source()` calls and adds their `.R` / `.r`
+scripts to the same dependency and scope model as `source()`. The qualified
+`targets::` / `targets:::` spellings are recognized directly; the bare
+`tar_source()` spelling requires an unshadowed top-level targets attachment.
+`files =` may be a string, a non-empty literal character vector, or a
+single-assignment top-level variable holding one of those shapes. Directories
+are walked recursively in deterministic path order; hidden entries are skipped
+unless the hidden path itself was named explicitly. Ordering compares the
+relative path's platform bytes/code units, which approximates
+`sort(..., method = "radix")` under `LC_COLLATE=C`. Locale-specific collation
+and mixed-case/non-ASCII names can therefore execute in a different order in R;
+use consistently cased ASCII script names when sibling order matters.
+
+The scripts execute as one ordered batch. Each member sees `_targets.R` state
+from before the call plus the definitions, removals, and package attachments
+produced by earlier members. A later member replaces an earlier binding of the
+same name. A member never sees a later sibling. `change_directory = TRUE` is
+honored, including for ordinary `source()` calls nested inside a member.
+Packages from `tar_option_set(packages = ...)` and packages attached by earlier
+members flow through the same ordered environment.
+
+In the language server, workspace watcher events keep membership live:
+creating, deleting, or renaming a script under a finalized request refreshes
+the parent metadata, artifacts, dependency edges, and affected diagnostics
+without editing `_targets.R`. Missing candidate paths, case-corrected paths,
+and symlink targets remain watchable when their paths are covered by the
+editor's workspace watcher. External paths and symlink targets outside that
+coverage are refreshed on the next workspace refresh/reopen (and every fresh
+`raven check` run), not by an independent external watcher.
+
+Scope resolution carries each batch execution's derived working-directory
+context through ordinary nested `source()` calls, so repeated members can
+contribute different symbols in different contexts without creating
+occurrence-specific graph nodes. The dependency graph itself remains URI-keyed:
+for a nested call whose lexical target differs between executions,
+go-to-definition, missing-file checks, and edit-triggered revalidation use the
+single URI-global edge. Use distinct small wrapper scripts when those
+graph-backed features must distinguish the executions as well as scope does.
+
+Only statically determined calls participate. Dynamic `files =` expressions,
+computed `change_directory` values, and calls hidden in functions or quoted
+expressions are ignored. A missing literal path can become active after a
+workspace event, but an external missing path cannot be watched reliably.
+
+Finalized metadata and the dependency graph remain indexed by URI, not by
+execution occurrence. Consequently, a nested `tar_source()` batch in one
+physical script is finalized once under that URI's global metadata context;
+context-dependent forward directives and propagated `# raven: nse` /
+`# raven: func` facts likewise retain their URI-global graph behavior. Scope
+can carry the two-valued supplied-`PathContext` mode through ordinary nested
+`source()` calls, but it does not create a second metadata or graph identity.
+When separate executions truly need distinct nested batches, directives, NSE
+contracts, navigation, or edit revalidation, route them through distinct small
+wrapper/loader scripts so each execution has its own URI.
 
 ### Keeping Packages in Sync
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,7 +175,18 @@ Rough pipeline:
 `tar_source()` expansion is caller-owned and filesystem-backed; it has no
 process-global cache. A finalized record stores its ordered ordinal sources and
 every existing or potential watch root. `WorldState` derives a bidirectional
-parent/root registry only after successful analysis commits. Watcher delivery
+parent/root registry only after successful analysis commits. Ordinary commits
+do not rebuild that registry eagerly: after the commit CAS succeeds, a bounded
+gate re-reads only the parents whose open/closed authority changed and compares
+their normalized roots with the installed parent map. The common `OpenEdit`
+checks one parent and is therefore O(1) in workspace size. Only an actual
+topology mismatch falls back to the full registry sweep, which remains the
+single writer of both map directions, net owner-set generation bumps, and
+removed-root tombstones. Artifact-cache installs and Pending admission include
+any implicit LRU eviction victim in that bounded parent set; a claim-time
+eviction is reconciled immediately because enrichment may later abort. Full
+workspace replacements rebuild directly. Rejected commits never reach either
+path. Watcher delivery
 first advances a global monotonic event generation, closing the new-request /
 pre-registry race, then advances the monotonic identities of overlapping roots
 and looks up their parents. An affected open parent receives a per-URI

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,11 +164,52 @@ Optional post-release packaging jobs are gated by repository variables:
 Cross-file awareness is implemented under `crates/raven/src/cross_file/`.
 
 Rough pipeline:
-1. Extract per-file metadata (directives + AST-detected `source()` + library calls)
-2. Update dependency graph edges (forward + backward)
-3. Compute per-file artifacts (exported interface, timeline, interface hash)
-4. Resolve scope at a position by traversing edges and applying call-site filtering
-5. Revalidate dependents on relevant changes (interface hash / edges / working directory changes)
+1. Extract per-file metadata (directives + AST-detected `source()` / `tar_source()` requests + library calls)
+2. Enrich inherited working directories and resolve `system.file()` sources
+3. Expand static `tar_source()` requests off-lock
+4. Compute per-file artifacts (exported interface, ordered timeline, interface hash)
+5. Update dependency graph edges (forward + backward)
+6. Resolve scope at a position by traversing edges and applying call-site filtering
+7. Revalidate dependents on relevant changes (interface hash / edges / working directory changes)
+
+`tar_source()` expansion is caller-owned and filesystem-backed; it has no
+process-global cache. A finalized record stores its ordered ordinal sources and
+every existing or potential watch root. `WorldState` derives a bidirectional
+parent/root registry only after successful analysis commits. Watcher delivery
+first advances a global monotonic event generation, closing the new-request /
+pre-registry race, then advances the monotonic identities of overlapping roots
+and looks up their parents. An affected open parent receives a per-URI
+latest-arrival refresh owner on the backend's tracked routing-task lifecycle:
+newer events update one desired-generation register while one coordinator
+serializes physical filesystem walks for that parent. Exact-basis conflicts
+retry with bounded backoff until commit, close/reopen, or shutdown. Coordinator
+retirement releases single-flight admission before re-reading desired work, so
+an event published during the exit window is either reclaimed or owned by a
+successor. This prevents both consumed-event loss during unrelated graph/config
+churn and bursts of uncancellable same-tree walks. `AnalysisBasis` validates
+both the global fence and
+the subject parent's captured root identities at the same write-lock commit
+that installs metadata, artifacts, graph edges, and the rebuilt registry.
+Removed roots remain generation tombstones; workspace replacement never resets
+or reuses an identity. Ordered execution is represented by one `TarBatch`
+timeline event, while dependency edges retain individual ordinals so a member's
+backward prefix contains exactly its earlier siblings. Batch members bypass
+URI-only forward/standalone caches because their rolling symbol, removal,
+package, and working-directory inputs are execution-specific. Descendant
+ordinary sources carry a two-valued "prefer supplied `PathContext`" resolution
+mode, never a call-site/ordinal occurrence identity; the forward-child memo
+keys that mode alongside the context fingerprint. This preserves scope for
+repeated members without multiplying graph or prefix-cache identities. The
+graph remains URI-global, so navigation, missing-file checks, and revalidation
+for nested context-dependent targets deliberately use its single winning edge.
+For `raven check`, a pure bounded collector walks `(provider URI,
+PathContext, lexical-first mode)` states from finalized tar members. The CLI
+materializes any external providers through the normal
+parse/enrich/`system.file()`/tar-finalize/artifact pipeline into its sole
+`WorkspaceIndex`, then passes only providers outside the graph neighborhood to
+the diagnostic snapshot's content-precollection seam. Context divergence or
+budget truncation disables the standalone-scope cache for that snapshot, but
+the collector never mutates graph edges or revisions.
 
 Package-state seeds follow the same snapshot/off-lock/install discipline as
 cross-file diagnostics. Callers snapshot the exact raw/derived/config/root


### PR DESCRIPTION
## Summary

- detect statically resolvable `targets::tar_source()` calls, expand file and directory inputs deterministically, and represent each expanded member as an ordered graph occurrence
- evaluate tar batches sequentially so definitions, removals, packages, and data effects flow across members and back into the calling `_targets.R`
- preserve per-occurrence working-directory semantics for repeated members while retaining Raven's URI-global dependency graph for navigation and revalidation
- refresh open and closed tar-source roots from workspace file events with generation fencing and a single-flight coordinator
- share contextual provider planning between language-server diagnostics and `raven check`, including external CLI provider materialization
- document supported static forms, ordering, watcher scope, contextual limitations, and wrapper-script workarounds

## Architecture

Static detection is filesystem-free. A later finalization phase expands requests after working-directory enrichment and installs detached results into metadata and the dependency graph. Expanded edges carry a tar-source ordinal in addition to their call site, preserving execution order and repeated occurrences without changing URI identity.

Diagnostics use a bounded, pure provider planner. Before the first tar edge it follows the exact URI-global graph edge by parent URI, call site, and ordinal; after the tar edge it carries the occurrence-specific `PathContext`. Unknown trimmed graph state and missing providers fail closed by disabling URI-keyed standalone caching. Locality remains scope merge policy: `NonInheriting` edges are still traversed for process-wide package and data effects while ordinary symbols remain filtered by scope.

Watcher refreshes publish desired generations into per-URI state and admit one coordinator per open root. The coordinator serializes filesystem walks, retries stale compare-and-swap attempts, services only the latest generation, and performs an exit handoff so bursts, close/reopen, and shutdown cannot strand work or install retired results.

## User impact

`_targets.R` files can now consume functions and package effects from statically expanded tar-source members. Members see packages configured earlier by `tar_option_set()`, execute in deterministic order, and respect supported `change_directory` and Raven working-directory contexts. CLI and editor diagnostics now agree for nested and repeated tar-source execution contexts.

Dynamic path expressions remain deliberately unsupported. External membership changes are not watched by the workspace-only language-server watcher; reopening, a workspace refresh, or a fresh CLI check recomputes them.

## Validation

- `cargo test --workspace --all-targets --features test-support --no-fail-fast`
- `cargo test -p raven --lib -- --nocapture` — 6,471 passed, 12 ignored
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `git diff --check`

Regression coverage includes the original issue scenarios, repeated-member path contexts, nested normal-LSP and CLI snapshots, URI-global graph-prefix conflicts, `tar_option_set(packages=...)` flow into members, member definitions flowing back, NonInheriting package/symbol behavior, watcher burst supersession, close/reopen, shutdown, symlinks, broken targets, raw-byte ordering, working-directory tiers, mutation poisoning, and bounded traversal.

Closes #653
Closes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end support for statically recognized `targets::tar_source()` batches, preserving ordered execution context across scope and dependency resolution.
  * Enhanced `raven check` with context-aware tar providers for more complete diagnostics across tar-source boundaries.
  * Improved background refresh behavior when tar-source inputs (files/directories) change.

* **Bug Fixes**
  * More reliable handling of repeated, nested, missing, reordered, and converging tar-source scenarios, including proper refresh cancellation and eviction-aware updates.

* **Documentation**
  * Updated CLI and cross-file documentation to describe tar-source behavior, ordering, and workspace watching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->