### PR TITLE
Stabilize config reload and close race tests

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -17129,12 +17129,13 @@ impl LanguageServer for Backend {
             params.changes.len()
         );
         #[cfg(test)]
-        let final_handoff_test_capture = self
-            .state
-            .read()
-            .await
-            .watched_final_handoff_test_capture
-            .claim();
+        let (final_handoff_test_capture, config_reload_publish_test_capture) = {
+            let state = self.state.read().await;
+            (
+                state.watched_final_handoff_test_capture.claim(),
+                state.config_reload_publish_test_capture.claim(),
+            )
+        };
         let tar_source_parents = if params.changes.is_empty() {
             Vec::new()
         } else {
@@ -17254,17 +17255,45 @@ impl LanguageServer for Backend {
             // can't race a still-running reload publish.
             const MAX_CONCURRENT_PUBLISHES: usize = 8;
             let mut join_set = tokio::task::JoinSet::new();
+            #[cfg(test)]
+            let mut completed = Vec::with_capacity(to_publish.len());
+            #[cfg(test)]
+            let mut scheduled = to_publish.clone();
             for uri in to_publish {
                 while join_set.len() >= MAX_CONCURRENT_PUBLISHES {
-                    join_set.join_next().await;
+                    let _joined = join_set.join_next().await;
+                    #[cfg(test)]
+                    if let Some(Ok(uri)) = _joined {
+                        completed.push(uri);
+                    }
                 }
                 let state_arc = self.state.clone();
                 let client = self.client.clone();
                 join_set.spawn(async move {
                     publish_diagnostics_inner(&state_arc, &client, &uri).await;
+                    #[cfg(test)]
+                    {
+                        uri
+                    }
                 });
             }
-            while join_set.join_next().await.is_some() {}
+            while let Some(_joined) = join_set.join_next().await {
+                #[cfg(test)]
+                if let Ok(uri) = _joined {
+                    completed.push(uri);
+                }
+            }
+            #[cfg(test)]
+            if let Some(capture) = &config_reload_publish_test_capture {
+                scheduled.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+                completed.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+                capture
+                    .record_and_pause(crate::state::ConfigReloadPublishForTest {
+                        scheduled,
+                        completed,
+                    })
+                    .await;
+            }
         }
 
         // If every change was a config file, the source-file flow below has
@@ -42179,15 +42208,11 @@ mod project_config_initialize_tests {
     /// ordering.
     ///
     /// We exercise 12 open `.R` files (above the concurrency cap of 8).
-    /// The reload's reconciliation helper marks every open URI for
-    /// force-republish (counter increment); a successful publish
-    /// decrements that counter via `try_consume_publish`. Asserting that
-    /// every URI's `force_republish_count_for_test == 0` after the
-    /// handler returns is a stronger signal than checking
-    /// `last_published_version` — the gate's prior-publish state from
-    /// `did_open` would already make `can_publish(uri, 1)` return
-    /// false, so that observable could pass without the reload doing
-    /// anything.
+    /// An invocation-scoped capture records both the scheduled URI set and
+    /// every successfully joined task. This avoids attributing shared
+    /// force-republish counters that may still be draining from `did_open`
+    /// setup while still proving the reload joined work above and below the
+    /// concurrency cap.
     #[tokio::test]
     async fn watched_files_reload_publishes_all_open_documents_in_parallel() {
         use tower_lsp::lsp_types::{
@@ -42210,6 +42235,10 @@ mod project_config_initialize_tests {
                     uri: Url::from_file_path(tmp.path()).unwrap(),
                     name: "t".into(),
                 }]),
+                initialization_options: Some(serde_json::json!({
+                    "crossFile": { "indexWorkspace": false },
+                    "packages": { "enabled": false }
+                })),
                 ..Default::default()
             })
             .await
@@ -42234,47 +42263,40 @@ mod project_config_initialize_tests {
             uris.push(uri);
         }
 
-        // Sanity: pre-reload, no outstanding force-republish markers — the
-        // reload is the only path under test that will mark and then
-        // consume them.
-        {
-            let state = backend.state.read().await;
-            for uri in &uris {
-                assert_eq!(
-                    state.diagnostics_gate.force_republish_count_for_test(uri),
-                    0,
-                    "unexpected pre-reload force-republish marker for {uri}"
-                );
-            }
-        }
-
         // Edit raven.toml and trigger a reload.
         fs::write(
             tmp.path().join("raven.toml"),
             "[linting]\nenabled = true\nlineLength = 140\n",
         )
         .unwrap();
-        backend
-            .did_change_watched_files(DidChangeWatchedFilesParams {
-                changes: vec![FileEvent {
-                    uri: Url::from_file_path(tmp.path().join("raven.toml")).unwrap(),
-                    typ: FileChangeType::CHANGED,
-                }],
-            })
-            .await;
-
-        // After the handler returns, every URI's force-republish marker
-        // (set by the reconciliation helper) must have been consumed by
-        // a successful `try_consume_publish` — a stuck or un-awaited
-        // task would leave its URI's counter at 1.
-        let state = backend.state.read().await;
-        for uri in &uris {
-            assert_eq!(
-                state.diagnostics_gate.force_republish_count_for_test(uri),
-                0,
-                "reload's parallel publish driver left an outstanding force-republish marker for {uri}",
-            );
-        }
+        let capture = backend
+            .state
+            .read()
+            .await
+            .config_reload_publish_test_capture
+            .arm();
+        let task_backend = backend.clone();
+        let config_uri = Url::from_file_path(tmp.path().join("raven.toml")).unwrap();
+        let reload = tokio::spawn(async move {
+            task_backend
+                .did_change_watched_files(DidChangeWatchedFilesParams {
+                    changes: vec![FileEvent {
+                        uri: config_uri,
+                        typ: FileChangeType::CHANGED,
+                    }],
+                })
+                .await;
+        });
+        let handoff =
+            tokio::time::timeout(std::time::Duration::from_secs(5), capture.wait_payload())
+                .await
+                .expect("config reload must join every scheduled diagnostics publish");
+        let mut expected = uris;
+        expected.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        assert_eq!(handoff.scheduled, expected);
+        assert_eq!(handoff.completed, expected);
+        capture.release();
+        reload.await.unwrap();
     }
 
     /// Characterization test for the watched-files CREATED/CHANGED async
