### PR TITLE
chore(deps): bump fast-uri to 4.1.2

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -3804,9 +3804,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "dev": true,
       "funding": [
         {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2456,7 +2456,7 @@
     "@babel/core": "^7.29.6",
     "serialize-javascript": "^7.0.3",
     "uuid": ">=14.0.0",
-    "fast-uri": ">=4.1.1",
+    "fast-uri": ">=4.1.2",
     "diff": ">=8.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- raise the `fast-uri` override from 4.1.1 to 4.1.2
- regenerate the VS Code extension lockfile
- address Dependabot alert #71 (GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446)

## Validation
- `npm --prefix editors/vscode run typecheck`
- `npm --prefix editors/vscode audit --cache "$TMPDIR/npm-cache"` (0 vulnerabilities)
- `npm --prefix editors/vscode ls fast-uri` (resolves 4.1.2)
- `bun test`: 1,775 passed; the environment-dependent workspace wrapper was the only failure because the cached VS Code Electron executable was absent (`ENOENT`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported `fast-uri` version to 4.1.2 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->