### PR TITLE
Suppress undefined cascades for packages outside active renv

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6374,6 +6374,26 @@ fn package_available_outside_active_renv(snapshot: &DiagnosticsSnapshot, package
             .package_available_outside_active_renv(package)
 }
 
+/// Whether a true search-path attachment supplies `name` from an installation
+/// hidden by this workspace's active renv library.
+///
+/// This is intentionally narrower than ordinary package resolution: the
+/// single-workspace gate matches the actionable environment diagnostic, and
+/// callers pass `ScopeAtPosition::attached_packages` so `loadNamespace()` and
+/// NAMESPACE imports cannot acquire bare-name attachment semantics.
+fn attached_outside_active_renv_exports(
+    snapshot: &DiagnosticsSnapshot,
+    name: &str,
+    attached_packages: &HashSet<String>,
+) -> bool {
+    snapshot.workspace_folders.len() == 1
+        && attached_packages.iter().any(|package| {
+            snapshot
+                .package_library
+                .outside_active_renv_has_explicit_export(package, name)
+        })
+}
+
 /// Emit `namespace-member-not-found` for `pkg::member` references whose package
 /// has a *complete* export set that does not contain `member`. Exports-
 /// authoritative: a `Partial`/`Unknown` set (or a never-warmed package) stays
@@ -6973,6 +6993,9 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
                     .cloned()
                     .collect();
                 if !pkgs.is_empty() && is_package_export(name, &pkgs, &snapshot.package_library) {
+                    break;
+                }
+                if attached_outside_active_renv_exports(snapshot, name, &scope.attached_packages) {
                     break;
                 }
             }
@@ -7936,6 +7959,9 @@ fn collect_undefined_variables_from_snapshot(
                 &position_aware_packages_buf,
                 &snapshot.package_library,
             ) {
+                continue;
+            }
+            if attached_outside_active_renv_exports(snapshot, &name, &scope.attached_packages) {
                 continue;
             }
 
@@ -54630,6 +54656,168 @@ pacman::p_load(__qualified_missing_package__)";
         }));
     }
 
