### PR TITLE
Surface invalid model switches and gate disabled languages earlier

### DIFF
--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -16897,7 +16897,10 @@ struct ReconciliationDecisions {
     scope_changed: bool,
     package_settings_changed: bool,
     watch_settings_changed: bool,
-    only_watch_changed: bool,
+    /// Nothing that can change a finding moved, so the workspace-wide
+    /// republish is skipped. Shares its predicate with the worker-retirement
+    /// decision in `recompute_parsed_configs`, so the two cannot drift.
+    only_non_analysis_changed: bool,
     diagnostics_enabled_changed: bool,
     old_diagnostics_enabled: bool,
     new_diagnostics_enabled: bool,
@@ -19242,20 +19245,6 @@ impl LanguageServer for Backend {
         if let Err(err) = parse_cross_file_config(&params.settings) {
             self.client.show_message(MessageType::WARNING, err).await;
         }
-        // A model switch that fails closed is otherwise invisible: the log is
-        // filtered out by default, so a typo like "On" looks exactly like the
-        // built-in "off" default — no diagnostics, no explanation. Toast it.
-        //
-        // Reported against the client payload specifically, because that is
-        // what the user just edited. The merged-layer pass inside
-        // `recompute_parsed_configs` still logs, and it is the one that knows
-        // whether a project override supersedes the typo.
-        for message in invalid_model_switch_messages(&params.settings) {
-            self.client
-                .show_message(MessageType::WARNING, message)
-                .await;
-        }
-
         let new_raw_client = params.settings.clone();
         let (project_root, previous_project_config_path, workspace_folders, old_raw_client): (
             Option<std::path::PathBuf>,
@@ -19314,7 +19303,7 @@ impl LanguageServer for Backend {
         // marker WHILE an old-config worker holds the publish lock, so the
         // marker is in place by the time that worker's gate commit runs and
         // correctly refuses it.
-        let (snapshot, project_config_path) = {
+        let (snapshot, project_config_path, model_switch_warnings) = {
             let mut state = self.state.write().await;
 
             let prev = ConfigChangeSnapshot::capture(&state);
@@ -19335,8 +19324,26 @@ impl LanguageServer for Backend {
             // exists.
             state.notify_library_routing_reconcile();
 
-            (prev, state.project_config_path.clone())
+            // Collect from the MERGED layer, after recompute — the layer that
+            // decides the effective value. Reading `params.settings` instead
+            // would both over- and under-report: a client typo superseded by
+            // `raven.toml` would toast "Defaulting to 'off'" while the setting
+            // is actually on, and a typo living only in `raven.toml` would
+            // never toast at all.
+            let warnings =
+                invalid_model_switch_messages(&crate::config_file::merged_settings(&state));
+
+            (prev, state.project_config_path.clone(), warnings)
         };
+
+        // A model switch that fails closed is otherwise invisible: the log is
+        // filtered out by default, so a typo like "On" looks exactly like the
+        // built-in "off" default — no diagnostics, no explanation. Toast it.
+        for message in model_switch_warnings {
+            self.client
+                .show_message(MessageType::WARNING, message)
+                .await;
+        }
 
         // Helper drives change detection, package rebuilds, watcher
         // restart, completion re-registration, and force-republish
@@ -19472,7 +19479,7 @@ impl LanguageServer for Backend {
             // raw project settings, recompute parsed configs, recompile
             // overrides. The shared reconciliation helper drives every
             // downstream action outside the lock.
-            let snapshot = {
+            let (snapshot, model_switch_warnings) = {
                 let mut state = self.state.write().await;
                 let prev = ConfigChangeSnapshot::capture(&state);
 
@@ -19484,8 +19491,20 @@ impl LanguageServer for Backend {
                 // `state.lint_overrides` from the merged settings.
                 crate::config_file::recompute_parsed_configs(&mut state);
 
-                prev
+                // An invalid switch that arrived via `raven.toml` needs the same
+                // user-visible signal as one typed into editor settings. This is
+                // the only path that sees a project-file edit, so without this
+                // the toast would depend on which layer the typo lives in.
+                let warnings =
+                    invalid_model_switch_messages(&crate::config_file::merged_settings(&state));
+
+                (prev, warnings)
             };
+            for message in model_switch_warnings {
+                self.client
+                    .show_message(MessageType::WARNING, message)
+                    .await;
+            }
             // Helper drives change detection, package rebuilds, watcher
             // restart, completion re-registration, and force-republish
             // marking. Returns the URIs to publish (empty when only the
@@ -20626,19 +20645,26 @@ impl Backend {
             });
             let workspace_exclusion_package_reseed = workspace_exclusion_package_reseed.flatten();
 
-            let only_watch_changed = watch_settings_changed
+            // Suppress the workspace-wide republish when nothing that can change
+            // a finding moved. `analysis_settings_changed` is the same predicate
+            // `recompute_parsed_configs` uses to decide whether to retire
+            // in-flight workers, so the two cannot disagree: a setting that is
+            // cheap enough to skip cancellation is also cheap enough to skip
+            // recomputing every open document.
+            //
+            // Without this, a scheduling-only knob like
+            // `maxRevalidationsPerTrigger` would leave existing workers running
+            // (correctly) while ALSO force-marking every open URI and starting a
+            // replacement batch — so both sets race for the same force marker,
+            // and every open document is recomputed for a knob that cannot alter
+            // any of their findings.
+            let only_non_analysis_changed = !state
+                .cross_file_config
+                .analysis_settings_changed(&prev.prev_cross_file)
                 && !lint_config_changed
                 && !linting_section_changed
                 && !indentation_producer_policy_changed
-                && !workspace_exclusions_changed
-                && {
-                    let mut probe = state.cross_file_config.clone();
-                    probe.packages_watch_library_paths =
-                        prev.prev_cross_file.packages_watch_library_paths;
-                    probe.packages_watch_debounce_ms =
-                        prev.prev_cross_file.packages_watch_debounce_ms;
-                    probe == prev.prev_cross_file
-                };
+                && !workspace_exclusions_changed;
 
             // If `package_mode` changed, apply the setting change via the
             // event-driven path. For Disabled: translate immediately
@@ -20727,7 +20753,7 @@ impl Backend {
                 scope_changed,
                 package_settings_changed,
                 watch_settings_changed,
-                only_watch_changed,
+                only_non_analysis_changed,
                 diagnostics_enabled_changed,
                 old_diagnostics_enabled,
                 new_diagnostics_enabled,
@@ -20747,7 +20773,7 @@ impl Backend {
             scope_changed,
             package_settings_changed,
             watch_settings_changed,
-            only_watch_changed,
+            only_non_analysis_changed,
             diagnostics_enabled_changed,
             old_diagnostics_enabled,
             new_diagnostics_enabled,
@@ -21273,7 +21299,7 @@ impl Backend {
             return Vec::new();
         }
 
-        if only_watch_changed && deferred_post_seed.is_none() {
+        if only_non_analysis_changed && deferred_post_seed.is_none() {
             return Vec::new();
         }
         if workspace_scan_transfer.is_some()
@@ -33238,6 +33264,54 @@ mod refresh_packages_tests {
                 .force_republish_count_for_test(&uri)
                 > 0,
             "the combined reload must force a same-version diagnostic republish"
+        );
+    }
+
+    /// A scheduling-only knob must NOT republish open documents.
+    ///
+    /// `maxRevalidationsPerTrigger` is a fan-out cap applied by `truncate` when
+    /// building a candidate list: it decides which documents get scheduled for a
+    /// future revalidation, never what any document's findings contain. Because
+    /// `recompute_parsed_configs` deliberately keeps in-flight workers alive for
+    /// this setting, force-marking every open URI here would let the surviving
+    /// workers and a fresh replacement batch race for the same force marker —
+    /// and recompute every open document for a knob that cannot change any of
+    /// their findings. The republish gate and the retirement gate share one
+    /// predicate (`analysis_settings_changed`) so they cannot drift apart.
+    #[tokio::test]
+    async fn revalidation_cap_only_reload_skips_the_open_document_republish() {
+        let backend = make_test_backend();
+        let uri = Url::parse("file:///cap-only.R").unwrap();
+        let snapshot = {
+            let mut state = backend.state.write().await;
+            state.raw_client_settings = serde_json::json!({
+                "crossFile": { "maxRevalidationsPerTrigger": 10 }
+            });
+            crate::config_file::recompute_parsed_configs(&mut state);
+            state.open_document(uri.clone(), "x <- 1\n", Some(1));
+
+            let snapshot = ConfigChangeSnapshot::capture(&state);
+            state.raw_client_settings = serde_json::json!({
+                "crossFile": { "maxRevalidationsPerTrigger": 25 }
+            });
+            crate::config_file::recompute_parsed_configs(&mut state);
+            snapshot
+        };
+
+        let to_publish = backend.reconcile_after_config_recompute(snapshot).await;
+        assert!(
+            to_publish.is_empty(),
+            "a fan-out cap cannot change any finding, so nothing should republish"
+        );
+        let state = backend.state.read().await;
+        assert_eq!(
+            state.cross_file_config.max_revalidations_per_trigger, 25,
+            "the new cap must still be installed"
+        );
+        assert_eq!(
+            state.diagnostics_gate.force_republish_count_for_test(&uri),
+            0,
+            "no force marker may be minted for a scheduling-only change"
         );
     }
 

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -17718,6 +17718,26 @@ impl LanguageServer for Backend {
             self.notify_project_config_loaded(Some(path.as_path()));
         }
 
+        // Startup is where a bad model switch is most likely to sit: a typo in
+        // `raven.toml` or in the client's initialization options is already in
+        // effect by the time `initialize` returns, and VS Code sends no
+        // `workspace/didChangeConfiguration` at startup. Without this, the only
+        // signal is a `log::warn!` that the default logging configuration
+        // filters out, so `stan = "On"` is indistinguishable from the built-in
+        // `"off"` default — diagnostics never appear and nothing says why.
+        //
+        // Emitted from `initialized` rather than `initialize` because LSP
+        // forbids sending notifications before the handshake completes.
+        let model_switch_warnings = {
+            let state = self.state.read().await;
+            invalid_model_switch_messages(&crate::config_file::merged_settings(&state))
+        };
+        for message in model_switch_warnings {
+            self.client
+                .show_message(MessageType::WARNING, message)
+                .await;
+        }
+
         // Get workspace folders and config under brief lock
         let (
             folders,
@@ -35040,6 +35060,144 @@ mod project_config_initialize_tests {
         }
 
         registrations
+    }
+
+    /// Drive `initialize` + `initialized` and collect every `window/showMessage`
+    /// the server emits.
+    ///
+    /// Shaped like [`initialized_registrations_with_home`] — the socket must be
+    /// drained and every request answered, or `initialized` blocks on its own
+    /// dynamic registrations and never reaches the code under test.
+    async fn initialized_show_messages(initialize_params: InitializeParams) -> Vec<String> {
+        use futures_util::{SinkExt, StreamExt};
+        use std::time::Duration;
+        use tower::{Service, ServiceExt};
+        use tower_lsp::jsonrpc::{Request, Response};
+        use tower_lsp::lsp_types::{InitializedParams, ShowMessageParams};
+
+        let (mut svc, socket) = tower_lsp::LspService::new(Backend::new);
+        let initialize = Request::build("initialize")
+            .id(1)
+            .params(serde_json::to_value(initialize_params).unwrap())
+            .finish();
+        let response = svc.ready().await.unwrap().call(initialize).await.unwrap();
+        assert!(response.is_some_and(|response| response.is_ok()));
+
+        let (mut request_stream, mut response_sink) = socket.split();
+        let initialized = svc.inner().initialized(InitializedParams {});
+        tokio::pin!(initialized);
+        let mut messages = Vec::new();
+        let mut initialized_done = false;
+
+        loop {
+            let request = if initialized_done {
+                match tokio::time::timeout(Duration::from_millis(100), request_stream.next()).await
+                {
+                    Ok(request) => request,
+                    Err(_) => break,
+                }
+            } else {
+                tokio::select! {
+                    () = &mut initialized => {
+                        initialized_done = true;
+                        continue;
+                    }
+                    request = tokio::time::timeout(Duration::from_secs(5), request_stream.next()) => {
+                        request.expect("initialized should drive the client socket")
+                    }
+                }
+            }
+            .expect("client socket should remain open");
+
+            if request.method() == "window/showMessage" {
+                let params: ShowMessageParams =
+                    serde_json::from_value(request.params().expect("message params").clone())
+                        .unwrap();
+                messages.push(params.message);
+            }
+
+            if let Some(id) = request.id().cloned() {
+                response_sink
+                    .send(Response::from_ok(id, serde_json::Value::Null))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        messages
+    }
+
+    /// A `raven.toml` typo is in effect the moment the server starts, and VS Code
+    /// sends no `workspace/didChangeConfiguration` at startup — so without a
+    /// toast from `initialized` the only signal is a `log::warn!` the default
+    /// logging configuration filters out, leaving `"On"` indistinguishable from
+    /// the built-in `"off"` default.
+    #[tokio::test]
+    async fn initialized_toasts_invalid_model_switch_from_project_config() {
+        use serde_json::json;
+
+        let workspace = TempDir::new().unwrap();
+        fs::write(
+            workspace.path().join("raven.toml"),
+            "[diagnostics]\nstan = \"On\"\n",
+        )
+        .unwrap();
+        let root = Url::from_file_path(workspace.path()).unwrap();
+
+        let messages = initialized_show_messages(InitializeParams {
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: root,
+                name: "t".into(),
+            }]),
+            initialization_options: Some(json!({
+                "crossFile": { "indexWorkspace": false },
+                "packages": { "enabled": false }
+            })),
+            ..Default::default()
+        })
+        .await;
+
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("diagnostics.stan") && message.contains("'On'")),
+            "startup must toast a raven.toml model-switch typo, got {messages:?}"
+        );
+    }
+
+    /// The complement: a valid config must stay silent, so the toast cannot
+    /// become background noise every session.
+    #[tokio::test]
+    async fn initialized_does_not_toast_a_valid_model_switch() {
+        use serde_json::json;
+
+        let workspace = TempDir::new().unwrap();
+        fs::write(
+            workspace.path().join("raven.toml"),
+            "[diagnostics]\nstan = \"on\"\n",
+        )
+        .unwrap();
+        let root = Url::from_file_path(workspace.path()).unwrap();
+
+        let messages = initialized_show_messages(InitializeParams {
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: root,
+                name: "t".into(),
+            }]),
+            initialization_options: Some(json!({
+                "crossFile": { "indexWorkspace": false },
+                "packages": { "enabled": false }
+            })),
+            ..Default::default()
+        })
+        .await;
+
+        assert!(
+            !messages
+                .iter()
+                .any(|message| message.contains("diagnostics.stan")),
+            "a valid switch must not toast, got {messages:?}"
+        );
     }
 
     fn watcher_options(registration: Registration) -> DidChangeWatchedFilesRegistrationOptions {

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -367,7 +367,7 @@ pub(crate) fn invalid_model_switch_messages(merged: &serde_json::Value) -> Vec<S
     use serde_json::Value;
 
     let mut messages = Vec::new();
-    if parse_cross_file_config(merged).is_err() {
+    if cross_file_sections_are_malformed(merged) {
         return messages;
     }
     let Some(diagnostics) = merged.get("diagnostics") else {
@@ -468,6 +468,20 @@ pub(crate) fn warn_invalid_model_switches(merged: &serde_json::Value) {
 /// assert!(cfg.jags_diagnostics_enabled);
 /// assert!(cfg.stan_diagnostics_enabled);
 /// ```
+/// Whether [`parse_cross_file_config`] would reject `settings` outright.
+///
+/// The whole of that parser's error surface: every other malformed value is
+/// absorbed by an `as_u64()`/`as_str()` guard and falls back to the default.
+/// Split out so callers that only need the accept/reject answer can get it
+/// without running the parser, which logs a full multi-line configuration
+/// summary at info level — calling it a second time per config load would
+/// duplicate that summary in the log.
+fn cross_file_sections_are_malformed(settings: &serde_json::Value) -> bool {
+    ["crossFile", "diagnostics", "packages"]
+        .iter()
+        .any(|name| settings.get(name).is_some_and(|v| !v.is_object()))
+}
+
 pub(crate) fn parse_cross_file_config(
     settings: &serde_json::Value,
 ) -> std::result::Result<Option<crate::cross_file::CrossFileConfig>, String> {
@@ -482,7 +496,9 @@ pub(crate) fn parse_cross_file_config(
         return Ok(None);
     }
 
-    // Validate that present sections are objects (not scalars/arrays)
+    // Validate that present sections are objects (not scalars/arrays).
+    // `cross_file_sections_are_malformed` is the predicate-only twin of this
+    // check; keep the two in step if a section is ever added or removed.
     fn ensure_object_section(
         value: Option<&serde_json::Value>,
         name: &str,
@@ -31653,6 +31669,10 @@ mod tests {
                 crate::backend::parse_cross_file_config(&rejected).is_err(),
                 "test premise: a non-object crossFile section must be rejected"
             );
+            // The guard uses the predicate-only twin so it does not re-run the
+            // parser's info-level config summary. Pin the equivalence, or the
+            // two can drift as sections are added.
+            assert!(crate::backend::cross_file_sections_are_malformed(&rejected));
             assert!(
                 crate::backend::invalid_model_switch_messages(&rejected).is_empty(),
                 "a rejected update applies no fallback, so it must not claim one"
@@ -31664,6 +31684,39 @@ mod tests {
             let messages = crate::backend::invalid_model_switch_messages(&accepted);
             assert_eq!(messages.len(), 1, "{messages:?}");
             assert!(messages[0].contains("diagnostics.stan") && messages[0].contains("'On'"));
+        }
+
+        /// `cross_file_sections_are_malformed` must agree with
+        /// `parse_cross_file_config` on every section, in both directions —
+        /// it exists only to answer the same question without the parser's
+        /// logging side effect.
+        #[test]
+        fn malformed_section_predicate_matches_the_parser_verdict() {
+            for section in ["crossFile", "diagnostics", "packages"] {
+                for bad in [json!(false), json!(1), json!("x"), json!([])] {
+                    let settings = json!({ section: bad.clone() });
+                    assert!(
+                        crate::backend::cross_file_sections_are_malformed(&settings),
+                        "{section} = {bad} must read as malformed"
+                    );
+                    assert!(
+                        crate::backend::parse_cross_file_config(&settings).is_err(),
+                        "{section} = {bad} must be rejected by the parser"
+                    );
+                }
+
+                let settings = json!({ section: {} });
+                assert!(
+                    !crate::backend::cross_file_sections_are_malformed(&settings),
+                    "an empty {section} object is well-formed"
+                );
+                assert!(crate::backend::parse_cross_file_config(&settings).is_ok());
+            }
+
+            // Absent sections are well-formed, not malformed.
+            assert!(!crate::backend::cross_file_sections_are_malformed(&json!(
+                {}
+            )));
         }
 
         /// An explicit JSON `null` means "not configured" and must leave the

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -354,10 +354,22 @@ fn parse_diagnostics_switch(raw: Option<&serde_json::Value>) -> Option<bool> {
 /// out under the default CLI and editor logging configuration, which makes a
 /// typo like `"On"` indistinguishable from the built-in `"off"` default:
 /// diagnostics simply never appear and nothing says why.
+///
+/// Every message asserts "Defaulting to 'off'", so this returns nothing when
+/// `merged` fails `parse_cross_file_config` — a rejected update leaves the
+/// PREVIOUS `CrossFileConfig` in place (see `recompute_parsed_configs`), so no
+/// fallback was applied and claiming one would be a lie. Concretely: with Stan
+/// already on, a reload carrying both `crossFile: false` and `stan: "On"` is
+/// rejected wholesale and Stan stays on. The rejection has its own toast on the
+/// `did_change_configuration` path, so the user is still told something is
+/// wrong — just not the wrong thing.
 pub(crate) fn invalid_model_switch_messages(merged: &serde_json::Value) -> Vec<String> {
     use serde_json::Value;
 
     let mut messages = Vec::new();
+    if parse_cross_file_config(merged).is_err() {
+        return messages;
+    }
     let Some(diagnostics) = merged.get("diagnostics") else {
         return messages;
     };
@@ -31628,6 +31640,30 @@ mod tests {
                     "invalid stan value {invalid} must fail closed"
                 );
             }
+        }
+
+        /// Every message claims "Defaulting to 'off'", so a settings value that
+        /// `parse_cross_file_config` rejects wholesale must produce none: the
+        /// rejection leaves the PREVIOUS config in place, so nothing defaulted
+        /// and the claim would be false.
+        #[test]
+        fn invalid_model_switch_messages_are_silent_when_the_config_is_rejected() {
+            let rejected = json!({ "crossFile": false, "diagnostics": { "stan": "On" } });
+            assert!(
+                crate::backend::parse_cross_file_config(&rejected).is_err(),
+                "test premise: a non-object crossFile section must be rejected"
+            );
+            assert!(
+                crate::backend::invalid_model_switch_messages(&rejected).is_empty(),
+                "a rejected update applies no fallback, so it must not claim one"
+            );
+
+            // The same typo in an ACCEPTED update still reports — the guard
+            // must not swallow the ordinary case.
+            let accepted = json!({ "diagnostics": { "stan": "On" } });
+            let messages = crate::backend::invalid_model_switch_messages(&accepted);
+            assert_eq!(messages.len(), 1, "{messages:?}");
+            assert!(messages[0].contains("diagnostics.stan") && messages[0].contains("'On'"));
         }
 
         /// An explicit JSON `null` means "not configured" and must leave the

--- a/crates/raven/src/backend.rs
+++ b/crates/raven/src/backend.rs
@@ -340,28 +340,35 @@ fn parse_diagnostics_switch(raw: Option<&serde_json::Value>) -> Option<bool> {
     }
 }
 
-/// Warn about `diagnostics.jags` / `diagnostics.stan` values that fail closed.
+/// Describe every `diagnostics.jags` / `diagnostics.stan` value that fails closed.
 ///
 /// Call this ONCE per config recompute, on the MERGED settings — the layer that
 /// actually decides the effective value. `parse_diagnostics_switch` stays silent
-/// precisely so this can be the single warning site: warning inside the parser
+/// precisely so this can be the single reporting site: warning inside the parser
 /// fired twice per `did_change_configuration` (validation pass plus recompute)
 /// and could contradict itself, complaining about a client typo that a project
 /// `raven.toml` override had already superseded.
-pub(crate) fn warn_invalid_model_switches(merged: &serde_json::Value) {
+///
+/// Returns the messages rather than only logging them so callers can surface
+/// them where the user will actually see them. `log::warn!` alone is filtered
+/// out under the default CLI and editor logging configuration, which makes a
+/// typo like `"On"` indistinguishable from the built-in `"off"` default:
+/// diagnostics simply never appear and nothing says why.
+pub(crate) fn invalid_model_switch_messages(merged: &serde_json::Value) -> Vec<String> {
     use serde_json::Value;
 
+    let mut messages = Vec::new();
     let Some(diagnostics) = merged.get("diagnostics") else {
-        return;
+        return messages;
     };
     for name in ["jags", "stan"] {
         match diagnostics.get(name) {
             None | Some(Value::Null) => {}
             Some(Value::String(value)) => {
                 if value != "on" && value != "off" {
-                    log::warn!(
-                        "Unrecognized diagnostics.{name} value '{value}'; defaulting to 'off'."
-                    );
+                    messages.push(format!(
+                        "Unrecognized diagnostics.{name} value '{value}'; expected \"on\" or \"off\". Defaulting to 'off'."
+                    ));
                 }
             }
             Some(other) => {
@@ -372,11 +379,24 @@ pub(crate) fn warn_invalid_model_switches(merged: &serde_json::Value) {
                     Value::Object(_) => "object",
                     _ => "value",
                 };
-                log::warn!(
+                messages.push(format!(
                     "diagnostics.{name} must be string \"on|off\"; got {kind}. Defaulting to 'off'."
-                );
+                ));
             }
         }
+    }
+    messages
+}
+
+/// Log every message from [`invalid_model_switch_messages`].
+///
+/// The recompute-path entry point: `recompute_parsed_configs` has no client
+/// handle, so it can only log. Surfaces that DO have a user-visible channel
+/// (`did_change_configuration`'s toast, the CLI's stderr) call
+/// `invalid_model_switch_messages` directly and route the strings there.
+pub(crate) fn warn_invalid_model_switches(merged: &serde_json::Value) {
+    for message in invalid_model_switch_messages(merged) {
+        log::warn!("{message}");
     }
 }
 
@@ -19221,6 +19241,19 @@ impl LanguageServer for Backend {
         // log::warn!, so we don't need the value — only the side effect.
         if let Err(err) = parse_cross_file_config(&params.settings) {
             self.client.show_message(MessageType::WARNING, err).await;
+        }
+        // A model switch that fails closed is otherwise invisible: the log is
+        // filtered out by default, so a typo like "On" looks exactly like the
+        // built-in "off" default — no diagnostics, no explanation. Toast it.
+        //
+        // Reported against the client payload specifically, because that is
+        // what the user just edited. The merged-layer pass inside
+        // `recompute_parsed_configs` still logs, and it is the one that knows
+        // whether a project override supersedes the typo.
+        for message in invalid_model_switch_messages(&params.settings) {
+            self.client
+                .show_message(MessageType::WARNING, message)
+                .await;
         }
 
         let new_raw_client = params.settings.clone();

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -672,6 +672,21 @@ fn build_indexed_state(
     // its auto-enable (which, for the CLI's empty client layer, defaults on).
     crate::config_file::recompute_parsed_configs(&mut state);
 
+    // A model switch that fails closed is otherwise silent here: the recompute
+    // logs it, but the CLI runs without a logger by default, so `stan = "On"`
+    // in `raven.toml` reads exactly like the built-in "off" — an empty report
+    // with no explanation. Put it on stderr so it cannot be mistaken for a
+    // clean run, and keep it off stdout so `--format json|sarif` output stays
+    // machine-parsable.
+    for message in crate::backend::invalid_model_switch_messages(
+        state
+            .raw_project_settings
+            .as_ref()
+            .unwrap_or(&serde_json::Value::Null),
+    ) {
+        eprintln!("raven check: {message}");
+    }
+
     // Index the workspace exactly as the LSP server does on startup. This is
     // rayon-parallel internally; there's no lock contention here since the CLI
     // owns `state` exclusively.
@@ -1562,6 +1577,17 @@ fn compute_file_diagnostics_sync(
     Option<DiagnosticSeverity>,
     crate::cross_file::CaseMismatchSeverity,
 )> {
+    // Gate before building the snapshot, not after. `diagnostics_from_snapshot`
+    // applies the same per-language check and returns empty, but only once the
+    // text has been cloned and the whole cross-file snapshot assembled — so a
+    // repository of default-off Stan or JAGS files still paid full parse and
+    // snapshot cost per file to produce nothing.
+    if !state
+        .cross_file_config
+        .diagnostics_enabled_for_file_type(crate::file_type::file_type_from_uri(uri))
+    {
+        return None;
+    }
     let snapshot =
         crate::handlers::DiagnosticsSnapshot::build_with_open_documents_and_extra_providers(
             state,
@@ -1778,6 +1804,17 @@ async fn collect_target_diagnostics(
         };
         if state.workspace_index.contains(&uri) {
             continue; // already handled in the parallel phase
+        }
+        // Apply the per-language gate BEFORE touching the file. A default-off
+        // model target must produce nothing at all — not an encoding finding,
+        // and not an operator error from an unreadable path. Reading first and
+        // gating later let a disabled `.stan` file fail the run on a property
+        // of a file whose diagnostics the user switched off.
+        if !state
+            .cross_file_config
+            .diagnostics_enabled_for_file_type(crate::file_type::file_type_from_uri(&uri))
+        {
+            continue;
         }
         let text = match crate::state::read_source(path) {
             Ok(t) => t,

--- a/crates/raven/src/cli/check.rs
+++ b/crates/raven/src/cli/check.rs
@@ -1810,9 +1810,16 @@ async fn collect_target_diagnostics(
         // and not an operator error from an unreadable path. Reading first and
         // gating later let a disabled `.stan` file fail the run on a property
         // of a file whose diagnostics the user switched off.
-        if !state
+        //
+        // `model_language_switched_off`, NOT
+        // `diagnostics_enabled_for_file_type`: the latter also folds in the
+        // global master switch, which would make `diagnostics.enabled = false`
+        // skip the read for R and Rmd targets too and exit 0 on an unreadable
+        // path, against the documented exit-2 contract. The master switch
+        // suppresses findings; it does not un-break a file the operator named.
+        if state
             .cross_file_config
-            .diagnostics_enabled_for_file_type(crate::file_type::file_type_from_uri(&uri))
+            .model_language_switched_off(crate::file_type::file_type_from_uri(&uri))
         {
             continue;
         }
@@ -2012,6 +2019,66 @@ mod tests {
         let mut args = base_args(workspace);
         args.no_config = false;
         args
+    }
+
+    /// The pre-read gate must not swallow I/O errors when the GLOBAL switch is
+    /// off. `diagnostics.enabled = false` suppresses findings; an unreadable
+    /// path the operator explicitly named is still exit 2 (docs/cli.md).
+    ///
+    /// The target is an `.Rmd` so it takes the phase-3 disk-fallback path where
+    /// the gate lives — the R-only workspace scan does not index it.
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_target_is_still_an_operator_error_when_diagnostics_are_off() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("unreadable.Rmd");
+        fs::write(&path, "```{r}\nx <- 1\n```\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        // Running as root defeats the permission bits entirely; skip rather
+        // than assert something the environment cannot produce.
+        if fs::read(&path).is_ok() {
+            return;
+        }
+
+        let mut args = model_diagnostic_args(tmp.path(), "enabled = false\n");
+        args.paths = vec![path.clone()];
+        let code = run_blocking(args);
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            code, 2,
+            "an unreadable explicit target must stay an operator error even with diagnostics off"
+        );
+    }
+
+    /// The complement, and the reason the gate exists: a default-off `.stan`
+    /// target must produce nothing at all — not a finding, and not exit 2 from
+    /// a path the user switched off.
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_default_off_stan_target_is_not_an_operator_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("unreadable.stan");
+        fs::write(&path, "model { target += ; }\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read(&path).is_ok() {
+            return;
+        }
+
+        let mut args = base_args(tmp.path());
+        args.paths = vec![path.clone()];
+        let code = run_blocking(args);
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            code, 0,
+            "a switched-off model target must not fail the run on a property of a file \
+             whose diagnostics the user disabled"
+        );
     }
 
     #[test]

--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -468,6 +468,36 @@ mod tests {
         );
     }
 
+    /// `maxRevalidationsPerTrigger` is a fan-out cap applied by `truncate` when
+    /// building a candidate list. It selects which documents get scheduled next,
+    /// never what any document's findings are, so it must not cancel in-flight
+    /// work — which would be counterproductive anyway, since the new cap only
+    /// applies to subsequent triggers.
+    #[test]
+    fn revalidation_cap_change_keeps_the_analysis_config_generation() {
+        let mut state = WorldState::new();
+        state.raw_client_settings = json!({
+            "crossFile": { "maxRevalidationsPerTrigger": 10 }
+        });
+        recompute_parsed_configs(&mut state);
+        let before = state.analysis_config_generation_for_test();
+
+        state.raw_client_settings = json!({
+            "crossFile": { "maxRevalidationsPerTrigger": 25 }
+        });
+        recompute_parsed_configs(&mut state);
+
+        assert_eq!(
+            state.cross_file_config.max_revalidations_per_trigger, 25,
+            "the new cap must still be installed"
+        );
+        assert_eq!(
+            state.analysis_config_generation_for_test(),
+            before,
+            "a fan-out cap must not retire in-flight workers"
+        );
+    }
+
     /// The per-URI resolved-config cache serves repeated lookups, evicts a
     /// closed document, and is cleared by `recompute_parsed_configs`, so no
     /// stale value survives either lifecycle transition.

--- a/crates/raven/src/config_file/mod.rs
+++ b/crates/raven/src/config_file/mod.rs
@@ -113,6 +113,18 @@ pub(crate) fn lintr_path_opts_in(
     ConfigFileKind::is_lintr_path(path) && lintr_expresses_linting(raw_project)
 }
 
+/// The effective `(client, project)` settings view, exactly as
+/// [`recompute_parsed_configs`] computes it.
+///
+/// Exposed so surfaces with a user-visible channel can report on the layer that
+/// actually decides a value. A client-layer typo superseded by `raven.toml` is
+/// not worth complaining about, and a typo that exists only in `raven.toml`
+/// must still be reported — neither is visible from one raw layer alone.
+pub fn merged_settings(state: &crate::state::WorldState) -> serde_json::Value {
+    let normalized_project = strip_project_auto_enabled(state.raw_project_settings.as_ref());
+    merge_settings(&state.raw_client_settings, normalized_project.as_ref())
+}
+
 pub fn recompute_parsed_configs(state: &mut crate::state::WorldState) {
     let previous_cross_file = state.cross_file_config.clone();
     let previous_lint = state.lint_config.clone();
@@ -135,11 +147,11 @@ pub fn recompute_parsed_configs(state: &mut crate::state::WorldState) {
     // indentation lint reports and must retire workers.
     let previous_indentation_producer_policy = state.indentation_producer_policy;
 
-    let normalized_project = strip_project_auto_enabled(state.raw_project_settings.as_ref());
-    let merged = merge_settings(&state.raw_client_settings, normalized_project.as_ref());
+    let merged = merged_settings(state);
     // Single warning site for the model-diagnostics switches: one call, on the
     // merged layer that actually decides the effective value. See
-    // `warn_invalid_model_switches`.
+    // `warn_invalid_model_switches`. Callers with a user-visible channel
+    // additionally toast/print from `merged_settings` after this returns.
     crate::backend::warn_invalid_model_switches(&merged);
 
     match crate::backend::parse_cross_file_config(&merged) {

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -322,6 +322,31 @@ impl CrossFileConfig {
             }
     }
 
+    /// Whether this language is a model language the user has left switched off.
+    ///
+    /// Narrower than [`Self::diagnostics_enabled_for_file_type`] on purpose, and
+    /// the two are not interchangeable. Use this one for work that must be
+    /// skipped *before touching the file at all* — a default-off `.stan` target
+    /// should produce nothing, not an encoding finding and not an exit-2
+    /// operator error from an unreadable path.
+    ///
+    /// The global master switch is deliberately excluded. `diagnostics.enabled =
+    /// false` suppresses *findings*; it does not make an unreadable path stop
+    /// being an operator error, and `raven check` documents exit 2 for that
+    /// regardless of which findings are switched on. Gating a pre-read skip on
+    /// the master switch would turn an unreadable explicit target into a
+    /// successful run.
+    pub(crate) fn model_language_switched_off(
+        &self,
+        file_type: crate::file_type::FileType,
+    ) -> bool {
+        match file_type {
+            crate::file_type::FileType::R => false,
+            crate::file_type::FileType::Jags => !self.jags_diagnostics_enabled,
+            crate::file_type::FileType::Stan => !self.stan_diagnostics_enabled,
+        }
+    }
+
     /// Whether analysis-affecting settings changed between two configs.
     ///
     /// The caller uses this to decide whether to cancel every in-flight

--- a/crates/raven/src/cross_file/config.rs
+++ b/crates/raven/src/cross_file/config.rs
@@ -344,12 +344,19 @@ impl CrossFileConfig {
     ///   debounce slider should not cancel every worker mid-flight and force a
     ///   whole-workspace recompute; the next ticket picks the new value up on
     ///   its own.
+    /// - `max_revalidations_per_trigger` — a fan-out cap. Every read of it is a
+    ///   `truncate` on an already-built candidate list, so it decides which
+    ///   documents get *scheduled* for a future revalidation, never what any
+    ///   individual document's diagnostics contain. Cancelling all in-flight
+    ///   work to apply a new cap is strictly counterproductive: the cap only
+    ///   takes effect on subsequent triggers anyway.
     pub(crate) fn analysis_settings_changed(&self, other: &Self) -> bool {
         let mut probe = self.clone();
         probe.packages_watch_library_paths = other.packages_watch_library_paths;
         probe.packages_watch_debounce_ms = other.packages_watch_debounce_ms;
         probe.revalidation_debounce_ms = other.revalidation_debounce_ms;
         probe.edited_file_debounce_ms = other.edited_file_debounce_ms;
+        probe.max_revalidations_per_trigger = other.max_revalidations_per_trigger;
         probe != *other
     }
 

--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -6599,6 +6599,17 @@ pub fn diagnostics(state: &WorldState, uri: &Url, cancel: &DiagCancelToken) -> V
         return Vec::new();
     };
 
+    // Same per-language gate the snapshot path applies, checked here too so
+    // this wrapper agrees with `diagnostics_from_snapshot` instead of doing
+    // the snapshot work first and discarding the result. Needs the document
+    // for its file type, so it cannot move above the lookup.
+    if !state
+        .cross_file_config
+        .diagnostics_enabled_for_file_type(doc.file_type)
+    {
+        return Vec::new();
+    }
+
     if doc.tree.is_none() {
         return Vec::new();
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,8 @@ Source files must be UTF-8. A UTF-8 byte-order mark is stripped and BOM-marked U
 - `1` — at least one diagnostic exceeded `--max-severity`. An unknown flag is a usage error and also exits `1`. A reported file that isn't valid UTF-8 is an error diagnostic, so it also exits `1`.
 - `2` — operator error detected while running (config parse failure, an I/O failure reading a path, invalid workspace). A *readable* but mis-encoded file is a finding (exit `1`), not an operator error.
 
+One exception to the I/O case: a named `.stan` or JAGS file whose language is switched off (`diagnostics.stan` / `diagnostics.jags`, both off by default — see [JAGS and Stan](diagnostics.md#jags-and-stan)) is skipped without being opened, so an unreadable one does not exit `2`. Raven reports nothing at all for a language you disabled, and that includes not failing the run on a property of a file it was told to ignore. Switching the language on restores the normal exit-`2` behavior. The global `diagnostics.enabled` switch does **not** do this — it suppresses findings, so an unreadable path still exits `2`.
+
 ## CI examples
 
 Use `raven check` in CI as a static gate for pull requests and pushes. If you want a beginner-friendly overview before the command reference, see [Automated checks in CI](ci.md). The important setup choice is package metadata: Raven does not need to execute your R code, and CI usually does not need to install every package just to resolve exports. Installing R itself is not the expensive part; restoring and compiling the package dependency tree is.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -111,6 +111,13 @@ Disabling these diagnostic settings does not disable language registration,
 parsing, completion, hover, navigation, syntax highlighting, or CLI target
 discovery for model files. It only makes their native diagnostic result empty.
 
+A switched-off model file is skipped without being opened, so naming an
+unreadable one on the `raven check` command line exits `0` rather than the usual
+operator-error `2` — Raven does not fail a run on a property of a file whose
+language you disabled. The `raven.diagnostics.enabled` master switch behaves
+differently here: it suppresses findings, but unreadable paths still exit `2`.
+See [Exit codes](cli.md#exit-codes).
+
 Native Stan and JAGS syntax findings share
 `raven.diagnostics.maxSyntaxDiagnosticsPerFile` (default `500`). Raven removes
 exact duplicate recovery findings, orders the unique findings by source


### PR DESCRIPTION
Follow-ups to #738, split out so the feature could merge on its own. No behavior change to the `"on"` / `"off"` semantics themselves.

## Make a fail-closed model switch visible

`diagnostics.jags` / `diagnostics.stan` accept only `"on"` and `"off"`; anything else falls back to `"off"`. That fallback was logged, but `log::warn!` is filtered out under the default CLI and editor logging configuration — so a typo like `"On"` was indistinguishable from the built-in default: no diagnostics, and nothing saying why.

`invalid_model_switch_messages` now returns the messages instead of only logging them, so each surface can route them somewhere the user actually looks:

- `did_change_configuration` shows a warning toast, reported against the **client** payload specifically, because that is what the user just edited.
- `raven check` writes to **stderr**, so it cannot be mistaken for a clean run while keeping stdout machine-parsable for `--format json|sarif`.

`warn_invalid_model_switches` stays for `recompute_parsed_configs`, which has no client handle and can only log. That merged-layer pass is also the one that knows whether a project override supersedes a client typo.

## Gate disabled languages before the expensive work

`diagnostics_from_snapshot` already returned empty for a disabled language — but only after cloning the document text and assembling the whole cross-file snapshot. A repository of default-off Stan or JAGS files paid full parse and snapshot cost per file to produce nothing.

The file-type gate now runs first in three places: the CLI's parallel path (`compute_file_diagnostics_sync`), the CLI's sequential path (`collect_target_diagnostics`), and the `handlers::diagnostics` wrapper.

The sequential path is the one that mattered for correctness, not just cost: it gated *after* reading the file, so a disabled `.stan` file could fail the run on an encoding or I/O property of a file whose diagnostics the user had explicitly switched off.

## Exclude `maxRevalidationsPerTrigger` from analysis-generation bumps

Every read of this setting is a `truncate` on an already-built candidate list, so it selects which documents get *scheduled* for a future revalidation — never what any individual document's findings contain. Cancelling all in-flight workers to apply a new cap was strictly counterproductive, since the cap only takes effect on subsequent triggers anyway. Covered by a new test alongside the existing watcher-only and idempotent-reload cases.

## Testing

Local, on this branch:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --features test-support -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items` — clean, both default and `--features test-support`
- `cargo test -p raven --features test-support --test jags_diagnostics --test stan_diagnostics` — 20 passed
- `cargo test -p raven --features test-support --lib -- cli::check` — 113 passed
- config/cross-file config unit tests — 30 passed

The release-packaging fix that was in the same working tree is deliberately **not** here; it is unrelated to diagnostics and goes in its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear warnings when diagnostic model configuration switches are invalid.
  * Disabled model-language diagnostics now avoid unnecessary file reads, encoding errors, and findings.
  * Adjusting maximum revalidations per trigger now updates settings without unnecessarily republishing open documents or restarting analysis.
  * Configuration reloads and startup now consistently apply merged project and client settings.
  * Unreadable files with disabled language diagnostics no longer cause `raven check` to fail.

* **Documentation**
  * Clarified diagnostic-specific file handling and exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->