### PR TITLE
Stabilize repeated async pause sequencing

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -43241,14 +43241,15 @@ mod project_config_initialize_tests {
             !deletion.is_finished(),
             "delete-only handler skipped the first routing attempt"
         );
-        first_pause.release();
-
         let second_pause = backend
             .state
             .read()
             .await
             .system_file_pre_commit_test_pause
-            .arm(Url::parse("raven-test://system-file-pre-commit").unwrap());
+            .rearm_before_release(
+                Url::parse("raven-test://system-file-pre-commit").unwrap(),
+                first_pause,
+            );
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
             second_pause.wait_arrived(),
@@ -43259,14 +43260,15 @@ mod project_config_initialize_tests {
             !deletion.is_finished(),
             "delete-only handler skipped the second routing attempt"
         );
-        second_pause.release();
-
         let deferred_pause = backend
             .state
             .read()
             .await
             .system_file_pre_commit_test_pause
-            .arm(Url::parse("raven-test://system-file-pre-commit").unwrap());
+            .rearm_before_release(
+                Url::parse("raven-test://system-file-pre-commit").unwrap(),
+                second_pause,
+            );
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
             deferred_pause.wait_arrived(),
@@ -52057,6 +52059,7 @@ infixContinuationStyle = "aligned"
     ) -> String {
         let capture_status = capture.status();
         let state = backend.state.read().await;
+        let system_file_routing_owner_generation = state.system_file_routing_owner_generation();
         let target_state: Vec<_> = targets
             .iter()
             .map(|uri| {
@@ -52071,10 +52074,19 @@ infixContinuationStyle = "aligned"
                 )
             })
             .collect();
+        drop(state);
+        let routing_derivation_slot = library_routing_derivation_slot()
+            .lock()
+            .entry
+            .as_ref()
+            .map(|entry| (entry.id, entry.key));
         format!(
             "kind={kind} operation_id={} owner={:?} claimed={} recorded={} completed={} \
              outstanding={:?} abnormal_exits={:?} \
              targets=(uri,version,revision,epoch,force,pending){target_state:?} \
+             system_file_routing_owner_generation={system_file_routing_owner_generation} \
+             library_routing_derivation_available_permits={} \
+             library_routing_derivation_slot={routing_derivation_slot:?} \
              close_resync_available_permits={}",
             capture_status.operation_id,
             capture_status.owner,
@@ -52083,6 +52095,7 @@ infixContinuationStyle = "aligned"
             capture_status.completed,
             capture_status.outstanding,
             capture_status.abnormal_exits,
+            library_routing_derivation_gate().available_permits(),
             backend.close_resync_permits.available_permits(),
         )
     }

--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -8,6 +8,9 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::atomic::AtomicBool;
+
 use tokio_util::sync::CancellationToken;
 use tower_lsp::lsp_types::Url;
 