+    fn outside_active_export_diagnostics(
+        code: &str,
+        workspace_folders: Vec<Url>,
+        exports: std::collections::HashSet<String>,
+    ) -> Vec<Diagnostic> {
+        let main_url = Url::parse("file:///synthetic-project/main.R").unwrap();
+        let mut state = WorldState::new();
+        state.workspace_folders = workspace_folders;
+        state.workspace_scan_complete = true;
+        state.package_library_ready = true;
+        state.cross_file_config.packages_report_generic_uninstalled = false;
+        let mut package_library = crate::package_library::PackageLibrary::new_empty();
+        package_library.set_lib_paths(vec![std::path::PathBuf::from(
+            "/nonexistent-active-library",
+        )]);
+        package_library.set_renv_outside_active_exports_for_test(
+            std::path::PathBuf::from("/synthetic-project"),
+            "plotpkg".to_string(),
+            exports,
+        );
+        state.package_library = std::sync::Arc::new(package_library);
+        state
+            .documents
+            .insert(main_url.clone(), Document::new(code, None));
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_url).expect("snapshot built for main.R");
+        diagnostics_from_snapshot(&snapshot, &main_url, &DiagCancelToken::never())
+            .expect("diagnostics completed")
+    }
+
+    #[test]
+    fn renv_outside_active_exports_suppress_only_attached_cascades() {
+        let diagnostics = outside_active_export_diagnostics(
+            "known_plot()\nlibrary(plotpkg)\nknown_plot()\nunknown_plot()\n\
+             plotpkg::known_plot\nplotpkg::unknown_member\n",
+            vec![Url::parse("file:///synthetic-project").unwrap()],
+            std::collections::HashSet::from(["known_plot".to_string()]),
+        );
+
+        let outside: Vec<_> = diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                crate::diagnostic_code::diagnostic_has_code(
+                    &diagnostic.code,
+                    crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY,
+                )
+            })
+            .collect();
+        assert_eq!(
+            outside.len(),
+            1,
+            "one actionable root diagnostic: {diagnostics:?}"
+        );
+
+        let known_undefined: Vec<_> = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.message == "known_plot is not defined")
+            .collect();
+        assert_eq!(
+            known_undefined.len(),
+            1,
+            "only the use before library() remains undefined: {diagnostics:?}"
+        );
+        assert_eq!(known_undefined[0].range.start.line, 0);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message == "unknown_plot is not defined")
+        );
+        assert!(diagnostics.iter().all(|diagnostic| {
+            !crate::diagnostic_code::diagnostic_has_code(
+                &diagnostic.code,
+                crate::diagnostic_code::NAMESPACE_MEMBER_NOT_FOUND,
+            )
+        }));
+
+        let require_diagnostics = outside_active_export_diagnostics(
+            "require(plotpkg)\nknown_plot()\n",
+            vec![Url::parse("file:///synthetic-project").unwrap()],
+            std::collections::HashSet::from(["known_plot".to_string()]),
+        );
+        assert!(
+            require_diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message != "known_plot is not defined")
+        );
+    }
+
+    #[test]
+    fn renv_outside_active_exports_do_not_attach_load_namespace_or_multi_root() {
+        let single_root = outside_active_export_diagnostics(
+            "loadNamespace(plotpkg)\nknown_plot()\n",
+            vec![Url::parse("file:///synthetic-project").unwrap()],
+            std::collections::HashSet::from(["known_plot".to_string()]),
+        );
+        assert!(
+            single_root
+                .iter()
+                .any(|diagnostic| diagnostic.message == "known_plot is not defined")
+        );
+
+        let multi_root = outside_active_export_diagnostics(
+            "library(plotpkg)\nknown_plot()\n",
+            vec![
+                Url::parse("file:///synthetic-project").unwrap(),
+                Url::parse("file:///synthetic-project/nested").unwrap(),
+            ],
+            std::collections::HashSet::from(["known_plot".to_string()]),
+        );
+        assert!(
+            multi_root
+                .iter()
+                .any(|diagnostic| diagnostic.message == "known_plot is not defined")
+        );
+        assert!(multi_root.iter().all(|diagnostic| {
+            !crate::diagnostic_code::diagnostic_has_code(
+                &diagnostic.code,
+                crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY,
+            )
+        }));
+    }
+
+    #[test]
+    fn renv_outside_active_s3_registration_is_not_attachment_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let namespace = temp.path().join("NAMESPACE");
+        std::fs::write(
+            &namespace,
+            "export(plain_fn)\nexportMethods(s4_method)\n\
+             exportClasses(S4Class)\nS3method(print, plotpkg)\n",
+        )
+        .unwrap();
+        let exports = crate::namespace_parser::parse_namespace_attachment_visible_explicit_exports(
+            &namespace,
+        )
+        .into_iter()
+        .collect();
+
+        let diagnostics = outside_active_export_diagnostics(
+            "library(plotpkg)\nplain_fn()\ns4_method()\nS4Class()\nprint.plotpkg()\n",
+            vec![Url::parse("file:///synthetic-project").unwrap()],
+            exports,
+        );
+
+        for attached_export in ["plain_fn", "s4_method", "S4Class"] {
+            assert!(
+                diagnostics
+                    .iter()
+                    .all(|diagnostic| diagnostic.message
+                        != format!("{attached_export} is not defined")),
+                "true explicit export should suppress its cascade: {diagnostics:?}"
+            );
+        }
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message == "print.plotpkg is not defined"),
+            "an S3 registration alone must not suppress a bare-name diagnostic: {diagnostics:?}"
+        );
+    }
+
     #[test]
     fn renv_outside_active_package_fails_closed_in_multi_root_session() {
         let code = "library(plotpkg)\n";
@@ -60176,6 +60364,64 @@ source(\"helpers.R\")
                 .iter()
                 .map(|d| (d.message.clone(), d.range))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Outside-active export evidence must also suppress the out-of-scope
+    /// collector's alternate `undefined-variable` cascade when a later source
+    /// happens to export the same attached name.
+    #[test]
+    fn outside_active_attached_export_is_not_misattributed_to_later_source() {
+        let mut state = create_test_state();
+        state.workspace_folders = vec![Url::parse("file:///synthetic-project").unwrap()];
+        state.workspace_scan_complete = true;
+        state.package_library_ready = true;
+        state.cross_file_config.out_of_scope_severity = Some(DiagnosticSeverity::WARNING);
+        state.cross_file_config.undefined_variable_severity = Some(DiagnosticSeverity::WARNING);
+        let mut package_library = crate::package_library::PackageLibrary::new_empty();
+        package_library.set_lib_paths(vec![std::path::PathBuf::from(
+            "/nonexistent-active-library",
+        )]);
+        package_library.set_renv_outside_active_exports_for_test(
+            std::path::PathBuf::from("/synthetic-project"),
+            "plotpkg".to_string(),
+            std::collections::HashSet::from(["known_plot".to_string()]),
+        );
+        state.package_library = std::sync::Arc::new(package_library);
+
+        let main_uri = Url::parse("file:///synthetic-project/main.R").unwrap();
+        let helper_uri = Url::parse("file:///synthetic-project/helper.R").unwrap();
+        let main_code = "library(plotpkg)\nknown_plot()\nsource(\"helper.R\")\n";
+        let helper_code = "known_plot <- function() NULL\n";
+        for (uri, code) in [(&main_uri, main_code), (&helper_uri, helper_code)] {
+            state
+                .documents
+                .insert(uri.clone(), Document::new(code, None));
+            state.cross_file_graph.update_file(
+                uri,
+                &crate::cross_file::extract_metadata(code),
+                Some(&state.workspace_folders[0]),
+                |_| None,
+            );
+        }
+
+        let snapshot =
+            DiagnosticsSnapshot::build(&state, &main_uri).expect("snapshot built for main.R");
+        let diagnostics =
+            diagnostics_from_snapshot(&snapshot, &main_uri, &DiagCancelToken::never())
+                .expect("diagnostics completed");
+        assert!(
+            diagnostics.iter().all(|diagnostic| {
+                !diagnostic
+                    .message
+                    .contains("'known_plot' is used before it's available")
+            }),
+            "outside-attached known export must not be blamed on the later source: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| { diagnostic.message != "known_plot is not defined" })
         );
     }
 

--- a/crates/raven/src/namespace_parser.rs
+++ b/crates/raven/src/namespace_parser.rs
@@ -78,6 +78,40 @@ pub fn parse_namespace_explicit_exports(namespace_path: &Path) -> (Vec<String>, 
     }
 }
 
+/// Extract explicit names that a successful package attachment places on the
+/// search path.
+///
+/// Unlike [`parse_namespace_explicit_exports`], this diagnostic-only view does
+/// not include `S3method(...)` registrations: registering a method does not by
+/// itself export or attach the method binding. Pattern exports are also omitted
+/// because this static parser cannot expand them. Missing or unreadable files
+/// therefore fail closed to no positive evidence.
+pub(crate) fn parse_namespace_attachment_visible_explicit_exports(
+    namespace_path: &Path,
+) -> Vec<String> {
+    let Ok(content) = fs::read_to_string(namespace_path) else {
+        return Vec::new();
+    };
+    let normalized = normalize_multiline_directives(&content);
+    let mut exports = Vec::new();
+
+    for line in normalized.lines().map(str::trim) {
+        let args = extract_directive_args(line, "export")
+            .or_else(|| extract_directive_args(line, "exportClasses"))
+            .or_else(|| extract_directive_args(line, "exportMethods"));
+        let Some(args) = args else {
+            continue;
+        };
+        exports.extend(
+            parse_comma_separated_args(&args)
+                .into_iter()
+                .filter(|name| !name.is_empty()),
+        );
+    }
+
+    exports
+}
+
 /// Parse NAMESPACE file content to extract exported symbols and pattern markers.
 ///
 /// This function scans normalized NAMESPACE directives and collects:

--- a/crates/raven/src/package_library.rs
+++ b/crates/raven/src/package_library.rs
@@ -148,8 +148,8 @@ fn is_readable_file(path: &Path) -> bool {
 /// `DESCRIPTION` whose `Package:` field exactly agrees with the directory
 /// name. Lock/staging directories, symlinks, invalid names, and malformed
 /// metadata fail closed.
-fn validated_package_names(lib_paths: &[PathBuf]) -> HashSet<String> {
-    let mut names = HashSet::new();
+fn validated_package_directories(lib_paths: &[PathBuf]) -> HashMap<String, PathBuf> {
+    let mut packages = HashMap::new();
     for lib_path in lib_paths {
         let Ok(entries) = std::fs::read_dir(lib_path) else {
             continue;
@@ -185,26 +185,53 @@ fn validated_package_names(lib_paths: &[PathBuf]) -> HashSet<String> {
                 continue;
             };
             if declared.trim() == name {
-                names.insert(name);
+                // Match `.libPaths()` lookup precedence when duplicate package
+                // names exist across vanilla libraries.
+                packages.entry(name).or_insert_with(|| entry.path());
             }
         }
     }
-    names
+    packages
+}
+
+fn validated_package_names(lib_paths: &[PathBuf]) -> HashSet<String> {
+    validated_package_directories(lib_paths)
+        .into_keys()
+        .collect()
 }
 
 fn build_renv_outside_active_overlay(
     transition: crate::r_subprocess::RenvLibraryPathTransition,
     active_paths: &[PathBuf],
 ) -> Option<RenvOutsideActiveOverlay> {
-    let mut package_names = validated_package_names(&transition.outside_paths);
+    let outside_packages = validated_package_directories(&transition.outside_paths);
+    let mut package_names: HashSet<String> = outside_packages.keys().cloned().collect();
     let active_names = validated_package_names(active_paths);
     let base_names: HashSet<_> = crate::r_subprocess::get_base_priority_packages()
         .into_iter()
         .collect();
     package_names.retain(|name| !active_names.contains(name) && !base_names.contains(name));
+    let mut explicit_exports = HashMap::new();
+    for name in &package_names {
+        // Preserve `.libPaths()` precedence: the first validated installation
+        // supplies positive export evidence. Pattern exports deliberately stay
+        // unexpanded; the explicit subset remains safe to use for suppression.
+        let exports = outside_packages
+            .get(name)
+            .map(|dir| {
+                crate::namespace_parser::parse_namespace_attachment_visible_explicit_exports(
+                    &dir.join("NAMESPACE"),
+                )
+                .into_iter()
+                .collect()
+            })
+            .unwrap_or_default();
+        explicit_exports.insert(name.clone(), exports);
+    }
     (!package_names.is_empty()).then_some(RenvOutsideActiveOverlay {
         _project_root: transition.project_root,
         package_names,
+        explicit_exports,
     })
 }
 
@@ -458,14 +485,21 @@ enum CachedCompletionEntry {
     },
 }
 
-/// Names visible in vanilla R but removed by this workspace's active renv
-/// library. Paths are deliberately discarded after construction so this
+/// Packages visible in vanilla R but removed by this workspace's active renv
+/// library, with positive-only explicit export evidence for cascade
+/// suppression. Paths are deliberately discarded after construction so this
 /// diagnostic overlay cannot affect package resolution or metadata routing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RenvOutsideActiveOverlay {
     /// Retained as lifecycle identity for the workspace-specific discovery.
     _project_root: PathBuf,
     package_names: HashSet<String>,
+    /// Explicit exports captured from each validated outside installation.
+    ///
+    /// This is positive-only diagnostic evidence. It is deliberately kept out
+    /// of the ordinary package caches so an unavailable package cannot feed
+    /// completion, namespace resolution, `system.file()`, or runtime routing.
+    explicit_exports: HashMap<String, HashSet<String>>,
 }
 
 /// Package library manager
@@ -524,8 +558,9 @@ pub struct PackageLibrary {
     /// Consulted by the three resolution chokepoints before the installed caches.
     /// Refreshed by the shared derived-package installer.
     local_dev_overlay: ArcSwap<Option<Arc<LocalDevPackage>>>,
-    /// Diagnostic-only names removed from `.libPaths()` by a successfully
-    /// activated renv project. Never consulted by package resolution.
+    /// Diagnostic-only package and attachment-visible export evidence removed
+    /// from `.libPaths()` by a successfully activated renv project. Never
+    /// consulted by package resolution.
     renv_outside_active_overlay: Option<Arc<RenvOutsideActiveOverlay>>,
     /// Operation-level ownership for cache mutations.
     ///
@@ -1834,9 +1869,14 @@ impl PackageLibrary {
         let Some(overlay) = self.renv_outside_active_overlay.as_mut() else {
             return;
         };
-        Arc::make_mut(overlay)
+        let overlay = Arc::make_mut(overlay);
+        overlay
             .package_names
             .retain(|name| !active_names.contains(name) && !base_packages.contains(name));
+        let retained_names = &overlay.package_names;
+        overlay
+            .explicit_exports
+            .retain(|name, _| retained_names.contains(name));
         if overlay.package_names.is_empty() {
             self.renv_outside_active_overlay = None;
         }
@@ -2742,14 +2782,34 @@ impl PackageLibrary {
     /// a vanilla library path removed by this workspace's renv activation.
     ///
     /// Active availability always wins, including after configured library
-    /// paths are added. The overlay contains names only and cannot participate
-    /// in export lookup, completion, package loading, or filesystem watching.
+    /// paths are added. The overlay's package names and diagnostic-only export
+    /// evidence cannot participate in ordinary export lookup, completion,
+    /// package loading, or filesystem watching.
     pub(crate) fn package_available_outside_active_renv(&self, name: &str) -> bool {
         !self.package_exists(name)
             && self
                 .renv_outside_active_overlay
                 .as_ref()
                 .is_some_and(|overlay| overlay.package_names.contains(name))
+    }
+
+    /// Whether a package unavailable in the active renv library explicitly
+    /// exports `symbol` from a validated outside installation.
+    ///
+    /// This query is diagnostic-only. Keeping it separate from the ordinary
+    /// caches and export APIs prevents outside installations from contributing
+    /// completion, namespace resolution, or runtime/path-sensitive behavior.
+    pub(crate) fn outside_active_renv_has_explicit_export(
+        &self,
+        package: &str,
+        symbol: &str,
+    ) -> bool {
+        self.package_available_outside_active_renv(package)
+            && self
+                .renv_outside_active_overlay
+                .as_ref()
+                .and_then(|overlay| overlay.explicit_exports.get(package))
+                .is_some_and(|exports| exports.contains(symbol))
     }
 
     #[cfg(test)]
@@ -2761,6 +2821,21 @@ impl PackageLibrary {
         self.renv_outside_active_overlay = Some(Arc::new(RenvOutsideActiveOverlay {
             _project_root: project_root,
             package_names,
+            explicit_exports: HashMap::new(),
+        }));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_renv_outside_active_exports_for_test(
+        &mut self,
+        project_root: PathBuf,
+        package: String,
+        exports: HashSet<String>,
+    ) {
+        self.renv_outside_active_overlay = Some(Arc::new(RenvOutsideActiveOverlay {
+            _project_root: project_root,
+            package_names: HashSet::from([package.clone()]),
+            explicit_exports: HashMap::from([(package, exports)]),
         }));
     }
 
@@ -3711,6 +3786,11 @@ mod tests {
             std::fs::create_dir(path).unwrap();
         }
         write_synthetic_package(&outside, "plotpkg", "plotpkg");
+        std::fs::write(
+            outside.join("plotpkg").join("NAMESPACE"),
+            "export(known_plot)\nexportPattern(\"^generated_\")\n",
+        )
+        .unwrap();
         write_synthetic_package(&outside, "sharedpkg", "sharedpkg");
         write_synthetic_package(&outside, "misleading", "differentpkg");
         write_synthetic_package(&outside, "00LOCK-stagedpkg", "stagedpkg");
@@ -3729,6 +3809,13 @@ mod tests {
         assert_eq!(
             overlay.package_names,
             HashSet::from(["plotpkg".to_string()])
+        );
+        assert_eq!(
+            overlay.explicit_exports,
+            HashMap::from([(
+                "plotpkg".to_string(),
+                HashSet::from(["known_plot".to_string()]),
+            )])
         );
     }
 
@@ -3751,6 +3838,41 @@ mod tests {
         library.add_library_paths(&[active]);
         assert!(library.package_exists("plotpkg"));
         assert!(!library.package_available_outside_active_renv("plotpkg"));
+    }
+
+    #[test]
+    fn outside_active_exports_are_diagnostic_only_and_pruned_with_availability() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let active = temp.path().join("active");
+        let initial_active = temp.path().join("initial-active");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&active).unwrap();
+        std::fs::create_dir(&initial_active).unwrap();
+
+        let mut library = PackageLibrary::new_empty();
+        library.set_lib_paths(vec![initial_active]);
+        library.set_renv_outside_active_exports_for_test(
+            project,
+            "plotpkg".to_string(),
+            HashSet::from(["known_plot".to_string()]),
+        );
+
+        assert!(library.outside_active_renv_has_explicit_export("plotpkg", "known_plot"));
+        assert!(!library.outside_active_renv_has_explicit_export("plotpkg", "unknown_plot"));
+        assert!(!library.package_exists("plotpkg"));
+        assert_eq!(library.find_package_directory("plotpkg"), None);
+        assert_eq!(library.get_exports_sync("plotpkg"), None);
+        assert!(
+            library
+                .get_owned_exports_for_completions(&["plotpkg".to_string()])
+                .is_empty()
+        );
+        assert!(!library.is_symbol_from_loaded_packages("known_plot", &["plotpkg".to_string()]));
+
+        write_synthetic_package(&active, "plotpkg", "plotpkg");
+        library.add_library_paths(&[active]);
+        assert!(!library.outside_active_renv_has_explicit_export("plotpkg", "known_plot"));
     }
 
     fn provider_load_key_for_test(name: &str) -> ProviderLoadKey {

--- a/docs/development.md
+++ b/docs/development.md
@@ -766,15 +766,17 @@ output, missing paths, or a project mismatch fail closed to no renv evidence;
 the ordinary active-path/fallback contract remains unchanged.
 
 The pre-activation paths never enter `PackageLibrary.lib_paths`. They are
-reduced immediately to conservative package-name evidence: a real package
-directory with a readable regular `DESCRIPTION` whose `Package:` field agrees
-with its valid directory name. Names present in the active paths, configured
-additional paths, or the base-priority set are removed. The surviving
-names-only `renv_outside_active_overlay` drives only the
-`package-outside-active-library` diagnostic. It must never feed export lookup,
-completion, `package_exists()`, `system.file()`, watchers, enumeration, or
-freeze/build commands. Library forks retain it, full rebuilds recompute it, and
-`clear_cache` leaves it intact; adding an active library path prunes it
+reduced immediately to conservative package evidence: a real package directory
+with a readable regular `DESCRIPTION` whose `Package:` field agrees with its
+valid directory name, plus its explicitly declared `NAMESPACE` exports. Names
+present in the active paths, configured additional paths, or the base-priority
+set are removed. The surviving `renv_outside_active_overlay` drives the
+`package-outside-active-library` diagnostic and supplies positive-only export
+evidence solely to the undefined-variable collectors after a true search-path
+attachment. It must never feed ordinary export lookup, completion,
+`package_exists()`, `system.file()`, watchers, enumeration, or freeze/build
+commands. Library forks retain it, full rebuilds recompute it, and `clear_cache`
+leaves it intact; adding an active library path prunes its names and exports
 immediately. Outside-library filesystem changes intentionally require an
 explicit package refresh. Diagnostic collection consults the overlay only when
 the snapshot has exactly one workspace folder; multi-root routing activates the

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -204,11 +204,14 @@ exists only in a path removed by activation, Raven reports
 `package-outside-active-library` and suggests restoring or installing it into
 the project library. Raven reports this project-level setup problem at most once
 per package per document, even when that document contains many qualified
-references. This names-only evidence never makes the package available for
-exports, completion, `system.file()`, or package loading. Packages installed
-after startup are recognized when the library is rebuilt (for example with
-`raven.refreshPackages`); changes made only in an outside vanilla library are
-picked up by the next refresh rather than watched continuously. Suppressing
+references. Raven may use explicitly declared exports from that outside
+installation only to suppress undefined-variable cascades after a true
+`library()` / `require()` attachment. This diagnostic-only evidence never makes
+the package available for completion, `system.file()`, or package loading.
+Packages installed after startup are recognized when the library is rebuilt
+(for example with `raven.refreshPackages`); changes made only in an outside
+vanilla library are picked up by the next refresh rather than watched
+continuously. Suppressing
 `package-not-installed` also suppresses this child code. Multi-root editor
 sessions fail closed to no subtype because package routing has no unambiguous
 single-project renv identity there.


### PR DESCRIPTION
## Summary

- Retain positive-only explicit NAMESPACE exports in the existing diagnostic-only outside-renv overlay.
- Suppress bare undefined-variable cascades only after a true position-aware `library()` / `require()` attachment and only in the existing single-workspace case.
- Keep outside installations unavailable to normal package caches, completion, namespace resolution, loading, `system.file()`, and filesystem routing.
- Preserve genuine unknowns, pre-attachment uses, `loadNamespace()` semantics, multi-root fail-closed behavior, and S3-registration-only names.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- Both required rustdoc configurations
- Two full `cargo test --workspace --all-targets --features test-support` runs
- Independent nested cause and final regression/new-bug review
- Generated end-to-end A/B fixtures with zero-package control and 500 outside packages
- Measured overhead approximately 18–28 µs per outside package (9–14 ms at deliberately large N=500); no performance blocker

Closes #692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false undefined-variable diagnostics after packages are attached from outside the active environment.
  * Prevented export evidence from incorrectly affecting namespace loading, multi-root sessions, S3 registrations, or later source files.
  * Ensured only explicitly declared package exports suppress relevant diagnostics.

* **Documentation**
  * Clarified how outside-library package evidence affects diagnostics, refresh behavior, and package availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->