### PR TITLE
Optimize package-state preamble derivation

### DIFF
--- a/crates/raven/src/package_state/derive.rs
+++ b/crates/raven/src/package_state/derive.rs
@@ -133,17 +133,10 @@ fn build_scope_contribution(
                     // transitive `source()` targets (issue #638), union them
                     // in (allocating only for preambles that actually source
                     // something).
-                    let sourced = inputs.preamble_sourced_symbols.get(path);
-                    let defs = match sourced.filter(|s| !s.is_empty()) {
-                        None => facts.top_level_defs.clone(),
-                        Some(harvested) => Arc::new(
-                            facts
-                                .top_level_defs
-                                .union(harvested)
-                                .cloned()
-                                .collect::<BTreeSet<String>>(),
-                        ),
-                    };
+                    let defs = union_or_share(
+                        &facts.top_level_defs,
+                        inputs.preamble_sourced_symbols.get(path),
+                    );
                     test_helper_symbols.insert(path.clone(), defs);
                     // Same for top-level `library()`/`require()` attaches — a
                     // helper/setup file's attaches propagate to sibling tests
@@ -152,20 +145,10 @@ fn build_scope_contribution(
                     // closure (issue #638). Skip the entry entirely when there
                     // are no attaches so the map stays sparse (most preamble
                     // files attach nothing).
-                    let sourced_attached = inputs
-                        .preamble_sourced_attached_packages
-                        .get(path)
-                        .filter(|s| !s.is_empty());
-                    let attached = match sourced_attached {
-                        None => facts.attached_packages.clone(),
-                        Some(harvested) => Arc::new(
-                            facts
-                                .attached_packages
-                                .union(harvested)
-                                .cloned()
-                                .collect::<BTreeSet<String>>(),
-                        ),
-                    };
+                    let attached = union_or_share(
+                        &facts.attached_packages,
+                        inputs.preamble_sourced_attached_packages.get(path),
+                    );
                     if !attached.is_empty() {
                         test_helper_attached_packages.insert(path.clone(), attached);
                     }
@@ -230,6 +213,20 @@ fn build_scope_contribution(
         rprofile_symbols: Arc::new(rprofile_symbols.clone()),
         rprofile_attached_packages: Arc::new(rprofile_attached_packages.clone()),
         rprofile_root,
+    }
+}
+
+/// Return the cached immutable set when adding `harvested` cannot change it.
+fn union_or_share(
+    cached: &Arc<BTreeSet<String>>,
+    harvested: Option<&BTreeSet<String>>,
+) -> Arc<BTreeSet<String>> {
+    match harvested {
+        None => Arc::clone(cached),
+        Some(harvested) if harvested.is_empty() || harvested.is_subset(cached) => {
+            Arc::clone(cached)
+        }
+        Some(harvested) => Arc::new(cached.union(harvested).cloned().collect()),
     }
 }
 
@@ -418,6 +415,89 @@ mod tests {
         let mut i = empty_inputs(mode);
         i.description = Some(DescriptionInput { text: text.into() });
         i
+    }
+
+    #[test]
+    fn union_or_share_reuses_cached_set_without_added_values() {
+        let cached = Arc::new(BTreeSet::from(["cached".to_string()]));
+        let empty = BTreeSet::new();
+
+        assert!(Arc::ptr_eq(&union_or_share(&cached, None), &cached));
+        assert!(Arc::ptr_eq(&union_or_share(&cached, Some(&empty)), &cached));
+    }
+
+    #[test]
+    fn union_or_share_allocates_complete_union_for_new_values() {
+        let cached = Arc::new(BTreeSet::from(["cached".to_string()]));
+        let harvested = BTreeSet::from(["added".to_string()]);
+        let merged = union_or_share(&cached, Some(&harvested));
+
+        assert!(!Arc::ptr_eq(&merged, &cached));
+        assert_eq!(
+            merged.as_ref(),
+            &BTreeSet::from(["added".to_string(), "cached".to_string()])
+        );
+    }
+
+    #[test]
+    fn contribution_reuses_cached_helper_defs_for_subset_closure() {
+        let helper_path: PathBuf = "/work/pkg/tests/testthat/helper-shared.R".into();
+        let helper_text: Arc<str> = "shared <- 1\n".into();
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            helper_path.clone(),
+            RFileInput {
+                kind: RFileKind::Test,
+                text: helper_text.clone(),
+                content_digest: ContentDigest::of(&helper_text),
+            },
+        );
+        inputs
+            .preamble_sourced_symbols
+            .insert(helper_path.clone(), BTreeSet::from(["shared".to_string()]));
+
+        let state = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        let cached = &state.r_file_facts[&helper_path].top_level_defs;
+        let contributed = &state.scope_contribution.test_helper_symbols[&helper_path];
+
+        assert!(Arc::ptr_eq(contributed, cached));
+        assert_eq!(
+            contributed.as_ref(),
+            &BTreeSet::from(["shared".to_string()])
+        );
+    }
+
+    #[test]
+    fn contribution_reuses_cached_helper_attaches_for_subset_closure() {
+        let helper_path: PathBuf = "/work/pkg/tests/testthat/helper-shared.R".into();
+        let helper_text: Arc<str> = "library(tidyr)\n".into();
+        let mut inputs = with_description(PackageMode::Auto, "Package: foo\n");
+        inputs.r_files.insert(
+            helper_path.clone(),
+            RFileInput {
+                kind: RFileKind::Test,
+                text: helper_text.clone(),
+                content_digest: ContentDigest::of(&helper_text),
+            },
+        );
+        inputs
+            .preamble_sourced_attached_packages
+            .insert(helper_path.clone(), BTreeSet::from(["tidyr".to_string()]));
+
+        let state = derive_package_state(
+            &PackageState::default(),
+            &inputs,
+            &PackageInputDelta::Initial,
+        );
+        let cached = &state.r_file_facts[&helper_path].attached_packages;
+        let contributed = &state.scope_contribution.test_helper_attached_packages[&helper_path];
+
+        assert!(Arc::ptr_eq(contributed, cached));
+        assert_eq!(contributed.as_ref(), &BTreeSet::from(["tidyr".to_string()]));
     }
 
     #[test]