@@ -50408,8 +50430,6 @@ infixContinuationStyle = "aligned"
         watched: HashMap<Url, u64>,
         chunk_overrides: HashMap<Url, crate::chunks::ChunkKind>,
         pins: std::collections::HashSet<Url>,
-        reservations: usize,
-        force: u32,
     }
 
     fn close_central_snapshot(state: &WorldState, uri: &Url) -> CloseCentralSnapshot {
@@ -50448,15 +50468,14 @@ infixContinuationStyle = "aligned"
             watched: state.watched_file_resync_generations.clone(),
             chunk_overrides: state.editor_chunk_kind_overrides.clone(),
             pins: state.workspace_index.pinned_uris_for_test(),
-            reservations: state.analysis_revalidation_reservation_count,
-            force: state.diagnostics_gate.force_republish_count_for_test(uri),
         }
     }
 
     #[tokio::test]
     async fn did_close_target_edit_is_terminal_and_never_rebases() {
         let tmp = TempDir::new().unwrap();
-        let (svc, uri) = open_in_workspace(&tmp, "close-edit-owner.R", "r", "before <- 1\n").await;
+        let (svc, uri) =
+            open_in_quiescent_workspace(&tmp, "close-edit-owner.R", "r", "before <- 1\n").await;
         let backend = svc.inner();
         let pause = backend
             .state
@@ -50894,6 +50913,10 @@ infixContinuationStyle = "aligned"
                     uri: Url::from_file_path(tmp.path()).unwrap(),
                     name: "t".into(),
                 }]),
+                initialization_options: Some(serde_json::json!({
+                    "crossFile": { "indexWorkspace": false },
+                    "packages": { "enabled": false }
+                })),
                 ..Default::default()
             })
             .await

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -955,6 +955,8 @@ pub struct WorldState {
     #[cfg(test)]
     pub(crate) watched_final_handoff_test_capture: FinalHandoffCapture<WatchedFinalHandoffForTest>,
     #[cfg(test)]
+    pub(crate) config_reload_publish_test_capture: FinalHandoffCapture<ConfigReloadPublishForTest>,
+    #[cfg(test)]
     pub(crate) did_close_final_handoff_test_capture:
         FinalHandoffCapture<Vec<AnalysisRevalidationTicketFingerprint>>,
     #[cfg(test)]
@@ -3175,6 +3177,13 @@ impl From<&AnalysisRevalidationTicket> for AnalysisRevalidationTicketFingerprint
 pub(crate) struct WatchedFinalHandoffForTest {
     pub(crate) reserved: Vec<AnalysisRevalidationTicketFingerprint>,
     pub(crate) transferred: Vec<AnalysisRevalidationTicketFingerprint>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigReloadPublishForTest {
+    pub(crate) scheduled: Vec<Url>,
+    pub(crate) completed: Vec<Url>,
 }
 
 #[cfg(test)]
@@ -6441,6 +6450,8 @@ impl WorldState {
                 crate::cross_file::revalidation::DiagnosticsPublishPause::default(),
             #[cfg(test)]
             watched_final_handoff_test_capture: FinalHandoffCapture::default(),
+            #[cfg(test)]
+            config_reload_publish_test_capture: FinalHandoffCapture::default(),
             #[cfg(test)]
             did_close_final_handoff_test_capture: FinalHandoffCapture::default(),
             #[cfg(test)]


### PR DESCRIPTION
## Summary

- replace shared force-marker observation in the config-reload parallel-publish test with an invocation-scoped scheduled/completed JoinSet capture
- exclude asynchronous diagnostic reservation bookkeeping from the durable close-cancellation snapshot
- isolate all three CAS/join fixtures from unrelated startup workspace-index and package-routing work

## CI evidence

This follows two Cargo Tests failures on #670:

- attempt 1: `watched_files_reload_publishes_all_open_documents_in_parallel` observed a setup-owned pre-reload force marker (`1` vs `0`)
- retry: `did_close_target_edit_is_terminal_and_never_rebases` differed only in asynchronously drained reservation/force bookkeeping (`3/1` vs `2/0`), while `did_close_retries_non_subject_watched_generation_and_leaves_unrelated_untouched` exhausted its final bounded CAS attempt after unrelated default initialization churn and left the alias open

The failing Cargo job is [here](https://github.com/jbearak/raven/actions/runs/29703387985/job/88237021147). The changes are confined to `backend.rs` and `state.rs`; the new capture and payload are `cfg(test)`, and production JoinSet output remains `()`.

Relates to #656. Does not close it.

## Validation

- three exact regression tests
- full `project_config_initialize_tests` module under 16 threads: 328 passed
- 100 rounds of all three affected tests: 300/300 passed
- two consecutive `cargo test -p raven --features test-support` runs: 6482 unit tests, all integration tests, and 53 doctests passed each run
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- rustdoc with `-D warnings`, default and `test-support`
- independent cause audit and final regression/new-bug review clean
- Fable architecture review approved before implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for configuration reloads triggered by watched-file changes.
  * Added validation that document updates are scheduled and completed consistently during reload publishing.
  * Expanded LSP test scenarios with controlled initialization settings and quiescent workspace behavior.
  * Improved test synchronization and deterministic result checking for reload-related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->