### PR TITLE
Diagnose packages hidden by active renv

### DIFF
--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -476,12 +476,12 @@ async fn run_with_cwd(args: CheckArgs, cwd: &Path) -> i32 {
         Err(code) => return code,
     };
 
-    // CI default: suppress the missing-package ("not installed") diagnostic,
-    // because CI deliberately omits installation (spec §10.1). The CLI owns
-    // `state` exclusively, so a direct field set here is safe.
-    // `--report-uninstalled` opts back in.
+    // CI default: suppress generic missing-package diagnostics because CI
+    // deliberately omits installation (spec §10.1). Actionable subtypes such
+    // as "available outside this active renv project" remain enabled.
+    // `--report-uninstalled` opts the generic diagnostic back in.
     if !args.report_uninstalled {
-        state.cross_file_config.packages_missing_package_severity = None;
+        state.cross_file_config.packages_report_generic_uninstalled = false;
     }
 
     // Auto-detect R for installed-package / base-symbol awareness. Any failure
@@ -3008,7 +3008,7 @@ infixContinuationStyle = "indented"
         let mut state =
             build_indexed_state(&root, &workspace_url, args.no_config, None, &root).unwrap();
         if !args.report_uninstalled {
-            state.cross_file_config.packages_missing_package_severity = None;
+            state.cross_file_config.packages_report_generic_uninstalled = false;
         }
         maybe_init_r(&mut state, &root).await;
         state.resolve_system_file_in_workspace_cli_compat(None);

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -140,6 +140,12 @@ pub struct CrossFileConfig {
     pub packages_r_path: Option<PathBuf>,
     /// Severity for missing package diagnostics (None = disabled)
     pub packages_missing_package_severity: Option<DiagnosticSeverity>,
+    /// Whether to emit the generic `package-not-installed` diagnostic.
+    ///
+    /// The CLI disables this by default because CI commonly omits all package
+    /// installation, while retaining the actionable renv-specific child
+    /// diagnostic. Editor/LSP operation leaves it enabled.
+    pub(crate) packages_report_generic_uninstalled: bool,
     /// Severity for `namespace-member-not-found` diagnostics (None = disabled).
     /// Fires only when a package's *complete* export set lacks the referenced
     /// `pkg::member`. See `namespace_member_status_sync`.
@@ -260,6 +266,7 @@ impl Default for CrossFileConfig {
             packages_additional_library_paths: Vec::new(),
             packages_r_path: None,
             packages_missing_package_severity: Some(DiagnosticSeverity::WARNING),
+            packages_report_generic_uninstalled: true,
             packages_namespace_member_severity: Some(DiagnosticSeverity::WARNING),
             packages_watch_library_paths: true,
             packages_watch_debounce_ms: 500,

--- a/crates/raven/src/diagnostic_code.rs
+++ b/crates/raven/src/diagnostic_code.rs
@@ -50,6 +50,9 @@ pub const SOURCE_PATH_CASE_MISMATCH: &str = "source-path-case-mismatch";
 pub const ASSIGN_TO_STRING_LITERAL: &str = "assign-to-string-literal";
 /// A `library()`/`require()` of a package that is not installed / not found.
 pub const PACKAGE_NOT_INSTALLED: &str = "package-not-installed";
+/// A missing package that is installed in a vanilla R library removed from
+/// `.libPaths()` by the workspace's active renv project.
+pub const PACKAGE_OUTSIDE_ACTIVE_LIBRARY: &str = "package-outside-active-library";
 /// A `pkg::member` reference where a *complete* package export set has no such
 /// exported member or data object. Never emitted for `pkg:::member` (internal
 /// access) or from partial/unknown metadata. See `namespace_member_status_sync`.
@@ -87,18 +90,20 @@ pub const ANALYZER_CODES: &[&str] = &[
     UNUSED_SUPPRESSION,
 ];
 
-/// Analyzer codes that ignore directives may suppress. This is the subset of
-/// [`ANALYZER_CODES`] that the suppression machinery actually honors:
-/// `undefined-variable`, `assign-to-string-literal`, and `package-not-installed`.
-/// Deliberately excludes `syntax-error` (parse errors are not suppressible),
-/// `unresolved-source-path` and the other dependency-graph diagnostics (governed
-/// only by their severity settings), and `unused-suppression` itself. Used by
-/// the range/file/chunk post-filter so block- and chunk-level suppression covers
-/// these codes the same way the inline per-line checks do. See `docs/linting.md`.
+/// Analyzer codes that ignore directives may suppress.
+///
+/// This includes suppressible canonical analyzer codes from [`ANALYZER_CODES`]
+/// and independently suppressible child codes. Deliberately excludes
+/// `syntax-error` (parse errors are not suppressible), `unresolved-source-path`
+/// and the other dependency-graph diagnostics (governed only by their severity
+/// settings), and `unused-suppression` itself. Used by the range/file/chunk
+/// post-filter so block- and chunk-level suppression covers these codes the same
+/// way the inline per-line checks do. See `docs/linting.md`.
 pub const SUPPRESSIBLE_ANALYZER_CODES: &[&str] = &[
     UNDEFINED_VARIABLE,
     ASSIGN_TO_STRING_LITERAL,
     PACKAGE_NOT_INSTALLED,
+    PACKAGE_OUTSIDE_ACTIVE_LIBRARY,
     NAMESPACE_MEMBER_NOT_FOUND,
 ];
 
@@ -146,6 +151,9 @@ pub fn parent(code: &str) -> Option<&'static str> {
     let norm = normalize(code);
     if SYNTAX_ERROR_CHILDREN.contains(&norm.as_str()) {
         return Some(SYNTAX_ERROR);
+    }
+    if norm == PACKAGE_OUTSIDE_ACTIVE_LIBRARY {
+        return Some(PACKAGE_NOT_INSTALLED);
     }
     None
 }
@@ -625,6 +633,14 @@ mod tests {
         }
         assert!(suppresses("unclosed-paren", "unclosed-paren"));
         assert!(!suppresses("unclosed-paren", "unclosed-brace"));
+        assert!(suppresses(
+            PACKAGE_NOT_INSTALLED,
+            PACKAGE_OUTSIDE_ACTIVE_LIBRARY
+        ));
+        assert!(!suppresses(
+            PACKAGE_OUTSIDE_ACTIVE_LIBRARY,
+            PACKAGE_NOT_INSTALLED
+        ));
     }
 
     #[test]
