### PR TITLE
Recommend renv::hydrate() for outside packages

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6393,8 +6393,8 @@ fn library_call_activation_satisfied(
 fn missing_package_message(package: &str, outside_active_renv: bool) -> String {
     if outside_active_renv {
         format!(
-            "Package '{package}' is available outside this active renv project library, \
-             but is unavailable here; run renv::restore() or install it into the project library"
+            "Package '{package}' is installed outside this active renv project library; \
+             run renv::hydrate() to add installed packages to the project library."
         )
     } else {
         format!("No installed package named '{package}'")
@@ -54994,10 +54994,11 @@ pacman::p_load(__qualified_missing_package__)";
                     crate::diagnostic_code::PACKAGE_OUTSIDE_ACTIVE_LIBRARY.to_string(),
                 ))
         }));
-        assert!(diagnostics.iter().all(|diagnostic| {
-            diagnostic.message.contains("active renv project library")
-                && diagnostic.message.contains("renv::restore()")
-        }));
+        assert_eq!(
+            diagnostics[0].message,
+            "Package 'plotpkg' is installed outside this active renv project library; \
+             run renv::hydrate() to add installed packages to the project library."
+        );
     }
 
     fn outside_active_export_diagnostics(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,8 +104,8 @@ One actionable subtype remains enabled even without the flag:
 workspace's renv project, the referenced package is unavailable in its active
 library, and a validated package with that name exists in a vanilla system/user
 library removed by activation. That is evidence of a project setup problem, not
-the ordinary "CI did not install dependencies" case; run `renv::restore()` or
-install the package into the project library. See
+the ordinary "CI did not install dependencies" case; run `renv::hydrate()` to
+add installed packages to the project library. See
 [Diagnostics](diagnostics.md#package-names-vs-install-status) for the full
 model.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -201,12 +201,12 @@ When enabled, `--report-uninstalled` reports `library()` calls **not present in 
 When Raven successfully activates an explicit workspace's `renv/activate.R`, it
 also compares the vanilla and active library paths. If a referenced package
 exists only in a path removed by activation, Raven reports
-`package-outside-active-library` and suggests restoring or installing it into
-the project library. Raven reports this project-level setup problem at most once
-per package per document, even when that document contains many qualified
-references. Raven may use explicitly declared exports from that outside
-installation only to suppress undefined-variable cascades after a true
-`library()` / `require()` attachment. This diagnostic-only evidence never makes
+`package-outside-active-library` and suggests running `renv::hydrate()` to add
+installed packages to the project library. Raven reports this project-level
+setup problem at most once per package per document, even when that document
+contains many qualified references. Raven may use explicitly declared exports
+from that outside installation only to suppress undefined-variable cascades
+after a true `library()` / `require()` attachment. This diagnostic-only evidence never makes
 the package available for completion, `system.file()`, or package loading.
 Packages installed after startup are recognized when the library is rebuilt
 (for example with `raven.refreshPackages`); changes made only in an outside


### PR DESCRIPTION
## Summary

Updates the `package-outside-active-library` diagnostic recommendation.

**Old message**

> Package '<package>' is available outside this active renv project library, but is unavailable here; run renv::restore() or install it into the project library

**New message**

> Package '<package>' is installed outside this active renv project library; run renv::hydrate() to add installed packages to the project library.

The restore-vs-hydrate split was not implemented because diagnostic collection does not already have parsed `renv.lock` package state. Adding that state would require new infrastructure; the existing lockfile reader is limited to package-database CLI operations.

## Tests

- Updated the outside-active-library integration test to assert the exact new message.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo test`

Closes #704

Related to #665.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package diagnostics to provide clearer guidance when a package is installed outside the active project library.
  * The recommended remediation is now to run `renv::hydrate()`.

* **Documentation**
  * Updated CI troubleshooting and diagnostic guidance to reflect the new `renv::hydrate()` recommendation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->