### PR TITLE
Add Haven col_select NSE policies

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -65693,6 +65693,59 @@ my_func <- function(a = default_value) {
         );
     }
 
+    /// Issue #689: attaching Haven makes its reader policies available to bare
+    /// calls. `col_select` is tidy-selected, but the file and row controls are
+    /// ordinary evaluated arguments and must continue to report typos.
+    #[test]
+    fn nse_haven_attached_reader_captures_bare_col_select_only_end_to_end() {
+        let messages = collect_undefined_messages(
+            "library(haven)\nread_dta(typo_path, col_select = mpg, skip = typo_skip)",
+        );
+        assert!(
+            !messages.iter().any(|m| m.contains("mpg is not defined")),
+            "bare selected column should be suppressed; got {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("typo_path is not defined")),
+            "evaluated file argument should be checked; got {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("typo_skip is not defined")),
+            "evaluated skip argument should be checked; got {messages:?}"
+        );
+    }
+
+    /// Issue #689: a qualified Haven reader receives the same per-formal
+    /// policy without an attachment. The tidyselect helper supplied inside
+    /// `col_select` is part of that captured expression, while evaluated
+    /// arguments remain visible to the collector.
+    #[test]
+    fn nse_haven_qualified_reader_captures_all_of_col_select_only_end_to_end() {
+        let messages = collect_undefined_messages(
+            "vars <- \"mpg\"\nhaven::read_sas(typo_path, col_select = all_of(vars), skip = typo_skip)",
+        );
+        assert!(
+            !messages.iter().any(|m| m.contains("all_of is not defined")),
+            "tidyselect helper should be suppressed in col_select; got {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("typo_path is not defined")),
+            "evaluated data_file argument should be checked; got {messages:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("typo_skip is not defined")),
+            "evaluated skip argument should be checked; got {messages:?}"
+        );
+    }
+
     #[test]
     fn nse_targets_make_suppresses_only_target_name_selectors_end_to_end() {
         for code in [

--- a/crates/raven/src/nse.rs
+++ b/crates/raven/src/nse.rs
@@ -34,12 +34,12 @@
 //! data-masking and tidy-select verbs, `tibble`/`targets` constructors and
 //! target-name helpers, `gt`/`gtsummary` table-column selectors, `recipes`
 //! step/role column captures, ggplot2 mapping helpers (`aes`/`vars`/`qplot`),
-//! `tidytext`/`modelr`/`drake` column- and target-name captures, rlang capture
-//! helpers, the plyr `.()` quoting helper and `*ply` split-apply verbs (whose
-//! `...` are suppressed only when `.fun` is a data-masking verb — see
-//! `is_plyr_split_apply_verb` and the call-site upgrade in `handlers.rs`), and a
-//! few established DSLs); it is intentionally extensible rather
-//! than exhaustive. A handful of large, uniform export families
+//! Haven reader `col_select` arguments, `tidytext`/`modelr`/`drake` column- and
+//! target-name captures, rlang capture helpers, the plyr `.()` quoting helper
+//! and `*ply` split-apply verbs (whose `...` are suppressed only when `.fun` is
+//! a data-masking verb — see `is_plyr_split_apply_verb` and the call-site
+//! upgrade in `handlers.rs`), and a few established DSLs); it is intentionally
+//! extensible rather than exhaustive. A handful of large, uniform export families
 //! (`recipes::step_*`, `gt::fmt_*`/`sub_*`/`cells_*`) are matched by name
 //! prefix rather than enumerated, since every member shares one empirically
 //! verified contract.
@@ -306,6 +306,70 @@ pub(crate) fn package_policy(package: &str, name: &str) -> Option<ArgPolicy> {
         "data.table" => match name {
             // Column-name NSE; the `v`-suffixed variants take character vectors.
             "setkey" | "setorder" | "setindex" => ArgPolicy::per_formal(&["x", "..."], &[], true),
+            _ => return None,
+        },
+        "haven" => match name {
+            // Haven 2.5.5 evaluates only `col_select` through tidyselect. Keep
+            // the complete exported signatures here so positional calls bind
+            // that one captured formal while file paths, row controls, and
+            // name-repair expressions remain checked.
+            "read_dta" | "read_stata" => ArgPolicy::per_formal(
+                &[
+                    "file",
+                    "encoding",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &["col_select"],
+                false,
+            ),
+            "read_sav" => ArgPolicy::per_formal(
+                &[
+                    "file",
+                    "encoding",
+                    "user_na",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &["col_select"],
+                false,
+            ),
+            "read_spss" | "read_por" => ArgPolicy::per_formal(
+                &[
+                    "file",
+                    "user_na",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &["col_select"],
+                false,
+            ),
+            "read_sas" => ArgPolicy::per_formal(
+                &[
+                    "data_file",
+                    "catalog_file",
+                    "encoding",
+                    "catalog_encoding",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    "cols_only",
+                    ".name_repair",
+                ],
+                &["col_select"],
+                false,
+            ),
+            "read_xpt" => ArgPolicy::per_formal(
+                &["file", "col_select", "skip", "n_max", ".name_repair"],
+                &["col_select"],
+                false,
+            ),
             _ => return None,
         },
         "pacman" => match name {
@@ -1744,6 +1808,109 @@ mod tests {
         let p = package_policy("drake", "readd").unwrap();
         let mask = suppressed_arguments(&p, &labels(&[None, Some("character_only")]), false);
         assert_eq!(mask, vec![true, false]);
+    }
+
+    #[test]
+    fn haven_reader_signatures_capture_only_col_select() {
+        let cases: &[(&str, &[&str], &[bool])] = &[
+            (
+                "read_dta",
+                &[
+                    "file",
+                    "encoding",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &[false, false, true, false, false, false],
+            ),
+            (
+                "read_stata",
+                &[
+                    "file",
+                    "encoding",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &[false, false, true, false, false, false],
+            ),
+            (
+                "read_sav",
+                &[
+                    "file",
+                    "encoding",
+                    "user_na",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &[false, false, false, true, false, false, false],
+            ),
+            (
+                "read_spss",
+                &[
+                    "file",
+                    "user_na",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &[false, false, true, false, false, false],
+            ),
+            (
+                "read_por",
+                &[
+                    "file",
+                    "user_na",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    ".name_repair",
+                ],
+                &[false, false, true, false, false, false],
+            ),
+            (
+                "read_sas",
+                &[
+                    "data_file",
+                    "catalog_file",
+                    "encoding",
+                    "catalog_encoding",
+                    "col_select",
+                    "skip",
+                    "n_max",
+                    "cols_only",
+                    ".name_repair",
+                ],
+                &[false, false, false, false, true, false, false, false, false],
+            ),
+            (
+                "read_xpt",
+                &["file", "col_select", "skip", "n_max", ".name_repair"],
+                &[false, true, false, false, false],
+            ),
+        ];
+
+        for (name, formals, expected_mask) in cases {
+            let policy = package_policy("haven", name).unwrap();
+            assert_eq!(
+                policy,
+                ArgPolicy::per_formal(formals, &["col_select"], false),
+                "haven::{name} exact policy"
+            );
+            assert_eq!(
+                suppressed_arguments(&policy, &vec![None; formals.len()], false),
+                *expected_mask,
+                "haven::{name} positional mask"
+            );
+        }
+
+        assert_eq!(package_policy("haven", "write_dta"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add Haven NSE policies for `col_select` on all seven exported reader functions
- preserve standard evaluation for file paths, skip/control arguments, and unrelated Haven functions
- add exact signature-mask and attached/qualified collector regression coverage

## Root cause

Haven evaluates `col_select` through tidyselect, but Raven had no Haven package policy, so both bare selected columns and tidyselect helpers were analyzed as ordinary lexical references.

## Validation

- `cargo fmt --all --check`
- focused Haven policy and collector tests
- independent compile/correctness review
- independent frozen-diff regression/new-bug/scope review

Full workspace gates and fresh CI will be completed before merge.

Closes #689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Haven reader analysis so `col_select` expressions are handled correctly.
  * Reduced false diagnostics for valid column selections while continuing to report undefined file paths, options, and evaluated arguments.
  * Added support for Haven reader-specific argument handling across multiple `read_*` functions.

* **Tests**
  * Added regression coverage for bare and qualified Haven reader usage, including tidyselect helpers and positional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->