--- a/crates/raven/src/package_state/preamble.rs
+++ b/crates/raven/src/package_state/preamble.rs
@@ -432,9 +432,11 @@ fn read_source_with_overrides(
     if let Some(text) = overrides.get(path) {
         return Some(text.to_string());
     }
-    let routing_path = canonicalize_for_routing(path);
-    if let Some(text) = overrides.get(&routing_path) {
-        return Some(text.to_string());
+    if !overrides.is_empty() {
+        let routing_path = canonicalize_for_routing(path);
+        if let Some(text) = overrides.get(&routing_path) {
+            return Some(text.to_string());
+        }
     }
     allow_disk_fallback
         .then(|| crate::state::read_source(path).ok())


### PR DESCRIPTION
References #656; does not close it.

## Summary

This is the first bounded subsystem group from the revalidated #656 cleanup list. It keeps package-state behavior unchanged while avoiding work on production-hot preamble paths:

- reuse cached immutable definition and attachment sets when harvested additions are already a subset;
- skip routing-path canonicalization when no open-buffer override can match.

## Checklist items addressed

- Share cached-set merging in `package_state/derive.rs` and preserve the existing `Arc` when the added set is already a subset.
- Skip routing canonicalization in preamble source reads when the override map is empty.

## Revalidated but intentionally not changed

- The duplicate watched package R-file scanners are now test/compatibility-only after #650; production watched batches use complete frozen package projections. Refactoring that adapter would not improve production behavior.
- The incremental `sourced_files` union/apply seam is now a test invariant probe after #650. Its live-keyed recomputation is required to preserve unrelated concurrent preamble updates, so the old simplification is obsolete and a naive implementation would be unsafe.

## Remaining #656 groups

- content-provider open-predicate reuse;
- scope artifact-builder delegation and single finalization pass;
- dependency cache-revision condition;
- binding representation/event simplifications;
- duplicate revalidation-test assignment;
- backend watcher empty-set fast path;
- Rprofile documentation deduplication.

Each remains deferred to a separate subsystem-specific PR after this one lands.

## Rebase evidence

After prerequisite PR #669 merged, this branch was rebased onto exact main commit `0076369eedf1cbcbd7578f840ebcf27691c75da2`.

- rebased HEAD: `d21ecf3a4a0ee52616eefaa7c4d75d8f99f8567e`;
- `HEAD^` is exactly `0076369eedf1cbcbd7578f840ebcf27691c75da2`;
- range-diff reports the original and rebased package-state commits as identical, and their stable patch IDs match;
- the new-base diff contains only `package_state/derive.rs` and `package_state/preamble.rs`;
- stabilized `backend.rs` and `state.rs` test code from #669 is unchanged by this branch.

An independent read-only re-review confirmed the base relationship, patch preservation, file scope, and package-state correctness with no blockers.

## Validation

- `cargo test -p raven package_state::` — 202 passed
- `cargo test -p raven --features test-support` — 6482 library tests passed, 12 ignored; all integration suites and 53 doctests passed
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `git diff --check 0076369e..HEAD`

The design was reviewed by Fable before implementation, and the original regression/new-bug reviews plus the post-rebase independent review were clean.
