### PR TITLE
Fix release-blocking folding and packaging regressions

### DIFF
--- a/crates/raven/src/handlers.rs
+++ b/crates/raven/src/handlers.rs
@@ -5611,7 +5611,7 @@ pub fn folding_range(state: &WorldState, uri: &Url) -> Option<Vec<FoldingRange>>
     let tree = doc.tree.as_ref()?;
     let mut ranges = Vec::new();
 
-    collect_folding_ranges(tree.root_node(), &mut ranges);
+    collect_folding_ranges(tree.root_node(), doc.file_type, &mut ranges);
 
     // A Stan top-level block and its `block_statement` share a range. Keep the
     // existing R/JAGS ordering untouched and remove only these Stan duplicates.
@@ -5635,26 +5635,28 @@ pub fn folding_range(state: &WorldState, uri: &Url) -> Option<Vec<FoldingRange>>
     Some(ranges)
 }
 
-fn collect_folding_ranges(node: Node, ranges: &mut Vec<FoldingRange>) {
+fn collect_folding_ranges(node: Node, file_type: FileType, ranges: &mut Vec<FoldingRange>) {
     let kind = node.kind();
 
-    // Fold braced expressions, function definitions, and control structures
+    // Keep model-language node names scoped to their grammar: `parameters` is
+    // also the R grammar's function-formals node, where folding it competes
+    // with the existing function-body range.
     let should_fold = matches!(
         kind,
-        "brace_list"
-            | "block_statement"
-            | "function_definition"
-            | "if_statement"
-            | "for_statement"
-            | "while_statement"
-            | "functions"
-            | "data"
-            | "transformed_data"
-            | "parameters"
-            | "transformed_parameters"
-            | "model"
-            | "generated_quantities"
-    );
+        "brace_list" | "function_definition" | "if_statement" | "for_statement" | "while_statement"
+    ) || (file_type == FileType::Stan
+        && matches!(
+            kind,
+            "block_statement"
+                | "functions"
+                | "data"
+                | "transformed_data"
+                | "parameters"
+                | "transformed_parameters"
+                | "model"
+                | "generated_quantities"
+        ))
+        || (file_type == FileType::Jags && kind == "block_statement");
 
     if should_fold && node.start_position().row != node.end_position().row {
         ranges.push(FoldingRange {
@@ -5670,7 +5672,7 @@ fn collect_folding_ranges(node: Node, ranges: &mut Vec<FoldingRange>) {
     // Recurse into children
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_folding_ranges(child, ranges);
+        collect_folding_ranges(child, file_type, ranges);
     }
 }
 
@@ -44043,6 +44045,32 @@ result <- data %>% filter(x > 0)
             .documents
             .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
         (state, uri)
+    }
+
+    #[test]
+    fn test_r_folding_does_not_treat_function_parameters_as_stan_block() {
+        use crate::state::{Document, WorldState};
+
+        let code = "f <- function(\n  a,\n  b\n) {\n  a + b\n}\n";
+        let uri = Url::parse("file:///folding.R").unwrap();
+        let mut state = WorldState::new();
+        state
+            .documents
+            .insert(uri.clone(), Document::new_with_uri(code, None, &uri));
+
+        let folds = super::folding_range(&state, &uri).expect("folding_range Some");
+        assert!(
+            folds
+                .iter()
+                .any(|fold| fold.start_line == 0 && fold.end_line == 5),
+            "the complete function must remain foldable, got {folds:?}"
+        );
+        assert!(
+            !folds
+                .iter()
+                .any(|fold| fold.start_line == 0 && fold.end_line == 3),
+            "R function formals must not produce a competing model-language fold, got {folds:?}"
+        );
     }
 
     #[test]

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2454,7 +2454,7 @@
     "pretest": "bun run compile:test && bun run bundle && bun run bundle:webview-test && bun run copy-binary",
     "test": "vscode-test",
     "package": "bun run bundle && bun run copy-binary && bun run copy-notice && vsce package --allow-missing-repository",
-    "package:target": "bun run bundle && bun run copy-binary && bun run copy-notice && vsce package --target",
+    "package:target": "node scripts/package-target.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p src/plot/webview && tsc --noEmit -p src/help/webview && tsc --noEmit -p src/data-viewer/webview"
   },
   "dependencies": {

--- a/editors/vscode/scripts/package-target.js
+++ b/editors/vscode/scripts/package-target.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const extensionRoot = path.join(__dirname, '..');
+
+function targetNeedsPreplaced(target, platform = process.platform, arch = process.arch) {
+    const hostTarget = `${platform}-${arch}`;
+    return Boolean(target) && target !== hostTarget;
+}
+
+function run(command, args, env) {
+    const result = spawnSync(command, args, {
+        cwd: extensionRoot,
+        env,
+        stdio: 'inherit',
+    });
+    if (result.error) {
+        throw result.error;
+    }
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const env = { ...process.env };
+
+    // A cross-target invocation necessarily relies on a binary placed in bin/;
+    // protect it both here and in the `vscode:prepublish` lifecycle that VSCE
+    // invokes. Same-host packaging keeps the normal freshness refresh. The
+    // release workflow's explicit marker still wins for its same-host target.
+    if (targetNeedsPreplaced(args[0])) {
+        env.RAVEN_BUNDLE_PREPLACED = '1';
+    }
+
+    run('bun', ['run', 'bundle'], env);
+    run('bun', ['run', 'copy-binary'], env);
+    run('bun', ['run', 'copy-notice'], env);
+
+    // Invoke the JavaScript entry point through Node rather than spawning the
+    // platform shim (`vsce.cmd` on Windows), which is not directly executable
+    // by spawnSync without a shell.
+    const vsce = path.join(extensionRoot, 'node_modules', '@vscode', 'vsce', 'vsce');
+    run(process.execPath, [vsce, 'package', '--target', ...args], env);
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { targetNeedsPreplaced };

--- a/tests/bun/vscode-config.test.ts
+++ b/tests/bun/vscode-config.test.ts
@@ -306,3 +306,27 @@ test("VS Code package metadata exposes send method setting", () => {
   expect(setting.enumDescriptions).toHaveLength(3);
   expect(setting.description).toContain("Controls how Raven sends code to R");
 });
+
+test("cross-target packaging preserves only deliberately pre-placed binaries", () => {
+  const extensionRoot = path.join(import.meta.dir, "..", "..", "editors", "vscode");
+  const packageTargetPath = path.join(
+    extensionRoot,
+    "scripts",
+    "package-target.js",
+  );
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(extensionRoot, "package.json"), "utf8"),
+  );
+  const wrapper = fs.readFileSync(packageTargetPath, "utf8");
+  const { targetNeedsPreplaced } = require(packageTargetPath) as {
+    targetNeedsPreplaced(target: string, platform: string, arch: string): boolean;
+  };
+
+  expect(pkg.scripts["package:target"]).toBe("node scripts/package-target.js");
+  expect(targetNeedsPreplaced("linux-x64", "linux", "x64")).toBe(false);
+  expect(targetNeedsPreplaced("linux-arm64", "linux", "x64")).toBe(true);
+  expect(targetNeedsPreplaced("alpine-x64", "linux", "x64")).toBe(true);
+  expect(targetNeedsPreplaced("win32-x64", "win32", "x64")).toBe(false);
+  expect(wrapper).toContain("run(process.execPath");
+  expect(wrapper).toContain("env.RAVEN_BUNDLE_PREPLACED = '1'");
+});


### PR DESCRIPTION
## Summary
- scope model-language folding nodes by file type so multiline R formals do not compete with function folds
- preserve pre-placed binaries for cross-target VSIX packaging while refreshing same-host builds
- invoke VSCE through Node for Windows compatibility
- add regression coverage for both paths

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --features test-support -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p raven --no-deps --document-private-items (default and test-support)
- cargo test --workspace --features test-support
- bun test (1784 pass, 0 fail)
- focused post-fix review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code folding for Stan, JAGS, and R files using language-appropriate rules.
  - Stan-specific blocks are no longer incorrectly folded in R files.
  - R function parameters no longer create competing fold regions.

- **Chores**
  - Improved VS Code extension packaging for different platforms and targets.
  - Packaging now handles bundled binaries and failures more reliably.

- **Tests**
  - Added coverage for cross-target extension packaging and language-specific folding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->