### PR TITLE
Model deterministic package-loader loops

### DIFF
--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -758,9 +758,9 @@ fn scan_workspace_referenced_packages(root: &std::path::Path) -> Vec<String> {
 /// - the `namespace_identifier` (LHS) of each `pkg::name` / `pkg:::name`
 ///   (`namespace_operator` node — the package id is `child(0)`, confirmed against
 ///   `find_namespace_context` in `handlers.rs`), and
-/// - the first argument of each `library`/`require`/`loadNamespace`/
-///   `requireNamespace` call (mirrors `state::extract_loaded_packages`, extended
-///   to cover `requireNamespace`).
+/// - statically detected package loaders from the canonical detector, and
+/// - a string literal statically matched to `requireNamespace()`'s `package`
+///   formal.
 fn collect_referenced_packages(
     tree: &tree_sitter::Tree,
     text: &str,
@@ -794,27 +794,12 @@ fn collect_referenced_packages(
             "call" => {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &text[func.byte_range()];
-                    if matches!(
-                        func_text,
-                        "library" | "require" | "loadNamespace" | "requireNamespace"
-                    ) && let Some(args) = node.child_by_field_name("arguments")
+                    if func_text == "requireNamespace"
+                        && let Some(args) = node.child_by_field_name("arguments")
+                        && let Some(name) = static_require_namespace_package(args, text)
+                        && is_valid_package_name(&name)
                     {
-                        for i in 0..args.child_count() {
-                            let Some(arg) = args.child(i as u32) else {
-                                continue;
-                            };
-                            if arg.kind() != "argument" {
-                                continue;
-                            }
-                            if let Some(value) = arg.child_by_field_name("value") {
-                                let name = text[value.byte_range()]
-                                    .trim_matches(|c| c == '"' || c == '\'');
-                                if is_valid_package_name(name) {
-                                    out.insert(name.to_string());
-                                }
-                                break; // only the first arg names the package
-                            }
-                        }
+                        out.insert(name);
                     }
                 }
             }
@@ -826,6 +811,44 @@ fn collect_referenced_packages(
             }
         }
     }
+}
+
+fn static_require_namespace_package(arguments: tree_sitter::Node, text: &str) -> Option<String> {
+    if arguments.has_error() {
+        return None;
+    }
+    let mut named_package = None;
+    let mut first_positional = None;
+    let mut cursor = arguments.walk();
+    for argument in arguments.named_children(&mut cursor) {
+        if argument.kind() != "argument" {
+            continue;
+        }
+        let value = argument.child_by_field_name("value")?;
+        match argument.child_by_field_name("name") {
+            Some(name) => {
+                let name = crate::cross_file::binding::plain_argument_name(name, text)?;
+                if "package".starts_with(name.as_ref())
+                    && (name.is_empty() || named_package.replace(value).is_some())
+                {
+                    return None;
+                }
+            }
+            None => {
+                if first_positional.is_none() {
+                    first_positional = Some(value);
+                }
+            }
+        }
+    }
+    let value = match named_package {
+        Some(value) => value,
+        None => first_positional?,
+    };
+    if value.kind() != "string" {
+        return None;
+    }
+    crate::cross_file::binding::extract_plain_string(value, text)
 }
 
 fn read_description_depends_imports(path: &std::path::Path) -> Vec<String> {
@@ -1816,6 +1839,59 @@ mod tests {
         let mut packages = std::collections::BTreeSet::new();
         super::collect_referenced_packages(&parse(generic), generic, &mut packages);
         assert!(!packages.contains("not_a_package"), "got {packages:?}");
+    }
+
+    #[test]
+    fn collect_referenced_packages_resolves_static_loader_loop_without_iterator() {
+        let source = "packages <- c(\"alpha\", \"beta\", NULL)\n\
+                      for (package in packages) {\n\
+                        requireNamespace(package, quietly = TRUE)\n\
+                        library(package, character.only = TRUE)\n\
+                      }";
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .expect("load R grammar");
+        let tree = parser.parse(source, None).expect("parse R snippet");
+        let mut packages = std::collections::BTreeSet::new();
+        super::collect_referenced_packages(&tree, source, &mut packages);
+
+        assert_eq!(
+            packages,
+            ["alpha".to_string(), "beta".to_string()]
+                .into_iter()
+                .collect()
+        );
+        assert!(!packages.contains("package"));
+    }
+
+    #[test]
+    fn collect_referenced_packages_does_not_promote_other_require_namespace_strings() {
+        let source = "requireNamespace(package_name, lib.loc = \"not_a_package\")\n\
+                      requireNamespace(quietly = TRUE, package = \"namedpkg\")\n\
+                      requireNamespace(\"dot_value\", package = \"named_with_dots\")\n\
+                      requireNamespace(pack = \"partialpkg\")";
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_r::LANGUAGE.into())
+            .expect("load R grammar");
+        let tree = parser.parse(source, None).expect("parse R snippet");
+        let mut packages = std::collections::BTreeSet::new();
+        super::collect_referenced_packages(&tree, source, &mut packages);
+
+        assert_eq!(
+            packages,
+            [
+                "named_with_dots".to_string(),
+                "namedpkg".to_string(),
+                "partialpkg".to_string(),
+            ]
+            .into_iter()
+            .collect()
+        );
+        assert!(!packages.contains("not_a_package"));
+        assert!(!packages.contains("package_name"));
+        assert!(!packages.contains("dot_value"));
     }
 
     #[test]

--- a/crates/raven/src/cross_file/binding.rs
+++ b/crates/raven/src/cross_file/binding.rs
@@ -185,6 +185,24 @@ impl<T> Binding<T> {
         (*offset < before_byte).then_some((candidate, *offset))
     }
 
