### PR TITLE
Fix #639: make targets worker packages pipeline-scoped

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -139,21 +139,21 @@ impl Drop for DiagnosticsSupersessionGuardForTest {
     }
 }
 
-/// Extract a permissive package warm set from metadata-derived library calls.
+/// Extract a permissive package warm set from durable metadata.
 ///
-/// Conditional calls are intentionally included even when their attachment
-/// prerequisite is not active. This function only prefetches metadata; it
-/// cannot make a package visible in semantic scope, and resolving the full
-/// graph here would make the edit-time warm path disproportionately expensive.
-fn extract_loaded_packages_from_library_calls(
-    library_calls: &[crate::cross_file::LibraryCall],
+/// Conditional lexical calls and targets pipeline packages are intentionally
+/// included. Warming cannot make a package semantically visible, and resolving
+/// the full graph here would make the edit-time path disproportionately
+/// expensive.
+fn extract_loaded_packages_from_metadata(
+    metadata: &crate::cross_file::CrossFileMetadata,
 ) -> Vec<String> {
     let mut packages = Vec::new();
-    for lib_call in library_calls {
-        if is_valid_package_name(&lib_call.package) {
-            packages.push(lib_call.package.clone());
+    for package in metadata.referenced_packages() {
+        if is_valid_package_name(package) {
+            packages.push(package.to_string());
         } else {
-            log::warn!("Skipping suspicious package name: {}", lib_call.package);
+            log::warn!("Skipping suspicious package name: {package}");
         }
     }
     packages
@@ -168,10 +168,10 @@ fn extract_loaded_packages_from_library_calls(
 /// the `is_valid_package_name` filter the caller applies to the merged
 /// prefetch set (mirroring the did_open path). Extracted for unit testing.
 fn edited_document_warm_packages(
-    library_calls: &[crate::cross_file::LibraryCall],
+    metadata: &crate::cross_file::CrossFileMetadata,
     doc: &crate::state::Document,
 ) -> Vec<String> {
-    let mut packages = extract_loaded_packages_from_library_calls(library_calls);
+    let mut packages = extract_loaded_packages_from_metadata(metadata);
     packages.extend(doc.data_packages.iter().cloned());
     packages
 }
@@ -10127,8 +10127,7 @@ fn derive_open_edit_fallback(
         .collect();
     let mut plan = captured.plan;
     if captured.packages_enabled {
-        plan.packages_to_prefetch =
-            extract_loaded_packages_from_library_calls(&local_metadata.library_calls);
+        plan.packages_to_prefetch = extract_loaded_packages_from_metadata(&local_metadata);
         plan.packages_to_prefetch
             .extend(namespace_warm_packages(&local_metadata));
         plan.packages_to_prefetch.extend(
@@ -10172,8 +10171,7 @@ fn capture_live_package_open_edit_with_metadata(
     let subject_excluded = state.is_project_excluded_uri(uri);
     let workspace_root = state.workspace_folders.first().cloned();
     let packages_to_prefetch = if state.cross_file_config.packages_enabled {
-        let mut packages =
-            edited_document_warm_packages(&metadata.library_calls, prepared.document());
+        let mut packages = edited_document_warm_packages(&metadata, prepared.document());
         packages.extend(namespace_warm_packages(&metadata));
         packages
     } else {
@@ -11291,9 +11289,7 @@ fn derive_open_close_analysis(mut captured: CapturedOpenCloseAnalysis) -> Derive
                     entry: crate::workspace_index::IndexEntry {
                         contents: ropey::Rope::from_str(&content),
                         tree: tree.clone(),
-                        loaded_packages: extract_loaded_packages_from_library_calls(
-                            &semantic.library_calls,
-                        ),
+                        loaded_packages: extract_loaded_packages_from_metadata(&semantic),
                         data_packages: crate::state::extract_data_packages(&tree, &analysis),
                         snapshot: snapshot.clone(),
                         metadata: Arc::new(semantic.clone()),
@@ -11886,7 +11882,7 @@ fn derive_open_install_analysis(
     });
     let mut packages_to_prefetch = Vec::new();
     if captured.packages_enabled {
-        packages_to_prefetch = extract_loaded_packages_from_library_calls(&metadata.library_calls);
+        packages_to_prefetch = extract_loaded_packages_from_metadata(&metadata);
         packages_to_prefetch.extend(namespace_warm_packages(&metadata));
         packages_to_prefetch.extend(
             captured
@@ -13367,8 +13363,7 @@ async fn resync_file_from_disk(
         None => crate::cross_file::scope::ScopeArtifacts::default(),
     });
     let new_interface_hash = artifacts.interface_hash;
-    let loaded_packages =
-        extract_loaded_packages_from_library_calls(&cross_file_meta.library_calls);
+    let loaded_packages = extract_loaded_packages_from_metadata(&cross_file_meta);
     let data_packages = crate::state::extract_data_packages(&tree, &analysis);
 
     let fresh_entry = crate::workspace_index::IndexEntry {
@@ -18244,8 +18239,7 @@ impl LanguageServer for Backend {
                         Vec::new()
                     };
                     let packages_to_prefetch = if packages_enabled {
-                        let mut packages =
-                            extract_loaded_packages_from_library_calls(&meta.library_calls);
+                        let mut packages = extract_loaded_packages_from_metadata(&meta);
                         packages.extend(namespace_warm_packages(&meta));
                         packages
                     } else {
@@ -18368,8 +18362,7 @@ impl LanguageServer for Backend {
                     extract_enriched_live_metadata_with_contexts(&state, &uri, &text);
                 let workspace_root = state.workspace_folders.first().cloned();
                 let packages_to_prefetch: Vec<String> = if packages_enabled {
-                    let mut packages =
-                        edited_document_warm_packages(&meta.library_calls, prepared.document());
+                    let mut packages = edited_document_warm_packages(&meta, prepared.document());
                     packages.extend(namespace_warm_packages(&meta));
                     packages
                 } else {
@@ -21486,8 +21479,7 @@ impl Backend {
         let snapshot =
             crate::cross_file::file_cache::FileSnapshot::with_content_hash(&metadata, &content);
 
-        let loaded_packages =
-            extract_loaded_packages_from_library_calls(&cross_file_meta.library_calls);
+        let loaded_packages = extract_loaded_packages_from_metadata(&cross_file_meta);
         let data_packages = crate::state::extract_data_packages(&tree, analysis_text);
         let packages_to_prefetch = if packages_enabled {
             loaded_packages.clone()
@@ -21990,8 +21982,7 @@ impl Backend {
             None => crate::cross_file::scope::ScopeArtifacts::default(),
         });
 
-        let loaded_packages =
-            extract_loaded_packages_from_library_calls(&cross_file_meta.library_calls);
+        let loaded_packages = extract_loaded_packages_from_metadata(&cross_file_meta);
         let data_packages = crate::state::extract_data_packages(&tree, analysis_text);
         let packages_to_prefetch = if packages_enabled {
             loaded_packages.clone()
@@ -31992,12 +31983,35 @@ mod refresh_packages_tests {
         use crate::state::Document;
 
         let doc = Document::new("data(api, package = \"survey\")\n", Some(1));
-        let pkgs = edited_document_warm_packages(&[], &doc);
+        let metadata = crate::cross_file::CrossFileMetadata::default();
+        let pkgs = edited_document_warm_packages(&metadata, &doc);
 
         assert!(
             pkgs.contains(&"survey".to_string()),
             "did_change warm set must include data(package=) packages (issue #429); got {:?}",
             pkgs
+        );
+    }
+
+    #[test]
+    fn targets_pipeline_packages_remain_in_metadata_warm_set() {
+        let mut metadata = crate::cross_file::CrossFileMetadata::default();
+        metadata.targets_pipeline_packages = vec![
+            crate::cross_file::TargetsPackageDeclaration {
+                package: "dplyr".to_string(),
+                line: 1,
+                column: 34,
+            },
+            crate::cross_file::TargetsPackageDeclaration {
+                package: "not a package".to_string(),
+                line: 2,
+                column: 34,
+            },
+        ];
+
+        assert_eq!(
+            extract_loaded_packages_from_metadata(&metadata),
+            vec!["dplyr".to_string()]
         );
     }
 

--- a/crates/raven/src/cli/packages.rs
+++ b/crates/raven/src/cli/packages.rs
@@ -753,7 +753,8 @@ fn scan_workspace_referenced_packages(root: &std::path::Path) -> Vec<String> {
 /// - the `namespace_identifier` (LHS) of each `pkg::name` / `pkg:::name`
 ///   (`namespace_operator` node — the package id is `child(0)`, confirmed against
 ///   `find_namespace_context` in `handlers.rs`), and
-/// - statically detected package loaders from the canonical detector, and
+/// - statically detected lexical package loaders and targets pipeline packages,
+///   and
 /// - a string literal statically matched to `requireNamespace()`'s `package`
 ///   formal.
 fn collect_referenced_packages(
@@ -772,6 +773,13 @@ fn collect_referenced_packages(
         }
         if is_valid_package_name(&call.package) {
             out.insert(call.package);
+        }
+    }
+    for declaration in
+        crate::cross_file::source_detect::detect_targets_pipeline_packages(tree, text)
+    {
+        if is_valid_package_name(&declaration.package) {
+            out.insert(declaration.package);
         }
     }
 
@@ -1790,6 +1798,7 @@ mod tests {
                    require(tibble)\n\
                    loadNamespace(\"jsonlite\")\n\
                    requireNamespace(\"rlang\")\n\
+                   targets::tar_option_set(packages = \"tidyr\")\n\
                    bare_var\n";
         let mut parser = tree_sitter::Parser::new();
         parser
@@ -1800,7 +1809,9 @@ mod tests {
         let mut out = std::collections::BTreeSet::new();
         super::collect_referenced_packages(&tree, src, &mut out);
 
-        for expected in ["dplyr", "utils", "ggplot2", "tibble", "jsonlite", "rlang"] {
+        for expected in [
+            "dplyr", "utils", "ggplot2", "tibble", "jsonlite", "rlang", "tidyr",
+        ] {
             assert!(out.contains(expected), "expected {expected}, got {out:?}");
         }
         assert!(

--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -39,13 +39,13 @@ pub use source_detect::*;
 pub use tar_source::*;
 pub use types::*;
 
-/// Extract cross-file metadata from R source by combining directive parsing with AST-detected `source()` and library-related calls.
+/// Extract cross-file metadata from R source by combining directive parsing with AST-detected sources and package facts.
 ///
-/// Directive-derived `source` entries take precedence over AST-detected `source()` calls when they occur on the same line. When a thread-local parser is available the function also detects `library()`, `require()`, and `loadNamespace()` calls and records them in `library_calls`; if parsing fails those AST-derived detections are skipped.
+/// Directive-derived `source` entries take precedence over AST-detected `source()` calls when they occur on the same line. When a thread-local parser is available the function also detects lexical package loads (`library()`, `require()`, and `loadNamespace()`) and file-level targets worker-package declarations; if parsing fails those AST-derived detections are skipped.
 ///
 /// # Returns
 ///
-/// A `CrossFileMetadata` containing collected `sources`, `sourced_by` entries, and `library_calls`. `sources` and `library_calls` are sorted by document order (line, column).
+/// A `CrossFileMetadata` containing collected sources, backward declarations, lexical package loads, and targets pipeline packages. Positional collections are sorted by document order (line, column).
 ///
 /// # Examples
 ///
@@ -196,13 +196,18 @@ pub fn extract_metadata_with_tree(
         // Sort by line number for consistent ordering
         meta.sources.sort_by_key(|s| (s.line, s.column));
 
-        // Detect library(), require(), loadNamespace(), and static
-        // targets::tar_source() calls with one shared lazy binding table.
-        let (mut library_calls, tar_source_requests, list_files_source_requests) =
-            source_detect::detect_library_and_tar_source_requests(tree, content);
+        // Detect lexical package loads, targets worker-package declarations,
+        // and static source-batch requests with one shared lazy binding table.
+        let (
+            mut library_calls,
+            targets_pipeline_packages,
+            tar_source_requests,
+            list_files_source_requests,
+        ) = source_detect::detect_library_and_tar_source_requests(tree, content);
         // Sort by line/column for document order (Requirement 1.8)
         library_calls.sort_by_key(|lc| (lc.line, lc.column));
         meta.library_calls = library_calls;
+        meta.targets_pipeline_packages = targets_pipeline_packages;
         meta.tar_source_requests = tar_source_requests;
         meta.list_files_source_requests = list_files_source_requests;
         meta.namespace_references = source_detect::detect_namespace_references(tree, content);
@@ -211,12 +216,13 @@ pub fn extract_metadata_with_tree(
     }
 
     log::trace!(
-        "Metadata extraction complete: {} total sources ({} from directives, {} from AST), {} backward directives, {} library calls",
+        "Metadata extraction complete: {} total sources ({} from directives, {} from AST), {} backward directives, {} library calls, {} targets pipeline packages",
         meta.sources.len(),
         meta.sources.iter().filter(|s| s.is_directive).count(),
         meta.sources.iter().filter(|s| !s.is_directive).count(),
         meta.sourced_by.len(),
-        meta.library_calls.len()
+        meta.library_calls.len(),
+        meta.targets_pipeline_packages.len()
     );
 
     meta

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -908,6 +908,12 @@ pub struct ScopeAtPosition {
     /// Raven's existing namespace-awareness for `loadNamespace()`. Attachment-
     /// sensitive helpers such as bare `pacman::p_load()` must consult this set.
     pub attached_packages: HashSet<String>,
+    /// Packages whose availability in this scope comes only from the targets
+    /// pipeline worker-package channel. Kept separate so ordinary `source()` and
+    /// `ListFiles` edges can filter that channel while `TarSource` edges lend it.
+    pub(crate) targets_only_loaded_packages: HashSet<String>,
+    /// Attached-package counterpart of [`Self::targets_only_loaded_packages`].
+    pub(crate) targets_only_attached_packages: HashSet<String>,
     /// Per-package origin tracking: maps each package name to the set of file
     /// URIs that loaded the package. Populated whenever a package is added to
     /// `inherited_packages` or `loaded_packages`. Used at cross-file merge
@@ -964,6 +970,42 @@ fn record_package_origin(
         .entry(package.to_string())
         .or_default()
         .insert(Arc::new(origin_uri.clone()));
+}
+
+/// Merge a targets pipeline's order-independent worker packages into a scope.
+///
+/// Call this only after ordinary source-timeline execution, or on the private
+/// initial scope supplied to a `TarSource` batch. That ordering is load-bearing:
+/// the packages must be visible throughout the declaring pipeline and every tar
+/// member, but must not leak into ordinary `source()` or `ListFiles` children.
+fn append_targets_pipeline_packages<'a>(
+    scope: &mut ScopeAtPosition,
+    origin_uri: &Url,
+    packages: impl IntoIterator<Item = &'a str>,
+) {
+    for package in packages {
+        if !scope.inherited_packages.contains(package) && !scope.loaded_packages.contains(package) {
+            scope
+                .targets_only_loaded_packages
+                .insert(package.to_string());
+        }
+        if !scope.attached_packages.contains(package) {
+            scope
+                .targets_only_attached_packages
+                .insert(package.to_string());
+        }
+        scope.loaded_packages.insert(package.to_string());
+        scope.attached_packages.insert(package.to_string());
+        record_package_origin(&mut scope.package_origins, package, origin_uri);
+    }
+}
+
+/// Whether this ordered source batch is a targets worker batch rather than the
+/// independent bounded `list.files()` idiom.
+fn is_tar_source_batch(members: &[ForwardSource]) -> bool {
+    members.first().is_some_and(|source| {
+        source.source_batch_kind == Some(super::types::SourceBatchKind::TarSource)
+    })
 }
 
 /// Returns `true` when the only known origin for `package` is `uri` — i.e.
@@ -1030,27 +1072,55 @@ fn child_source_symbol_is_leak(
     symbol.source_uri == *queried_uri || child_parent_prefix_names.contains(name)
 }
 
-/// Same-file leak filter for packages, shared by the recursive resolver and
+/// Merge one package channel while preserving the invariant that an ordinary
+/// package contribution dominates a targets-only contribution of the same name.
+/// Parent prefixes union multiple incoming edges, so marker state cannot use
+/// last-writer-wins without becoming traversal-order-dependent.
+fn merge_package_channel_with_ordinary_precedence(
+    packages: &mut HashSet<String>,
+    targets_only_packages: &mut HashSet<String>,
+    package: &str,
+    incoming_targets_only: bool,
+) {
+    let already_ordinary = packages.contains(package) && !targets_only_packages.contains(package);
+    packages.insert(package.to_string());
+    if incoming_targets_only {
+        if !already_ordinary {
+            targets_only_packages.insert(package.to_string());
+        }
+    } else {
+        targets_only_packages.remove(package);
+    }
+}
+
+/// Ordinary-forward-source package filter shared by the recursive resolver and
 /// `ScopeStream::resolve_source_contribution`. Iterates the child's loaded and
-/// inherited packages, skipping any whose only known origin is the queried file
-/// (`queried_uri`) — a child whose own cross-file recursion brought packages
-/// back from a path through the queried file would otherwise re-import them.
-/// Surviving packages are inserted into `dst_packages` and their origins
-/// propagated into `dst_origins` so downstream merge sites can run the same
-/// filter.
+/// inherited packages, skipping targets-only worker packages and any package
+/// whose only known origin is the queried file (`queried_uri`) — a child whose
+/// own cross-file recursion brought packages back from a path through the
+/// queried file would otherwise re-import them. Surviving packages are inserted
+/// into `dst_packages` and their origins propagated into `dst_origins` so
+/// downstream merge sites can run the same filter.
 fn merge_child_source_packages(
     child_loaded: &HashSet<String>,
     child_inherited: &HashSet<String>,
+    child_targets_only_loaded: &HashSet<String>,
     child_origins: &HashMap<String, HashSet<Arc<Url>>>,
     queried_uri: &Url,
-    dst_packages: &mut HashSet<String>,
+    dst_packages: (&mut HashSet<String>, Option<&mut HashSet<String>>),
     dst_origins: &mut HashMap<String, HashSet<Arc<Url>>>,
 ) {
+    let (dst_packages, mut dst_targets_only_loaded) = dst_packages;
     for pkg in child_loaded.iter().chain(child_inherited.iter()) {
-        if package_only_origin_is_uri(child_origins, pkg, queried_uri) {
+        if child_targets_only_loaded.contains(pkg)
+            || package_only_origin_is_uri(child_origins, pkg, queried_uri)
+        {
             continue;
         }
         dst_packages.insert(pkg.clone());
+        if let Some(targets_only) = dst_targets_only_loaded.as_deref_mut() {
+            targets_only.remove(pkg);
+        }
         propagate_package_origins(child_origins, pkg, dst_origins);
     }
 }
@@ -1058,17 +1128,23 @@ fn merge_child_source_packages(
 fn merge_child_source_attachments(
     child_attached: &HashSet<String>,
     child_loaded: Option<&HashSet<String>>,
+    child_targets_only_attached: &HashSet<String>,
     child_origins: &HashMap<String, HashSet<Arc<Url>>>,
     queried_uri: &Url,
     dst_attached: &mut HashSet<String>,
+    mut dst_targets_only_attached: Option<&mut HashSet<String>>,
 ) {
     for package in child_attached {
-        if child_loaded.is_some_and(|loaded| !loaded.contains(package))
+        if child_targets_only_attached.contains(package)
+            || child_loaded.is_some_and(|loaded| !loaded.contains(package))
             || package_only_origin_is_uri(child_origins, package, queried_uri)
         {
             continue;
         }
         dst_attached.insert(package.clone());
+        if let Some(targets_only) = dst_targets_only_attached.as_deref_mut() {
+            targets_only.remove(package);
+        }
     }
 }
 
@@ -2601,10 +2677,14 @@ pub fn compute_artifacts_with_metadata(
     let nse_decls: &[super::types::NseDeclaration] = metadata
         .map(|m| m.nse_declarations.as_slice())
         .unwrap_or(&[]);
+    let targets_pipeline_packages: &[super::types::TargetsPackageDeclaration] = metadata
+        .map(|m| m.targets_pipeline_packages.as_slice())
+        .unwrap_or(&[]);
     let declarations = extract_top_level_declarations(&artifacts.timeline);
     artifacts.interface_hash = compute_interface_hash(
         &top_level,
         &loaded_packages,
+        targets_pipeline_packages,
         &declared_symbols,
         nse_decls,
         &removal_refs,
@@ -5708,6 +5788,7 @@ fn extract_package_load_positions(timeline: &[ScopeEvent]) -> Vec<PackageLoadKey
 fn compute_interface_hash(
     interface: &HashMap<Arc<str>, ScopedSymbol>,
     package_loads: &[PackageLoadKey],
+    targets_pipeline_packages: &[super::types::TargetsPackageDeclaration],
     declared_symbols: &[super::types::DeclaredSymbol],
     nse_declarations: &[super::types::NseDeclaration],
     top_level_removals: &[TopLevelRemoval<'_>],
@@ -5759,6 +5840,18 @@ fn compute_interface_hash(
         attaches.hash(&mut hasher);
         requires_attached.hash(&mut hasher);
     }
+
+    // Targets worker packages are an order-independent file/pipeline-level set,
+    // so hash only their sorted names. Declaration movement does not alter
+    // semantics, while an add/remove/rename must revalidate every batch member
+    // and connected dependent.
+    let mut sorted_targets_packages: Vec<_> = targets_pipeline_packages
+        .iter()
+        .map(|declaration| declaration.package.as_str())
+        .collect();
+    sorted_targets_packages.sort_unstable();
+    sorted_targets_packages.dedup();
+    sorted_targets_packages.hash(&mut hasher);
 
     // Include declared symbols in the hash (sorted for determinism)
     // This ensures cache invalidation when declarations change (Requirements 10.1-10.4)
@@ -6456,6 +6549,8 @@ pub(crate) struct ParentPrefix {
     // always be empty and was removed in I2.
     pub inherited_packages: HashSet<String>,
     pub attached_packages: HashSet<String>,
+    pub targets_only_loaded_packages: HashSet<String>,
+    pub targets_only_attached_packages: HashSet<String>,
     pub package_origins: HashMap<String, HashSet<Arc<Url>>>,
 }
 
@@ -6477,6 +6572,8 @@ impl ParentPrefix {
             depth_exceeded,
             inherited_packages,
             attached_packages,
+            targets_only_loaded_packages,
+            targets_only_attached_packages,
             package_origins,
         } = self;
         symbols.is_empty()
@@ -6485,6 +6582,8 @@ impl ParentPrefix {
             && depth_exceeded.is_empty()
             && inherited_packages.is_empty()
             && attached_packages.is_empty()
+            && targets_only_loaded_packages.is_empty()
+            && targets_only_attached_packages.is_empty()
             && package_origins.is_empty()
     }
 }
@@ -6678,6 +6777,8 @@ where
         // bump the graph revision and revalidate dependents.
         let declared_only_parent = edge.uses_declared_only_parent_inheritance();
         let package_barrier = edge.locality == super::types::SourceLocality::NonInheriting;
+        let lends_targets_packages =
+            edge.source_batch_kind == Some(super::types::SourceBatchKind::TarSource);
 
         // Check if we would exceed max depth
         if current_depth + 1 >= max_depth {
@@ -6825,6 +6926,7 @@ where
                 .depth_exceeded
                 .extend(contribution.depth_exceeded);
             for package in contribution.packages {
+                parent_scope.targets_only_loaded_packages.remove(&package);
                 parent_scope.loaded_packages.insert(package.clone());
                 propagate_package_origins(
                     &contribution.package_origins,
@@ -6832,9 +6934,10 @@ where
                     &mut parent_scope.package_origins,
                 );
             }
-            parent_scope
-                .attached_packages
-                .extend(contribution.attached_packages);
+            for package in contribution.attached_packages {
+                parent_scope.targets_only_attached_packages.remove(&package);
+                parent_scope.attached_packages.insert(package);
+            }
         }
 
         // Merge parent symbols (they are available at the START of this file).
@@ -6953,10 +7056,20 @@ where
                                 &edge_attached_packages,
                             )
                         {
-                            prefix.inherited_packages.insert(package.clone());
+                            merge_package_channel_with_ordinary_precedence(
+                                &mut prefix.inherited_packages,
+                                &mut prefix.targets_only_loaded_packages,
+                                package,
+                                false,
+                            );
                             if *attaches {
                                 edge_attached_packages.insert(package.clone());
-                                prefix.attached_packages.insert(package.clone());
+                                merge_package_channel_with_ordinary_precedence(
+                                    &mut prefix.attached_packages,
+                                    &mut prefix.targets_only_attached_packages,
+                                    package,
+                                    false,
+                                );
                             }
                             // Record the parent file as origin so downstream
                             // merge sites can apply the same-file leak filter.
@@ -6980,10 +7093,18 @@ where
             if i & 63 == 0 && is_cancelled() {
                 return prefix;
             }
-            if package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri) {
+            if package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri)
+                || (!lends_targets_packages
+                    && parent_scope.targets_only_loaded_packages.contains(pkg))
+            {
                 continue;
             }
-            prefix.inherited_packages.insert(pkg.clone());
+            merge_package_channel_with_ordinary_precedence(
+                &mut prefix.inherited_packages,
+                &mut prefix.targets_only_loaded_packages,
+                pkg,
+                parent_scope.targets_only_loaded_packages.contains(pkg),
+            );
             propagate_package_origins(
                 &parent_scope.package_origins,
                 pkg,
@@ -6997,10 +7118,18 @@ where
             if i & 63 == 0 && is_cancelled() {
                 return prefix;
             }
-            if package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri) {
+            if package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri)
+                || (!lends_targets_packages
+                    && parent_scope.targets_only_loaded_packages.contains(pkg))
+            {
                 continue;
             }
-            prefix.inherited_packages.insert(pkg.clone());
+            merge_package_channel_with_ordinary_precedence(
+                &mut prefix.inherited_packages,
+                &mut prefix.targets_only_loaded_packages,
+                pkg,
+                parent_scope.targets_only_loaded_packages.contains(pkg),
+            );
             propagate_package_origins(
                 &parent_scope.package_origins,
                 pkg,
@@ -7008,9 +7137,18 @@ where
             );
         }
         for pkg in &parent_scope.attached_packages {
-            if !package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri) {
-                prefix.attached_packages.insert(pkg.clone());
+            if package_only_origin_is_uri(&parent_scope.package_origins, pkg, uri)
+                || (!lends_targets_packages
+                    && parent_scope.targets_only_attached_packages.contains(pkg))
+            {
+                continue;
             }
+            merge_package_channel_with_ordinary_precedence(
+                &mut prefix.attached_packages,
+                &mut prefix.targets_only_attached_packages,
+                pkg,
+                parent_scope.targets_only_attached_packages.contains(pkg),
+            );
         }
     }
 
@@ -7061,6 +7199,8 @@ where
         .cloned()
         .collect();
     let mut rolling_attached_packages = initial_scope.attached_packages.clone();
+    let mut rolling_targets_only_loaded = initial_scope.targets_only_loaded_packages.clone();
+    let mut rolling_targets_only_attached = initial_scope.targets_only_attached_packages.clone();
     let mut rolling_origins = initial_scope.package_origins.clone();
 
     for source in members {
@@ -7108,6 +7248,8 @@ where
                 symbols: rolling_symbols.clone(),
                 inherited_packages: rolling_packages.clone(),
                 attached_packages: rolling_attached_packages.clone(),
+                targets_only_loaded_packages: rolling_targets_only_loaded.clone(),
+                targets_only_attached_packages: rolling_targets_only_attached.clone(),
                 package_origins: rolling_origins.clone(),
                 ..ParentPrefix::default()
             })
@@ -7185,6 +7327,10 @@ where
         // effects. Their origin remains the loading member (or its descendant),
         // never the batch parent, so same-file leak filtering stays sound.
         for package in member_scope.loaded_packages {
+            if member_scope.targets_only_loaded_packages.contains(&package) {
+                continue;
+            }
+            rolling_targets_only_loaded.remove(&package);
             rolling_packages.insert(package.clone());
             contribution.packages.insert(package.clone());
             propagate_package_origins(
@@ -7199,6 +7345,13 @@ where
             );
         }
         for package in member_scope.attached_packages {
+            if member_scope
+                .targets_only_attached_packages
+                .contains(&package)
+            {
+                continue;
+            }
+            rolling_targets_only_attached.remove(&package);
             if rolling_attached_packages.insert(package.clone()) {
                 contribution.attached_packages.insert(package);
             }
@@ -7566,6 +7719,12 @@ where
                         .attached_packages
                         .extend(prefix.attached_packages.iter().cloned());
                 }
+                scope
+                    .targets_only_loaded_packages
+                    .extend(prefix.targets_only_loaded_packages.iter().cloned());
+                scope
+                    .targets_only_attached_packages
+                    .extend(prefix.targets_only_attached_packages.iter().cloned());
                 for (pkg, origins) in &prefix.package_origins {
                     scope
                         .package_origins
@@ -7613,6 +7772,12 @@ where
                 if !inherited_attached_packages_authoritative {
                     scope.attached_packages.extend(prefix.attached_packages);
                 }
+                scope
+                    .targets_only_loaded_packages
+                    .extend(prefix.targets_only_loaded_packages);
+                scope
+                    .targets_only_attached_packages
+                    .extend(prefix.targets_only_attached_packages);
                 for (pkg, origins) in prefix.package_origins {
                     scope
                         .package_origins
@@ -7945,22 +8110,27 @@ where
                         };
                         let empty_packages_for_child = HashSet::new();
                         let owned_packages: HashSet<String>;
-                        let packages_for_child: &HashSet<String> = if child_is_standalone
-                            || package_effects_only
-                        {
-                            &empty_packages_for_child
-                        } else if extra_packages.is_empty() && scope.loaded_packages.is_empty() {
-                            &scope.inherited_packages
-                        } else {
-                            owned_packages = scope
-                                .inherited_packages
-                                .iter()
-                                .chain(extra_packages.iter())
-                                .chain(scope.loaded_packages.iter())
-                                .cloned()
-                                .collect();
-                            &owned_packages
-                        };
+                        let packages_for_child: &HashSet<String> =
+                            if child_is_standalone || package_effects_only {
+                                &empty_packages_for_child
+                            } else if extra_packages.is_empty()
+                                && scope.loaded_packages.is_empty()
+                                && scope.targets_only_loaded_packages.is_empty()
+                            {
+                                &scope.inherited_packages
+                            } else {
+                                owned_packages = scope
+                                    .inherited_packages
+                                    .iter()
+                                    .chain(scope.loaded_packages.iter())
+                                    .filter(|package| {
+                                        !scope.targets_only_loaded_packages.contains(*package)
+                                    })
+                                    .chain(extra_packages.iter())
+                                    .cloned()
+                                    .collect();
+                                &owned_packages
+                            };
                         let attached_union_matches_packages =
                             packages_for_child.iter().all(|package| {
                                 scope.attached_packages.contains(package)
@@ -7968,6 +8138,9 @@ where
                             }) && scope
                                 .attached_packages
                                 .iter()
+                                .filter(|package| {
+                                    !scope.targets_only_attached_packages.contains(*package)
+                                })
                                 .chain(extra_attached_packages.iter())
                                 .all(|package| packages_for_child.contains(package));
                         let owned_attached_packages: HashSet<String>;
@@ -7980,12 +8153,17 @@ where
                                 // is unsound because pre-execution attachments
                                 // may not yet appear in the loaded-package set.
                                 packages_for_child
-                            } else if extra_attached_packages.is_empty() {
+                            } else if extra_attached_packages.is_empty()
+                                && scope.targets_only_attached_packages.is_empty()
+                            {
                                 &scope.attached_packages
                             } else {
                                 owned_attached_packages = scope
                                     .attached_packages
                                     .iter()
+                                    .filter(|package| {
+                                        !scope.targets_only_attached_packages.contains(*package)
+                                    })
                                     .chain(extra_attached_packages.iter())
                                     .cloned()
                                     .collect();
@@ -8189,17 +8367,23 @@ where
                         merge_child_source_packages(
                             &child_scope.loaded_packages,
                             child_inherited_packages,
+                            &child_scope.targets_only_loaded_packages,
                             &child_scope.package_origins,
                             uri,
-                            &mut scope.loaded_packages,
+                            (
+                                &mut scope.loaded_packages,
+                                Some(&mut scope.targets_only_loaded_packages),
+                            ),
                             &mut scope.package_origins,
                         );
                         merge_child_source_attachments(
                             &child_scope.attached_packages,
                             package_effects_only.then_some(&child_scope.loaded_packages),
+                            &child_scope.targets_only_attached_packages,
                             &child_scope.package_origins,
                             uri,
                             &mut scope.attached_packages,
+                            Some(&mut scope.targets_only_attached_packages),
                         );
                     }
                 }
@@ -8220,10 +8404,23 @@ where
                     continue;
                 }
                 let visited_base = forward_visited_base.as_ref().unwrap_or(visited);
+                let mut batch_initial_scope = scope.clone();
+                if is_tar_source_batch(members)
+                    && let Some(metadata) = get_metadata(uri)
+                {
+                    append_targets_pipeline_packages(
+                        &mut batch_initial_scope,
+                        uri,
+                        metadata
+                            .targets_pipeline_packages
+                            .iter()
+                            .map(|declaration| declaration.package.as_str()),
+                    );
+                }
                 let contribution = resolve_tar_batch_contribution(
                     uri,
                     members,
-                    &scope,
+                    &batch_initial_scope,
                     get_artifacts,
                     get_metadata,
                     graph,
@@ -8260,6 +8457,7 @@ where
                 );
                 scope.depth_exceeded.extend(contribution.depth_exceeded);
                 for package in contribution.packages {
+                    scope.targets_only_loaded_packages.remove(&package);
                     scope.loaded_packages.insert(package.clone());
                     propagate_package_origins(
                         &contribution.package_origins,
@@ -8267,9 +8465,10 @@ where
                         &mut scope.package_origins,
                     );
                 }
-                scope
-                    .attached_packages
-                    .extend(contribution.attached_packages);
+                for package in contribution.attached_packages {
+                    scope.targets_only_attached_packages.remove(&package);
+                    scope.attached_packages.insert(package);
+                }
             }
             ScopeEvent::FunctionScope {
                 start_line,
@@ -8362,8 +8561,10 @@ where
                     if should_include
                         && (running_requirement_satisfied || late_requirement_satisfied)
                     {
+                        scope.targets_only_loaded_packages.remove(package);
                         scope.loaded_packages.insert(package.clone());
                         if *attaches {
+                            scope.targets_only_attached_packages.remove(package);
                             scope.attached_packages.insert(package.clone());
                         }
                         record_package_origin(&mut scope.package_origins, package, uri);
@@ -8471,6 +8672,22 @@ where
         scope
             .parent_prefix_symbol_names
             .retain(|n| !forward_contributed.contains(n));
+    }
+
+    // Targets worker packages are a file/pipeline-level declaration rather
+    // than a lexical event. Add them only after this file's ordinary timeline
+    // has run so they are visible at every query position without being passed
+    // into ordinary `source()` children. TarSource batches receive the same set
+    // through their private initial scope above.
+    if let Some(metadata) = get_metadata(uri) {
+        append_targets_pipeline_packages(
+            &mut scope,
+            uri,
+            metadata
+                .targets_pipeline_packages
+                .iter()
+                .map(|declaration| declaration.package.as_str()),
+        );
     }
 
     // Phase 5a: inject package-mode contribution at depth 0 only.
@@ -9299,6 +9516,10 @@ where
     /// from ordinary source contributions because the two event kinds have
     /// different merge semantics.
     tar_batch_contributions: HashMap<(u32, u32, bool), ChildSourceContribution>,
+    /// Durable file/pipeline-level targets worker package set, copied once from
+    /// metadata at stream construction. It is projected into snapshots and
+    /// TarSource batch initial scopes without rescanning syntax.
+    targets_pipeline_packages: HashSet<String>,
 
     /// Cross-file resolution context (closures + config, mirrors
     /// `scope_at_position_with_graph_cached`'s parameters).
@@ -9630,6 +9851,16 @@ where
         // events can resolve child paths even when the dependency graph
         // edge is absent (e.g. unresolvable path).
         let meta = get_metadata(queried_uri);
+        let targets_pipeline_packages = meta
+            .as_ref()
+            .map(|metadata| {
+                metadata
+                    .targets_pipeline_packages
+                    .iter()
+                    .map(|declaration| declaration.package.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
         let path_ctx = meta
             .as_ref()
             .and_then(|m| {
@@ -9666,6 +9897,7 @@ where
             evaluated_conditional_shiny_scopes: HashSet::new(),
             source_contributions: HashMap::new(),
             tar_batch_contributions: HashMap::new(),
+            targets_pipeline_packages,
             get_artifacts,
             get_metadata,
             graph,
@@ -9726,6 +9958,16 @@ where
             .attached_packages
             .extend(attached_packages.iter().cloned());
         let meta = get_metadata(queried_uri);
+        let targets_pipeline_packages = meta
+            .as_ref()
+            .map(|metadata| {
+                metadata
+                    .targets_pipeline_packages
+                    .iter()
+                    .map(|declaration| declaration.package.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
         let path_ctx = meta
             .as_ref()
             .and_then(|metadata| {
@@ -9758,6 +10000,7 @@ where
             evaluated_conditional_shiny_scopes: HashSet::new(),
             source_contributions: HashMap::new(),
             tar_batch_contributions: HashMap::new(),
+            targets_pipeline_packages,
             get_artifacts,
             get_metadata,
             graph,
@@ -9932,6 +10175,12 @@ where
             &self.prefix_top
         };
         attached.extend(prefix.attached_packages.iter().cloned());
+        // targets worker packages are a durable, order-independent property of
+        // the declaring pipeline. Let them classify conditional helpers at any
+        // call position, but keep them out of the running frames: Source and
+        // ListFiles propagation reads those frames, while TarSource receives the
+        // package set through its dedicated private initial scope.
+        attached.extend(self.targets_pipeline_packages.iter().cloned());
         for (interval, frame) in &self.function_stack {
             if interval.contains(candidate.call_position) {
                 attached.extend(frame.attached_packages.iter().cloned());
@@ -10072,7 +10321,7 @@ where
                 }
                 // Resolve once per call site, reuse on every application
                 // with the same inherited attachment environment.
-                let attached_for_child = self.attached_packages_so_far();
+                let attached_for_child = self.attached_packages_for_ordinary_source();
                 let key = (
                     src_line,
                     src_col,
@@ -10126,8 +10375,15 @@ where
             } => {
                 let key = (line, column, false);
                 if !self.tar_batch_contributions.contains_key(&key) {
-                    let initial_scope =
+                    let mut initial_scope =
                         Self::tar_batch_initial_scope(&self.prefix_top, &self.global_strict_frame);
+                    if is_tar_source_batch(&members) {
+                        append_targets_pipeline_packages(
+                            &mut initial_scope,
+                            self.queried_uri,
+                            self.targets_pipeline_packages.iter().map(String::as_str),
+                        );
+                    }
                     let contribution =
                         self.resolve_tar_batch(line, column, &members, &initial_scope);
                     self.tar_batch_contributions.insert(key, contribution);
@@ -10232,6 +10488,34 @@ where
         out
     }
 
+    /// Attachment environment inherited by an ordinary `source()` child.
+    ///
+    /// Targets worker packages remain available while evaluating the current
+    /// pipeline or TarSource member, but they do not cross an ordinary Source
+    /// edge. A real lexical load in an active frame overrides a targets-only
+    /// prefix marker for the same package and therefore still propagates.
+    fn attached_packages_for_ordinary_source(&self) -> HashSet<String> {
+        let mut out: HashSet<String> = self
+            .choose_global_frame()
+            .attached_packages
+            .iter()
+            .cloned()
+            .collect();
+        let target = Position::new(self.advance_target.0, self.advance_target.1);
+        for (interval, frame) in &self.function_stack {
+            if interval.contains(target) {
+                out.extend(frame.attached_packages.iter().cloned());
+            }
+        }
+        let prefix = self.choose_prefix();
+        for package in &prefix.attached_packages {
+            if !prefix.targets_only_attached_packages.contains(package) || out.contains(package) {
+                out.insert(package.clone());
+            }
+        }
+        out
+    }
+
     /// Materialize the environment visible immediately before a global tar
     /// batch from the supplied streaming frame.
     fn tar_batch_initial_scope(prefix: &ParentPrefix, frame: &ScopeFrame) -> ScopeAtPosition {
@@ -10268,6 +10552,8 @@ where
                 .union(&frame.attached_packages)
                 .cloned()
                 .collect(),
+            targets_only_loaded_packages: prefix.targets_only_loaded_packages.clone(),
+            targets_only_attached_packages: prefix.targets_only_attached_packages.clone(),
             package_origins,
         }
     }
@@ -10469,6 +10755,8 @@ where
             // a few lines below.
             loaded_packages: HashSet::new(),
             attached_packages: prefix.attached_packages.clone(),
+            targets_only_loaded_packages: prefix.targets_only_loaded_packages.clone(),
+            targets_only_attached_packages: prefix.targets_only_attached_packages.clone(),
             package_origins: prefix.package_origins.clone(),
         };
 
@@ -10486,11 +10774,13 @@ where
             scope.symbols.insert(name.clone(), symbol.clone());
         }
         for pkg in &global.packages {
+            scope.targets_only_loaded_packages.remove(pkg);
             scope.loaded_packages.insert(pkg.clone());
         }
-        scope
-            .attached_packages
-            .extend(global.attached_packages.iter().cloned());
+        for pkg in &global.attached_packages {
+            scope.targets_only_attached_packages.remove(pkg);
+            scope.attached_packages.insert(pkg.clone());
+        }
         for (pkg, origins) in &global.package_origins {
             scope
                 .package_origins
@@ -10505,11 +10795,13 @@ where
                 scope.symbols.insert(name.clone(), symbol.clone());
             }
             for pkg in &frame.packages {
+                scope.targets_only_loaded_packages.remove(pkg);
                 scope.loaded_packages.insert(pkg.clone());
             }
-            scope
-                .attached_packages
-                .extend(frame.attached_packages.iter().cloned());
+            for pkg in &frame.attached_packages {
+                scope.targets_only_attached_packages.remove(pkg);
+                scope.attached_packages.insert(pkg.clone());
+            }
             for (pkg, origins) in &frame.package_origins {
                 scope
                     .package_origins
@@ -10594,6 +10886,15 @@ where
                     .extend(contrib.depth_exceeded.iter().cloned());
             }
         }
+
+        // Project the durable targets worker-package set after timeline
+        // execution. This makes it order-independent for the queried pipeline
+        // without feeding it into ordinary Source events.
+        append_targets_pipeline_packages(
+            &mut scope,
+            self.queried_uri,
+            self.targets_pipeline_packages.iter().map(String::as_str),
+        );
 
         // Apply package-mode contribution at the queried URI, mirroring the
         // recursive resolver's depth-0 injection. Keeping the call here (not
@@ -10900,8 +11201,15 @@ where
             } => {
                 let key = (*line, *column, true);
                 if !self.tar_batch_contributions.contains_key(&key) {
-                    let initial_scope =
+                    let mut initial_scope =
                         Self::tar_batch_initial_scope(&self.prefix_in_function, frame);
+                    if is_tar_source_batch(members) {
+                        append_targets_pipeline_packages(
+                            &mut initial_scope,
+                            self.queried_uri,
+                            self.targets_pipeline_packages.iter().map(String::as_str),
+                        );
+                    }
                     let contribution =
                         self.resolve_tar_batch(*line, *column, members, &initial_scope);
                     self.tar_batch_contributions.insert(key, contribution);
@@ -11182,17 +11490,20 @@ where
         merge_child_source_packages(
             &child_scope.loaded_packages,
             child_inherited_packages,
+            &child_scope.targets_only_loaded_packages,
             &child_scope.package_origins,
             self.queried_uri,
-            &mut contrib.packages,
+            (&mut contrib.packages, None),
             &mut contrib.package_origins,
         );
         merge_child_source_attachments(
             &child_scope.attached_packages,
             package_effects_only.then_some(&child_scope.loaded_packages),
+            &child_scope.targets_only_attached_packages,
             &child_scope.package_origins,
             self.queried_uri,
             &mut contrib.attached_packages,
+            None,
         );
 
         contrib
@@ -12652,6 +12963,31 @@ mod tests {
         assert_eq!(
             artifacts1.interface_hash, artifacts2.interface_hash,
             "rm() inside a function body must not change interface_hash"
+        );
+    }
+
+    #[test]
+    fn targets_pipeline_package_set_participates_in_interface_hash() {
+        let uri = test_uri();
+        let code1 = "targets::tar_option_set(packages = c(\"dplyr\", \"tidyr\"))";
+        let code2 = "\ntargets::tar_option_set(packages = c(\"tidyr\", \"dplyr\"))";
+        let code3 = "\ntargets::tar_option_set(packages = c(\"tidyr\", \"shiny\"))";
+
+        let artifacts_for_code = |code: &str| {
+            let metadata = crate::cross_file::extract_metadata(code);
+            compute_artifacts_with_metadata(&uri, &parse_r(code), code, Some(&metadata))
+        };
+        let artifacts1 = artifacts_for_code(code1);
+        let artifacts2 = artifacts_for_code(code2);
+        let artifacts3 = artifacts_for_code(code3);
+
+        assert_eq!(
+            artifacts1.interface_hash, artifacts2.interface_hash,
+            "declaration position and package order must not change the semantic set hash"
+        );
+        assert_ne!(
+            artifacts2.interface_hash, artifacts3.interface_hash,
+            "adding, removing, or renaming a targets worker package must invalidate dependents"
         );
     }
 
@@ -23707,21 +24043,24 @@ sapply(libs, library, character.only = TRUE)
     }
 
     #[test]
-    fn test_package_propagation_tar_option_set_parent_packages_in_child() {
-        // Issue #637: a `_targets.R`-style parent that attaches packages via
-        // `tar_option_set(packages = ...)` propagates them to sourced children,
-        // exactly like `library()` — mirrors
-        // `test_package_propagation_child_packages_in_parent` wiring.
+    fn targets_pipeline_packages_do_not_propagate_to_ordinary_source_child() {
+        // Issue #639: targets worker packages are a pipeline contribution, not
+        // an ordinary lexical attach. An ordinary source() child must not inherit
+        // them, even when the declaration precedes the call.
         use crate::cross_file::dependency::DependencyGraph;
-        use crate::cross_file::types::{CrossFileMetadata, ForwardSource};
+        use crate::cross_file::types::CrossFileMetadata;
 
-        // Parent (_targets.R shape): library(targets), tar_option_set, then
-        // source("child.R") at line 2.
         let parent_code =
             "library(targets)\ntar_option_set(packages = c(\"dplyr\"))\nsource(\"child.R\")";
         let parent_tree = parse_r(parent_code);
         let parent_uri = Url::parse("file:///project/parent.R").unwrap();
-        let parent_artifacts = compute_artifacts(&parent_uri, &parent_tree, parent_code);
+        let parent_meta = crate::cross_file::extract_metadata(parent_code);
+        let parent_artifacts = compute_artifacts_with_metadata(
+            &parent_uri,
+            &parent_tree,
+            parent_code,
+            Some(&parent_meta),
+        );
 
         // Child file: uses a dplyr verb.
         let child_code = "mutate(df, y = 1)";
@@ -23732,18 +24071,6 @@ sapply(libs, library, character.only = TRUE)
         let workspace_root = Url::parse("file:///project").unwrap();
 
         let mut graph = DependencyGraph::new();
-        let parent_meta = CrossFileMetadata {
-            sources: vec![ForwardSource {
-                path: "child.R".to_string(),
-                line: 2,
-                column: 0,
-                is_directive: false,
-                chdir: false,
-                is_sys_source: false,
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
         graph.update_file(&parent_uri, &parent_meta, Some(&workspace_root), |_| None);
 
         let get_artifacts = |uri: &Url| -> Option<Arc<ScopeArtifacts>> {
@@ -23764,8 +24091,8 @@ sapply(libs, library, character.only = TRUE)
             }
         };
 
-        // Query the child's scope: dplyr comes from the parent's
-        // tar_option_set(), which precedes the source() call.
+        // Query the child's scope: the parent's pipeline-only package must be
+        // filtered from this ordinary source edge.
         let child_scope = scope_at_position_with_graph(
             &child_uri,
             0,
@@ -23784,9 +24111,8 @@ sapply(libs, library, character.only = TRUE)
         );
 
         assert!(
-            child_scope.inherited_packages.contains("dplyr"),
-            "child sourced by a _targets.R-style parent should inherit dplyr from \
-             tar_option_set(packages = ...); inherited: {:?}",
+            !child_scope.inherited_packages.contains("dplyr"),
+            "ordinary source child must not inherit dplyr from tar_option_set(packages = ...): {:?}",
             child_scope.inherited_packages,
         );
     }
@@ -33737,6 +34063,670 @@ mod package_contribution_tests {
             Some(&member_uri),
             "the tar member definition must flow back into `_targets.R` after the batch"
         );
+    }
+
+    #[test]
+    fn targets_pipeline_packages_are_order_independent_and_tar_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        std::fs::create_dir(root.join("listed")).unwrap();
+        let first_code = "first <- function(df) mutate(df, first = TRUE)\n";
+        let second_code = "second <- function(df) mutate(df, second = TRUE)\n";
+        let ordinary_code = "ordinary <- function(df) mutate(df, ordinary = TRUE)\n";
+        let listed_code = "listed <- function(df) mutate(df, listed = TRUE)\n";
+        let unrelated_code = "unrelated <- function(df) mutate(df, unrelated = TRUE)\n";
+        std::fs::write(root.join("R/01-first.R"), first_code).unwrap();
+        std::fs::write(root.join("R/02-second.R"), second_code).unwrap();
+        std::fs::write(root.join("ordinary.R"), ordinary_code).unwrap();
+        std::fs::write(root.join("listed/01-listed.R"), listed_code).unwrap();
+        std::fs::write(root.join("unrelated.R"), unrelated_code).unwrap();
+
+        let parent_path = root.join("_targets.R");
+        let parent_code = "library(targets)\n\
+                           targets::tar_source(\"R\")\n\
+                           source(\"ordinary.R\")\n\
+                           files <- list.files(\"listed\", pattern = \"\\\\.R$\", full.names = TRUE)\n\
+                           for (file in files) source(file)\n\
+                           targets::tar_option_set(packages = \"dplyr\")\n";
+        std::fs::write(&parent_path, parent_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(&parent_path).unwrap();
+        let first_uri = Url::from_file_path(root.join("R/01-first.R")).unwrap();
+        let second_uri = Url::from_file_path(root.join("R/02-second.R")).unwrap();
+        let ordinary_uri = Url::from_file_path(root.join("ordinary.R")).unwrap();
+        let listed_uri = Url::from_file_path(root.join("listed/01-listed.R")).unwrap();
+        let unrelated_uri = Url::from_file_path(root.join("unrelated.R")).unwrap();
+
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let mut metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> =
+            HashMap::new();
+        metadata.insert(parent_uri.clone(), Arc::new(parent_metadata.clone()));
+        for (uri, code) in [
+            (&first_uri, first_code),
+            (&second_uri, second_code),
+            (&ordinary_uri, ordinary_code),
+            (&listed_uri, listed_code),
+            (&unrelated_uri, unrelated_code),
+        ] {
+            metadata.insert(
+                uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(code)),
+            );
+        }
+
+        let mut artifacts: HashMap<Url, Arc<ScopeArtifacts>> = HashMap::new();
+        for (uri, code) in [
+            (&parent_uri, parent_code),
+            (&first_uri, first_code),
+            (&second_uri, second_code),
+            (&ordinary_uri, ordinary_code),
+            (&listed_uri, listed_code),
+            (&unrelated_uri, unrelated_code),
+        ] {
+            artifacts.insert(
+                uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    uri,
+                    &parse_r(code),
+                    code,
+                    metadata.get(uri).map(Arc::as_ref),
+                )),
+            );
+        }
+
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let resolve = |uri: &Url, line, column, mode| {
+            scope_at_position_with_graph(
+                uri,
+                line,
+                column,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root_uri),
+                10,
+                &HashSet::new(),
+                false,
+                mode,
+                &|| false,
+                None,
+                None,
+            )
+        };
+
+        for (line, column) in [(0, 0), (u32::MAX, u32::MAX)] {
+            let scope = resolve(
+                &parent_uri,
+                line,
+                column,
+                super::super::config::BackwardDependencyMode::Explicit,
+            );
+            assert!(
+                scope.loaded_packages.contains("dplyr"),
+                "the declaring pipeline must see worker packages at {line}:{column}: {:?}",
+                scope.loaded_packages
+            );
+        }
+
+        for member_uri in [&first_uri, &second_uri] {
+            let recursive = resolve(
+                member_uri,
+                0,
+                0,
+                super::super::config::BackwardDependencyMode::Auto,
+            );
+            assert!(
+                recursive.inherited_packages.contains("dplyr"),
+                "every tar member, including ordinal zero, must inherit dplyr: {recursive:?}"
+            );
+
+            let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+            let base_exports = HashSet::new();
+            let mut stream = ScopeStream::new(
+                member_uri,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root_uri),
+                10,
+                &base_exports,
+                false,
+                super::super::config::BackwardDependencyMode::Auto,
+                &|| false,
+                &prefix_cache,
+                None,
+                None,
+            )
+            .unwrap();
+            stream.advance_to(0, 0);
+            let streamed = stream.snapshot();
+            assert_eq!(
+                recursive.inherited_packages.contains("dplyr"),
+                streamed.inherited_packages.contains("dplyr"),
+                "recursive and streaming scope must agree for {member_uri}"
+            );
+        }
+
+        for non_member_uri in [&ordinary_uri, &listed_uri, &unrelated_uri] {
+            let scope = resolve(
+                non_member_uri,
+                0,
+                0,
+                super::super::config::BackwardDependencyMode::Auto,
+            );
+            assert!(
+                !scope.inherited_packages.contains("dplyr")
+                    && !scope.loaded_packages.contains("dplyr"),
+                "targets worker packages must not leak to {non_member_uri}: {scope:?}"
+            );
+        }
+
+        let changed_code = parent_code.replace("\"dplyr\"", "\"shiny\"");
+        let mut changed_metadata = crate::cross_file::extract_metadata(&changed_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut changed_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let changed_artifacts = compute_artifacts_with_metadata(
+            &parent_uri,
+            &parse_r(&changed_code),
+            &changed_code,
+            Some(&changed_metadata),
+        );
+        let old_hash = artifacts.get(&parent_uri).unwrap().interface_hash;
+        assert_ne!(old_hash, changed_artifacts.interface_hash);
+        let affected = crate::cross_file::revalidation::compute_affected_dependents_after_edit(
+            &parent_uri,
+            old_hash != changed_artifacts.interface_hash,
+            false,
+            &graph,
+            |uri| uri == &first_uri || uri == &second_uri,
+            10,
+            100,
+        );
+        assert!(affected.contains(&first_uri));
+        assert!(affected.contains(&second_uri));
+    }
+
+    #[test]
+    fn sourced_targets_declaration_does_not_become_an_ordinary_package_load() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let parent_code = "source(\"options.R\")\nsource(\"ordinary.R\")\n";
+        let options_code = "targets::tar_option_set(packages = \"dplyr\")\n";
+        let ordinary_code = "result <- 1\n";
+        std::fs::write(root.join("parent.R"), parent_code).unwrap();
+        std::fs::write(root.join("options.R"), options_code).unwrap();
+        std::fs::write(root.join("ordinary.R"), ordinary_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(root.join("parent.R")).unwrap();
+        let options_uri = Url::from_file_path(root.join("options.R")).unwrap();
+        let ordinary_uri = Url::from_file_path(root.join("ordinary.R")).unwrap();
+        let mut metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> =
+            HashMap::new();
+        for (uri, code) in [
+            (&parent_uri, parent_code),
+            (&options_uri, options_code),
+            (&ordinary_uri, ordinary_code),
+        ] {
+            metadata.insert(
+                uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(code)),
+            );
+        }
+        let mut artifacts = HashMap::new();
+        for (uri, code) in [
+            (&parent_uri, parent_code),
+            (&options_uri, options_code),
+            (&ordinary_uri, ordinary_code),
+        ] {
+            artifacts.insert(
+                uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    uri,
+                    &parse_r(code),
+                    code,
+                    metadata.get(uri).map(Arc::as_ref),
+                )),
+            );
+        }
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(
+            &parent_uri,
+            metadata.get(&parent_uri).unwrap(),
+            Some(&root_uri),
+            |_| None,
+        );
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let recursive = scope_at_position_with_graph(
+            &parent_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(!recursive.loaded_packages.contains("dplyr"));
+        assert!(!recursive.attached_packages.contains("dplyr"));
+
+        let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+        let base_exports = HashSet::new();
+        let mut stream = ScopeStream::new(
+            &parent_uri,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            false,
+            super::super::config::BackwardDependencyMode::Explicit,
+            &|| false,
+            &prefix_cache,
+            None,
+            None,
+        )
+        .unwrap();
+        stream.advance_to(u32::MAX, u32::MAX);
+        let streamed = stream.snapshot();
+        assert!(!streamed.loaded_packages.contains("dplyr"));
+        assert!(!streamed.attached_packages.contains("dplyr"));
+
+        let ordinary = scope_at_position_with_graph(
+            &ordinary_uri,
+            0,
+            0,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(!ordinary.inherited_packages.contains("dplyr"));
+    }
+
+    #[test]
+    fn targets_attachment_barrier_yields_to_real_source_load_in_both_resolvers() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join("R")).unwrap();
+        let parent_code = "targets::tar_source(\"R\")\n\
+                           targets::tar_option_set(packages = \"shiny\")\n";
+        let member_code = "source(\"../unloaded.R\")\n\
+                           source(\"../loader.R\")\n\
+                           source(\"../consumer.R\")\n";
+        let unloaded_code = "renderPlot({ leaked <- 1 })\n";
+        let loader_code = "library(shiny)\n";
+        let consumer_code = "renderPlot({ isolated <- 1 })\n";
+        std::fs::write(root.join("_targets.R"), parent_code).unwrap();
+        std::fs::write(root.join("R/member.R"), member_code).unwrap();
+        std::fs::write(root.join("unloaded.R"), unloaded_code).unwrap();
+        std::fs::write(root.join("loader.R"), loader_code).unwrap();
+        std::fs::write(root.join("consumer.R"), consumer_code).unwrap();
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let parent_uri = Url::from_file_path(root.join("_targets.R")).unwrap();
+        let member_uri = Url::from_file_path(root.join("R/member.R")).unwrap();
+        let unloaded_uri = Url::from_file_path(root.join("unloaded.R")).unwrap();
+        let loader_uri = Url::from_file_path(root.join("loader.R")).unwrap();
+        let consumer_uri = Url::from_file_path(root.join("consumer.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (
+                member_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(member_code)),
+            ),
+            (
+                unloaded_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(unloaded_code)),
+            ),
+            (
+                loader_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(loader_code)),
+            ),
+            (
+                consumer_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(consumer_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut artifacts = HashMap::new();
+        for (uri, code) in [
+            (&parent_uri, parent_code),
+            (&member_uri, member_code),
+            (&unloaded_uri, unloaded_code),
+            (&loader_uri, loader_code),
+            (&consumer_uri, consumer_code),
+        ] {
+            artifacts.insert(
+                uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    uri,
+                    &parse_r(code),
+                    code,
+                    metadata.get(uri).map(Arc::as_ref),
+                )),
+            );
+        }
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        graph.update_file(
+            &member_uri,
+            metadata.get(&member_uri).unwrap(),
+            Some(&root_uri),
+            |_| None,
+        );
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+        let recursive = scope_at_position_with_graph(
+            &member_uri,
+            u32::MAX,
+            u32::MAX,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            true,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(
+            recursive.symbols.contains_key("leaked"),
+            "an ordinary source child before the real load must not see targets-only shiny"
+        );
+        assert!(
+            !recursive.symbols.contains_key("isolated"),
+            "a real sourced library(shiny) load must clear the targets-only marker for later children"
+        );
+
+        let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+        let base_exports = HashSet::new();
+        let mut stream = ScopeStream::new(
+            &member_uri,
+            &get_artifacts,
+            &get_metadata,
+            &graph,
+            Some(&root_uri),
+            10,
+            &base_exports,
+            true,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            &prefix_cache,
+            None,
+            None,
+        )
+        .unwrap();
+        stream.advance_to(u32::MAX, u32::MAX);
+        let streamed = stream.snapshot();
+        for symbol in ["leaked", "isolated"] {
+            assert_eq!(
+                recursive.symbols.contains_key(symbol),
+                streamed.symbols.contains_key(symbol),
+                "recursive and streaming ordinary-source attachment filtering must agree for {symbol}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_parent_channel_dominates_targets_only_parent_in_any_edge_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let targets_code = "targets::tar_source(\"shared.R\")\n\
+                            targets::tar_option_set(packages = \"shiny\")\n";
+        let ordinary_parent_code = "library(shiny)\nsource(\"shared.R\")\n";
+        let shared_code = "source(\"consumer.R\")\n";
+        let consumer_code = "renderPlot({ inner <- 1 })\n";
+        for (path, code) in [
+            ("_targets.R", targets_code),
+            ("ordinary-parent.R", ordinary_parent_code),
+            ("shared.R", shared_code),
+            ("consumer.R", consumer_code),
+        ] {
+            std::fs::write(root.join(path), code).unwrap();
+        }
+
+        let root_uri = Url::from_directory_path(root).unwrap();
+        let targets_uri = Url::from_file_path(root.join("_targets.R")).unwrap();
+        let ordinary_parent_uri = Url::from_file_path(root.join("ordinary-parent.R")).unwrap();
+        let shared_uri = Url::from_file_path(root.join("shared.R")).unwrap();
+        let consumer_uri = Url::from_file_path(root.join("consumer.R")).unwrap();
+        let mut targets_metadata = crate::cross_file::extract_metadata(targets_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut targets_metadata,
+            &targets_uri,
+            Some(&root_uri),
+        );
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (targets_uri.clone(), Arc::new(targets_metadata.clone())),
+            (
+                ordinary_parent_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(ordinary_parent_code)),
+            ),
+            (
+                shared_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(shared_code)),
+            ),
+            (
+                consumer_uri.clone(),
+                Arc::new(crate::cross_file::extract_metadata(consumer_code)),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut artifacts = HashMap::new();
+        for (uri, code) in [
+            (&targets_uri, targets_code),
+            (&ordinary_parent_uri, ordinary_parent_code),
+            (&shared_uri, shared_code),
+            (&consumer_uri, consumer_code),
+        ] {
+            artifacts.insert(
+                uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    uri,
+                    &parse_r(code),
+                    code,
+                    metadata.get(uri).map(Arc::as_ref),
+                )),
+            );
+        }
+        let get_artifacts = |uri: &Url| artifacts.get(uri).cloned();
+        let get_metadata = |uri: &Url| metadata.get(uri).cloned();
+
+        for targets_first in [true, false] {
+            let mut graph = super::super::dependency::DependencyGraph::new();
+            let add_targets_parent = |graph: &mut super::super::dependency::DependencyGraph| {
+                graph.update_file(&targets_uri, &targets_metadata, Some(&root_uri), |_| None);
+            };
+            let add_ordinary_parent = |graph: &mut super::super::dependency::DependencyGraph| {
+                graph.update_file(
+                    &ordinary_parent_uri,
+                    metadata.get(&ordinary_parent_uri).unwrap(),
+                    Some(&root_uri),
+                    |_| None,
+                );
+            };
+            if targets_first {
+                add_targets_parent(&mut graph);
+                add_ordinary_parent(&mut graph);
+            } else {
+                add_ordinary_parent(&mut graph);
+                add_targets_parent(&mut graph);
+            }
+            graph.update_file(
+                &shared_uri,
+                metadata.get(&shared_uri).unwrap(),
+                Some(&root_uri),
+                |_| None,
+            );
+
+            let recursive = scope_at_position_with_graph(
+                &shared_uri,
+                u32::MAX,
+                u32::MAX,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root_uri),
+                10,
+                &HashSet::new(),
+                true,
+                super::super::config::BackwardDependencyMode::Auto,
+                &|| false,
+                None,
+                None,
+            );
+            assert!(recursive.inherited_packages.contains("shiny"));
+            assert!(!recursive.targets_only_loaded_packages.contains("shiny"));
+            assert!(!recursive.targets_only_attached_packages.contains("shiny"));
+            assert!(
+                !recursive.symbols.contains_key("inner"),
+                "ordinary shiny channel must reach the shared file's ordinary child"
+            );
+
+            let prefix_cache = std::cell::RefCell::new(ParentPrefixCache::new());
+            let base_exports = HashSet::new();
+            let mut stream = ScopeStream::new(
+                &shared_uri,
+                &get_artifacts,
+                &get_metadata,
+                &graph,
+                Some(&root_uri),
+                10,
+                &base_exports,
+                true,
+                super::super::config::BackwardDependencyMode::Auto,
+                &|| false,
+                &prefix_cache,
+                None,
+                None,
+            )
+            .unwrap();
+            stream.advance_to(u32::MAX, u32::MAX);
+            let streamed = stream.snapshot();
+            assert_eq!(
+                recursive.symbols.contains_key("inner"),
+                streamed.symbols.contains_key("inner"),
+                "recursive and streaming multi-parent package dominance must agree"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targets_pipeline_packages_follow_symlink_spelled_tar_batch() {
+        let temp = tempfile::tempdir().unwrap();
+        let real_root = temp.path().join("real");
+        let link_root = temp.path().join("link");
+        std::fs::create_dir_all(real_root.join("R")).unwrap();
+        std::os::unix::fs::symlink(&real_root, &link_root).unwrap();
+        let parent_code =
+            "targets::tar_source(\"R\")\ntargets::tar_option_set(packages = \"dplyr\")\n";
+        let member_code = "build <- function(df) mutate(df, ready = TRUE)\n";
+        std::fs::write(real_root.join("_targets.R"), parent_code).unwrap();
+        std::fs::write(real_root.join("R/member.R"), member_code).unwrap();
+
+        let root_uri = Url::from_directory_path(&link_root).unwrap();
+        let parent_uri = Url::from_file_path(link_root.join("_targets.R")).unwrap();
+        let member_uri = Url::from_file_path(link_root.join("R/member.R")).unwrap();
+        let mut parent_metadata = crate::cross_file::extract_metadata(parent_code);
+        crate::cross_file::tar_source::finalize_tar_source_requests(
+            &mut parent_metadata,
+            &parent_uri,
+            Some(&root_uri),
+        );
+        assert_eq!(
+            parent_metadata.sources[0].resolved_uri.as_ref(),
+            Some(&member_uri),
+            "the fixture must retain the symlink URI spelling"
+        );
+        let member_metadata = crate::cross_file::extract_metadata(member_code);
+        let metadata: HashMap<Url, Arc<super::super::types::CrossFileMetadata>> = [
+            (parent_uri.clone(), Arc::new(parent_metadata.clone())),
+            (member_uri.clone(), Arc::new(member_metadata.clone())),
+        ]
+        .into_iter()
+        .collect();
+        let artifacts: HashMap<Url, Arc<ScopeArtifacts>> = [
+            (
+                parent_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &parent_uri,
+                    &parse_r(parent_code),
+                    parent_code,
+                    Some(&parent_metadata),
+                )),
+            ),
+            (
+                member_uri.clone(),
+                Arc::new(compute_artifacts_with_metadata(
+                    &member_uri,
+                    &parse_r(member_code),
+                    member_code,
+                    Some(&member_metadata),
+                )),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let mut graph = super::super::dependency::DependencyGraph::new();
+        graph.update_file(&parent_uri, &parent_metadata, Some(&root_uri), |_| None);
+        let scope = scope_at_position_with_graph(
+            &member_uri,
+            0,
+            0,
+            &|uri| artifacts.get(uri).cloned(),
+            &|uri| metadata.get(uri).cloned(),
+            &graph,
+            Some(&root_uri),
+            10,
+            &HashSet::new(),
+            false,
+            super::super::config::BackwardDependencyMode::Auto,
+            &|| false,
+            None,
+            None,
+        );
+        assert!(scope.inherited_packages.contains("dplyr"), "{scope:?}");
     }
 
     #[test]

--- a/crates/raven/src/cross_file/scope.rs
+++ b/crates/raven/src/cross_file/scope.rs
@@ -984,6 +984,9 @@ fn append_targets_pipeline_packages<'a>(
     packages: impl IntoIterator<Item = &'a str>,
 ) {
     for package in packages {
+        if package.is_empty() {
+            continue;
+        }
         if !scope.inherited_packages.contains(package) && !scope.loaded_packages.contains(package) {
             scope
                 .targets_only_loaded_packages
@@ -34062,6 +34065,36 @@ mod package_contribution_tests {
                 .map(|symbol| &symbol.source_uri),
             Some(&member_uri),
             "the tar member definition must flow back into `_targets.R` after the batch"
+        );
+    }
+
+    #[test]
+    fn targets_pipeline_packages_skip_empty_names() {
+        let origin_uri = Url::parse("file:///workspace/_targets.R").unwrap();
+        let mut scope = ScopeAtPosition::default();
+
+        append_targets_pipeline_packages(&mut scope, &origin_uri, ["", "dplyr"]);
+
+        assert_eq!(scope.loaded_packages, HashSet::from(["dplyr".to_string()]));
+        assert_eq!(
+            scope.attached_packages,
+            HashSet::from(["dplyr".to_string()])
+        );
+        assert_eq!(
+            scope.targets_only_loaded_packages,
+            HashSet::from(["dplyr".to_string()])
+        );
+        assert_eq!(
+            scope.targets_only_attached_packages,
+            HashSet::from(["dplyr".to_string()])
+        );
+        assert_eq!(
+            scope
+                .package_origins
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>(),
+            HashSet::from(["dplyr".to_string()])
         );
     }
 

--- a/crates/raven/src/cross_file/source_detect.rs
+++ b/crates/raven/src/cross_file/source_detect.rs
@@ -13,7 +13,7 @@ use super::binding::RuntimeFunctionScope;
 use super::scope::FunctionScopeInterval;
 use super::types::{
     ForwardSource, ListFilesSourceRequest, SourceLocality, TarSourceRequest,
-    byte_offset_to_utf16_column,
+    TargetsPackageDeclaration, byte_offset_to_utf16_column,
 };
 
 /// Maximum depth followed by suppressive-only static source-closure scans.
@@ -154,7 +154,11 @@ pub(crate) struct FramedLibraryCall {
     pub(crate) runtime_function_scope: RuntimeFunctionScope,
 }
 
-/// Detected library/require/loadNamespace call
+/// Detected lexical library/require/loadNamespace call.
+///
+/// Targets worker packages are stored separately as
+/// [`TargetsPackageDeclaration`] because they apply to the whole pipeline,
+/// independent of declaration position.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LibraryCall {
     /// Package name (if statically determinable)
@@ -168,9 +172,7 @@ pub struct LibraryCall {
     /// Whether the call *attaches* the package to the search path so its exports
     /// become available as bare names: `true` for `library()` / `require()`,
     /// `false` for `loadNamespace()` (which loads the namespace for qualified
-    /// `pkg::fn` access only). Packages recognized from a {targets}
-    /// `tar_option_set(packages = ...)` call are also `true` — targets attaches
-    /// them before running each target, so downstream scripts use bare names.
+    /// `pkg::fn` access only).
     ///
     /// Consumers must require `attaches` only when they gate on a *bare function*
     /// being resolvable — e.g. Shiny deferred-helper recognition
@@ -1573,11 +1575,14 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 // Library Call Detection
 // ============================================================================
 
-/// Detects package loads in the file: direct `library()`/`require()`/`loadNamespace()`
-/// calls, static pacman `p_load()` calls, apply-family calls whose FUN argument
-/// is a bare reference to `library` or `require`, deterministic package-loader
-/// `for` loops, and {targets}
-/// `tar_option_set(packages = ...)` calls (see `try_parse_tar_option_set_call`).
+/// Detects lexical package loads in the file: direct
+/// `library()`/`require()`/`loadNamespace()` calls, static pacman `p_load()`
+/// calls, apply-family calls whose FUN argument is a bare reference to
+/// `library` or `require`, and deterministic package-loader `for` loops.
+///
+/// Targets `tar_option_set(packages = ...)` declarations are deliberately
+/// excluded; use [`detect_targets_pipeline_packages`] for that distinct,
+/// pipeline-level channel.
 ///
 /// For direct calls, the package must be a bare identifier (`library(dplyr)`)
 /// or a string literal (`library("dplyr")`); direct calls with
@@ -1600,16 +1605,6 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 /// level. The emitted calls share the loop's end position, after every package
 /// has been attached.
 ///
-/// For `tar_option_set(packages = ...)` calls, the bare spelling is honored
-/// only when the same file also attaches targets (`library(targets)` /
-/// `require(targets)` anywhere in the file); `targets::` / `targets:::`
-/// qualified spellings are honored unconditionally. See
-/// `append_gated_tar_option_set_calls` for the gate. Calls nested in a proven
-/// capture wrapper (`quote(...)`, `expression(...)`, qualified rlang `expr(...)`,
-/// and related forms) are not detected. Evaluated portions remain visible:
-/// `substitute()` environment arguments, `bquote()` controls and `.()` splices,
-/// and rlang `!!`/`!!!` operands are traversed.
-///
 /// Qualified `pacman::p_load()` calls are unconditional. Bare `p_load()` calls
 /// carry a `requires_attached = Some("pacman")` precondition that graph-aware
 /// scope resolution evaluates at the call; this permits a parent file's
@@ -1625,7 +1620,7 @@ fn extract_c_string_args(node: Node, content: &str) -> Vec<String> {
 ///
 /// let mut parser = tree_sitter::Parser::new();
 /// parser.set_language(&tree_sitter_r::LANGUAGE.into()).unwrap();
-/// let source = "library(targets)\ntar_option_set(packages = c(\"dplyr\"))";
+/// let source = "library(targets)\nlibrary(dplyr)";
 /// let tree = parser.parse(source, None).unwrap();
 /// let calls = detect_library_calls(&tree, source);
 /// assert_eq!(calls.len(), 2);
@@ -1647,7 +1642,8 @@ pub(crate) fn detect_library_calls_with_bindings<'tree, 'text>(
     content: &'text str,
     capture_bindings: &mut super::static_path::LazyStaticBindings<'tree, 'text>,
 ) -> Vec<LibraryCall> {
-    detect_library_calls_with_bindings_and_order(tree, content, capture_bindings)
+    detect_library_walk_output(tree, content, capture_bindings)
+        .library_calls
         .into_iter()
         .map(|detected| detected.call)
         .collect()
@@ -1658,7 +1654,8 @@ pub(crate) fn detect_library_calls_with_bindings_for_scope<'tree, 'text>(
     content: &'text str,
     capture_bindings: &mut super::static_path::LazyStaticBindings<'tree, 'text>,
 ) -> Vec<FramedLibraryCall> {
-    detect_library_calls_with_bindings_and_order(tree, content, capture_bindings)
+    detect_library_walk_output(tree, content, capture_bindings)
+        .library_calls
         .into_iter()
         .filter_map(|detected| {
             detected.scope_orderable.then_some(FramedLibraryCall {
@@ -1669,12 +1666,12 @@ pub(crate) fn detect_library_calls_with_bindings_for_scope<'tree, 'text>(
         .collect()
 }
 
-fn detect_library_calls_with_bindings_and_order<'tree, 'text>(
+fn detect_library_walk_output<'tree, 'text>(
     tree: &'tree Tree,
     content: &'text str,
     capture_bindings: &mut super::static_path::LazyStaticBindings<'tree, 'text>,
-) -> Vec<LibraryWalkCall> {
-    log::trace!("Starting tree-sitter parsing for library() call detection");
+) -> LibraryWalkOutput {
+    log::trace!("Starting tree-sitter parsing for package detection");
     let mut output = LibraryWalkOutput {
         scan_p_load: content.contains("p_load"),
         ..Default::default()
@@ -1689,27 +1686,19 @@ fn detect_library_calls_with_bindings_and_order<'tree, 'text>(
         true,
         &mut output,
     );
-    append_gated_tar_option_set_calls(&mut output);
-    // Restore document order: gated tar_option_set entries are appended after
-    // the walk, so sort by position. The sort is stable, keeping same-position
-    // entries (an apply-family call's per-package fan-out all shares the apply
-    // call's end position) in emission order.
+    finalize_tar_option_set_candidates(&mut output);
     output
         .library_calls
         .sort_by_key(|detected| (detected.call.line, detected.call.column));
+    output
+        .targets_pipeline_packages
+        .sort_by_key(|declaration| (declaration.line, declaration.column));
     log::trace!(
-        "Completed library() call detection, found {} calls",
-        output.library_calls.len()
+        "Completed package detection: {} lexical loads, {} targets pipeline packages",
+        output.library_calls.len(),
+        output.targets_pipeline_packages.len()
     );
-    for detected in &output.library_calls {
-        log::trace!(
-            "  Detected library() call: package='{}' at line {} column {}",
-            detected.call.package,
-            detected.call.line,
-            detected.call.column
-        );
-    }
-    output.library_calls
+    output
 }
 
 /// Parse `text` and return the set of packages it *attaches* via a
@@ -1733,12 +1722,6 @@ fn detect_library_calls_with_bindings_and_order<'tree, 'text>(
 ///
 /// `requireNamespace()` is NOT a match (it isn't a `library`/`require`/
 /// `loadNamespace` call), so it never attaches here.
-///
-/// Top-level {targets} `tar_option_set(packages = ...)` calls also attach
-/// (targets attaches the listed packages before running each target); the bare
-/// spelling requires a top-level `library(targets)`/`require(targets)` in the
-/// same text, while `targets::`/`targets:::` qualified spellings do not — see
-/// `append_gated_tar_option_set_calls`.
 ///
 /// Returns an empty set when the text cannot be parsed.
 ///
@@ -1792,7 +1775,6 @@ fn top_level_attaching_library_calls_with_bindings<'tree, 'text>(
         true,
         &mut output,
     );
-    append_gated_tar_option_set_calls(&mut output);
     output
         .library_calls
         .sort_by_key(|detected| (detected.call.line, detected.call.column));
@@ -1833,6 +1815,7 @@ struct LibraryWalkCall {
 struct LibraryWalkOutput {
     library_calls: Vec<LibraryWalkCall>,
     tar_candidates: Vec<TarOptionSetCandidate>,
+    targets_pipeline_packages: Vec<TargetsPackageDeclaration>,
     scan_p_load: bool,
 }
 
@@ -1879,7 +1862,7 @@ impl LibraryWalkOutput {
 ///
 /// Direct calls push at most one [`LibraryCall`]; apply calls may push one entry
 /// per package. `tar_option_set` calls are collected separately so the caller
-/// can apply [`append_gated_tar_option_set_calls`] after the walk.
+/// can apply [`finalize_tar_option_set_candidates`] after the walk.
 fn visit_node_for_library(
     node: Node,
     content: &str,
@@ -1966,14 +1949,14 @@ fn visit_node_for_library(
                     runtime_function_scope,
                     scope_orderable,
                 );
-                collect_tar_option_set_candidates(
-                    node,
-                    content,
-                    capture_bindings,
-                    runtime_function_scope,
-                    scope_orderable,
-                    &mut output.tar_candidates,
-                );
+                if !runtime_function_scope.is_function_scoped_at(node) {
+                    collect_tar_option_set_candidates(
+                        node,
+                        content,
+                        capture_bindings,
+                        &mut output.tar_candidates,
+                    );
+                }
             }
         }
     }
@@ -2913,19 +2896,12 @@ fn try_parse_pacman_p_load_call(
 // targets::tar_option_set Package Detection (issue #637)
 // ============================================================================
 
-/// A package attachment extracted from a {targets}
-/// `tar_option_set(packages = ...)` call during a library-detection walk,
-/// tagged with whether the callee was the bare spelling (`tar_option_set`)
-/// rather than the qualified `targets::tar_option_set` /
-/// `targets:::tar_option_set`.
-///
-/// Bare candidates are subject to the targets-in-play gate applied after the
-/// walk — see [`append_gated_tar_option_set_calls`].
+/// A statically resolved worker package from a top-level {targets}
+/// `tar_option_set(packages = ...)` call, pending the file-wide bare-callee
+/// targets-in-play gate.
 struct TarOptionSetCandidate {
-    call: LibraryCall,
+    declaration: TargetsPackageDeclaration,
     bare: bool,
-    runtime_function_scope: RuntimeFunctionScope,
-    scope_orderable: bool,
 }
 
 /// Whether `func_node` (a call's `function` child) names {targets}'
@@ -2959,8 +2935,6 @@ fn collect_tar_option_set_candidates(
     node: Node,
     content: &str,
     bindings: &mut super::static_path::LazyStaticBindings,
-    runtime_function_scope: RuntimeFunctionScope,
-    scope_orderable: bool,
     tar_candidates: &mut Vec<TarOptionSetCandidate>,
 ) {
     let Some(func_node) = node.child_by_field_name("function") else {
@@ -2969,42 +2943,29 @@ fn collect_tar_option_set_candidates(
     let Some(bare) = targets_callee_kind(func_node, content, "tar_option_set") else {
         return;
     };
+    if bare
+        && bindings
+            .get()
+            .named_binding_may_shadow_at("tar_option_set", node, false)
+    {
+        return;
+    }
     tar_candidates.extend(
         try_parse_tar_option_set_call(node, content, bindings)
             .into_iter()
-            .map(|call| TarOptionSetCandidate {
-                call,
-                bare,
-                runtime_function_scope,
-                scope_orderable,
-            }),
+            .map(|declaration| TarOptionSetCandidate { declaration, bare }),
     );
 }
 
-/// Append gate-filtered `tar_option_set(packages = ...)` attachments to
-/// `library_calls`.
+/// Move gate-approved `tar_option_set(packages = ...)` candidates into the
+/// distinct pipeline-package channel.
 ///
-/// The targets-in-play gate: a QUALIFIED callee (`targets::tar_option_set` /
-/// `targets:::tar_option_set`) is accepted unconditionally — the author has
-/// unambiguously named the {targets} package. A BARE `tar_option_set` callee
-/// is accepted only when the same walk already found an attaching load of
-/// targets (`library(targets)` / `require(targets)`), so that an unrelated
-/// user function that happens to be called `tar_option_set` doesn't silently
-/// attach packages. This mirrors the `shiny_in_play` gate precedent in
-/// `scope.rs`'s `push_shiny_deferred_scopes`. The gate is position-independent
-/// within the file: a `library(targets)` anywhere the walk visited counts,
-/// regardless of whether it appears before or after the `tar_option_set` call.
-/// On the position-aware path (`detect_library_calls`) the gate is also
-/// file-wide and scope-blind by design — an attaching `library(targets)`
-/// inside a function body satisfies it (the top-level walker naturally
-/// excludes those); it limits name-collision false attaches and is not a
-/// correctness guarantee.
-///
-/// Must be called after the walk completes (the gate inspects the walk's
-/// collected `library_calls`), and must stay the single shared post-filter for
-/// both `detect_library_calls` and `extract_attached_packages` so the two
-/// walkers cannot drift.
-fn append_gated_tar_option_set_calls(output: &mut LibraryWalkOutput) {
+/// Qualified calls are accepted unconditionally. A bare call requires an
+/// attaching `library(targets)` / `require(targets)` somewhere in the same
+/// evaluated file. This gate is deliberately position-independent, matching
+/// the pipeline-level semantics; local callee shadowing is rejected earlier by
+/// [`collect_tar_option_set_candidates`].
+fn finalize_tar_option_set_candidates(output: &mut LibraryWalkOutput) {
     let mut ordered_calls: Vec<_> = output.library_calls.iter().collect();
     ordered_calls.sort_by_key(|detected| (detected.call.line, detected.call.column));
     let mut attached = std::collections::BTreeSet::new();
@@ -3022,20 +2983,20 @@ fn append_gated_tar_option_set_calls(output: &mut LibraryWalkOutput) {
     let targets_attached = attached.contains("targets");
     for candidate in std::mem::take(&mut output.tar_candidates) {
         if !candidate.bare || targets_attached {
-            output.push_call(
-                candidate.call,
-                candidate.runtime_function_scope,
-                candidate.scope_orderable,
-            );
+            output.targets_pipeline_packages.push(candidate.declaration);
         }
     }
+    output.targets_pipeline_packages.sort_by(|left, right| {
+        (&left.package, left.line, left.column).cmp(&(&right.package, right.line, right.column))
+    });
+    output
+        .targets_pipeline_packages
+        .dedup_by(|left, right| left.package == right.package);
 }
 
 /// Try to interpret `node` as a {targets} `tar_option_set(packages = ...)`
-/// call and return one `LibraryCall` per statically determinable package,
-/// each with `attaches: true` — targets attaches these packages before
-/// running each target, so scripts sourced by `_targets.R` use their exports
-/// as bare names.
+/// call and return one anchored [`TargetsPackageDeclaration`] per statically
+/// determinable package.
 ///
 /// Only the NAMED `packages =` argument is honored. This is an intentional
 /// limitation: `tar_option_set`'s first formal is `tidy_eval`, not `packages`,
@@ -3057,9 +3018,9 @@ fn append_gated_tar_option_set_calls(output: &mut LibraryWalkOutput) {
 /// Anything else (dynamic calls, `character(0)`, empty `c()`) yields nothing.
 ///
 /// Position anchoring: `tar_option_set()` calls routinely span 10–30 lines,
-/// and the missing-package diagnostic builds its range from a `LibraryCall`'s
+/// and the missing-package diagnostic builds its range from a `TargetsPackageDeclaration`'s
 /// line/column while `# raven: ignore` suppression is line-keyed — so for the
-/// string-literal and `c()`-of-literals shapes, each package's `LibraryCall`
+/// string-literal and `c()`-of-literals shapes, each package's `TargetsPackageDeclaration`
 /// carries the end position of ITS OWN string-literal node (not the call's
 /// closing paren). The variable-resolved shape has no literal at the call
 /// site, so it falls back to the call's end position, mirroring the
@@ -3072,13 +3033,13 @@ fn append_gated_tar_option_set_calls(output: &mut LibraryWalkOutput) {
 /// verb as undefined) — do not "fix" this to last-call-wins.
 ///
 /// The caller is responsible for the bare-vs-qualified targets-in-play gate
-/// (see [`append_gated_tar_option_set_calls`]); this function parses any
+/// (see [`finalize_tar_option_set_candidates`]); this function parses any
 /// callee matching [`targets_callee_kind`].
 fn try_parse_tar_option_set_call(
     node: Node,
     content: &str,
     bindings: &mut super::static_path::LazyStaticBindings,
-) -> Vec<LibraryCall> {
+) -> Vec<TargetsPackageDeclaration> {
     let Some(func_node) = node.child_by_field_name("function") else {
         return Vec::new();
     };
@@ -3110,25 +3071,22 @@ fn try_parse_tar_option_set_call(
         return Vec::new();
     };
 
-    // Build a LibraryCall anchored at `anchor`'s end position (line + UTF-16
+    // Build an anchored declaration at `anchor`'s end position (line + UTF-16
     // column), matching how the other detectors in this file anchor.
-    let call_at = |package: String, anchor: Node| -> LibraryCall {
+    let declaration_at = |package: String, anchor: Node| -> TargetsPackageDeclaration {
         let end = anchor.end_position();
         let line_text = content.lines().nth(end.row).unwrap_or("");
-        LibraryCall {
+        TargetsPackageDeclaration {
             package,
             line: end.row as u32,
             column: byte_offset_to_utf16_column(line_text, end.column),
-            function_scope: None,
-            attaches: true,
-            requires_attached: None,
         }
     };
 
     match value_node.kind() {
         // `packages = "dplyr"` — anchored at the literal itself.
         "string" => match extract_string_literal(*value_node, content) {
-            Some(package) => vec![call_at(package, *value_node)],
+            Some(package) => vec![declaration_at(package, *value_node)],
             None => Vec::new(),
         },
         // `pkgs <- c("a", "b"); tar_option_set(packages = pkgs)` — no literal
@@ -3140,7 +3098,7 @@ fn try_parse_tar_option_set_call(
             match bindings.resolve_package_vector(text, node) {
                 Some(packages) => packages
                     .into_iter()
-                    .map(|package| call_at(package, node))
+                    .map(|package| declaration_at(package, node))
                     .collect(),
                 None => Vec::new(),
             }
@@ -3157,10 +3115,26 @@ fn try_parse_tar_option_set_call(
             }
             pairs
                 .into_iter()
-                .map(|(package, literal)| call_at(package, literal))
+                .map(|(package, literal)| declaration_at(package, literal))
                 .collect()
         }
     }
+}
+
+/// Detect the file/pipeline-level worker package set declared by statically
+/// recognized top-level `tar_option_set(packages = ...)` calls.
+///
+/// Bare calls require `{targets}` to be attached somewhere in the same file and
+/// must not be shadowed by a local binding. Qualified `targets::` / `targets:::`
+/// calls are unconditional. Multiple calls union their statically resolved
+/// packages; unsupported dynamic forms contribute nothing.
+pub fn detect_targets_pipeline_packages(
+    tree: &Tree,
+    content: &str,
+) -> Vec<TargetsPackageDeclaration> {
+    let root = tree.root_node();
+    let mut bindings = super::static_path::LazyStaticBindings::new(root, content);
+    detect_library_walk_output(tree, content, &mut bindings).targets_pipeline_packages
 }
 
 // ============================================================================
@@ -3212,16 +3186,28 @@ pub(crate) fn detect_library_and_tar_source_requests(
     content: &str,
 ) -> (
     Vec<LibraryCall>,
+    Vec<TargetsPackageDeclaration>,
     Vec<TarSourceRequest>,
     Vec<ListFilesSourceRequest>,
 ) {
     let root = tree.root_node();
     let mut bindings = super::static_path::LazyStaticBindings::new(root, content);
-    let library_calls = detect_library_calls_with_bindings(tree, content, &mut bindings);
+    let package_output = detect_library_walk_output(tree, content, &mut bindings);
+    let library_calls = package_output
+        .library_calls
+        .into_iter()
+        .map(|detected| detected.call)
+        .collect();
+    let targets_pipeline_packages = package_output.targets_pipeline_packages;
     let requests = detect_tar_source_requests_with_bindings(root, content, &mut bindings);
     let list_files_requests =
         detect_list_files_source_requests_with_bindings(root, content, &mut bindings);
-    (library_calls, requests, list_files_requests)
+    (
+        library_calls,
+        targets_pipeline_packages,
+        requests,
+        list_files_requests,
+    )
 }
 
 /// Detect the deliberately bounded directory-source idiom:
@@ -7036,10 +7022,12 @@ server <- function(input, output, session) {
   output$plot <- renderPlot({ inner <- 1 })
 }
 "#;
-        let calls = detect_library_calls(&parse_r(code), code);
+        let packages = detect_targets_pipeline_packages(&parse_r(code), code);
         assert!(
-            calls.iter().any(|call| call.package == "shiny"),
-            "got: {calls:?}"
+            packages
+                .iter()
+                .any(|declaration| declaration.package == "shiny"),
+            "got: {packages:?}"
         );
     }
 
@@ -7461,10 +7449,12 @@ bquote(.(assign("libs", c("dplyr"))))"#,
             let code = format!(
                 "library(targets)\n{assign}(\"libs\", c(\"shiny\"), pos = 1)\ntar_option_set(packages = libs)"
             );
-            let calls = detect_library_calls(&parse_r(&code), &code);
+            let packages = detect_targets_pipeline_packages(&parse_r(&code), &code);
             assert!(
-                calls.iter().any(|call| call.package == "shiny"),
-                "{assign}: {calls:?}"
+                packages
+                    .iter()
+                    .any(|declaration| declaration.package == "shiny"),
+                "{assign}: {packages:?}"
             );
         }
     }
@@ -8254,24 +8244,18 @@ sapply(libs, library, character.only = TRUE)"#;
 
     // ==================== tar_option_set package detection (#637) ====================
 
-    /// Convenience: the detected calls minus the `targets` load itself.
-    fn tar_calls(code: &str) -> Vec<LibraryCall> {
-        let tree = parse_r(code);
-        detect_library_calls(&tree, code)
-            .into_iter()
-            .filter(|c| c.package != "targets")
-            .collect()
+    /// Convenience: the distinct file/pipeline-level targets package channel.
+    fn tar_packages(code: &str) -> Vec<TargetsPackageDeclaration> {
+        detect_targets_pipeline_packages(&parse_r(code), code)
     }
 
     #[test]
     fn test_tar_option_set_inline_c_with_library_targets() {
         let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\", \"tidyr\"))";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 2, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
         assert_eq!(calls[1].package, "tidyr");
-        assert!(calls[0].attaches);
-        assert!(calls[1].attaches);
         // Each package is anchored at its OWN string literal, not the call end.
         assert_eq!(calls[0].line, 1);
         assert_eq!(calls[1].line, 1);
@@ -8280,16 +8264,14 @@ sapply(libs, library, character.only = TRUE)"#;
             "per-literal anchoring: distinct literals have distinct columns"
         );
         assert!(calls[0].column < calls[1].column);
-        assert!(calls[0].function_scope.is_none());
     }
 
     #[test]
     fn test_tar_option_set_single_string_literal() {
         let code = "library(targets)\ntar_option_set(packages = \"dplyr\")";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 1, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
-        assert!(calls[0].attaches);
         assert_eq!(calls[0].line, 1);
     }
 
@@ -8298,16 +8280,26 @@ sapply(libs, library, character.only = TRUE)"#;
         // Qualified spellings are accepted unconditionally — no library(targets)
         // needed.
         let code = "targets::tar_option_set(packages = c(\"dplyr\"))";
-        let tree = parse_r(code);
-        let calls = detect_library_calls(&tree, code);
-        assert_eq!(calls.len(), 1, "got: {calls:?}");
-        assert_eq!(calls[0].package, "dplyr");
+        let packages = tar_packages(code);
+        assert_eq!(packages.len(), 1, "got: {packages:?}");
+        assert_eq!(packages[0].package, "dplyr");
 
         let code = "targets:::tar_option_set(packages = c(\"dplyr\"))";
-        let tree = parse_r(code);
-        let calls = detect_library_calls(&tree, code);
-        assert_eq!(calls.len(), 1, "got: {calls:?}");
-        assert_eq!(calls[0].package, "dplyr");
+        let packages = tar_packages(code);
+        assert_eq!(packages.len(), 1, "got: {packages:?}");
+        assert_eq!(packages[0].package, "dplyr");
+    }
+
+    #[test]
+    fn test_tar_option_set_bare_shadowed_but_qualified_still_detected() {
+        let code = "library(targets)\ntar_option_set <- function(...) NULL\ntar_option_set(packages = \"dplyr\")";
+        assert!(tar_packages(code).is_empty());
+
+        let code =
+            "tar_option_set <- function(...) NULL\ntargets::tar_option_set(packages = \"dplyr\")";
+        let packages = tar_packages(code);
+        assert_eq!(packages.len(), 1, "got: {packages:?}");
+        assert_eq!(packages[0].package, "dplyr");
     }
 
     #[test]
@@ -8315,16 +8307,15 @@ sapply(libs, library, character.only = TRUE)"#;
         // The bare spelling requires targets to be attached somewhere in the
         // file (targets-in-play gate).
         let code = "tar_option_set(packages = c(\"dplyr\"))";
-        let tree = parse_r(code);
-        let calls = detect_library_calls(&tree, code);
-        assert_eq!(calls.len(), 0, "got: {calls:?}");
+        let packages = tar_packages(code);
+        assert!(packages.is_empty(), "got: {packages:?}");
     }
 
     #[test]
     fn test_tar_option_set_bare_gate_is_position_independent() {
         // library(targets) AFTER the call still satisfies the gate.
         let code = "tar_option_set(packages = \"dplyr\")\nlibrary(targets)";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 1, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
     }
@@ -8334,7 +8325,7 @@ sapply(libs, library, character.only = TRUE)"#;
         // loadNamespace("targets") does not attach, so it does not enable the
         // bare spelling.
         let code = "loadNamespace(\"targets\")\ntar_option_set(packages = c(\"dplyr\"))";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 0, "got: {calls:?}");
     }
 
@@ -8342,7 +8333,7 @@ sapply(libs, library, character.only = TRUE)"#;
     fn test_tar_option_set_var_resolved_anchored_at_call_end() {
         let code =
             "library(targets)\npkgs <- c(\"dplyr\", \"tidyr\")\ntar_option_set(packages = pkgs)";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 2, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
         assert_eq!(calls[1].package, "tidyr");
@@ -8357,7 +8348,7 @@ sapply(libs, library, character.only = TRUE)"#;
     #[test]
     fn test_tar_option_set_var_replacement_binding_disqualifies() {
         let code = "library(targets)\npkgs <- c(\"dplyr\")\npkgs[1] <- \"tidyr\"\ntar_option_set(packages = pkgs)";
-        assert!(tar_calls(code).is_empty());
+        assert!(tar_packages(code).is_empty());
     }
 
     #[test]
@@ -8365,36 +8356,36 @@ sapply(libs, library, character.only = TRUE)"#;
         // tar_option_set's first formal is tidy_eval, so positional matching
         // is not attempted (documented limitation).
         let code = "library(targets)\ntar_option_set(TRUE, c(\"dplyr\"))";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 0, "got: {calls:?}");
     }
 
     #[test]
     fn test_tar_option_set_dynamic_value_skipped() {
         let code = "library(targets)\ntar_option_set(packages = getOption(\"my.pkgs\"))";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 0, "got: {calls:?}");
     }
 
     #[test]
     fn test_tar_option_set_no_packages_arg_skipped() {
         let code = "library(targets)\ntar_option_set(format = \"qs\")";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 0, "got: {calls:?}");
     }
 
     #[test]
     fn test_tar_option_set_character0_and_empty_c_skipped() {
         let code = "library(targets)\ntar_option_set(packages = character(0))";
-        assert_eq!(tar_calls(code).len(), 0);
+        assert_eq!(tar_packages(code).len(), 0);
         let code = "library(targets)\ntar_option_set(packages = c())";
-        assert_eq!(tar_calls(code).len(), 0);
+        assert_eq!(tar_packages(code).len(), 0);
     }
 
     #[test]
     fn test_tar_option_set_unrelated_named_args_still_detected() {
         let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\"), format = \"qs\", memory = \"transient\")";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 1, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
     }
@@ -8404,7 +8395,7 @@ sapply(libs, library, character.only = TRUE)"#;
         // targets' runtime is last-call-wins, but raven deliberately unions
         // (favoring false negatives) — see try_parse_tar_option_set_call.
         let code = "library(targets)\ntar_option_set(packages = c(\"dplyr\"))\ntar_option_set(packages = c(\"tidyr\"))";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 2, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
         assert_eq!(calls[1].package, "tidyr");
@@ -8416,7 +8407,7 @@ sapply(libs, library, character.only = TRUE)"#;
         // `# raven: ignore` suppression is line-keyed, so each package must
         // anchor at its own literal's line — not the closing paren's.
         let code = "library(targets)\ntar_option_set(\n  packages = c(\n    \"dplyr\",\n    \"tidyr\"\n  ),\n  format = \"qs\"\n)";
-        let calls = tar_calls(code);
+        let calls = tar_packages(code);
         assert_eq!(calls.len(), 2, "got: {calls:?}");
         assert_eq!(calls[0].package, "dplyr");
         assert_eq!(calls[0].line, 3, "anchored at its own literal's line");
@@ -8425,15 +8416,15 @@ sapply(libs, library, character.only = TRUE)"#;
     }
 
     #[test]
-    fn extract_attached_packages_includes_top_level_tar_option_set() {
+    fn extract_attached_packages_excludes_top_level_tar_option_set() {
         let pkgs =
             extract_attached_packages("library(targets)\ntar_option_set(packages = c(\"dplyr\"))");
         assert!(pkgs.contains("targets"));
-        assert!(pkgs.contains("dplyr"));
+        assert!(!pkgs.contains("dplyr"));
 
-        // Qualified spelling needs no library(targets).
+        // Pipeline worker packages must not become test preamble attachments.
         let pkgs = extract_attached_packages("targets::tar_option_set(packages = \"dplyr\")");
-        assert!(pkgs.contains("dplyr"));
+        assert!(!pkgs.contains("dplyr"));
     }
 
     #[test]
@@ -8478,18 +8469,27 @@ sapply(libs, library, character.only = TRUE)"#;
     }
 
     #[test]
-    fn test_detect_library_calls_sorted_after_tar_append() {
-        // tar_option_set entries are appended after the walk; the final Vec
-        // must still come back in document order by (line, column).
+    fn targets_packages_are_separate_and_source_sorted() {
         let code = "tar_option_set(packages = c(\"aaa\", \"bbb\"))\nlibrary(targets)\nlibrary(zzz)";
         let tree = parse_r(code);
+
         let calls = detect_library_calls(&tree, code);
-        let positions: Vec<(u32, u32)> = calls.iter().map(|c| (c.line, c.column)).collect();
+        let loaded: Vec<&str> = calls.iter().map(|call| call.package.as_str()).collect();
+        assert_eq!(loaded, vec!["targets", "zzz"]);
+
+        let declarations = detect_targets_pipeline_packages(&tree, code);
+        let positions: Vec<(u32, u32)> = declarations
+            .iter()
+            .map(|declaration| (declaration.line, declaration.column))
+            .collect();
         let mut sorted = positions.clone();
         sorted.sort();
-        assert_eq!(positions, sorted, "got: {calls:?}");
-        let packages: Vec<&str> = calls.iter().map(|c| c.package.as_str()).collect();
-        assert_eq!(packages, vec!["aaa", "bbb", "targets", "zzz"]);
+        assert_eq!(positions, sorted, "got: {declarations:?}");
+        let packages: Vec<&str> = declarations
+            .iter()
+            .map(|declaration| declaration.package.as_str())
+            .collect();
+        assert_eq!(packages, vec!["aaa", "bbb"]);
     }
 
     // ==================== system.file() detection in source() ====================

--- a/crates/raven/src/cross_file/types.rs
+++ b/crates/raven/src/cross_file/types.rs
@@ -181,6 +181,23 @@ impl SuppressionDirective {
     }
 }
 
+/// One statically recognized package from a top-level {targets}
+/// `tar_option_set(packages = ...)` declaration.
+///
+/// This is intentionally separate from [`LibraryCall`]: targets worker
+/// packages are a file/pipeline-level contribution, not a lexical package-load
+/// event. The source anchor is retained for missing-package diagnostics and
+/// line-scoped suppressions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TargetsPackageDeclaration {
+    /// Statically resolved package name.
+    pub package: String,
+    /// 0-based line of the package literal or call-end fallback.
+    pub line: u32,
+    /// 0-based UTF-16 column of the package literal or call-end fallback.
+    pub column: u32,
+}
+
 /// Complete cross-file metadata for a document
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CrossFileMetadata {
@@ -234,6 +251,10 @@ pub struct CrossFileMetadata {
     pub suppression_directives: Vec<SuppressionDirective>,
     /// Detected package-load calls, including static pacman `p_load()` forms.
     pub library_calls: Vec<LibraryCall>,
+    /// File/pipeline-level worker packages declared by statically recognized
+    /// top-level `tar_option_set(packages = ...)` calls.
+    #[serde(default)]
+    pub targets_pipeline_packages: Vec<TargetsPackageDeclaration>,
     /// Variables declared via `# raven: var` directives
     #[serde(default)]
     pub declared_variables: Vec<DeclaredSymbol>,
@@ -268,6 +289,25 @@ pub struct CrossFileMetadata {
     /// Detected `pkg::member` namespace references (issue #503).
     #[serde(default)]
     pub namespace_references: Vec<NamespaceReference>,
+}
+
+impl CrossFileMetadata {
+    /// Package names referenced by lexical package loaders or the targets
+    /// pipeline worker-package declaration.
+    ///
+    /// This is a warming/inventory view only. Semantic scope keeps the two
+    /// channels separate because ordinary loaders are position-sensitive while
+    /// targets packages are pipeline-level.
+    pub fn referenced_packages(&self) -> impl Iterator<Item = &str> {
+        self.library_calls
+            .iter()
+            .map(|call| call.package.as_str())
+            .chain(
+                self.targets_pipeline_packages
+                    .iter()
+                    .map(|declaration| declaration.package.as_str()),
+            )
+    }
 }
 
 /// One statically recognized top-level `{targets}` `tar_source()` call.

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6250,6 +6250,51 @@ fn collect_missing_package_diagnostics_from_snapshot_for_uri(
         });
     }
 
+    for declaration in &snapshot.directive_meta.targets_pipeline_packages {
+        if snapshot
+            .package_library
+            .package_exists(&declaration.package)
+        {
+            continue;
+        }
+        let outside_active = package_available_outside_active_renv(snapshot, &declaration.package);
+        if !outside_active
+            && !snapshot
+                .cross_file_config
+                .packages_report_generic_uninstalled
+        {
+            continue;
+        }
+        let code = if outside_active {
+            crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY
+        } else {
+            crate::diagnostic_code::PACKAGE_NOT_INSTALLED
+        };
+        if crate::cross_file::directive::is_line_ignored_for_code(
+            &snapshot.directive_meta,
+            declaration.line,
+            Some(code),
+        ) {
+            if let Some(out) = suppressed_out.as_deref_mut() {
+                out.push((declaration.line, code.to_string()));
+            }
+            continue;
+        }
+        if outside_active && !reported_outside_active.insert(declaration.package.as_str()) {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            range: Range {
+                start: Position::new(declaration.line, 0),
+                end: Position::new(declaration.line, declaration.column),
+            },
+            severity: Some(severity),
+            message: missing_package_message(&declaration.package, outside_active),
+            code: Some(NumberOrString::String(code.to_string())),
+            ..Default::default()
+        });
+    }
+
     for ns_ref in &snapshot.directive_meta.namespace_references {
         // Both `::` and `:::` qualify for the missing-package diagnostic.
         if snapshot.package_library.package_exists(&ns_ref.package) {
@@ -7037,10 +7082,18 @@ fn collect_out_of_scope_diagnostics_from_snapshot(
 
 /// File/workspace-level set of packages detectably in play for NSE callee
 /// classification (issue #398): `library()` / `require()` calls, DESCRIPTION
-/// `Imports` (`full_imports`), `importFrom` packages, and test-attached
-/// packages. Deliberately file-level rather than position-aware — the
-/// conservative "unresolved callee suppresses its arguments" fallback keeps the
-/// approximation safe.
+/// `Imports` (`full_imports`), `importFrom` packages, test-attached packages,
+/// and targets worker packages for the declaring pipeline or a direct
+/// `tar_source()` member. Deliberately file-level rather than position-aware —
+/// the conservative "unresolved callee suppresses its arguments" fallback keeps
+/// the approximation safe.
+///
+/// Targets declarations deliberately bypass the broad ancestor/descendant
+/// library walk below. They are a pipeline contribution, not an ordinary
+/// lexical attach: the declaring file always receives its own set, and only a
+/// direct incoming `TarSource` edge lends its parent's set to a batch member.
+/// This prevents leakage through ordinary `source()` edges, `ListFiles` batches,
+/// and unrelated graph branches.
 fn collect_in_play_packages(
     snapshot: &DiagnosticsSnapshot,
     uri: &Url,
@@ -7074,6 +7127,37 @@ fn collect_in_play_packages(
         }
         packages.insert(package);
     }
+
+    // A targets worker package is attached throughout its declaring pipeline,
+    // independent of declaration position.
+    for declaration in &snapshot.directive_meta.targets_pipeline_packages {
+        if declaration.package.is_empty() {
+            continue;
+        }
+        packages.insert(declaration.package.clone());
+        attached_packages_for_meta.insert(declaration.package.clone());
+    }
+
+    // Direct `tar_source()` members execute in the pipeline's worker package
+    // environment. Inspect only incoming TarSource edges: using the generic
+    // ancestor walk would incorrectly lend the declaration through ordinary
+    // source chains and across unrelated branches.
+    for edge in snapshot.cross_file_graph.get_dependents(uri) {
+        if edge.source_batch_kind != Some(crate::cross_file::types::SourceBatchKind::TarSource) {
+            continue;
+        }
+        let Some(parent_meta) = snapshot.metadata_map.get(&edge.from) else {
+            continue;
+        };
+        for declaration in &parent_meta.targets_pipeline_packages {
+            if declaration.package.is_empty() {
+                continue;
+            }
+            packages.insert(declaration.package.clone());
+            attached_packages_for_meta.insert(declaration.package.clone());
+        }
+    }
+
     // Include packages loaded by ancestor files in the cross-file source chain.
     // Without this, a child file inheriting `dplyr` from a parent would not get
     // NSE suppression for verbs like `filter` that shadow base/stats exports.

--- a/crates/raven/src/state.rs
+++ b/crates/raven/src/state.rs
@@ -672,8 +672,8 @@ pub(crate) fn extract_loaded_packages(tree: &Option<Tree>, text: &str) -> Vec<St
         return Vec::new();
     };
 
-    // Use the canonical detector for direct, apply-family, loop, targets, and
-    // pacman package loads. `Document.loaded_packages`
+    // Use the canonical detectors for lexical package loads and targets
+    // pipeline worker-package declarations. `Document.loaded_packages`
     // also feeds CLI reporting, so conditional bare `p_load()` targets must
     // stay out until a graph-aware scope query proves their prerequisite.
     // Backend edit-time prefetching deliberately keeps its separate permissive
@@ -684,6 +684,11 @@ pub(crate) fn extract_loaded_packages(tree: &Option<Tree>, text: &str) -> Vec<St
             .filter(|call| call.requires_attached.is_none())
             .map(|call| call.package)
             .collect();
+    packages.extend(
+        crate::cross_file::source_detect::detect_targets_pipeline_packages(tree, text)
+            .into_iter()
+            .map(|declaration| declaration.package),
+    );
     packages.sort();
     packages.dedup();
     packages
@@ -14475,6 +14480,15 @@ mod tests {
 
         let qualified = Document::new("pacman::p_load(ggplot2)", None);
         assert_eq!(qualified.loaded_packages, vec!["ggplot2"]);
+    }
+
+    #[test]
+    fn document_loaded_packages_includes_targets_pipeline_packages() {
+        let document = Document::new(
+            "targets::tar_option_set(packages = c(\"dplyr\", \"tidyr\"))",
+            None,
+        );
+        assert_eq!(document.loaded_packages, ["dplyr", "tidyr"]);
     }
 
     #[test]

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -276,29 +276,38 @@ may `break` or `return()` before loading every package are ignored. A named
 vector is resolved only for a loop known to execute eagerly in the file; a
 deferred function-body loop can still use an inline `c("a", "b")` sequence.
 
-### targets::tar_option_set() Loads
+### targets::tar_option_set() Worker Packages
 
-Raven treats a [{targets}](https://docs.ropensci.org/targets/)
-`tar_option_set(packages = ...)` call as a package attachment — targets
-attaches the listed packages before running each target, so scripts sourced by
-`_targets.R` use their exports as bare names:
+Raven models a [{targets}](https://docs.ropensci.org/targets/)
+`tar_option_set(packages = ...)` declaration as a file/pipeline-level worker
+package contribution, not as a source-positioned `library()` call. The package
+set is therefore available throughout the declaring targets pipeline and to
+every member of each `tar_source()` batch, regardless of whether the declaration
+appears before or after the batch:
 
 ```r
 # _targets.R
 library(targets)
+tar_source("R")
 tar_option_set(packages = c("dplyr", "tidyr"))
-source("R/functions.R")  # dplyr and tidyr verbs resolve in functions.R
+
+# dplyr and tidyr resolve throughout _targets.R and in every tar_source() member.
 ```
+
+This special propagation is limited to targets execution. It does not flow into
+an ordinary `source()` child or a `source(list.files(...))` batch. Actual
+`library()`, `require()`, and `loadNamespace()` calls remain position-sensitive
+and retain their normal cross-file propagation behavior.
 
 Details:
 
 - **Bare vs. qualified callee.** The qualified spellings
   `targets::tar_option_set(...)` / `targets:::tar_option_set(...)` are
-  recognized unconditionally. The bare spelling `tar_option_set(...)` is
-  recognized only when the same file also attaches targets via
-  `library(targets)` / `require(targets)` — anywhere in the file, before or
-  after the call — so an unrelated user function named `tar_option_set`
-  doesn't silently attach packages.
+  recognized directly. The bare spelling `tar_option_set(...)` is recognized
+  only when the same file also attaches targets via `library(targets)` /
+  `require(targets)` — anywhere in the file, before or after the call — and the
+  bare name is not locally shadowed. A qualified call remains recognized when a
+  local binding named `tar_option_set` exists.
 - **Named `packages =` only.** `tar_option_set`'s first formal is
   `tidy_eval`, not `packages`, so positional forms like
   `tar_option_set(TRUE, c("dplyr"))` are deliberately not matched.
@@ -308,14 +317,14 @@ Details:
   such a vector (including eligible bare/base-qualified `assign()` with the
   same global-destination rules as apply-family loads). Nested, conditional,
   dynamic, non-global, reassigned, or removed bindings, `character(0)`, and
-  empty `c()` are ignored.
+  empty `c()` are ignored. Raven never evaluates R to resolve a dynamic value.
 - **Per-literal anchoring.** `tar_option_set()` calls routinely span many
   lines, so each package's missing-package diagnostic is anchored at that
   package's own string literal — a `# nolint` on the literal's line suppresses
   it. The variable-resolved shape anchors at the call's end instead.
 - **Union across calls.** Multiple `tar_option_set()` calls in one file union
   their `packages =` vectors. targets' real runtime semantics are
-  last-call-wins, but raven deliberately favors false negatives here.
+  last-call-wins, but Raven deliberately favors false negatives here.
 
 ### targets::tar_source() Scripts
 
@@ -337,8 +346,9 @@ from before the call plus the definitions, removals, and package attachments
 produced by earlier members. A later member replaces an earlier binding of the
 same name. A member never sees a later sibling. `change_directory = TRUE` is
 honored, including for ordinary `source()` calls nested inside a member.
-Packages from `tar_option_set(packages = ...)` and packages attached by earlier
-members flow through the same ordered environment.
+The file-level `tar_option_set(packages = ...)` set seeds every member, including
+ordinal zero, while actual package loads from members continue to flow through
+the ordered environment.
 
 In the language server, workspace watcher events keep membership live:
 creating, deleting, or renaming a script under a finalized request refreshes

--- a/docs/development.md
+++ b/docs/development.md
@@ -541,6 +541,25 @@ Scope resolution has two distinct graph traversals:
 
 Ordered source batches share the detached expansion, watch-root ownership, generation fencing, graph identity, and left-to-right scope resolver originally built for `{targets}` `tar_source()`. `SourceBatchKind` separates tar's contextual working-directory semantics from ordinary bounded `list.files()` source loops. The serialized `tar_source_ordinal` and `tar_source_expansion_watch_paths` names remain for metadata compatibility, but their runtime contract is batch-generic: kind plus call site plus ordinal identify a member, and expansions replace all derived members atomically. Detection never touches the filesystem; expansion runs only after working-directory enrichment and outside state locks. Request-bearing `didChange` operations enumerate inside the existing detached OpenEdit derivation and await its atomic document/metadata/graph commit. If any source-file event in one normalized watcher notification belongs to an open source-batch parent, every normalized source-file event in that notification runs as one invocation-owned watched transaction (including any package projection). Config-layer mutations are applied first, but their diagnostic publication joins the same completion boundary. This prevents the parent from publishing after its batch member lands but before an ordinary dependency event from the same notification commits. The owned transaction drains its diagnostic reservations before completing the receipt-backed parent refresh; if package convergence crosses the existing coalesced retry boundary, the parent-refresh obligation moves with that owner and the original handler awaits the shared terminal receipt. A cancelled parent refresh cancels the outer receipt and withholds sysdata admission. Sysdata continuation otherwise keeps the ordinary watcher contract: admission is ordered after the owned transaction, but convergence remains lifecycle-owned. Workspace-replay refreshes use the same generation-owned parent receipts. Workspace graph derivations reuse the expansion already owned by the scan candidate, keeping the complete-graph pin pass and final graph pass on one filesystem observation. Unsafe enumeration and member-cap overflow fail closed without publishing a partial batch; traversal-budget overflow uses the deterministic ordered fallback described below.
 
+`tar_option_set(packages = ...)` uses a distinct durable metadata channel,
+`CrossFileMetadata::targets_pipeline_packages`, rather than synthetic
+line-zero `PackageLoad` events. Detection and static-vector resolution happen
+once during metadata extraction; query-time scope resolution never reparses the
+declaring file. Recursive and streaming resolution project the package-name set
+onto the declaring pipeline only after its ordinary timeline, making the set
+order-independent without feeding it into ordinary `Source` events. A private
+TarSource initial scope is seeded with the same set before ordinal zero executes;
+ListFiles batches are not seeded. Targets-only loaded/attached provenance markers
+survive parent-prefix and ordered-batch merging so TarSource edges can lend the
+contribution while ordinary Source/ListFiles edges filter it. A real lexical
+package load clears the corresponding marker, preserving normal propagation
+when both channels name the same package. Conditional helper classification
+(such as Shiny deferred scopes) reads the stored targets set directly without
+installing it in the running frames, maintaining the same propagation barrier.
+The interface hash includes the sorted, deduplicated package-name set: package
+order and source anchors are hash-neutral, while a semantic set change
+revalidates dependents.
+
 The cached/streaming parent prefix is seeded with the queried URI at `(u32::MAX, u32::MAX)` so a single cache slot covers all positions in that file within a snapshot, whereas the uncached point resolver (`scope_at_position_with_graph`) seeds the visited map at the real `(line, column)`. For acyclic graphs the two seeds are identical. In a cyclic graph the cached prefix is a deliberate over-approximation: a back-edge can re-enter the queried file at `(MAX, MAX)` and so could "see" symbols defined later in that file, but the same-file leak filter (a symbol whose `source_uri` equals the queried URI is dropped from a parent prefix) plus `entry().or_insert()` merging keep the result sound at the symbol level, so those later symbols never surface. Tightening this would require position-dependent cache keys, which would defeat the cache; it is therefore pinned as intentional — `test_cyclic_cached_overapproximates_vs_uncached_point_query` observes the cached and uncached resolvers agreeing on every field at the boundary query (issue #374).
 
 ### Interface hash + selective invalidation
@@ -555,6 +574,9 @@ The hash is deterministic and includes:
   helper call. Scope results retain a separate attached-package fact because
   `loadNamespace()` remains available for namespace-aware analysis but must not
   enable attachment-sensitive helpers.
+- The semantic package-name set from `tar_option_set(packages = ...)`, sorted
+  and deduplicated so declaration position and order do not cause needless
+  dependent revalidation.
 - Declared symbols (from `# raven: var` / `# raven: func` directives)
 - Source-edge inputs, including precise `SourceLocality`, call site, path, `chdir`, function scope, and resolved URI. `CurrentFrame` and `NonInheriting` remain distinct runtime/hash values even though old serialized readers see the same lossy `local = true` compatibility projection for regular `source()` calls.
 


### PR DESCRIPTION
## Summary

- store statically recognized `tar_option_set(packages = ...)` values in a dedicated durable pipeline-package metadata channel instead of lexical `PackageLoad` events
- project that package set order-independently onto the declaring targets pipeline and seed every `tar_source()` member, while preserving position-sensitive `library()` / `require()` semantics
- track targets-only package provenance so ordinary `source()` and ListFiles batches do not inherit worker packages; real lexical loads and ordinary multi-parent channels take precedence over targets-only markers
- include the semantic package-name set in interface hashing, dependent revalidation, warming, package inventory, missing-package diagnostics, and Shiny deferred-helper classification
- keep recursive and streaming scope resolution aligned without reparsing `_targets.R` at query time

## Test coverage

- declarations before and after `tar_source()`
- declaring-pipeline visibility at the beginning and end of the file
- ordinal zero and later TarSource members
- ordinary Source, ListFiles, unrelated-file, and sourced-declaration leakage barriers
- real package-load overrides and multi-parent ordinary-channel precedence in both edge orders
- bare callee shadowing, qualified calls, conservative dynamic forms, and symlink-spelled paths
- interface hash set semantics and dependent revalidation
- recursive/streaming parity, Shiny deferred scopes, warming, CLI inventory, and missing-package diagnostics

Related: #665

Closes #639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing `{targets}` pipeline worker packages declared via `tar_option_set(packages=...)`.
  * Pipeline worker packages are now consistently seeded across relevant pipeline files while staying isolated from ordinary source propagation.
  * Worker package references are included in loaded-package lists and workspace discovery.

* **Bug Fixes**
  * Missing-package diagnostics now correctly report worker packages with proper location and de-duplication.
  * Warm-package prefetching now derives from durable metadata and filters invalid/suspicious package names.
  * Interface hashing now accounts for the worker package set, triggering correct revalidation.

* **Documentation**
  * Updated cross-file documentation and development notes to clarify propagation, accepted declaration shapes, and diagnostic anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->