@@ -636,6 +652,7 @@ mod tests {
         assert!(is_suppressible("undefined-variable"));
         assert!(is_suppressible("assign-to-string-literal"));
         assert!(is_suppressible("package-not-installed"));
+        assert!(is_suppressible("package-outside-active-library"));
         // Non-suppressible codes.
         assert!(!is_suppressible("syntax-error"));
         assert!(!is_suppressible("unclosed-paren"));

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5998,6 +5998,7 @@ fn collect_missing_package_diagnostics_from_snapshot(
     let Some(severity) = snapshot.cross_file_config.packages_missing_package_severity else {
         return;
     };
+    let mut reported_outside_active = HashSet::new();
 
     for lib_call in &snapshot.directive_meta.library_calls {
         // Confirm the package is actually missing *before* consulting the
@@ -6006,17 +6007,30 @@ fn collect_missing_package_diagnostics_from_snapshot(
         if snapshot.package_library.package_exists(&lib_call.package) {
             continue;
         }
+        let outside_active = package_available_outside_active_renv(snapshot, &lib_call.package);
+        if !outside_active
+            && !snapshot
+                .cross_file_config
+                .packages_report_generic_uninstalled
+        {
+            continue;
+        }
+        let code = if outside_active {
+            crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY
+        } else {
+            crate::diagnostic_code::PACKAGE_NOT_INSTALLED
+        };
         if crate::cross_file::directive::is_line_ignored_for_code(
             &snapshot.directive_meta,
             lib_call.line,
-            Some(crate::diagnostic_code::PACKAGE_NOT_INSTALLED),
+            Some(code),
         ) {
             if let Some(out) = suppressed_out.as_deref_mut() {
-                out.push((
-                    lib_call.line,
-                    crate::diagnostic_code::PACKAGE_NOT_INSTALLED.to_string(),
-                ));
+                out.push((lib_call.line, code.to_string()));
             }
+            continue;
+        }
+        if outside_active && !reported_outside_active.insert(lib_call.package.as_str()) {
             continue;
         }
         diagnostics.push(Diagnostic {
@@ -6025,10 +6039,8 @@ fn collect_missing_package_diagnostics_from_snapshot(
                 end: Position::new(lib_call.line, lib_call.column),
             },
             severity: Some(severity),
-            message: format!("No installed package named '{}'", lib_call.package),
-            code: Some(NumberOrString::String(
-                crate::diagnostic_code::PACKAGE_NOT_INSTALLED.to_string(),
-            )),
+            message: missing_package_message(&lib_call.package, outside_active),
+            code: Some(NumberOrString::String(code.to_string())),
             ..Default::default()
         });
     }
@@ -6038,18 +6050,31 @@ fn collect_missing_package_diagnostics_from_snapshot(
         if snapshot.package_library.package_exists(&ns_ref.package) {
             continue;
         }
+        let outside_active = package_available_outside_active_renv(snapshot, &ns_ref.package);
+        if !outside_active
+            && !snapshot
+                .cross_file_config
+                .packages_report_generic_uninstalled
+        {
+            continue;
+        }
+        let code = if outside_active {
+            crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY
+        } else {
+            crate::diagnostic_code::PACKAGE_NOT_INSTALLED
+        };
         let line = ns_ref.package_range.start_line;
         if crate::cross_file::directive::is_line_ignored_for_code(
             &snapshot.directive_meta,
             line,
-            Some(crate::diagnostic_code::PACKAGE_NOT_INSTALLED),
+            Some(code),
         ) {
             if let Some(out) = suppressed_out.as_deref_mut() {
-                out.push((
-                    line,
-                    crate::diagnostic_code::PACKAGE_NOT_INSTALLED.to_string(),
-                ));
+                out.push((line, code.to_string()));
             }
+            continue;
+        }
+        if outside_active && !reported_outside_active.insert(ns_ref.package.as_str()) {
             continue;
         }
         diagnostics.push(Diagnostic {
@@ -6061,13 +6086,32 @@ fn collect_missing_package_diagnostics_from_snapshot(
                 ),
             },
             severity: Some(severity),
-            message: format!("No installed package named '{}'", ns_ref.package),
-            code: Some(NumberOrString::String(
-                crate::diagnostic_code::PACKAGE_NOT_INSTALLED.to_string(),
-            )),
+            message: missing_package_message(&ns_ref.package, outside_active),
+            code: Some(NumberOrString::String(code.to_string())),
             ..Default::default()
         });
     }
+}
+
+fn missing_package_message(package: &str, outside_active_renv: bool) -> String {
+    if outside_active_renv {
+        format!(
+            "Package '{package}' is available outside this active renv project library, \
+             but is unavailable here; run renv::restore() or install it into the project library"
+        )
+    } else {
+        format!("No installed package named '{package}'")
+    }
+}
+
+fn package_available_outside_active_renv(snapshot: &DiagnosticsSnapshot, package: &str) -> bool {
+    // Package routing is process-global and currently activates only the first
+    // workspace root. In a multi-root session that overlay has no unambiguous
+    // ownership for another root (including nested roots), so fail closed.
+    snapshot.workspace_folders.len() == 1
+        && snapshot
+            .package_library
+            .package_available_outside_active_renv(package)
 }
 
 /// Emit `namespace-member-not-found` for `pkg::member` references whose package
@@ -6098,6 +6142,9 @@ fn collect_namespace_member_diagnostics_from_snapshot(
     for ns_ref in &snapshot.directive_meta.namespace_references {
         if ns_ref.internal {
             continue; // never validate `:::`
+        }
+        if package_available_outside_active_renv(snapshot, &ns_ref.package) {
+            continue;
         }
         let Some(member) = &ns_ref.member else {
             continue;
@@ -54086,6 +54133,123 @@ result <- helper_with_spaces(42)"#;
         );
         assert!(diagnostics[0].message.contains("No installed package"));
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
+    }
+
+    #[tokio::test]
+    async fn renv_outside_active_package_reports_actionable_child_without_generic_cli_policy() {
+        let code = "library(plotpkg)\nplotpkg::missing_member\n";
+        let main_url = Url::parse("file:///synthetic-project/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state
+            .workspace_folders
+            .push(Url::parse("file:///synthetic-project").unwrap());
+        state.package_library_ready = true;
+        state.cross_file_config.packages_report_generic_uninstalled = false;
+        let mut package_library = crate::package_library::PackageLibrary::new_empty();
+        package_library.set_lib_paths(vec![std::path::PathBuf::from(
+            "/nonexistent-active-library",
+        )]);
+        package_library.set_renv_outside_active_packages_for_test(
+            std::path::PathBuf::from("/synthetic-project"),
+            HashSet::from(["plotpkg".to_string()]),
+        );
+        let mut info = crate::package_library::PackageInfo::with_details(
+            "plotpkg".to_string(),
+            HashSet::from(["known_member".to_string()]),
+            vec![],
+            vec![],
+        );
+        info.exports_completeness = crate::package_library::MemberCompleteness::Complete;
+        package_library.insert_package(info).await;
+        state.package_library = Arc::new(package_library);
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+        collect_namespace_member_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "the renv setup problem is reported once per package per document; got: {diagnostics:?}"
+        );
+        assert!(diagnostics.iter().all(|diagnostic| {
+            diagnostic.code
+                == Some(NumberOrString::String(
+                    crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY.to_string(),
+                ))
+        }));
+        assert!(diagnostics.iter().all(|diagnostic| {
+            diagnostic.message.contains("active renv project library")
+                && diagnostic.message.contains("renv::restore()")
+        }));
+    }
+
+    #[test]
+    fn renv_outside_active_package_fails_closed_in_multi_root_session() {
+        let code = "library(plotpkg)\n";
+        let main_url = Url::parse("file:///synthetic-project/nested/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state.workspace_folders = vec![
+            Url::parse("file:///synthetic-project").unwrap(),
+            Url::parse("file:///synthetic-project/nested").unwrap(),
+        ];
+        state.package_library_ready = true;
+        state.cross_file_config.packages_report_generic_uninstalled = false;
+        let mut package_library = crate::package_library::PackageLibrary::new_empty();
+        package_library.set_lib_paths(vec![std::path::PathBuf::from(
+            "/nonexistent-active-library",
+        )]);
+        package_library.set_renv_outside_active_packages_for_test(
+            std::path::PathBuf::from("/synthetic-project"),
+            HashSet::from(["plotpkg".to_string()]),
+        );
+        state.package_library = Arc::new(package_library);
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn package_not_installed_umbrella_suppresses_renv_outside_child() {
+        let code = "library(plotpkg) # raven: ignore[package-not-installed]\n";
+        let main_url = Url::parse("file:///synthetic-project/main.R").unwrap();
+
+        let mut state = WorldState::new();
+        state
+            .workspace_folders
+            .push(Url::parse("file:///synthetic-project").unwrap());
+        state.package_library_ready = true;
+        let mut package_library = crate::package_library::PackageLibrary::new_empty();
+        package_library.set_lib_paths(vec![std::path::PathBuf::from(
+            "/nonexistent-active-library",
+        )]);
+        package_library.set_renv_outside_active_packages_for_test(
+            std::path::PathBuf::from("/synthetic-project"),
+            HashSet::from(["plotpkg".to_string()]),
+        );
+        state.package_library = Arc::new(package_library);
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        let mut diagnostics = Vec::new();
+        collect_missing_package_diagnostics_from_snapshot(&snapshot, &mut diagnostics, None);
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6104,10 +6104,12 @@ fn missing_package_message(package: &str, outside_active_renv: bool) -> String {
     }
 }
 
+/// Return whether `package` is installed outside the active renv library.
+///
+/// Package routing is process-global and currently activates only the first
+/// workspace root. In a multi-root session the overlay has no unambiguous
+/// owner for another root, including a nested root, so this fails closed.
 fn package_available_outside_active_renv(snapshot: &DiagnosticsSnapshot, package: &str) -> bool {
-    // Package routing is process-global and currently activates only the first
-    // workspace root. In a multi-root session that overlay has no unambiguous
-    // ownership for another root (including nested roots), so fail closed.
     snapshot.workspace_folders.len() == 1
         && snapshot
             .package_library

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -142,6 +142,72 @@ fn is_readable_file(path: &Path) -> bool {
     path.is_file() && std::fs::File::open(path).is_ok()
 }
 
+/// Enumerate conservative, diagnostic-only installed-package evidence.
+///
+/// Every candidate must be a real directory with a real, readable
+/// `DESCRIPTION` whose `Package:` field exactly agrees with the directory
+/// name. Lock/staging directories, symlinks, invalid names, and malformed
+/// metadata fail closed.
+fn validated_package_names(lib_paths: &[PathBuf]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for lib_path in lib_paths {
+        let Ok(entries) = std::fs::read_dir(lib_path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if name.starts_with("00LOCK")
+                || name.starts_with('.')
+                || !crate::r_subprocess::is_valid_package_name(&name)
+            {
+                continue;
+            }
+            let description = entry.path().join("DESCRIPTION");
+            let Ok(metadata) = std::fs::symlink_metadata(&description) else {
+                continue;
+            };
+            if !metadata.file_type().is_file() {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(description) else {
+                continue;
+            };
+            let Some(declared) = crate::package_namespace::parse_dcf_field_pub(&content, "Package")
+            else {
+                continue;
+            };
+            if declared.trim() == name {
+                names.insert(name);
+            }
+        }
+    }
+    names
+}
+
+fn build_renv_outside_active_overlay(
+    transition: crate::r_subprocess::RenvLibraryPathTransition,
+    active_paths: &[PathBuf],
+) -> Option<RenvOutsideActiveOverlay> {
+    let mut package_names = validated_package_names(&transition.outside_paths);
+    let active_names = validated_package_names(active_paths);
+    let base_names: HashSet<_> = crate::r_subprocess::get_base_priority_packages()
+        .into_iter()
+        .collect();
+    package_names.retain(|name| !active_names.contains(name) && !base_names.contains(name));
+    (!package_names.is_empty()).then_some(RenvOutsideActiveOverlay {
+        _project_root: transition.project_root,
+        package_names,
+    })
+}
+
 /// How complete a package's exported-member set is, for absence diagnostics.
 /// `Absent` may be concluded only from a `Complete` set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -392,6 +458,16 @@ enum CachedCompletionEntry {
     },
 }
 
+/// Names visible in vanilla R but removed by this workspace's active renv
+/// library. Paths are deliberately discarded after construction so this
+/// diagnostic overlay cannot affect package resolution or metadata routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenvOutsideActiveOverlay {
+    /// Retained as lifecycle identity for the workspace-specific discovery.
+    _project_root: PathBuf,
+    package_names: HashSet<String>,
+}
+
 /// Package library manager
 ///
 /// Manages the collection of installed R packages and their cached exports.
@@ -448,6 +524,9 @@ pub struct PackageLibrary {
     /// Consulted by the three resolution chokepoints before the installed caches.
     /// Refreshed by the shared derived-package installer.
     local_dev_overlay: ArcSwap<Option<Arc<LocalDevPackage>>>,
+    /// Diagnostic-only names removed from `.libPaths()` by a successfully
+    /// activated renv project. Never consulted by package resolution.
+    renv_outside_active_overlay: Option<Arc<RenvOutsideActiveOverlay>>,
     /// Operation-level ownership for cache mutations.
     ///
     /// A shared lease spans one complete logical load, including every
@@ -489,6 +568,7 @@ impl PackageLibrary {
             r_subprocess: None,
             providers: Vec::new(),
             local_dev_overlay: ArcSwap::from_pointee(None),
+            renv_outside_active_overlay: None,
             cache_operation_gate: tokio::sync::RwLock::new(()),
             cache_operation_epoch: AtomicU64::new(0),
             retired: AtomicBool::new(false),
@@ -516,6 +596,7 @@ impl PackageLibrary {
             r_subprocess,
             providers: Vec::new(),
             local_dev_overlay: ArcSwap::from_pointee(None),
+            renv_outside_active_overlay: None,
             cache_operation_gate: tokio::sync::RwLock::new(()),
             cache_operation_epoch: AtomicU64::new(0),
             retired: AtomicBool::new(false),
@@ -624,6 +705,7 @@ impl PackageLibrary {
             r_subprocess: self.r_subprocess.clone(),
             providers: self.providers.clone(),
             local_dev_overlay: ArcSwap::new(self.local_dev_overlay.load_full()),
+            renv_outside_active_overlay: self.renv_outside_active_overlay.clone(),
             cache_operation_gate: tokio::sync::RwLock::new(()),
             cache_operation_epoch: AtomicU64::new(0),
             retired: AtomicBool::new(false),
@@ -1731,10 +1813,32 @@ impl PackageLibrary {
     /// This method adds paths to the library search paths, avoiding duplicates.
     /// Used to apply user-configured additional library paths.
     pub fn add_library_paths(&mut self, paths: &[PathBuf]) {
+        let original_len = self.lib_paths.len();
         for path in paths {
             if !self.lib_paths.contains(path) {
                 self.lib_paths.push(path.clone());
             }
+        }
+        if self.lib_paths.len() == original_len {
+            return;
+        }
+        self.prune_renv_outside_active_overlay();
+    }
+
+    fn prune_renv_outside_active_overlay(&mut self) {
+        if self.renv_outside_active_overlay.is_none() {
+            return;
+        }
+        let active_names = validated_package_names(&self.lib_paths);
+        let base_packages = &self.base_packages;
+        let Some(overlay) = self.renv_outside_active_overlay.as_mut() else {
+            return;
+        };
+        Arc::make_mut(overlay)
+            .package_names
+            .retain(|name| !active_names.contains(name) && !base_packages.contains(name));
+        if overlay.package_names.is_empty() {
+            self.renv_outside_active_overlay = None;
         }
     }
 
@@ -2040,7 +2144,14 @@ impl PackageLibrary {
         // tests, or future explicit configuration), respect that and skip
         // rediscovery — overwriting their choice would be surprising.
         if self.lib_paths.is_empty() {
-            self.lib_paths = self.get_lib_paths_with_fallback().await?;
+            let discovery = self.get_lib_paths_with_fallback().await?;
+            self.lib_paths = discovery.active;
+            self.renv_outside_active_overlay = discovery
+                .renv_transition
+                .and_then(|transition| {
+                    build_renv_outside_active_overlay(transition, &self.lib_paths)
+                })
+                .map(Arc::new);
         }
 
         if self.lib_paths.is_empty() {
@@ -2291,13 +2402,15 @@ impl PackageLibrary {
     }
 
     /// Get library paths with fallback strategy
-    async fn get_lib_paths_with_fallback(&self) -> anyhow::Result<Vec<PathBuf>> {
+    async fn get_lib_paths_with_fallback(
+        &self,
+    ) -> anyhow::Result<crate::r_subprocess::LibraryPathDiscovery> {
         // Try R subprocess first (most accurate)
         if let Some(ref r_subprocess) = self.r_subprocess {
-            match r_subprocess.get_lib_paths().await {
-                Ok(paths) if !paths.is_empty() => {
-                    log::trace!("Got {} library paths from R", paths.len());
-                    return Ok(paths);
+            match r_subprocess.discover_lib_paths().await {
+                Ok(discovery) if !discovery.active.is_empty() => {
+                    log::trace!("Got {} library paths from R", discovery.active.len());
+                    return Ok(discovery);
                 }
                 Ok(_) => {
                     log::trace!("R returned empty lib_paths, using fallback");
@@ -2316,7 +2429,10 @@ impl PackageLibrary {
         // Use platform-specific fallback
         let fallback = crate::r_subprocess::get_fallback_lib_paths();
         log::trace!("Using fallback library paths: {:?}", fallback);
-        Ok(fallback)
+        Ok(crate::r_subprocess::LibraryPathDiscovery {
+            active: fallback,
+            renv_transition: None,
+        })
     }
     /// Get package info using tiered loading strategy
     ///
@@ -2620,6 +2736,32 @@ impl PackageLibrary {
             return true;
         }
         self.find_package_directory(name).is_some()
+    }
+
+    /// Whether `name` is unavailable in the active library but was observed in
+    /// a vanilla library path removed by this workspace's renv activation.
+    ///
+    /// Active availability always wins, including after configured library
+    /// paths are added. The overlay contains names only and cannot participate
+    /// in export lookup, completion, package loading, or filesystem watching.
+    pub(crate) fn package_available_outside_active_renv(&self, name: &str) -> bool {
+        !self.package_exists(name)
+            && self
+                .renv_outside_active_overlay
+                .as_ref()
+                .is_some_and(|overlay| overlay.package_names.contains(name))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_renv_outside_active_packages_for_test(
+        &mut self,
+        project_root: PathBuf,
+        package_names: HashSet<String>,
+    ) {
+        self.renv_outside_active_overlay = Some(Arc::new(RenvOutsideActiveOverlay {
+            _project_root: project_root,
+            package_names,
+        }));
     }
 
     /// Get all exports for a package including Depends and attached packages
@@ -3548,6 +3690,68 @@ mod tests {
     /// (defined in `package_db` so every lib-test that touches the var shares one
     /// instance / one audited `unsafe` mutation site).
     use crate::package_db::{NamesDbEnvGuard, RAVEN_NAMES_DB_ENV_LOCK};
+
+    fn write_synthetic_package(lib: &Path, directory: &str, declared: &str) {
+        let package = lib.join(directory);
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(
+            package.join("DESCRIPTION"),
+            format!("Package: {declared}\nVersion: 1.0.0\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn renv_outside_overlay_keeps_only_valid_names_absent_from_active_library() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        let active = temp.path().join("active");
+        for path in [&project, &outside, &active] {
+            std::fs::create_dir(path).unwrap();
+        }
+        write_synthetic_package(&outside, "plotpkg", "plotpkg");
+        write_synthetic_package(&outside, "sharedpkg", "sharedpkg");
+        write_synthetic_package(&outside, "misleading", "differentpkg");
+        write_synthetic_package(&outside, "00LOCK-stagedpkg", "stagedpkg");
+        write_synthetic_package(&outside, "stats", "stats");
+        write_synthetic_package(&active, "sharedpkg", "sharedpkg");
+
+        let overlay = build_renv_outside_active_overlay(
+            crate::r_subprocess::RenvLibraryPathTransition {
+                project_root: project,
+                outside_paths: vec![outside],
+            },
+            &[active],
+        )
+        .unwrap();
+
+        assert_eq!(
+            overlay.package_names,
+            HashSet::from(["plotpkg".to_string()])
+        );
+    }
+
+    #[test]
+    fn configured_active_path_prunes_renv_outside_overlay() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let active = temp.path().join("configured-library");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&active).unwrap();
+        write_synthetic_package(&active, "plotpkg", "plotpkg");
+
+        let mut library = PackageLibrary::new_empty();
+        library.set_renv_outside_active_packages_for_test(
+            project,
+            HashSet::from(["plotpkg".to_string()]),
+        );
+        assert!(library.package_available_outside_active_renv("plotpkg"));
+
+        library.add_library_paths(&[active]);
+        assert!(library.package_exists("plotpkg"));
+        assert!(!library.package_available_outside_active_renv("plotpkg"));
+    }
 
     fn provider_load_key_for_test(name: &str) -> ProviderLoadKey {
         ProviderLoadKey {

--- a/crates/raven/src/r_subprocess.rs
+++ b/crates/raven/src/r_subprocess.rs
@@ -124,6 +124,25 @@ pub struct RSubprocess {
     working_dir: Option<PathBuf>,
 }
 
+/// Library-path discovery from one R invocation.
+///
+/// `active` is the only path list package resolution may consume.
+/// `renv_transition` is diagnostic-only evidence that a successfully activated
+/// renv project removed paths from the vanilla R search path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LibraryPathDiscovery {
+    pub(crate) active: Vec<PathBuf>,
+    pub(crate) renv_transition: Option<RenvLibraryPathTransition>,
+}
+
+/// Diagnostic-only renv transition. Callers must reduce `outside_paths` to
+/// validated package names and must never add these paths to package routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenvLibraryPathTransition {
+    pub(crate) project_root: PathBuf,
+    pub(crate) outside_paths: Vec<PathBuf>,
+}
+
 /// Stable identity of the executable backing one configured R runtime.
 ///
 /// The requested path alone is insufficient: an installer can replace the
@@ -722,19 +741,72 @@ impl RSubprocess {
     /// # }
     /// ```
     pub async fn get_lib_paths(&self) -> Result<Vec<PathBuf>> {
-        // Use cat() with sep="\n" to output each path on its own line without R's vector formatting
-        // Check for renv/activate.R and source it if it exists (handles renv projects)
-        // Security: Validate that renv/activate.R is in the working directory to prevent path traversal
-        let r_code = r#"renv_path <- normalizePath("renv/activate.R", mustWork=FALSE); if (file.exists(renv_path) && dirname(renv_path) == file.path(getwd(), "renv")) try(source(renv_path), silent=TRUE); cat(.libPaths(), sep="\n")"#;
+        Ok(self.discover_lib_paths().await?.active)
+    }
+
+    /// Discover active R library paths and a diagnostic-only renv transition.
+    ///
+    /// Raven already sources `<working-dir>/renv/activate.R` during package
+    /// discovery. This extends that same bounded subprocess: when an explicit
+    /// working directory contains that file, it records `.libPaths()` before
+    /// and after activation and emits a versioned, hex-encoded frame. Arbitrary
+    /// activation output is ignored; only the last complete valid frame is
+    /// accepted. Missing/malformed frames, activation errors, and project-root
+    /// mismatches fail closed to no transition.
+    pub(crate) async fn discover_lib_paths(&self) -> Result<LibraryPathDiscovery> {
+        let renv_candidate = self
+            .working_dir
+            .as_ref()
+            .is_some_and(|root| root.join("renv").join("activate.R").is_file());
+        let r_code = if renv_candidate {
+            // Hex encoding makes the line protocol unambiguous for paths that
+            // contain tabs, newlines, or marker-looking text.
+            r#"base::local({
+  raven_hex <- function(xs) base::vapply(base::enc2utf8(xs), function(x) base::paste(base::sprintf("%02x", base::as.integer(base::charToRaw(x))), collapse=""), base::character(1), USE.NAMES=FALSE)
+  raven_before <- base::.libPaths()
+  raven_root <- base::normalizePath(base::getwd(), winslash="/", mustWork=TRUE)
+  raven_renv_dir <- base::normalizePath(base::file.path(raven_root, "renv"), winslash="/", mustWork=TRUE)
+  raven_activate <- base::normalizePath(base::file.path(raven_renv_dir, "activate.R"), winslash="/", mustWork=TRUE)
+  raven_ok <- FALSE
+  if (base::dirname(raven_activate) == raven_renv_dir) {
+    raven_ok <- base::isTRUE(base::tryCatch({ base::source(raven_activate, local=base::globalenv()); TRUE }, error=function(e) FALSE))
+  }
+  raven_after <- base::.libPaths()
+  raven_project <- ""
+  if (raven_ok && "renv" %in% base::loadedNamespaces()) {
+    raven_project <- base::tryCatch(base::getExportedValue("renv", "project")(default=""), error=function(e) "")
+  }
+  if (base::nzchar(raven_project)) raven_project <- base::normalizePath(raven_project, winslash="/", mustWork=FALSE)
+  base::cat("__RAVEN_LIB_PATHS_V1_BEGIN__\n")
+  base::cat("S\t", if (raven_ok) "1" else "0", "\n", sep="")
+  base::cat("P\t", raven_hex(raven_project), "\n", sep="")
+  for (x in raven_before) base::cat("B\t", raven_hex(x), "\n", sep="")
+  for (x in raven_after) base::cat("A\t", raven_hex(x), "\n", sep="")
+  base::cat("__RAVEN_LIB_PATHS_V1_END__\n")
+})"#
+        } else {
+            r#"cat(.libPaths(), sep="\n")"#
+        };
 
         match self.execute_r_code(r_code).await {
             Ok(output) => {
-                let paths = parse_lib_paths_output(&output);
-                if paths.is_empty() {
-                    log::trace!("R returned empty .libPaths(), using fallback paths");
-                    Ok(get_fallback_lib_paths())
+                let discovery = if renv_candidate {
+                    parse_renv_lib_paths_output(&output, self.working_dir.as_deref())
                 } else {
-                    Ok(paths)
+                    let active = parse_lib_paths_output(&output);
+                    (!active.is_empty()).then_some(LibraryPathDiscovery {
+                        active,
+                        renv_transition: None,
+                    })
+                };
+                if let Some(discovery) = discovery {
+                    Ok(discovery)
+                } else {
+                    log::trace!("R returned empty .libPaths(), using fallback paths");
+                    Ok(LibraryPathDiscovery {
+                        active: get_fallback_lib_paths(),
+                        renv_transition: None,
+                    })
                 }
             }
             Err(error) if error.downcast_ref::<OuterDeadlineExpired>().is_some() => Err(error),
@@ -743,7 +815,10 @@ impl RSubprocess {
                     "Failed to get .libPaths() from R: {}, using fallback paths",
                     e
                 );
-                Ok(get_fallback_lib_paths())
+                Ok(LibraryPathDiscovery {
+                    active: get_fallback_lib_paths(),
+                    renv_transition: None,
+                })
             }
         }
     }
@@ -1187,6 +1262,140 @@ fn parse_lib_paths_output(output: &str) -> Vec<PathBuf> {
         .collect()
 }
 
+#[derive(Default)]
+struct RenvLibPathsFrame {
+    source_succeeded: Option<bool>,
+    project_seen: bool,
+    project_root: Option<PathBuf>,
+    before: Vec<PathBuf>,
+    active: Vec<PathBuf>,
+    malformed: bool,
+}
+
+fn decode_hex_path(encoded: &str) -> Option<PathBuf> {
+    if !encoded.len().is_multiple_of(2) {
+        return None;
+    }
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let text = std::str::from_utf8(pair).ok()?;
+            u8::from_str_radix(text, 16).ok()
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let path = String::from_utf8(bytes).ok().map(PathBuf::from)?;
+    (!path.as_os_str().is_empty() && path.is_absolute()).then_some(path)
+}
+
+/// Parse the last complete valid Raven frame from an activation probe.
+///
+/// Paths must exist. The transition is retained only when activation succeeded
+/// and renv reports a project root matching the explicit working directory.
+fn parse_renv_lib_paths_output(
+    output: &str,
+    expected_project_root: Option<&std::path::Path>,
+) -> Option<LibraryPathDiscovery> {
+    const BEGIN: &str = "__RAVEN_LIB_PATHS_V1_BEGIN__";
+    const END: &str = "__RAVEN_LIB_PATHS_V1_END__";
+
+    let mut current: Option<RenvLibPathsFrame> = None;
+    let mut last_complete: Option<RenvLibPathsFrame> = None;
+    for line in output.lines() {
+        if line == BEGIN {
+            current = Some(RenvLibPathsFrame::default());
+            continue;
+        }
+        if line == END {
+            if let Some(frame) = current.take() {
+                last_complete = Some(frame);
+            }
+            continue;
+        }
+        let Some(frame) = current.as_mut() else {
+            continue;
+        };
+        let Some((tag, encoded)) = line.split_once('\t') else {
+            frame.malformed = true;
+            continue;
+        };
+        match tag {
+            "S" if frame.source_succeeded.is_none() => {
+                frame.source_succeeded = match encoded {
+                    "0" => Some(false),
+                    "1" => Some(true),
+                    _ => {
+                        frame.malformed = true;
+                        None
+                    }
+                };
+            }
+            "P" if !frame.project_seen => {
+                frame.project_seen = true;
+                if !encoded.is_empty() {
+                    frame.project_root = decode_hex_path(encoded);
+                    frame.malformed |= frame.project_root.is_none();
+                }
+            }
+            "B" => match decode_hex_path(encoded) {
+                Some(path) if path.exists() => frame.before.push(path),
+                _ => frame.malformed = true,
+            },
+            "A" => match decode_hex_path(encoded) {
+                Some(path) if path.exists() => frame.active.push(path),
+                _ => frame.malformed = true,
+            },
+            _ => frame.malformed = true,
+        }
+    }
+
+    if current.is_some() {
+        return None;
+    }
+    let frame = last_complete?;
+    if frame.malformed
+        || frame.source_succeeded.is_none()
+        || !frame.project_seen
+        || frame.active.is_empty()
+    {
+        return None;
+    }
+
+    let renv_transition = (|| {
+        if frame.source_succeeded != Some(true) {
+            return None;
+        }
+        let expected = std::fs::canonicalize(expected_project_root?).ok()?;
+        let reported = std::fs::canonicalize(frame.project_root.as_ref()?).ok()?;
+        if expected != reported {
+            return None;
+        }
+        let active: std::collections::HashSet<_> = frame
+            .active
+            .iter()
+            .filter_map(|path| std::fs::canonicalize(path).ok())
+            .collect();
+        let mut outside_paths = Vec::new();
+        for path in &frame.before {
+            let Ok(canonical) = std::fs::canonicalize(path) else {
+                continue;
+            };
+            if !active.contains(&canonical) && !outside_paths.contains(&canonical) {
+                outside_paths.push(canonical);
+            }
+        }
+        Some(RenvLibraryPathTransition {
+            project_root: expected,
+            outside_paths,
+        })
+    })();
+
+    Some(LibraryPathDiscovery {
+        active: frame.active,
+        renv_transition,
+    })
+}
+
 /// Parse the output of R's `.packages()` (one package name per line) into a list of package names.
 ///
 fn parse_packages_output(output: &str) -> Vec<String> {
@@ -1600,6 +1809,112 @@ mod tests {
         let output = "   \n   \n";
         let paths = parse_lib_paths_output(output);
         assert!(paths.is_empty());
+    }
+
+    fn hex_path(path: &std::path::Path) -> String {
+        path.to_string_lossy()
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn renv_frame(
+        succeeded: bool,
+        project: &std::path::Path,
+        before: &[&std::path::Path],
+        active: &[&std::path::Path],
+    ) -> String {
+        let mut output = String::from("activation noise\n__RAVEN_LIB_PATHS_V1_BEGIN__\n");
+        output.push_str(if succeeded { "S\t1\n" } else { "S\t0\n" });
+        output.push_str(&format!("P\t{}\n", hex_path(project)));
+        for path in before {
+            output.push_str(&format!("B\t{}\n", hex_path(path)));
+        }
+        for path in active {
+            output.push_str(&format!("A\t{}\n", hex_path(path)));
+        }
+        output.push_str("__RAVEN_LIB_PATHS_V1_END__\n");
+        output
+    }
+
+    #[test]
+    fn renv_lib_paths_frame_retains_only_removed_vanilla_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let shared = temp.path().join("shared");
+        let outside = temp.path().join("outside");
+        let added = temp.path().join("project-library");
+        for path in [&project, &shared, &outside, &added] {
+            std::fs::create_dir(path).unwrap();
+        }
+        let output = renv_frame(
+            true,
+            &project,
+            &[shared.as_path(), outside.as_path()],
+            &[shared.as_path(), added.as_path()],
+        );
+
+        let discovery = parse_renv_lib_paths_output(&output, Some(&project)).unwrap();
+        assert_eq!(discovery.active, vec![shared.clone(), added]);
+        let transition = discovery.renv_transition.unwrap();
+        assert_eq!(
+            transition.project_root,
+            std::fs::canonicalize(project).unwrap()
+        );
+        assert_eq!(
+            transition.outside_paths,
+            vec![std::fs::canonicalize(outside).unwrap()]
+        );
+    }
+
+    #[test]
+    fn renv_lib_paths_frame_fails_closed_for_source_or_project_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let other = temp.path().join("other");
+        let active = temp.path().join("active");
+        let outside = temp.path().join("outside");
+        for path in [&project, &other, &active, &outside] {
+            std::fs::create_dir(path).unwrap();
+        }
+
+        let source_failed = renv_frame(false, &project, &[outside.as_path()], &[active.as_path()])
+            .replace(&format!("P\t{}\n", hex_path(&project)), "P\t\n");
+        let discovery = parse_renv_lib_paths_output(&source_failed, Some(&project)).unwrap();
+        assert_eq!(discovery.active, vec![active.clone()]);
+        assert!(discovery.renv_transition.is_none());
+
+        let mismatch = renv_frame(true, &other, &[outside.as_path()], &[active.as_path()]);
+        let discovery = parse_renv_lib_paths_output(&mismatch, Some(&project)).unwrap();
+        assert_eq!(discovery.active, vec![active.clone()]);
+        assert!(discovery.renv_transition.is_none());
+
+        let missing_project = renv_frame(true, &project, &[outside.as_path()], &[active.as_path()])
+            .replace(&format!("P\t{}\n", hex_path(&project)), "P\t\n");
+        let discovery = parse_renv_lib_paths_output(&missing_project, Some(&project)).unwrap();
+        assert!(discovery.renv_transition.is_none());
+    }
+
+    #[test]
+    fn renv_lib_paths_frame_rejects_relative_and_truncated_final_frames() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let active = temp.path().join("active");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&active).unwrap();
+
+        let relative = format!(
+            "__RAVEN_LIB_PATHS_V1_BEGIN__\nS\t1\nP\t{}\nA\t{}\n\
+             __RAVEN_LIB_PATHS_V1_END__\n",
+            hex_path(std::path::Path::new("relative-project")),
+            hex_path(&active)
+        );
+        assert!(parse_renv_lib_paths_output(&relative, Some(&project)).is_none());
+
+        let mut truncated = renv_frame(true, &project, &[], &[active.as_path()]);
+        truncated.push_str("__RAVEN_LIB_PATHS_V1_BEGIN__\nS\t1\n");
+        assert!(parse_renv_lib_paths_output(&truncated, Some(&project)).is_none());
     }
 
     #[tokio::test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,9 +95,19 @@ Before reporting, `raven check` warms the export cache for the packages each rep
 
 `raven check` resolves package **export names** through an ordered three-tier fallback — installed packages, then a committed `.raven/packages.json`, then Raven's broad CRAN/Bioconductor metadata when available — so symbols from attached packages can resolve even when no R is installed. That metadata is downloaded with `raven packages update` — it isn't bundled with the binary — so a CI image that installs Raven needs that step for broad CRAN/Bioconductor coverage; embedded base R-platform coverage is in the binary regardless. This stops the undefined-variable storm that otherwise makes Raven unusable in CI. See [Package database](package-database.md).
 
-Knowing a package's exports is **separate** from knowing whether it is installed. The **missing-package** diagnostic answers a different question — *"will `library(X)` succeed at runtime?"*, i.e. is `X` installed? — so it is driven solely by what is present in the local library paths, never by the package symbol database. Because CI deliberately omits package installation, `raven check` **suppresses missing-package warnings by default**.
+Knowing a package's exports is **separate** from knowing whether it is installed. The **missing-package** diagnostic answers a different question — *"will `library(X)` succeed at runtime?"*, i.e. is `X` installed? — so it is driven solely by what is present in the local library paths, never by the package symbol database. Because CI deliberately omits package installation, `raven check` **suppresses generic missing-package warnings by default**.
 
-`--report-uninstalled` re-enables them. Reach for it whenever a `library(X)` call must really succeed at runtime: a pipeline that *does* install packages (e.g. `renv::restore()`) and wants to fail if any didn't, **or** any CI that **actually runs your R scripts** after `raven check` (e.g. R-package CI), where an uninstalled package is a genuine failure rather than CI noise. Gate-only CI that never executes the scripts wants the default (suppressed). It reports `library()` calls **not present in the local library paths** — **not** relative to the package symbol databases (`.raven/packages.json` or the `names.db` database). One consequence: with the default off, a genuine typo such as `library(dpylr)` is silent (no database knows it, but `raven check` isn't checking install status); it is reported only with `--report-uninstalled`. The language server is unchanged — it still fires missing-package whenever install state is known. See [Diagnostics](diagnostics.md#package-names-vs-install-status) for the full model.
+`--report-uninstalled` re-enables them. Reach for it whenever a `library(X)` call must really succeed at runtime: a pipeline that *does* install packages (e.g. `renv::restore()`) and wants to fail if any didn't, **or** any CI that **actually runs your R scripts** after `raven check` (e.g. R-package CI), where an uninstalled package is a genuine failure rather than CI noise. Gate-only CI that never executes the scripts wants the default (suppressed). It reports `library()` calls **not present in the local library paths** — **not** relative to the package symbol databases (`.raven/packages.json` or the `names.db` database). One consequence: with the default off, a genuine typo such as `library(dpylr)` is silent (no database knows it, but `raven check` isn't checking install status); it is reported only with `--report-uninstalled`. The language server is unchanged — it still fires missing-package whenever install state is known.
+
+One actionable subtype remains enabled even without the flag:
+`package-outside-active-library` means Raven successfully activated the
+workspace's renv project, the referenced package is unavailable in its active
+library, and a validated package with that name exists in a vanilla system/user
+library removed by activation. That is evidence of a project setup problem, not
+the ordinary "CI did not install dependencies" case; run `renv::restore()` or
+install the package into the project library. See
+[Diagnostics](diagnostics.md#package-names-vs-install-status) for the full
+model.
 
 ### File encoding
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -702,6 +702,31 @@ Key ideas:
 - If R is unavailable, fall back to `INDEX` parsing (best-effort)
 - When merging `Depends` with meta-package `attached_packages`, keep a companion `HashSet` for dedupe; repeated `Vec::contains()` checks make recursive export expansion quadratic.
 
+Library-path discovery keeps renv activation and diagnostic provenance in one
+bounded R subprocess. For an explicit workspace containing
+`renv/activate.R`, the probe records `.libPaths()` before and after the existing
+activation, then emits a versioned hex-encoded frame. Rust accepts only the last
+complete valid frame and verifies the activated project reported by renv
+against the canonical workspace root. Source failure, malformed/truncated
+output, missing paths, or a project mismatch fail closed to no renv evidence;
+the ordinary active-path/fallback contract remains unchanged.
+
+The pre-activation paths never enter `PackageLibrary.lib_paths`. They are
+reduced immediately to conservative package-name evidence: a real package
+directory with a readable regular `DESCRIPTION` whose `Package:` field agrees
+with its valid directory name. Names present in the active paths, configured
+additional paths, or the base-priority set are removed. The surviving
+names-only `renv_outside_active_overlay` drives only the
+`package-outside-active-library` diagnostic. It must never feed export lookup,
+completion, `package_exists()`, `system.file()`, watchers, enumeration, or
+freeze/build commands. Library forks retain it, full rebuilds recompute it, and
+`clear_cache` leaves it intact; adding an active library path prunes it
+immediately. Outside-library filesystem changes intentionally require an
+explicit package refresh. Diagnostic collection consults the overlay only when
+the snapshot has exactly one workspace folder; multi-root routing activates the
+first root globally, so attributing that evidence to any document in a
+multi-root session would be ambiguous (especially for nested workspace roots).
+
 `PackageLibrary` owns two in-memory side caches: `packages` for direct per-package metadata and `combined_entries` for aggregate availability/ownership snapshots. Both are atomic read-copy snapshots (`arc_swap::ArcSwap<HashMap<...>>`) with a small writer mutex per map to serialize copy-on-write publication. Synchronous cache readers load an immutable snapshot and do normal `HashMap` lookups, so an in-progress writer publication is never semantic absence and cannot produce transient diagnostics. Writers clone the current map, mutate the clone, and publish a new `Arc<HashMap<...>>`; keep those publication sections small and never hold a writer mutex across `.await`, R subprocess calls, disk/provider reads, or recursive package expansion. Multi-map operations such as invalidation publish the two maps sequentially rather than nesting writer gates. Completion readers should clone only the relevant `Arc<PackageInfo>` / `Arc<CombinedEntry>` handles from snapshots before doing string iteration/dedupe.
 
 Logical cache operations also hold one shared library-operation lease from their

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -36,6 +36,7 @@ are governed only by their severity settings). The suppressible analyzer codes a
 | `source-path-case-mismatch` | A `source()` / forward-directive **or** backward-directive (`# raven: sourced-by` etc.) path that resolves only by a case difference from the real filename (`templates.r` vs `templates.R`) | No |
 | `assign-to-string-literal` | Assignment to a string literal or other almost-certainly-unintended target | Yes |
 | `package-not-installed` | `library()` / `require()` of a package that is not installed (also fires on `pkg::member` / `pkg:::member` when `pkg` is not installed) | Yes |
+| `package-outside-active-library` | A package exists in a vanilla system/user library but is unavailable in the active renv project library; child of `package-not-installed` | Yes |
 | `namespace-member-not-found` | `pkg::member` where a *complete* package export set has no such exported object (never for `pkg:::member`) | Yes |
 | `unused-suppression` | A `# raven: expect[...]` (or, under the global sweep, any suppression) that suppressed nothing — see below | No |
 
@@ -177,7 +178,8 @@ Two opt-out settings turn off this descent and restore blanket suppression for h
 
 | Diagnostic | Default Severity | Trigger |
 |---|---|---|
-| Missing package | warning | `library()`/`require()`, or `pkg::member` / `pkg:::member`, references a package not installed on the system |
+| Missing package | warning | `library()`/`require()`, or `pkg::member` / `pkg:::member`, references a package unavailable in the active library paths |
+| Package outside active renv library | warning | A referenced package is installed in a vanilla R library that the active renv project removed from `.libPaths()` |
 | Namespace member not found | warning | `pkg::member` where `pkg`'s *complete* export set has no such exported object (never for `pkg:::member`) |
 
 ### Package names vs. install status
@@ -192,9 +194,24 @@ Raven can resolve a package's **export names** from three sources, consulted in 
 | | Export resolution | Missing-package ("not installed") |
 |---|---|---|
 | **Language server (interactive)** | tiers 1→2→3 (prevents an undefined-variable storm when R is absent and Tier 2 metadata or the Tier 3 database covers the package) | Fires when install state is known and the package is absent — regardless of the database. Export metadata stops the symbol storm when coverage exists but never masks the "install this dependency" nudge. |
-| **`raven check` (CI)** | tiers 1→2→3 | **Suppressed by default** (CI deliberately omits installation). Re-enable with [`--report-uninstalled`](cli.md#missing-package-reporting-in-ci). |
+| **`raven check` (CI)** | tiers 1→2→3 | Generic absence is **suppressed by default** (CI deliberately omits installation). The actionable `package-outside-active-library` subtype remains enabled. Re-enable generic absence with [`--report-uninstalled`](cli.md#missing-package-reporting-in-ci). |
 
 When enabled, `--report-uninstalled` reports `library()` calls **not present in the local library paths** — *not* relative to the Tier 2/Tier 3 export metadata. Reach for it when a `library(X)` call must really succeed at runtime: CI that installs packages (e.g. `renv::restore()`) and wants to catch failures, or CI that **actually runs your R scripts** after `raven check` (e.g. R-package development), where an uninstalled package is a real error. Gate-only CI that never executes the scripts wants the default.
+
+When Raven successfully activates an explicit workspace's `renv/activate.R`, it
+also compares the vanilla and active library paths. If a referenced package
+exists only in a path removed by activation, Raven reports
+`package-outside-active-library` and suggests restoring or installing it into
+the project library. Raven reports this project-level setup problem at most once
+per package per document, even when that document contains many qualified
+references. This names-only evidence never makes the package available for
+exports, completion, `system.file()`, or package loading. Packages installed
+after startup are recognized when the library is rebuilt (for example with
+`raven.refreshPackages`); changes made only in an outside vanilla library are
+picked up by the next refresh rather than watched continuously. Suppressing
+`package-not-installed` also suppresses this child code. Multi-root editor
+sessions fail closed to no subtype because package routing has no unambiguous
+single-project renv identity there.
 
 #### Accepted gap
 


### PR DESCRIPTION
## Summary

- detect when an active renv project hides a package that is available in the user's other R libraries
- report `package-outside-active-library` with `renv::restore()` / project-install guidance
- preserve normal package routing: outside libraries contribute validated package names only, never exports, completions, resolution, watchers, or `system.file()` paths
- fail closed for uncertain activation and multi-root LSP sessions
- document CLI, diagnostic, suppression, and lifecycle behavior

## Root cause

Raven previously saw only the post-activation `.libPaths()` result. A checkout with `renv/activate.R` could therefore make a machine-installed package disappear without leaving enough information to distinguish it from a genuinely uninstalled package.

The existing bounded R discovery invocation now frames the before/after library transition and verifies the activated renv project. Raven reduces removed libraries immediately to validated package names and attaches that names-only overlay to the matching package-library lifecycle.

## User impact

`raven check` now explains that a referenced package exists outside the active renv project and suggests restoring or installing it into the project library. The CLI keeps the generic `package-not-installed` diagnostic suppressed by default while leaving this actionable child diagnostic enabled. Direct and umbrella suppression remain available.

## Validation

- synthetic, machine-independent probe/parser, package-overlay, diagnostic, suppression, CLI, lifecycle, and multi-root regressions
- `cargo test --workspace --all-targets --features test-support`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- rustdoc with warnings denied, default and `test-support`
- two independent agent reviews, both approved
- committed-patch audit found no machine paths or external-checkout material
- exact local release A/B: warm median full-check time was 1.18s on both current main and this commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `package-outside-active-library` missing-package diagnostic for packages present only outside the active `renv` library.
  * Provides actionable `renv::restore()` / install guidance and reports at most once per package per document.
  * Improves accuracy by avoiding related “missing member” noise when the package is only outside the active `renv` library.
* **Bug Fixes**
  * CI/default now suppresses generic missing-package diagnostics while keeping the new subtype enabled.
  * Multi-root and invalid `renv` evidence now fail closed (no subtype reporting).
* **Documentation**
  * Updated CLI and diagnostics docs to reflect the new subtype and `--report-uninstalled` behavior.
* **Tests**
  * Expanded coverage for suppression, deduping, and multi-root fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->