+    /// Resolve against the collector state immediately before an effect node.
+    ///
+    /// Unlike [`Self::resolved_with_offset_before`], this uses the current
+    /// generation before whole-file finalization. It is intended only for
+    /// checkpoints taken synchronously by the binding walk, before the current
+    /// node installs its mutation barrier.
+    pub(crate) fn resolved_at_generation_before(
+        &self,
+        before_byte: usize,
+        generation: u32,
+    ) -> Option<(&T, usize)> {
+        if self.effective_count(generation) != 1 {
+            return None;
+        }
+        let (candidate, offset) = self.candidate.as_ref()?;
+        (*offset < before_byte).then_some((candidate, *offset))
+    }
+
     fn has_safe_eager_value_before(&self, before_byte: usize, generation: u32) -> bool {
         self.effective_count(generation) == 1
             && self
@@ -238,10 +256,28 @@ impl<T> Default for BindingCollection<T> {
 /// provides a payload; binding counting is independent of that decision. In
 /// particular, callers can share exact binding semantics without widening their
 /// distinct payload policies.
+#[cfg(test)]
 pub(crate) fn collect_bindings<'tree, T>(
     root: Node<'tree>,
     content: &str,
     mut candidate_for: impl FnMut(BindingSite<'tree>) -> Option<T>,
+) -> HashMap<String, Binding<T>> {
+    collect_bindings_with_checkpoints(root, content, &mut candidate_for, &mut |_, _, _| {})
+}
+
+/// Collect bindings while exposing immediate `for` pre-effect checkpoints.
+///
+/// The checkpoint runs after the loop sequence's preceding syntax has been
+/// collected but before the loop installs its unknown-mutation barrier. This
+/// lets consumers snapshot facts needed to interpret the sequence without
+/// weakening the barrier seen by every later use. Checkpoints are limited to
+/// ordinary top-level execution and proven eager/evaluated contexts; deferred
+/// function bodies do not receive one.
+pub(crate) fn collect_bindings_with_checkpoints<'tree, T>(
+    root: Node<'tree>,
+    content: &str,
+    candidate_for: &mut impl FnMut(BindingSite<'tree>) -> Option<T>,
+    checkpoint: &mut impl FnMut(Node<'tree>, &HashMap<String, Binding<T>>, u32),
 ) -> HashMap<String, Binding<T>> {
     let mut collection = BindingCollection {
         // Almost every document has no `readLines` call. Avoid the additional
@@ -256,7 +292,8 @@ pub(crate) fn collect_bindings<'tree, T>(
         root,
         content,
         &mut collection,
-        &mut candidate_for,
+        candidate_for,
+        checkpoint,
         &mut visited_effect_nodes,
         BindingVisitState {
             current_frame_kills_are_definite: true,
@@ -287,6 +324,14 @@ const UNKNOWN_LOADED_BINDING_KEY: &str = "\0raven-unknown-loaded-binding";
 const ASSIGN_FORMALS: [&str; 6] = ["x", "value", "pos", "envir", "inherits", "immediate"];
 const LOAD_FORMALS: [&str; 3] = ["file", "envir", "verbose"];
 const SYS_LOAD_IMAGE_FORMALS: [&str; 2] = ["name", "quiet"];
+
+/// Whether the in-progress binding walk has seen a persistent unknown
+/// mutation that finalization will apply to every candidate.
+pub(crate) fn has_pending_persistent_invalidation<T>(
+    bindings: &HashMap<String, Binding<T>>,
+) -> bool {
+    bindings.contains_key(UNKNOWN_BINDING_KEY)
+}
 
 /// Whether recognized syntax in the document may create a binding for `name`.
 ///
@@ -368,6 +413,15 @@ fn document_may_bind_name(root: Node, content: &str, name: &str) -> bool {
     visit(root, content, name, bare_assign_trusted)
 }
 
+/// Whether syntax in `root` may create or replace the named binding.
+///
+/// This deliberately preserves [`document_may_bind_name`]'s conservative
+/// nested-scope and dynamic-assignment policy. Consumers use it only as a
+/// fail-closed guard, never to create a static fact.
+pub(crate) fn subtree_may_bind_name(root: Node, content: &str, name: &str) -> bool {
+    document_may_bind_name(root, content, name)
+}
+
 fn call_may_bind_name(
     function: Node,
     call: Node,
@@ -443,6 +497,7 @@ fn visit_bindings<'tree, T>(
     content: &str,
     collection: &mut BindingCollection<T>,
     candidate_for: &mut impl FnMut(BindingSite<'tree>) -> Option<T>,
+    checkpoint: &mut impl FnMut(Node<'tree>, &HashMap<String, Binding<T>>, u32),
     visited_effect_nodes: &mut HashSet<Node<'tree>>,
     state: BindingVisitState,
 ) {
@@ -494,6 +549,7 @@ fn visit_bindings<'tree, T>(
                         content,
                         collection,
                         candidate_for,
+                        checkpoint,
                         visited_effect_nodes,
                         BindingVisitState {
                             current_frame_kills_are_definite: state
@@ -534,6 +590,10 @@ fn visit_bindings<'tree, T>(
                 return;
             }
             if first_effect_visit && state.evaluation_frame.is_caller_or_global() {
+                if state.effective_immediate_binding_context() || state.eager_assignment_value_root
+                {
+                    checkpoint(node, &collection.map, collection.immediate_generation);
+                }
                 // The sequence is evaluated eagerly and the body may execute;
                 // either can mutate unrelated bindings through indirect calls.
                 invalidate_unknown_mutation_in_context(
@@ -565,6 +625,7 @@ fn visit_bindings<'tree, T>(
             content,
             collection,
             candidate_for,
+            checkpoint,
             visited_effect_nodes,
             BindingVisitState {
                 current_frame_kills_are_definite: state.current_frame_kills_are_definite,
@@ -3940,6 +4001,59 @@ pub(crate) fn extract_bare_c_plain_strings<'tree>(
     }
 }
 
+/// Extract a bare `c()` package vector containing plain strings and optional
+/// literal `NULL` entries.
+///
+/// Base `c()` drops `NULL`, so accepting it here preserves the exact package
+/// sequence that a loader loop or apply-family call receives. All arguments
+/// must remain positional and syntactically complete; named, missing,
+/// malformed, or other non-string entries are rejected. At least one package
+/// string is required.
+pub(crate) fn extract_bare_c_package_strings<'tree>(
+    node: Node<'tree>,
+    content: &str,
+) -> Option<Vec<(String, Node<'tree>)>> {
+    if node.kind() != "call"
+        || node
+            .child_by_field_name("function")
+            .is_none_or(|function| node_text(function, content) != "c")
+    {
+        return None;
+    }
+    let arguments = node.child_by_field_name("arguments")?;
+    if arguments.has_error() {
+        return None;
+    }
+    let mut strings = Vec::new();
+    let mut argument_count = 0usize;
+    let mut comma_count = 0usize;
+    let mut cursor = arguments.walk();
+    for child in arguments.children(&mut cursor) {
+        if child.kind() == "comma" {
+            comma_count += 1;
+            continue;
+        }
+        if child.kind() != "argument" {
+            continue;
+        }
+        if child.child_by_field_name("name").is_some() {
+            return None;
+        }
+        let value = child.child_by_field_name("value")?;
+        argument_count += 1;
+        match value.kind() {
+            "string" => strings.push((extract_plain_string(value, content)?, value)),
+            "null" => {}
+            _ => return None,
+        }
+    }
+    if strings.is_empty() || comma_count + 1 != argument_count {
+        None
+    } else {
+        Some(strings)
+    }
+}
+
 pub(crate) fn extract_plain_string(node: Node, content: &str) -> Option<String> {
     let text = node_text(node, content);
     if let Some(raw) = crate::config_file::lintr_loader::parse_r_raw_string_literal(text) {
@@ -4224,6 +4338,35 @@ mod tests {
             let tree = parse_r(code);
             let call = tree.root_node().named_child(0).unwrap();
             assert!(extract_bare_c_plain_strings(call, code).is_none(), "{code}");
+        }
+    }
+
+    #[test]
+    fn package_c_strings_drop_literal_null_but_reject_other_dynamic_shapes() {
+        let code = "c(\"alpha\", NULL, 'beta')";
+        let tree = parse_r(code);
+        let call = tree.root_node().named_child(0).unwrap();
+        let pairs = extract_bare_c_package_strings(call, code).unwrap();
+        assert_eq!(
+            pairs
+                .iter()
+                .map(|(package, _)| package.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+
+        for code in [
+            "c(NULL)",
+            "c(\"alpha\", dynamic)",
+            "c(package = \"alpha\", NULL)",
+            "c(\"alpha\",)",
+        ] {
+            let tree = parse_r(code);
+            let call = tree.root_node().named_child(0).unwrap();
+            assert!(
+                extract_bare_c_package_strings(call, code).is_none(),
+                "{code}"
+            );
         }
     }
 

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -20623,6 +20623,32 @@ base::bquote(.(source("child.R", local = TRUE)), where = env)"#,
     }
 
     #[test]
+    fn static_loader_loop_exports_become_visible_only_after_loop() {
+        let code = concat!(
+            "packages <- c(\"alpha\", \"beta\", NULL)\n",
+            "for (package in packages) {\n",
+            "  library(package, character.only = TRUE)\n",
+            "}\n",
+            "alpha_export()\n",
+            "beta_export()",
+        );
+        let artifacts = compute_artifacts(&test_uri(), &parse_r(code), code);
+        let get_exports =
+            mock_package_exports(&[("alpha", &["alpha_export"]), ("beta", &["beta_export"])]);
+        let base_exports = empty_base_exports();
+
+        let inside =
+            scope_at_position_with_packages(&artifacts, 2, 0, &get_exports, &base_exports, false);
+        assert!(!inside.symbols.contains_key("alpha_export"));
+        assert!(!inside.symbols.contains_key("beta_export"));
+
+        let after =
+            scope_at_position_with_packages(&artifacts, 5, 0, &get_exports, &base_exports, false);
+        assert!(after.symbols.contains_key("alpha_export"));
+        assert!(after.symbols.contains_key("beta_export"));
+    }
+
+    #[test]
     fn test_scope_with_packages_at_library_call_line() {
         // Requirement 2.2: Package exports available at or after the library() call position
         let code = "library(dplyr)\nx <- mutate";
@@ -35767,6 +35793,38 @@ mod package_contribution_tests {
 
     #[test]
     fn attachment_projection_regressions_match_recursive_and_streaming_scope() {
+        let (recursive, streamed, stepped) = projection_fixture_scopes(
+            "static-loop-source-propagation",
+            &[
+                (
+                    "main.R",
+                    concat!(
+                        "packages <- c(\"alpha\", \"beta\", NULL)\n",
+                        "for (package in packages) {\n",
+                        "  if (!requireNamespace(package, quietly = TRUE)) install.packages(package)\n",
+                        "  library(package, character.only = TRUE)\n",
+                        "}\n",
+                        "source(\"child.R\")",
+                    ),
+                ),
+                ("child.R", "synthetic_export()"),
+            ],
+            "child.R",
+            u32::MAX,
+            Some((0, 0)),
+        );
+        assert_eq!(
+            recursive.attached_packages,
+            ["alpha".to_string(), "beta".to_string()]
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(streamed.attached_packages, recursive.attached_packages);
+        assert_eq!(
+            stepped.unwrap().attached_packages,
+            recursive.attached_packages
+        );
+
         let (recursive, streamed, _) = projection_fixture_scopes(
             "deferred-body-attachment",
             &[

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -1449,7 +1449,8 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 
 /// Detects package loads in the file: direct `library()`/`require()`/`loadNamespace()`
 /// calls, static pacman `p_load()` calls, apply-family calls whose FUN argument
-/// is a bare reference to `library` or `require`, and {targets}
+/// is a bare reference to `library` or `require`, deterministic package-loader
+/// `for` loops, and {targets}
 /// `tar_option_set(packages = ...)` calls (see `try_parse_tar_option_set_call`).
 ///
 /// For direct calls, the package must be a bare identifier (`library(dplyr)`)
@@ -1466,6 +1467,12 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 /// removed bindings cannot supply candidates.
 /// Each apply emits one `LibraryCall` per package, all sharing the apply
 /// call's end position.
+///
+/// A package-loader `for` loop is recognized only when its sequence meets the
+/// same static-vector policy and its body unconditionally calls
+/// `library(iterator, character.only = TRUE)` or `require()` at the body's top
+/// level. The emitted calls share the loop's end position, after every package
+/// has been attached.
 ///
 /// For `tar_option_set(packages = ...)` calls, the bare spelling is honored
 /// only when the same file also attaches targets (`library(targets)` /
@@ -1731,7 +1738,8 @@ impl LibraryWalkOutput {
 
 /// Recursively traverse an AST subtree and collect statically determinable
 /// package loads: direct `library`/`require`/`loadNamespace` calls, apply-family
-/// calls whose FUN is `library`/`require`, and {targets}
+/// calls whose FUN is `library`/`require`, deterministic package-loader `for`
+/// loops, and {targets}
 /// `tar_option_set(packages = ...)` candidates.
 ///
 /// When `top_level_only` is true, calls lexically inside a
@@ -1758,6 +1766,16 @@ fn visit_node_for_library(
     // Identifier nodes have no children and cannot be calls.
     if node.kind() == "identifier" {
         return;
+    }
+
+    if node.kind() == "for_statement"
+        && (!top_level_only || !runtime_function_scope.is_function_scoped_at(node))
+    {
+        output.extend_calls(
+            try_parse_for_library_loop(node, content, capture_bindings),
+            runtime_function_scope,
+            scope_orderable,
+        );
     }
 
     if node.kind() == "call" {
@@ -1850,6 +1868,259 @@ fn visit_node_for_library(
             output,
         );
     }
+}
+
+/// Recognize a deterministic package-loader `for` loop.
+///
+/// The sequence must be a trusted inline `c()` package vector or a resolvable
+/// same-file package-vector binding. The body must contain exactly one
+/// top-level `library(iterator, character.only = TRUE)` or equivalent
+/// `require()` call. A loader nested in control flow is deliberately rejected,
+/// as are loops that can reach `next` before the loader, `break` anywhere in
+/// the body, or `return()` from the enclosing function. Emitted
+/// attachment events are anchored after the complete loop so packages do not
+/// become visible while individual iterations are still running.
+fn try_parse_for_library_loop(
+    node: Node,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+) -> Vec<LibraryCall> {
+    let Some(variable) = node.child_by_field_name("variable") else {
+        return Vec::new();
+    };
+    let Some(iterator) = super::binding::plain_identifier_name(variable, content) else {
+        return Vec::new();
+    };
+    let Some(body) = node.child_by_field_name("body") else {
+        return Vec::new();
+    };
+    if contains_loop_break(body) || contains_loop_return(body, content) {
+        return Vec::new();
+    }
+    let statements: Vec<Node> = if body.kind() == "braced_expression" {
+        let mut cursor = body.walk();
+        body.named_children(&mut cursor).collect()
+    } else {
+        vec![body]
+    };
+    let mut loader_index = None;
+    for (index, statement) in statements.iter().copied().enumerate() {
+        if is_iterator_library_call(statement, iterator, content, bindings)
+            && loader_index.replace(index).is_some()
+        {
+            return Vec::new();
+        }
+    }
+    let Some(loader_index) = loader_index else {
+        return Vec::new();
+    };
+    if statements[..loader_index]
+        .iter()
+        .copied()
+        .any(contains_loop_skip)
+        || statements[..loader_index].iter().copied().any(|statement| {
+            super::binding::subtree_may_bind_name(statement, content, iterator)
+                || contains_remove_call(statement, content)
+        })
+    {
+        return Vec::new();
+    }
+
+    let Some(sequence) = node.child_by_field_name("sequence") else {
+        return Vec::new();
+    };
+    let packages = match sequence.kind() {
+        "identifier" => {
+            let Some(name) = super::binding::plain_identifier_name(sequence, content) else {
+                return Vec::new();
+            };
+            let Some(packages) = bindings.resolve_package_vector_before_for(name, node) else {
+                return Vec::new();
+            };
+            packages
+        }
+        _ => {
+            let Some(packages) = extract_c_strings_strict(sequence, content) else {
+                return Vec::new();
+            };
+            if !bindings.package_c_is_trusted_at(node) {
+                return Vec::new();
+            }
+            packages
+        }
+    };
+
+    let end = node.end_position();
+    let line_text = content.lines().nth(end.row).unwrap_or("");
+    let column = byte_offset_to_utf16_column(line_text, end.column);
+    packages
+        .into_iter()
+        .map(|package| LibraryCall {
+            package,
+            line: end.row as u32,
+            column,
+            function_scope: None,
+            attaches: true,
+            requires_attached: None,
+        })
+        .collect()
+}
+
+fn is_iterator_library_call(
+    node: Node,
+    iterator: &str,
+    content: &str,
+    bindings: &mut super::static_path::LazyStaticBindings,
+) -> bool {
+    if node.kind() != "call" {
+        return false;
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    let loader = node_text(function, content);
+    if !matches!(loader, "library" | "require") {
+        return false;
+    }
+    let deferred = !super::binding::is_known_immediate_context(node);
+    if bindings
+        .get()
+        .named_local_binding_may_shadow_without_helper_uncertainty(loader, node, deferred)
+    {
+        return false;
+    }
+    let Some(arguments) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    if arguments.has_error() {
+        return false;
+    }
+
+    let mut package = None;
+    let mut character_only = None;
+    let mut positional = 0usize;
+    let mut cursor = arguments.walk();
+    for argument in arguments.named_children(&mut cursor) {
+        if argument.kind() != "argument" {
+            continue;
+        }
+        let Some(value) = argument.child_by_field_name("value") else {
+            return false;
+        };
+        match argument
+            .child_by_field_name("name")
+            .map(|name| node_text(name, content))
+        {
+            Some("package") => {
+                if package.replace(value).is_some() {
+                    return false;
+                }
+            }
+            Some("character.only") => {
+                if character_only
+                    .replace(matches!(node_text(value, content), "TRUE" | "T"))
+                    .is_some()
+                {
+                    return false;
+                }
+            }
+            Some(_) => {}
+            None => {
+                positional += 1;
+                if positional == 1 {
+                    if package.replace(value).is_some() {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+    character_only == Some(true)
+        && package.is_some_and(|value| {
+            super::binding::plain_identifier_name(value, content) == Some(iterator)
+        })
+}
+
+fn contains_remove_call(node: Node, content: &str) -> bool {
+    if node.kind() == "call"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| {
+                let leaf = function.child_by_field_name("rhs").unwrap_or(function);
+                matches!(
+                    super::binding::plain_identifier_name(leaf, content),
+                    Some("rm" | "remove")
+                )
+            })
+    {
+        return true;
+    }
+    if node.kind() == "function_definition" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| contains_remove_call(child, content))
+}
+
+fn contains_loop_skip(node: Node) -> bool {
+    if matches!(node.kind(), "next" | "break") {
+        return true;
+    }
+    if node.kind() == "function_definition" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(contains_loop_skip)
+}
+
+fn contains_loop_break(node: Node) -> bool {
+    if node.kind() == "break" {
+        return true;
+    }
+    if node.kind() == "function_definition" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(contains_loop_break)
+}
+
+fn contains_loop_return(node: Node, content: &str) -> bool {
+    if node.kind() == "call"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| is_base_return_function(function, content))
+    {
+        return true;
+    }
+    if node.kind() == "function_definition" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| contains_loop_return(child, content))
+}
+
+fn is_base_return_function(function: Node, content: &str) -> bool {
+    let is_plain_name = |node: Node, expected: &str| {
+        super::binding::plain_identifier_name(node, content) == Some(expected)
+            || super::binding::extract_plain_string(node, content).as_deref() == Some(expected)
+    };
+    if is_plain_name(function, "return") {
+        return true;
+    }
+    if function.kind() != "namespace_operator" {
+        return false;
+    }
+    let Some(lhs) = function.child_by_field_name("lhs") else {
+        return false;
+    };
+    let Some(rhs) = function.child_by_field_name("rhs") else {
+        return false;
+    };
+    is_plain_name(lhs, "base") && is_plain_name(rhs, "return")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2214,7 +2485,7 @@ fn apply_arg_positions(func_node: Node, content: &str) -> Option<(usize, usize)>
 
 /// Return the strings from a strict bare `c()` character vector.
 fn extract_c_strings_strict(node: Node, content: &str) -> Option<Vec<String>> {
-    super::binding::extract_bare_c_plain_strings(node, content)
+    super::binding::extract_bare_c_package_strings(node, content)
         .map(|pairs| pairs.into_iter().map(|(string, _)| string).collect())
 }
 
@@ -5974,6 +6245,155 @@ library(ggplot2)"#;
         assert!(lib_calls[0].function_scope.is_none());
     }
 
+    // ==================== for-loop library detection ====================
+
+    #[test]
+    fn static_for_library_loop_attaches_after_loop() {
+        let code = r#"
+packages <- c("alpha", "beta", NULL)
+for (package in packages) {
+  if (!requireNamespace(package, quietly = TRUE)) {
+    install.packages(package)
+  }
+  library(package, character.only = TRUE)
+}
+"#;
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| call.package.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert!(calls.iter().all(|call| call.attaches));
+        assert!(calls.iter().all(|call| call.line == 7));
+    }
+
+    #[test]
+    fn static_inline_for_require_loop_is_detected() {
+        let code =
+            r#"for (package in c("alpha", NULL, "beta")) require(package, character.only = T)"#;
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| call.package.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn loop_checkpoint_does_not_weaken_post_loop_binding_barrier() {
+        let code = r#"
+packages <- c("alpha")
+for (package in packages) library(package, character.only = TRUE)
+sapply(packages, library, character.only = TRUE)
+packages <- c("beta")
+"#;
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| (call.package.as_str(), call.line))
+                .collect::<Vec<_>>(),
+            [("alpha", 2)]
+        );
+    }
+
+    #[test]
+    fn loop_checkpoint_honors_prior_persistent_unknown_mutation() {
+        let code = r#"
+packages <- c("alpha")
+if (flag) assign(dynamic_name, c("beta"))
+for (package in packages) library(package, character.only = TRUE)
+"#;
+        let tree = parse_r(code);
+        let calls = detect_library_calls(&tree, code);
+        assert!(
+            calls.iter().all(|call| call.package != "alpha"),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn eager_capture_can_checkpoint_named_vector_but_deferred_function_cannot() {
+        let eager = r#"
+packages <- c("alpha")
+bquote(.(for (package in packages) library(package, character.only = TRUE)))
+"#;
+        let eager_calls = detect_library_calls(&parse_r(eager), eager);
+        assert_eq!(
+            eager_calls
+                .iter()
+                .map(|call| call.package.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha"]
+        );
+
+        let deferred = r#"
+packages <- c("alpha")
+f <- function() {
+  for (package in packages) library(package, character.only = TRUE)
+}
+"#;
+        let deferred_calls = detect_library_calls(&parse_r(deferred), deferred);
+        assert!(
+            deferred_calls.iter().all(|call| call.package != "alpha"),
+            "{deferred_calls:?}"
+        );
+    }
+
+    #[test]
+    fn loop_loader_rejects_iterator_writes_and_shadowed_helpers() {
+        for code in [
+            "packages <- c(\"alpha\")\nfor (package in packages) { package <- \"other\"; library(package, character.only = TRUE) }",
+            "packages <- c(\"alpha\")\nfor (package in packages) { assign(\"package\", \"other\"); library(package, character.only = TRUE) }",
+            "packages <- c(\"alpha\")\nfor (package in packages) { rm(package); library(package, character.only = TRUE) }",
+            "packages <- c(\"alpha\")\nlibrary <- function(...) NULL\nfor (package in packages) library(package, character.only = TRUE)",
+            "packages <- c(\"alpha\")\nrequire <- function(...) NULL\nfor (package in packages) require(package, character.only = TRUE)",
+        ] {
+            let calls = detect_library_calls(&parse_r(code), code);
+            assert!(
+                calls.iter().all(|call| call.package != "alpha"),
+                "{code}: {calls:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dynamic_or_nonmandatory_for_loaders_are_skipped() {
+        for code in [
+            "for (package in packages) library(package, character.only = TRUE)",
+            "packages <- c(\"alpha\")\npackages <- get_packages()\nfor (package in packages) library(package, character.only = TRUE)",
+            "packages <- c(\"alpha\")\nassign(target, value)\nfor (package in packages) library(package, character.only = TRUE)",
+            "packages <- c(\"alpha\")\nfor (package in packages) library(other, character.only = TRUE)",
+            "packages <- c(\"alpha\")\nfor (package in packages) library(package)",
+            "packages <- c(\"alpha\")\nfor (package in packages) if (enabled) library(package, character.only = TRUE)",
+            "packages <- c(\"alpha\")\nfor (package in packages) { if (skip) next; library(package, character.only = TRUE) }",
+            "packages <- c(\"alpha\")\nfor (package in packages) { if (stop) break; library(package, character.only = TRUE) }",
+            "packages <- c(\"alpha\", \"beta\")\nfor (package in packages) { library(package, character.only = TRUE); if (stop) break }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); return() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); `return`() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); base::return() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); base:::return() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); \"return\"() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); base::\"return\"() }",
+            "f <- function() for (package in c(\"alpha\", \"beta\")) { library(package, character.only = TRUE); \"base\"::return() }",
+        ] {
+            let tree = parse_r(code);
+            let calls = detect_library_calls(&tree, code);
+            assert!(
+                calls.iter().all(|call| call.package != "alpha"),
+                "loop inference unexpectedly attached alpha for {code}: {calls:?}"
+            );
+        }
+    }
+
     // ==================== apply-family library detection (#172) ====================
 
     #[test]
@@ -6085,7 +6505,7 @@ library(ggplot2)"#;
 
     #[test]
     fn package_vector_bindings_are_collected_only_on_demand() {
-        let code = "x <- 1\nlibrary(dplyr)\nrequire(tidyr)";
+        let code = "packages <- c(\"alpha\")\nfor (x in packages) print(x)\nlibrary(dplyr)\nrequire(tidyr)";
         let tree = parse_r(code);
         let root = tree.root_node();
         let mut bindings = super::super::static_path::LazyStaticBindings::new(root, code);

--- a/crates/raven/src/cross_file/static_path.rs
+++ b/crates/raven/src/cross_file/static_path.rs
@@ -29,6 +29,7 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use tree_sitter::Node;
 
@@ -52,7 +53,7 @@ pub(crate) fn collection_count_for_current_thread() -> usize {
 #[derive(Debug)]
 struct StaticCandidate<'tree> {
     path_rhs: Option<Node<'tree>>,
-    package_vector: Option<Vec<String>>,
+    package_vector: Option<Arc<[String]>>,
 }
 
 /// Single-assignment facts usable by static path and package-vector consumers,
@@ -66,6 +67,9 @@ struct StaticCandidate<'tree> {
 pub(crate) struct StaticBindings<'tree, 'text> {
     content: &'text str,
     bindings: HashMap<String, super::binding::Binding<StaticCandidate<'tree>>>,
+    /// Package-vector values captured immediately before an eager `for`
+    /// installs its conservative unknown-mutation barrier.
+    package_vectors_before_for: HashMap<usize, Arc<[String]>>,
     /// Memoized intrinsic fold of each candidate's RHS, keyed by name.
     ///
     /// Participating literals are retained with the value so callback-enabled
@@ -89,7 +93,8 @@ impl<'tree, 'text> StaticBindings<'tree, 'text> {
         #[cfg(test)]
         COLLECTION_COUNT.with(|count| count.set(count.get() + 1));
 
-        let bindings = super::binding::collect_bindings(root, content, |site| {
+        let mut package_vectors_before_for = HashMap::new();
+        let mut candidate_for = |site| {
             let (path_rhs, package_rhs) = match site {
                 BindingSite::Binary {
                     target,
@@ -108,16 +113,50 @@ impl<'tree, 'text> StaticBindings<'tree, 'text> {
                 } => (None, value),
                 _ => (None, None),
             };
-            let package_vector =
-                package_rhs.and_then(|value| extract_package_vector(value, content));
+            let package_vector = package_rhs
+                .and_then(|value| extract_package_vector(value, content))
+                .map(Arc::from);
             (path_rhs.is_some() || package_vector.is_some()).then_some(StaticCandidate {
                 path_rhs,
                 package_vector,
             })
-        });
+        };
+        let bindings = super::binding::collect_bindings_with_checkpoints(
+            root,
+            content,
+            &mut candidate_for,
+            &mut |loop_node, bindings, generation| {
+                if super::binding::has_pending_persistent_invalidation(bindings) {
+                    return;
+                }
+                let Some(sequence) = loop_node.child_by_field_name("sequence") else {
+                    return;
+                };
+                let Some(name) = super::binding::plain_identifier_name(sequence, content) else {
+                    return;
+                };
+                let Some((candidate, candidate_offset)) = bindings.get(name).and_then(|binding| {
+                    binding.resolved_at_generation_before(loop_node.start_byte(), generation)
+                }) else {
+                    return;
+                };
+                if super::binding::unknown_loaded_names_may_affect_candidate(
+                    bindings,
+                    candidate_offset,
+                    loop_node,
+                    false,
+                ) {
+                    return;
+                }
+                if let Some(packages) = &candidate.package_vector {
+                    package_vectors_before_for.insert(loop_node.id(), packages.clone());
+                }
+            },
+        );
         Self {
             content,
             bindings,
+            package_vectors_before_for,
             memo: RefCell::new(HashMap::new()),
             visiting: RefCell::new(HashSet::new()),
         }
@@ -274,6 +313,24 @@ impl<'tree, 'text> StaticBindings<'tree, 'text> {
         candidate.package_vector.as_deref()
     }
 
+    /// Resolve the sequence vector captured before this exact eager loop's
+    /// mutation barrier. `name` is rechecked against the loop sequence so a
+    /// caller cannot reuse the checkpoint for a different binding.
+    pub(crate) fn resolve_package_vector_before_for(
+        &self,
+        name: &str,
+        loop_node: Node,
+    ) -> Option<&[String]> {
+        let sequence = loop_node.child_by_field_name("sequence")?;
+        (super::binding::plain_identifier_name(sequence, self.content) == Some(name))
+            .then(|| {
+                self.package_vectors_before_for
+                    .get(&loop_node.id())
+                    .map(AsRef::as_ref)
+            })
+            .flatten()
+    }
+
     /// Whether an inline bare `c()` has provable base semantics at `use_node`.
     pub(crate) fn package_c_is_trusted_at(&self, use_node: Node) -> bool {
         let deferred_use = !super::binding::is_known_immediate_context(use_node);
@@ -355,6 +412,16 @@ impl<'tree, 'text> LazyStaticBindings<'tree, 'text> {
             .map(<[String]>::to_vec)
     }
 
+    pub(crate) fn resolve_package_vector_before_for(
+        &mut self,
+        name: &str,
+        loop_node: Node,
+    ) -> Option<Vec<String>> {
+        self.get()
+            .resolve_package_vector_before_for(name, loop_node)
+            .map(<[String]>::to_vec)
+    }
+
     pub(crate) fn package_c_is_trusted_at(&mut self, use_node: Node) -> bool {
         self.get().package_c_is_trusted_at(use_node)
     }
@@ -376,7 +443,7 @@ impl<'tree, 'text> LazyStaticBindings<'tree, 'text> {
 /// package-vector payload. Helper trust is established by the binding-site
 /// policy before this function is called.
 fn extract_package_vector(node: Node, content: &str) -> Option<Vec<String>> {
-    super::binding::extract_bare_c_plain_strings(node, content)
+    super::binding::extract_bare_c_package_strings(node, content)
         .map(|pairs| pairs.into_iter().map(|(package, _)| package).collect())
 }
 

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -672,58 +672,18 @@ pub(crate) fn extract_loaded_packages(tree: &Option<Tree>, text: &str) -> Vec<St
         return Vec::new();
     };
 
-    let mut packages = Vec::new();
-    let mut stack = Vec::new();
-    stack.push(tree.root_node());
-
-    while let Some(node) = stack.pop() {
-        if node.kind() == "call" {
-            // Check if this is a library/require/loadNamespace call
-            if let Some(func_node) = node.child_by_field_name("function") {
-                let func_text = &text[func_node.byte_range()];
-
-                if func_text == "library" || func_text == "require" || func_text == "loadNamespace"
-                {
-                    // Extract the first argument
-                    if let Some(args_node) = node.child_by_field_name("arguments") {
-                        for i in 0..args_node.child_count() {
-                            if let Some(child) = args_node.child(i as u32)
-                                && child.kind() == "argument"
-                                && let Some(value_node) = child.child_by_field_name("value")
-                            {
-                                let value_text = &text[value_node.byte_range()];
-                                let pkg_name =
-                                    value_text.trim_matches(|c: char| c == '"' || c == '\'');
-                                packages.push(pkg_name.to_string());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let child_count = node.child_count();
-        for i in (0..child_count).rev() {
-            if let Some(child) = node.child(i as u32) {
-                stack.push(child);
-            }
-        }
-    }
-    // Add unconditional packages recognized by the canonical detector
-    // (apply/targets/qualified pacman included). `Document.loaded_packages`
+    // Use the canonical detector for direct, apply-family, loop, targets, and
+    // pacman package loads. `Document.loaded_packages`
     // also feeds CLI reporting, so conditional bare `p_load()` targets must
     // stay out until a graph-aware scope query proves their prerequisite.
     // Backend edit-time prefetching deliberately keeps its separate permissive
     // warm set; that path cannot affect semantic or user-visible package state.
-    if text.contains("p_load") {
-        packages.extend(
-            crate::cross_file::source_detect::detect_library_calls(tree, text)
-                .into_iter()
-                .filter(|call| call.requires_attached.is_none())
-                .map(|call| call.package),
-        );
-    }
+    let mut packages: Vec<String> =
+        crate::cross_file::source_detect::detect_library_calls(tree, text)
+            .into_iter()
+            .filter(|call| call.requires_attached.is_none())
+            .map(|call| call.package)
+            .collect();
     packages.sort();
     packages.dedup();
     packages
@@ -14352,6 +14312,22 @@ mod tests {
 
         let qualified = Document::new("pacman::p_load(ggplot2)", None);
         assert_eq!(qualified.loaded_packages, vec!["ggplot2"]);
+    }
+
+    #[test]
+    fn document_loaded_packages_uses_static_loop_packages_not_iterator_name() {
+        let document = Document::new(
+            "packages <- c(\"alpha\", \"beta\", NULL)\n\
+             for (package in packages) library(package, character.only = TRUE)",
+            None,
+        );
+        assert_eq!(document.loaded_packages, ["alpha", "beta"]);
+
+        let dynamic = Document::new(
+            "for (package in packages) library(package, character.only = TRUE)",
+            None,
+        );
+        assert!(dynamic.loaded_packages.is_empty());
     }
 
     #[test]

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -212,6 +212,7 @@ Packages loaded in child files do NOT propagate back to parents (forward-only).
 | `sapply(c("a","b"), library, character.only = TRUE)` | Yes (apply family) |
 | `sapply(libs, library, character.only = TRUE)` where `libs <- c("a","b")` | Yes (same-file variable) |
 | `purrr::map(c("a","b"), library, character.only = TRUE)` | Yes (purrr family) |
+| `for (pkg in libs) library(pkg, character.only = TRUE)` where `libs <- c("a","b")` | Yes (deterministic loader loop) |
 | `sapply(paste0(...), library, character.only = TRUE)` | No (dynamic vector) |
 | `tar_option_set(packages = c("a","b"))` | Yes, when the file also attaches targets (see below) |
 | `targets::tar_option_set(packages = "a")` | Yes (qualified — no `library(targets)` needed) |
@@ -229,7 +230,8 @@ sapply(libs, require, character.only = TRUE)
 
 This works for `sapply`, `lapply`, `vapply`, `mapply`, and the purrr forms
 (`map`, `walk`, `map_chr`, etc., bare or `purrr::`-qualified). The package
-vector must be either an inline non-empty `c("a","b",...)` of string literals,
+vector must be either an inline non-empty `c("a","b",...)` of string literals
+(literal `NULL` entries are allowed and dropped, matching base `c()`),
 or a same-file variable assigned exactly once at the top level to such a vector
 via `<-`/`=` or eligible bare/base-qualified `assign()`. For `assign()`, Raven
 accepts only destinations proven to create the file's top-level binding: the
@@ -246,6 +248,31 @@ not load the strings as packages). Empty vectors (`c()`, `character(0)`),
 dynamic constructions such as `paste0(...)`, `tolower(x)`, or
 `c(libs1, libs2)`, function-parameter origins, and values defined in another
 file are silently ignored.
+
+### Deterministic Package-Loader Loops
+
+Raven recognizes the common explicit-loop equivalent when the package vector
+meets the same static rules:
+
+```r
+packages <- c("dplyr", "ggplot2", NULL)
+for (package in packages) {
+  if (!requireNamespace(package, quietly = TRUE)) install.packages(package)
+  library(package, character.only = TRUE)
+}
+source("analysis.R")
+```
+
+The `library()` or `require()` call must be an unconditional top-level
+statement in the loop body, must load the loop iterator, and must set
+`character.only = TRUE`. Raven records the attachments only after the loop
+finishes, so they propagate into later sourced files without appearing inside
+the loop itself. Dynamic vectors, vectors reassigned before the loop,
+conditional loaders, a different package expression, iterator writes/removals
+before the loader, locally shadowed `library`/`require` helpers, and loops that
+may `break` or `return()` before loading every package are ignored. A named
+vector is resolved only for a loop known to execute eagerly in the file; a
+deferred function-body loop can still use an inline `c("a", "b")` sequence.
 
 ### targets::tar_option_set() Loads
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -489,7 +489,7 @@ Key files under `crates/raven/src/cross_file/`:
 - `path_resolve.rs` — Path resolution (forward vs backward invariant)
 - `revalidation.rs` — Real-time updates, diagnostics gating, debounce
 - `source_detect.rs` — AST-based detection of `source()`, `sys.source()`, and related calls
-- `binding.rs` — Shared conservative binding-count and `assign()` argument-matching walk used by static path and package-vector inference. Its bounded bare-helper policy recognizes exact local shadowing rather than attempting runtime search-path resolution; the `readLines` direct-effect classification uses a whole-document precheck so later or nested recognized bindings cannot make results traversal-order-dependent
+- `binding.rs` — Shared conservative binding-count and `assign()` argument-matching walk used by static path and package-vector inference. Its bounded bare-helper policy recognizes exact local shadowing rather than attempting runtime search-path resolution; the `readLines` direct-effect classification uses a whole-document precheck so later or nested recognized bindings cannot make results traversal-order-dependent. Eager `for` nodes expose a pre-effect checkpoint before installing their unknown-mutation barrier, allowing deterministic loop consumers to snapshot an immutable shared package vector while every post-loop query still sees the barrier; pending persistent invalidations suppress the checkpoint
 - `static_path.rs` — Strict folding of computed `source()` path expressions
 - `directive.rs` — Parsing of `# raven:` / `@lsp-` directive comments
 - `types.rs` — Shared types (`CrossFileMetadata`, `SymbolKind`, etc.)


### PR DESCRIPTION
## Summary

- recognize deterministic for loops that attach literal package vectors through library() or require()
- share canonical package-load detection across diagnostics, CLI package collection, and package-state extraction
- preserve eager binding checkpoints and fail closed on control flow, helper shadowing, iterator mutation, or dynamic vectors
- document the supported pattern and architecture

## Regression coverage

All fixtures are synthetic and repository-independent. Tests cover inline and eager named vectors, trailing NULL, source-child propagation, require(), conditional and dynamic rejection, loop control flow, iterator mutation, loader shadowing, deferred function bodies, CLI package collection, and package-state extraction.

## External A/B

Against the reported checkout, exact current main produced 253 undefined-symbol diagnostics plus 2 unresolved-source diagnostics. This patch produced 150 plus the same 2 unresolved-source diagnostics: 103 false positives removed and 0 diagnostics added. The bogus iterator-package footer was also removed.

## Performance

Local Criterion comparison for artifact_compute/representative_400loc: main median 4.7321 ms; patched median 4.7752 ms (about +0.9%).

## Validation

- two complete cargo test --workspace --all-targets --features test-support runs
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --features test-support -- -D warnings
- rustdoc with warnings denied, default and test-support configurations
- git diff --check
- two independent agent reviews, including iterative regression/new-bug review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for deterministically statically-resolved `for` loops that load packages via `library()`/`require()` patterns.
  * Improved recognition of statically defined package vectors, including `c(...)` vectors containing `NULL`.

* **Bug Fixes**
  * Fixed package visibility so packages loaded inside supported `for` loops only appear after the loop completes.
  * Refined `requireNamespace()` package extraction to avoid promoting unrelated string arguments.

* **Tests**
  * Added/extended unit tests covering loop attachment, projection consistency, and safe package-vector parsing.

* **Documentation**
  * Documented deterministic package-loader loops and updated static package-vector rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->