### PR TITLE
Avoid empty R profile routing canonicalization

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -3143,11 +3143,17 @@ fn is_package_relevant_open_uri(uri: &Url, root: &std::path::Path) -> bool {
 /// `.Rprofile` or preamble scan. Routing canonicalization tolerates a missing
 /// target by canonicalizing its parent, so delete/create events under symlinked
 /// roots keep matching the same set entry. Used for helpers outside the tracked
-/// package R directories as well as ordinary existing targets.
+/// package R directories as well as ordinary existing targets. Empty sets
+/// return before filesystem-backed routing canonicalization because live
+/// routing snapshots may hold the state read guard.
 fn path_in_rprofile_sourced_set(
     p: &std::path::Path,
     sourced: &std::collections::BTreeSet<std::path::PathBuf>,
 ) -> bool {
+    if sourced.is_empty() {
+        return false;
+    }
+
     sourced.contains(p)
         || sourced.contains(&crate::package_state::preamble::canonicalize_for_routing(p))
 }
@@ -28416,6 +28422,7 @@ mod tests {
             let canonical = helper.canonicalize().unwrap();
 
             let mut sourced: BTreeSet<PathBuf> = BTreeSet::new();
+            assert!(!path_in_rprofile_sourced_set(&canonical, &sourced));
             sourced.insert(canonical.clone());
 
             // Canonical path is a member.


### PR DESCRIPTION
## Summary
- return immediately when the `.Rprofile` sourced-path set is empty
- avoid filesystem-backed routing canonicalization while callers may hold a live state read guard
- cover the empty-set branch while preserving existing canonical and missing-path coverage

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo test --workspace --all-targets --features test-support`
- independent parent-and-child regression review (clean)

Relates to #656.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing path checks when no sourced paths are available.
  * Added coverage to ensure canonical paths correctly return no match for empty path sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->