### PR TITLE
chore: release v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "raven"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/raven"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Jonathan Marc Bearak <jonathan@bearak.net>"]
 edition = "2024"
 license = "GPL-3.0"

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raven-r",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raven-r",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -14,7 +14,7 @@
     "JAGS",
     "BUGS"
   ],
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "jbearak",
   "icon": "icon.png",
   "license": "GPL-3.0",


### PR DESCRIPTION
Release v0.18.0 — module systems and tarchetypes support.

Bumps the workspace and VS Code extension version 0.17.0 → 0.18.0. Release notes: `docs/release-notes-v0.18.0.md`.

Ships the three tracked features from #666, all merged since v0.17.0:

- #662 — static `box::use()` modules & selective imports (PR #710)
- #663 — `{import}` package selective imports (PR #711)
- #661 — `{tarchetypes}` NSE & cross-document conventions (PR #712)

A follow-up latent-diagnostics item (#713) was filed rather than release-gated, per scope discipline.

Tracker: #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace and VS Code extension to version 0.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->