### PR TITLE
Never overwrite a pre-placed release binary with a host build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -267,6 +267,11 @@ jobs:
           esac
 
       - name: Package extension
+        env:
+          # The step above unzipped the cross-compiled binary for this target
+          # into bin/. `vsce package` runs copy-binary, which must preserve it
+          # rather than compare it against any host target/release build.
+          RAVEN_BUNDLE_PREPLACED: '1'
         run: |
           cd editors/vscode
           npm run copy-notice

--- a/editors/vscode/scripts/bundle-binary.js
+++ b/editors/vscode/scripts/bundle-binary.js
@@ -46,20 +46,15 @@ if (
     process.exit(0);
 }
 
-// A pre-placed binary for a DIFFERENT target than this host also wins: there is
-// no host build that could legitimately replace it.
-if (!fs.existsSync(destBinary)) {
-    const foreign = [path.join(binDir, 'raven'), path.join(binDir, 'raven.exe')].find(candidate =>
-        fs.existsSync(candidate),
-    );
-    if (foreign) {
-        console.log(`Preserving pre-placed ${path.basename(foreign)}; it is not this host's target name`);
-        process.exit(0);
-    }
-}
-
-// Otherwise refresh from target/release when it is newer. Size is a tie-breaker
-// for rebuilds on filesystems with coarse timestamps.
+// Note there is deliberately NO guard here for a pre-placed binary under the
+// OTHER platform's filename. It would be redundant — the copy below writes to
+// `destBinary`, this host's name, so a foreign-named artifact is untouched
+// either way — and actively harmful: `copy-binary` also runs from `pretest` and
+// ordinary dev builds, where exiting early would skip creating the host binary
+// and leave the extension with no runnable server while reporting success.
+//
+// Refresh from target/release when it is newer. Size is a tie-breaker for
+// rebuilds on filesystems with coarse timestamps.
 //
 // Neither mtime nor size is a content hash, so a rebuild that produces
 // different bytes at the same length AND the same timestamp is not detected.

--- a/editors/vscode/scripts/bundle-binary.js
+++ b/editors/vscode/scripts/bundle-binary.js
@@ -23,8 +23,50 @@ function copyAndChmod(message = 'Bundled raven binary') {
     console.log(message);
 }
 
