### PR TITLE
Gate test-only box import helper

### DIFF
--- a/crates/raven/src/cross_file/mod.rs
+++ b/crates/raven/src/cross_file/mod.rs
@@ -281,6 +281,7 @@ pub fn extract_metadata_with_tree(
 /// box-only helpers that have no workspace context. Production mixed-dialect
 /// analysis must call [`enrich_selective_import_resolutions`] so `{import}` keeps
 /// its workspace-root fallback.
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) fn enrich_box_import_resolutions(
     meta: &mut CrossFileMetadata,
     importing_uri: &tower_lsp::lsp_types::Url,


### PR DESCRIPTION
## Summary

- compile `enrich_box_import_resolutions` only for unit tests or the `test-support` feature
- remove the default-build `dead_code` warning without suppressing lints
- preserve the workspace-aware production path through `enrich_selective_import_resolutions`

## Root cause

All callers of `enrich_box_import_resolutions` are already gated by `cfg(test)` or `feature = "test-support"`, but the helper itself was compiled unconditionally. Default library builds therefore saw it as dead code.

## Validation

- `cargo check -p raven`
- `cargo check -p raven --features test-support`
- `cargo clippy -p raven --lib -- -D warnings`
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items --features test-support`
- `cargo test -p raven --lib --no-run`
- `cargo fmt --all`