### PR TITLE
docs: give box/import their own user-altitude home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ All three block merge. Fix the underlying issue rather than suppressing it; when
 User-facing:
 - `README.md`
 - `docs/cross-file.md`
+- `docs/modules.md`
 - `docs/r-package-dev.md`
 - `docs/rprofile.md`
 - `docs/package-database.md`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Raven's sibling project [Sight](https://github.com/jbearak/sight) implements a l
 - **Workspace symbols** — Project-wide symbol search (Cmd/Ctrl+T)
 - **File path intellisense** — Completions and cmd-click inside `source()` paths
 - **[Smart indentation](docs/indentation.md)** — Context-aware auto-indent with configurable argument and chain styles
-- **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains and static `targets::tar_source()` batches, connects supported `{tarchetypes}` target factories and report documents, and models static `{box}` and `{import}` selective imports with module privacy
+- **[Cross-file awareness](docs/cross-file.md)** — Follows `source()` chains and static `targets::tar_source()` batches, and connects supported `{tarchetypes}` target factories and report documents
+- **[Module & import systems](docs/modules.md)** — Models static `{box}` and `{import}` selective imports, binding only the names an import requests, with module privacy
 - **[Directives](docs/directives.md)** — Declare relationships and symbols the analyzer can't infer
 - **[Syntax highlighting](docs/syntax-highlighting.md)** — R function names via LSP semantic tokens, plus JAGS and Stan syntax highlighting
 

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -57,7 +57,7 @@ Inside a `pkg::` expression no other completions are offered (keywords, local sy
 
 ### box Namespace and Attached Completions
 
-A static [`box::use()` import](cross-file.md#box-module-imports-boxuse) contributes only the bindings it requests. A namespace import offers known exported members after `$` or `@`; a literal `[["member"]]` access resolves the same member for hover/navigation. Selective and renamed attachments appear as bare-name completions under their local names, and wildcard attachment expands the known export set.
+A static [`box::use()` import](modules.md#box-modules-boxuse) contributes only the bindings it requests. A namespace import offers known exported members after `$` or `@`; a literal `[["member"]]` access resolves the same member for hover/navigation. Selective and renamed attachments appear as bare-name completions under their local names, and wildcard attachment expands the known export set.
 
 ```r
 box::use(./model, ./format[render, fmt = format_value])

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -488,39 +488,18 @@ code fail closed.
 
 #### Static `tar_map()` names
 
-For `tar_map()`, Raven records only the generated declarations that exist at
-runtime; the unsuffixed target objects supplied through `...` are not separate
-pipeline targets. Generated declarations are predicted only for a bounded
-literal table grammar:
-
-- `values` is a literal `list()`, `data.frame()`, or `tibble()` call (including
-  the corresponding direct namespace-qualified constructor);
-- every column is explicitly and uniquely named and contains scalar literals or
-  an unshadowed literal `c(...)` vector of strings, integers, booleans, or simple
-  decimal numbers whose R character spelling is unambiguous; constructor controls
-  such as `data.frame(check.names = ...)` and `tibble(.name_repair = ...)` fail
-  closed;
-- scalar columns may recycle, while non-scalar column lengths must agree;
-- target-definition objects may be unnamed or named arguments in `...`; exact
-  formal matching is applied before deciding which arguments belong to dots;
-- `names` is omitted, one column identifier, `c(column, ...)`, or an unshadowed
-  `everything()` (the qualified `tidyselect::everything()` form is always
-  authoritative); and
-- `delimiter` is omitted or one non-empty ASCII string literal.
-
-A base target name that collides with a values-table column is rejected, matching
-`tar_map()`'s runtime validation. Raven mirrors tarchetypes' quote stripping,
-`make.unique(..., sep = delimiter)`, and the ASCII subset of `make.names()`. The
-whole expansion is transactional: if any selected suffix or generated target
-name is not reproducible, Raven contributes no generated declarations or nested
-report links. A reference to a generated name navigates to the base target-name
-token because the generated spelling does not occur in source.
-
-Dynamic tables/selections/delimiters, empty selections (the runtime hash
-fallback), non-ASCII generated spellings, incompatible lengths, arbitrary
-metaprogramming, and replication/dynamic-branching factories are not predicted.
-Unsupported `tar_map()` name generation contributes no base or generated target
-declaration.
+`tar_map()` generates one set of targets per row of a value table. Raven
+predicts those generated names when the table and selection are **literal and
+statically resolvable** — a literal `list()` / `data.frame()` / `tibble()` with
+named scalar or literal-vector columns, a static column selection, and a literal
+delimiter — reproducing tarchetypes' own name mangling. A reference to a
+generated name navigates to the base target token, since the generated spelling
+never appears in source. Expansion is all-or-nothing: if any generated name is
+not statically reproducible, Raven expands none of them, and the unsuffixed
+target objects passed through `...` are not themselves pipeline targets. Dynamic
+tables, selections, or delimiters — and the runtime-hash fallback for an empty
+selection — are left unexpanded. The exact grammar and its edge cases are in
+[Limitations — targets and tarchetypes](limitations.md#targets-and-tarchetypes).
 
 #### Connected R Markdown and Quarto documents
 
@@ -562,148 +541,13 @@ Raven watches `.libPaths()` directories and invalidates caches when packages are
 
 See [Configuration](configuration.md) for watcher settings (`packages.watchLibraryPaths`, `packages.watchDebounceMs`).
 
-## box module imports (`box::use`)
+## Module & import systems
 
-Raven understands the [box](https://klmr.me/box/) module system's `box::use()`
-imports and `box::export()` / `#' @export` interface declarations. box is
-modelled as its own kind of cross-file relationship — a **selective import** —
-which is deliberately distinct from both a package `library()` load and an
-ordinary `source()` edge:
-
-- Unlike `library(pkg)`, a box import never dumps a package's whole export set
-  in as bare names. It binds a **namespace object** (used as `alias$member`)
-  and/or an explicitly listed subset of members.
-- Unlike `source("file.R")`, a box module import does **not** merge the target
-  file's top-level definitions into the importer, does not propagate
-  `# raven: nse` / `# raven: func`, and never takes part in the backward
-  parent-prefix walk. Only the target's **exported** names cross the boundary,
-  and only under the names the import requests.
-
-### Supported import forms
-
-```r
-box::use(
-  dplyr,                 # bind the `dplyr` namespace  -> dplyr$filter(...)
-  dr = dplyr,            # ... under an explicit alias -> dr$filter(...)
-  dplyr[filter, select], # attach `filter`, `select` directly (no namespace)
-  dplyr[f = filter],     # attach dplyr's `filter` under the local name `f`
-  dplyr[...],            # attach every export
-  ./helpers,             # local module: helpers.r / helpers/__init__.r
-  ../lib/util[foo],      # attach `foo` from ../lib/util
-)
-```
-
-- A **bare name** is an installed package; a **local module** *must* begin with
-  `./` or `../`. Both top-level and function-scoped `box::use()` calls are
-  recognised, as is the `box:::use()` spelling.
-- The **default namespace alias** is the final path/package component
-  (`../lib/util` binds `util`); `alias = spec` overrides it.
-- An **attach-only** spec (`pkg[a, b]`, `pkg[...]`) binds no namespace object
-  unless you also write an explicit `alias = pkg[...]`.
-
-### Local module path resolution
-
-Local module paths resolve **relative to the importing file's own directory**
-and intentionally ignore `# raven: cd`, the implicit testthat/testit working
-directory, and the forward workspace-root fallback — none of those apply to
-box. The extension is omitted in the spec; candidates are tried in this order,
-first existing wins:
-
-1. `<path>.r`
-2. `<path>.R`
-3. `<path>/__init__.r`
-4. `<path>/__init__.R`
-
-so a `.r`/`.R` **file module** wins over an `__init__` **package module**, and
-a lowercase extension wins over uppercase, matching box. Resolution is
-**case-sensitive**: a path that exists only under a different case is reported
-as a case mismatch rather than silently corrected.
-
-### Exported interface
-
-A module's exports are determined by, in order of authority:
-
-- `box::export(a, b, c)` — the union of unquoted names across all such calls.
-  `box::export()` with no arguments is an explicit **empty** interface.
-- `#' @export` roxygen tags on top-level definitions, and on top-level
-  `box::use()` imports (which **re-export** the imported names).
-
-If **either** explicit mechanism is present the interface is authoritative, so
-member absence (`module$missingName`) is decidable. If **neither** is present,
-the module falls back to the legacy default — every top-level binding whose name
-does not begin with a dot — which is treated as *non-authoritative* (a missing
-member is not concluded, because a statically-invisible dynamic binding might
-supply it). Names that are private, or merely transitively imported without an
-explicit re-export, never cross the boundary.
-
-### Language intelligence and revalidation
-
-Static box imports participate in the same canonical artifact, scope, package,
-and diagnostic lifecycles as the rest of Raven:
-
-- Imported namespace aliases and attached/renamed members are position-aware,
-  function-scoped when the call is inside a function, and available to
-  diagnostics, completion, hover, signatures, and go-to-definition.
-- Namespace-member completion and navigation understand `$`, `@`, and a single
-  positional literal-string `[[...]]` subscript. Local-module members navigate
-  to their original definitions through named, renamed, and wildcard
-  re-exports. Installed-package members use Raven's package export metadata but
-  do not fabricate source-file navigation.
-- Find-references for a resolved selective member follows definition identity
-  across namespace access, attached names, renames, and indexed importers,
-  rather than pooling unrelated same-named members. Ordinary non-box references
-  keep Raven's broad name-based behavior.
-- Local module imports add a selective dependency edge. Export/import interface
-  edits revalidate dependents, but the edge never lends ordinary `source()`
-  scope and never propagates `# raven: nse` / `# raven: func` declarations.
-- Missing local modules, case-only mismatches, missing installed packages, and
-  names absent from a complete export set produce diagnostics. Partial or
-  unknown export metadata never proves absence.
-
-The same model is used for open files, closed workspace-indexed files, excluded
-open documents, the language server, and `raven check`. The `/` in a box spec
-remains exempt from the `infix_spaces` lint, while ordinary `/` expressions keep
-their existing parsing and lint behavior.
-
-Raven does not execute module code or hooks, evaluate dynamic `box.path`
-configuration, search user-global/remote module locations, or guess computed
-imports. Unsupported forms fail conservatively — they neither bind names nor
-emit misleading diagnostics. See
-[Limitations](limitations.md#box-module-system-boxuse) for the exact static
-boundary.
-
-## import package selective imports
-
-Raven recognizes static double-colon `import::from()`, `import::here()`, and
-`import::into()` calls. Package sources use Raven's package export snapshots.
-Literal `.R`/`.r` sources are private script modules resolved with Raven's
-forward path context; a literal `.directory` is supported. The extension is
-part of the source and no box-style candidate names are inferred.
-
-Explicit names and `local = exported` aliases are supported. `.all = TRUE` adds
-known exports, `.all = FALSE` disables that expansion, and a nonempty static
-`.except` implies `.all` unless explicitly disabled. Exclusions compare the
-exported/source name, so excluding an export also removes its explicit alias.
-An explicit alias plus `.all` does not additionally attach the bare export.
-Imports otherwise follow R's sequential assignment behavior: if a different
-later export from `.all` targets the same local name, that later binding wins.
-
-`here()` contributes to the current lexical environment from the call position;
-inside a function its effect stays in that function. `from()` uses the lower-
-priority `"imports"` destination by default, and literal named `.into`/`into()`
-destinations are supported. These are fallback bindings below lexical/current-
-environment bindings, not namespace objects, and never enable `$` access.
-
-A script module's candidate interface is its partial live private top-level
-environment, including dotted names and top-level `import::here()` bindings.
-Synthetic `.packageName` and `__last_modified__` names are excluded. Box export
-markers do not govern `{import}` modules. Local relationships use non-lending
-`SelectiveModule` edges, so edits revalidate importers without ordinary scope or
-NSE lending.
-
-Dynamic `.character_only`, computed sources/options/destinations, URL/pins
-modules, environment-valued destinations, detach simulation, and `import:::`
-calls are outside this first phase and remain inert.
+The `box` and `import` packages define selective-import systems that Raven
+models distinctly from `source()` and `library()` — binding only the names an
+import requests rather than merging a file's definitions or attaching a whole
+package. They are documented separately in
+[Module & import systems](modules.md).
 
 ## NSE directive propagation
 

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -40,7 +40,7 @@ If you need a result scoped to one ordinary symbol's definition, use [Go-to-Defi
 
 ### Selective-import member identity
 
-For a resolved local-module member imported through static [`box::use()`](cross-file.md#box-module-imports-boxuse) or a supported [`import::` call](cross-file.md#import-package-selective-imports), Raven starts from the original definition and keeps only occurrences that resolve to that exact identity. The result can include namespace access through `$`, `@`, or literal `[["name"]]` where the syntax supports it, named/wildcard attachments, renamed local bindings, re-export chains, and the underlying definition in open or workspace-indexed files.
+For a resolved local-module member imported through static [`box::use()`](modules.md#box-modules-boxuse) or a supported [`import::` call](modules.md#import-package-importfrom), Raven starts from the original definition and keeps only occurrences that resolve to that exact identity. The result can include namespace access through `$`, `@`, or literal `[["name"]]` where the syntax supports it, named/wildcard attachments, renamed local bindings, re-export chains, and the underlying definition in open or workspace-indexed files.
 
 Selected installed-package members have no navigable source definition, so Raven instead preserves the exact `(package, exported name)` identity. Renamed declaration tokens and uses remain linked to the original export, while unrelated local bindings or imports from another package with the same spelling are excluded. Ordinary non-selective structural references retain the broad pooling described above.
 

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -87,7 +87,7 @@ See [Cross-File Awareness](cross-file.md#automatic-source-detection) and [Direct
 
 ### box module paths and exports
 
-Cmd-click on a static relative [`box::use()` module spec](cross-file.md#box-module-imports-boxuse) opens the exact resolved module. box path resolution is file-relative and case-sensitive, ignores Raven's `source()` working-directory/fallback rules, and checks `path.r`, `path.R`, `path/__init__.r`, then `path/__init__.R`.
+Cmd-click on a static relative [`box::use()` module spec](modules.md#box-modules-boxuse) opens the exact resolved module. box path resolution is file-relative and case-sensitive, ignores Raven's `source()` working-directory/fallback rules, and checks `path.r`, `path.R`, `path/__init__.r`, then `path/__init__.R`.
 
 For namespace aliases and attached/renamed bindings, navigation crosses only the exported interface. `$`, `@`, and a single positional literal-string `[[...]]` access resolve to the original local-module definition, following named, renamed, or wildcard re-export chains with cycle guards. Private names and merely transitive imports do not navigate. Installed-package box imports reuse package export metadata but remain non-navigable for the same reason as other installed package exports.
 

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -38,7 +38,7 @@ Each step takes the first hit and stops; steps 3–5 never run once a match is f
 
 ### box module members
 
-Static [`box::use()` imports](cross-file.md#box-module-imports-boxuse) are resolved before ordinary structural-member scanning. Hover on an exported local-module member follows exact definition provenance through named, renamed, and wildcard re-exports, including when the defining module is closed but workspace-indexed. Private members and members proven absent from a complete export set produce no hover. Partial/unknown export metadata remains conservative. Installed-package imports use Raven's package metadata and help attribution, but Raven does not invent a source-file location for installed code.
+Static [`box::use()` imports](modules.md#box-modules-boxuse) are resolved before ordinary structural-member scanning. Hover on an exported local-module member follows exact definition provenance through named, renamed, and wildcard re-exports, including when the defining module is closed but workspace-indexed. Private members and members proven absent from a complete export set produce no hover. Partial/unknown export metadata remains conservative. Installed-package imports use Raven's package metadata and help attribution, but Raven does not invent a source-file location for installed code.
 
 ## File Location Lines
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,7 +13,7 @@ Raven is under active development. The gaps below reflect features that exist in
 
 ## box module system (`box::use`)
 
-Raven models the statically analyzable subset of the [box](https://klmr.me/box/) module system across diagnostics, completion, hover, go-to-definition, find-references, dependency revalidation, the language server, and `raven check`. See [Cross-File & Package Awareness — box module imports](./cross-file.md#box-module-imports-boxuse).
+Raven models the statically analyzable subset of the [box](https://klmr.me/box/) module system across diagnostics, completion, hover, go-to-definition, find-references, dependency revalidation, the language server, and `raven check`. See [Module & import systems — box modules](./modules.md#box-modules-boxuse).
 
 **Only static `box::use()` is recognised.** The call must be a literal `box::use(...)` / `box:::use(...)`. Programmatic invocation — `do.call(box::use, ...)`, aliasing `box::use` to another name, or building the argument list at runtime — is not recognised.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,99 @@
+# Module & import systems
+
+Raven understands two R module/import systems whose semantics ordinary
+`library()` and `source()` cannot express: the [`box`](https://klmr.me/box/)
+package and the [`import`](https://rticulate.github.io/import/) package. Both are
+modelled as **selective imports** — Raven brings in only the names an import
+actually requests, under the names it requests. It never merges a whole file's
+definitions the way `source()` does, and never dumps a package's entire export
+set in as bare names the way `library()` does.
+
+Everything here is **static**: Raven does not run your code to discover what a
+module exports or where it lives. Forms it cannot read statically are left inert
+— they neither bind names nor produce misleading diagnostics. For the exact
+boundaries see [Limitations](limitations.md); for the diagnostic codes see
+[Diagnostics](diagnostics.md).
+
+## box modules (`box::use()`)
+
+A box import binds a **namespace object** (used as `alias$member`) and/or an
+explicitly chosen subset of a module's exports:
+
+```r
+box::use(
+  dplyr,                 # namespace object:        dplyr$filter(...)
+  dr = dplyr,            # ... under an alias:       dr$filter(...)
+  dplyr[filter, select], # attach members directly (no namespace object)
+  dplyr[f = filter],     # attach under a local name: f()
+  dplyr[...],            # attach every export
+  ./helpers,             # local module: helpers.r or helpers/__init__.r
+  ../lib/util[foo],      # attach `foo` from a module one directory up
+)
+```
+
+- A **bare name** is an installed package; a **local module** must begin with
+  `./` or `../`. Both top-level and function-scoped calls are recognised, as is
+  the `box:::use()` spelling.
+- The default namespace name is the final path/package component (`../lib/util`
+  binds `util`); write `alias = spec` to override it.
+- An **attach-only** spec (`pkg[a, b]`, `pkg[...]`) binds no namespace object
+  unless you also alias it (`alias = pkg[...]`).
+
+**Local modules** resolve relative to the importing file's own directory — box
+does not use Raven's `source()` working-directory or workspace-root fallback
+rules. The extension is omitted in the spec; Raven tries `path.r`, `path.R`,
+`path/__init__.r`, then `path/__init__.R` (so a file module wins over a package
+module), and resolution is case-sensitive.
+
+**Exports** come from `box::export()` and `#' @export` tags. When either is
+present the interface is authoritative, so a missing member (`module$typo`) is
+diagnosable. A module with no export markers falls back to "every top-level name
+that does not begin with a dot," treated as *non-authoritative* — absence is not
+concluded, because a dynamic binding might supply it. Private names, and names
+only transitively imported, never cross the boundary.
+
+Imported namespace aliases and attached members work everywhere Raven's
+intelligence does — diagnostics, completion, hover, signatures, go-to-definition,
+and find-references — in open and workspace-indexed files, in the language server
+and `raven check`. Editing a local module's exports revalidates its importers,
+but a box edge never lends ordinary `source()` scope or `# raven: nse` /
+`# raven: func` declarations. The `/` inside a box spec stays exempt from the
+`infix_spaces` lint; ordinary `/` expressions are unaffected.
+
+## import package (`import::from()`)
+
+The import package selects names from an installed package or a local `.R`/`.r`
+script module:
+
+```r
+import::from(dplyr, filter, select)     # selected names
+import::from(dplyr, keep = filter)       # renamed
+import::from(dplyr, .except = "lag")     # every export except some
+import::here(clean, .from = "utils.R")   # into the current environment
+```
+
+- A source is a package name or a **literal** `.R`/`.r` path (the extension is
+  part of the path — no box-style candidate guessing). A literal `.directory`
+  is honoured.
+- `.all = TRUE` attaches the known export set; a non-empty static `.except`
+  implies `.all`. When several `.all` bindings target the same local name, R's
+  sequential last-write-wins order applies.
+- `here()` binds into the current (lexical) environment at the call position —
+  inside a function, its effect stays in that function. `from()` and `into()`
+  bind into a lower-priority search-path destination: these are fallback bindings
+  *below* your lexical names, not namespace objects, so they enable no `$` access.
+
+A local script module's candidate exports are its private top-level environment
+(including dotted names and top-level `import::here()` bindings). box export
+markers do not govern import modules. Editing a local module revalidates its
+importers without lending ordinary scope.
+
+## What is not covered
+
+Both systems deliberately stop at what is statically knowable. Programmatic
+invocation, computed or dynamic sources and paths, remote/pins modules, runtime
+`options(box.path = ...)`, `.character_only` package vectors, and side-effecting
+load/unload hooks are left inert rather than guessed. For the exact per-system
+lists, see [Limitations — box module system](limitations.md#box-module-system-boxuse)
+and [Limitations — import package](limitations.md#import-package); for the
+`box-*` and `import-*` diagnostic codes, see [Diagnostics](diagnostics.md).


### PR DESCRIPTION
## Why

The v0.18.0 work (box::use / import:: / tarchetypes) added a lot of documentation, much of it at grammar-level detail and duplicated across several files. The same selective-import behavior was described inside `cross-file.md`, `limitations.md`, and the per-feature docs, which made the user-facing docs harder to read than they needed to be.

## What changed (structural reorg — no behavior change)

- **New `docs/modules.md`** — a single user-altitude home for both the `box` and `import` module systems. Explains the shared "selective import" model, the two `box`/`import` sections, and a short "what is not covered" that links out rather than inlining non-goals.
- **`cross-file.md`** — dropped the box/import sections (now a short pointer stub → `modules.md`); kept the tarchetypes section; trimmed the `tar_map()` name-mangling grammar dump to a paragraph that links to `limitations.md#targets-and-tarchetypes`.
- **Inbound links repointed** to the new `modules.md` anchors: `completion.md`, `hover.md`, `go-to-definition.md`, `find-references.md` (both box + import), `limitations.md`.
- **`README.md`** — split the cross-file bullet; added a dedicated **Module & import systems** bullet → `modules.md`.
- **`AGENTS.md`/`CLAUDE.md`** — added `docs/modules.md` to the *What to read* list.

## Invariants preserved

- `limitations.md` remains the single source of truth for non-goals; `diagnostics.md` remains authoritative for codes. Narrative docs link to those instead of restating them.
- `docs/release-notes-v0.18.0.md` is left **frozen** — its pinned `blob/v0.18.0/` links correctly point at the tagged tree.

Docs-only change; no Rust source touched, so the Rust CI gates and the settings-reference drift test are unaffected.

Not auto-merging — this is a judgment call about doc altitude/readability, so leaving it for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new guide covering `box::use()` modules and `import::from()` imports, including selection, renaming, exports, namespaces, and limitations.
  - Updated feature documentation to distinguish cross-file awareness from module and import systems.
  - Refined guidance on static target-name prediction for `tar_map()`.
  - Updated related documentation links for completion, references, definitions, hover, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->