-// When target/release is available, refresh the bundled binary if it is newer.
-// Use size as a tie-breaker for rebuilds on filesystems with coarse timestamps.
+// A deliberately pre-placed binary always wins, and is never compared against
+// `target/release`.
+//
+// The release workflow cross-compiles for every target, unzips the correct
+// artifact into `bin/`, and only then runs `vsce package` (which triggers this
+// script). On a runner that also has a host `target/release/raven` — a warm
+// cache, a self-hosted runner, a local `vsce package` after a dev build — a
+// freshness comparison would happily overwrite the cross-compiled binary with
+// the host one, shipping a VSIX whose server cannot execute on the platform it
+// claims to target. Content freshness cannot distinguish that case: the host
+// binary is legitimately newer.
+//
+// `RAVEN_BUNDLE_PREPLACED=1` marks the pre-placed case explicitly. Both target
+// names are checked because cross-platform packaging (e.g. win32 on Linux)
+// means `process.platform` does not match the target.
+if (
+    process.env.RAVEN_BUNDLE_PREPLACED === '1' &&
+    (fs.existsSync(path.join(binDir, 'raven')) || fs.existsSync(path.join(binDir, 'raven.exe')))
+) {
+    console.log('Preserving pre-placed raven binary (RAVEN_BUNDLE_PREPLACED=1)');
+    process.exit(0);
+}
+
+// A pre-placed binary for a DIFFERENT target than this host also wins: there is
+// no host build that could legitimately replace it.
+if (!fs.existsSync(destBinary)) {
+    const foreign = [path.join(binDir, 'raven'), path.join(binDir, 'raven.exe')].find(candidate =>
+        fs.existsSync(candidate),
+    );
+    if (foreign) {
+        console.log(`Preserving pre-placed ${path.basename(foreign)}; it is not this host's target name`);
+        process.exit(0);
+    }
+}
+
+// Otherwise refresh from target/release when it is newer. Size is a tie-breaker
+// for rebuilds on filesystems with coarse timestamps.
+//
+// Neither mtime nor size is a content hash, so a rebuild that produces
+// different bytes at the same length AND the same timestamp is not detected.
+// That is vanishingly unlikely for a compiled binary (both must collide), and
+// the cost of being wrong here is a stale dev/test binary, not a bad release —
+// releases take the pre-placed path above. `cargo build` also updates mtime on
+// every relink, so the normal rebuild path is always caught.
 if (fs.existsSync(srcBinary)) {
     if (fs.existsSync(destBinary)) {
         const srcStat = fs.statSync(srcBinary);
@@ -43,8 +85,7 @@ if (fs.existsSync(srcBinary)) {
     process.exit(0);
 }
 
-// Without a matching target/release binary, preserve either pre-placed name.
-// Cross-platform packaging (e.g. win32 on Linux) may not match process.platform.
+// No matching target/release binary — preserve whatever is already bundled.
 if (fs.existsSync(path.join(binDir, 'raven')) || fs.existsSync(path.join(binDir, 'raven.exe'))) {
     console.log('Preserving pre-placed raven binary; no matching target/release binary found');
     process.exit(0);

--- a/tests/bun/bundle-binary.test.ts
+++ b/tests/bun/bundle-binary.test.ts
@@ -31,6 +31,7 @@ type BundleCase = {
   sourceTime?: Date;
   destinationTime: Date;
   destinationName?: string;
+  prePlaced?: boolean;
 };
 
 function runBundleCase(testCase: BundleCase): {
@@ -72,6 +73,7 @@ function runBundleCase(testCase: BundleCase): {
       env: {
         ...process.env,
         RAVEN_BUNDLE_NO_BUILD: "1",
+        ...(testCase.prePlaced ? { RAVEN_BUNDLE_PREPLACED: "1" } : {}),
       },
     });
     return {
@@ -127,6 +129,51 @@ test("bundle-binary refreshes a size mismatch when mtimes are equal", () => {
   expect(result.output).toContain("Refreshed stale raven binary");
 });
 
+// Release packaging cross-compiles, unzips the TARGET binary into bin/, then
+// runs this script. A runner that also has a host `target/release/raven` (warm
+// cache, self-hosted runner, local `vsce package` after a dev build) must not
+// have that host binary overwrite the cross-compiled one — the VSIX would ship
+// a server that cannot execute on the platform it claims to target. Freshness
+// cannot catch this: the host binary is legitimately newer.
+test("bundle-binary preserves a pre-placed binary even when target/release is newer", () => {
+  const result = runBundleCase({
+    sourceContent: "host binary for the wrong platform",
+    destinationContent: "cross-compiled target binary",
+    sourceTime: new Date("2021-01-01T00:00:00Z"),
+    destinationTime: new Date("2020-01-01T00:00:00Z"),
+    prePlaced: true,
+  });
+
+  expect(result.status, result.output).toBe(0);
+  expect(result.destinationContent).toBe("cross-compiled target binary");
+  expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
+  expect(result.output).toContain(
+    "Preserving pre-placed raven binary (RAVEN_BUNDLE_PREPLACED=1)",
+  );
+});
+
+// Same protection without the env var: a pre-placed binary under the OTHER
+// platform's name can never be replaced by a host build, because the host build
+// writes a different filename.
+test("bundle-binary preserves a foreign-target binary when target/release is newer", () => {
+  const result = runBundleCase({
+    sourceContent: "host binary",
+    destinationContent: "foreign target binary",
+    sourceTime: new Date("2021-01-01T00:00:00Z"),
+    destinationTime: new Date("2020-01-01T00:00:00Z"),
+    destinationName: alternateBinaryName,
+  });
+
+  expect(result.status, result.output).toBe(0);
+  expect(result.destinationContent).toBe("foreign target binary");
+  expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
+  expect(result.output).toContain("is not this host's target name");
+});
+
+// With no host build present at all, an alternate-platform binary is still
+// preserved. It exits via the foreign-name guard (which runs first and does not
+// need target/release to exist) rather than the no-source fallback, but the
+// outcome that matters is the same: the pre-placed binary survives untouched.
 test("bundle-binary preserves an alternate-platform binary when the source is missing", () => {
   const result = runBundleCase({
     destinationContent: "pre-placed",
@@ -137,7 +184,5 @@ test("bundle-binary preserves an alternate-platform binary when the source is mi
   expect(result.status, result.output).toBe(0);
   expect(result.destinationContent).toBe("pre-placed");
   expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
-  expect(result.output).toContain(
-    "Preserving pre-placed raven binary; no matching target/release binary found",
-  );
+  expect(result.output).toContain("Preserving pre-placed");
 });

--- a/tests/bun/bundle-binary.test.ts
+++ b/tests/bun/bundle-binary.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -32,12 +33,19 @@ type BundleCase = {
   destinationTime: Date;
   destinationName?: string;
   prePlaced?: boolean;
+  /**
+   * When set, also read back `bin/<hostBinaryName>` after the run. Use it to
+   * assert whether the host copy happened, which matters when the pre-placed
+   * artifact under test carries the OTHER platform's filename.
+   */
+  hostBinaryName?: string;
 };
 
 function runBundleCase(testCase: BundleCase): {
   status: number | null;
   output: string;
   destinationContent: string;
+  hostBinaryContent: string | undefined;
   beforeMtimeMs: number;
   afterMtimeMs: number;
 } {
@@ -76,10 +84,17 @@ function runBundleCase(testCase: BundleCase): {
         ...(testCase.prePlaced ? { RAVEN_BUNDLE_PREPLACED: "1" } : {}),
       },
     });
+    const hostBinaryPath = testCase.hostBinaryName
+      ? path.join(binDir, testCase.hostBinaryName)
+      : undefined;
     return {
       status: result.status,
       output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
       destinationContent: readFileSync(destinationPath, "utf8"),
+      hostBinaryContent:
+        hostBinaryPath && existsSync(hostBinaryPath)
+          ? readFileSync(hostBinaryPath, "utf8")
+          : undefined,
       beforeMtimeMs,
       afterMtimeMs: statSync(destinationPath).mtimeMs,
     };
@@ -152,28 +167,53 @@ test("bundle-binary preserves a pre-placed binary even when target/release is ne
   );
 });
 
-// Same protection without the env var: a pre-placed binary under the OTHER
-// platform's name can never be replaced by a host build, because the host build
-// writes a different filename.
-test("bundle-binary preserves a foreign-target binary when target/release is newer", () => {
+// A foreign-named artifact left in bin/ (e.g. raven.exe after packaging a
+// Windows target on Linux) must NOT suppress the host copy. `copy-binary` also
+// runs from `pretest` and ordinary dev builds; skipping the copy there would
+// report success while leaving the extension — which resolves bin/raven from
+// process.platform — with no runnable server. The foreign file is untouched
+// regardless, because the copy writes to this host's filename.
+test("bundle-binary still creates the host binary alongside a foreign-target one", () => {
   const result = runBundleCase({
     sourceContent: "host binary",
     destinationContent: "foreign target binary",
     sourceTime: new Date("2021-01-01T00:00:00Z"),
     destinationTime: new Date("2020-01-01T00:00:00Z"),
     destinationName: alternateBinaryName,
+    hostBinaryName: binaryName,
   });
 
   expect(result.status, result.output).toBe(0);
+  // The foreign artifact survives untouched...
   expect(result.destinationContent).toBe("foreign target binary");
   expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
-  expect(result.output).toContain("is not this host's target name");
+  // ...and the host binary is created, so pretest/dev runs have a server.
+  expect(result.hostBinaryContent).toBe("host binary");
+  expect(result.output).toContain("Bundled raven binary");
 });
 
-// With no host build present at all, an alternate-platform binary is still
-// preserved. It exits via the foreign-name guard (which runs first and does not
-// need target/release to exist) rather than the no-source fallback, but the
-// outcome that matters is the same: the pre-placed binary survives untouched.
+// Release packaging still preserves a foreign-named artifact when it is marked
+// pre-placed — that is the env-var guard's job, and it must win over the copy.
+test("bundle-binary preserves a foreign-target binary when marked pre-placed", () => {
+  const result = runBundleCase({
+    sourceContent: "host binary",
+    destinationContent: "cross-compiled target binary",
+    sourceTime: new Date("2021-01-01T00:00:00Z"),
+    destinationTime: new Date("2020-01-01T00:00:00Z"),
+    destinationName: alternateBinaryName,
+    hostBinaryName: binaryName,
+    prePlaced: true,
+  });
+
+  expect(result.status, result.output).toBe(0);
+  expect(result.destinationContent).toBe("cross-compiled target binary");
+  expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
+  expect(result.hostBinaryContent).toBeUndefined();
+  expect(result.output).toContain(
+    "Preserving pre-placed raven binary (RAVEN_BUNDLE_PREPLACED=1)",
+  );
+});
+
 test("bundle-binary preserves an alternate-platform binary when the source is missing", () => {
   const result = runBundleCase({
     destinationContent: "pre-placed",
@@ -184,5 +224,7 @@ test("bundle-binary preserves an alternate-platform binary when the source is mi
   expect(result.status, result.output).toBe(0);
   expect(result.destinationContent).toBe("pre-placed");
   expect(result.afterMtimeMs).toBe(result.beforeMtimeMs);
-  expect(result.output).toContain("Preserving pre-placed");
+  expect(result.output).toContain(
+    "Preserving pre-placed raven binary; no matching target/release binary found",
+  );
 });


### PR DESCRIPTION
Found while working on #738/#741, but entirely unrelated to diagnostics — filed separately.

## The bug

The release workflow cross-compiles for every target, unzips the correct artifact into `bin/`, and only then runs `vsce package`, which triggers `bundle-binary.js`. That script refreshes `bin/` from `target/release` whenever the latter looks newer.

On a runner that also has a host `target/release/raven` — a warm cache, a self-hosted runner, or a local `vsce package` after a dev build — the host binary replaces the cross-compiled one. The result is a VSIX whose bundled server **cannot execute on the platform it claims to target**.

Content freshness cannot distinguish this case. The host binary is legitimately newer, so mtime and size both agree with overwriting it. No amount of comparison logic fixes it, because the comparison is answering the wrong question: not "which is newer" but "was this deliberately placed here".

## The fix

Two guards, in order:

1. **`RAVEN_BUNDLE_PREPLACED=1`** — set on the release workflow's package step, marks the pre-placed case explicitly and skips the comparison entirely.
2. **Foreign target name** — a pre-placed binary stored under the *other* platform's filename wins even without the env var, since a host build writes a different name and so can never be its legitimate replacement.

Both target names (`raven` and `raven.exe`) are checked in each guard, because cross-platform packaging (e.g. win32 on Linux) means `process.platform` does not match the target being built.

The ordinary dev path is unchanged: with no pre-placed binary, `target/release` still refreshes `bin/` when newer, with size as a tie-breaker for filesystems with coarse timestamps. I left a note on that path spelling out its one blind spot — a rebuild producing different bytes at the same length *and* the same timestamp — since it is worth knowing the check is not a content hash. It needs both to collide, and the cost of being wrong is a stale dev binary rather than a bad release, because releases now take the pre-placed path.

## Testing

`bun test tests/bun/bundle-binary.test.ts` — 6 pass. Two new cases:

- a pre-placed binary survives a *newer* `target/release` under `RAVEN_BUNDLE_PREPLACED=1`
- a foreign-target-name binary survives a newer `target/release` without the env var

The pre-existing "preserves an alternate-platform binary when the source is missing" case now exits via the foreign-name guard rather than the no-source fallback, so its message assertion is relaxed to the shared prefix. The outcome it checks — the pre-placed binary survives untouched, same mtime — is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code extension packaging to preserve pre-placed, platform-specific language server binaries.
  * Prevented valid bundled binaries from being replaced or removed during packaging.
  * Ensured missing host binaries can still be created when appropriate.

* **Tests**
  * Added coverage for pre-placed binaries, platform-specific files, and fallback packaging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->