### PR TITLE
Remove duplicate locality test setup

### DIFF
--- a/crates/raven/src/cross_file/revalidation.rs
+++ b/crates/raven/src/cross_file/revalidation.rs
@@ -2163,7 +2163,6 @@ mod tests {
         let parent = affected_url("parent.R");
         let child = affected_url("child.R");
         let mut meta = make_meta_with_source("child.R", 1);
-        meta.sources[0].locality = crate::cross_file::types::SourceLocality::CurrentFrame;
         meta.sources[0].locality = SourceLocality::CurrentFrame;
         graph.update_file(&parent, &meta, Some(&affected_workspace_root()), |_| None);
 


### PR DESCRIPTION
## Summary

Remove the consecutive duplicate `SourceLocality::CurrentFrame` assignment from `locality_only_edge_change_revalidates_child`.

The retained assignment still establishes the baseline before the first graph update; the later `NonInheriting` assignment and all edge-change/revalidation assertions are unchanged.

## Validation

- `cargo fmt --all --check`
- focused `locality_only_edge_change_revalidates_child` test
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- both required strict rustdoc configurations
- full `cargo test --workspace --all-targets --features test-support`: 6,503 passed, 12 ignored
- independent parent/child final review: clean

Relates to #656.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified an internal test reference without changing application behavior or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->