@@ -422,9 +425,20 @@ impl CrossFileDiagnosticsGate {
 /// pause's lifetime is tied to the backend under test and cannot leak into
 /// unrelated tests sharing the process.
 #[cfg(any(test, feature = "test-support"))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DiagnosticsPublishPause {
     gates: RwLock<HashMap<Url, std::sync::Arc<PauseGate>>>,
+    identity: std::sync::Arc<()>,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl Default for DiagnosticsPublishPause {
+    fn default() -> Self {
+        Self {
+            gates: RwLock::default(),
+            identity: std::sync::Arc::new(()),
+        }
+    }
 }
 
 /// One armed pause point. `arrived`/`release` are `Notify`s, so the
@@ -434,6 +448,7 @@ pub struct DiagnosticsPublishPause {
 pub struct PauseGate {
     arrived: tokio::sync::Notify,
     release: tokio::sync::Notify,
+    has_arrived: AtomicBool,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -442,8 +457,55 @@ impl DiagnosticsPublishPause {
     /// wait for a worker to arrive at the pause point and later release it.
     pub fn arm(&self, uri: Url) -> PauseHandle {
         let gate = std::sync::Arc::new(PauseGate::default());
-        self.gates.write().unwrap().insert(uri, gate.clone());
-        PauseHandle { gate }
+        self.gates
+            .write()
+            .unwrap()
+            .insert(uri.clone(), gate.clone());
+        PauseHandle {
+            gate,
+            registry_identity: self.identity.clone(),
+            uri,
+        }
+    }
+
+    /// Arm the next one-shot pause before releasing an arrived predecessor.
+    ///
+    /// Repeated interceptions at the same seam must use this handoff instead
+    /// of releasing and then calling [`Self::arm`]. The latter leaves a
+    /// scheduler-visible gap in which the worker can cross the seam before the
+    /// successor exists.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `predecessor` has not arrived, belongs to another pause
+    /// registry or URI, or if another pause is already armed for `uri`.
+    pub fn rearm_before_release(&self, uri: Url, predecessor: PauseHandle) -> PauseHandle {
+        assert!(
+            predecessor.gate.has_arrived.load(Ordering::Acquire),
+            "a pause successor can only replace an arrived predecessor"
+        );
+        assert!(
+            std::sync::Arc::ptr_eq(&self.identity, &predecessor.registry_identity),
+            "a pause successor must use its predecessor's registry"
+        );
+        assert_eq!(
+            uri, predecessor.uri,
+            "a pause successor must use its predecessor's URI"
+        );
+        let gate = std::sync::Arc::new(PauseGate::default());
+        let mut gates = self.gates.write().unwrap();
+        assert!(
+            !gates.contains_key(&uri),
+            "the arrived predecessor must already be consumed before rearming"
+        );
+        gates.insert(uri.clone(), gate.clone());
+        drop(gates);
+        predecessor.release();
+        PauseHandle {
+            gate,
+            registry_identity: self.identity.clone(),
+            uri,
+        }
     }
 
     /// Worker-side lookup, consuming the armed entry (one-shot so a respawn
@@ -459,6 +521,7 @@ impl DiagnosticsPublishPause {
 impl PauseGate {
     /// Worker side: signal arrival, then park until the test releases.
     pub async fn pause(&self) {
+        self.has_arrived.store(true, Ordering::Release);
         self.arrived.notify_one();
         self.release.notified().await;
     }
@@ -468,6 +531,8 @@ impl PauseGate {
 #[cfg(any(test, feature = "test-support"))]
 pub struct PauseHandle {
     gate: std::sync::Arc<PauseGate>,
+    registry_identity: std::sync::Arc<()>,
+    uri: Url,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -478,7 +543,7 @@ impl PauseHandle {
     }
 
     /// Release the parked worker.
-    pub fn release(&self) {
+    pub fn release(self) {
         self.gate.release.notify_one();
     }
 }
@@ -786,6 +851,81 @@ mod tests {
 
     fn test_uri(name: &str) -> Url {
         Url::parse(&format!("file:///{}", name)).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pause_rearm_registers_successor_before_releasing_predecessor() {
+        let pauses = std::sync::Arc::new(DiagnosticsPublishPause::default());
+        let uri = test_uri("pause");
+        let first = pauses.arm(uri.clone());
+        let first_gate = pauses.take_armed(&uri).unwrap();
+        let worker_pauses = pauses.clone();
+        let worker_uri = uri.clone();
+        let first_worker = tokio::spawn(async move {
+            first_gate.pause().await;
+            let second_gate = worker_pauses
+                .take_armed(&worker_uri)
+                .expect("successor is visible before the predecessor resumes");
+            second_gate.pause().await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), first.wait_arrived())
+            .await
+            .expect("predecessor arrives");
+
+        let second = pauses.rearm_before_release(uri.clone(), first);
+        tokio::time::timeout(std::time::Duration::from_secs(1), second.wait_arrived())
+            .await
+            .expect("successor arrives");
+        second.release();
+        tokio::time::timeout(std::time::Duration::from_secs(1), first_worker)
+            .await
+            .expect("both pause generations finish")
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "a pause successor must use its predecessor's registry")]
+    fn pause_rearm_rejects_a_predecessor_from_another_registry() {
+        let pauses = DiagnosticsPublishPause::default();
+        let other = DiagnosticsPublishPause::default();
+        let uri = test_uri("pause");
+        let predecessor = other.arm(uri.clone());
+        predecessor.gate.has_arrived.store(true, Ordering::Release);
+
+        pauses.rearm_before_release(uri, predecessor);
+    }
+
+    #[test]
+    #[should_panic(expected = "a pause successor must use its predecessor's URI")]
+    fn pause_rearm_rejects_a_predecessor_from_another_uri() {
+        let pauses = DiagnosticsPublishPause::default();
+        let predecessor = pauses.arm(test_uri("first"));
+        predecessor.gate.has_arrived.store(true, Ordering::Release);
+
+        pauses.rearm_before_release(test_uri("second"), predecessor);
+    }
+
+    #[test]
+    #[should_panic(expected = "a pause successor can only replace an arrived predecessor")]
+    fn pause_rearm_rejects_a_predecessor_that_has_not_arrived() {
+        let pauses = DiagnosticsPublishPause::default();
+        let uri = test_uri("pause");
+        let predecessor = pauses.arm(uri.clone());
+
+        pauses.rearm_before_release(uri, predecessor);
+    }
+
+    #[test]
+    #[should_panic(expected = "the arrived predecessor must already be consumed before rearming")]
+    fn pause_rearm_rejects_an_occupied_seam() {
+        let pauses = DiagnosticsPublishPause::default();
+        let uri = test_uri("pause");
+        let predecessor = pauses.arm(uri.clone());
+        pauses.take_armed(&uri).unwrap();
+        predecessor.gate.has_arrived.store(true, Ordering::Release);
+        let _occupied = pauses.arm(uri.clone());
+
+        pauses.rearm_before_release(uri, predecessor);
     }
 
     // CrossFileRevalidationState tests

--- a/docs/development.md
+++ b/docs/development.md
@@ -1428,6 +1428,13 @@ subject is marker/prerequisite drainage may still poll that contract, but their
 timeout is only a deadlock watchdog and must report the target lifecycle,
 force/pending state, outstanding causal labels, and relevant permit state.
 
+When a test intercepts consecutive attempts at the same one-shot pause seam,
+it must arm the successor after observing arrival and before releasing the
+predecessor. `DiagnosticsPublishPause::rearm_before_release` enforces that
+ordering and rejects a handle from another registry or seam. Releasing one
+pause and arming its successor separately leaves an uninstrumented scheduling
+gap in which the worker can cross the seam.
+
 Use `open_in_quiescent_workspace` when workspace scanning and package routing
 are outside the test's subject. It disables those two startup authorities while
 preserving on-demand cross-file indexing. Keep separate tests with normal


### PR DESCRIPTION
## Summary

- add an identity-bound, single-use `rearm_before_release` handoff for consecutive one-shot async test pauses
- close the release-before-rearm scheduling gap reproduced by fresh full CI in `watched_delete_only_awaits_deferred_routing_finalization`
- add concurrent ordering and misuse regressions, plus routing owner/global derivation-permit state to timeout watchdogs
- document the deterministic pause-sequencing invariant

## Systemic failure matrix

| Area | Finding |
| --- | --- |
| Detached/background work | Watched package deletion performs two foreground routing attempts and then an inline retained-owner deferred finalizer before its invocation-owned final handoff. The #674 receipt correctly spans the eventual handoff and diagnostic descendants, but it cannot intercept earlier internal retry seams. |
| Polling, sleeps, deadlines | The failing test used one-shot pre-commit pauses with 5-second deadlock watchdogs. It released generation N before arming N+1, creating a real uninstrumented scheduler gap; increasing the deadline cannot recover a missed event. |
| Diagnostic reservations / pending state | Quiescent didOpen completion and the typed watched final-handoff receipt were already clean. The retained setup transfer is intentional; no leaked force marker or pending revalidation caused this failure. |
| Shared resources | The process-wide one-permit `system.file()` derivation gate is intentional and was not leaked. Watchdogs now report its available permit and exact occupied worker/key, along with routing-owner generation, so future contention is distinguishable from a missed seam. |
| Irrelevant setup work | Workspace scanning is disabled and library-path watching is disabled for this package fixture. Fresh CI still reproduced the failure, excluding those prior noise sources. |

PR #676 changes only `dependency.rs`; its fresh full-suite failure is therefore scheduler-dependent exposure of this inherited harness race, not a dependency-graph regression.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- both required rustdoc configurations with `RUSTDOCFLAGS="-D warnings"`
- 50/50 exact focused iterations after the final review fixes
- two 331-test backend runs at 32 test threads
- two final `cargo test --workspace --all-targets --features test-support` runs: 6,503 passed, 12 ignored each
- independent parent/child cause analysis and final two-pass regression review: clean

Fable architectural feedback was attempted, but the account review quota was exhausted.

Relates to #656.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling of diagnostic test pauses to prevent timing gaps during consecutive operations.
  * Enhanced routing diagnostics with additional status and permit information.

* **Tests**
  * Added concurrency coverage and validation checks for diagnostic pause coordination.

* **Documentation**
  * Clarified guidance for coordinating consecutive diagnostic-publish pauses in backend tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->