### PR TITLE
chore: release v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/raven"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Jonathan Marc Bearak <jonathan@bearak.net>"]
 edition = "2024"
 license = "GPL-3.0"

--- a/docs/release-notes-v0.17.0.md
+++ b/docs/release-notes-v0.17.0.md
@@ -1,0 +1,47 @@
+# Raven v0.17.0 — targets worker packages and Shiny application loading
+
+Raven 0.17.0 expands static cross-file analysis for `{targets}` pipelines and Shiny applications, hardens filesystem-driven source batches, improves `renv` guidance, and resolves the JavaScript dependency alerts tracked for this release.
+
+## Highlights
+
+### Order-independent `{targets}` worker packages
+
+`tar_option_set(packages = ...)` now contributes worker packages to the entire targets pipeline, including every member loaded by `tar_source()`, whether the declaration appears before or after `tar_source()`. This package set also participates in package inventory, missing-package diagnostics, cache warming, and dependent revalidation without leaking into ordinary `source()` relationships. ([#702](https://github.com/jbearak/raven/pull/702))
+
+This is full support for the documented statically analyzable forms: a string literal, a literal character vector, or an eligible same-file, single-assignment static vector. Dynamic `packages` expressions are deliberately not evaluated or resolved. Positional `packages` arguments are also not inferred because `packages` is not `tar_option_set()`'s first formal.
+
+### Shiny implicit application loading
+
+Raven now models Shiny's conventional application layouts without running R. ([#703](https://github.com/jbearak/raven/pull/703))
+
+- Legacy applications load `global.R`, immediate `R/*.[Rr]` helpers, and the separate `ui.R` and `server.R` entry environments.
+- Single-file applications load immediate `R/*.[Rr]` helpers and then `app.R`; an adjacent `global.R` is not implicitly loaded.
+- Helper files load in deterministic C-locale filename order.
+- `R/_disable_autoload.R`, matched case-insensitively, disables helper autoloading while leaving legacy `global.R` behavior intact.
+- Application-root working-directory behavior and filesystem changes are reflected across diagnostics, completion, hover, navigation, references, and `raven check`.
+
+Support intentionally follows the current conventional layouts. Historical process-global `options(shiny.autoload.r = ...)` state is deliberately not modeled, and arbitrary filenames passed to `shinyAppFile()` are out of scope.
+
+### Reliability and diagnostics
+
+Sustained watcher-churn coverage now exercises repeated creation, modification, restoration, and deletion across `tar_source()`, Shiny helper loading, and bounded `list.files()` source batches. Fail-closed expansion cases—member-cap overflow, unreadable entries or matching files, and matching directories—now produce debug-level records while retaining all-or-nothing behavior. User-facing hints are deliberately deferred until they can be lifecycle-aware and avoid stale or repeated notices. ([#705](https://github.com/jbearak/raven/pull/705))
+
+The `package-outside-active-library` diagnostic now recommends `renv::hydrate()` when a package is installed outside the active project library. ([#706](https://github.com/jbearak/raven/pull/706))
+
+### Dependency updates
+
+The VS Code extension lockfile now resolves `js-yaml` 4.3.0 and patched `brace-expansion` releases, resolving Dependabot alerts #59–62. The exact DOMPurify pin remains unchanged. ([#701](https://github.com/jbearak/raven/pull/701))
+
+## Install
+
+- **VS Code:** install or update from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=jbearak.raven-r).
+- **Cursor, Positron, and other VS Code-based editors:** use [Open VSX](https://open-vsx.org/extension/jbearak/raven-r) or the matching platform `.vsix` from the GitHub release.
+- **Other editors and CI:** download the matching `raven-<os>-<arch>.zip` and run `raven --stdio` or the desired CLI command.
+
+## Learn more
+
+- [Cross-file analysis](https://github.com/jbearak/raven/blob/v0.17.0/docs/cross-file.md)
+- [Diagnostics](https://github.com/jbearak/raven/blob/v0.17.0/docs/diagnostics.md)
+- [CLI](https://github.com/jbearak/raven/blob/v0.17.0/docs/cli.md)
+
+**Full changelog:** [v0.16.0...v0.17.0](https://github.com/jbearak/raven/compare/v0.16.0...v0.17.0)

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raven-r",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raven-r",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -14,7 +14,7 @@
     "JAGS",
     "BUGS"
   ],
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publisher": "jbearak",
   "icon": "icon.png",
   "license": "GPL-3.0",


### PR DESCRIPTION
## Summary

- bump the Raven workspace/package version from `0.16.0` to `0.17.0` in `Cargo.toml`, the Raven entry in `Cargo.lock`, `editors/vscode/package.json`, and both root package version fields in `editors/vscode/package-lock.json`
- add the GitHub release-body draft at [`docs/release-notes-v0.17.0.md`](https://github.com/jbearak/raven/blob/release/v0.17.0/docs/release-notes-v0.17.0.md)
- document the v0.17.0 targets, Shiny, watcher-hardening, renv-diagnostic, and dependency-update work

## Release contents

- **targets worker packages:** statically analyzable `tar_option_set(packages = ...)` declarations now contribute packages to the whole targets pipeline and every `tar_source()` member, order-independently. Dynamic `packages` expressions are deliberately not evaluated or resolved.
- **Shiny implicit loading:** conventional legacy `server.R`/`ui.R` plus `global.R`, and single-file `app.R`, now receive their modeled implicit scopes, including C-locale `R/*.[Rr]` helper ordering and `_disable_autoload.R`. Historical `shiny.autoload.r` runtime-option state and arbitrary `shinyAppFile()` filenames remain deliberately out of scope.
- **hardening:** sustained watcher-churn coverage and debug-level fail-closed observability for member-cap, unreadable-entry/file, and matching-directory cases; user-facing hints remain deferred.
- **diagnostics:** `package-outside-active-library` now recommends `renv::hydrate()`.
- **dependencies:** lockfile updates resolve `js-yaml` 4.3.0 and patched `brace-expansion` releases, closing Dependabot alerts #59–62.

`docs/limitations.md` was checked and did not contain an outdated limitation for these features, so it remains unchanged. `docs/cross-file.md` already accurately distinguishes the supported static forms from the deliberately unsupported dynamic/runtime forms.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo build`

Related to #665.
